### PR TITLE
deploy(preprod): update backend + frontend image to 2c4c6db

### DIFF
--- a/deploy/openshift/overlays/preprod/kustomization.yaml
+++ b/deploy/openshift/overlays/preprod/kustomization.yaml
@@ -12,6 +12,6 @@ patches:
 
 images:
   - name: quay.io/org-pulse/team-tracker-backend
-    newTag: "95620a54e0103a0fd65d133edd37ca01c566f026"
+    newTag: "2c4c6db3d5eedc1ffdd41ae16d92ad1859a0fe79"
   - name: quay.io/org-pulse/team-tracker-frontend
-    newTag: "95620a54e0103a0fd65d133edd37ca01c566f026"
+    newTag: "2c4c6db3d5eedc1ffdd41ae16d92ad1859a0fe79"


### PR DESCRIPTION
## Summary
- Updates preprod overlay image tags from `95620a5` → `2c4c6db` for both backend and frontend
- Images built from [CI run #24540771945](https://github.com/red-hat-data-services/rhai-org-pulse/actions/runs/24540771945) (all jobs passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)