### PR TITLE
fix: preserve RHOAIENG legacy storage path in multi-project refresh

### DIFF
--- a/modules/allocation-tracker/__tests__/server/orchestration.test.js
+++ b/modules/allocation-tracker/__tests__/server/orchestration.test.js
@@ -851,6 +851,32 @@ describe('performMultiProjectRefresh', () => {
     expect(result.projects[0].success).toBe(false);
     expect(result.projects[1].success).toBe(true);
   });
+
+  it('uses getDeps when provided instead of default prefix logic', async () => {
+    const customRead = vi.fn().mockImplementation((key) => {
+      if (key === 'teams.json') return { teams: [{ boardId: 1, boardName: 'Board A', enabled: true }] };
+      return null;
+    });
+    const customWrite = vi.fn();
+    const getDeps = vi.fn().mockReturnValue({ readStorage: customRead, writeStorage: customWrite });
+
+    const defaultReadStorage = vi.fn();
+    const defaultWriteStorage = vi.fn();
+
+    await performMultiProjectRefresh({
+      projects: [{ key: 'LEGACY', name: 'Legacy Project' }],
+      hardRefresh: false,
+      getDeps,
+      fetchSprints: vi.fn().mockResolvedValue([]),
+      fetchSprintIssues: vi.fn().mockResolvedValue([]),
+      readStorage: defaultReadStorage,
+      writeStorage: defaultWriteStorage
+    });
+
+    expect(getDeps).toHaveBeenCalledWith('LEGACY');
+    expect(customRead).toHaveBeenCalledWith('teams.json');
+    expect(defaultReadStorage).not.toHaveBeenCalled();
+  });
 });
 
 describe('processKanbanBoard', () => {

--- a/modules/allocation-tracker/server/index.js
+++ b/modules/allocation-tracker/server/index.js
@@ -47,7 +47,8 @@ module.exports = function registerRoutes(router, context) {
     if (project && project !== 'RHOAIENG') {
       return moduleRead(`data/${project}/${key}`);
     }
-    return moduleRead(`data/RHOAIENG/${key}`) || moduleRead(key);
+    // RHOAIENG uses root-level storage (legacy); data/RHOAIENG/ is only a fallback
+    return moduleRead(key) || moduleRead(`data/RHOAIENG/${key}`);
   }
 
   /**

--- a/modules/allocation-tracker/server/index.js
+++ b/modules/allocation-tracker/server/index.js
@@ -220,7 +220,8 @@ module.exports = function registerRoutes(router, context) {
             fetchFilterJql: jiraClient.fetchFilterJql,
             fetchIssuesByJql: jiraClient.fetchIssuesByJql,
             readStorage: moduleRead,
-            writeStorage: moduleWrite
+            writeStorage: moduleWrite,
+            getDeps: getDepsForProject
           });
 
           const totalBoards = result.projects.reduce((sum, p) => sum + (p.boardCount || 0), 0);

--- a/modules/allocation-tracker/server/jira/orchestration.js
+++ b/modules/allocation-tracker/server/jira/orchestration.js
@@ -436,15 +436,24 @@ async function performRefresh({ projectKey, hardRefresh, fetchSprints, fetchSpri
  * Multi-project refresh: iterate over projects, refresh each with prefixed storage,
  * then generate rollup summaries.
  */
-async function performMultiProjectRefresh({ projects, hardRefresh, fetchSprints, fetchSprintIssues, fetchBoardConfiguration, fetchFilterJql, fetchIssuesByJql, readStorage, writeStorage }) {
+async function performMultiProjectRefresh({ projects, hardRefresh, fetchSprints, fetchSprintIssues, fetchBoardConfiguration, fetchFilterJql, fetchIssuesByJql, readStorage, writeStorage, getDeps }) {
   console.log(`Starting multi-project refresh for ${projects.length} projects`);
   const refreshStart = Date.now();
 
   const projectResults = [];
 
   for (const project of projects) {
-    const prefix = getStoragePrefix(project.key);
-    const { read: prefixedRead, write: prefixedWrite } = createPrefixedStorage(prefix, readStorage, writeStorage);
+    let projRead, projWrite;
+    if (getDeps) {
+      const deps = getDeps(project.key);
+      projRead = deps.readStorage;
+      projWrite = deps.writeStorage;
+    } else {
+      const prefix = getStoragePrefix(project.key);
+      const { read, write } = createPrefixedStorage(prefix, readStorage, writeStorage);
+      projRead = read;
+      projWrite = write;
+    }
 
     try {
       const result = await performRefresh({
@@ -455,8 +464,8 @@ async function performMultiProjectRefresh({ projects, hardRefresh, fetchSprints,
         fetchBoardConfiguration,
         fetchFilterJql,
         fetchIssuesByJql,
-        readStorage: prefixedRead,
-        writeStorage: prefixedWrite
+        readStorage: projRead,
+        writeStorage: projWrite
       });
       projectResults.push({ ...result, success: true });
     } catch (error) {


### PR DESCRIPTION
## Summary
- Fixes RHOAIENG ("OpenShift AI Engineering") showing "No data available" after #292/#294 enabled multi-project refresh.
- `performMultiProjectRefresh` blindly applied a `data/{key}/` storage prefix to every project, but RHOAIENG's `teams.json` and sprint data live at the module root (legacy layout). The refresh found zero boards, wrote an empty `dashboard-summary.json` to `data/RHOAIENG/`, and `readWithFallback` returned it instead of the original data.
- Adds an optional `getDeps` callback to `performMultiProjectRefresh` so the caller can provide per-project storage functions that respect RHOAIENG's root-level paths while AIPCC/INFERENG continue using `data/{key}/`.

## Test plan
- [ ] Click Refresh — all three projects (RHOAIENG, AIPCC, INFERENG) should show allocation data
- [ ] Verify RHOAIENG shows its full board count and point totals (previously 4339 pts / 39 boards)
- [ ] Verify AIPCC and INFERENG continue to show data (no regression from #292)
- [ ] Existing orchestration tests pass (getDeps is optional, fallback to prefix logic)

Made with [Cursor](https://cursor.com)