### PR TITLE
docs: centralize review criteria and add agent conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -225,36 +225,29 @@ docs/
   MODULES.md            # Module development guide
   module-template/      # Starter template for new modules
 
+.github/
+  instructions/
+    review.instructions.md  # Shared code review criteria
+  workflows/                # CI/CD workflows
+
+AGENTS.md           # Vendor-neutral AI agent conventions
 data/               # Local dev data (gitignored)
 secrets/            # Service account keys (gitignored)
 ```
 
-## Code Style
+## Code Style, Testing & Documentation
 
-- Use `<script setup>` for new Vue components
-- CommonJS (`require`) for server-side code
-- ES modules (`import`) for frontend code
-- No TypeScript — plain JavaScript throughout
-- Prefer composables (`src/composables/`) for shared state logic
-- Tailwind utility classes for styling; custom `primary` color palette defined in tailwind.config.mjs
-- **Always run `npm run lint` before committing** — CI will reject lint failures. A pre-commit hook (`lint-staged` + `husky`) auto-runs ESLint on staged files, but verify manually if unsure.
+See [`AGENTS.md`](../AGENTS.md) for code style, testing, and documentation
+maintenance conventions. Those apply to all AI agents and are the single source
+of truth. A pre-commit hook (`lint-staged` + `husky`) auto-runs ESLint on staged
+files, but always verify with `npm run lint` before committing.
 
-## Testing
+## Code Review
 
-- Vitest + @vue/test-utils for frontend tests in `src/__tests__/` and `modules/*/__tests__/client/`
-- Vitest for backend unit tests in `modules/*/__tests__/server/`
-- Module manifest validation: `npm run validate:modules`
-- Run `npm test` before committing
-
-## Documentation Maintenance
-
-Keep docs in sync with code changes. When making changes, update the relevant docs in the same PR:
-
-- **Data format changes** (how JSON is read/written in `data/`): Update `docs/DATA-FORMATS.md` AND the corresponding `fixtures/` files to match
-- **New or changed API routes**: Update the API Routes section in this file
-- **New data files or storage paths**: Update the Data Flow section in this file and add schema to `docs/DATA-FORMATS.md`
-- **New shared exports**: Update `shared/API.md`
-- **Module system changes**: Update `docs/MODULES.md`
+Review criteria are centralized in
+[`.github/instructions/review.instructions.md`](../.github/instructions/review.instructions.md).
+This file is used by the CI review workflow, the `/pr-review` slash command, and
+GitHub Copilot code review.
 
 ## API Routes
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,15 @@
+Review a GitHub pull request.
+
+## Arguments
+
+This command accepts a PR number as its argument: `/pr-review <PR_NUMBER>`
+
+## Steps
+
+1. Fetch the PR diff using `gh pr diff $ARGUMENTS`
+2. Fetch the PR description using `gh pr view $ARGUMENTS`
+3. Read `.github/instructions/review.instructions.md` and apply its review criteria to the diff.
+4. Read any files from the repo that you need additional context on to complete the review.
+5. Print a review summary to the terminal with:
+   - An overall assessment
+   - Specific issues found, organized by file, with line references

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -1,0 +1,37 @@
+# Code Review Criteria
+
+This file defines the review criteria for all code reviews — automated (CI) and
+manual (local `/pr-review` command). All reviewers (human or AI) should apply
+these criteria consistently.
+
+## Review checklist
+
+1. **Security** — OWASP top 10 vulnerabilities: injection (SQL, command, XSS),
+   broken auth, sensitive data exposure, insecure deserialization, etc. Pay
+   special attention to user input handling, API boundaries, and secrets.
+
+2. **Correctness** — Bugs, logic errors, off-by-one errors, unhandled edge
+   cases, race conditions, null/undefined access, and incorrect assumptions
+   about data shape or API behavior.
+
+3. **Code quality** — Readability, maintainability, appropriate abstraction
+   level. Flag unnecessary complexity, dead code, or misleading names. Prefer
+   clarity over cleverness.
+
+4. **Project conventions** — Adherence to the conventions in `AGENTS.md` and
+   `.claude/CLAUDE.md`: module structure, import style (ESM frontend, CJS
+   backend), `<script setup>` for Vue components, Tailwind for styling, test
+   coverage for changed logic.
+
+5. **Performance** — Unnecessary re-renders, N+1 queries, unbounded data
+   fetching, missing pagination, expensive operations in hot paths, memory
+   leaks (event listeners, timers not cleaned up).
+
+## Review tone
+
+- Be concise. Focus on actionable feedback.
+- Don't nitpick style unless it impacts readability.
+- Only flag issues you're confident about. If something is ambiguous or
+  subjective, frame it as a suggestion, not a blocker.
+- Don't comment on files outside the scope of the PR unless they're directly
+  affected (e.g., a missing import).

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -138,12 +138,8 @@ jobs:
                  post a comment explaining that no PR was found and exit.
                - Run `gh pr checkout <PR_NUMBER>` to switch to the PR branch.
 
-            2. **Review** the PR diff for:
-               - Code quality and maintainability
-               - Security vulnerabilities (OWASP top 10, injection, XSS, etc.)
-               - Potential bugs and edge cases
-               - Adherence to project conventions (see CLAUDE.md)
-               - Performance concerns
+            2. **Review** the PR diff. Read `.github/instructions/review.instructions.md`
+               for the full review checklist. Apply all criteria from that file.
 
             3. **Fix** any issues you find by editing the files directly:
                - Use Edit/Write tools to modify the source files
@@ -313,12 +309,8 @@ jobs:
             1. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the
                full diff of the PR.
 
-            2. **Review** the diff for:
-               - Code quality and maintainability
-               - Security vulnerabilities (OWASP top 10, injection, XSS, etc.)
-               - Potential bugs and edge cases
-               - Adherence to project conventions (see CLAUDE.md)
-               - Performance concerns
+            2. **Review** the diff. Read `.github/instructions/review.instructions.md`
+               for the full review checklist. Apply all criteria from that file.
 
             3. **Report** your findings:
                - Use inline comments for specific issues in the diff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent Conventions
+
+Vendor-neutral conventions for AI agents working on this codebase. Tool-specific
+configuration (e.g., `.claude/CLAUDE.md`) should reference this file rather than
+duplicating these conventions.
+
+## Code style
+
+- `<script setup>` for Vue components
+- CommonJS (`require`) for server-side code
+- ES modules (`import`) for frontend code
+- No TypeScript — plain JavaScript throughout
+- Tailwind CSS utility classes for styling; custom `primary` palette in `tailwind.config.mjs`
+- Composables (`src/composables/`, `shared/client/composables/`) for shared state logic
+- Always run `npm run lint` before committing — CI rejects lint failures
+
+## Testing
+
+- Vitest + @vue/test-utils for frontend tests (`src/__tests__/`, `modules/*/__tests__/client/`)
+- Vitest for backend unit tests (`modules/*/__tests__/server/`)
+- Module manifest validation: `npm run validate:modules`
+- Run `npm test` before committing
+
+## Code review
+
+Review criteria are defined in
+[`.github/instructions/review.instructions.md`](.github/instructions/review.instructions.md).
+All automated reviews (CI) and manual reviews (`/pr-review`) use this shared
+checklist.
+
+## Documentation
+
+Keep docs in sync with code changes:
+
+- **Data format changes**: Update `docs/DATA-FORMATS.md` and `fixtures/`
+- **API route changes**: Update the API Routes section in `.claude/CLAUDE.md`
+- **New data files or storage paths**: Update Data Flow in `.claude/CLAUDE.md` and `docs/DATA-FORMATS.md`
+- **New shared exports**: Update `shared/API.md`
+- **Module system changes**: Update `docs/MODULES.md`
+
+## Agent instruction files
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` (this file) | Vendor-neutral conventions | All AI agents |
+| `.claude/CLAUDE.md` | Architecture, integrations, deployment | Claude Code / Claude CI |
+| `.github/instructions/review.instructions.md` | Code review checklist | CI review bots, Copilot, `/pr-review` |
+| `CONTRIBUTING.md` | Getting started, workflow | Human contributors |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,10 @@ Use descriptive branch names:
 5. Run `npm run build` to confirm the production build works
 6. Open a PR against `main`
 
