### PR TITLE
feat: add Ambient PR review workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -220,6 +220,8 @@ secrets/            # Service account keys (gitignored)
 
 ## Code Style
 
+See `CONVENTIONS.md` at the repo root for the full set of coding and architecture conventions.
+
 - Use `<script setup>` for new Vue components
 - CommonJS (`require`) for server-side code
 - ES modules (`import`) for frontend code

--- a/.github/workflows/ambient-review.yml
+++ b/.github/workflows/ambient-review.yml
@@ -1,0 +1,164 @@
+name: Ambient PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    name: Ambient Review
+    runs-on: ubuntu-latest
+    # Skip automated deploy PRs from github-actions bot
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.actor != 'github-actions[bot]'
+    steps:
+      - uses: ambient-code/ambient-action@v0.0.2
+        with:
+          api-url: ${{ secrets.AMBIENT_API_URL }}
+          api-token: ${{ secrets.AMBIENT_BOT_TOKEN }}
+          project: rhai-org-pulse
+          timeout: '45'
+          display-name: 'PR Review: ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})'
+          repos: >-
+            [{"url": "https://github.com/accorvin/team-tracker", "branch": "${{ github.head_ref }}", "autoPush": true}]
+          labels: >-
+            {"pr_number": "${{ github.event.pull_request.number }}", "pr_author": "${{ github.event.pull_request.user.login }}", "type": "pr-review"}
+          prompt: |
+            You are reviewing PR #${{ github.event.pull_request.number }} on the team-tracker repo.
+
+            PR title: ${{ github.event.pull_request.title }}
+            PR author: ${{ github.event.pull_request.user.login }}
+            Base branch: ${{ github.base_ref }}
+            Head branch: ${{ github.head_ref }}
+
+            ## Instructions
+
+            Read `CONVENTIONS.md` and `.claude/CLAUDE.md` at the repo root to understand the project's
+            architecture, code style, and patterns. Follow those conventions in all feedback and fixes.
+
+            ## Review Philosophy
+
+            Optimize for VELOCITY. The goal is to ship working, safe code fast — not to achieve perfection.
+            Do not nitpick style preferences, suggest unnecessary refactors, or request changes that don't
+            materially improve the PR. Be concise and actionable.
+
+            ## Review Priorities
+
+            Focus your review on these four areas, in order of importance:
+
+            1. **Security**: Flag any security vulnerabilities (injection, XSS, auth bypass, secret exposure,
+               OWASP top 10). These are blockers.
+            2. **Coherence**: Ensure changes are consistent with what the app does today. Flag anything that
+               would break existing functionality or contradict established patterns.
+            3. **Architecture**: Check that the design is sound — correct module boundaries, proper use of
+               shared vs module code, no circular dependencies, sensible data flow.
+            4. **Correctness**: Look for bugs, logic errors, off-by-one mistakes, unhandled edge cases that
+               would realistically occur, and missing error handling at system boundaries.
+
+            ## Fix-up Commits
+
+            You MAY push fix-up commits directly to the PR branch for:
+            - Linting errors or formatting issues
+            - Missing or outdated documentation (README, code comments for non-obvious logic)
+            - Adding missing test coverage for changed code
+            - Trivial typos
+
+            You MUST NOT push fix-up commits for:
+            - Functional behavior changes
+            - Refactoring code the PR didn't touch
+            - Adding new features or capabilities
+            - Architectural changes
+
+            When pushing fix-up commits, use clear commit messages prefixed with `fixup:` (e.g.,
+            `fixup: add missing test for new endpoint`).
+
+            ## Output
+
+            After reviewing, post a summary comment on the PR with:
+            - A short verdict: approve, request changes, or comment
+            - Any issues found, grouped by priority (security/coherence/architecture/correctness)
+            - A list of any fix-up commits you pushed
+
+            If the PR looks good and you have no substantive feedback, just approve it with a brief note.
+
+  respond:
+    name: Ambient Respond
+    runs-on: ubuntu-latest
+    # Only run on PR comments that start with @ambient, from repo members
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@ambient') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "head_ref=$(echo "$PR_JSON" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$PR_JSON" | jq -r .title)" >> "$GITHUB_OUTPUT"
+          echo "author=$(echo "$PR_JSON" | jq -r .user.login)" >> "$GITHUB_OUTPUT"
+
+      - uses: ambient-code/ambient-action@v0.0.2
+        with:
+          api-url: ${{ secrets.AMBIENT_API_URL }}
+          api-token: ${{ secrets.AMBIENT_BOT_TOKEN }}
+          project: rhai-org-pulse
+          timeout: '30'
+          display-name: 'PR Comment: #${{ github.event.issue.number }} by ${{ github.event.comment.user.login }}'
+          repos: >-
+            [{"url": "https://github.com/accorvin/team-tracker", "branch": "${{ steps.pr.outputs.head_ref }}", "autoPush": true}]
+          labels: >-
+            {"pr_number": "${{ github.event.issue.number }}", "pr_author": "${{ steps.pr.outputs.author }}", "comment_author": "${{ github.event.comment.user.login }}", "type": "pr-comment"}
+          prompt: |
+            You are responding to a comment on PR #${{ github.event.issue.number }} on the team-tracker repo.
+
+            PR title: ${{ steps.pr.outputs.title }}
+            PR author: ${{ steps.pr.outputs.author }}
+            PR branch: ${{ steps.pr.outputs.head_ref }}
+            Comment author: ${{ github.event.comment.user.login }}
+
+            ## The comment
+
+            ${{ github.event.comment.body }}
+
+            ## Instructions
+
+            Read `CONVENTIONS.md` and `.claude/CLAUDE.md` at the repo root to understand the project's
+            architecture, code style, and patterns.
+
+            Respond to the commenter's question or request. Be concise and helpful. If they're asking
+            about the code, read the relevant files and give a clear answer. If they're asking you to
+            make a change, evaluate whether it falls within the fix-up commit rules below.
+
+            ## Fix-up Commits
+
+            You MAY push fix-up commits directly to the PR branch for:
+            - Linting errors or formatting issues
+            - Missing or outdated documentation
+            - Adding missing test coverage for changed code
+            - Trivial typos
+            - Changes the commenter explicitly requests, as long as they are minor and well-scoped
+
+            You MUST NOT push fix-up commits for:
+            - Substantial functional behavior changes (suggest these but don't implement)
+            - Refactoring code the PR didn't touch
+            - Adding new features or capabilities
+            - Architectural changes
+
+            When pushing fix-up commits, use clear commit messages prefixed with `fixup:`.
+
+            ## Output
+
+            Post a reply comment on the PR answering the question or confirming what you did.
+            If you pushed any commits, list them in the reply.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,44 @@
+# Project Conventions
+
+This document defines the canonical coding and architecture conventions for the Team Tracker project. All contributors (human and automated) should follow these.
+
+## Code Style
+
+- **Vue components**: Use `<script setup>` (Composition API). No Options API.
+- **Server code**: CommonJS (`require`/`module.exports`)
+- **Client code**: ES modules (`import`/`export`)
+- **Language**: Plain JavaScript only. No TypeScript.
+- **Styling**: Tailwind CSS utility classes. Custom `primary` color palette in `tailwind.config.mjs`.
+- **Composables**: Shared reactive state logic goes in composables (`useXxx` naming convention)
+
+## Architecture
+
+- **Module system**: Built-in modules live in `modules/<slug>/` with `module.json` manifests. Modules are self-contained with `client/`, `server/`, and `__tests__/` directories.
+- **Shared code**: Reusable code lives in `shared/client/` and `shared/server/`, imported via the `@shared` Vite alias. Modules must not import from other modules.
+- **App shell**: `src/` contains only the application shell (sidebar, landing page, module loader). Business logic belongs in modules.
+- **Backend**: Single Express server (`server/dev-server.js`). Module routes mount at `/api/modules/<slug>/`.
+- **Storage**: Filesystem-based (`./data/` directory). No database.
+- **Auth**: OpenShift OAuth proxy in production sets `X-Forwarded-Email`. Backend checks against `data/allowlist.json`.
+
+## Testing
+
+- **Framework**: Vitest for all tests
+- **Frontend tests**: Vitest + `@vue/test-utils` in `src/__tests__/` and `modules/*/__tests__/client/`
+- **Backend tests**: Vitest in `modules/*/__tests__/server/`
+- **Module validation**: `npm run validate:modules` checks manifests (runs in CI)
+- **Run before committing**: `npm test`
+
+## Patterns
+
+- **Caching**: Frontend uses localStorage stale-while-revalidate (`tt_cache:` prefix). API functions accept `onData` callbacks.
+- **Composite keys**: Teams are identified by `orgKey::teamName` (e.g., `shgriffi::Model Serving`).
+- **Module navigation**: Use `inject('moduleNav')` for `navigateTo(viewId, params)` and `goBack()`.
+- **Hash routing**: `#/<module-slug>/<view-id>?key=value`
+
+## What to Avoid
+
+- Don't over-engineer. Keep solutions simple and focused on the task at hand.
+- Don't add TypeScript, type annotations, or JSDoc types.
+- Don't add features, refactor code, or make "improvements" beyond what was asked.
+- Don't create abstractions for one-time operations.
+- Don't add error handling for scenarios that can't happen.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ambient-review.yml` with two jobs:
  - **review**: Automatically reviews PRs on open/sync/reopen (skips `github-actions[bot]` deploy PRs). Uses opus model with velocity-focused review priorities (security > coherence > architecture > correctness). Can push fix-up commits for lint, docs, and missing tests.
  - **respond**: Responds to `@ambient ...` comments on PRs — answers questions about the code or makes minor requested changes.
- Add `CONVENTIONS.md` at repo root as the canonical, tool-agnostic source of truth for coding and architecture conventions. Referenced by both `.claude/CLAUDE.md` and the Ambient review prompt.
- Update `.claude/CLAUDE.md` to reference `CONVENTIONS.md`.

## Setup Required

Two repository secrets must be added before this workflow will function:
- `AMBIENT_API_URL` — Ambient platform API endpoint
- `AMBIENT_BOT_TOKEN` — Bot bearer token

## Test plan

- [ ] Add `AMBIENT_API_URL` and `AMBIENT_BOT_TOKEN` secrets to the repo
- [ ] Merge this PR, then open a test PR to verify the review job triggers
- [ ] Comment `@ambient what does this workflow do?` on the test PR to verify the respond job triggers
- [ ] Verify automated deploy PRs from `github-actions[bot]` are skipped

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>