### PR TITLE
feat(upstream-pulse): add strategic classification UI for portfolio management

### DIFF
--- a/modules/upstream-pulse/__tests__/client/useStrategicClassification.test.js
+++ b/modules/upstream-pulse/__tests__/client/useStrategicClassification.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getEngagementStatus,
+  getStrategicLabel,
+  getStrategicBadgeClass,
+  getStrategicDescription,
+} from '../../client/composables/useStrategicClassification.js'
+
+describe('useStrategicClassification', () => {
+  describe('getEngagementStatus', () => {
+    it('returns New Entrant when no contributions or governance', () => {
+      const result = getEngagementStatus(0, 0, 0)
+      expect(result.label).toBe('New Entrant')
+      expect(result.classes).toContain('text-gray-600')
+      expect(result.description).toBe('No contributions or governance positions yet')
+    })
+
+    it('returns Established Leader with 3+ leadership positions', () => {
+      const result = getEngagementStatus(3, 0, 10)
+      expect(result.label).toBe('Established Leader')
+      expect(result.classes).toContain('text-blue-700')
+      expect(result.description).toContain('3+ leadership positions')
+    })
+
+    it('returns Established Leader with 5+ maintainers', () => {
+      const result = getEngagementStatus(0, 5, 10)
+      expect(result.label).toBe('Established Leader')
+      expect(result.classes).toContain('text-blue-700')
+    })
+
+    it('returns Core Contributor with any governance', () => {
+      const result = getEngagementStatus(1, 0, 5)
+      expect(result.label).toBe('Core Contributor')
+      expect(result.classes).toContain('text-indigo-700')
+      expect(result.description).toContain('leadership or maintainer positions')
+    })
+
+    it('returns Active with contributions but no governance', () => {
+      const result = getEngagementStatus(0, 0, 50)
+      expect(result.label).toBe('Active')
+      expect(result.classes).toContain('text-gray-600')
+      expect(result.description).toContain('Contributing code')
+    })
+
+    it('prioritizes high governance over contributions', () => {
+      const result = getEngagementStatus(5, 0, 1000)
+      expect(result.label).toBe('Established Leader')
+    })
+
+    it('returns Active when only contributions exist', () => {
+      const result = getEngagementStatus(0, 0, 100)
+      expect(result.label).toBe('Active')
+    })
+  })
+
+  describe('getStrategicLabel', () => {
+    it('returns correct label for evaluating_participation', () => {
+      expect(getStrategicLabel('evaluating_participation')).toBe('Evaluating Participation')
+    })
+
+    it('returns correct label for sustaining_participation', () => {
+      expect(getStrategicLabel('sustaining_participation')).toBe('Sustaining Participation')
+    })
+
+    it('returns correct label for increasing_participation', () => {
+      expect(getStrategicLabel('increasing_participation')).toBe('Increasing Participation')
+    })
+
+    it('returns correct label for evaluating_leadership', () => {
+      expect(getStrategicLabel('evaluating_leadership')).toBe('Evaluating Leadership')
+    })
+
+    it('returns correct label for sustaining_leadership', () => {
+      expect(getStrategicLabel('sustaining_leadership')).toBe('Sustaining Leadership')
+    })
+
+    it('returns correct label for increasing_leadership', () => {
+      expect(getStrategicLabel('increasing_leadership')).toBe('Increasing Leadership')
+    })
+
+    it('returns empty string for null/undefined', () => {
+      expect(getStrategicLabel(null)).toBe('')
+      expect(getStrategicLabel(undefined)).toBe('')
+    })
+
+    it('returns the input for unknown values', () => {
+      expect(getStrategicLabel('unknown')).toBe('unknown')
+    })
+  })
+
+  describe('getStrategicBadgeClass', () => {
+    it('returns yellow classes for evaluating strategies', () => {
+      expect(getStrategicBadgeClass('evaluating_participation')).toContain('bg-yellow-100')
+      expect(getStrategicBadgeClass('evaluating_leadership')).toContain('bg-yellow-100')
+    })
+
+    it('returns blue classes for sustaining strategies', () => {
+      expect(getStrategicBadgeClass('sustaining_participation')).toContain('bg-blue-100')
+      expect(getStrategicBadgeClass('sustaining_leadership')).toContain('bg-blue-100')
+    })
+
+    it('returns green classes for increasing strategies', () => {
+      expect(getStrategicBadgeClass('increasing_participation')).toContain('bg-green-100')
+      expect(getStrategicBadgeClass('increasing_leadership')).toContain('bg-green-100')
+    })
+
+    it('returns default gray classes for unknown values', () => {
+      expect(getStrategicBadgeClass('unknown')).toContain('bg-gray-100')
+    })
+  })
+
+  describe('getStrategicDescription', () => {
+    it('returns correct description for evaluating_participation', () => {
+      const desc = getStrategicDescription('evaluating_participation')
+      expect(desc).toContain('evaluating whether to increase participation')
+    })
+
+    it('returns correct description for sustaining_participation', () => {
+      const desc = getStrategicDescription('sustaining_participation')
+      expect(desc).toContain('sustaining current participation levels')
+    })
+
+    it('returns correct description for increasing_participation', () => {
+      const desc = getStrategicDescription('increasing_participation')
+      expect(desc).toContain('actively increasing participation')
+    })
+
+    it('returns correct description for evaluating_leadership', () => {
+      const desc = getStrategicDescription('evaluating_leadership')
+      expect(desc).toContain('evaluating whether to pursue leadership')
+    })
+
+    it('returns correct description for sustaining_leadership', () => {
+      const desc = getStrategicDescription('sustaining_leadership')
+      expect(desc).toContain('sustaining current leadership presence')
+    })
+
+    it('returns correct description for increasing_leadership', () => {
+      const desc = getStrategicDescription('increasing_leadership')
+      expect(desc).toContain('actively pursuing more leadership')
+    })
+
+    it('returns empty string for unknown values', () => {
+      expect(getStrategicDescription('unknown')).toBe('')
+    })
+  })
+})

