### PR TITLE
fix(team-tracker): re-add org name mapping UI

### DIFF
--- a/modules/team-tracker/client/components/TeamStructureSettings.vue
+++ b/modules/team-tracker/client/components/TeamStructureSettings.vue
@@ -204,6 +204,82 @@
       </div>
     </div>
 
+    <!-- Org Name Mapping -->
+    <div v-if="orgConfig.teamBoardsTab" class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+      <div class="flex items-center justify-between mb-1">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Org Name Mapping</h3>
+        <button
+          @click="handleDetectOrgs"
+          :disabled="detectingOrgs"
+          class="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ detectingOrgs ? 'Detecting...' : 'Detect & Match' }}
+        </button>
+      </div>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        Maps org names from the spreadsheet to configured org display names. Only teams in configured orgs are synced.
+      </p>
+
+      <div v-if="orgMappingRows.length > 0" class="space-y-2">
+        <!-- Auto-matched orgs -->
+        <div
+          v-for="row in autoMatchedOrgs"
+          :key="'matched-' + row.sheetOrg"
+          class="flex gap-2 items-center px-3 py-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg"
+        >
+          <span class="flex-1 text-sm text-green-800 dark:text-green-300">{{ row.sheetOrg }}</span>
+          <span class="text-green-400 text-sm">→</span>
+          <span class="flex-1 text-sm text-green-800 dark:text-green-300">{{ row.sheetOrg }}</span>
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300">matched</span>
+        </div>
+
+        <!-- Unmatched / suggested orgs -->
+        <div
+          v-for="row in unmatchedOrgs"
+          :key="'unmatched-' + row.sheetOrg"
+          class="rounded-lg"
+          :class="row.isSuggestion && row.selectedOrg ? 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-3' : ''"
+        >
+          <div class="flex gap-2 items-center">
+            <span class="flex-1 px-3 py-1.5 text-sm bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300">{{ row.sheetOrg }}</span>
+            <span class="text-gray-400 text-sm">→</span>
+            <select
+              v-model="row.selectedOrg"
+              class="flex-1 px-3 py-1.5 text-sm border rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              :class="row.isSuggestion && row.selectedOrg ? 'border-amber-300 dark:border-amber-600' : 'border-gray-300 dark:border-gray-600'"
+              @change="row.isSuggestion && (row.isSuggestion = false)"
+            >
+              <option value="">— skip (don't sync) —</option>
+              <option v-for="org in configuredOrgs" :key="org" :value="org">{{ org }}</option>
+            </select>
+          </div>
+          <div v-if="row.isSuggestion && row.selectedOrg" class="flex items-center justify-between mt-2">
+            <span class="text-xs text-amber-700 dark:text-amber-300">Suggested match — does this look right?</span>
+            <div class="flex gap-2">
+              <button
+                @click="row.isSuggestion = false"
+                class="px-2.5 py-1 text-xs font-medium text-white bg-green-600 rounded hover:bg-green-700 transition-colors"
+              >
+                Accept
+              </button>
+              <button
+                @click="row.selectedOrg = ''; row.isSuggestion = false"
+                class="px-2.5 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-else-if="!detectingOrgs" class="text-xs text-gray-400 dark:text-gray-500 py-2">
+        Click "Detect & Match" to discover org names from the spreadsheet.
+      </div>
+
+      <p v-if="detectError" class="mt-2 text-xs text-red-600 dark:text-red-400">{{ detectError }}</p>
+    </div>
+
     <!-- Save -->
     <div class="flex items-center gap-3">
       <button
@@ -223,6 +299,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRosterSync } from '../composables/useRosterSync'
+import { useOrgRoster } from '../composables/useOrgRoster'
 
 const emit = defineEmits(['toast'])
 
@@ -233,6 +310,13 @@ const {
   saveConfig,
   discoverSheets
 } = useRosterSync()
+
+const {
+  loadSheetOrgs,
+  loadConfiguredOrgs,
+  loadConfig: loadOrgConfig,
+  saveConfig: saveOrgConfig
+} = useOrgRoster()
 
 const editSheetId = ref('')
 const editNameColumn = ref('')
