### PR TITLE
deploy: update backend image to f4931ae

### DIFF
--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -12,6 +12,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/team-tracker-backend
-  newTag: fb96eb58cebdebb10fdd1d4417a95e4440d54b40
+  newTag: f4931ae09497ff99c909ea68dcaac685c8a7980b
 - name: quay.io/org-pulse/team-tracker-frontend
   newTag: 7a99fee7aeb3bb8d4c9fe849b0ef17e5653feaee


### PR DESCRIPTION
Automated image tag update for `team-tracker-backend` to `f4931ae09497ff99c909ea68dcaac685c8a7980b`.