--- a/modules/upstream-pulse/client/components/LeadershipStrategy.vue
+++ b/modules/upstream-pulse/client/components/LeadershipStrategy.vue
@@ -1,0 +1,215 @@
+<template>
+  <div>
+    <!-- Increase Investment -->
+    <div v-if="increaseInvestment.length > 0" class="mb-6">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Increase Investment</h4>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <div
+          v-for="org in increaseInvestment"
+          :key="org.org"
+          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
+          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
+          @click="$emit('org-click', org.org)"
+        >
+          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
+            {{ org.orgName }}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center">
+            <span
+              v-if="org.strategicLeadership"
+              :class="getStrategicBadgeClass(org.strategicLeadership)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicLeadership) }}
+            </span>
+            <span
+              v-if="org.strategicParticipation"
+              :class="getStrategicBadgeClass(org.strategicParticipation)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicParticipation) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sustain Investment -->
+    <div v-if="sustainInvestment.length > 0" class="mb-6">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Sustain Investment</h4>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <div
+          v-for="org in sustainInvestment"
+          :key="org.org"
+          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
+          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
+          @click="$emit('org-click', org.org)"
+        >
+          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
+            {{ org.orgName }}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center">
+            <span
+              v-if="org.strategicLeadership"
+              :class="getStrategicBadgeClass(org.strategicLeadership)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicLeadership) }}
+            </span>
+            <span
+              v-if="org.strategicParticipation"
+              :class="getStrategicBadgeClass(org.strategicParticipation)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicParticipation) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Evaluating Investment -->
+    <div v-if="evaluatingInvestment.length > 0">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Evaluating Investment</h4>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <div
+          v-for="org in evaluatingInvestment"
+          :key="org.org"
+          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
+          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
+          @click="$emit('org-click', org.org)"
+        >
+          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
+            {{ org.orgName }}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center">
+            <span
+              v-if="org.strategicLeadership"
+              :class="getStrategicBadgeClass(org.strategicLeadership)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicLeadership) }}
+            </span>
+            <span
+              v-if="org.strategicParticipation"
+              :class="getStrategicBadgeClass(org.strategicParticipation)"
+              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
+            >
+              {{ getStrategicLabel(org.strategicParticipation) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="increaseInvestment.length === 0 && sustainInvestment.length === 0 && evaluatingInvestment.length === 0" class="text-center py-8">
+      <p class="text-sm text-gray-500 dark:text-gray-400">No organizations with strategic importance assigned</p>
+    </div>
+
+    <!-- Legend -->
+    <div v-if="increaseInvestment.length > 0 || sustainInvestment.length > 0 || evaluatingInvestment.length > 0" class="flex items-center justify-center gap-6 text-sm mt-6 pt-4 border-t border-gray-100 dark:border-gray-700">
+      <div class="flex items-center gap-2">
+        <div class="w-4 h-4 rounded bg-red-400 dark:bg-red-800/35"></div>
+        <span class="text-gray-600 dark:text-gray-400 font-medium">Red Hat Leads</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <div class="w-4 h-4 rounded bg-gray-200 dark:bg-gray-700/40"></div>
+        <span class="text-gray-600 dark:text-gray-400 font-medium">Red Hat Participates</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+defineEmits(['org-click'])
+
+const props = defineProps({
+  orgActivity: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const increaseInvestment = computed(() => {
+  return props.orgActivity
+    .filter(org =>
+      org.strategicParticipation === 'increasing_participation' ||
+      org.strategicLeadership === 'increasing_leadership'
+    )
+    .filter(org => org.leadershipCount > 0 || org.total > 0 || org.maintainerCount > 0)
+    .map(org => ({
+      ...org,
+      leads: org.leadershipCount > 0
+    }))
+})
+
+const sustainInvestment = computed(() => {
+  return props.orgActivity
+    .filter(org => {
+      // No increase tags
+      const hasIncrease = org.strategicParticipation === 'increasing_participation' ||
+                         org.strategicLeadership === 'increasing_leadership'
+      if (hasIncrease) return false
+
+      // Has at least one sustain tag
+      return org.strategicParticipation === 'sustaining_participation' ||
+             org.strategicLeadership === 'sustaining_leadership'
+    })
+    .filter(org => org.leadershipCount > 0 || org.total > 0 || org.maintainerCount > 0)
+    .map(org => ({
+      ...org,
+      leads: org.leadershipCount > 0
+    }))
+})
+
+const evaluatingInvestment = computed(() => {
+  return props.orgActivity
+    .filter(org => {
+      // No increase tags
+      const hasIncrease = org.strategicParticipation === 'increasing_participation' ||
+                         org.strategicLeadership === 'increasing_leadership'
+      if (hasIncrease) return false
+
+      // No sustain tags
+      const hasSustain = org.strategicParticipation === 'sustaining_participation' ||
+                        org.strategicLeadership === 'sustaining_leadership'
+      if (hasSustain) return false
+
+      // Has at least one evaluating tag
+      return org.strategicParticipation === 'evaluating_participation' ||
+             org.strategicLeadership === 'evaluating_leadership'
+    })
+    .filter(org => org.leadershipCount > 0 || org.total > 0 || org.maintainerCount > 0)
+    .map(org => ({
+      ...org,
+      leads: org.leadershipCount > 0
+    }))
+})
+
+function getStrategicLabel(strategic) {
+  if (!strategic) return ''
+  const labels = {
+    'evaluating_participation': 'Evaluating Participation',
+    'sustaining_participation': 'Sustaining Participation',
+    'increasing_participation': 'Increasing Participation',
+    'evaluating_leadership': 'Evaluating Leadership',
+    'sustaining_leadership': 'Sustaining Leadership',
+    'increasing_leadership': 'Increasing Leadership',
+  }
+  return labels[strategic] || strategic
+}
+
+function getStrategicBadgeClass(strategic) {
+  const classes = {
+    'evaluating_participation': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_participation': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_participation': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    'evaluating_leadership': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_leadership': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_leadership': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  }
+  return classes[strategic] || 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
+}
+</script>

--- a/modules/upstream-pulse/client/components/LeadershipStrategy.vue
+++ b/modules/upstream-pulse/client/components/LeadershipStrategy.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
-    <!-- Increase Investment -->
-    <div v-if="increaseInvestment.length > 0" class="mb-6">
-      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Increase Investment</h4>
+    <div v-for="tier in tiers" :key="tier.title" class="mb-6">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">{{ tier.title }}</h4>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
         <div
-          v-for="org in increaseInvestment"
+          v-for="org in tier.items"
           :key="org.org"
           class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
           :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
@@ -34,80 +33,12 @@
       </div>
     </div>
 
-    <!-- Sustain Investment -->
-    <div v-if="sustainInvestment.length > 0" class="mb-6">
-      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Sustain Investment</h4>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-        <div
-          v-for="org in sustainInvestment"
-          :key="org.org"
-          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
-          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
-          @click="$emit('org-click', org.org)"
-        >
-          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
-            {{ org.orgName }}
-          </div>
-          <div class="flex flex-wrap gap-1 justify-center">
-            <span
-              v-if="org.strategicLeadership"
-              :class="getStrategicBadgeClass(org.strategicLeadership)"
-              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
-            >
-              {{ getStrategicLabel(org.strategicLeadership) }}
-            </span>
-            <span
-              v-if="org.strategicParticipation"
-              :class="getStrategicBadgeClass(org.strategicParticipation)"
-              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
-            >
-              {{ getStrategicLabel(org.strategicParticipation) }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Evaluating Investment -->
-    <div v-if="evaluatingInvestment.length > 0">
-      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Evaluating Investment</h4>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-        <div
-          v-for="org in evaluatingInvestment"
-          :key="org.org"
-          class="rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
-          :class="org.leads ? 'bg-red-400 dark:bg-red-800/35' : 'bg-gray-200 dark:bg-gray-700/40'"
-          @click="$emit('org-click', org.org)"
-        >
-          <div class="text-sm font-semibold text-center mb-2 text-gray-900 dark:text-gray-100">
-            {{ org.orgName }}
-          </div>
-          <div class="flex flex-wrap gap-1 justify-center">
-            <span
-              v-if="org.strategicLeadership"
-              :class="getStrategicBadgeClass(org.strategicLeadership)"
-              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
-            >
-              {{ getStrategicLabel(org.strategicLeadership) }}
-            </span>
-            <span
-              v-if="org.strategicParticipation"
-              :class="getStrategicBadgeClass(org.strategicParticipation)"
-              class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap"
-            >
-              {{ getStrategicLabel(org.strategicParticipation) }}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div v-if="increaseInvestment.length === 0 && sustainInvestment.length === 0 && evaluatingInvestment.length === 0" class="text-center py-8">
+    <div v-if="tiers.length === 0" class="text-center py-8">
       <p class="text-sm text-gray-500 dark:text-gray-400">No organizations with strategic importance assigned</p>
     </div>
 
     <!-- Legend -->
-    <div v-if="increaseInvestment.length > 0 || sustainInvestment.length > 0 || evaluatingInvestment.length > 0" class="flex items-center justify-center gap-6 text-sm mt-6 pt-4 border-t border-gray-100 dark:border-gray-700">
+    <div v-if="tiers.length > 0" class="flex items-center justify-center gap-6 text-sm mt-6">
       <div class="flex items-center gap-2">
         <div class="w-4 h-4 rounded bg-red-400 dark:bg-red-800/35"></div>
         <span class="text-gray-600 dark:text-gray-400 font-medium">Red Hat Leads</span>
@@ -122,6 +53,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { getStrategicLabel, getStrategicBadgeClass } from '../composables/useStrategicClassification.js'
 
 defineEmits(['org-click'])
 
@@ -188,28 +120,9 @@ const evaluatingInvestment = computed(() => {
     }))
 })
 
-function getStrategicLabel(strategic) {
-  if (!strategic) return ''
-  const labels = {
-    'evaluating_participation': 'Evaluating Participation',
-    'sustaining_participation': 'Sustaining Participation',
-    'increasing_participation': 'Increasing Participation',
-    'evaluating_leadership': 'Evaluating Leadership',
-    'sustaining_leadership': 'Sustaining Leadership',
-    'increasing_leadership': 'Increasing Leadership',
-  }
-  return labels[strategic] || strategic
-}
-
-function getStrategicBadgeClass(strategic) {
-  const classes = {
-    'evaluating_participation': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    'sustaining_participation': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-    'increasing_participation': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-    'evaluating_leadership': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    'sustaining_leadership': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-    'increasing_leadership': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  }
-  return classes[strategic] || 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
-}
+const tiers = computed(() => [
+  { title: 'Increase Investment', items: increaseInvestment.value },
+  { title: 'Sustain Investment', items: sustainInvestment.value },
+  { title: 'Evaluating Investment', items: evaluatingInvestment.value },
+].filter(t => t.items.length > 0))
 </script>

--- a/modules/upstream-pulse/client/components/OrgActivityCard.vue
+++ b/modules/upstream-pulse/client/components/OrgActivityCard.vue
@@ -78,6 +78,7 @@ import {
   Shield as ShieldIcon,
   ChevronRight as ChevronRightIcon,
 } from 'lucide-vue-next'
+import { getEngagementStatus } from '../composables/useStrategicClassification.js'
 
 defineEmits(['click'])
 
@@ -99,33 +100,9 @@ const props = defineProps({
 
 const teamShareLabel = computed(() => Number(props.teamSharePercent).toFixed(1))
 
-const engagementStatus = computed(() => {
-  const hasGovernance = props.leadershipCount > 0 || props.maintainerCount > 0
-  const highGovernance = props.leadershipCount >= 3 || props.maintainerCount >= 5
-
-  if (props.teamContributions === 0 && !hasGovernance) {
-    return {
-      label: 'New Entrant',
-      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
-    }
-  }
-  if (highGovernance) {
-    return {
-      label: 'Established Leader',
-      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700'
-    }
-  }
-  if (hasGovernance) {
-    return {
-      label: 'Core Contributor',
-      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700'
-    }
-  }
-  return {
-    label: 'Active',
-    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
-  }
-})
+const engagementStatus = computed(() =>
+  getEngagementStatus(props.leadershipCount, props.maintainerCount, props.teamContributions)
+)
 
 const trendArrow = computed(() => {
   if (props.percentChange > 0) return '↑'

--- a/modules/upstream-pulse/client/components/OrgActivityCard.vue
+++ b/modules/upstream-pulse/client/components/OrgActivityCard.vue
@@ -4,14 +4,20 @@
     :class="{ 'cursor-pointer': clickable }"
     @click="$emit('click')"
   >
-    <!-- Row 1: Name + engagement badge + hover chevron -->
+    <!-- Row 1: Name + engagement status + hover chevron -->
     <div class="flex items-start justify-between mb-3">
       <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{{ orgName }}</h3>
-      <ChevronRightIcon
-        v-if="clickable"
-        :size="16"
-        class="shrink-0 ml-2 text-gray-300 dark:text-gray-600 opacity-0 group-hover/card:opacity-100 transition-opacity duration-200"
-      />
+      <div class="flex items-center gap-2 shrink-0 ml-2">
+        <span :class="engagementStatus.classes"
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap border">
+          {{ engagementStatus.label }}
+        </span>
+        <ChevronRightIcon
+          v-if="clickable"
+          :size="16"
+          class="text-gray-300 dark:text-gray-600 opacity-0 group-hover/card:opacity-100 transition-opacity duration-200"
+        />
+      </div>
     </div>
 
     <!-- Row 2: Contribution count + trend -->
@@ -77,6 +83,8 @@ defineEmits(['click'])
 
 const props = defineProps({
   orgName: { type: String, default: '' },
+  strategicParticipation: { type: String, default: null },
+  strategicLeadership: { type: String, default: null },
   teamContributions: { type: Number, default: 0 },
   totalContributions: { type: Number, default: 0 },
   teamSharePercent: { type: Number, default: 0 },
@@ -90,6 +98,34 @@ const props = defineProps({
 })
 
 const teamShareLabel = computed(() => Number(props.teamSharePercent).toFixed(1))
+
+const engagementStatus = computed(() => {
+  const hasGovernance = props.leadershipCount > 0 || props.maintainerCount > 0
+  const highGovernance = props.leadershipCount >= 3 || props.maintainerCount >= 5
+
+  if (props.teamContributions === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700'
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700'
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+  }
+})
 
 const trendArrow = computed(() => {
   if (props.percentChange > 0) return '↑'

--- a/modules/upstream-pulse/client/components/OrgActivityCard.vue
+++ b/modules/upstream-pulse/client/components/OrgActivityCard.vue
@@ -84,8 +84,6 @@ defineEmits(['click'])
 
 const props = defineProps({
   orgName: { type: String, default: '' },
-  strategicParticipation: { type: String, default: null },
-  strategicLeadership: { type: String, default: null },
   teamContributions: { type: Number, default: 0 },
   totalContributions: { type: Number, default: 0 },
   teamSharePercent: { type: Number, default: 0 },

--- a/modules/upstream-pulse/client/composables/useStrategicClassification.js
+++ b/modules/upstream-pulse/client/composables/useStrategicClassification.js
@@ -1,0 +1,70 @@
+const STRATEGIC_LABELS = {
+  evaluating_participation: 'Evaluating Participation',
+  sustaining_participation: 'Sustaining Participation',
+  increasing_participation: 'Increasing Participation',
+  evaluating_leadership: 'Evaluating Leadership',
+  sustaining_leadership: 'Sustaining Leadership',
+  increasing_leadership: 'Increasing Leadership',
+}
+
+const STRATEGIC_BADGE_CLASSES = {
+  evaluating_participation: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  sustaining_participation: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  increasing_participation: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  evaluating_leadership: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  sustaining_leadership: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  increasing_leadership: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+}
+
+const STRATEGIC_DESCRIPTIONS = {
+  evaluating_participation: 'Red Hat is evaluating whether to increase participation in this project',
+  sustaining_participation: 'Red Hat is sustaining current participation levels in this project',
+  increasing_participation: 'Red Hat is actively increasing participation in this project',
+  evaluating_leadership: 'Red Hat is evaluating whether to pursue leadership positions in this project',
+  sustaining_leadership: 'Red Hat is sustaining current leadership presence in this project',
+  increasing_leadership: 'Red Hat is actively pursuing more leadership positions in this project',
+}
+
+export function getStrategicLabel(strategic) {
+  return STRATEGIC_LABELS[strategic] || strategic || ''
+}
+
+export function getStrategicBadgeClass(strategic) {
+  return STRATEGIC_BADGE_CLASSES[strategic] || 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
+}
+
+export function getStrategicDescription(strategic) {
+  return STRATEGIC_DESCRIPTIONS[strategic] || ''
+}
+
+export function getEngagementStatus(leadershipCount, maintainerCount, total) {
+  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
+  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
+
+  if (total === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+      description: 'No contributions or governance positions yet',
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700',
+      description: 'Significant influence with 3+ leadership positions or 5+ maintainers',
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700',
+      description: 'Active participation with leadership or maintainer positions',
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+    description: 'Contributing code without formal governance positions',
+  }
+}

--- a/modules/upstream-pulse/client/views/Dashboard.vue
+++ b/modules/upstream-pulse/client/views/Dashboard.vue
@@ -194,9 +194,11 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <OrgActivityCard
-            v-for="activity in orgActivity"
+            v-for="activity in orgActivity.slice(0, 4)"
             :key="activity.org"
             :org-name="activity.orgName"
+            :strategic-participation="activity.strategicParticipation"
+            :strategic-leadership="activity.strategicLeadership"
             :team-contributions="activity.total || 0"
             :total-contributions="activity.totalContributions || 0"
             :team-share-percent="activity.teamSharePercent || 0"
@@ -345,6 +347,15 @@
           <p class="text-sm text-gray-500 dark:text-gray-400 hidden sm:block">Team influence in upstream governance</p>
         </div>
 
+        <!-- Leadership Strategy -->
+        <div v-if="orgActivity.length" class="mb-6">
+          <h4 class="text-base font-semibold text-gray-700 dark:text-gray-300 mb-3">Leadership Strategy</h4>
+          <LeadershipStrategy
+            :org-activity="orgActivity"
+            @org-click="(org) => nav.navigateTo('org-detail', { org })"
+          />
+        </div>
+
         <div v-if="!leadership && !communityOrgs.length" class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/60 p-8 text-center">
           <p class="text-sm text-gray-500 dark:text-gray-400">No leadership data available</p>
         </div>
@@ -392,7 +403,7 @@
                       <p class="text-xs text-gray-500 dark:text-gray-400">{{ leader.positionCount === 1 ? 'position' : 'positions' }}</p>
                     </div>
                   </div>
-                  <div class="hidden group-hover:block pl-16 pr-4 pb-3">
+                  <div class="pl-16 pr-4 pb-3 pt-1">
                     <div class="flex flex-wrap gap-1.5">
                       <span
                         v-for="detail in leader.roleDetails"
@@ -549,6 +560,7 @@ import LeadershipCard from '../components/LeadershipCard.vue'
 import ContributionTrendChart from '../components/ContributionTrendChart.vue'
 import OrgActivityCard from '../components/OrgActivityCard.vue'
 import ProjectCard from '../components/ProjectCard.vue'
+import LeadershipStrategy from '../components/LeadershipStrategy.vue'
 import AddProjectModal from '../components/AddProjectModal.vue'
 import { StatCardSkeleton, ContributionCardSkeleton, OrgCardSkeleton, ProjectCardSkeleton, ContributorRowSkeleton } from '../components/SkeletonLoaders.vue'
 import { useGovernanceCards, uniqueRoles } from '../composables/useGovernanceCards.js'

--- a/modules/upstream-pulse/client/views/Dashboard.vue
+++ b/modules/upstream-pulse/client/views/Dashboard.vue
@@ -194,7 +194,7 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <OrgActivityCard
-            v-for="activity in orgActivity.slice(0, 4)"
+            v-for="activity in orgActivity.slice(0, DASHBOARD_ORG_LIMIT)"
             :key="activity.org"
             :org-name="activity.orgName"
             :strategic-participation="activity.strategicParticipation"
@@ -569,6 +569,8 @@ const nav = inject('moduleNav')
 const { isAdmin } = useAuth()
 const showAddProject = ref(false)
 const MODULE_API = '/modules/upstream-pulse'
+
+const DASHBOARD_ORG_LIMIT = 4
 
 const periodOptions = [
   { label: '30d', value: '30' },

--- a/modules/upstream-pulse/client/views/Dashboard.vue
+++ b/modules/upstream-pulse/client/views/Dashboard.vue
@@ -197,8 +197,6 @@
             v-for="activity in orgActivity.slice(0, DASHBOARD_ORG_LIMIT)"
             :key="activity.org"
             :org-name="activity.orgName"
-            :strategic-participation="activity.strategicParticipation"
-            :strategic-leadership="activity.strategicLeadership"
             :team-contributions="activity.total || 0"
             :total-contributions="activity.totalContributions || 0"
             :team-share-percent="activity.teamSharePercent || 0"

--- a/modules/upstream-pulse/client/views/OrgDetail.vue
+++ b/modules/upstream-pulse/client/views/OrgDetail.vue
@@ -17,6 +17,8 @@
           <div v-if="dashboard" class="relative group/engagement">
             <span
               :class="engagementStatus.classes"
+              :title="engagementStatus.description"
+              :aria-label="engagementStatus.description"
               class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border"
             >
               {{ engagementStatus.label }}
@@ -32,8 +34,10 @@
             <span
               class="px-3 py-1 rounded-full text-xs font-semibold"
               :class="getStrategicBadgeClass(strategicLeadership)"
+              :title="getStrategicDescription(strategicLeadership)"
+              :aria-label="getStrategicDescription(strategicLeadership)"
             >
-              {{ getStrategicLabel(strategicLeadership, 'leadership') }}
+              {{ getStrategicLabel(strategicLeadership) }}
             </span>
             <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/leadership:opacity-100 group-hover/leadership:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
               {{ getStrategicDescription(strategicLeadership) }}
@@ -46,8 +50,10 @@
             <span
               class="px-3 py-1 rounded-full text-xs font-semibold"
               :class="getStrategicBadgeClass(strategicParticipation)"
+              :title="getStrategicDescription(strategicParticipation)"
+              :aria-label="getStrategicDescription(strategicParticipation)"
             >
-              {{ getStrategicLabel(strategicParticipation, 'participation') }}
+              {{ getStrategicLabel(strategicParticipation) }}
             </span>
             <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/participation:opacity-100 group-hover/participation:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
               {{ getStrategicDescription(strategicParticipation) }}
@@ -514,6 +520,7 @@ import LeadershipCard from '../components/LeadershipCard.vue'
 import ContributionTrendChart from '../components/ContributionTrendChart.vue'
 import ImpactBanner from '../components/ImpactBanner.vue'
 import { useGovernanceCards, uniqueRoles } from '../composables/useGovernanceCards.js'
+import { getStrategicLabel, getStrategicBadgeClass, getStrategicDescription, getEngagementStatus } from '../composables/useStrategicClassification.js'
 
 const nav = inject('moduleNav')
 
@@ -545,42 +552,6 @@ const membersExpanded = ref(false)
 const governanceExpanded = ref(false)
 const orgProjects = ref([])
 
-function getStrategicLabel(strategic, _type) {
-  if (!strategic) return ''
-  const labels = {
-    'evaluating_participation': 'Evaluating Participation',
-    'sustaining_participation': 'Sustaining Participation',
-    'increasing_participation': 'Increasing Participation',
-    'evaluating_leadership': 'Evaluating Leadership',
-    'sustaining_leadership': 'Sustaining Leadership',
-    'increasing_leadership': 'Increasing Leadership',
-  }
-  return labels[strategic] || strategic
-}
-
-function getStrategicBadgeClass(strategic) {
-  const classes = {
-    'evaluating_participation': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    'sustaining_participation': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-    'increasing_participation': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-    'evaluating_leadership': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
-    'sustaining_leadership': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-    'increasing_leadership': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  }
-  return classes[strategic] || ''
-}
-
-function getStrategicDescription(strategic) {
-  const descriptions = {
-    'evaluating_participation': 'Red Hat is evaluating whether to increase participation in this project',
-    'sustaining_participation': 'Red Hat is sustaining current participation levels in this project',
-    'increasing_participation': 'Red Hat is actively increasing participation in this project',
-    'evaluating_leadership': 'Red Hat is evaluating whether to pursue leadership positions in this project',
-    'sustaining_leadership': 'Red Hat is sustaining current leadership presence in this project',
-    'increasing_leadership': 'Red Hat is actively pursuing more leadership positions in this project',
-  }
-  return descriptions[strategic] || ''
-}
 
 const visibleContributors = computed(() => {
   if (contributorsExpanded.value) return contributors.value
@@ -706,36 +677,7 @@ const engagementStatus = computed(() => {
   const leadershipCount = orgLeadershipCount.value
   const maintainerCount = orgMaintainerCount.value
   const teamContributions = dashboard.value?.contributions?.all?.team || 0
-
-  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
-  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
-
-  if (teamContributions === 0 && !hasGovernance) {
-    return {
-      label: 'New Entrant',
-      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
-      description: 'No contributions or governance positions yet'
-    }
-  }
-  if (highGovernance) {
-    return {
-      label: 'Established Leader',
-      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700',
-      description: 'Significant influence with 3+ leadership positions or 5+ maintainers'
-    }
-  }
-  if (hasGovernance) {
-    return {
-      label: 'Core Contributor',
-      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700',
-      description: 'Active participation with leadership or maintainer positions'
-    }
-  }
-  return {
-    label: 'Active',
-    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
-    description: 'Contributing code without formal governance positions'
-  }
+  return getEngagementStatus(leadershipCount, maintainerCount, teamContributions)
 })
 
 const projectCoveragePercent = computed(() => {

--- a/modules/upstream-pulse/client/views/OrgDetail.vue
+++ b/modules/upstream-pulse/client/views/OrgDetail.vue
@@ -10,7 +10,51 @@
     <!-- Header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
       <div>
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ displayName }}</h2>
+        <div class="flex items-center gap-2 mb-1 flex-wrap">
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ displayName }}</h2>
+
+          <!-- Engagement Status Badge with Tooltip -->
+          <div v-if="dashboard" class="relative group/engagement">
+            <span
+              :class="engagementStatus.classes"
+              class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border"
+            >
+              {{ engagementStatus.label }}
+            </span>
+            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/engagement:opacity-100 group-hover/engagement:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+              {{ engagementStatus.description }}
+              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+            </div>
+          </div>
+
+          <!-- Strategic Leadership Badge with Tooltip -->
+          <div v-if="strategicLeadership" class="relative group/leadership">
+            <span
+              class="px-3 py-1 rounded-full text-xs font-semibold"
+              :class="getStrategicBadgeClass(strategicLeadership)"
+            >
+              {{ getStrategicLabel(strategicLeadership, 'leadership') }}
+            </span>
+            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/leadership:opacity-100 group-hover/leadership:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+              {{ getStrategicDescription(strategicLeadership) }}
+              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+            </div>
+          </div>
+
+          <!-- Strategic Participation Badge with Tooltip -->
+          <div v-if="strategicParticipation" class="relative group/participation">
+            <span
+              class="px-3 py-1 rounded-full text-xs font-semibold"
+              :class="getStrategicBadgeClass(strategicParticipation)"
+            >
+              {{ getStrategicLabel(strategicParticipation, 'participation') }}
+            </span>
+            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/participation:opacity-100 group-hover/participation:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+              {{ getStrategicDescription(strategicParticipation) }}
+              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+            </div>
+          </div>
+        </div>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Team engagement in {{ displayName }} projects</p>
       </div>
       <div class="flex items-center gap-3">
@@ -484,6 +528,10 @@ const periodOptions = [
 
 const githubOrg = computed(() => nav.params.value?.org || '')
 const displayName = ref('')
+const strategicParticipation = ref(null)
+const strategicLeadership = ref(null)
+const orgLeadershipCount = ref(0)
+const orgMaintainerCount = ref(0)
 
 const selectedDays = ref('30')
 const loading = ref(true)
@@ -496,6 +544,43 @@ const leadership = ref(null)
 const membersExpanded = ref(false)
 const governanceExpanded = ref(false)
 const orgProjects = ref([])
+
+function getStrategicLabel(strategic, _type) {
+  if (!strategic) return ''
+  const labels = {
+    'evaluating_participation': 'Evaluating Participation',
+    'sustaining_participation': 'Sustaining Participation',
+    'increasing_participation': 'Increasing Participation',
+    'evaluating_leadership': 'Evaluating Leadership',
+    'sustaining_leadership': 'Sustaining Leadership',
+    'increasing_leadership': 'Increasing Leadership',
+  }
+  return labels[strategic] || strategic
+}
+
+function getStrategicBadgeClass(strategic) {
+  const classes = {
+    'evaluating_participation': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_participation': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_participation': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    'evaluating_leadership': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    'sustaining_leadership': 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    'increasing_leadership': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  }
+  return classes[strategic] || ''
+}
+
+function getStrategicDescription(strategic) {
+  const descriptions = {
+    'evaluating_participation': 'Red Hat is evaluating whether to increase participation in this project',
+    'sustaining_participation': 'Red Hat is sustaining current participation levels in this project',
+    'increasing_participation': 'Red Hat is actively increasing participation in this project',
+    'evaluating_leadership': 'Red Hat is evaluating whether to pursue leadership positions in this project',
+    'sustaining_leadership': 'Red Hat is sustaining current leadership presence in this project',
+    'increasing_leadership': 'Red Hat is actively pursuing more leadership positions in this project',
+  }
+  return descriptions[strategic] || ''
+}
 
 const visibleContributors = computed(() => {
   if (contributorsExpanded.value) return contributors.value
@@ -617,6 +702,42 @@ const totalGovernancePositions = computed(() => {
   return count
 })
 
+const engagementStatus = computed(() => {
+  const leadershipCount = orgLeadershipCount.value
+  const maintainerCount = orgMaintainerCount.value
+  const teamContributions = dashboard.value?.contributions?.all?.team || 0
+
+  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
+  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
+
+  if (teamContributions === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+      description: 'No contributions or governance positions yet'
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700',
+      description: 'Significant influence with 3+ leadership positions or 5+ maintainers'
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700',
+      description: 'Active participation with leadership or maintainer positions'
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+    description: 'Contributing code without formal governance positions'
+  }
+})
+
 const projectCoveragePercent = computed(() => {
   if (!leadership.value?.summary || !dashboard.value?.summary) return 0
   const covered = leadership.value.summary.projectsWithTeamLeadership || 0
@@ -652,6 +773,10 @@ async function loadData() {
 
     const match = orgsData.orgs?.find(o => o.githubOrg === org)
     displayName.value = match?.name || org
+    strategicParticipation.value = match?.strategicParticipation || null
+    strategicLeadership.value = match?.strategicLeadership || null
+    orgLeadershipCount.value = match?.leadershipCount || 0
+    orgMaintainerCount.value = match?.maintainerCount || 0
 
     const topProjects = dashData.topProjects || []
     const metricsById = new Map()

--- a/modules/upstream-pulse/client/views/OrgDetail.vue
+++ b/modules/upstream-pulse/client/views/OrgDetail.vue
@@ -552,7 +552,6 @@ const membersExpanded = ref(false)
 const governanceExpanded = ref(false)
 const orgProjects = ref([])
 
-
 const visibleContributors = computed(() => {
   if (contributorsExpanded.value) return contributors.value
   return contributors.value.slice(0, 5)

--- a/modules/upstream-pulse/client/views/Portfolio.vue
+++ b/modules/upstream-pulse/client/views/Portfolio.vue
@@ -515,6 +515,7 @@ import { useAuth } from '@shared/client/composables/useAuth'
 import OrgActivityCard from '../components/OrgActivityCard.vue'
 import AddProjectModal from '../components/AddProjectModal.vue'
 import { OrgCardSkeleton, StatCardSkeleton, TableRowSkeleton } from '../components/SkeletonLoaders.vue'
+import { getEngagementStatus } from '../composables/useStrategicClassification.js'
 
 const nav = inject('moduleNav')
 const { isAdmin } = useAuth()
@@ -660,6 +661,17 @@ const sortedOrgsList = computed(() => {
       const cmp = aVal - bVal
       return orgSortDirection.value === 'asc' ? cmp : -cmp
     }
+    if (field === 'strategicImportance') {
+      const importanceOrder = {
+        increasing_leadership: 6, increasing_participation: 5,
+        sustaining_leadership: 4, sustaining_participation: 3,
+        evaluating_leadership: 2, evaluating_participation: 1,
+      }
+      const aVal = Math.max(importanceOrder[a.strategicLeadership] || 0, importanceOrder[a.strategicParticipation] || 0)
+      const bVal = Math.max(importanceOrder[b.strategicLeadership] || 0, importanceOrder[b.strategicParticipation] || 0)
+      const cmp = aVal - bVal
+      return orgSortDirection.value === 'asc' ? cmp : -cmp
+    }
     const cmp = (a[field] || 0) - (b[field] || 0)
     return orgSortDirection.value === 'asc' ? cmp : -cmp
   })
@@ -735,34 +747,6 @@ function handleProjectSort(field) {
     projectSortDirection.value = field === 'teamContributions' ? 'desc' : 'asc'
   }
   projectCurrentPage.value = 1
-}
-
-function getEngagementStatus(leadershipCount, maintainerCount, total) {
-  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
-  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
-
-  if (total === 0 && !hasGovernance) {
-    return {
-      label: 'New Entrant',
-      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
-    }
-  }
-  if (highGovernance) {
-    return {
-      label: 'Established Leader',
-      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700'
-    }
-  }
-  if (hasGovernance) {
-    return {
-      label: 'Core Contributor',
-      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700'
-    }
-  }
-  return {
-    label: 'Active',
-    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
-  }
 }
 
 async function loadData() {

--- a/modules/upstream-pulse/client/views/Portfolio.vue
+++ b/modules/upstream-pulse/client/views/Portfolio.vue
@@ -263,6 +263,14 @@
                   <td class="px-6 py-4">
                     <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ org.name }}</span>
                   </td>
+                  <td class="px-6 py-4">
+                    <span
+                      :class="getEngagementStatus(org.leadershipCount || 0, org.maintainerCount || 0, org.contributionCount || 0).classes"
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap border"
+                    >
+                      {{ getEngagementStatus(org.leadershipCount || 0, org.maintainerCount || 0, org.contributionCount || 0).label }}
+                    </span>
+                  </td>
                   <td class="px-6 py-4 text-right">
                     <span class="text-sm font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ (org.contributionCount || 0).toLocaleString() }}</span>
                     <span
@@ -525,11 +533,13 @@ const orgSortOptions = [
   { label: 'Contributions', value: 'contributionCount' },
   { label: 'Team Share', value: 'teamSharePercent' },
   { label: 'Active Members', value: 'activeTeamMembers' },
+  { label: 'Strategic Importance', value: 'strategicImportance' },
   { label: 'Name', value: 'name' },
 ]
 
 const orgTableColumns = [
   { label: 'Organization', field: 'name', align: 'left' },
+  { label: 'Engagement Status', field: 'engagementStatus', align: 'left' },
   { label: 'Contributions', field: 'contributionCount', align: 'right' },
   { label: 'Team Share', field: 'teamSharePercent', align: 'right' },
   { label: 'Members', field: 'activeTeamMembers', align: 'right' },
@@ -592,7 +602,7 @@ watch(searchInput, (val) => {
 watch(orgPageSize, () => { orgCurrentPage.value = 1 })
 watch(projectPageSize, () => { projectCurrentPage.value = 1 })
 watch(orgSortField, (field) => {
-  orgSortDirection.value = field === 'name' ? 'asc' : 'desc'
+  orgSortDirection.value = (field === 'name') ? 'asc' : 'desc'
   orgCurrentPage.value = 1
 })
 
@@ -605,7 +615,7 @@ function handleOrgTableSort(field) {
     orgSortDirection.value = orgSortDirection.value === 'asc' ? 'desc' : 'asc'
   } else {
     orgSortField.value = field
-    orgSortDirection.value = field === 'name' ? 'asc' : 'desc'
+    orgSortDirection.value = (field === 'name') ? 'asc' : 'desc'
   }
   orgCurrentPage.value = 1
 }
@@ -634,6 +644,20 @@ const sortedOrgsList = computed(() => {
     const field = orgSortField.value
     if (field === 'name') {
       const cmp = (a.name || '').localeCompare(b.name || '')
+      return orgSortDirection.value === 'asc' ? cmp : -cmp
+    }
+    if (field === 'engagementStatus') {
+      const statusOrder = {
+        'Established Leader': 4,
+        'Core Contributor': 3,
+        'Active': 2,
+        'New Entrant': 1
+      }
+      const aStatus = getEngagementStatus(a.leadershipCount || 0, a.maintainerCount || 0, a.contributionCount || 0).label
+      const bStatus = getEngagementStatus(b.leadershipCount || 0, b.maintainerCount || 0, b.contributionCount || 0).label
+      const aVal = statusOrder[aStatus] || 0
+      const bVal = statusOrder[bStatus] || 0
+      const cmp = aVal - bVal
       return orgSortDirection.value === 'asc' ? cmp : -cmp
     }
     const cmp = (a[field] || 0) - (b[field] || 0)
@@ -711,6 +735,34 @@ function handleProjectSort(field) {
     projectSortDirection.value = field === 'teamContributions' ? 'desc' : 'asc'
   }
   projectCurrentPage.value = 1
+}
+
+function getEngagementStatus(leadershipCount, maintainerCount, total) {
+  const hasGovernance = leadershipCount > 0 || maintainerCount > 0
+  const highGovernance = leadershipCount >= 3 || maintainerCount >= 5
+
+  if (total === 0 && !hasGovernance) {
+    return {
+      label: 'New Entrant',
+      classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+    }
+  }
+  if (highGovernance) {
+    return {
+      label: 'Established Leader',
+      classes: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 border-blue-200 dark:border-blue-700'
+    }
+  }
+  if (hasGovernance) {
+    return {
+      label: 'Core Contributor',
+      classes: 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 border-indigo-200 dark:border-indigo-700'
+    }
+  }
+  return {
+    label: 'Active',
+    classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+  }
 }
 
 async function loadData() {


### PR DESCRIPTION
## Summary
- Add Leadership Strategy section to Dashboard with visual organization of strategic priorities
- Organizations categorized across two dimensions: Participation and Leadership
- Each dimension has three levels: evaluating, sustaining, increasing

## Changes
- **New component**: LeadershipStrategy.vue with three investment tiers (Increase, Sustain, Evaluating)
- **Dashboard updates**: Include Leadership Strategy section
- **Engagement status badges**: New Entrant, Active, Core Contributor, Established Leader on org cards
- **OrgDetail enhancements**: Strategic classification badges in header with descriptive tooltips
- **Portfolio table**: Engagement status column support
- **Visual indicators**: Red Hat leads (red-400 bg), Red Hat participates (gray bg)

## Code Quality Improvements
Following PR review feedback:
- **Extracted shared composable**: `useStrategicClassification.js` eliminates code duplication across 4 files
- **Fixed sort bug**: Strategic importance sort now properly ranks organizations
- **Refactored templates**: LeadershipStrategy uses v-for pattern (~90 lines → ~30 lines)
- **Accessibility**: Added `title` and `aria-label` attributes to tooltips for keyboard/screen reader users
- **Unit tests**: Comprehensive test coverage (26 tests) for strategic classification logic

## Test plan
- [x] Verify Leadership Strategy section renders on Dashboard
- [x] Check engagement status badges display correctly on org cards
- [x] Confirm strategic badges appear in OrgDetail headers with tooltips
- [x] Test with missing backend data (graceful degradation)
- [x] Verify color scheme matches design system
- [x] All tests passing (980/980)
- [x] ESLint passing

## Notes
Frontend changes are backward-compatible and handle missing strategic classification data gracefully. The backend PR with strategic classification API support is at dpanshug/upstream-pulse#27.

Supersedes #253 (moved from fork to upstream branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)