### PR TITLE
fix(ai-impact): use stable windowing for metrics, show revised as count

### DIFF
--- a/modules/ai-impact/__tests__/client/AIImpactView.test.js
+++ b/modules/ai-impact/__tests__/client/AIImpactView.test.js
@@ -66,16 +66,17 @@ describe('MetricsRow', () => {
   it('renders metrics when data is loaded', () => {
     const metrics = {
       createdPct: 77,
-      revisedPct: 69,
       createdChange: 5,
-      revisedChange: 3,
       trend: 'growing',
+      revisedCount: 14,
+      priorRevisedCount: 11,
       windowTotal: 20,
       totalRFEs: 62
     }
     const wrapper = mount(MetricsRow, { props: { metrics } })
     expect(wrapper.text()).toContain('77%')
-    expect(wrapper.text()).toContain('69%')
+    expect(wrapper.text()).toContain('14')
+    expect(wrapper.text()).toContain('11 prev period')
     expect(wrapper.text()).toContain('20')
     expect(wrapper.text()).toContain('growing')
   })

--- a/modules/ai-impact/__tests__/server/metrics.test.js
+++ b/modules/ai-impact/__tests__/server/metrics.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeMetrics, buildTrendData, buildBreakdownData, computeAllMetrics, getRelevantDate } from '../../server/metrics.js';
+import { computeMetrics, buildTrendData, buildBreakdownData, computeAllMetrics } from '../../server/metrics.js';
 
 function makeIssue(daysAgo, aiInvolvement = 'none', { createdLabelDate, revisedLabelDate } = {}) {
   const created = new Date();
@@ -15,47 +15,8 @@ function makeIssue(daysAgo, aiInvolvement = 'none', { createdLabelDate, revisedL
   };
 }
 
-describe('getRelevantDate', () => {
-  it('returns created when no label dates exist', () => {
-    const issue = { created: '2026-03-01T10:00:00Z', createdLabelDate: null, revisedLabelDate: null };
-    expect(getRelevantDate(issue)).toBe('2026-03-01T10:00:00Z');
-  });
-
-  it('returns created when label date fields are missing (backward compat)', () => {
-    const issue = { created: '2026-03-01T10:00:00Z' };
-    expect(getRelevantDate(issue)).toBe('2026-03-01T10:00:00Z');
-  });
-
-  it('returns createdLabelDate when it is later than created', () => {
-    const issue = {
-      created: '2026-03-01T10:00:00Z',
-      createdLabelDate: '2026-03-20T14:30:00Z',
-      revisedLabelDate: null
-    };
-    expect(getRelevantDate(issue)).toBe('2026-03-20T14:30:00Z');
-  });
-
-  it('returns revisedLabelDate when it is the latest', () => {
-    const issue = {
-      created: '2026-03-01T10:00:00Z',
-      createdLabelDate: '2026-03-10T10:00:00Z',
-      revisedLabelDate: '2026-03-25T09:15:00Z'
-    };
-    expect(getRelevantDate(issue)).toBe('2026-03-25T09:15:00Z');
-  });
-
-  it('returns the latest of all dates', () => {
-    const issue = {
-      created: '2026-03-30T10:00:00Z',
-      createdLabelDate: '2026-03-10T10:00:00Z',
-      revisedLabelDate: '2026-03-20T10:00:00Z'
-    };
-    expect(getRelevantDate(issue)).toBe('2026-03-30T10:00:00Z');
-  });
-});
-
 describe('computeMetrics', () => {
-  it('computes percentages for "month" time window', () => {
+  it('computes created percentage for "month" time window', () => {
     const issues = [
       makeIssue(5, 'created'),  // within month
       makeIssue(10, 'both'),    // within month
@@ -68,8 +29,6 @@ describe('computeMetrics', () => {
 
     // Current: 3 issues, 2 with created (created + both) = 67%
     expect(result.createdPct).toBe(67);
-    // Current: 3 issues, 1 with revised (both) = 33%
-    expect(result.revisedPct).toBe(33);
     expect(result.windowTotal).toBe(3);
     expect(result.totalRFEs).toBe(5);
   });
@@ -85,7 +44,6 @@ describe('computeMetrics', () => {
 
     expect(result.windowTotal).toBe(3);
     expect(result.createdPct).toBe(33);
-    expect(result.revisedPct).toBe(33);
   });
 
   it('computes "3months" time window', () => {
@@ -160,7 +118,7 @@ describe('computeMetrics', () => {
     const result = computeMetrics([], 'month', { trendThresholdPp: 2 });
 
     expect(result.createdPct).toBe(0);
-    expect(result.revisedPct).toBe(0);
+    expect(result.revisedCount).toBe(0);
     expect(result.windowTotal).toBe(0);
     expect(result.totalRFEs).toBe(0);
     expect(result.trend).toBe('stable');
@@ -175,7 +133,6 @@ describe('computeMetrics', () => {
     const result = computeMetrics(issues, 'month', { trendThresholdPp: 2 });
 
     expect(result.createdPct).toBe(100);
-    expect(result.revisedPct).toBe(100);
   });
 
   it('uses default threshold of 2 when config is null', () => {
@@ -183,8 +140,8 @@ describe('computeMetrics', () => {
     expect(result.trend).toBe('stable');
   });
 
-  it('includes old issue in window when label was recently added', () => {
-    // Issue created 60 days ago, but label added 5 days ago
+  it('windows issues by created date, not label date', () => {
+    // Issue created 60 days ago, label added 5 days ago — should NOT be in the month window
     const labelDate = new Date();
     labelDate.setDate(labelDate.getDate() - 5);
     const issues = [
@@ -194,28 +151,51 @@ describe('computeMetrics', () => {
 
     const result = computeMetrics(issues, 'month', { trendThresholdPp: 2 });
 
-    // Both issues should be in the window (label date pulls old issue in)
-    expect(result.windowTotal).toBe(2);
-    expect(result.createdPct).toBe(50);
-    // Percentage must be <= 100%
-    expect(result.createdPct).toBeLessThanOrEqual(100);
+    // Only the recently-created issue should be in the window
+    expect(result.windowTotal).toBe(1);
+    expect(result.createdPct).toBe(0);
   });
 
-  it('old cached data without label date fields falls back to created', () => {
-    const created = new Date();
-    created.setDate(created.getDate() - 5);
-    const issues = [{
-      key: 'RFE-old',
-      summary: 'Old cached',
-      status: 'New',
-      created: created.toISOString(),
-      aiInvolvement: 'created'
-      // No createdLabelDate or revisedLabelDate fields
-    }];
+  it('counts revisions by revisedLabelDate within the window', () => {
+    const recentLabel = new Date();
+    recentLabel.setDate(recentLabel.getDate() - 3);
+    const issues = [
+      // Old issue revised recently — should count as a revision in this window
+      makeIssue(60, 'revised', { revisedLabelDate: recentLabel.toISOString() }),
+      // Recent issue revised recently
+      makeIssue(5, 'both', { revisedLabelDate: recentLabel.toISOString() }),
+      // Recent issue, no revision
+      makeIssue(5, 'none'),
+    ];
 
     const result = computeMetrics(issues, 'month', { trendThresholdPp: 2 });
-    expect(result.windowTotal).toBe(1);
-    expect(result.createdPct).toBe(100);
+
+    expect(result.revisedCount).toBe(2);
+    // windowTotal only counts issues created in the window
+    expect(result.windowTotal).toBe(2);
+  });
+
+  it('falls back to created date when revisedLabelDate is missing', () => {
+    const issues = [
+      makeIssue(5, 'revised'), // no revisedLabelDate, falls back to created (5 days ago)
+    ];
+
+    const result = computeMetrics(issues, 'month', { trendThresholdPp: 2 });
+
+    expect(result.revisedCount).toBe(1);
+  });
+
+  it('returns priorRevisedCount for the prior window', () => {
+    const priorLabel = new Date();
+    priorLabel.setDate(priorLabel.getDate() - 35);
+    const issues = [
+      makeIssue(60, 'revised', { revisedLabelDate: priorLabel.toISOString() }),
+    ];
+
+    const result = computeMetrics(issues, 'month', { trendThresholdPp: 2 });
+
+    expect(result.revisedCount).toBe(0);
+    expect(result.priorRevisedCount).toBe(1);
   });
 });
 
@@ -226,7 +206,7 @@ describe('buildTrendData', () => {
     expect(buildTrendData([], '3months')).toHaveLength(13);
   });
 
-  it('buckets issues by week', () => {
+  it('buckets issues by week using created date', () => {
     const issues = [
       makeIssue(1, 'created'),
       makeIssue(2, 'both'),
@@ -241,7 +221,7 @@ describe('buildTrendData', () => {
     expect(lastPoint.date).toBeTruthy();
   });
 
-  it('computes per-week percentages correctly', () => {
+  it('computes per-week created percentages correctly', () => {
     // All issues in the same recent week
     const issues = [
       makeIssue(1, 'created'),
@@ -263,13 +243,13 @@ describe('buildTrendData', () => {
     const points = buildTrendData([], 'week');
     for (const p of points) {
       expect(p.createdPct).toBe(0);
-      expect(p.revisedPct).toBe(0);
+      expect(p.revisedCount).toBe(0);
       expect(p.total).toBe(0);
     }
   });
 
-  it('counts label-added issues in the correct week bucket', () => {
-    // Issue created 60 days ago, label added 3 days ago → should appear in recent week
+  it('buckets revised count by revisedLabelDate', () => {
+    // Issue created 60 days ago, label added 3 days ago → revised count in recent week
     const labelDate = new Date();
     labelDate.setDate(labelDate.getDate() - 3);
     const issues = [
@@ -278,9 +258,9 @@ describe('buildTrendData', () => {
 
     const points = buildTrendData(issues, 'month');
     const lastPoint = points[points.length - 1];
-    // The issue should be bucketed in the most recent week (by label date, not created)
-    expect(lastPoint.total).toBe(1);
-    expect(lastPoint.revisedPct).toBe(100);
+    expect(lastPoint.revisedCount).toBe(1);
+    // Total (created-based) should NOT include this old issue
+    expect(lastPoint.total).toBe(0);
   });
 });
 

--- a/modules/ai-impact/client/components/MetricsRow.vue
+++ b/modules/ai-impact/client/components/MetricsRow.vue
@@ -58,18 +58,9 @@ function formatChange(change) {
           Revised with AI
         </p>
         <div class="flex items-baseline gap-2">
-          <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.revisedPct }}%</span>
-          <span class="text-sm flex items-center gap-1" :class="getTrendClass(metrics.revisedTrend)">
-            <svg v-if="metrics.revisedTrend === 'growing'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-            </svg>
-            <svg v-else-if="metrics.revisedTrend === 'declining'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6" />
-            </svg>
-            <svg v-else class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
-            </svg>
-            {{ formatChange(metrics.revisedChange) }}
+          <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.revisedCount }}</span>
+          <span v-if="metrics.priorRevisedCount != null" class="text-xs text-gray-400 dark:text-gray-500">
+            {{ metrics.priorRevisedCount }} prev period
           </span>
         </div>
       </div>

--- a/modules/ai-impact/client/components/TrendCharts.vue
+++ b/modules/ai-impact/client/components/TrendCharts.vue
@@ -36,15 +36,16 @@ const adoptionChartData = computed(() => ({
       borderColor: '#10b981',
       backgroundColor: 'rgba(16, 185, 129, 0.1)',
       fill: true,
-      tension: 0.3
+      tension: 0.3,
+      type: 'line',
+      yAxisID: 'y'
     },
     {
-      label: 'Revised with AI (%)',
-      data: props.trendData.map(p => p.revisedPct),
-      borderColor: '#f59e0b',
-      backgroundColor: 'rgba(245, 158, 11, 0.1)',
-      fill: true,
-      tension: 0.3
+      label: 'Revised with AI',
+      data: props.trendData.map(p => p.revisedCount),
+      backgroundColor: 'rgba(245, 158, 11, 0.5)',
+      type: 'bar',
+      yAxisID: 'y1'
     }
   ]
 }))
@@ -55,7 +56,8 @@ const adoptionChartOptions = {
   plugins: { legend: { display: true, position: 'top', labels: { font: { size: 11 } } } },
   scales: {
     x: { ticks: { font: { size: 10 } } },
-    y: { ticks: { font: { size: 10 } }, title: { display: true, text: '% AI Involvement' } }
+    y: { position: 'left', ticks: { font: { size: 10 } }, title: { display: true, text: '% Created with AI' } },
+    y1: { position: 'right', ticks: { font: { size: 10 }, precision: 0 }, title: { display: true, text: 'Revised (count)' }, grid: { drawOnChartArea: false } }
   }
 }
 
@@ -111,7 +113,7 @@ const breakdownChartOptions = {
                 d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
-              Shows the percentage of RFEs created or revised with AI assistance per week over the selected time window.
+              Shows the percentage of RFEs created with AI per week (line) and the count of RFEs revised with AI per week (bars) over the selected time window.
             </div>
           </div>
         </div>

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -34,7 +34,7 @@ module.exports = function registerRoutes(router, context) {
       return res.json({
         fetchedAt: null,
         jiraHost: JIRA_HOST,
-        metrics: { createdPct: 0, revisedPct: 0, createdChange: 0, revisedChange: 0, trend: 'stable', windowTotal: 0, totalRFEs: 0 },
+        metrics: { createdPct: 0, createdChange: 0, trend: 'stable', revisedCount: 0, priorRevisedCount: 0, windowTotal: 0, totalRFEs: 0 },
         trendData: [],
         breakdown: [],
         issues: []

--- a/modules/ai-impact/server/metrics.js
+++ b/modules/ai-impact/server/metrics.js
@@ -1,23 +1,18 @@
 /**
  * Compute adoption metrics for a given time window.
  *
+ * All windowing is based on issue.created (when the RFE was filed).
+ * The "revised" metric uses revisedLabelDate to count revisions that
+ * happened within the window, reported as a count rather than a percentage.
+ *
  * @param {Array} issues - Cached RFE issue list
  * @param {string} timeWindow - 'week' | 'month' | '3months'
  * @param {object} config - Module config (for trendThresholdPp)
  * @returns {{ metrics, trendData, breakdown }}
  */
-function getRelevantDate(issue) {
-  const dates = [issue.created];
-  if (issue.createdLabelDate) dates.push(issue.createdLabelDate);
-  if (issue.revisedLabelDate) dates.push(issue.revisedLabelDate);
-  return dates.reduce((latest, d) =>
-    new Date(d) > new Date(latest) ? d : latest
-  );
-}
-
 function computeAllMetrics(issues, timeWindow, config) {
   const { cutoff } = getTimeWindowDates(new Date(), timeWindow);
-  const windowIssues = issues.filter(i => new Date(getRelevantDate(i)) >= cutoff);
+  const windowIssues = issues.filter(i => new Date(i.created) >= cutoff);
   return {
     metrics: computeMetrics(issues, timeWindow, config),
     trendData: buildTrendData(issues, timeWindow),
@@ -37,36 +32,43 @@ function computeMetrics(issues, timeWindow, config) {
   const now = new Date();
   const { cutoff, priorCutoff } = getTimeWindowDates(now, timeWindow);
 
-  const currentIssues = issues.filter(i => new Date(getRelevantDate(i)) >= cutoff);
+  // Window issues filtered by creation date only
+  const currentIssues = issues.filter(i => new Date(i.created) >= cutoff);
   const priorIssues = issues.filter(i => {
-    const d = new Date(getRelevantDate(i));
+    const d = new Date(i.created);
     return d >= priorCutoff && d < cutoff;
   });
 
   const currentCreated = currentIssues.filter(i =>
     i.aiInvolvement === 'created' || i.aiInvolvement === 'both').length;
-  const currentRevised = currentIssues.filter(i =>
-    i.aiInvolvement === 'revised' || i.aiInvolvement === 'both').length;
   const currentTotal = currentIssues.length;
 
   const priorCreated = priorIssues.filter(i =>
     i.aiInvolvement === 'created' || i.aiInvolvement === 'both').length;
-  const priorRevised = priorIssues.filter(i =>
-    i.aiInvolvement === 'revised' || i.aiInvolvement === 'both').length;
   const priorTotal = priorIssues.length;
 
   const createdPct = currentTotal > 0 ? Math.round((currentCreated / currentTotal) * 100) : 0;
-  const revisedPct = currentTotal > 0 ? Math.round((currentRevised / currentTotal) * 100) : 0;
   const priorCreatedPct = priorTotal > 0 ? Math.round((priorCreated / priorTotal) * 100) : 0;
-  const priorRevisedPct = priorTotal > 0 ? Math.round((priorRevised / priorTotal) * 100) : 0;
 
   const createdChange = createdPct - priorCreatedPct;
-  const revisedChange = revisedPct - priorRevisedPct;
   const trend = createdChange > threshold ? 'growing' : createdChange < -threshold ? 'declining' : 'stable';
-  const revisedTrend = revisedChange > threshold ? 'growing' : revisedChange < -threshold ? 'declining' : 'stable';
+
+  // Revised count: number of RFEs revised with AI during this window (by label date)
+  const revisedCount = issues.filter(i => {
+    if (i.aiInvolvement !== 'revised' && i.aiInvolvement !== 'both') return false;
+    const d = new Date(i.revisedLabelDate || i.created);
+    return d >= cutoff;
+  }).length;
+
+  const priorRevisedCount = issues.filter(i => {
+    if (i.aiInvolvement !== 'revised' && i.aiInvolvement !== 'both') return false;
+    const d = new Date(i.revisedLabelDate || i.created);
+    return d >= priorCutoff && d < cutoff;
+  }).length;
 
   return {
-    createdPct, revisedPct, createdChange, revisedChange, trend, revisedTrend,
+    createdPct, createdChange, trend,
+    revisedCount, priorRevisedCount,
     windowTotal: currentTotal,
     totalRFEs: issues.length
   };
@@ -81,20 +83,26 @@ function buildTrendData(issues, timeWindow) {
     const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000);
     const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000);
 
+    // Created %: bucket by issue creation date
     const weekIssues = issues.filter(i => {
-      const d = new Date(getRelevantDate(i));
+      const d = new Date(i.created);
       return d >= weekStart && d < weekEnd;
     });
     const total = weekIssues.length;
     const createdWithAI = weekIssues.filter(i =>
       i.aiInvolvement === 'created' || i.aiInvolvement === 'both').length;
-    const revisedWithAI = weekIssues.filter(i =>
-      i.aiInvolvement === 'revised' || i.aiInvolvement === 'both').length;
+
+    // Revised count: bucket by revisedLabelDate (when the revision happened)
+    const revisedCount = issues.filter(i => {
+      if (i.aiInvolvement !== 'revised' && i.aiInvolvement !== 'both') return false;
+      const d = new Date(i.revisedLabelDate || i.created);
+      return d >= weekStart && d < weekEnd;
+    }).length;
 
     points.push({
       date: weekEnd.toISOString().slice(0, 10),
       createdPct: total > 0 ? Math.round((createdWithAI / total) * 100) : 0,
-      revisedPct: total > 0 ? Math.round((revisedWithAI / total) * 100) : 0,
+      revisedCount,
       total
     });
   }
@@ -111,4 +119,4 @@ function buildBreakdownData(issues) {
   ];
 }
 
-module.exports = { computeAllMetrics, computeMetrics, buildTrendData, buildBreakdownData, getTimeWindowDates, getRelevantDate };
+module.exports = { computeAllMetrics, computeMetrics, buildTrendData, buildBreakdownData, getTimeWindowDates };


### PR DESCRIPTION
## Summary

- **Created %** now windows by `issue.created` only, making it stable and
  interpretable ("of RFEs filed this period, what % used the RFE Creator?")
- **Revised metric** is now a raw count instead of a percentage, bucketed by
  `revisedLabelDate` ("how many RFEs were revised with AI this period?")
- Removes `getRelevantDate` which picked the latest of all dates, causing
  issues to jump between time windows and inflating both numerators and
  denominators
- Trend chart shows created % as a line (left axis) and revised count as
  bars (right axis)

## Test plan

- [x] All 85 ai-impact module tests pass
- [x] Lint clean
- [ ] Verify metrics row shows revised as a count with "N prev period" context
- [ ] Verify trend chart renders dual-axis (line + bars) correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)