@@ -245,6 +329,68 @@ const editSelectedSheets = ref([])
 const discoveredSheets = ref(null)
 const discoveringSheets = ref(false)
 const discoverError = ref(null)
+
+// Org name mapping state
+const orgConfig = ref({ teamBoardsTab: '', orgNameMapping: {} })
+const orgMappingRows = ref([])
+const configuredOrgs = ref([])
+const detectingOrgs = ref(false)
+const detectError = ref('')
+
+const autoMatchedOrgs = computed(() => orgMappingRows.value.filter(r => r.isExactMatch))
+const unmatchedOrgs = computed(() => orgMappingRows.value.filter(r => !r.isExactMatch))
+
+function findBestMatch(sheetOrg, configured) {
+  const lower = sheetOrg.toLowerCase()
+  for (const org of configured) {
+    const orgLower = org.toLowerCase()
+    if (lower.includes(orgLower) || orgLower.includes(lower)) {
+      return org
+    }
+  }
+  const sheetWords = new Set(lower.split(/\s+/))
+  let bestOrg = null
+  let bestOverlap = 0
+  for (const org of configured) {
+    const orgWords = org.toLowerCase().split(/\s+/)
+    const overlap = orgWords.filter(w => sheetWords.has(w)).length
+    if (overlap > bestOverlap && overlap >= Math.ceil(orgWords.length / 2)) {
+      bestOverlap = overlap
+      bestOrg = org
+    }
+  }
+  return bestOrg
+}
+
+async function handleDetectOrgs() {
+  detectingOrgs.value = true
+  detectError.value = ''
+  try {
+    const [sheetData, configData] = await Promise.all([
+      loadSheetOrgs(),
+      loadConfiguredOrgs()
+    ])
+    const sheetOrgs = sheetData.sheetOrgs || []
+    configuredOrgs.value = configData.configuredOrgs || []
+    const savedMapping = orgConfig.value.orgNameMapping || {}
+    const configuredSet = new Set(configuredOrgs.value)
+
+    orgMappingRows.value = sheetOrgs.map(sheetOrg => {
+      if (configuredSet.has(sheetOrg)) {
+        return { sheetOrg, selectedOrg: sheetOrg, isSuggestion: false, isExactMatch: true }
+      }
+      if (savedMapping[sheetOrg] && configuredSet.has(savedMapping[sheetOrg])) {
+        return { sheetOrg, selectedOrg: savedMapping[sheetOrg], isSuggestion: false, isExactMatch: false }
+      }
+      const suggestion = findBestMatch(sheetOrg, configuredOrgs.value)
+      return { sheetOrg, selectedOrg: suggestion || '', isSuggestion: !!suggestion, isExactMatch: false }
+    })
+  } catch (err) {
+    detectError.value = err.message
+  } finally {
+    detectingOrgs.value = false
+  }
+}
 
 let populatingForm = false
 function populateForm() {
@@ -296,7 +442,13 @@ async function handleDiscoverSheets() {
 }
 
 onMounted(async () => {
-  await fetchConfig()
+  const [, orgCfg] = await Promise.all([
+    fetchConfig(),
+    loadOrgConfig().catch(() => null)
+  ])
+  if (orgCfg) {
+    orgConfig.value = orgCfg
+  }
   populateForm()
 })
 
@@ -403,6 +555,21 @@ async function handleSave() {
         nameColumn: editNameColumn.value.trim(),
         teamGroupingColumn: editTeamGroupingColumn.value.trim(),
         customFields
+      }
+    }
+
+    // Save org name mapping if detect has been run
+    if (orgMappingRows.value.length > 0) {
+      const mapping = {}
+      for (const row of orgMappingRows.value) {
+        if (!row.isExactMatch && row.selectedOrg) {
+          mapping[row.sheetOrg] = row.selectedOrg
+        }
+      }
+      await saveOrgConfig({ orgNameMapping: mapping })
+      orgConfig.value.orgNameMapping = mapping
+      for (const row of orgMappingRows.value) {
+        if (row.selectedOrg) row.isSuggestion = false
       }
     }
 

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -4,10 +4,11 @@
  * sheets sync, components, and org-level config.
  */
 
