### PR TITLE
fix(release-analysis): show Monte Carlo 95% predicted date on sub-product headers

### DIFF
--- a/modules/release-analysis/client/components/MonteCarloChart.vue
+++ b/modules/release-analysis/client/components/MonteCarloChart.vue
@@ -60,6 +60,8 @@ import {
   Title
 } from 'chart.js'
 
+import { gammaSample } from '../utils/monteCarlo'
+
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Title)
 
 const ITERATIONS = 1000
@@ -73,38 +75,6 @@ const props = defineProps({
   codeFreezeDate: { type: String, default: null },
   releaseDate: { type: String, default: null }
 })
-
-// ── Random sampling ──
-
-function boxMullerNormal() {
-  const u1 = Math.random()
-  const u2 = Math.random()
-  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
-}
-
-/**
- * Gamma(shape, scale) via Marsaglia & Tsang.
- * Used to model the waiting time for `shape` Poisson events at rate 1/scale.
- */
-function gammaSample(shape, scale) {
-  if (shape < 1) {
-    return gammaSample(shape + 1, scale) * Math.pow(Math.random(), 1 / shape)
-  }
-  const d = shape - 1 / 3
-  const c = 1 / Math.sqrt(9 * d)
-  for (let iter = 0; iter < 1000; iter++) {
-    let x, v
-    do {
-      x = boxMullerNormal()
-      v = 1 + c * x
-    } while (v <= 0)
-    v = v * v * v
-    const u = Math.random()
-    if (u < 1 - 0.0331 * x * x * x * x) return d * v * scale
-    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v * scale
-  }
-  return shape * scale
-}
 
 // ── Date helpers ──
 

--- a/modules/release-analysis/client/components/ProductReleaseCard.vue
+++ b/modules/release-analysis/client/components/ProductReleaseCard.vue
@@ -41,6 +41,13 @@
         <span class="text-xs text-gray-500 dark:text-gray-400">
           Due {{ formatDate(release.dueDate) }} · {{ release.daysRemaining }}d left
         </span>
+        <span
+          v-if="predictedDate"
+          class="inline-flex items-center gap-1 text-xs text-teal-600 dark:text-teal-400"
+          title="95% confidence predicted completion date (Monte Carlo)"
+        >
+          Predicted {{ predictedDate }}
+        </span>
       </div>
       <div class="flex items-center gap-4 shrink-0">
         <!-- Compact progress bar -->
@@ -337,6 +344,53 @@ const issueSum = computed(() => {
 })
 
 const releaseHasNoIssues = computed(() => issueSum.value === 0)