+PRs receive an automated Claude code review that can fix minor issues directly.
+The review criteria are defined in
+[`.github/instructions/review.instructions.md`](.github/instructions/review.instructions.md).
+
 ### Code style
 
 - `<script setup>` for new Vue components


### PR DESCRIPTION
## Summary

- Create `.github/instructions/review.instructions.md` as the single source of truth for code review criteria, following GitHub's emerging scoped instructions convention
- Create `AGENTS.md` with vendor-neutral AI agent conventions (code style, testing, documentation), deduplicating what was previously scattered across `CLAUDE.md` and `CONTRIBUTING.md`
- Update all consumers to reference the shared files instead of inlining criteria:
  - CI workflow prompt (`claude-review.yml`)
  - `/pr-review` slash command
  - `.claude/CLAUDE.md`
  - `CONTRIBUTING.md`

### File responsibilities after this PR

| File | Purpose | Audience |
|------|---------|----------|
| `AGENTS.md` | Vendor-neutral conventions (code style, testing, docs) | All AI agents |
| `.claude/CLAUDE.md` | Architecture, integrations, deployment details | Claude Code / Claude CI |
| `.github/instructions/review.instructions.md` | Code review checklist | CI bots, Copilot, `/pr-review` |
| `CONTRIBUTING.md` | Getting started, dev workflow | Human contributors |

## Test plan

- [ ] Run `/pr-review` locally and verify it reads from the new review.instructions.md
- [ ] Verify CI review workflow still references the criteria correctly
- [ ] Confirm no duplication remains between CLAUDE.md and AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)