### PR TITLE
fix(team-tracker): show unassigned people and handle missing teams

### DIFF
--- a/modules/team-tracker/__tests__/client/TeamRosterView.test.js
+++ b/modules/team-tracker/__tests__/client/TeamRosterView.test.js
@@ -18,6 +18,7 @@ vi.mock('@shared/client/composables/useRoster', () => ({
         ]
       }
     ]),
+    loading: ref(false),
     multiTeamMembers: ref(new Set()),
     getTeamsForPerson: () => ['Model Serving'],
     visibleFields: ref([]),

--- a/modules/team-tracker/client/composables/useOrgRoster.js
+++ b/modules/team-tracker/client/composables/useOrgRoster.js
@@ -41,6 +41,7 @@ async function cachedRequest(cacheKey, path, onData) {
 
 // Shared reactive state
 const teams = ref([])
+const unassigned = ref([])
 const people = ref([])
 const orgs = ref([])
 const selectedOrg = ref(null)
@@ -59,6 +60,7 @@ export function useOrgRoster() {
       const cacheKey = orgFilter ? `teams:${orgFilter}` : 'teams:all'
       await cachedRequest(cacheKey, path, (data) => {
         teams.value = data.teams || []
+        unassigned.value = data.unassigned || []
         fetchedAt.value = data.fetchedAt || null
       })
     } catch (err) {
@@ -179,6 +181,7 @@ export function useOrgRoster() {
 
   return {
     teams,
+    unassigned,
     people,
     orgs,
     selectedOrg,

--- a/modules/team-tracker/client/views/TeamDirectoryView.vue
+++ b/modules/team-tracker/client/views/TeamDirectoryView.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { onMounted, inject } from 'vue'
+import { ref, onMounted, inject } from 'vue'
 import { useOrgRoster } from '../composables/useOrgRoster'
 import OrgSelector from '../components/OrgSelector.vue'
 import TeamCard from '../components/TeamCard.vue'
 
 const nav = inject('moduleNav')
-const { orgs, selectedOrg, loading, searchQuery, sortBy, filteredTeams, loadTeams, loadOrgs } = useOrgRoster()
+const { orgs, selectedOrg, loading, searchQuery, sortBy, filteredTeams, unassigned, loadTeams, loadOrgs } = useOrgRoster()
+const unassignedExpanded = ref(false)
 
 function openTeam(team) {
   nav.navigateTo('team-detail', { teamKey: `${team.org}::${team.name}` })
@@ -57,6 +58,42 @@ onMounted(async () => {
       @select="selectOrg"
       class="mb-6"
     />
+
+    <!-- Unassigned people banner -->
+    <div v-if="unassigned.length > 0 && !loading" class="mb-6 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800/30 rounded-lg">
+      <button
+        @click="unassignedExpanded = !unassignedExpanded"
+        class="w-full flex items-center justify-between px-4 py-3 text-left"
+      >
+        <div class="flex items-center gap-2">
+          <svg class="h-4 w-4 text-amber-500 dark:text-amber-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span class="text-sm font-medium text-amber-800 dark:text-amber-300">
+            {{ unassigned.length }} {{ unassigned.length === 1 ? 'person' : 'people' }} not assigned to any team
+          </span>
+        </div>
+        <svg
+          class="h-4 w-4 text-amber-500 dark:text-amber-400 transition-transform"
+          :class="{ 'rotate-180': unassignedExpanded }"
+          xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div v-if="unassignedExpanded" class="px-4 pb-3">
+        <div class="flex flex-wrap gap-2">
+          <span
+            v-for="person in unassigned"
+            :key="person.name"
+            class="inline-flex items-center px-2.5 py-1 rounded-md text-xs bg-white dark:bg-gray-800 border border-amber-200 dark:border-amber-800/30 text-gray-700 dark:text-gray-300"
+            :title="[person.title, person.org].filter(Boolean).join(' · ')"
+          >
+            {{ person.name }}
+          </span>
+        </div>
+      </div>
+    </div>
 
     <div v-if="loading" class="flex items-center justify-center py-12">
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>

--- a/modules/team-tracker/client/views/TeamRosterView.vue
+++ b/modules/team-tracker/client/views/TeamRosterView.vue
@@ -1,8 +1,22 @@
 <template>
   <div>
     <!-- Loading state when team not yet resolved from roster -->
-    <div v-if="!team" class="flex items-center justify-center py-12">
+    <div v-if="!team && rosterLoading" class="flex items-center justify-center py-12">
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    </div>
+
+    <!-- Team not found after roster loaded -->
+    <div v-else-if="!team" class="flex flex-col items-center justify-center py-12 text-center">
+      <svg class="h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+      <p class="text-gray-500 dark:text-gray-400 text-sm">This team has no members or could not be found.</p>
+      <button
+        @click="nav.goBack()"
+        class="mt-4 px-4 py-2 text-sm text-primary-600 dark:text-primary-400 hover:underline"
+      >
+        Back to directory
+      </button>
     </div>
 
     <template v-else>
@@ -166,7 +180,7 @@ import { useOrgRoster } from '../composables/useOrgRoster'
 import { refreshMetrics, getTeamMetrics } from '@shared/client/services/api'
 
 const nav = inject('moduleNav')
-const { teams: allTeams } = useRoster()
+const { teams: allTeams, loading: rosterLoading } = useRoster()
 const { loadTeamDetail, loadRfeConfig } = useOrgRoster()
 const { loadGitlabStats } = useGitlabStats()
 const { isAdmin } = useAuth()

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -99,23 +99,34 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
       const boards = (team.boardUrls || []).map(url => ({ url, name: boardNames[url] || null }));
 
       return { ...team, boards, engLeads, productManagers, headcount: counts, components, memberCount: teamPeople.length, jiraFilter };
-    });
+    }).filter(t => t.memberCount > 0);
 
-    return { teams, fetchedAt: metaData.fetchedAt };
+    // Find people with no team assignment
+    const relevantPeople = orgFilter
+      ? allPeople.filter(p => (orgKeyToDisplay[p.orgKey] || '') === orgFilter)
+      : allPeople;
+    const unassigned = relevantPeople
+      .filter(p => {
+        const grouping = p._teamGrouping || p.miroTeam || '';
+        return !grouping.trim();
+      })
+      .map(p => ({ name: p.name, orgKey: p.orgKey, org: orgKeyToDisplay[p.orgKey] || p.orgKey, title: p.title || '' }));
+
+    return { teams, unassigned, fetchedAt: metaData.fetchedAt };
   }
 
   // ─── GET /org-teams ───
 
   router.get('/org-teams', function(req, res) {
     try {
-      const { teams, fetchedAt } = buildEnrichedTeams(req.query.org);
+      const { teams, unassigned, fetchedAt } = buildEnrichedTeams(req.query.org);
       const rfeData = readFromStorage('org-roster/rfe-backlog.json');
       const enriched = rfeData ? teams.map(function(t) {
         const teamKey = `${t.org}::${t.name}`;
         const rfe = rfeData.byTeam?.[teamKey];
         return { ...t, rfeCount: rfe?.count || 0 };
       }) : teams;
-      res.json({ teams: enriched, fetchedAt });
+      res.json({ teams: enriched, unassigned, fetchedAt });
     } catch (error) {
       console.error('[team-tracker] GET /org-teams error:', error);
       res.status(500).json({ error: 'Failed to load team data' });

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -110,7 +110,8 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
         const grouping = p._teamGrouping || p.miroTeam || '';
         return !grouping.trim();
       })
-      .map(p => ({ name: p.name, orgKey: p.orgKey, org: orgKeyToDisplay[p.orgKey] || p.orgKey, title: p.title || '' }));
+      .map(p => ({ name: p.name, orgKey: p.orgKey, org: orgKeyToDisplay[p.orgKey] || p.orgKey, title: p.title || '' }))
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     return { teams, unassigned, fetchedAt: metaData.fetchedAt };
   }


### PR DESCRIPTION
## Summary
- **Unassigned people banner**: The team directory now shows an expandable amber banner listing people who aren't assigned to any team, with counts that respect the current org filter
- **Empty team filtering**: Teams with zero members are filtered out of the directory listing
- **Missing team handling**: The team roster view now shows a proper "not found" state with a back button instead of an infinite spinner when a team has no members

## Test plan
- [ ] Navigate to team directory — verify unassigned people banner appears if any exist
- [ ] Expand the banner and confirm names are listed with title tooltips
- [ ] Switch org filter — banner count should update accordingly
- [ ] Verify empty teams no longer appear in the directory
- [ ] Navigate to a team with no members — verify "not found" state with back button
- [ ] Confirm existing team roster views still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)