### PR TITLE
fix: trigger allocation tracker refresh from cron job and UI for all projects

### DIFF
--- a/deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml
+++ b/deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml
@@ -132,12 +132,12 @@ spec:
                     echo "WARNING: AI Impact refresh timed out (non-fatal, continuing)"
                   fi
 
-                  # Step 4: Trigger Allocation Tracker refresh
+                  # Step 4: Trigger Allocation Tracker refresh (all projects)
                   echo "=== Triggering Allocation Tracker refresh ==="
                   curl -sf -X POST "$BACKEND/api/modules/allocation-tracker/refresh" \
                     -H "Content-Type: application/json" \
                     -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" \
-                    -d '{"projectKey":"RHOAIENG"}' || echo "Allocation Tracker refresh failed (non-fatal)"
+                    -d '{}' || echo "Allocation Tracker refresh failed (non-fatal)"
                   sleep 5
                   ATTEMPTS=0
                   MAX_ATTEMPTS=60

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -690,7 +690,17 @@ export default {
       this.showRefreshModal = false
       this.isRefreshing = true
       try {
-        await refreshMetrics({ scope: 'all', force, sources })
+        const refreshes = [refreshMetrics({ scope: 'all', force, sources })]
+        if (this.enabledBuiltInSlugs.includes('allocation-tracker')) {
+          refreshes.push(
+            apiRequest('/modules/allocation-tracker/refresh', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ hardRefresh: force })
+            }).catch(err => console.error('Allocation tracker refresh failed:', err))
+          )
+        }
+        await Promise.all(refreshes)
         this.showToast('Refresh started — data will update shortly')
       } catch (err) {
         console.error('Failed to start refresh:', err)

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -691,7 +691,7 @@ export default {
       this.isRefreshing = true
       try {
         const refreshes = [refreshMetrics({ scope: 'all', force, sources })]
-        if (this.enabledBuiltInSlugs.includes('allocation-tracker')) {
+        if (this.enabledBuiltInSlugs?.includes('allocation-tracker')) {
           refreshes.push(
             apiRequest('/modules/allocation-tracker/refresh', {
               method: 'POST',


### PR DESCRIPTION
## Summary
Follows up on #292 which fixed the server-side multi-project refresh logic. That PR alone wasn't enough because:

- **Cron job** (`cronjob-sync-refresh.yaml`): Hardcoded `{"projectKey":"RHOAIENG"}`, so AIPCC and INFERENG were never refreshed by the scheduled job. Changed to `{}` so it triggers multi-project refresh for all configured projects.
- **UI Refresh button** (`App.vue`): The header Refresh button only called team-tracker's generic `/api/refresh` endpoint — it never triggered the allocation tracker's own `/api/modules/allocation-tracker/refresh`. Added a parallel call to the allocation tracker's refresh when the module is enabled.

## Test plan
- [ ] After deploy, verify the cron job refreshes all three projects (RHOAIENG, AIPCC, INFERENG)
- [ ] Click the header Refresh button while on any view — allocation tracker data should refresh alongside team-tracker metrics
- [ ] AIPCC and INFERENG project cards on the org dashboard should show allocation data after refresh completes
- [ ] Verify the allocation tracker refresh failure doesn't block the main refresh (caught with `.catch()`)

Made with [Cursor](https://cursor.com)