### PR TITLE
feat(upstream-pulse): add strategic classification UI for portfolio management

### DIFF
--- a/modules/upstream-pulse/client/components/LeadershipStrategy.vue
+++ b/modules/upstream-pulse/client/components/LeadershipStrategy.vue
@@ -1,0 +1,215 @@
+<template>
+  <div>
+    <!-- Increase Investment -->
+    <div v-if="increaseInvestment.length > 0" class="mb-6">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Increase Investment</h4>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <div
+          v-for="org in increaseInvestment"
+          :key="org.org"
+          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
+          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
+          @click="$emit('org-click', org.org)"
+        >
+          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
+            {{ org.orgName }}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center">
+            <span
+              v-if="org.strategicLeadership"
+              :class="getStrategicBadgeClass(org.strategicLeadership)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicLeadership) }}
+            </span>
+            <span
+              v-if="org.strategicParticipation"
+              :class="getStrategicBadgeClass(org.strategicParticipation)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicParticipation) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sustain Investment -->
+    <div v-if="sustainInvestment.length > 0" class="mb-6">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Sustain Investment</h4>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <div
+          v-for="org in sustainInvestment"
+          :key="org.org"
+          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
+          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
+          @click="$emit('org-click', org.org)"
+        >
+          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
+            {{ org.orgName }}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center">
+            <span
+              v-if="org.strategicLeadership"
+              :class="getStrategicBadgeClass(org.strategicLeadership)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicLeadership) }}
+            </span>
+            <span
+              v-if="org.strategicParticipation"
+              :class="getStrategicBadgeClass(org.strategicParticipation)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicParticipation) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Evaluating Investment -->
+    <div v-if="evaluatingInvestment.length > 0">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Evaluating Investment</h4>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <div
+          v-for="org in evaluatingInvestment"
+          :key="org.org"
+          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
+          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
+          @click="$emit('org-click', org.org)"
+        >
+          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
+            {{ org.orgName }}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center">
+            <span
+              v-if="org.strategicLeadership"
+              :class="getStrategicBadgeClass(org.strategicLeadership)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicLeadership) }}
+            </span>
+            <span
+              v-if="org.strategicParticipation"
+              :class="getStrategicBadgeClass(org.strategicParticipation)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicParticipation) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="increaseInvestment.length === 0 && sustainInvestment.length === 0 && evaluatingInvestment.length === 0" class="text-center py-8">
+      <p class="text-sm text-gray-500 dark:text-gray-400">No organizations with strategic importance assigned</p>
+    </div>
+
+    <!-- Legend -->
+    <div v-if="increaseInvestment.length > 0 || sustainInvestment.length > 0 || evaluatingInvestment.length > 0" class="flex items-center justify-center gap-6 text-sm mt-6 pt-4 border-t border-gray-100 dark:border-gray-700">
+      <div class="flex items-center gap-2">
+        <div class="w-4 h-4 rounded bg-red-400 dark:bg-red-800/35"></div>
+        <span class="text-gray-600 dark:text-gray-400 font-medium">Red Hat Leads</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <div class="w-4 h-4 rounded bg-gray-200 dark:bg-gray-700/40"></div>
+        <span class="text-gray-600 dark:text-gray-400 font-medium">Red Hat Participates</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+defineEmits(['org-click'])
+
+const props = defineProps({
+  orgActivity: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const increaseInvestment = computed(() => {
+  return props.orgActivity
+    .filter(org =>
+      org.strategicParticipation === 'increasing_participation' ||
+      org.strategicLeadership === 'increasing_leadership'
+    )
+    .filter(org => org.leadershipCount > 0 || org.total > 0 || org.maintainerCount > 0)
+    .map(org => ({
+      ...org,
+      leads: org.leadershipCount > 0
+    }))
+})
+
+const sustainInvestment = computed(() => {
+  return props.orgActivity
+    .filter(org => {
+      // No increase tags
+      const hasIncrease = org.strategicParticipation === 'increasing_participation' ||
+                         org.strategicLeadership === 'increasing_leadership'
+      if (hasIncrease) return false
+
+      // Has at least one sustain tag
+      return org.strategicParticipation === 'sustaining_participation' ||
+             org.strategicLeadership === 'sustaining_leadership'
+    })
+    .filter(org => org.leadershipCount > 0 || org.total > 0 || org.maintainerCount > 0)
+    .map(org => ({
+      ...org,
+      leads: org.leadershipCount > 0
+    }))
+})
+
+const evaluatingInvestment = computed(() => {
+  return props.orgActivity
+    .filter(org => {
+      // No increase tags
+      const hasIncrease = org.strategicParticipation === 'increasing_participation' ||
+                         org.strategicLeadership === 'increasing_leadership'
+      if (hasIncrease) return false
+
+      // No sustain tags
+      const hasSustain = org.strategicParticipation === 'sustaining_participation' ||
+                        org.strategicLeadership === 'sustaining_leadership'
+      if (hasSustain) return false
+
+      // Has at least one evaluating tag
+      return org.strategicParticipation === 'evaluating_participation' ||
+             org.strategicLeadership === 'evaluating_leadership'
+    })
+    .filter(org => org.leadershipCount > 0 || org.total > 0 || org.maintainerCount > 0)
+    .map(org => ({
+      ...org,
+      leads: org.leadershipCount > 0
+    }))
+})
+
+function getStrategicLabel(strategic) {
+  if (!strategic) return ''
+  const labels = {
+    'evaluating_participation': 'Evaluating Participation',
+    'sustaining_participation': 'Sustaining Participation',
+    'increasing_participation': 'Increasing Participation',
+    'evaluating_leadership': 'Evaluating Leadership',
+    'sustaining_leadership': 'Sustaining Leadership',
+    'increasing_leadership': 'Increasing Leadership',
+  }
+  return labels[strategic] || strategic
+}
+
+function getStrategicBadgeClass(strategic) {
+  const classes = {
+    'evaluating_participation': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_participation': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_participation': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    'evaluating_leadership': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_leadership': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_leadership': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  }
+  return classes[strategic] || 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
+}
+</script>

--- a/modules/upstream-pulse/client/components/OrgActivityCard.vue
+++ b/modules/upstream-pulse/client/components/OrgActivityCard.vue
@@ -4,14 +4,20 @@
     :class="{ 'cursor-pointer': clickable }"
     @click="$emit('click')"
   >
-    <!-- Row 1: Name + engagement badge + hover chevron -->
+    <!-- Row 1: Name + engagement status + hover chevron -->
     <div class="flex items-start justify-between mb-3">
       <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{{ orgName }}</h3>
-      <ChevronRightIcon
-        v-if="clickable"
-        :size="16"
-        class="shrink-0 ml-2 text-gray-300 dark:text-gray-600 opacity-0 group-hover/card:opacity-100 transition-opacity duration-200"
-      />
+      <div class="flex items-center gap-2 shrink-0 ml-2">
+        <span :class="engagementStatus.classes"
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap border">
+          {{ engagementStatus.label }}
+        </span>
+        <ChevronRightIcon
+          v-if="clickable"
+          :size="16"
+          class="text-gray-300 dark:text-gray-600 opacity-0 group-hover/card:opacity-100 transition-opacity duration-200"
+        />
+      </div>
     </div>
 
     <!-- Row 2: Contribution count + trend -->
@@ -77,6 +83,8 @@ defineEmits(['click'])
 
 const props = defineProps({
   orgName: { type: String, default: '' },
+  strategicParticipation: { type: String, default: null },
+  strategicLeadership: { type: String, default: null },
   teamContributions: { type: Number, default: 0 },
   totalContributions: { type: Number, default: 0 },
   teamSharePercent: { type: Number, default: 0 },
@@ -90,6 +98,34 @@ const props = defineProps({
 })
 
 const teamShareLabel = computed(() => Number(props.teamSharePercent).toFixed(1))
+
+const engagementStatus = computed(() => {
+  const hasGovernance = props.leadershipCount > 0 || props.maintainerCount > 0
+  const highGovernance = props.leadershipCount >= 3 || props.maintainerCount >= 5
+
+  if (props.teamContributions === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700'
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700'
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+  }
+})
 
 const trendArrow = computed(() => {
   if (props.percentChange > 0) return '↑'

--- a/modules/upstream-pulse/client/views/Dashboard.vue
+++ b/modules/upstream-pulse/client/views/Dashboard.vue
@@ -194,9 +194,11 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <OrgActivityCard
-            v-for="activity in orgActivity"
+            v-for="activity in orgActivity.slice(0, 4)"
             :key="activity.org"
             :org-name="activity.orgName"
+            :strategic-participation="activity.strategicParticipation"
+            :strategic-leadership="activity.strategicLeadership"
             :team-contributions="activity.total || 0"
             :total-contributions="activity.totalContributions || 0"
             :team-share-percent="activity.teamSharePercent || 0"
@@ -345,6 +347,15 @@
           <p class="text-sm text-gray-500 dark:text-gray-400 hidden sm:block">Team influence in upstream governance</p>
         </div>
 
+        <!-- Leadership Strategy -->
+        <div v-if="orgActivity.length" class="mb-6">
+          <h4 class="text-base font-semibold text-gray-700 dark:text-gray-300 mb-3">Leadership Strategy</h4>
+          <LeadershipStrategy
+            :org-activity="orgActivity"
+            @org-click="(org) => nav.navigateTo('org-detail', { org })"
+          />
+        </div>
+
         <div v-if="!leadership && !communityOrgs.length" class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/60 p-8 text-center">
           <p class="text-sm text-gray-500 dark:text-gray-400">No leadership data available</p>
         </div>
@@ -392,7 +403,7 @@
                       <p class="text-xs text-gray-500 dark:text-gray-400">{{ leader.positionCount === 1 ? 'position' : 'positions' }}</p>
                     </div>
                   </div>
-                  <div class="hidden group-hover:block pl-16 pr-4 pb-3">
+                  <div class="pl-16 pr-4 pb-3 pt-1">
                     <div class="flex flex-wrap gap-1.5">
                       <span
                         v-for="detail in leader.roleDetails"
@@ -549,6 +560,7 @@ import LeadershipCard from '../components/LeadershipCard.vue'
 import ContributionTrendChart from '../components/ContributionTrendChart.vue'
 import OrgActivityCard from '../components/OrgActivityCard.vue'
 import ProjectCard from '../components/ProjectCard.vue'
+import LeadershipStrategy from '../components/LeadershipStrategy.vue'
 import AddProjectModal from '../components/AddProjectModal.vue'
 import { StatCardSkeleton, ContributionCardSkeleton, OrgCardSkeleton, ProjectCardSkeleton, ContributorRowSkeleton } from '../components/SkeletonLoaders.vue'
 import { useGovernanceCards, uniqueRoles } from '../composables/useGovernanceCards.js'

--- a/modules/upstream-pulse/client/views/OrgDetail.vue
+++ b/modules/upstream-pulse/client/views/OrgDetail.vue
@@ -10,7 +10,51 @@
     <!-- Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
       <div>
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ displayName }}</h2>
+        <div class="flex items-center gap-2 mb-1 flex-wrap">
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ displayName }}</h2>
+
+          <!-- Engagement Status Badge with Tooltip -->
+          <div v-if="dashboard" class="relative group/engagement">
+            <span
+              :class="engagementStatus.classes"
+              class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border"
+            >
+              {{ engagementStatus.label }}
+            </span>
+            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/engagement:opacity-100 group-hover/engagement:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+              {{ engagementStatus.description }}
+              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+            </div>
+          </div>
+
+          <!-- Strategic Leadership Badge with Tooltip -->
+          <div v-if="strategicLeadership" class="relative group/leadership">
+            <span
+              class="px-3 py-1 rounded-full text-xs font-semibold"
+              :class="getStrategicBadgeClass(strategicLeadership)"
+            >
+              {{ getStrategicLabel(strategicLeadership, 'leadership') }}
+            </span>
+            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/leadership:opacity-100 group-hover/leadership:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+              {{ getStrategicDescription(strategicLeadership) }}
+              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+            </div>
+          </div>
+
+          <!-- Strategic Participation Badge with Tooltip -->
+          <div v-if="strategicParticipation" class="relative group/participation">
+            <span
+              class="px-3 py-1 rounded-full text-xs font-semibold"
+              :class="getStrategicBadgeClass(strategicParticipation)"
+            >
+              {{ getStrategicLabel(strategicParticipation, 'participation') }}
+            </span>
+            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/participation:opacity-100 group-hover/participation:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+              {{ getStrategicDescription(strategicParticipation) }}
+              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+            </div>
+          </div>
+        </div>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Team engagement in {{ displayName }} projects</p>
       </div>
       <div class="flex items-center gap-3">
@@ -484,6 +528,10 @@ const periodOptions = [
 
 const githubOrg = computed(() => nav.params.value?.org || '')
 const displayName = ref('')
+const strategicParticipation = ref(null)
+const strategicLeadership = ref(null)
+const orgLeadershipCount = ref(0)
+const orgMaintainerCount = ref(0)
 
 const selectedDays = ref('30')
 const loading = ref(true)
@@ -496,6 +544,43 @@ const leadership = ref(null)
 const membersExpanded = ref(false)
 const governanceExpanded = ref(false)
 const orgProjects = ref([])
+
+function getStrategicLabel(strategic, _type) {
+  if (!strategic) return ''
+  const labels = {
+    'evaluating_participation': 'Evaluating Participation',
+    'sustaining_participation': 'Sustaining Participation',
+    'increasing_participation': 'Increasing Participation',
+    'evaluating_leadership': 'Evaluating Leadership',
+    'sustaining_leadership': 'Sustaining Leadership',
+    'increasing_leadership': 'Increasing Leadership',
+  }
+  return labels[strategic] || strategic
+}
+
+function getStrategicBadgeClass(strategic) {
+  const classes = {
+    'evaluating_participation': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_participation': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_participation': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    'evaluating_leadership': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_leadership': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_leadership': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  }
+  return classes[strategic] || ''
+}
+
+function getStrategicDescription(strategic) {
+  const descriptions = {
+    'evaluating_participation': 'Red Hat is evaluating whether to increase participation in this project',
+    'sustaining_participation': 'Red Hat is sustaining current participation levels in this project',
+    'increasing_participation': 'Red Hat is actively increasing participation in this project',
+    'evaluating_leadership': 'Red Hat is evaluating whether to pursue leadership positions in this project',
+    'sustaining_leadership': 'Red Hat is sustaining current leadership presence in this project',
+    'increasing_leadership': 'Red Hat is actively pursuing more leadership positions in this project',
+  }
+  return descriptions[strategic] || ''
+}
 
 const visibleContributors = computed(() => {
   if (contributorsExpanded.value) return contributors.value
@@ -617,6 +702,42 @@ const totalGovernancePositions = computed(() => {
   return count
 })
 
+const engagementStatus = computed(() => {
+  const leadershipCount = orgLeadershipCount.value
+  const maintainerCount = orgMaintainerCount.value
+  const teamContributions = dashboard.value?.contributions?.all?.team || 0
+
+  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
+  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
+
+  if (teamContributions === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+      description: 'No contributions or governance positions yet'
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700',
+      description: 'Significant influence with 3+ leadership positions or 5+ maintainers'
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700',
+      description: 'Active participation with leadership or maintainer positions'
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+    description: 'Contributing code without formal governance positions'
+  }
+})
+
 const projectCoveragePercent = computed(() => {
   if (!leadership.value?.summary || !dashboard.value?.summary) return 0
   const covered = leadership.value.summary.projectsWithTeamLeadership || 0
@@ -652,6 +773,10 @@ async function loadData() {
 
     const match = orgsData.orgs?.find(o => o.githubOrg === org)
     displayName.value = match?.name || org
+    strategicParticipation.value = match?.strategicParticipation || null
+    strategicLeadership.value = match?.strategicLeadership || null
+    orgLeadershipCount.value = match?.leadershipCount || 0
+    orgMaintainerCount.value = match?.maintainerCount || 0
 
     const topProjects = dashData.topProjects || []
     const metricsById = new Map()

--- a/modules/upstream-pulse/client/views/Portfolio.vue
+++ b/modules/upstream-pulse/client/views/Portfolio.vue
@@ -263,6 +263,14 @@
                   <td class="px-6 py-4">
                     <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ org.name }}</span>
                   </td>
+                  <td class="px-6 py-4">
+                    <span
+                      :class="getEngagementStatus(org.leadershipCount || 0, org.maintainerCount || 0, org.contributionCount || 0).classes"
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap border"
+                    >
+                      {{ getEngagementStatus(org.leadershipCount || 0, org.maintainerCount || 0, org.contributionCount || 0).label }}
+                    </span>
+                  </td>
                   <td class="px-6 py-4 text-right">
                     <span class="text-sm font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ (org.contributionCount || 0).toLocaleString() }}</span>
                     <span
@@ -525,11 +533,13 @@ const orgSortOptions = [
   { label: 'Contributions', value: 'contributionCount' },
   { label: 'Team Share', value: 'teamSharePercent' },
   { label: 'Active Members', value: 'activeTeamMembers' },
+  { label: 'Strategic Importance', value: 'strategicImportance' },
   { label: 'Name', value: 'name' },
 ]
 
 const orgTableColumns = [
   { label: 'Organization', field: 'name', align: 'left' },
+  { label: 'Engagement Status', field: 'engagementStatus', align: 'left' },
   { label: 'Contributions', field: 'contributionCount', align: 'right' },
   { label: 'Team Share', field: 'teamSharePercent', align: 'right' },
   { label: 'Members', field: 'activeTeamMembers', align: 'right' },
@@ -592,7 +602,7 @@ watch(searchInput, (val) => {
 watch(orgPageSize, () => { orgCurrentPage.value = 1 })
 watch(projectPageSize, () => { projectCurrentPage.value = 1 })
 watch(orgSortField, (field) => {
-  orgSortDirection.value = field === 'name' ? 'asc' : 'desc'
+  orgSortDirection.value = (field === 'name') ? 'asc' : 'desc'
   orgCurrentPage.value = 1
 })
 
@@ -605,7 +615,7 @@ function handleOrgTableSort(field) {
     orgSortDirection.value = orgSortDirection.value === 'asc' ? 'desc' : 'asc'
   } else {
     orgSortField.value = field
-    orgSortDirection.value = field === 'name' ? 'asc' : 'desc'
+    orgSortDirection.value = (field === 'name') ? 'asc' : 'desc'
   }
   orgCurrentPage.value = 1
 }
@@ -634,6 +644,20 @@ const sortedOrgsList = computed(() => {
     const field = orgSortField.value
     if (field === 'name') {
       const cmp = (a.name || '').localeCompare(b.name || '')
+      return orgSortDirection.value === 'asc' ? cmp : -cmp
+    }
+    if (field === 'engagementStatus') {
+      const statusOrder = {
+        'Established Leader': 4,
+        'Core Contributor': 3,
+        'Active': 2,
+        'New Entrant': 1
+      }
+      const aStatus = getEngagementStatus(a.leadershipCount || 0, a.maintainerCount || 0, a.contributionCount || 0).label
+      const bStatus = getEngagementStatus(b.leadershipCount || 0, b.maintainerCount || 0, b.contributionCount || 0).label
+      const aVal = statusOrder[aStatus] || 0
+      const bVal = statusOrder[bStatus] || 0
+      const cmp = aVal - bVal
       return orgSortDirection.value === 'asc' ? cmp : -cmp
     }
     const cmp = (a[field] || 0) - (b[field] || 0)
@@ -711,6 +735,34 @@ function handleProjectSort(field) {
     projectSortDirection.value = field === 'teamContributions' ? 'desc' : 'asc'
   }
   projectCurrentPage.value = 1
+}
+
+function getEngagementStatus(leadershipCount, maintainerCount, total) {
+  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
+  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
+
+  if (total === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700'
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700'
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+  }
 }
 
 async function loadData() {


### PR DESCRIPTION
## Summary
- Add Leadership Strategy section to Dashboard with visual organization of strategic priorities
- Organizations categorized across two dimensions: Participation and Leadership
- Each dimension has three levels: evaluating, sustaining, increasing

## Changes
- **New component**: LeadershipStrategy.vue with three investment tiers (Increase, Sustain, Evaluating)
- **Dashboard updates**: Include Leadership Strategy section
- **Engagement status badges**: New Entrant, Active, Core Contributor, Established Leader on org cards
- **OrgDetail enhancements**: Strategic classification badges in header with descriptive tooltips
- **Portfolio table**: Engagement status column support
- **Visual indicators**: Red Hat leads (red-400 bg), Red Hat participates (gray bg)

## Test plan
- [ ] Verify Leadership Strategy section renders on Dashboard
- [ ] Check engagement status badges display correctly on org cards
- [ ] Confirm strategic badges appear in OrgDetail headers with tooltips
- [ ] Test with missing backend data (graceful degradation)
- [ ] Verify color scheme matches design system

## Notes
Frontend changes are backward-compatible and handle missing strategic classification data gracefully. The backend PR with strategic classification API support is at dpanshug/upstream-pulse#27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)