### PR TITLE
fix(lint): resolve 13 eslint errors from PR #264 merge

### DIFF
--- a/modules/team-tracker/client/views/TeamDirectoryView.vue
+++ b/modules/team-tracker/client/views/TeamDirectoryView.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { ref, computed, onMounted, inject } from 'vue'
+import { onMounted, inject } from 'vue'
 import { useOrgRoster } from '../composables/useOrgRoster'
 import OrgSelector from '../components/OrgSelector.vue'
 import TeamCard from '../components/TeamCard.vue'
 
 const nav = inject('moduleNav')
-const { teams, orgs, selectedOrg, loading, error, searchQuery, sortBy, filteredTeams, loadTeams, loadOrgs } = useOrgRoster()
+const { orgs, selectedOrg, loading, searchQuery, sortBy, filteredTeams, loadTeams, loadOrgs } = useOrgRoster()
 
 function openTeam(team) {
   nav.navigateTo('team-detail', { teamKey: `${team.org}::${team.name}` })

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -261,7 +261,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
   router.get('/components', function(req, res) {
     try {
       res.json(readFromStorage('org-roster/components.json') || { components: {} });
-    } catch (error) {
+    } catch {
       res.status(500).json({ error: 'Failed to load component data' });
     }
   });
@@ -283,7 +283,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
         }
       }
       res.json(data);
-    } catch (error) {
+    } catch {
       res.status(500).json({ error: 'Failed to load RFE backlog data' });
     }
   });
@@ -297,7 +297,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
         rfeIssueType: config.rfeIssueType || 'Feature Request',
         componentMapping: config.componentMapping || {}
       });
-    } catch (error) {
+    } catch {
       res.status(500).json({ error: 'Failed to load RFE config' });
     }
   });
@@ -306,7 +306,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
 
   router.get('/org-config', requireAdmin, function(req, res) {
     try { res.json(getOrgConfig()); }
-    catch (error) { res.status(500).json({ error: 'Failed to load configuration' }); }
+    catch { res.status(500).json({ error: 'Failed to load configuration' }); }
   });
 
   router.post('/org-config', requireAdmin, function(req, res) {
@@ -316,7 +316,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
         return res.status(400).json({ error: 'Request body must be a JSON object' });
       }
 
-      const allowedKeys = ['teamBoardsTab', 'componentsTab', 'jiraProject', 'rfeIssueType', 'orgNameMapping', 'componentMapping'];
+      const _allowedKeys = ['teamBoardsTab', 'componentsTab', 'jiraProject', 'rfeIssueType', 'orgNameMapping', 'componentMapping'];
       const config = getOrgConfig();
 
       if (body.teamBoardsTab !== undefined && typeof body.teamBoardsTab === 'string') config.teamBoardsTab = body.teamBoardsTab;
@@ -328,7 +328,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
 
       writeToStorage('org-roster/config.json', config);
       res.json({ status: 'saved', config });
-    } catch (error) {
+    } catch {
       res.status(500).json({ error: 'Failed to save configuration' });
     }
   });
@@ -339,7 +339,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
     try {
       const data = readFromStorage('org-roster/sync-status.json');
       res.json(data || { lastSyncAt: null, status: 'never', syncing: orgSyncInProgress });
-    } catch (error) {
+    } catch {
       res.status(500).json({ error: 'Failed to load sync status' });
     }
   });

--- a/shared/server/roster-sync/ipa-client.js
+++ b/shared/server/roster-sync/ipa-client.js
@@ -32,7 +32,7 @@ function escapeLdapFilter(value) {
     .replace(/\*/g, '\\2a')
     .replace(/\(/g, '\\28')
     .replace(/\)/g, '\\29')
-    .replace(/\x00/g, '\\00');
+    .replace(/\x00/g, '\\00'); // eslint-disable-line no-control-regex
 }
 
 const DEFAULT_HOST = 'ldaps://ipa.corp.redhat.com';

--- a/shared/server/roster-sync/ldap.js
+++ b/shared/server/roster-sync/ldap.js
@@ -104,7 +104,7 @@ function escapeLdapFilter(value) {
     .replace(/\*/g, '\\2a')
     .replace(/\(/g, '\\28')
     .replace(/\)/g, '\\29')
-    .replace(/\x00/g, '\\00');
+    .replace(/\x00/g, '\\00'); // eslint-disable-line no-control-regex
 }
 
 async function traverseOrg(client, rootUid) {


### PR DESCRIPTION
Fixes the 13 lint errors that came in with the team-data/org-roster consolidation (#264):

- **TeamDirectoryView.vue**: Remove unused imports (`ref`, `computed`) and unused destructured vars (`teams`, `error`)
- **org-teams.js**: Remove unused catch parameters in 6 route handlers; prefix unused `allowedKeys` with `_`
- **ipa-client.js / ldap.js**: Add `eslint-disable-line no-control-regex` for intentional `\x00` in LDAP filter escaping

All fixes are minimal — no logic changes.