### PR TITLE
feat: support Claude code review on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,12 @@ on:
       - 'docs/**'
       - '*.md'
       - 'deploy/openshift/overlays/*/kustomization.yaml'
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'deploy/openshift/overlays/*/kustomization.yaml'
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -22,6 +28,7 @@ permissions:
   id-token: write
 
 jobs:
+  # Full review with autofix — runs for same-repo PRs only (trusted code)
   claude-review:
     name: Claude Review
     timeout-minutes: 20
@@ -43,47 +50,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup fork PR branch (if applicable)
-        id: fork-setup
-        run: |
-          PR_NUM=${{ github.event.pull_request.number || github.event.issue.number }}
-          if [ -z "$PR_NUM" ]; then
-            echo "No PR number, skipping"
-            exit 0
-          fi
-
-          # Check if this is a fork PR
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/"$PR_NUM" \
-            --jq '{is_fork: (.head.repo.full_name != .base.repo.full_name), head_ref: .head.ref}')
-          IS_FORK=$(echo "$PR_JSON" | jq -r '.is_fork')
-          HEAD_REF=$(echo "$PR_JSON" | jq -r '.head_ref')
-
-          if [ "$IS_FORK" != "true" ]; then
-            echo "Same-repo PR, no special setup needed"
-            exit 0
-          fi
-
-          echo "Fork PR detected (branch: ${HEAD_REF})"
-
-          # The claude-code-action runs `git fetch origin <branchName>` internally,
-          # which fails for fork PRs because the branch only exists on the fork.
-          # Workaround: push the PR head commit to origin under the same branch name
-          # so the action's fetch succeeds. Clean up after the review completes.
-
-          # Safety: check if branch already exists on origin
-          if git ls-remote --exit-code origin "refs/heads/${HEAD_REF}" >/dev/null 2>&1; then
-            echo "::warning::Branch ${HEAD_REF} already exists on origin, skipping fork workaround"
-            exit 0
-          fi
-
-          git fetch origin "refs/pull/${PR_NUM}/head"
-          git push origin "FETCH_HEAD:refs/heads/${HEAD_REF}"
-
-          echo "fork_branch=${HEAD_REF}" >> "$GITHUB_OUTPUT"
-          echo "Pushed fork PR head to origin/${HEAD_REF}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -121,9 +87,6 @@ jobs:
             1. **Determine PR context**:
                - If no PR number is available (e.g., workflow_dispatch without context),
                  post a comment explaining that no PR was found and exit.
-               - Run `gh pr view <PR_NUMBER> --json isCrossRepository` to check if
-                 this is a fork PR. If `isCrossRepository` is true, do a **read-only
-                 review only** — post comments but do NOT edit files, commit, or push.
                - Run `gh pr checkout <PR_NUMBER>` to switch to the PR branch.
 
             2. **Review** the PR diff for:
@@ -171,6 +134,94 @@ jobs:
               subjective, comment instead of changing code.
             - Do not modify files outside the scope of the PR unless necessary to
               fix an issue (e.g., a missing import in another file).
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
+          CLOUD_ML_REGION: "us-east5"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
+
+  # Read-only review for fork PRs — never executes fork code
+  claude-review-fork:
+    name: Claude Review (Fork)
+    timeout-minutes: 20
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.pull_request.draft != true &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup fork PR branch for action
+        id: fork-setup
+        run: |
+          echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
+
+          # The claude-code-action runs `git fetch origin <branchName>` internally,
+          # which fails for fork PRs because the branch only exists on the fork.
+          # Workaround: push the PR head commit to origin under a namespaced ref
+          # so the action's fetch succeeds. Clean up after the review completes.
+          SAFE_BRANCH="claude-review/fork-pr-${PR_NUM}"
+
+          git fetch origin "refs/pull/${PR_NUM}/head"
+          git push origin "FETCH_HEAD:refs/heads/${SAFE_BRANCH}"
+
+          echo "fork_branch=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Pushed fork PR head to origin/${SAFE_BRANCH}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Claude Code Review (Read-Only)
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        with:
+          use_vertex: "true"
+          track_progress: true
+          display_report: "true"
+          claude_args: '--model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a **fork pull request**. This is a READ-ONLY review.
+            You must NEVER execute any code from the PR (no npm test, npm run, node,
+            or any other command that runs PR code). You do NOT have tools to edit
+            files, commit, or push — only read and comment.
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the
+               full diff of the PR.
+
+            2. **Review** the diff for:
+               - Code quality and maintainability
+               - Security vulnerabilities (OWASP top 10, injection, XSS, etc.)
+               - Potential bugs and edge cases
+               - Adherence to project conventions (see CLAUDE.md)
+               - Performance concerns
+
+            3. **Report** your findings:
+               - Use inline comments for specific issues in the diff
+               - Post a top-level PR comment summarizing:
+                 - Issues found (with brief descriptions and suggestions)
+                 - If no issues were found, say so briefly
+               - Note that this was a read-only review (fork PR) and no autofixes
+                 were applied
+
+            **Important rules:**
+            - This is a FORK PR. Do NOT run any commands that execute PR code.
+            - Do NOT attempt to check out the PR branch.
+            - Use `gh pr diff` and `Read` to understand the changes.
+            - Be concise. Focus on actionable feedback.
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
           CLOUD_ML_REGION: "us-east5"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,16 +3,11 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'deploy/openshift/overlays/*/kustomization.yaml'
