### PR TITLE
fix: use anonymized filenames in feature-traffic export

### DIFF
--- a/modules/feature-traffic/__tests__/server/export.test.js
+++ b/modules/feature-traffic/__tests__/server/export.test.js
@@ -76,7 +76,7 @@ describe('featureTrafficExport', () => {
 
     await featureTrafficExport(addFile, storage, mapping)
 
-    const featureFile = files.find(f => f.path === 'feature-traffic/features/RHAISTRAT-1.json')
+    const featureFile = files.find(f => f.path.startsWith('feature-traffic/features/') && f.path !== 'feature-traffic/features/RHAISTRAT-1.json')
     expect(featureFile).toBeDefined()
     expect(featureFile.data.key).not.toBe('RHAISTRAT-1')
     expect(featureFile.data.epics[0].key).not.toBe('EPIC-1')

--- a/modules/feature-traffic/server/export.js
+++ b/modules/feature-traffic/server/export.js
@@ -25,7 +25,8 @@ module.exports = async function featureTrafficExport(addFile, storage, mapping) 
     const feature = readFromStorage(`${DATA_PREFIX}/features/${fileName}`);
     if (!feature) continue;
     const anonymized = anonymizeFeatureDetail(feature, mapping);
-    addFile(`${DATA_PREFIX}/features/${fileName}`, anonymized);
+    const anonymizedFileName = anonymized.key ? `${anonymized.key}.json` : fileName;
+    addFile(`${DATA_PREFIX}/features/${anonymizedFileName}`, anonymized);
   }
 };
 


### PR DESCRIPTION
## Summary

- The export hook anonymizes Jira keys inside JSON content (e.g. `RHAISTRAT-104` → `TEST1-104`) but was keeping original filenames (`RHAISTRAT-104.json`)
- In demo mode, the frontend requests `TEST1-104.json` based on the anonymized key, resulting in "Feature not found" errors
- Now renames exported feature files to match their anonymized keys

## Test plan

- [x] All 902 tests pass
- [ ] Run `npm run dev:full` with `DEMO_MODE=true` and verify feature detail pages load correctly
- [ ] Download test data and verify feature detail files have anonymized filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)