### PR TITLE
fix: eliminate 504 timeouts on release analysis with stale-while-revalidate

### DIFF
--- a/deploy/openshift/base/api-route.yaml
+++ b/deploy/openshift/base/api-route.yaml
@@ -2,6 +2,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: team-tracker-api
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
   labels:
     app: team-tracker
     component: backend

--- a/modules/release-analysis/client/components/MonteCarloChart.vue
+++ b/modules/release-analysis/client/components/MonteCarloChart.vue
@@ -69,7 +69,9 @@ const props = defineProps({
   notDoneCount: { type: Number, required: true },
   velocity: { type: Number, required: true },
   dueDate: { type: String, required: true },
-  deadlineLabel: { type: String, default: 'Due Date' }
+  deadlineLabel: { type: String, default: 'Due Date' },
+  codeFreezeDate: { type: String, default: null },
+  releaseDate: { type: String, default: null }
 })
 
 // ── Random sampling ──
@@ -208,11 +210,30 @@ onUnmounted(() => { if (pendingIdleId != null) cancelIdle(pendingIdleId) })
 
 // ── Histogram binning ──
 
+const secondaryDates = computed(() => {
+  if (!sim.value) return { cfDays: null, relDays: null }
+  const t = getToday()
+  let cfDays = null
+  let relDays = null
+  if (props.codeFreezeDate && props.codeFreezeDate !== props.dueDate) {
+    const d = new Date(props.codeFreezeDate + 'T00:00:00')
+    if (!isNaN(d.getTime())) cfDays = daysBetween(t, d)
+  }
+  if (props.releaseDate && props.releaseDate !== props.dueDate) {
+    const d = new Date(props.releaseDate + 'T00:00:00')
+    if (!isNaN(d.getTime())) relDays = daysBetween(t, d)
+  }
+  return { cfDays, relDays }
+})
+
 const histogram = computed(() => {
   if (!sim.value) return null
   const { completionDays, minDays, maxDays, daysToDeadline, p85Days, p95Days } = sim.value
+  const { cfDays, relDays } = secondaryDates.value
 
   const allKeyDays = [minDays, maxDays, daysToDeadline, p85Days, p95Days]
+  if (cfDays != null) allKeyDays.push(cfDays)
+  if (relDays != null) allKeyDays.push(relDays)
   const effectiveMin = Math.max(0, Math.min(...allKeyDays))
   const effectiveMax = Math.min(MAX_DAYS, Math.max(...allKeyDays))
   const range = effectiveMax - effectiveMin
@@ -253,7 +274,9 @@ const histogram = computed(() => {
     firstBin,
     dueDateIdx: toChartIdx(daysToDeadline),
     p85Idx: toChartIdx(p85Days),
-    p95Idx: toChartIdx(p95Days)
+    p95Idx: toChartIdx(p95Days),
+    cfIdx: cfDays != null ? toChartIdx(cfDays) : null,
+    relIdx: relDays != null ? toChartIdx(relDays) : null
   }
 })
 
@@ -282,7 +305,7 @@ const markerPlugin = {
   id: 'monteCarloMarkers',
   afterDraw(chart) {
     if (!histogram.value) return
-    const { dueDateIdx, p85Idx, p95Idx } = histogram.value
+    const { dueDateIdx, p85Idx, p95Idx, cfIdx, relIdx } = histogram.value
     const { ctx, chartArea } = chart
     if (!chartArea) return
 
@@ -292,6 +315,13 @@ const markerPlugin = {
       { idx: p85Idx, color: '#f59e0b', dash: [4, 4], label: '85%', width: 2 },
       { idx: p95Idx, color: '#14b8a6', dash: [4, 4], label: '95%', width: 2 }
     ]
+
+    if (cfIdx != null) {
+      markers.push({ idx: cfIdx, color: '#ec4899', dash: [6, 3], label: 'Code Freeze', width: 2 })
+    }
+    if (relIdx != null) {
+      markers.push({ idx: relIdx, color: '#ef4444', dash: [6, 3], label: 'GA', width: 2 })
+    }
 
     for (const m of markers) {
       const px = xScale.getPixelForValue(m.idx)

--- a/modules/release-analysis/client/components/ProductReleaseCard.vue
+++ b/modules/release-analysis/client/components/ProductReleaseCard.vue
@@ -1,0 +1,383 @@
+<template>
+  <article
+    class="rounded-lg border border-gray-200/70 dark:border-gray-700/60 bg-white dark:bg-gray-900/50 shadow-sm overflow-hidden"
+  >
+    <!-- Collapsible header -->
+    <button
+      class="w-full flex flex-wrap items-center justify-between gap-2 px-4 py-3 text-left transition-colors hover:bg-gray-50/60 dark:hover:bg-gray-800/30"
+      @click="expanded = !expanded"
+    >
+      <div class="flex items-center gap-3 min-w-0 flex-wrap">
+        <svg
+          class="h-3.5 w-3.5 text-gray-400 transition-transform duration-200 shrink-0"
+          :class="{ 'rotate-90': expanded }"
+          viewBox="0 0 20 20" fill="currentColor"
+        >
+          <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+        </svg>
+        <p class="font-semibold text-gray-900 dark:text-gray-100 text-sm">
+          {{ release.releaseNumber }}
+        </p>
+        <span
+          class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-300"
+        >{{ productLabel }}</span>
+        <div
+          class="inline-flex items-center gap-1.5 rounded-full border border-gray-200/80 dark:border-gray-600 bg-gray-50/80 dark:bg-gray-800/50 px-2 py-0.5"
+        >
+          <span class="text-[9px] font-bold uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400 select-none">Risk</span>
+          <span class="h-2.5 w-px shrink-0 bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
+          <span
+            v-if="releaseHasNoIssues"
+            class="inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-gray-300 dark:bg-gray-600 ring-2 ring-white dark:ring-gray-900"
+            title="No risk — no issues in scope"
+          />
+          <span
+            v-else
+            class="inline-flex h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900"
+            :class="riskDotClass(release.risk)"
+            :title="releaseRiskTitle"
+          />
+        </div>
+        <span class="text-xs text-gray-500 dark:text-gray-400">
+          Due {{ formatDate(release.dueDate) }} · {{ release.daysRemaining }}d left
+        </span>
+      </div>
+      <div class="flex items-center gap-4 shrink-0">
+        <!-- Compact progress bar -->
+        <div class="hidden sm:flex items-center gap-2">
+          <div class="flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400">
+            <span class="inline-flex items-center gap-0.5"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(release.totals?.issues_done) }}</span>
+            <span class="inline-flex items-center gap-0.5"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(release.totals?.issues_doing) }}</span>
+            <span class="inline-flex items-center gap-0.5"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(release.totals?.issues_to_do) }}</span>
+          </div>
+          <div class="w-20 h-1.5 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
+            <div class="h-full flex">
+              <div class="h-full bg-emerald-500 dark:bg-emerald-600" :style="{ width: pct(release.totals?.issues_done, issueSum) }" />
+              <div class="h-full bg-blue-500 dark:bg-blue-600" :style="{ width: pct(release.totals?.issues_doing, issueSum) }" />
+              <div class="h-full bg-gray-400 dark:bg-gray-500" :style="{ width: pct(release.totals?.issues_to_do, issueSum) }" />
+            </div>
+          </div>
+        </div>
+        <span class="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+          {{ issueSum }} issues in scope
+        </span>
+      </div>
+    </button>
+
+    <!-- Collapsible body -->
+    <div v-show="expanded" class="border-t border-gray-100 dark:border-gray-800 px-4 py-3 flex flex-col gap-3">
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div class="min-w-0">
+          <p class="text-xs text-gray-500 dark:text-gray-400">{{ release.productName }}</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {{ releaseTeamsList.length }} project(s)
+            <span v-if="release.riskDriver"> · Driver: {{ release.riskDriver }}</span>
+          </p>
+          <p
+            v-if="!releaseHasNoIssues && release.riskSummary"
+            class="text-xs text-gray-600 dark:text-gray-300 mt-1.5 leading-snug border-l-2 pl-2 border-gray-200 dark:border-gray-600"
+          >
+            {{ release.riskSummary }}
+          </p>
+        </div>
+        <div class="grid grid-cols-3 gap-1.5 text-xs shrink-0">
+          <div class="rounded bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-center min-w-[3.5rem]">
+            <div class="text-gray-500 text-[10px]">To Do</div>
+            <div class="font-medium text-gray-900 dark:text-gray-100">{{ fmtCount(release.totals?.issues_to_do) }}</div>
+          </div>
+          <div class="rounded bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-center min-w-[3.5rem]">
+            <div class="text-gray-500 text-[10px]">Doing</div>
+            <div class="font-medium text-gray-900 dark:text-gray-100">{{ fmtCount(release.totals?.issues_doing) }}</div>
+          </div>
+          <div class="rounded bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-center min-w-[3.5rem]">
+            <div class="text-gray-500 text-[10px]">Done</div>
+            <div class="font-medium text-gray-900 dark:text-gray-100">{{ fmtCount(release.totals?.issues_done) }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="!releaseTeamsList.length" class="text-sm text-gray-500 dark:text-gray-400">
+        No issues mapped to this release yet.
+      </div>
+
+      <div v-else class="space-y-3">
+        <div
+          v-for="team in releaseTeamsList"
+          :key="team.projectKey"
+          class="space-y-1.5"
+        >
+          <div class="flex items-center justify-between gap-2 flex-wrap">
+            <span class="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+              {{ team.projectKey }}
+            </span>
+            <div
+              class="inline-flex items-center gap-1.5 rounded-full border border-gray-200/80 dark:border-gray-600 bg-gray-50/80 dark:bg-gray-800/50 px-2 py-0.5"
+            >
+              <span class="text-[9px] font-bold uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400 select-none">Risk</span>
+              <span class="h-2.5 w-px shrink-0 bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
+              <span
+                class="inline-flex h-2 w-2 shrink-0 rounded-full ring-1 ring-white dark:ring-gray-900"
+                :class="riskDotClass(team.risk)"
+              />
+            </div>
+          </div>
+          <div
+            class="flex h-2 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60"
+          >
+            <template v-if="teamIssueSum(team) > 0">
+              <div class="h-full bg-emerald-500 dark:bg-emerald-600" :style="{ width: pct(team.issues_done, teamIssueSum(team)) }" />
+              <div class="h-full bg-blue-500 dark:bg-blue-600" :style="{ width: pct(team.issues_doing, teamIssueSum(team)) }" />
+              <div class="h-full bg-gray-400 dark:bg-gray-500" :style="{ width: pct(team.issues_to_do, teamIssueSum(team)) }" />
+            </template>
+          </div>
+          <div class="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-gray-600 dark:text-gray-300">
+            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Done {{ fmtCount(team.issues_done) }}</span>
+            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" /> Doing {{ fmtCount(team.issues_doing) }}</span>
+            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" /> To do {{ fmtCount(team.issues_to_do) }}</span>
+            <span class="text-gray-500 dark:text-gray-400">· {{ teamIssueSum(team) }} issues</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Capacity table -->
+      <details class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30">
+        <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
+          <span class="text-gray-400 group-open:rotate-90 transition-transform">&#9656;</span>
+          Capacity &amp; throughput
+        </summary>
+        <div class="px-3 pb-3 overflow-x-auto border-t border-gray-100 dark:border-gray-800">
+          <table class="min-w-full text-sm mt-2">
+            <thead class="text-left text-gray-600 dark:text-gray-300">
+              <tr>
+                <th class="pr-3 py-1">Team</th>
+                <th class="pr-3 py-1">Remaining</th>
+                <th class="pr-3 py-1">Done</th>
+                <th class="pr-3 py-1">Expected to due</th>
+                <th class="pr-3 py-1">Required/day</th>
+                <th class="pr-3 py-1">Available/day</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="team in releaseTeamsList"
+                :key="`cap-${team.projectKey}`"
+                class="border-t border-gray-100 dark:border-gray-800"
+              >
+                <td class="py-2 pr-3 font-medium">{{ team.projectKey }}</td>
+                <td class="py-2 pr-3">{{ fmt(team.remaining) }}</td>
+                <td class="py-2 pr-3">{{ fmt(team.actualDoneThisRelease) }}</td>
+                <td class="py-2 pr-3">{{ fmt(team.expectedThroughputToDue) }}</td>
+                <td class="py-2 pr-3">{{ fmt(team.requiredRatePerDay) }}</td>
+                <td class="py-2 pr-3">{{ fmt(team.availableRatePerDay) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <!-- Issues table -->
+      <details class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30">
+        <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
+          <span class="text-gray-400 group-open:rotate-90 transition-transform">&#9656;</span>
+          Issues ({{ releaseIssues.length }})
+        </summary>
+        <div class="overflow-x-auto max-h-[min(440px,50vh)] border-t border-gray-100 dark:border-gray-800">
+          <table class="min-w-full text-sm">
+            <thead class="bg-white dark:bg-gray-900 sticky top-0 text-left text-gray-600 dark:text-gray-300">
+              <tr>
+                <th class="px-3 py-2">Issue</th>
+                <th class="px-3 py-2">Type</th>
+                <th class="px-3 py-2">Team</th>
+                <th class="px-3 py-2">Status</th>
+                <th class="px-3 py-2">Weight</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="issue in releaseIssues"
+                :key="issue.key"
+                class="border-b border-gray-100 dark:border-gray-800"
+              >
+                <td class="px-3 py-2">
+                  <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 hover:underline">{{ issue.key }}</a>
+                  <div class="text-xs text-gray-500 dark:text-gray-400 max-w-[320px] truncate">{{ issue.summary }}</div>
+                </td>
+                <td class="px-3 py-2">{{ issue.issueType || '—' }}</td>
+                <td class="px-3 py-2">{{ issue.projectKey }}</td>
+                <td class="px-3 py-2">
+                  <span class="text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700">{{ issue.statusBucket }}</span>
+                  <span class="text-xs text-gray-500 ml-1">{{ issue.status }}</span>
+                </td>
+                <td class="px-3 py-2">{{ fmt(issue.weight) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <!-- Monte Carlo -->
+      <details
+        v-if="mcInputs"
+        class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30"
+      >
+        <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
+          <span class="text-gray-400 group-open:rotate-90 transition-transform">&#9656;</span>
+          <span>Monte Carlo Simulation</span>
+          <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
+            {{ mcInputs.notDoneCount }} remaining · {{ mcInputs.totalVelocity }} issues/14d
+          </span>
+        </summary>
+        <div class="px-3 pb-3 border-t border-gray-100 dark:border-gray-800">
+          <div class="flex items-center justify-between gap-3 mt-3 mb-3">
+            <div class="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-0.5">
+              <div class="relative group/cf">
+                <button
+                  class="px-3 py-1 rounded-md text-xs font-medium transition-all duration-150"
+                  :disabled="!release.codeFreezeDate"
+                  :class="!release.codeFreezeDate
+                    ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                    : activeMcTarget === 'codeFreeze'
+                      ? 'bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-300 shadow-sm ring-1 ring-gray-200/60 dark:ring-gray-600/60'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+                  @click="$emit('set-mc-target', release.releaseNumber, 'codeFreeze')"
+                >Code Freeze</button>
+                <div v-if="!release.codeFreezeDate" class="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 hidden group-hover/cf:flex z-10">
+                  <div class="whitespace-nowrap rounded-md bg-gray-900 dark:bg-gray-700 px-2.5 py-1.5 text-[11px] font-medium text-white shadow-lg">
+                    <div class="absolute bottom-full left-1/2 -translate-x-1/2 border-4 border-transparent border-b-gray-900 dark:border-b-gray-700" />
+                    No code freeze date available
+                  </div>
+                </div>
+              </div>
+              <div class="relative group/ga">
+                <button
+                  class="px-3 py-1 rounded-md text-xs font-medium transition-all duration-150"
+                  :disabled="!release.dueDate"
+                  :class="!release.dueDate
+                    ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                    : activeMcTarget === 'ga'
+                      ? 'bg-white dark:bg-gray-700 text-purple-700 dark:text-purple-300 shadow-sm ring-1 ring-gray-200/60 dark:ring-gray-600/60'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+                  @click="$emit('set-mc-target', release.releaseNumber, 'ga')"
+                >GA</button>
+                <div v-if="!release.dueDate" class="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 hidden group-hover/ga:flex z-10">
+                  <div class="whitespace-nowrap rounded-md bg-gray-900 dark:bg-gray-700 px-2.5 py-1.5 text-[11px] font-medium text-white shadow-lg">
+                    <div class="absolute bottom-full left-1/2 -translate-x-1/2 border-4 border-transparent border-b-gray-900 dark:border-b-gray-700" />
+                    No GA date available
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mb-4 rounded-lg bg-gray-50/80 dark:bg-gray-800/40 border border-gray-200/60 dark:border-gray-700/40 px-4 py-3 text-xs text-gray-600 dark:text-gray-400 leading-relaxed space-y-1.5">
+            <p>
+              <span class="font-semibold text-gray-700 dark:text-gray-300">1,000 Monte Carlo simulations</span> to predict when remaining work will be completed.
+            </p>
+            <p>
+              <span class="font-medium text-gray-700 dark:text-gray-300">Inputs:</span>
+              <span class="font-semibold text-gray-700 dark:text-gray-300">{{ mcInputs.notDoneCount }}</span> not-done issues,
+              <span class="font-semibold text-gray-700 dark:text-gray-300">{{ mcInputs.totalVelocity }} issues / 14 days</span> throughput, measured against the
+              <template v-if="mcInputs.activeTarget === 'codeFreeze'">
+                code freeze date of <span class="font-semibold text-gray-700 dark:text-gray-300">{{ formatDueDate(mcInputs.codeFreezeDate) }}</span>
+                (GA: {{ formatDueDate(mcInputs.releaseDate) }}).
+              </template>
+              <template v-else>
+                GA date of <span class="font-semibold text-gray-700 dark:text-gray-300">{{ formatDueDate(mcInputs.releaseDate) }}</span><template v-if="mcInputs.codeFreezeDate">
+                (code freeze: {{ formatDueDate(mcInputs.codeFreezeDate) }})</template>.
+              </template>
+            </p>
+          </div>
+          <MonteCarloChart
+            :not-done-count="mcInputs.notDoneCount"
+            :velocity="mcInputs.totalVelocity"
+            :due-date="mcInputs.dueDate"
+            :deadline-label="mcInputs.activeTarget === 'codeFreeze' ? 'Code Freeze' : 'GA'"
+            :code-freeze-date="mcInputs.codeFreezeDate"
+            :release-date="mcInputs.releaseDate"
+          />
+        </div>
+      </details>
+    </div>
+  </article>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import MonteCarloChart from './MonteCarloChart.vue'
+import { extractProduct } from '../composables/useReleaseFilter'
+
+const props = defineProps({
+  release: { type: Object, required: true },
+  mcInputs: { type: Object, default: null },
+  activeMcTarget: { type: String, default: 'codeFreeze' },
+  defaultExpanded: { type: Boolean, default: false }
+})
+
+defineEmits(['set-mc-target'])
+
+const expanded = ref(props.defaultExpanded)
+
+const productLabel = computed(() => extractProduct(props.release.releaseNumber).toUpperCase())
+
+const releaseTeamsList = computed(() => {
+  if (!props.release?.teams) return []
+  return Object.values(props.release.teams).sort((a, b) => a.projectKey.localeCompare(b.projectKey))
+})
+
+const releaseIssues = computed(() => {
+  const r = props.release
+  if (!r) return []
+  if (Array.isArray(r.issues) && r.issues.length) return r.issues
+  return Array.isArray(r.features) ? r.features : []
+})
+
+const issueSum = computed(() => {
+  const t = props.release?.totals
+  if (!t) return 0
+  return (t.issues_to_do || 0) + (t.issues_doing || 0) + (t.issues_done || 0)
+})
+
+const releaseHasNoIssues = computed(() => issueSum.value === 0)
+
+const releaseRiskTitle = computed(() => {
+  return props.release?.riskSummary || 'Schedule risk from open issue count vs days to due date.'
+})
+
+function riskDotClass(risk) {
+  if (risk === 'red') return 'bg-red-500 dark:bg-red-600'
+  if (risk === 'yellow') return 'bg-amber-400 dark:bg-amber-500'
+  if (risk === 'none') return 'bg-gray-300 dark:bg-gray-600'
+  return 'bg-emerald-500 dark:bg-emerald-600'
+}
+
+function teamIssueSum(team) {
+  if (!team) return 0
+  return (team.issues_to_do || 0) + (team.issues_doing || 0) + (team.issues_done || 0)
+}
+
+function pct(part, total) {
+  if (!total || part <= 0) return '0%'
+  return `${Math.min(100, (part / total) * 100)}%`
+}
+
+function fmtCount(n) {
+  if (n == null || !Number.isFinite(Number(n))) return '0'
+  return String(Math.round(Number(n)))
+}
+
+function fmt(n) {
+  if (!Number.isFinite(Number(n))) return String(n)
+  return Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 })
+}
+
+function formatDate(iso) {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString()
+}
+
+function formatDueDate(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')
+  if (isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+</script>

--- a/modules/release-analysis/client/components/ReleaseFilterBar.vue
+++ b/modules/release-analysis/client/components/ReleaseFilterBar.vue
@@ -1,61 +1,10 @@
 <template>
   <div class="flex flex-wrap items-center gap-3">
     <div
-      v-if="productOpen || versionOpen"
+      v-if="versionOpen"
       class="fixed inset-0 z-10"
-      @click="productOpen = false; versionOpen = false"
+      @click="versionOpen = false"
     />
-
-    <!-- Product Filter -->
-    <div class="relative z-20">
-      <button
-        class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
-        :class="selectedProducts.size
-          ? 'border-indigo-300 dark:border-indigo-600 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
-          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'"
-        @click="productOpen = !productOpen; versionOpen = false"
-      >
-        <svg class="h-4 w-4 shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
-        </svg>
-        <span>Product</span>
-        <span
-          v-if="selectedProducts.size"
-          class="inline-flex items-center justify-center h-5 min-w-[1.25rem] rounded-full bg-indigo-600 dark:bg-indigo-500 text-white text-[10px] font-bold px-1.5"
-        >{{ selectedProducts.size }}</span>
-        <svg class="h-3.5 w-3.5 text-gray-400 transition-transform" :class="{ 'rotate-180': productOpen }" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-        </svg>
-      </button>
-      <div
-        v-if="productOpen"
-        class="absolute left-0 top-full mt-1.5 w-56 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg ring-1 ring-black/5 dark:ring-white/5 overflow-hidden"
-      >
-        <div class="flex items-center justify-between px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-          <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Products</span>
-          <button
-            v-if="selectedProducts.size"
-            class="text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300"
-            @click="clearProducts"
-          >Clear All</button>
-        </div>
-        <div class="max-h-52 overflow-y-auto py-1">
-          <label
-            v-for="product in visibleProducts"
-            :key="product"
-            class="flex items-center gap-2.5 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
-          >
-            <input
-              type="checkbox"
-              :checked="selectedProducts.has(product)"
-              class="h-3.5 w-3.5 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500"
-              @change="toggleProduct(product)"
-            />
-            <span class="text-sm font-medium text-gray-700 dark:text-gray-300 uppercase">{{ product }}</span>
-          </label>
-        </div>
-      </div>
-    </div>
 
     <!-- Version Filter -->
     <div class="relative z-20">
@@ -64,7 +13,7 @@
         :class="selectedVersions.size
           ? 'border-violet-300 dark:border-violet-600 bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300'
           : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'"
-        @click="versionOpen = !versionOpen; productOpen = false"
+        @click="versionOpen = !versionOpen"
       >
         <svg class="h-4 w-4 shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z" />
@@ -113,7 +62,7 @@
     <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
       <span>{{ filteredCount }} of {{ totalCount }} releases</span>
       <button
-        v-if="selectedProducts.size || selectedVersions.size"
+        v-if="selectedVersions.size"
         class="text-xs font-medium text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
         @click="resetFilters"
       >Reset filters</button>
@@ -125,19 +74,14 @@
 import { ref } from 'vue'
 
 defineProps({
-  selectedProducts: { type: Set, required: true },
   selectedVersions: { type: Set, required: true },
-  visibleProducts: { type: Array, required: true },
   visibleVersions: { type: Array, required: true },
   filteredCount: { type: Number, required: true },
   totalCount: { type: Number, required: true },
-  toggleProduct: { type: Function, required: true },
   toggleVersion: { type: Function, required: true },
-  clearProducts: { type: Function, required: true },
   clearVersions: { type: Function, required: true },
   resetFilters: { type: Function, required: true }
 })
 
-const productOpen = ref(false)
 const versionOpen = ref(false)
 </script>

--- a/modules/release-analysis/client/components/ReleaseVersionGroup.vue
+++ b/modules/release-analysis/client/components/ReleaseVersionGroup.vue
@@ -1,0 +1,380 @@
+<template>
+  <div
+    class="rounded-xl border bg-gradient-to-br shadow-[0_1px_3px_rgba(0,0,0,0.06),0_6px_20px_rgba(0,0,0,0.04)] overflow-hidden"
+    :class="containerBorder"
+  >
+    <!-- Accordion header -->
+    <button
+      class="w-full flex items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-gray-50/60 dark:hover:bg-gray-800/40"
+      @click="open = !open"
+    >
+      <div class="flex items-center gap-4 min-w-0 flex-wrap">
+        <div class="flex items-center gap-2">
+          <span
+            class="text-lg font-bold tabular-nums text-gray-900 dark:text-gray-100"
+          >RHAI {{ group.version }}</span>
+          <span
+            class="inline-flex h-3 w-3 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900"
+            :class="riskDotClass"
+            :title="`Aggregate risk: ${group.risk}`"
+          />
+        </div>
+        <span
+          v-if="group.earliestCodeFreeze"
+          class="inline-flex items-center gap-1.5 rounded-full border border-pink-200 dark:border-pink-700/50 bg-pink-50 dark:bg-pink-900/30 px-2.5 py-1 text-[11px] font-medium text-pink-700 dark:text-pink-300 shadow-sm"
+          @click.stop
+        >
+          <svg class="h-3.5 w-3.5 text-pink-500 dark:text-pink-400" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z" clip-rule="evenodd" /></svg>
+          Code Freeze · {{ formatDueDate(group.earliestCodeFreeze) }}
+        </span>
+        <span
+          v-if="group.earliestRelease"
+          class="inline-flex items-center gap-1.5 rounded-full border border-purple-200 dark:border-purple-700/50 bg-purple-50 dark:bg-purple-900/30 px-2.5 py-1 text-[11px] font-medium text-purple-700 dark:text-purple-300 shadow-sm"
+          @click.stop
+        >
+          <svg class="h-3.5 w-3.5 text-purple-500 dark:text-purple-400" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd" /></svg>
+          Release · {{ formatDueDate(group.earliestRelease) }}
+        </span>
+        <span class="text-xs font-medium text-gray-500 dark:text-gray-400">
+          {{ group.productCount }} product{{ group.productCount === 1 ? '' : 's' }}
+        </span>
+        <div class="hidden sm:flex items-center gap-2 flex-wrap">
+          <span
+            v-for="name in group.productNames"
+            :key="name"
+            class="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+          >
+            <span
+              class="inline-flex h-1.5 w-1.5 rounded-full"
+              :class="productDotClass(productRisk(name))"
+            />
+            {{ name }}
+          </span>
+        </div>
+      </div>
+      <div class="flex items-center gap-5 shrink-0">
+        <!-- Aggregated progress mini-bar -->
+        <div class="hidden md:flex items-center gap-3">
+          <div class="flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400">
+            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(group.totals.issues_done) }}</span>
+            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(group.totals.issues_doing) }}</span>
+            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(group.totals.issues_to_do) }}</span>
+          </div>
+          <div class="w-28 h-2 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
+            <div class="h-full flex">
+              <div class="h-full bg-emerald-500 dark:bg-emerald-600" :style="{ width: pct(group.totals.issues_done, totalIssues) }" />
+              <div class="h-full bg-blue-500 dark:bg-blue-600" :style="{ width: pct(group.totals.issues_doing, totalIssues) }" />
+              <div class="h-full bg-gray-400 dark:bg-gray-500" :style="{ width: pct(group.totals.issues_to_do, totalIssues) }" />
+            </div>
+          </div>
+        </div>
+        <span class="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+          {{ totalIssues }} issues
+        </span>
+        <svg
+          class="h-4 w-4 text-gray-400 transition-transform duration-200"
+          :class="{ 'rotate-180': open }"
+          xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+        >
+          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+        </svg>
+      </div>
+    </button>
+
+    <!-- Expanded content: product release cards -->
+    <transition
+      enter-active-class="transition-all duration-200 ease-out"
+      leave-active-class="transition-all duration-150 ease-in"
+      enter-from-class="opacity-0 max-h-0"
+      enter-to-class="opacity-100 max-h-[5000px]"
+      leave-from-class="opacity-100 max-h-[5000px]"
+      leave-to-class="opacity-0 max-h-0"
+    >
+      <div v-show="open" class="border-t border-gray-200/60 dark:border-gray-700/60">
+        <!-- Aggregated summary row -->
+        <div class="px-5 py-3 bg-gray-50/50 dark:bg-gray-800/30 flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-gray-600 dark:text-gray-300 border-b border-gray-100 dark:border-gray-800">
+          <span>
+            <span class="font-semibold text-gray-800 dark:text-gray-200">{{ totalIssues }}</span> total issues across
+            <span class="font-semibold text-gray-800 dark:text-gray-200">{{ group.releaseCount }}</span> release(s)
+          </span>
+          <span>
+            Earliest due: <span class="font-semibold text-gray-800 dark:text-gray-200">{{ formatDate(group.earliestDue) }}</span>
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            Completion:
+            <span class="font-semibold tabular-nums text-gray-800 dark:text-gray-200">{{ completionPct }}%</span>
+            <div class="w-16 h-1.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+              <div class="h-full bg-emerald-500 dark:bg-emerald-600 rounded-full" :style="{ width: completionPct + '%' }" />
+            </div>
+          </span>
+        </div>
+
+        <!-- Group-level Monte Carlo forecast -->
+        <div v-if="groupForecast" class="px-5 py-3 border-b border-gray-100 dark:border-gray-800">
+          <p class="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+            Monte Carlo Forecast — all {{ group.releaseCount }} release(s) complete
+          </p>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div class="rounded-lg border px-4 py-3" :class="pCardClass">
+              <p class="text-[10px] font-medium uppercase tracking-wider mb-1" :class="pLabelClass">
+                Probability at Release
+              </p>
+              <p class="text-2xl font-bold tabular-nums" :class="pValueClass">{{ groupForecast.pAtDeadline }}%</p>
+              <p class="text-[11px] mt-0.5" :class="pSubClass">{{ formatDueDate(group.earliestRelease) }}</p>
+            </div>
+
+            <div class="rounded-lg border border-amber-200 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/20 px-4 py-3">
+              <p class="text-[10px] font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400 mb-1">85% Confidence</p>
+              <p class="text-2xl font-bold text-amber-700 dark:text-amber-300 tabular-nums">{{ formatShortDate(groupForecast.p85Date) }}</p>
+              <p class="text-[11px] text-amber-500/80 dark:text-amber-500/60 mt-0.5">{{ daysLabel(groupForecast.p85Days) }}</p>
+            </div>
+
+            <div class="rounded-lg border border-teal-200 dark:border-teal-700/50 bg-teal-50/60 dark:bg-teal-900/20 px-4 py-3">
+              <p class="text-[10px] font-medium uppercase tracking-wider text-teal-600 dark:text-teal-400 mb-1">95% Confidence</p>
+              <p class="text-2xl font-bold text-teal-700 dark:text-teal-300 tabular-nums">{{ formatShortDate(groupForecast.p95Date) }}</p>
+              <p class="text-[11px] text-teal-500/80 dark:text-teal-500/60 mt-0.5">{{ daysLabel(groupForecast.p95Days) }}</p>
+            </div>
+          </div>
+          <p class="text-[9px] text-gray-400 dark:text-gray-500 mt-2">
+            1,000 simulations per release, worst-case per iteration.
+            {{ groupForecast.productCount }} release(s) simulated · {{ groupForecast.totalRemaining }} remaining issues.
+            <template v-if="groupForecast.redCount || groupForecast.yellowCount">
+              Risk-adjusted velocity:
+              <template v-if="groupForecast.redCount">{{ groupForecast.redCount }} red (-40%)</template><template v-if="groupForecast.redCount && groupForecast.yellowCount">, </template><template v-if="groupForecast.yellowCount">{{ groupForecast.yellowCount }} yellow (-20%)</template>.
+            </template>
+          </p>
+        </div>
+
+        <!-- Product cards -->
+        <div class="p-4 space-y-4">
+          <ProductReleaseCard
+            v-for="release in group.releases"
+            :key="release.releaseNumber"
+            :release="release"
+            :mc-inputs="mcInputsMap.get(release.releaseNumber) || null"
+            :active-mc-target="getMcTarget(release.releaseNumber)"
+            @set-mc-target="(rn, target) => $emit('set-mc-target', rn, target)"
+          />
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import ProductReleaseCard from './ProductReleaseCard.vue'
+import { extractProduct } from '../composables/useReleaseFilter'
+
+const ITERATIONS = 1000
+const MAX_DAYS = 730
+
+const props = defineProps({
+  group: { type: Object, required: true },
+  mcInputsMap: { type: Map, required: true },
+  getMcTarget: { type: Function, required: true },
+  defaultOpen: { type: Boolean, default: true }
+})
+
+defineEmits(['set-mc-target'])
+
+const open = ref(props.defaultOpen)
+
+const totalIssues = computed(() => {
+  const t = props.group.totals
+  return (t.issues_to_do || 0) + (t.issues_doing || 0) + (t.issues_done || 0)
+})
+
+const completionPct = computed(() => {
+  if (!totalIssues.value) return 0
+  return Math.round((props.group.totals.issues_done / totalIssues.value) * 100)
+})
+
+// ── Monte Carlo simulation (per-product independent, take max per iteration) ──
+
+function boxMullerNormal() {
+  const u1 = Math.random()
+  const u2 = Math.random()
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+}
+
+function gammaSample(shape, scale) {
+  if (shape < 1) return gammaSample(shape + 1, scale) * Math.pow(Math.random(), 1 / shape)
+  const d = shape - 1 / 3
+  const c = 1 / Math.sqrt(9 * d)
+  for (let iter = 0; iter < 1000; iter++) {
+    let x, v
+    do { x = boxMullerNormal(); v = 1 + c * x } while (v <= 0)
+    v = v * v * v
+    const u = Math.random()
+    if (u < 1 - 0.0331 * x * x * x * x) return d * v * scale
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v * scale
+  }
+  return shape * scale
+}
+
+function getToday() { const d = new Date(); d.setHours(0, 0, 0, 0); return d }
+function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() + days); return d }
+function daysBetween(from, to) { return Math.ceil((to - from) / (1000 * 60 * 60 * 24)) }
+
+/**
+ * Risk-adjusted velocity discount: at-risk products historically underperform
+ * their baseline throughput due to blockers, scope creep, and quality issues.
+ */
+const RISK_VELOCITY_FACTOR = { red: 0.6, yellow: 0.8, green: 1.0 }
+
+const groupForecast = computed(() => {
+  const products = []
+  let redCount = 0
+  let yellowCount = 0
+  for (const r of props.group.releases) {
+    const mc = props.mcInputsMap.get(r.releaseNumber)
+    if (mc && mc.notDoneCount > 0 && mc.totalVelocity > 0) {
+      const risk = r.risk || 'green'
+      const factor = RISK_VELOCITY_FACTOR[risk] ?? 1.0
+      products.push({
+        notDoneCount: mc.notDoneCount,
+        velocity: mc.totalVelocity * factor,
+        risk
+      })
+      if (risk === 'red') redCount++
+      else if (risk === 'yellow') yellowCount++
+    }
+  }
+  if (!products.length) return null
+
+  const deadline = props.group.earliestRelease
+  if (!deadline) return null
+
+  const today = getToday()
+  const dueObj = new Date(deadline + 'T00:00:00')
+  const daysToDeadline = daysBetween(today, dueObj)
+
+  const groupCompletionDays = new Array(ITERATIONS)
+  for (let i = 0; i < ITERATIONS; i++) {
+    let maxDays = 0
+    for (const p of products) {
+      const scale = 14 / p.velocity
+      const days = Math.min(Math.ceil(gammaSample(p.notDoneCount, scale)), MAX_DAYS)
+      if (days > maxDays) maxDays = days
+    }
+    groupCompletionDays[i] = maxDays
+  }
+  groupCompletionDays.sort((a, b) => a - b)
+
+  const completedByDeadline = groupCompletionDays.filter(d => d <= daysToDeadline).length
+  const pAtDeadline = Math.round((completedByDeadline / ITERATIONS) * 100)
+  const p85Days = groupCompletionDays[Math.ceil(ITERATIONS * 0.85) - 1]
+  const p95Days = groupCompletionDays[Math.ceil(ITERATIONS * 0.95) - 1]
+
+  return {
+    pAtDeadline,
+    p85Days,
+    p85Date: addDays(today, p85Days),
+    p95Days,
+    p95Date: addDays(today, p95Days),
+    productCount: products.length,
+    totalRemaining: products.reduce((s, p) => s + p.notDoneCount, 0),
+    redCount,
+    yellowCount
+  }
+})
+
+const pCardClass = computed(() => {
+  if (!groupForecast.value) return ''
+  const p = groupForecast.value.pAtDeadline
+  if (p >= 70) return 'border-emerald-200 dark:border-emerald-700/50 bg-emerald-50/60 dark:bg-emerald-900/20'
+  if (p >= 40) return 'border-amber-200 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/20'
+  return 'border-red-200 dark:border-red-700/50 bg-red-50/60 dark:bg-red-900/20'
+})
+
+const pLabelClass = computed(() => {
+  if (!groupForecast.value) return ''
+  const p = groupForecast.value.pAtDeadline
+  if (p >= 70) return 'text-emerald-600 dark:text-emerald-400'
+  if (p >= 40) return 'text-amber-600 dark:text-amber-400'
+  return 'text-red-600 dark:text-red-400'
+})
+
+const pValueClass = computed(() => {
+  if (!groupForecast.value) return ''
+  const p = groupForecast.value.pAtDeadline
+  if (p >= 70) return 'text-emerald-700 dark:text-emerald-300'
+  if (p >= 40) return 'text-amber-700 dark:text-amber-300'
+  return 'text-red-700 dark:text-red-300'
+})
+
+const pSubClass = computed(() => {
+  if (!groupForecast.value) return ''
+  const p = groupForecast.value.pAtDeadline
+  if (p >= 70) return 'text-emerald-500/80 dark:text-emerald-500/60'
+  if (p >= 40) return 'text-amber-500/80 dark:text-amber-500/60'
+  return 'text-red-500/80 dark:text-red-500/60'
+})
+
+// ── Styling helpers ──
+
+const containerBorder = computed(() => {
+  const risk = props.group.risk
+  if (risk === 'red') return 'border-red-200/80 dark:border-red-800/50 from-red-50/30 to-white dark:from-red-950/10 dark:to-gray-900/40'
+  if (risk === 'yellow') return 'border-amber-200/80 dark:border-amber-800/50 from-amber-50/30 to-white dark:from-amber-950/10 dark:to-gray-900/40'
+  return 'border-emerald-200/80 dark:border-emerald-800/50 from-emerald-50/20 to-white dark:from-emerald-950/10 dark:to-gray-900/40'
+})
+
+const riskDotClass = computed(() => {
+  const risk = props.group.risk
+  if (risk === 'red') return 'bg-red-500 dark:bg-red-600'
+  if (risk === 'yellow') return 'bg-amber-400 dark:bg-amber-500'
+  return 'bg-emerald-500 dark:bg-emerald-600'
+})
+
+function productRisk(productName) {
+  const matching = props.group.releases.filter(
+    r => extractProduct(r.releaseNumber) === productName
+  )
+  if (matching.some(r => r.risk === 'red')) return 'red'
+  if (matching.some(r => r.risk === 'yellow')) return 'yellow'
+  return 'green'
+}
+
+function productDotClass(risk) {
+  if (risk === 'red') return 'bg-red-500'
+  if (risk === 'yellow') return 'bg-amber-400'
+  return 'bg-emerald-500'
+}
+
+function pct(part, total) {
+  if (!total || part <= 0) return '0%'
+  return `${Math.min(100, (part / total) * 100)}%`
+}
+
+function fmtCount(n) {
+  if (n == null || !Number.isFinite(Number(n))) return '0'
+  return String(Math.round(Number(n)))
+}
+
+function daysLabel(days) {
+  if (days == null) return ''
+  if (days <= 0) return 'Today or past'
+  if (days === 1) return '1 day from now'
+  return `${days} days from now`
+}
+
+function formatDate(d) {
+  const date = d instanceof Date ? d : new Date(d)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleDateString()
+}
+
+function formatShortDate(d) {
+  const date = d instanceof Date ? d : new Date(d)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function formatDueDate(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')
+  if (isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+</script>

--- a/modules/release-analysis/client/composables/useReleaseAnalysis.js
+++ b/modules/release-analysis/client/composables/useReleaseAnalysis.js
@@ -1,7 +1,9 @@
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { apiRequest, SESSION_CACHE_PREFIX } from '@shared/client/services/api'
 
 const ANALYSIS_CACHE_KEY = `${SESSION_CACHE_PREFIX}release-analysis:analysis-v6`
+const POLL_INTERVAL_MS = 3000
+const MAX_POLL_MS = 5 * 60 * 1000
 
 function readCache() {
   if (typeof sessionStorage === 'undefined') return null
@@ -34,16 +36,75 @@ function clearCache() {
   }
 }
 
+function stripCacheMeta(data) {
+  if (!data) return data
+  const { _cacheStale, _refreshing, _noCache, ...rest } = data
+  return rest
+}
+
 /**
  * Shared composable for fetching and caching release-analysis data.
+ * Uses stale-while-revalidate: shows cached/stale data immediately and
+ * polls for background refresh completion when the server signals staleness.
  *
  * @param {Object} [options]
  * @param {Function} [options.onLoaded] - callback invoked after analysis data is set (cache hit or fetch)
  */
 export function useReleaseAnalysis({ onLoaded } = {}) {
   const loading = ref(false)
+  const refreshing = ref(false)
   const error = ref('')
   const analysis = ref(null)
+  let pollTimer = null
+  let pollStart = 0
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  async function pollRefreshStatus() {
+    if (Date.now() - pollStart > MAX_POLL_MS) {
+      stopPolling()
+      refreshing.value = false
+      return
+    }
+
+    try {
+      const status = await apiRequest('/modules/release-analysis/refresh/status')
+      if (!status.running) {
+        stopPolling()
+        refreshing.value = false
+        await reloadFreshData()
+        return
+      }
+    } catch {
+      // Polling failure is non-critical; keep trying
+    }
+
+    pollTimer = setTimeout(pollRefreshStatus, POLL_INTERVAL_MS)
+  }
+
+  function startPolling() {
+    stopPolling()
+    refreshing.value = true
+    pollStart = Date.now()
+    pollTimer = setTimeout(pollRefreshStatus, POLL_INTERVAL_MS)
+  }
+
+  async function reloadFreshData() {
+    try {
+      const data = await apiRequest('/modules/release-analysis/analysis')
+      const clean = stripCacheMeta(data)
+      analysis.value = clean
+      writeCache(clean)
+      onLoaded?.()
+    } catch {
+      // Silent — stale data is still displayed
+    }
+  }
 
   async function loadAnalysis(forceRefresh = false) {
     loading.value = true
@@ -53,9 +114,22 @@ export function useReleaseAnalysis({ onLoaded } = {}) {
         ? '/modules/release-analysis/analysis?refresh=true'
         : '/modules/release-analysis/analysis'
       const data = await apiRequest(url)
-      analysis.value = data
-      writeCache(data)
-      onLoaded?.()
+      const clean = stripCacheMeta(data)
+
+      if (data._noCache && data._refreshing) {
+        // Cold start — no data yet, server is building it
+        startPolling()
+      } else {
+        if (clean.releases?.length) {
+          analysis.value = clean
+          writeCache(clean)
+          onLoaded?.()
+        }
+
+        if (data._refreshing || data._cacheStale) {
+          startPolling()
+        }
+      }
     } catch (err) {
       error.value = err.message || 'Failed to load release analysis'
     } finally {
@@ -78,5 +152,9 @@ export function useReleaseAnalysis({ onLoaded } = {}) {
     loadAnalysis()
   })
 
-  return { loading, error, analysis, loadAnalysis, refreshAnalysis }
+  onUnmounted(() => {
+    stopPolling()
+  })
+
+  return { loading, refreshing, error, analysis, loadAnalysis, refreshAnalysis }
 }

--- a/modules/release-analysis/client/composables/useReleaseFilter.js
+++ b/modules/release-analysis/client/composables/useReleaseFilter.js
@@ -1,15 +1,39 @@
 import { computed, reactive, watch } from 'vue'
 
-function extractProduct(releaseNumber) {
+export function extractProduct(releaseNumber) {
   const s = (releaseNumber || '').toLowerCase()
   const dash = s.indexOf('-')
   return dash > 0 ? s.slice(0, dash) : s
 }
 
-function extractVersion(releaseNumber) {
+export function extractVersion(releaseNumber) {
   const s = releaseNumber || ''
   const dash = s.indexOf('-')
   return dash > 0 ? s.slice(dash + 1) : s
+}
+
+
+function aggregateRisk(releases) {
+  if (releases.some(r => r.risk === 'red')) return 'red'
+  if (releases.some(r => r.risk === 'yellow')) return 'yellow'
+  return 'green'
+}
+
+function aggregateTotals(releases) {
+  const agg = { to_do: 0, doing: 0, done: 0, remaining: 0, total: 0, issues: 0, issues_to_do: 0, issues_doing: 0, issues_done: 0 }
+  for (const r of releases) {
+    const t = r.totals || {}
+    agg.to_do += t.to_do || 0
+    agg.doing += t.doing || 0
+    agg.done += t.done || 0
+    agg.remaining += t.remaining || 0
+    agg.total += t.total || 0
+    agg.issues += t.issues || 0
+    agg.issues_to_do += t.issues_to_do || 0
+    agg.issues_doing += t.issues_doing || 0
+    agg.issues_done += t.issues_done || 0
+  }
+  return agg
 }
 
 /**
@@ -79,6 +103,51 @@ export function useReleaseFilter(allReleases) {
     })
   })
 
+  const groupedByVersion = computed(() => {
+    const map = new Map()
+    for (const r of filteredReleases.value) {
+      const majorVer = extractVersion(r.releaseNumber)
+      if (!map.has(majorVer)) map.set(majorVer, [])
+      map.get(majorVer).push(r)
+    }
+
+    const groups = []
+    for (const [version, releases] of map) {
+      const earliest = releases.reduce((min, r) => {
+        const d = new Date(r.dueDate)
+        return d < min ? d : min
+      }, new Date('9999-12-31'))
+
+      const cfDates = releases.map(r => r.codeFreezeDate).filter(Boolean)
+      const earliestCodeFreeze = cfDates.length
+        ? cfDates.reduce((min, d) => (new Date(d) < new Date(min) ? d : min))
+        : null
+
+      const dueDates = releases.map(r => r.dueDate).filter(Boolean)
+      const earliestRelease = dueDates.length
+        ? dueDates.reduce((min, d) => (new Date(d) < new Date(min) ? d : min))
+        : null
+
+      const products = [...new Set(releases.map(r => extractProduct(r.releaseNumber)))]
+
+      groups.push({
+        version,
+        releases,
+        risk: aggregateRisk(releases),
+        totals: aggregateTotals(releases),
+        earliestDue: earliest,
+        earliestCodeFreeze,
+        earliestRelease,
+        productCount: products.length,
+        productNames: products,
+        releaseCount: releases.length
+      })
+    }
+
+    groups.sort((a, b) => a.version.localeCompare(b.version, undefined, { numeric: true }))
+    return groups
+  })
+
   function clearProducts() {
     selectedProducts.clear()
   }
@@ -100,6 +169,7 @@ export function useReleaseFilter(allReleases) {
     visibleProducts,
     visibleVersions,
     filteredReleases,
+    groupedByVersion,
     toggleProduct,
     toggleVersion,
     clearProducts,

--- a/modules/release-analysis/client/views/MainView.vue
+++ b/modules/release-analysis/client/views/MainView.vue
@@ -31,9 +31,9 @@
       {{ error }}
     </div>
 
-    <div v-if="loading && !analysis" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
+    <div v-if="(loading || refreshing) && !analysis" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
 
-    <template v-if="!loading && analysis">
+    <template v-if="analysis">
       <div
         v-if="analysis.warning"
         class="rounded-lg border border-yellow-300 bg-yellow-50 text-yellow-800 px-4 py-3 text-sm"

--- a/modules/release-analysis/client/views/MainView.vue
+++ b/modules/release-analysis/client/views/MainView.vue
@@ -4,23 +4,34 @@
       <div>
         <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Release Analysis</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-          Per-release cards with project progress (done / doing / to do). Open the sections below a card for throughput and issues.
+          Releases grouped by version with per-product progress, capacity, and forecasting.
         </p>
       </div>
       <button
         class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800"
-        :disabled="loading"
+        :disabled="loading || refreshing"
         @click="refreshAnalysis"
       >
-        {{ loading ? 'Refreshing...' : 'Refresh' }}
+        {{ loading ? 'Loading...' : refreshing ? 'Updating...' : 'Refresh' }}
       </button>
+    </div>
+
+    <div
+      v-if="refreshing && analysis"
+      class="flex items-center gap-2 rounded-lg border border-indigo-200 dark:border-indigo-700/50 bg-indigo-50/60 dark:bg-indigo-900/20 px-4 py-2.5 text-sm text-indigo-700 dark:text-indigo-300"
+    >
+      <svg class="animate-spin h-4 w-4 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      Updating data in the background — you can keep working with the current data.
     </div>
 
     <div v-if="error" class="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm">
       {{ error }}
     </div>
 
-    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
+    <div v-if="loading && !analysis" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
 
     <template v-if="!loading && analysis">
       <div
@@ -48,15 +59,11 @@
           </p>
           <ReleaseFilterBar
             class="mt-4"
-            :selected-products="selectedProducts"
             :selected-versions="selectedVersions"
-            :visible-products="visibleProducts"
             :visible-versions="visibleVersions"
             :filtered-count="filteredReleases.length"
             :total-count="allReleases.length"
-            :toggle-product="toggleProduct"
             :toggle-version="toggleVersion"
-            :clear-products="clearProducts"
             :clear-versions="clearVersions"
             :reset-filters="resetFilters"
           />
@@ -66,343 +73,19 @@
           No releases match the current filters.
         </div>
 
-        <article
-          v-for="release in filteredReleases"
-          :key="release.releaseNumber"
-          class="rounded-xl border border-gray-200/80 dark:border-gray-700/80 bg-white dark:bg-gray-900/40 p-4 shadow-[0_1px_3px_rgba(0,0,0,0.06),0_4px_12px_rgba(0,0,0,0.04)] flex flex-col gap-4"
-        >
-          <div class="flex flex-wrap items-start justify-between gap-2 border-b border-gray-100 dark:border-gray-800 pb-3">
-            <div class="min-w-0">
-              <div class="flex flex-wrap items-center gap-3">
-                <p class="font-semibold text-gray-900 dark:text-gray-100 text-base">
-                  {{ release.releaseNumber }}
-                </p>
-                <div
-                  class="inline-flex items-center gap-2.5 rounded-full border border-gray-200/90 dark:border-gray-600 bg-gradient-to-r from-gray-50/95 to-white dark:from-gray-800/70 dark:to-gray-900/50 px-3 py-1.5 shadow-sm ring-1 ring-gray-100/90 dark:ring-gray-700/60"
-                >
-                  <span
-                    class="text-[10px] font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400 select-none"
-                  >Risk level</span>
-                  <span class="h-3.5 w-px shrink-0 bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
-                  <span
-                    v-if="releaseHasNoIssues(release)"
-                    class="inline-flex h-3 w-3 shrink-0 rounded-full bg-gray-300 dark:bg-gray-600 ring-2 ring-white dark:ring-gray-900"
-                    title="No risk — no issues in scope"
-                    aria-label="No risk"
-                  />
-                  <span
-                    v-else
-                    class="inline-flex h-3 w-3 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900"
-                    :class="riskDotClass(release.risk)"
-                    :title="releaseRiskTitle(release)"
-                    :aria-label="`Release risk: ${release.risk || 'unknown'}`"
-                  />
-                </div>
-              </div>
-              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ release.productName }}</p>
-              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                Due {{ formatDate(release.dueDate) }} · {{ release.daysRemaining }}d left ·
-                {{ releaseTeamsList(release).length }} project(s)
-                <span v-if="release.riskDriver"> · Driver: {{ release.riskDriver }}</span>
-              </p>
-              <p
-                v-if="!releaseHasNoIssues(release) && releaseRiskSummary(release)"
-                class="text-xs text-gray-600 dark:text-gray-300 mt-2 leading-snug border-l-2 pl-2 border-gray-200 dark:border-gray-600"
-              >
-                {{ releaseRiskSummary(release) }}
-              </p>
-            </div>
-            <div class="flex flex-col items-end gap-1 shrink-0 text-right">
-              <p class="text-[11px] text-gray-600 dark:text-gray-300">
-                <span class="font-medium text-gray-800 dark:text-gray-200">{{ releaseIssueSum(release) }}</span>
-                issues in scope
-              </p>
-              <div class="grid grid-cols-3 gap-2 text-xs">
-                <div class="rounded bg-gray-50 dark:bg-gray-800 px-2 py-1 text-center min-w-[4.5rem]">
-                  <div class="text-gray-500">To Do</div>
-                  <div class="font-medium text-gray-900 dark:text-gray-100">{{ fmtCount(release.totals?.issues_to_do) }}</div>
-                </div>
-                <div class="rounded bg-gray-50 dark:bg-gray-800 px-2 py-1 text-center min-w-[4.5rem]">
-                  <div class="text-gray-500">Doing</div>
-                  <div class="font-medium text-gray-900 dark:text-gray-100">{{ fmtCount(release.totals?.issues_doing) }}</div>
-                </div>
-                <div class="rounded bg-gray-50 dark:bg-gray-800 px-2 py-1 text-center min-w-[4.5rem]">
-                  <div class="text-gray-500">Done</div>
-                  <div class="font-medium text-gray-900 dark:text-gray-100">{{ fmtCount(release.totals?.issues_done) }}</div>
-                </div>
-              </div>
-            </div>
+        <template v-else>
+          <div class="space-y-5">
+            <ReleaseVersionGroup
+              v-for="group in groupedByVersion"
+              :key="group.version"
+              :group="group"
+              :mc-inputs-map="mcInputsMap"
+              :get-mc-target="getMcTarget"
+              :default-open="false"
+              @set-mc-target="setMcTarget"
+            />
           </div>
-
-          <div v-if="!releaseTeamsList(release).length" class="text-sm text-gray-500 dark:text-gray-400">
-            No issues mapped to this release yet.
-          </div>
-
-          <div v-else class="space-y-4">
-            <div
-              v-for="team in releaseTeamsList(release)"
-              :key="team.projectKey"
-              class="space-y-2"
-            >
-              <div class="flex items-center justify-between gap-2 flex-wrap">
-                <span class="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-                  {{ team.projectKey }}
-                </span>
-                <div
-                  class="inline-flex items-center gap-2 rounded-full border border-gray-200/80 dark:border-gray-600 bg-gray-50/80 dark:bg-gray-800/50 px-2.5 py-1 ring-1 ring-gray-100/80 dark:ring-gray-700/50"
-                >
-                  <span class="text-[9px] font-bold uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400 select-none">Risk level</span>
-                  <span class="h-3 w-px shrink-0 bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
-                  <span
-                    class="inline-flex h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900"
-                    :class="riskDotClass(team.risk)"
-                    :title="`Project risk (${team.projectKey}): ${team.risk}`"
-                    :aria-label="`Project ${team.projectKey} risk: ${team.risk}`"
-                  />
-                </div>
-              </div>
-              <div
-                class="flex h-2.5 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60"
-                role="img"
-                :aria-label="progressAriaTeam(team)"
-              >
-                <template v-if="teamIssueSum(team) > 0">
-                  <div
-                    class="h-full bg-emerald-500 dark:bg-emerald-600"
-                    :style="{ width: pct(team.issues_done, teamIssueSum(team)) }"
-                  />
-                  <div
-                    class="h-full bg-blue-500 dark:bg-blue-600"
-                    :style="{ width: pct(team.issues_doing, teamIssueSum(team)) }"
-                  />
-                  <div
-                    class="h-full bg-gray-400 dark:bg-gray-500"
-                    :style="{ width: pct(team.issues_to_do, teamIssueSum(team)) }"
-                  />
-                </template>
-              </div>
-              <div class="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-gray-600 dark:text-gray-300">
-                <span class="inline-flex items-center gap-1">
-                  <span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                  Done {{ fmtCount(team.issues_done) }}
-                </span>
-                <span class="inline-flex items-center gap-1">
-                  <span class="h-1.5 w-1.5 rounded-full bg-blue-500" />
-                  Doing {{ fmtCount(team.issues_doing) }}
-                </span>
-                <span class="inline-flex items-center gap-1">
-                  <span class="h-1.5 w-1.5 rounded-full bg-gray-400" />
-                  To do {{ fmtCount(team.issues_to_do) }}
-                </span>
-                <span class="text-gray-500 dark:text-gray-400">
-                  · {{ teamIssueSum(team) }} issues · capacity row uses {{ fmt(team.total) }} weighted pts
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <details class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30">
-            <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
-              <span class="text-gray-400 group-open:rotate-90 transition-transform">▸</span>
-              Capacity &amp; throughput by project
-            </summary>
-            <div class="px-3 pb-3 overflow-x-auto border-t border-gray-100 dark:border-gray-800">
-              <table class="min-w-full text-sm mt-2">
-                <thead class="text-left text-gray-600 dark:text-gray-300">
-                  <tr>
-                    <th class="pr-3 py-1">Team</th>
-                    <th class="pr-3 py-1">
-                      <span class="inline-flex items-center gap-1">
-                        Remaining
-                        <button
-                          class="inline-flex items-center justify-center h-4 w-4 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[10px] font-bold leading-none hover:bg-gray-300 dark:hover:bg-gray-600 cursor-help"
-                          :title="metricInfo.remaining"
-                        >i</button>
-                      </span>
-                    </th>
-                    <th class="pr-3 py-1">
-                      <span class="inline-flex items-center gap-1">
-                        Done
-                        <button
-                          class="inline-flex items-center justify-center h-4 w-4 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[10px] font-bold leading-none hover:bg-gray-300 dark:hover:bg-gray-600 cursor-help"
-                          :title="metricInfo.done"
-                        >i</button>
-                      </span>
-                    </th>
-                    <th class="pr-3 py-1">
-                      <span class="inline-flex items-center gap-1">
-                        Expected to due
-                        <button
-                          class="inline-flex items-center justify-center h-4 w-4 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[10px] font-bold leading-none hover:bg-gray-300 dark:hover:bg-gray-600 cursor-help"
-                          :title="metricInfo.expectedToDue"
-                        >i</button>
-                      </span>
-                    </th>
-                    <th class="pr-3 py-1">
-                      <span class="inline-flex items-center gap-1">
-                        Required/day
-                        <button
-                          class="inline-flex items-center justify-center h-4 w-4 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[10px] font-bold leading-none hover:bg-gray-300 dark:hover:bg-gray-600 cursor-help"
-                          :title="metricInfo.requiredPerDay"
-                        >i</button>
-                      </span>
-                    </th>
-                    <th class="pr-3 py-1">
-                      <span class="inline-flex items-center gap-1">
-                        Available/day
-                        <button
-                          class="inline-flex items-center justify-center h-4 w-4 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[10px] font-bold leading-none hover:bg-gray-300 dark:hover:bg-gray-600 cursor-help"
-                          :title="metricInfo.availablePerDay"
-                        >i</button>
-                      </span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    v-for="team in releaseTeamsList(release)"
-                    :key="`cap-${team.projectKey}`"
-                    class="border-t border-gray-100 dark:border-gray-800"
-                  >
-                    <td class="py-2 pr-3 font-medium">{{ team.projectKey }}</td>
-                    <td class="py-2 pr-3">{{ fmt(team.remaining) }}</td>
-                    <td class="py-2 pr-3">{{ fmt(team.actualDoneThisRelease) }}</td>
-                    <td class="py-2 pr-3">{{ fmt(team.expectedThroughputToDue) }}</td>
-                    <td class="py-2 pr-3">{{ fmt(team.requiredRatePerDay) }}</td>
-                    <td class="py-2 pr-3">{{ fmt(team.availableRatePerDay) }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </details>
-
-          <details class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30">
-            <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
-              <span class="text-gray-400 group-open:rotate-90 transition-transform">▸</span>
-              Issues for this release ({{ releaseIssues(release).length }})
-            </summary>
-            <div class="overflow-x-auto max-h-[min(440px,50vh)] border-t border-gray-100 dark:border-gray-800">
-              <table class="min-w-full text-sm">
-                <thead class="bg-white dark:bg-gray-900 sticky top-0 text-left text-gray-600 dark:text-gray-300">
-                  <tr>
-                    <th class="px-3 py-2">Issue</th>
-                    <th class="px-3 py-2">Type</th>
-                    <th class="px-3 py-2">Team</th>
-                    <th class="px-3 py-2">Status</th>
-                    <th class="px-3 py-2">Weight</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    v-for="issue in releaseIssues(release)"
-                    :key="issue.key"
-                    class="border-b border-gray-100 dark:border-gray-800"
-                  >
-                    <td class="px-3 py-2">
-                      <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 hover:underline">
-                        {{ issue.key }}
-                      </a>
-                      <div class="text-xs text-gray-500 dark:text-gray-400 max-w-[320px] truncate">{{ issue.summary }}</div>
-                    </td>
-                    <td class="px-3 py-2">{{ issue.issueType || '—' }}</td>
-                    <td class="px-3 py-2">{{ issue.projectKey }}</td>
-                    <td class="px-3 py-2">
-                      <span class="text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700">{{ issue.statusBucket }}</span>
-                      <span class="text-xs text-gray-500 ml-1">{{ issue.status }}</span>
-                    </td>
-                    <td class="px-3 py-2">{{ fmt(issue.weight) }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </details>
-
-          <details
-            v-if="mcInputsMap.get(release.releaseNumber)"
-            class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30"
-          >
-            <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
-              <span class="text-gray-400 group-open:rotate-90 transition-transform">▸</span>
-              <span>Forecasting using Monte Carlo Simulation</span>
-              <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
-                {{ mcInputsMap.get(release.releaseNumber).notDoneCount }} remaining · {{ mcInputsMap.get(release.releaseNumber).totalVelocity }} issues/14d throughput
-              </span>
-            </summary>
-            <div class="px-3 pb-3 border-t border-gray-100 dark:border-gray-800">
-              <div class="flex items-center justify-between gap-3 mt-3 mb-3">
-                <div class="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-0.5">
-                  <div class="relative group/cf">
-                    <button
-                      class="px-3 py-1 rounded-md text-xs font-medium transition-all duration-150"
-                      :disabled="!release.codeFreezeDate"
-                      :class="!release.codeFreezeDate
-                        ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                        : getMcTarget(release.releaseNumber) === 'codeFreeze'
-                          ? 'bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-300 shadow-sm ring-1 ring-gray-200/60 dark:ring-gray-600/60'
-                          : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
-                      @click="setMcTarget(release.releaseNumber, 'codeFreeze')"
-                    >
-                      Code Freeze
-                    </button>
-                    <div v-if="!release.codeFreezeDate" class="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 hidden group-hover/cf:flex z-10">
-                      <div class="whitespace-nowrap rounded-md bg-gray-900 dark:bg-gray-700 px-2.5 py-1.5 text-[11px] font-medium text-white shadow-lg">
-                        <div class="absolute bottom-full left-1/2 -translate-x-1/2 border-4 border-transparent border-b-gray-900 dark:border-b-gray-700" />
-                        No code freeze date available
-                      </div>
-                    </div>
-                  </div>
-                  <div class="relative group/ga">
-                    <button
-                      class="px-3 py-1 rounded-md text-xs font-medium transition-all duration-150"
-                      :disabled="!release.dueDate"
-                      :class="!release.dueDate
-                        ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                        : getMcTarget(release.releaseNumber) === 'ga'
-                          ? 'bg-white dark:bg-gray-700 text-purple-700 dark:text-purple-300 shadow-sm ring-1 ring-gray-200/60 dark:ring-gray-600/60'
-                          : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
-                      @click="setMcTarget(release.releaseNumber, 'ga')"
-                    >
-                      GA
-                    </button>
-                    <div v-if="!release.dueDate" class="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-2 hidden group-hover/ga:flex z-10">
-                      <div class="whitespace-nowrap rounded-md bg-gray-900 dark:bg-gray-700 px-2.5 py-1.5 text-[11px] font-medium text-white shadow-lg">
-                        <div class="absolute bottom-full left-1/2 -translate-x-1/2 border-4 border-transparent border-b-gray-900 dark:border-b-gray-700" />
-                        No GA date available
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="mb-4 rounded-lg bg-gray-50/80 dark:bg-gray-800/40 border border-gray-200/60 dark:border-gray-700/40 px-4 py-3 text-xs text-gray-600 dark:text-gray-400 leading-relaxed space-y-1.5">
-                <p>
-                  This forecast runs <span class="font-semibold text-gray-700 dark:text-gray-300">1,000 Monte Carlo simulations</span> to probabilistically predict when all remaining work for this release will be completed.
-                </p>
-                <p>
-                  <span class="font-medium text-gray-700 dark:text-gray-300">Inputs:</span>
-                  <span class="font-semibold text-gray-700 dark:text-gray-300">{{ mcInputsMap.get(release.releaseNumber).notDoneCount }}</span> not-done issues (To-Do + In-Progress) as the scope, and the aggregated historical
-                  <span class="font-semibold text-gray-700 dark:text-gray-300">{{ mcInputsMap.get(release.releaseNumber).totalVelocity }} issues / 14 days</span> throughput from contributing component teams as the delivery rate, measured against the
-                  <template v-if="mcInputsMap.get(release.releaseNumber).activeTarget === 'codeFreeze'">
-                    code freeze date of <span class="font-semibold text-gray-700 dark:text-gray-300">{{ formatDueDate(mcInputsMap.get(release.releaseNumber).codeFreezeDate) }}</span>
-                    (GA: {{ formatDueDate(mcInputsMap.get(release.releaseNumber).releaseDate) }}).
-                  </template>
-                  <template v-else>
-                    GA date of <span class="font-semibold text-gray-700 dark:text-gray-300">{{ formatDueDate(mcInputsMap.get(release.releaseNumber).releaseDate) }}</span><template v-if="mcInputsMap.get(release.releaseNumber).codeFreezeDate">
-                    (code freeze: {{ formatDueDate(mcInputsMap.get(release.releaseNumber).codeFreezeDate) }})</template>.
-                  </template>
-                </p>
-                <p>
-                  Each iteration samples a random completion timeline using the throughput rate with natural variance (Gamma distribution), producing a distribution of likely finish dates. The histogram below shows how often each date range appeared, and the confidence markers indicate when delivery is statistically likely.
-                </p>
-              </div>
-              <MonteCarloChart
-                :not-done-count="mcInputsMap.get(release.releaseNumber).notDoneCount"
-                :velocity="mcInputsMap.get(release.releaseNumber).totalVelocity"
-                :due-date="mcInputsMap.get(release.releaseNumber).dueDate"
-                :deadline-label="mcInputsMap.get(release.releaseNumber).activeTarget === 'codeFreeze' ? 'Code Freeze' : 'GA'"
-              />
-            </div>
-          </details>
-        </article>
+        </template>
       </section>
     </template>
   </div>
@@ -412,22 +95,19 @@
 import { computed, reactive } from 'vue'
 import { useReleaseAnalysis } from '../composables/useReleaseAnalysis'
 import { useReleaseFilter } from '../composables/useReleaseFilter'
-import MonteCarloChart from '../components/MonteCarloChart.vue'
 import ReleaseFilterBar from '../components/ReleaseFilterBar.vue'
+import ReleaseVersionGroup from '../components/ReleaseVersionGroup.vue'
 
-const { loading, error, analysis, refreshAnalysis } = useReleaseAnalysis()
+const { loading, refreshing, error, analysis, refreshAnalysis } = useReleaseAnalysis()
 
 const allReleases = computed(() => analysis.value?.releases || [])
 
 const {
-  selectedProducts,
   selectedVersions,
-  visibleProducts,
   visibleVersions,
   filteredReleases,
-  toggleProduct,
+  groupedByVersion,
   toggleVersion,
-  clearProducts,
   clearVersions,
   resetFilters
 } = useReleaseFilter(allReleases)
@@ -491,10 +171,10 @@ function getMonteCarloInputs(release) {
   }
 }
 
-function formatDueDate(dateStr) {
-  const d = new Date(dateStr + 'T00:00:00')
-  if (isNaN(d.getTime())) return '—'
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+function releaseIssues(release) {
+  if (!release) return []
+  if (Array.isArray(release.issues) && release.issues.length) return release.issues
+  return Array.isArray(release.features) ? release.features : []
 }
 
 const mcInputsMap = computed(() => {
@@ -506,14 +186,6 @@ const mcInputsMap = computed(() => {
   return map
 })
 
-const metricInfo = {
-  remaining: 'Remaining = Total weighted points (story points or feature weight) for issues in To Do + Doing status. Formula: Σ weight(issue) where status ≠ Done.',
-  done: 'Done = Total weighted points completed for this release within the baseline window. Formula: Σ weight(issue) where status = Done and resolved within this release.',
-  expectedToDue: 'Expected to Due = Projected throughput from now until the due date, based on historical capacity. Formula: (Baseline per month ÷ 30) × Days remaining. Baseline uses P90 or Avg monthly throughput over the trailing window.',
-  requiredPerDay: 'Required/day = The daily throughput rate needed to finish all remaining work by the due date. Formula: Remaining ÷ Days remaining. If days = 0 and work remains, this is ∞.',
-  availablePerDay: 'Available/day = Historical daily throughput capacity for this team. Formula: Baseline per month ÷ 30. Baseline = P90 (or Avg) of monthly completed weighted points over the trailing window (default 180 days).'
-}
-
 const riskLegendText = computed(() => {
   const a = analysis.value
   const g = a?.riskThresholds?.issuesPerDayGreenMax ?? 1
@@ -524,82 +196,10 @@ const riskLegendText = computed(() => {
   )
 })
 
-function releaseTeamsList(release) {
-  if (!release?.teams) return []
-  return Object.values(release.teams).sort((a, b) => a.projectKey.localeCompare(b.projectKey))
-}
-
-function releaseIssues(release) {
-  if (!release) return []
-  if (Array.isArray(release.issues) && release.issues.length) return release.issues
-  return Array.isArray(release.features) ? release.features : []
-}
-
-function pct(part, total) {
-  if (!total || part <= 0) return '0%'
-  return `${Math.min(100, (part / total) * 100)}%`
-}
-
-function teamIssueSum(team) {
-  if (!team) return 0
-  return (team.issues_to_do || 0) + (team.issues_doing || 0) + (team.issues_done || 0)
-}
-
-function releaseIssueSum(release) {
-  const t = release?.totals
-  if (!t) return 0
-  return (t.issues_to_do || 0) + (t.issues_doing || 0) + (t.issues_done || 0)
-}
-
-/** No mapped issues — schedule risk is not assessed (badge shows "No risk"). */
-function releaseHasNoIssues(release) {
-  return releaseIssueSum(release) === 0
-}
-
-function progressAriaTeam(team) {
-  return `${team.projectKey}: done ${team.issues_done ?? 0}, doing ${team.issues_doing ?? 0}, to do ${team.issues_to_do ?? 0} (${teamIssueSum(team)} issues)`
-}
-
-/** Integer issue counts (no decimals). */
-function fmtCount(n) {
-  if (n == null || !Number.isFinite(Number(n))) return '0'
-  return String(Math.round(Number(n)))
-}
-
-function fmt(n) {
-  if (!Number.isFinite(Number(n))) return String(n)
-  return Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 })
-}
-
-function formatDate(iso) {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return iso
-  return d.toLocaleDateString()
-}
 
 function formatDateTime(iso) {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
   return d.toLocaleString()
 }
-
-/** Solid color chip for schedule risk (open issues vs days remaining). Grey = no scope via `releaseHasNoIssues` + separate span. */
-function riskDotClass(risk) {
-  if (risk === 'red') return 'bg-red-500 dark:bg-red-600'
-  if (risk === 'yellow') return 'bg-amber-400 dark:bg-amber-500'
-  if (risk === 'none') return 'bg-gray-300 dark:bg-gray-600'
-  return 'bg-emerald-500 dark:bg-emerald-600'
-}
-
-function releaseRiskSummary(release) {
-  return release?.riskSummary || ''
-}
-
-function releaseRiskTitle(release) {
-  const s = release?.riskSummary
-  if (s) return s
-  return 'Schedule risk from open issue count (to do + in progress) vs days to due date.'
-}
-
-
 </script>

--- a/modules/release-analysis/client/views/ProjectBreakdownView.vue
+++ b/modules/release-analysis/client/views/ProjectBreakdownView.vue
@@ -9,18 +9,29 @@
       </div>
       <button
         class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800"
-        :disabled="loading"
+        :disabled="loading || refreshing"
         @click="refreshAnalysis"
       >
-        {{ loading ? 'Refreshing...' : 'Refresh' }}
+        {{ loading ? 'Loading...' : refreshing ? 'Updating...' : 'Refresh' }}
       </button>
+    </div>
+
+    <div
+      v-if="refreshing && analysis"
+      class="flex items-center gap-2 rounded-lg border border-indigo-200 dark:border-indigo-700/50 bg-indigo-50/60 dark:bg-indigo-900/20 px-4 py-2.5 text-sm text-indigo-700 dark:text-indigo-300"
+    >
+      <svg class="animate-spin h-4 w-4 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      Updating data in the background — you can keep working with the current data.
     </div>
 
     <div v-if="error" class="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm">
       {{ error }}
     </div>
 
-    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
+    <div v-if="loading && !analysis" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
 
     <template v-if="!loading && analysis">
       <div
@@ -368,7 +379,7 @@ const expandedProjects = reactive(new Set())
 const expandedComponents = reactive(new Set())
 const expandedStrategic = reactive(new Set())
 
-const { loading, error, analysis, refreshAnalysis } = useReleaseAnalysis()
+const { loading, refreshing, error, analysis, refreshAnalysis } = useReleaseAnalysis()
 
 function normalizeType(t) { return (t || '').toLowerCase().trim() }
 

--- a/modules/release-analysis/client/views/ProjectBreakdownView.vue
+++ b/modules/release-analysis/client/views/ProjectBreakdownView.vue
@@ -31,9 +31,9 @@
       {{ error }}
     </div>
 
-    <div v-if="loading && !analysis" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
+    <div v-if="(loading || refreshing) && !analysis" class="text-sm text-gray-500 dark:text-gray-400">Loading release analytics...</div>
 
-    <template v-if="!loading && analysis">
+    <template v-if="analysis">
       <div
         v-if="analysis.warning"
         class="rounded-lg border border-yellow-300 bg-yellow-50 text-yellow-800 px-4 py-3 text-sm"
@@ -50,15 +50,11 @@
       </div>
 
       <ReleaseFilterBar
-        :selected-products="selectedProducts"
         :selected-versions="selectedVersions"
-        :visible-products="visibleProducts"
         :visible-versions="visibleVersions"
         :filtered-count="enrichedReleases.length"
         :total-count="allReleases.length"
-        :toggle-product="toggleProduct"
         :toggle-version="toggleVersion"
-        :clear-products="clearProducts"
         :clear-versions="clearVersions"
         :reset-filters="resetFilters"
       />
@@ -386,14 +382,10 @@ function normalizeType(t) { return (t || '').toLowerCase().trim() }
 const allReleases = computed(() => analysis.value?.releases || [])
 
 const {
-  selectedProducts,
   selectedVersions,
-  visibleProducts,
   visibleVersions,
   filteredReleases,
-  toggleProduct,
   toggleVersion,
-  clearProducts,
   clearVersions,
   resetFilters
 } = useReleaseFilter(allReleases)

--- a/modules/release-analysis/server/index.js
+++ b/modules/release-analysis/server/index.js
@@ -1072,6 +1072,33 @@ module.exports = function registerRoutes(router, context) {
 
   let refreshState = { running: false, lastResult: null }
 
+  function triggerBackgroundRefresh() {
+    if (refreshState.running) return
+    refreshState = { running: true, startedAt: new Date().toISOString(), lastResult: refreshState.lastResult }
+    const config = getConfig(readFromStorage)
+    runFullAnalysis(storage, config)
+      .then(result => {
+        writeToStorage('release-analysis/analysis-cache.json', {
+          cachedAt: new Date().toISOString(),
+          data: result
+        })
+        refreshState.lastResult = {
+          status: 'success',
+          message: `Analysis generated with ${result.releases?.length || 0} release(s)`,
+          completedAt: new Date().toISOString()
+        }
+      })
+      .catch(err => {
+        console.error('[release-analysis] Background refresh failed:', err)
+        refreshState.lastResult = {
+          status: 'error',
+          message: err.message,
+          completedAt: new Date().toISOString()
+        }
+      })
+      .finally(() => { refreshState.running = false })
+  }
+
   // --- Config routes ---
 
   router.get('/config', requireAdmin, function(req, res) {
@@ -1116,74 +1143,71 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Refresh routes ---
 
-  router.get('/refresh/status', requireAdmin, function(req, res) {
+  router.get('/refresh/status', requireAuth, function(req, res) {
     res.json(refreshState)
   })
 
-  router.post('/refresh', requireAdmin, async function(req, res) {
+  router.post('/refresh', requireAdmin, function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' })
     }
     if (refreshState.running) {
       return res.json({ status: 'already_running' })
     }
-    refreshState = { running: true, startedAt: new Date().toISOString(), lastResult: refreshState.lastResult }
+    triggerBackgroundRefresh()
     res.json({ status: 'started' })
-
-    try {
-      const config = getConfig(readFromStorage)
-      const result = await runFullAnalysis(storage, config)
-      writeToStorage('release-analysis/analysis-cache.json', {
-        cachedAt: new Date().toISOString(),
-        data: result
-      })
-      refreshState.lastResult = {
-        status: 'success',
-        message: `Analysis generated with ${result.releases?.length || 0} release(s)`,
-        completedAt: new Date().toISOString()
-      }
-    } catch (err) {
-      console.error('[release-analysis] Refresh failed:', err)
-      refreshState.lastResult = {
-        status: 'error',
-        message: err.message,
-        completedAt: new Date().toISOString()
-      }
-    } finally {
-      refreshState.running = false
-    }
   })
 
-  // --- Analysis route ---
+  // --- Analysis route (stale-while-revalidate) ---
 
-  router.get('/analysis', requireAuth, async function(req, res) {
+  router.get('/analysis', requireAuth, function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
       const forceRefresh = req.query.refresh === 'true'
+      const cached = readFromStorage('release-analysis/analysis-cache.json')
+      const hasCachedData = cached?.data && cached.cachedAt
 
-      // Serve from cache if fresh
-      if (!forceRefresh) {
-        const cached = readFromStorage('release-analysis/analysis-cache.json')
-        if (cached?.data && cached.cachedAt) {
-          const age = Date.now() - new Date(cached.cachedAt).getTime()
-          if (age < CACHE_MAX_AGE_MS) {
-            return res.json(cached.data)
-          }
+      if (hasCachedData) {
+        const age = Date.now() - new Date(cached.cachedAt).getTime()
+        const isStale = age >= CACHE_MAX_AGE_MS
+
+        if (isStale || forceRefresh) {
+          triggerBackgroundRefresh()
         }
+
+        const payload = {
+          ...cached.data,
+          _cacheStale: isStale || forceRefresh,
+          _refreshing: refreshState.running
+        }
+        return res.json(payload)
       }
 
-      const result = await runFullAnalysis(storage, config)
-      // Update cache on live fetch so both refresh paths stay consistent
-      writeToStorage('release-analysis/analysis-cache.json', {
-        cachedAt: new Date().toISOString(),
-        data: result
+      // No cache at all — trigger background refresh, return a waiting status
+      triggerBackgroundRefresh()
+      res.status(202).json({
+        _cacheStale: true,
+        _refreshing: true,
+        _noCache: true,
+        releases: [],
+        warning: 'Analysis is being generated for the first time. This may take a few minutes.'
       })
-      res.json(result)
     } catch (error) {
       console.error('[release-analysis] analysis error:', error)
       res.status(500).json({ error: error.message })
     }
   })
+
+  // --- Startup cache seeding ---
+  // Warm the cache in the background so the first user request is instant
+  if (!DEMO_MODE) {
+    const existing = readFromStorage('release-analysis/analysis-cache.json')
+    const hasFreshCache = existing?.data && existing.cachedAt &&
+      (Date.now() - new Date(existing.cachedAt).getTime()) < CACHE_MAX_AGE_MS
+    if (!hasFreshCache) {
+      console.log('[release-analysis] No fresh cache found — seeding analysis in background')
+      setTimeout(() => triggerBackgroundRefresh(), 2000)
+    }
+  }
 
   router.post('/admin/releases', requireAdmin, function(req, res) {
     try {


### PR DESCRIPTION
## Summary

- **Fix 504 Gateway Timeout**: The `GET /analysis` endpoint previously blocked on `runFullAnalysis()` when cache expired, often exceeding proxy timeouts (120s nginx, 30s HAProxy). Now uses a stale-while-revalidate pattern — always returns cached data immediately and refreshes in the background. The client polls refresh status and seamlessly reloads fresh data with an unobtrusive "Updating data..." banner.
- **Server startup cache seeding**: Automatically triggers a background analysis on boot when no fresh cache exists, so the first user request is instant.
- **UI refinements**: Removed the Product dropdown from the release analysis filter bar, added code freeze date as a dotted line on Monte Carlo charts, removed release count from version group headings.
- **OpenShift HAProxy timeout**: Added `haproxy.router.openshift.io/timeout: 120s` annotation to the API route to match the nginx config.

## Test plan

- [ ] Verify Release Analysis tab loads instantly when cache exists (no 504)
- [ ] Verify stale cache triggers background refresh with "Updating data..." indicator
- [ ] Verify fresh data auto-reloads after background refresh completes
- [ ] Verify cold start (no cache) shows waiting message and auto-loads when ready
- [ ] Verify the Refresh button triggers background refresh without blocking
- [ ] Verify Component Breakdown tab has the same stale-while-revalidate behavior
- [ ] Verify code freeze date shows as a pink dotted line on Monte Carlo charts
- [ ] Verify Product dropdown is removed from the filter bar
- [ ] Verify release count is removed from version group headings


Made with [Cursor](https://cursor.com)