+    # NOTE: No paths-ignore here. "Claude Review" is a required status check,
+    # so the workflow must always run to report a result. Path filtering is
+    # handled inside the job via the "Check for reviewable changes" step.
   pull_request_target:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'deploy/openshift/overlays/*/kustomization.yaml'
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -46,31 +41,85 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
+      - name: Check for reviewable changes
+        id: check-paths
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "needs_review=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --paginate --jq '.[].filename')
+
+          needs_review=false
+          while IFS= read -r file; do
+            case "$file" in
+              deploy/openshift/overlays/*/kustomization.yaml)
+                ;; # matches ignore pattern
+              *)
+                needs_review=true
+                break
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          echo "needs_review=$needs_review" >> "$GITHUB_OUTPUT"
+          if [ "$needs_review" = "false" ]; then
+            echo "All changed files match ignore patterns — skipping review"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reject fork PRs on issue_comment trigger
+        id: fork-guard
+        if: steps.check-paths.outputs.needs_review == 'true' && github.event_name == 'issue_comment'
+        run: |
+          IS_FORK=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} \
+            --jq '.head.repo.full_name != .base.repo.full_name')
+
+          if [ "$IS_FORK" = "true" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --body "Autofix review via \`@claude\` is not available on fork PRs for security reasons. A read-only review runs automatically when the PR is opened."
+            echo "::warning::Skipping autofix review — fork PR detected on issue_comment trigger"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout code
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
 
       - name: Install dependencies
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         run: npm ci
 
       - name: Configure git identity
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         run: |
           git config user.name "claude-code-review[bot]"
           git config user.email "claude-code-review[bot]@users.noreply.github.com"
 
       - name: Authenticate to Google Cloud
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Claude Code Review
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        id: claude-review
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
@@ -125,6 +174,19 @@ jobs:
                  your autofix commit. Mention this in your summary so the PR author
                  knows to re-run CI if needed.
 
+            5. **Set review verdict**: After completing your review, write a result file
+               to signal whether the PR should be blocked:
+               ```
+               echo "PASS" > .claude-review-result    # No blocking issues remain
+               echo "FAIL" > .claude-review-result    # Critical unfixed issues
+               ```
+               Use **FAIL** only for issues you could NOT fix that are: security
+               vulnerabilities, clear bugs that will cause runtime errors, or breaking
+               changes. If you found issues but fixed them all, use PASS.
+               Use **PASS** for: clean code, minor suggestions, style nits, or when
+               all issues were fixed by your autofix commit.
+               Always write this file as your very last action.
+
             **Important rules:**
             - Never force push. Only push to the current PR branch via `git push origin HEAD`.
             - Use `git add -u` (not `git add -A`) to avoid staging untracked files.
@@ -140,6 +202,26 @@ jobs:
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_PROMPT_CACHING: "1"
 
+      - name: Check review result
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        run: |
+          # If the Claude action itself crashed, warn but don't block the PR
+          if [ "${{ steps.claude-review.outcome }}" = "failure" ]; then
+            echo "::warning::Claude review action failed (infrastructure issue) — not blocking PR"
+            exit 0
+          fi
+
+          # Check the verdict file Claude was instructed to write
+          if [ -f .claude-review-result ]; then
+            RESULT=$(tr -d '[:space:]' < .claude-review-result)
+            if [ "$RESULT" = "FAIL" ]; then
+              echo "::error::Claude review found critical issues that must be addressed before merging"
+              exit 1
+            fi
+          fi
+
+          echo "Claude review passed"
+
   # Read-only review for fork PRs — never executes fork code
   claude-review-fork:
     name: Claude Review (Fork)
@@ -151,12 +233,39 @@ jobs:
       github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Check for reviewable changes
+        id: check-paths
+        run: |
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --paginate --jq '.[].filename')
+
+          needs_review=false
+          while IFS= read -r file; do
+            case "$file" in
+              deploy/openshift/overlays/*/kustomization.yaml)
+                ;; # matches ignore pattern
+              *)
+                needs_review=true
+                break
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          echo "needs_review=$needs_review" >> "$GITHUB_OUTPUT"
+          if [ "$needs_review" = "false" ]; then
+            echo "All changed files match ignore patterns — skipping review"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout base branch
+        if: steps.check-paths.outputs.needs_review == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup fork PR branch for action
+        if: steps.check-paths.outputs.needs_review == 'true'
         id: fork-setup
         run: |
           echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
@@ -178,11 +287,13 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
 
       - name: Authenticate to Google Cloud
+        if: steps.check-paths.outputs.needs_review == 'true'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Claude Code Review (Read-Only)
+        if: steps.check-paths.outputs.needs_review == 'true'
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:


### PR DESCRIPTION
## Summary

- Split the Claude review workflow into two jobs: full autofix for same-repo PRs, read-only for fork PRs
- Fork PRs use `pull_request_target` trigger (required for secrets access) with hardened security: no code execution, restricted Claude tools (read/comment only), base branch checkout only
- Prevents the classic `pull_request_target` + untrusted code execution attack vector by never running `npm ci`, `npm test`, or `npm run lint` on fork code
- Uses namespaced temporary branches (`claude-review/fork-pr-<number>`) to avoid branch name injection and collision
- Passes attacker-controlled values via `env:` block instead of `${{ }}` interpolation to prevent expression injection

## Test plan

- [ ] Open a PR from a fork and verify the "Claude Review (Fork)" job runs with read-only review
- [ ] Open a same-repo PR and verify the "Claude Review" job runs with full autofix as before
- [ ] Verify the fork job's temporary branch is cleaned up after review
- [ ] Verify docs-only fork PRs are skipped by `paths-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)