### PR TITLE
deploy(preprod): update backend + frontend images to 95620a5

### DIFF
--- a/deploy/openshift/overlays/preprod/kustomization.yaml
+++ b/deploy/openshift/overlays/preprod/kustomization.yaml
@@ -9,3 +9,9 @@ resources:
 patches:
   - path: route-patch.yaml
   - path: api-route-patch.yaml
+
+images:
+  - name: quay.io/org-pulse/team-tracker-backend
+    newTag: "95620a54e0103a0fd65d133edd37ca01c566f026"
+  - name: quay.io/org-pulse/team-tracker-frontend
+    newTag: "95620a54e0103a0fd65d133edd37ca01c566f026"


### PR DESCRIPTION
Pins the preprod overlay to the newly built container images from the PR #264 consolidation merge.

**Images pushed to Quay (build [#24528758499](https://github.com/red-hat-data-services/rhai-org-pulse/actions/runs/24528758499)):**
- `quay.io/org-pulse/team-tracker-backend:95620a54e0103a0fd65d133edd37ca01c566f026`
- `quay.io/org-pulse/team-tracker-frontend:95620a54e0103a0fd65d133edd37ca01c566f026`

**Changes:**
- Adds `images:` block to `deploy/openshift/overlays/preprod/kustomization.yaml` pinning both images to the preprod SHA

Manifest-only change — no code changes.