-const { runSync, calculateHeadcountByRole } = require('../org-sync');
+const { runSync, calculateHeadcountByRole, parseTeamBoardsTab } = require('../org-sync');
 const { fetchAllRfeBacklog } = require('../rfe');
 const { getAllPeople, getTeamRollup } = require('../../../../shared/server/roster');
 const { getOrgDisplayNames } = require('../../../../shared/server/roster-sync/config');
+const { fetchRawSheet } = require('../../../../shared/server/google-sheets');
 
 let orgSyncInProgress = false;
 let orgDailyTimer = null;
@@ -330,6 +331,44 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
       res.json({ status: 'saved', config });
     } catch {
       res.status(500).json({ error: 'Failed to save configuration' });
+    }
+  });
+
+  // ─── Sheet Orgs & Configured Orgs (for org name mapping UI) ───
+
+  router.get('/sheet-orgs', requireAdmin, async function(req, res) {
+    try {
+      const config = getOrgConfig();
+      const tabName = config.teamBoardsTab;
+
+      if (tabName) {
+        const sheetId = getSheetId();
+        if (!sheetId) {
+          return res.status(400).json({ error: 'No Google Sheet ID configured.' });
+        }
+        const boardData = await fetchRawSheet(sheetId, tabName);
+        const teams = parseTeamBoardsTab(boardData.headers, boardData.rows);
+        const sheetOrgs = [...new Set(teams.map(t => t.org))].sort();
+        return res.json({ sheetOrgs });
+      }
+
+      const displayNames = getOrgDisplayNames(storage);
+      const sheetOrgs = Object.values(displayNames).sort();
+      res.json({ sheetOrgs });
+    } catch (error) {
+      console.error('[team-tracker] GET /sheet-orgs error:', error);
+      res.status(500).json({ error: 'Failed to fetch org names from sheet' });
+    }
+  });
+
+  router.get('/configured-orgs', function(req, res) {
+    try {
+      const displayNames = buildOrgKeyToDisplayName();
+      const orgs = Object.values(displayNames).sort();
+      res.json({ configuredOrgs: orgs });
+    } catch (error) {
+      console.error('[team-tracker] GET /configured-orgs error:', error);
+      res.status(500).json({ error: 'Failed to load configured orgs' });
     }
   });
 


### PR DESCRIPTION
## Summary
- Re-adds the org name mapping "Detect & Match" UI that was removed during the module consolidation (PR #264)
- Adds two backend routes (`GET /sheet-orgs`, `GET /configured-orgs`) to support the UI
- Fixes the root cause of 3 orgs (Inference Engineering, AI Platform Core Components, WatsonX.AI) being missing from the team directory — their Google Sheet names didn't match the configured display names

## Context
After deploying PR #264 to preprod, we discovered that only 3 of 6 configured orgs appeared in the team directory. The sync logs showed:
```
Skipped unconfigured orgs: Inf Engineering, AIPCC, watsonx Team
```
The backend already supports `orgNameMapping` in `org-roster/config.json` and applies it during sync, but there was no UI to populate the mapping.

## Changes
| File | Change |
|------|--------|
| `modules/team-tracker/server/routes/org-teams.js` | Add `GET /sheet-orgs` (admin) and `GET /configured-orgs` routes |
| `modules/team-tracker/client/components/TeamStructureSettings.vue` | Add "Org Name Mapping" section to Team Structure tab with Detect & Match workflow |

## Test plan
- [ ] All existing tests pass (916 tests verified)
- [ ] Settings > Team Tracker > Team Structure shows "Org Name Mapping" section when `teamBoardsTab` is configured
- [ ] "Detect & Match" fetches sheet orgs and shows auto-matched (green) vs unmatched (dropdown) orgs
- [ ] Fuzzy suggestions shown for close matches (e.g., "Inf Engineering" → "Inference Engineering")
- [ ] Saving persists `orgNameMapping` to `org-roster/config.json`
- [ ] After saving mappings and triggering sync, previously skipped orgs appear in team directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)