### PR TITLE
fix: show unique people count on team directory page

### DIFF
--- a/modules/team-tracker/client/composables/useOrgRoster.js
+++ b/modules/team-tracker/client/composables/useOrgRoster.js
@@ -42,6 +42,7 @@ async function cachedRequest(cacheKey, path, onData) {
 // Shared reactive state
 const teams = ref([])
 const unassigned = ref([])
+const totalPeople = ref(0)
 const people = ref([])
 const orgs = ref([])
 const selectedOrg = ref(null)
@@ -61,6 +62,7 @@ export function useOrgRoster() {
       await cachedRequest(cacheKey, path, (data) => {
         teams.value = data.teams || []
         unassigned.value = data.unassigned || []
+        totalPeople.value = data.totalPeople || 0
         fetchedAt.value = data.fetchedAt || null
       })
     } catch (err) {
@@ -182,6 +184,7 @@ export function useOrgRoster() {
   return {
     teams,
     unassigned,
+    totalPeople,
     people,
     orgs,
     selectedOrg,

--- a/modules/team-tracker/client/views/TeamDirectoryView.vue
+++ b/modules/team-tracker/client/views/TeamDirectoryView.vue
@@ -5,7 +5,7 @@ import OrgSelector from '../components/OrgSelector.vue'
 import TeamCard from '../components/TeamCard.vue'
 
 const nav = inject('moduleNav')
-const { orgs, selectedOrg, loading, searchQuery, sortBy, filteredTeams, unassigned, loadTeams, loadOrgs } = useOrgRoster()
+const { orgs, selectedOrg, loading, searchQuery, sortBy, filteredTeams, totalPeople, unassigned, loadTeams, loadOrgs } = useOrgRoster()
 const unassignedExpanded = ref(false)
 
 function openTeam(team) {
@@ -32,7 +32,7 @@ onMounted(async () => {
     <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
       <div>
         <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Team Directory</h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400">{{ filteredTeams.length }} teams</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">{{ filteredTeams.length }} teams · {{ totalPeople }} people</p>
       </div>
       <div class="flex items-center gap-3">
         <div class="relative">

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -125,21 +125,32 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
       .map(p => ({ name: p.name, orgKey: p.orgKey, org: orgKeyToDisplay[p.orgKey] || p.orgKey, title: p.title || '' }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    return { teams, unassigned, fetchedAt: metaData?.fetchedAt || null };
+    // Count unique people (a person on multiple teams should only count once)
+    const uniquePeople = new Set();
+    for (const teamPeople of Object.values(orgTeamPeopleMap)) {
+      for (const p of teamPeople) {
+        if (!orgFilter || (orgKeyToDisplay[p.orgKey] || '') === orgFilter) {
+          uniquePeople.add(p.name);
+        }
+      }
+    }
+    for (const p of unassigned) uniquePeople.add(p.name);
+
+    return { teams, unassigned, totalPeople: uniquePeople.size, fetchedAt: metaData?.fetchedAt || null };
   }
 
   // ─── GET /org-teams ───
 
   router.get('/org-teams', function(req, res) {
     try {
-      const { teams, unassigned, fetchedAt } = buildEnrichedTeams(req.query.org);
+      const { teams, unassigned, totalPeople, fetchedAt } = buildEnrichedTeams(req.query.org);
       const rfeData = readFromStorage('org-roster/rfe-backlog.json');
       const enriched = rfeData ? teams.map(function(t) {
         const teamKey = `${t.org}::${t.name}`;
         const rfe = rfeData.byTeam?.[teamKey];
         return { ...t, rfeCount: rfe?.count || 0 };
       }) : teams;
-      res.json({ teams: enriched, unassigned, fetchedAt });
+      res.json({ teams: enriched, unassigned, totalPeople, fetchedAt });
     } catch (error) {
       console.error('[team-tracker] GET /org-teams error:', error);
       res.status(500).json({ error: 'Failed to load team data' });


### PR DESCRIPTION
## Summary
- Adds a people count to the team directory subtitle (e.g. "26 teams · 192 people")
- Computes count server-side using a `Set` to deduplicate people on multiple teams
- Includes unassigned people in the count, matching the People Directory's number

Previously, summing `memberCount` across teams double-counted 18 people assigned to multiple teams and excluded 22 unassigned people.

## Test plan
- [x] All 1031 tests pass
- [ ] Restart backend, verify team directory shows correct people count
- [ ] Filter by org, verify count updates correctly
- [ ] Compare count with People Directory — numbers should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)