### PR TITLE
deploy(preprod): update image tags to 87e44ec

### DIFF
--- a/deploy/openshift/overlays/preprod/kustomization.yaml
+++ b/deploy/openshift/overlays/preprod/kustomization.yaml
@@ -12,6 +12,6 @@ patches:
 
 images:
   - name: quay.io/org-pulse/team-tracker-backend
-    newTag: "c978f9f4a6a79b8c7450da5caea03302b3371085"
+    newTag: "87e44ecf5402179f242aa8a0c38fe14b2c4d2052"
   - name: quay.io/org-pulse/team-tracker-frontend
-    newTag: "c978f9f4a6a79b8c7450da5caea03302b3371085"
+    newTag: "87e44ecf5402179f242aa8a0c38fe14b2c4d2052"


### PR DESCRIPTION
## Summary

Update preprod kustomize overlay image tags to `87e44ecf5402179f242aa8a0c38fe14b2c4d2052` from CI run [#24595250048](https://github.com/red-hat-data-services/rhai-org-pulse/actions/runs/24595250048).

🤖 Generated with [Claude Code](https://claude.com/claude-code)