### PR TITLE
fix: correct misleading metric subtitle labels

### DIFF
--- a/modules/team-tracker/client/views/TeamRosterView.vue
+++ b/modules/team-tracker/client/views/TeamRosterView.vue
@@ -45,14 +45,14 @@
       <MetricCard
         label="Issues Resolved"
         :value="teamMetrics?.aggregate?.resolvedCount"
-        subtitle="Last 90 days"
+        subtitle="Last year"
         @click="showResolvedIssues = true"
       />
       <MetricCard
         label="Story Points"
         :value="teamMetrics?.aggregate?.resolvedPoints"
         unit="pts"
-        subtitle="Last 90 days"
+        subtitle="Last year"
       />
       <MetricCard
         label="In Progress"


### PR DESCRIPTION
## Summary

- The team summary cards for **Issues Resolved** and **Story Points** displayed "Last 90 days" but the underlying Jira query uses a **365-day lookback** (`lookbackDays || 365` in `person-metrics.js`)
- This caused confusion when comparing the summary totals against monthly snapshot history (e.g., 903 total vs 52+70+99=221 for 3 months)
- Changed subtitle from "Last 90 days" → "Last year" to match the actual data

## Test plan

- [ ] Verify the team roster view shows "Last year" under Issues Resolved and Story Points
- [ ] Confirm snapshot history modal numbers are consistent with the corrected label

🤖 Generated with [Claude Code](https://claude.com/claude-code)