+
+// ── Lightweight Monte Carlo for header predicted date ──
+
+const MC_ITERATIONS = 1000
+const MC_MAX_DAYS = 730
+
+function boxMullerNormal() {
+  const u1 = Math.random()
+  const u2 = Math.random()
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+}
+
+function gammaSample(shape, scale) {
+  if (shape < 1) return gammaSample(shape + 1, scale) * Math.pow(Math.random(), 1 / shape)
+  const d = shape - 1 / 3
+  const c = 1 / Math.sqrt(9 * d)
+  for (let iter = 0; iter < 1000; iter++) {
+    let x, v
+    do { x = boxMullerNormal(); v = 1 + c * x } while (v <= 0)
+    v = v * v * v
+    const u = Math.random()
+    if (u < 1 - 0.0331 * x * x * x * x) return d * v * scale
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v * scale
+  }
+  return shape * scale
+}
+
+const predictedDate = computed(() => {
+  const mc = props.mcInputs
+  if (!mc || mc.notDoneCount <= 0 || mc.totalVelocity <= 0) return null
+
+  const scale = 14 / mc.totalVelocity
+  const n = mc.notDoneCount
+  const completionDays = new Array(MC_ITERATIONS)
+  for (let i = 0; i < MC_ITERATIONS; i++) {
+    completionDays[i] = Math.min(Math.ceil(gammaSample(n, scale)), MC_MAX_DAYS)
+  }
+  completionDays.sort((a, b) => a - b)
+
+  const p95Days = completionDays[Math.ceil(MC_ITERATIONS * 0.95) - 1]
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const p95Date = new Date(today)
+  p95Date.setDate(p95Date.getDate() + p95Days)
+
+  return p95Date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', year: 'numeric' })
+})
 
 const releaseRiskTitle = computed(() => {
   return props.release?.riskSummary || 'Schedule risk from open issue count vs days to due date.'

--- a/modules/release-analysis/client/components/ProductReleaseCard.vue
+++ b/modules/release-analysis/client/components/ProductReleaseCard.vue
@@ -311,6 +311,7 @@
 import { computed, ref } from 'vue'
 import MonteCarloChart from './MonteCarloChart.vue'
 import { extractProduct } from '../composables/useReleaseFilter'
+import { gammaSample } from '../utils/monteCarlo'
 
 const props = defineProps({
   release: { type: Object, required: true },
@@ -349,27 +350,6 @@ const releaseHasNoIssues = computed(() => issueSum.value === 0)
 
 const MC_ITERATIONS = 1000
 const MC_MAX_DAYS = 730
-
-function boxMullerNormal() {
-  const u1 = Math.random()
-  const u2 = Math.random()
-  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
-}
-
-function gammaSample(shape, scale) {
-  if (shape < 1) return gammaSample(shape + 1, scale) * Math.pow(Math.random(), 1 / shape)
-  const d = shape - 1 / 3
-  const c = 1 / Math.sqrt(9 * d)
-  for (let iter = 0; iter < 1000; iter++) {
-    let x, v
-    do { x = boxMullerNormal(); v = 1 + c * x } while (v <= 0)
-    v = v * v * v
-    const u = Math.random()
-    if (u < 1 - 0.0331 * x * x * x * x) return d * v * scale
-    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v * scale
-  }
-  return shape * scale
-}
 
 const predictedDate = computed(() => {
   const mc = props.mcInputs

--- a/modules/release-analysis/client/components/ReleaseVersionGroup.vue
+++ b/modules/release-analysis/client/components/ReleaseVersionGroup.vue
@@ -165,6 +165,7 @@
 import { ref, computed } from 'vue'
 import ProductReleaseCard from './ProductReleaseCard.vue'
 import { extractProduct } from '../composables/useReleaseFilter'
+import { gammaSample } from '../utils/monteCarlo'
 
 const ITERATIONS = 1000
 const MAX_DAYS = 730
@@ -191,27 +192,6 @@ const completionPct = computed(() => {
 })
 
 // ── Monte Carlo simulation (per-product independent, take max per iteration) ──
-
-function boxMullerNormal() {
-  const u1 = Math.random()
-  const u2 = Math.random()
-  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
-}
-
-function gammaSample(shape, scale) {
-  if (shape < 1) return gammaSample(shape + 1, scale) * Math.pow(Math.random(), 1 / shape)
-  const d = shape - 1 / 3
-  const c = 1 / Math.sqrt(9 * d)
-  for (let iter = 0; iter < 1000; iter++) {
-    let x, v
-    do { x = boxMullerNormal(); v = 1 + c * x } while (v <= 0)
-    v = v * v * v
-    const u = Math.random()
-    if (u < 1 - 0.0331 * x * x * x * x) return d * v * scale
-    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v * scale
-  }
-  return shape * scale
-}
 
 function getToday() { const d = new Date(); d.setHours(0, 0, 0, 0); return d }
 function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() + days); return d }

--- a/modules/release-analysis/client/utils/monteCarlo.js
+++ b/modules/release-analysis/client/utils/monteCarlo.js
@@ -1,0 +1,26 @@
+/**
+ * Box-Muller transform — returns a standard-normal random variate.
+ */
+export function boxMullerNormal() {
+  const u1 = Math.random()
+  const u2 = Math.random()
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+}
+
+/**
+ * Marsaglia & Tsang rejection method for gamma-distributed variates.
+ */
+export function gammaSample(shape, scale) {
+  if (shape < 1) return gammaSample(shape + 1, scale) * Math.pow(Math.random(), 1 / shape)
+  const d = shape - 1 / 3
+  const c = 1 / Math.sqrt(9 * d)
+  for (let iter = 0; iter < 1000; iter++) {
+    let x, v
+    do { x = boxMullerNormal(); v = 1 + c * x } while (v <= 0)
+    v = v * v * v
+    const u = Math.random()
+    if (u < 1 - 0.0331 * x * x * x * x) return d * v * scale
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v * scale
+  }
+  return shape * scale
+}


### PR DESCRIPTION
## Summary
- Adds a "Predicted: mm/dd/yyyy" date next to the "Due" date on each sub-product header in the release analysis view
- The predicted date is the 95% confidence completion date computed via a lightweight 1,000-iteration Monte Carlo simulation (same gamma-sampling algorithm used by MonteCarloChart and ReleaseVersionGroup)
- Only displays when valid Monte Carlo inputs are available (remaining issues > 0 and velocity > 0)

## Test plan
- [ ] Open the Release Analysis page and verify each sub-product card header shows "Predicted xx" in teal next to the existing "Due xx" date
- [ ] Confirm the predicted date only appears on products with valid throughput data
- [ ] Hover over the predicted date to verify the tooltip reads "95% confidence predicted completion date (Monte Carlo)"
- [ ] Expand a card's Monte Carlo Simulation section and confirm the 95% confidence date shown there is consistent with the header predicted date
- [ ] Verify dark mode styling renders correctly

Made with [Cursor](https://cursor.com)