### PR TITLE
feat: Add multi-instance GitLab contribution tracking with per-instance breakdown

### DIFF
--- a/fixtures/gitlab-contributions.json
+++ b/fixtures/gitlab-contributions.json
@@ -3,45 +3,73 @@
     "bobsmith": {
       "username": "bobsmith",
       "totalContributions": 198,
-      "fetchedAt": "2026-03-10T12:00:00.000Z",
-      "instances": [
-        { "baseUrl": "https://gitlab.com", "label": "GitLab.com", "contributions": 150 },
-        { "baseUrl": "https://gitlab.internal.example.com", "label": "Internal GitLab", "contributions": 48 }
-      ]
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 151, "months": {} },
+        "https://gitlab.com": { "totalContributions": 47, "months": {} }
+      },
+      "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "carolw": {
       "username": "carolw",
       "totalContributions": 143,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 143, "months": {} },
+        "https://gitlab.com": { "totalContributions": 0, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "davidlee": {
       "username": "davidlee",
       "totalContributions": 267,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 200, "months": {} },
+        "https://gitlab.com": { "totalContributions": 67, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "emmagarcia": {
       "username": "emmagarcia",
       "totalContributions": 112,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 112, "months": {} },
+        "https://gitlab.com": { "totalContributions": 0, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "gracekim": {
       "username": "gracekim",
       "totalContributions": 231,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 189, "months": {} },
+        "https://gitlab.com": { "totalContributions": 42, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "henryw": {
       "username": "henryw",
       "totalContributions": 98,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 98, "months": {} },
+        "https://gitlab.com": { "totalContributions": 0, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "alicechen": {
       "username": "alicechen",
       "totalContributions": 67,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 40, "months": {} },
+        "https://gitlab.com": { "totalContributions": 27, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     },
     "frankj": {
       "username": "frankj",
       "totalContributions": 55,
+      "instances": {
+        "https://gitlab.cee.redhat.com": { "totalContributions": 55, "months": {} },
+        "https://gitlab.com": { "totalContributions": 0, "months": {} }
+      },
       "fetchedAt": "2026-03-10T12:00:00.000Z"
     }
   },

--- a/modules/team-tracker/client/components/MetricCard.vue
+++ b/modules/team-tracker/client/components/MetricCard.vue
@@ -13,6 +13,7 @@
       <span v-if="unit" class="text-sm text-gray-500 dark:text-gray-400">{{ unit }}</span>
     </div>
     <p v-if="subtitle" class="text-xs text-gray-400 dark:text-gray-500 mt-1">{{ subtitle }}</p>
+    <slot name="footer" />
   </div>
 </template>
 

--- a/modules/team-tracker/client/components/PersonTable.vue
+++ b/modules/team-tracker/client/components/PersonTable.vue
@@ -59,7 +59,9 @@
             <span v-else class="text-gray-300 dark:text-gray-600 italic text-xs" title="GitHub username not configured">no GitHub</span>
           </td>
           <td class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-            <template v-if="getGitlabContribCount(member) != null">{{ getGitlabContribCount(member) }}</template>
+            <template v-if="getGitlabContribCount(member) != null">
+              <span :title="getGitlabInstanceTooltip(member) || undefined">{{ getGitlabContribCount(member) }}</span>
+            </template>
             <span v-else-if="member.gitlabUsername" class="text-gray-300 dark:text-gray-600">—</span>
             <span v-else class="text-gray-300 dark:text-gray-600 italic text-xs" title="GitLab username not configured">no GitLab</span>
           </td>
@@ -160,6 +162,15 @@ function getGithubContribCount(member) {
 function getGitlabContribCount(member) {
   if (!member.gitlabUsername) return null
   return getGitlabContributions(member.gitlabUsername)?.totalContributions ?? null
+}
+
+function getGitlabInstanceTooltip(member) {
+  if (!member.gitlabUsername) return ''
+  const instances = getGitlabContributions(member.gitlabUsername)?.instances
+  if (!instances || Object.keys(instances).length <= 1) return ''
+  return Object.entries(instances)
+    .map(([url, data]) => `${url.replace(/^https?:\/\//, '')}: ${data.totalContributions}`)
+    .join('\n')
 }
 
 const sortedMembers = computed(() => {

--- a/modules/team-tracker/client/components/ReportsMetricSelector.vue
+++ b/modules/team-tracker/client/components/ReportsMetricSelector.vue
@@ -27,7 +27,9 @@ const metrics = [
   { key: 'avgCycleTime', label: 'Avg Cycle Time' },
   { key: 'resolvedPerMember', label: 'Issues Resolved per Member (90d)' },
   { key: 'githubContributions', label: 'GitHub Contributions (1yr)' },
-  { key: 'githubPerMember', label: 'Avg GitHub Contributions per Member (1yr)' }
+  { key: 'githubPerMember', label: 'Avg GitHub Contributions per Member (1yr)' },
+  { key: 'gitlabContributions', label: 'GitLab Contributions (1yr)' },
+  { key: 'gitlabPerMember', label: 'Avg GitLab Contributions per Member (1yr)' }
 ]
 
 const props = defineProps({

--- a/modules/team-tracker/client/views/PersonDetail.vue
+++ b/modules/team-tracker/client/views/PersonDetail.vue
@@ -191,10 +191,23 @@
         />
         <MetricCard
           label="GitLab Contributions"
-          :value="gitlabContributions?.totalContributions ?? '—'"
-          :subtitle="person.gitlabUsername ? 'Last year' : 'No GitLab username'"
-          tooltip="Public contributions via GitLab calendar API."
-        />
+          :value="person.gitlabUsername ? (gitlabContributions?.totalContributions ?? '—') : 'N/A'"
+          :subtitle="person.gitlabUsername ? 'Last year' : 'Username not configured'"
+          tooltip="Contributions via GitLab GraphQL API, summed across all configured instances."
+        >
+          <template v-if="gitlabInstanceBreakdown.length > 1" #footer>
+            <div class="mt-1 space-y-0.5">
+              <div
+                v-for="inst in gitlabInstanceBreakdown"
+                :key="inst.baseUrl"
+                class="flex justify-between text-xs text-gray-400 dark:text-gray-500"
+              >
+                <span class="truncate mr-2">{{ inst.label }}</span>
+                <span class="font-medium tabular-nums">{{ inst.count }}</span>
+              </div>
+            </div>
+          </template>
+        </MetricCard>
       </div>
 
       <div class="mb-4 pl-1">
@@ -373,6 +386,15 @@ const gitlabContributions = computed(() => person.value ? getGitlabContributions
 const gitlabProfileUrls = computed(() => person.value?.gitlabUsername
   ? getGitlabProfileUrls(person.value.gitlabUsername)
   : [])
+
+const gitlabInstanceBreakdown = computed(() => {
+  if (!gitlabContributions.value?.instances) return []
+  return Object.entries(gitlabContributions.value.instances).map(([baseUrl, data]) => ({
+    label: baseUrl.replace(/^https?:\/\//, ''),
+    baseUrl,
+    count: data.totalContributions
+  }))
+})
 
 const jiraProfileUrl = computed(() => {
   if (metrics.value?.jiraAccountId) {

--- a/modules/team-tracker/client/views/ReportsView.vue
+++ b/modules/team-tracker/client/views/ReportsView.vue
@@ -81,12 +81,14 @@ import ReportsMetricSelector from '../components/ReportsMetricSelector.vue'
 import ReportsChartTypeSelector from '../components/ReportsChartTypeSelector.vue'
 import { useRoster } from '@shared/client/composables/useRoster'
 import { useGithubStats } from '@shared/client/composables/useGithubStats'
+import { useGitlabStats } from '@shared/client/composables/useGitlabStats'
 import { getTeamMetrics } from '@shared/client/services/api'
 
 const _nav = inject('moduleNav')
 
 const { orgs, teams, selectedOrgKey, selectOrg } = useRoster()
 const { getContributions } = useGithubStats()
+const { getContributions: getGitlabContributions } = useGitlabStats()
 
 const selectedTeamKeys = ref([])
 const selectedMetrics = ref([])
@@ -127,6 +129,16 @@ const METRIC_DEFS = {
   },
   githubPerMember: {
     label: 'Avg GitHub Contributions per Member (1yr)',
+    unit: '',
+    extract: null // handled specially in generate()
+  },
+  gitlabContributions: {
+    label: 'GitLab Contributions (1yr)',
+    unit: '',
+    extract: null // handled specially in generate()
+  },
+  gitlabPerMember: {
+    label: 'Avg GitLab Contributions per Member (1yr)',
     unit: '',
     extract: null // handled specially in generate()
   }
@@ -197,6 +209,39 @@ async function generate() {
             if (!team?.members) return 0
             return team.members.reduce((sum, m) => {
               const c = m.githubUsername ? getContributions(m.githubUsername) : null
+              return sum + (c?.totalContributions ?? 0)
+            }, 0)
+          })
+        })
+      } else if (metricKey === 'gitlabPerMember') {
+        newCharts.push({
+          metricKey,
+          title: def.label,
+          unit: '',
+          labels: activeKeys.map(k => teamLookup[k]?.displayName ?? k),
+          data: activeKeys.map(k => {
+            const team = teamLookup[k]
+            if (!team?.members?.length) return 0
+            const configured = team.members.filter(m => m.gitlabUsername)
+            if (configured.length === 0) return 0
+            const total = configured.reduce((sum, m) => {
+              const c = getGitlabContributions(m.gitlabUsername)
+              return sum + (c?.totalContributions ?? 0)
+            }, 0)
+            return Math.round((total / configured.length) * 10) / 10
+          })
+        })
+      } else if (metricKey === 'gitlabContributions') {
+        newCharts.push({
+          metricKey,
+          title: def.label,
+          unit: def.unit,
+          labels: activeKeys.map(k => teamLookup[k]?.displayName ?? k),
+          data: activeKeys.map(k => {
+            const team = teamLookup[k]
+            if (!team?.members) return 0
+            return team.members.reduce((sum, m) => {
+              const c = m.gitlabUsername ? getGitlabContributions(m.gitlabUsername) : null
               return sum + (c?.totalContributions ?? 0)
             }, 0)
           })

--- a/modules/team-tracker/client/views/TeamRosterView.vue
+++ b/modules/team-tracker/client/views/TeamRosterView.vue
@@ -72,8 +72,21 @@
       <MetricCard
         label="GitLab Contributions"
         :value="teamGitlabTotal"
-        subtitle="Last year"
-      />
+        :subtitle="gitlabConfiguredCount < uniqueCount ? `${gitlabConfiguredCount}/${uniqueCount} members configured` : 'Last year'"
+      >
+        <template v-if="Object.keys(teamGitlabByInstance).length > 1" #footer>
+          <div class="mt-1 space-y-0.5">
+            <div
+              v-for="(count, baseUrl) in teamGitlabByInstance"
+              :key="baseUrl"
+              class="flex justify-between text-xs text-gray-400 dark:text-gray-500"
+            >
+              <span class="truncate mr-2">{{ baseUrl.replace(/^https?:\/\//, '') }}</span>
+              <span class="font-medium tabular-nums">{{ count }}</span>
+            </div>
+          </div>
+        </template>
+      </MetricCard>
     </div>
 
     <div class="mb-4 pl-1">
@@ -289,6 +302,20 @@ const teamGitlabTotal = computed(() => {
     const c = m.gitlabUsername ? getGitlabContributions(m.gitlabUsername) : null
     return sum + (c?.totalContributions ?? 0)
   }, 0)
+})
+
+const gitlabConfiguredCount = computed(() => uniqueMembers.value.filter(m => m.gitlabUsername).length)
+
+const teamGitlabByInstance = computed(() => {
+  const totals = {}
+  for (const m of uniqueMembers.value) {
+    if (!m.gitlabUsername) continue
+    const instances = getGitlabContributions(m.gitlabUsername)?.instances || {}
+    for (const [baseUrl, data] of Object.entries(instances)) {
+      totals[baseUrl] = (totals[baseUrl] || 0) + (data.totalContributions || 0)
+    }
+  }
+  return totals
 })
 
 function exportCsv() {

--- a/modules/team-tracker/client/views/TrendsView.vue
+++ b/modules/team-tracker/client/views/TrendsView.vue
@@ -95,7 +95,7 @@
     <!-- No data -->
     <div v-else-if="!trendsData" class="bg-white dark:bg-gray-800 rounded-lg shadow p-12 text-center text-gray-400 dark:text-gray-500">
       <p class="text-lg mb-2">No trend data available</p>
-      <p class="text-sm">Click "Refresh Data (365d)" to fetch historical data from Jira and GitHub.</p>
+      <p class="text-sm">Click "Refresh Data (365d)" to fetch historical data from Jira, GitHub, and GitLab.</p>
     </div>
 
     <!-- Charts -->
@@ -113,6 +113,14 @@
           :labels="displayLabels"
           :datasets="githubDatasets"
           title="GitHub Contributions"
+        />
+      </div>
+
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <TrendChart
+          :labels="displayLabels"
+          :datasets="gitlabDatasets"
+          title="GitLab Contributions"
         />
       </div>
 
@@ -234,6 +242,16 @@ const monthLabels = computed(() => {
     }
   }
 
+  if (trendsData.value.gitlab?.users) {
+    for (const userData of Object.values(trendsData.value.gitlab.users)) {
+      if (userData?.months) {
+        for (const month of Object.keys(userData.months)) {
+          allMonths.add(month)
+        }
+      }
+    }
+  }
+
   const now = new Date()
   const cutoff = new Date(now.getFullYear(), now.getMonth() - 11, 1)
   const cutoffKey = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}`
@@ -324,6 +342,51 @@ const githubDatasets = computed(() => {
   return seriesConfig.value.map(series => ({
     label: series.label,
     data: labels.map(m => getGithubValue(m.key, series))
+  }))
+})
+
+const gitlabUserLookup = computed(() => {
+  const lookup = {}
+  for (const org of orgs.value) {
+    if (!org.teams) continue
+    for (const [teamName, team] of Object.entries(org.teams)) {
+      for (const member of team.members) {
+        if (member.gitlabUsername) {
+          lookup[member.gitlabUsername] = {
+            orgKey: org.key,
+            teamKey: `${org.key}::${teamName}`
+          }
+        }
+      }
+    }
+  }
+  return lookup
+})
+
+function getGitlabValue(monthKey, series) {
+  const gitlab = trendsData.value?.gitlab
+  if (!gitlab?.users) return 0
+  const lookup = gitlabUserLookup.value
+
+  let total = 0
+  for (const [username, userData] of Object.entries(gitlab.users)) {
+    if (!userData?.months) continue
+    const info = lookup[username]
+    if (series.type === 'org' && info?.orgKey !== series.key) continue
+    if (series.type === 'team' && info?.teamKey !== series.key) continue
+    if (series.type === 'orgs-aggregate' && !series.key.includes(info?.orgKey)) continue
+    if (series.type === 'teams-aggregate' && !series.key.includes(info?.teamKey)) continue
+    total += userData.months[monthKey] || 0
+  }
+  return total
+}
+
+const gitlabDatasets = computed(() => {
+  const labels = monthLabels.value
+  if (labels.length === 0) return []
+  return seriesConfig.value.map(series => ({
+    label: series.label,
+    data: labels.map(m => getGitlabValue(m.key, series))
   }))
 })
 

--- a/modules/team-tracker/server/gitlab/__tests__/contributions.test.js
+++ b/modules/team-tracker/server/gitlab/__tests__/contributions.test.js
@@ -297,11 +297,13 @@ describe('fetchGitlabData integration', () => {
       expect(results.dhellmann.instances).toBeDefined()
       expect(results.dhellmann.fetchedAt).toBeTruthy()
       expect(Object.keys(results.dhellmann.months).length).toBe(12)
-      // Should have instances array
-      expect(results.dhellmann.instances).toBeTruthy()
-      expect(results.dhellmann.instances).toHaveLength(1)
-      expect(results.dhellmann.instances[0].baseUrl).toBe('https://gitlab.test')
-      expect(results.dhellmann.instances[0].contributions).toBe(1200)
+      // instances should be an object keyed by baseUrl
+      expect(typeof results.dhellmann.instances).toBe('object')
+      expect(Array.isArray(results.dhellmann.instances)).toBe(false)
+      const inst = results.dhellmann.instances['https://gitlab.test']
+      expect(inst).toBeTruthy()
+      expect(inst.totalContributions).toBe(1200)
+      expect(typeof inst.months).toBe('object')
 
       // Should not include otheruser (not in requested usernames)
       expect(results.otheruser).toBeUndefined()
@@ -452,7 +454,8 @@ describe('fetchGitlabData integration', () => {
 
       // Only the first instance contributes (second is skipped)
       expect(results.testuser.totalContributions).toBe(120) // 10 * 12
-      expect(results.testuser.instances).toHaveLength(1)
+      expect(Object.keys(results.testuser.instances)).toHaveLength(1)
+      expect(results.testuser.instances['https://gitlab.test'].totalContributions).toBe(120)
     } finally {
       cleanup(refs)
     }
@@ -516,12 +519,12 @@ describe('fetchGitlabData integration', () => {
 
       // 10 + 5 = 15 per month, 12 months = 180
       expect(results.testuser.totalContributions).toBe(180)
-      expect(results.testuser.instances).toHaveLength(2)
+      expect(Object.keys(results.testuser.instances)).toHaveLength(2)
 
-      const inst1 = results.testuser.instances.find(i => i.baseUrl === 'https://gitlab.test')
-      const inst2 = results.testuser.instances.find(i => i.baseUrl === 'https://internal.gl')
-      expect(inst1.contributions).toBe(120)
-      expect(inst2.contributions).toBe(60)
+      const inst1 = results.testuser.instances['https://gitlab.test']
+      const inst2 = results.testuser.instances['https://internal.gl']
+      expect(inst1.totalContributions).toBe(120)
+      expect(inst2.totalContributions).toBe(60)
     } finally {
       delete process.env.GITLAB_TOKEN_2
       cleanup(refs)

--- a/modules/team-tracker/server/gitlab/__tests__/contributions.test.js
+++ b/modules/team-tracker/server/gitlab/__tests__/contributions.test.js
@@ -294,6 +294,7 @@ describe('fetchGitlabData integration', () => {
       expect(results.dhellmann).toBeTruthy()
       expect(results.dhellmann.totalContributions).toBe(1200) // 100 * 12 months
       expect(results.dhellmann.source).toBe('graphql')
+      expect(results.dhellmann.instances).toBeDefined()
       expect(results.dhellmann.fetchedAt).toBeTruthy()
       expect(Object.keys(results.dhellmann.months).length).toBe(12)
       // Should have instances array

--- a/modules/team-tracker/server/gitlab/contributions.js
+++ b/modules/team-tracker/server/gitlab/contributions.js
@@ -256,7 +256,7 @@ async function fetchGitlabData(usernames, options = {}) {
 
   // Merge results across instances
   // { username: { "YYYY-MM": count } } for aggregated months
-  // { username: [{ baseUrl, label, contributions }] } for per-instance breakdown
+  // { username: { baseUrl: { totalContributions, months } } } for per-instance breakdown
   const userMonths = {};
   const userInstances = {};
 
@@ -268,19 +268,18 @@ async function fetchGitlabData(usernames, options = {}) {
     const { counts, instanceInfo } = result.value;
     for (const [username, months] of Object.entries(counts)) {
       if (!userMonths[username]) userMonths[username] = {};
+      if (!userInstances[username]) userInstances[username] = {};
+      const instanceMonths = {};
       let instanceTotal = 0;
       for (const [monthKey, count] of Object.entries(months)) {
         userMonths[username][monthKey] = (userMonths[username][monthKey] || 0) + count;
+        instanceMonths[monthKey] = count;
         instanceTotal += count;
       }
-      if (instanceTotal > 0) {
-        if (!userInstances[username]) userInstances[username] = [];
-        userInstances[username].push({
-          baseUrl: instanceInfo.baseUrl,
-          label: instanceInfo.label,
-          contributions: instanceTotal
-        });
-      }
+      userInstances[username][instanceInfo.baseUrl] = {
+        totalContributions: instanceTotal,
+        months: instanceMonths
+      };
     }
   }
 
@@ -294,12 +293,10 @@ async function fetchGitlabData(usernames, options = {}) {
     results[username] = {
       totalContributions,
       months,
+      instances: userInstances[username] || {},
       fetchedAt: now,
       source: 'graphql'
     };
-    if (userInstances[username] && userInstances[username].length > 0) {
-      results[username].instances = userInstances[username];
-    }
   }
 
   const withContribs = Object.values(results).filter(r => r.totalContributions > 0).length;

--- a/shared/client/composables/useGitlabStats.js
+++ b/shared/client/composables/useGitlabStats.js
@@ -15,6 +15,31 @@ export function useGitlabStats() {
     return contributionsMap.value[gitlabUsername] || null
   }
 
+  /**
+   * Returns contributions for a specific instance URL, or null if not available.
+   * @param {string} gitlabUsername
+   * @param {string} baseUrl - e.g. "https://gitlab.cee.redhat.com"
+   */
+  function getInstanceContributions(gitlabUsername, baseUrl) {
+    if (!gitlabUsername) return null
+    return contributionsMap.value[gitlabUsername]?.instances?.[baseUrl] || null
+  }
+
+  /**
+   * Returns the list of instance baseUrls that have data for at least one user.
+   */
+  const knownInstances = computed(() => {
+    const instanceSet = new Set()
+    for (const userData of Object.values(contributionsMap.value)) {
+      if (userData?.instances) {
+        for (const baseUrl of Object.keys(userData.instances)) {
+          instanceSet.add(baseUrl)
+        }
+      }
+    }
+    return [...instanceSet]
+  })
+
   async function loadGitlabStats() {
     if (gitlabData.value) return
     loading.value = true
@@ -52,6 +77,8 @@ export function useGitlabStats() {
   return {
     contributionsMap,
     getContributions,
+    getInstanceContributions,
+    knownInstances,
     loadGitlabStats,
     setUserContributions,
     getProfileUrls,

--- a/shared/client/composables/useGitlabStats.js
+++ b/shared/client/composables/useGitlabStats.js
@@ -64,13 +64,13 @@ export function useGitlabStats() {
   function getProfileUrls(gitlabUsername) {
     const contrib = getContributions(gitlabUsername)
     if (!contrib) return []
-    if (!contrib.instances || contrib.instances.length === 0) {
-      return [{ baseUrl: 'https://gitlab.com', label: 'GitLab', url: `https://gitlab.com/${gitlabUsername}` }]
+    if (!contrib.instances || Object.keys(contrib.instances).length === 0) {
+      return [{ baseUrl: 'https://gitlab.com', label: 'gitlab.com', url: `https://gitlab.com/${gitlabUsername}` }]
     }
-    return contrib.instances.map(i => ({
-      baseUrl: i.baseUrl,
-      label: i.label,
-      url: `${i.baseUrl}/${gitlabUsername}`
+    return Object.entries(contrib.instances).map(([baseUrl]) => ({
+      baseUrl,
+      label: baseUrl.replace(/^https?:\/\//, ''),
+      url: `${baseUrl}/${gitlabUsername}`
     }))
   }
 


### PR DESCRIPTION
Fixes: https://github.com/red-hat-data-services/rhai-org-pulse/issues/205

## Problem
GitLab contributions showed 0 for teams using an internal instance (e.g.
`gitlab.cee.redhat.com`) because the backend hardcoded `gitlab.com`. There was
also no visual distinction between "username not configured" and "no activity".

## What's changed

**Backend**
- New `GITLAB_INSTANCES` env var (JSON array) to configure multiple GitLab
  instances. Falls back to existing `GITLAB_BASE_URL`/`GITLAB_TOKEN` for
  backward compatibility.
- Results include a per-instance breakdown alongside the combined total.

**Frontend**
- GitLab cards show `N/A` when `gitlabUsername` is missing, with per-instance
  breakdown in card footers and table tooltips.
- New GitLab Contributions chart in Trends, two new metrics in Reports.

### Config
```env
GITLAB_INSTANCES=[{"baseUrl":"https://gitlab.com","token":"xxx","label":"Public"},{"baseUrl":"https://gitlab.cee.redhat.com","token":"yyy","label":"Internal"}]
```

<img width="1782" height="846" alt="Screenshot 2026-04-06 at 6 53 35 PM" src="https://github.com/user-attachments/assets/76cca809-07e6-4200-836b-ca2c9d766e00" />
<img width="1782" height="846" alt="Screenshot 2026-04-06 at 6 53 13 PM" src="https://github.com/user-attachments/assets/6104edc2-ecf1-4ff2-93c1-f590e43f6457" />


