### PR TITLE
fix: redesign Release Analysis component view

### DIFF
--- a/modules/release-analysis/client/components/ComponentDetailRow.vue
+++ b/modules/release-analysis/client/components/ComponentDetailRow.vue
@@ -1,0 +1,275 @@
+<template>
+  <div>
+    <button
+      class="w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left transition-colors"
+      :class="variant === 'risk'
+        ? 'hover:bg-red-100/40 dark:hover:bg-red-900/20'
+        : 'hover:bg-gray-50/60 dark:hover:bg-gray-800/30'"
+      @click="toggleExpand"
+    >
+      <div class="flex items-center gap-2.5 min-w-0 flex-wrap">
+        <span
+          class="transition-transform text-[10px]"
+          :class="[
+            isExpanded ? 'rotate-90' : '',
+            variant === 'risk' ? 'text-red-400 dark:text-red-500' : 'text-gray-400 dark:text-gray-500'
+          ]"
+        >&#9654;</span>
+        <span class="font-medium text-gray-700 dark:text-gray-200 text-sm">{{ comp.name }}</span>
+        <span class="text-xs text-gray-400 dark:text-gray-500">{{ total }} issue{{ total !== 1 ? 's' : '' }}</span>
+        <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
+          <span class="h-1.5 w-1.5 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
+          {{ comp.forecast.paceStatus }}
+        </span>
+        <span
+          v-for="proj in comp.projects"
+          :key="proj"
+          class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/40 border border-indigo-200/70 dark:border-indigo-700/50 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-indigo-600 dark:text-indigo-300"
+        >{{ proj }}</span>
+      </div>
+      <div class="flex items-center gap-3 shrink-0">
+        <div class="grid grid-cols-3 gap-1.5 text-[10px]">
+          <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(comp.issues_done) }}</span>
+          <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(comp.issues_doing) }}</span>
+          <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(comp.issues_to_do) }}</span>
+        </div>
+        <div class="flex h-2 w-24 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
+          <div class="h-full bg-emerald-500" :style="{ width: pct(comp.issues_done, total) }" />
+          <div class="h-full bg-blue-500" :style="{ width: pct(comp.issues_doing, total) }" />
+          <div class="h-full bg-gray-400" :style="{ width: pct(comp.issues_to_do, total) }" />
+        </div>
+      </div>
+    </button>
+
+    <!-- Expanded detail -->
+    <div v-if="isExpanded" class="border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900/50">
+      <!-- Capacity strip -->
+      <div class="px-4 py-2.5 bg-gray-50/40 dark:bg-gray-800/20 border-b border-gray-100 dark:border-gray-800">
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1.5 text-[11px]">
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Feature Velocity (V) — 6mo avg</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.velocity }} <span class="font-normal text-gray-400 dark:text-gray-500">issues / 14d</span></p>
+          </div>
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Remaining Issues (RI)</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.remaining }} <span class="font-normal text-gray-400 dark:text-gray-500">not done</span></p>
+          </div>
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Sprint (14d window) Remaining (W)</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.windowsRemaining }} <span class="font-normal text-gray-400 dark:text-gray-500">({{ comp.forecast.T }}d ÷ 14)</span></p>
+          </div>
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Capacity (C = V x W)</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.totalCapacity }} <span class="font-normal text-gray-400 dark:text-gray-500">projected</span></p>
+          </div>
+        </div>
+        <div class="mt-2 flex items-center gap-3 text-xs flex-wrap">
+          <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
+            <span class="h-2 w-2 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
+            {{ comp.forecast.paceStatus }}
+          </span>
+          <span v-if="comp.forecast.remaining > 0" class="text-gray-500 dark:text-gray-400">
+            Needs {{ comp.forecast.remaining }}; Projected {{ comp.forecast.totalCapacity }}
+            <span class="font-semibold" :class="comp.forecast.delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
+              ({{ comp.forecast.delta >= 0 ? '+' : '' }}{{ comp.forecast.delta }})
+            </span>
+          </span>
+          <span v-else class="text-emerald-600 dark:text-emerald-400 font-medium">All issues resolved</span>
+        </div>
+      </div>
+
+      <!-- Strategic items -->
+      <div
+        v-for="si in comp.strategicItems"
+        :key="si.key"
+        class="border-b border-gray-100/60 dark:border-gray-800/60 last:border-b-0"
+      >
+        <button
+          class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
+          @click.stop="toggleStrategic(si.key)"
+        >
+          <div class="flex items-center gap-2 min-w-0 flex-wrap">
+            <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': isStrategicExpanded(si.key) }">&#9654;</span>
+            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider" :class="issueTypePillClass(si.issueType)">{{ si.issueType }}</span>
+            <a :href="si.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline text-xs font-medium" @click.stop>{{ si.key }}</a>
+            <span class="text-xs text-gray-700 dark:text-gray-300 truncate">{{ si.summary }}</span>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+            <span class="inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full font-medium" :class="statusBadgeClass(si.statusBucket)">
+              <span class="h-1.5 w-1.5 rounded-full" :class="statusDotClass(si.statusBucket)" />
+              {{ si.status }}
+            </span>
+            <span class="text-xs font-medium tabular-nums" :class="childProgressColor(si.childCounts)">
+              {{ si.childCounts.done }}/{{ si.children.length }} Done
+            </span>
+          </div>
+        </button>
+
+        <!-- Children table -->
+        <div v-if="isStrategicExpanded(si.key) && si.children.length" class="px-4 pb-2 pl-14">
+          <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
+            <table class="min-w-full text-sm">
+              <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                <tr>
+                  <th class="px-3 py-1.5 font-medium">Key</th>
+                  <th class="px-3 py-1.5 font-medium">Summary</th>
+                  <th class="px-3 py-1.5 font-medium">Status</th>
+                  <th class="px-3 py-1.5 font-medium">Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="child in si.children" :key="child.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
+                  <td class="px-3 py-1.5 whitespace-nowrap">
+                    <a :href="child.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ child.key }}</a>
+                  </td>
+                  <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ child.summary }}</span></td>
+                  <td class="px-3 py-1.5 whitespace-nowrap">
+                    <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(child.statusBucket)">
+                      <span class="h-1 w-1 rounded-full" :class="statusDotClass(child.statusBucket)" />
+                      {{ child.status }}
+                    </span>
+                  </td>
+                  <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ child.issueType || '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div v-else-if="isStrategicExpanded(si.key) && !si.children.length" class="px-4 pb-2 pl-14">
+          <p class="text-[10px] text-gray-400 dark:text-gray-500 italic">No child issues in this release.</p>
+        </div>
+      </div>
+
+      <!-- Other items -->
+      <div v-if="comp.otherItems.length" class="border-t border-gray-100/60 dark:border-gray-800/60">
+        <button
+          class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
+          @click.stop="toggleStrategic('__other__')"
+        >
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': isStrategicExpanded('__other__') }">&#9654;</span>
+            <span class="font-medium text-gray-500 dark:text-gray-400 text-xs italic">Other items</span>
+            <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ comp.otherItems.length }}</span>
+          </div>
+          <div class="grid grid-cols-3 gap-1.5 text-[10px] shrink-0">
+            <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1 w-1 rounded-full bg-emerald-500" />{{ comp.otherCounts.done }}</span>
+            <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1 w-1 rounded-full bg-blue-500" />{{ comp.otherCounts.doing }}</span>
+            <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1 w-1 rounded-full bg-gray-400" />{{ comp.otherCounts.to_do }}</span>
+          </div>
+        </button>
+
+        <div v-if="isStrategicExpanded('__other__')" class="px-4 pb-2 pl-14">
+          <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
+            <table class="min-w-full text-sm">
+              <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                <tr>
+                  <th class="px-3 py-1.5 font-medium">Key</th>
+                  <th class="px-3 py-1.5 font-medium">Summary</th>
+                  <th class="px-3 py-1.5 font-medium">Status</th>
+                  <th class="px-3 py-1.5 font-medium">Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="issue in comp.otherItems" :key="issue.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
+                  <td class="px-3 py-1.5 whitespace-nowrap">
+                    <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ issue.key }}</a>
+                  </td>
+                  <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ issue.summary }}</span></td>
+                  <td class="px-3 py-1.5 whitespace-nowrap">
+                    <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(issue.statusBucket)">
+                      <span class="h-1 w-1 rounded-full" :class="statusDotClass(issue.statusBucket)" />
+                      {{ issue.status }}
+                    </span>
+                  </td>
+                  <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType || '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, reactive } from 'vue'
+
+const props = defineProps({
+  comp: { type: Object, required: true },
+  variant: { type: String, default: 'default' }
+})
+
+const expandedSelf = reactive({ open: false })
+const expandedStrategic = reactive(new Set())
+
+const isExpanded = computed(() => expandedSelf.open)
+
+function toggleExpand() {
+  expandedSelf.open = !expandedSelf.open
+  if (!expandedSelf.open) expandedStrategic.clear()
+}
+
+function toggleStrategic(key) {
+  if (expandedStrategic.has(key)) expandedStrategic.delete(key)
+  else expandedStrategic.add(key)
+}
+
+function isStrategicExpanded(key) {
+  return expandedStrategic.has(key)
+}
+
+const total = computed(() =>
+  (props.comp.issues_to_do || 0) + (props.comp.issues_doing || 0) + (props.comp.issues_done || 0)
+)
+
+function pct(part, whole) {
+  if (!whole || part <= 0) return '0%'
+  return `${Math.min(100, (part / whole) * 100)}%`
+}
+
+function fmtCount(n) {
+  if (n == null || !Number.isFinite(Number(n))) return '0'
+  return String(Math.round(Number(n)))
+}
+
+function normalizeType(t) { return (t || '').toLowerCase().trim() }
+
+function confidenceBadgeClass(level) {
+  if (level === 'High') return 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+  return 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300'
+}
+
+function confidenceDotClass(level) {
+  if (level === 'High') return 'bg-emerald-500'
+  return 'bg-red-500'
+}
+
+function issueTypePillClass(type) {
+  const t = normalizeType(type)
+  if (t === 'feature') return 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300'
+  if (t === 'initiative') return 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300'
+  if (t === 'spike') return 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300'
+  return 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
+}
+
+function statusBadgeClass(bucket) {
+  if (bucket === 'done') return 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+  if (bucket === 'doing') return 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+  return 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
+}
+
+function statusDotClass(bucket) {
+  if (bucket === 'done') return 'bg-emerald-500'
+  if (bucket === 'doing') return 'bg-blue-500'
+  return 'bg-gray-400'
+}
+
+function childProgressColor(counts) {
+  const total = counts.done + counts.doing + counts.to_do
+  if (total === 0) return 'text-gray-400 dark:text-gray-500'
+  if (counts.done === total) return 'text-emerald-600 dark:text-emerald-400'
+  if (counts.done / total > 0.5) return 'text-blue-600 dark:text-blue-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+</script>

--- a/modules/release-analysis/client/components/ProductReleaseCard.vue
+++ b/modules/release-analysis/client/components/ProductReleaseCard.vue
@@ -163,188 +163,7 @@
             <span class="text-[10px] text-red-500/70 dark:text-red-400/60">{{ atRiskComponents.length }} component{{ atRiskComponents.length !== 1 ? 's' : '' }}</span>
           </div>
           <div class="divide-y divide-red-100 dark:divide-red-900/30">
-            <div v-for="comp in atRiskComponents" :key="comp.name">
-              <button
-                class="w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-red-100/40 dark:hover:bg-red-900/20 transition-colors"
-                @click="toggleComponentExpand(comp.name)"
-              >
-                <div class="flex items-center gap-2.5 min-w-0 flex-wrap">
-                  <span class="text-red-400 dark:text-red-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedComponents.has(comp.name) }">&#9654;</span>
-                  <span class="font-medium text-gray-700 dark:text-gray-200 text-sm">{{ comp.name }}</span>
-                  <span class="text-xs text-gray-400 dark:text-gray-500">{{ compIssueSum(comp) }} issue{{ compIssueSum(comp) !== 1 ? 's' : '' }}</span>
-                  <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
-                    <span class="h-1.5 w-1.5 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
-                    {{ comp.forecast.paceStatus }}
-                  </span>
-                  <span
-                    v-for="proj in comp.projects"
-                    :key="proj"
-                    class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/40 border border-indigo-200/70 dark:border-indigo-700/50 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-indigo-600 dark:text-indigo-300"
-                  >{{ proj }}</span>
-                </div>
-                <div class="flex items-center gap-3 shrink-0">
-                  <div class="grid grid-cols-3 gap-1.5 text-[10px]">
-                    <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(comp.issues_done) }}</span>
-                    <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(comp.issues_doing) }}</span>
-                    <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(comp.issues_to_do) }}</span>
-                  </div>
-                  <div class="flex h-2 w-24 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
-                    <div class="h-full bg-emerald-500" :style="{ width: pct(comp.issues_done, compIssueSum(comp)) }" />
-                    <div class="h-full bg-blue-500" :style="{ width: pct(comp.issues_doing, compIssueSum(comp)) }" />
-                    <div class="h-full bg-gray-400" :style="{ width: pct(comp.issues_to_do, compIssueSum(comp)) }" />
-                  </div>
-                </div>
-              </button>
-
-              <!-- Expanded component detail -->
-              <div v-if="expandedComponents.has(comp.name)" class="border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900/50">
-                <!-- Capacity strip -->
-                <div class="px-4 py-2.5 bg-gray-50/40 dark:bg-gray-800/20 border-b border-gray-100 dark:border-gray-800">
-                  <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1.5 text-[11px]">
-                    <div>
-                      <span class="text-gray-400 dark:text-gray-500">Feature Velocity (V) — 6mo avg</span>
-                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.velocity }} <span class="font-normal text-gray-400 dark:text-gray-500">issues / 14d</span></p>
-                    </div>
-                    <div>
-                      <span class="text-gray-400 dark:text-gray-500">Remaining Issues (RI)</span>
-                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.remaining }} <span class="font-normal text-gray-400 dark:text-gray-500">not done</span></p>
-                    </div>
-                    <div>
-                      <span class="text-gray-400 dark:text-gray-500">Sprint (14d window) Remaining (W)</span>
-                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.windowsRemaining }} <span class="font-normal text-gray-400 dark:text-gray-500">({{ comp.forecast.T }}d ÷ 14)</span></p>
-                    </div>
-                    <div>
-                      <span class="text-gray-400 dark:text-gray-500">Capacity (C = V x W)</span>
-                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.totalCapacity }} <span class="font-normal text-gray-400 dark:text-gray-500">projected</span></p>
-                    </div>
-                  </div>
-                  <div class="mt-2 flex items-center gap-3 text-xs flex-wrap">
-                    <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
-                      <span class="h-2 w-2 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
-                      {{ comp.forecast.paceStatus }}
-                    </span>
-                    <span v-if="comp.forecast.remaining > 0" class="text-gray-500 dark:text-gray-400">
-                      Needs {{ comp.forecast.remaining }}; Projected {{ comp.forecast.totalCapacity }}
-                      <span class="font-semibold" :class="comp.forecast.delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
-                        ({{ comp.forecast.delta >= 0 ? '+' : '' }}{{ comp.forecast.delta }})
-                      </span>
-                    </span>
-                    <span v-else class="text-emerald-600 dark:text-emerald-400 font-medium">All issues resolved</span>
-                  </div>
-                </div>
-
-                <!-- Strategic items -->
-                <div
-                  v-for="si in comp.strategicItems"
-                  :key="si.key"
-                  class="border-b border-gray-100/60 dark:border-gray-800/60 last:border-b-0"
-                >
-                  <button
-                    class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
-                    @click.stop="toggleStrategicExpand(comp.name, si.key)"
-                  >
-                    <div class="flex items-center gap-2 min-w-0 flex-wrap">
-                      <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, si.key)) }">&#9654;</span>
-                      <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider" :class="issueTypePillClass(si.issueType)">{{ si.issueType }}</span>
-                      <a :href="si.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline text-xs font-medium" @click.stop>{{ si.key }}</a>
-                      <span class="text-xs text-gray-700 dark:text-gray-300 truncate">{{ si.summary }}</span>
-                    </div>
-                    <div class="flex items-center gap-3 shrink-0">
-                      <span class="inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full font-medium" :class="statusBadgeClass(si.statusBucket)">
-                        <span class="h-1.5 w-1.5 rounded-full" :class="statusDotClass(si.statusBucket)" />
-                        {{ si.status }}
-                      </span>
-                      <span class="text-xs font-medium tabular-nums" :class="childProgressColor(si.childCounts)">
-                        {{ si.childCounts.done }}/{{ si.children.length }} Done
-                      </span>
-                    </div>
-                  </button>
-
-                  <!-- Children table -->
-                  <div v-if="expandedStrategic.has(strategicId(comp.name, si.key)) && si.children.length" class="px-4 pb-2 pl-14">
-                    <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
-                      <table class="min-w-full text-sm">
-                        <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                          <tr>
-                            <th class="px-3 py-1.5 font-medium">Key</th>
-                            <th class="px-3 py-1.5 font-medium">Summary</th>
-                            <th class="px-3 py-1.5 font-medium">Status</th>
-                            <th class="px-3 py-1.5 font-medium">Type</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr v-for="child in si.children" :key="child.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
-                            <td class="px-3 py-1.5 whitespace-nowrap">
-                              <a :href="child.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ child.key }}</a>
-                            </td>
-                            <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ child.summary }}</span></td>
-                            <td class="px-3 py-1.5 whitespace-nowrap">
-                              <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(child.statusBucket)">
-                                <span class="h-1 w-1 rounded-full" :class="statusDotClass(child.statusBucket)" />
-                                {{ child.status }}
-                              </span>
-                            </td>
-                            <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ child.issueType || '—' }}</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                  <div v-else-if="expandedStrategic.has(strategicId(comp.name, si.key)) && !si.children.length" class="px-4 pb-2 pl-14">
-                    <p class="text-[10px] text-gray-400 dark:text-gray-500 italic">No child issues in this release.</p>
-                  </div>
-                </div>
-
-                <!-- Other items -->
-                <div v-if="comp.otherItems.length" class="border-t border-gray-100/60 dark:border-gray-800/60">
-                  <button
-                    class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
-                    @click.stop="toggleStrategicExpand(comp.name, '__other__')"
-                  >
-                    <div class="flex items-center gap-2 min-w-0">
-                      <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, '__other__')) }">&#9654;</span>
-                      <span class="font-medium text-gray-500 dark:text-gray-400 text-xs italic">Other items</span>
-                      <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ comp.otherItems.length }}</span>
-                    </div>
-                    <div class="grid grid-cols-3 gap-1.5 text-[10px] shrink-0">
-                      <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1 w-1 rounded-full bg-emerald-500" />{{ comp.otherCounts.done }}</span>
-                      <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1 w-1 rounded-full bg-blue-500" />{{ comp.otherCounts.doing }}</span>
-                      <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1 w-1 rounded-full bg-gray-400" />{{ comp.otherCounts.to_do }}</span>
-                    </div>
-                  </button>
-
-                  <div v-if="expandedStrategic.has(strategicId(comp.name, '__other__'))" class="px-4 pb-2 pl-14">
-                    <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
-                      <table class="min-w-full text-sm">
-                        <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                          <tr>
-                            <th class="px-3 py-1.5 font-medium">Key</th>
-                            <th class="px-3 py-1.5 font-medium">Summary</th>
-                            <th class="px-3 py-1.5 font-medium">Status</th>
-                            <th class="px-3 py-1.5 font-medium">Type</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr v-for="issue in comp.otherItems" :key="issue.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
-                            <td class="px-3 py-1.5 whitespace-nowrap">
-                              <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ issue.key }}</a>
-                            </td>
-                            <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ issue.summary }}</span></td>
-                            <td class="px-3 py-1.5 whitespace-nowrap">
-                              <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(issue.statusBucket)">
-                                <span class="h-1 w-1 rounded-full" :class="statusDotClass(issue.statusBucket)" />
-                                {{ issue.status }}
-                              </span>
-                            </td>
-                            <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType || '—' }}</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <ComponentDetailRow v-for="comp in atRiskComponents" :key="comp.name" :comp="comp" variant="risk" />
           </div>
         </div>
 
@@ -356,191 +175,7 @@
             <span class="text-[10px] text-emerald-500/70 dark:text-emerald-400/60">{{ nonRiskComponents.length }} component{{ nonRiskComponents.length !== 1 ? 's' : '' }}</span>
           </div>
           <div class="divide-y divide-gray-100 dark:divide-gray-800">
-          <div
-            v-for="comp in nonRiskComponents"
-            :key="comp.name"
-          >
-            <button
-              class="w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-gray-50/60 dark:hover:bg-gray-800/30 transition-colors"
-              @click="toggleComponentExpand(comp.name)"
-            >
-              <div class="flex items-center gap-2.5 min-w-0 flex-wrap">
-                <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedComponents.has(comp.name) }">&#9654;</span>
-                <span class="font-medium text-gray-700 dark:text-gray-200 text-sm">{{ comp.name }}</span>
-                <span class="text-xs text-gray-400 dark:text-gray-500">{{ compIssueSum(comp) }} issue{{ compIssueSum(comp) !== 1 ? 's' : '' }}</span>
-                <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
-                  <span class="h-1.5 w-1.5 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
-                  {{ comp.forecast.paceStatus }}
-                </span>
-                <span
-                  v-for="proj in comp.projects"
-                  :key="proj"
-                  class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/40 border border-indigo-200/70 dark:border-indigo-700/50 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-indigo-600 dark:text-indigo-300"
-                >{{ proj }}</span>
-              </div>
-              <div class="flex items-center gap-3 shrink-0">
-                <div class="grid grid-cols-3 gap-1.5 text-[10px]">
-                  <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(comp.issues_done) }}</span>
-                  <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(comp.issues_doing) }}</span>
-                  <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(comp.issues_to_do) }}</span>
-                </div>
-                <div class="flex h-2 w-24 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
-                  <div class="h-full bg-emerald-500" :style="{ width: pct(comp.issues_done, compIssueSum(comp)) }" />
-                  <div class="h-full bg-blue-500" :style="{ width: pct(comp.issues_doing, compIssueSum(comp)) }" />
-                  <div class="h-full bg-gray-400" :style="{ width: pct(comp.issues_to_do, compIssueSum(comp)) }" />
-                </div>
-              </div>
-            </button>
-
-            <!-- Expanded component detail -->
-            <div v-if="expandedComponents.has(comp.name)" class="border-t border-gray-100 dark:border-gray-800">
-              <!-- Capacity strip -->
-              <div class="px-4 py-2.5 bg-gray-50/40 dark:bg-gray-800/20 border-b border-gray-100 dark:border-gray-800">
-                <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1.5 text-[11px]">
-                  <div>
-                    <span class="text-gray-400 dark:text-gray-500">Feature Velocity (V) — 6mo avg</span>
-                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.velocity }} <span class="font-normal text-gray-400 dark:text-gray-500">issues / 14d</span></p>
-                  </div>
-                  <div>
-                    <span class="text-gray-400 dark:text-gray-500">Remaining Issues (RI)</span>
-                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.remaining }} <span class="font-normal text-gray-400 dark:text-gray-500">not done</span></p>
-                  </div>
-                  <div>
-                    <span class="text-gray-400 dark:text-gray-500">Sprint (14d window) Remaining (W)</span>
-                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.windowsRemaining }} <span class="font-normal text-gray-400 dark:text-gray-500">({{ comp.forecast.T }}d ÷ 14)</span></p>
-                  </div>
-                  <div>
-                    <span class="text-gray-400 dark:text-gray-500">Capacity (C = V x W)</span>
-                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.totalCapacity }} <span class="font-normal text-gray-400 dark:text-gray-500">projected</span></p>
-                  </div>
-                </div>
-                <div class="mt-2 flex items-center gap-3 text-xs flex-wrap">
-                  <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
-                    <span class="h-2 w-2 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
-                    {{ comp.forecast.paceStatus }}
-                  </span>
-                  <span v-if="comp.forecast.remaining > 0" class="text-gray-500 dark:text-gray-400">
-                    Needs {{ comp.forecast.remaining }}; Projected {{ comp.forecast.totalCapacity }}
-                    <span class="font-semibold" :class="comp.forecast.delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
-                      ({{ comp.forecast.delta >= 0 ? '+' : '' }}{{ comp.forecast.delta }})
-                    </span>
-                  </span>
-                  <span v-else class="text-emerald-600 dark:text-emerald-400 font-medium">All issues resolved</span>
-                </div>
-              </div>
-
-              <!-- Strategic items -->
-              <div
-                v-for="si in comp.strategicItems"
-                :key="si.key"
-                class="border-b border-gray-100/60 dark:border-gray-800/60 last:border-b-0"
-              >
-                <button
-                  class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
-                  @click.stop="toggleStrategicExpand(comp.name, si.key)"
-                >
-                  <div class="flex items-center gap-2 min-w-0 flex-wrap">
-                    <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, si.key)) }">&#9654;</span>
-                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider" :class="issueTypePillClass(si.issueType)">{{ si.issueType }}</span>
-                    <a :href="si.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline text-xs font-medium" @click.stop>{{ si.key }}</a>
-                    <span class="text-xs text-gray-700 dark:text-gray-300 truncate">{{ si.summary }}</span>
-                  </div>
-                  <div class="flex items-center gap-3 shrink-0">
-                    <span class="inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full font-medium" :class="statusBadgeClass(si.statusBucket)">
-                      <span class="h-1.5 w-1.5 rounded-full" :class="statusDotClass(si.statusBucket)" />
-                      {{ si.status }}
-                    </span>
-                    <span class="text-xs font-medium tabular-nums" :class="childProgressColor(si.childCounts)">
-                      {{ si.childCounts.done }}/{{ si.children.length }} Done
-                    </span>
-                  </div>
-                </button>
-
-                <!-- Children table -->
-                <div v-if="expandedStrategic.has(strategicId(comp.name, si.key)) && si.children.length" class="px-4 pb-2 pl-14">
-                  <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
-                    <table class="min-w-full text-sm">
-                      <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                        <tr>
-                          <th class="px-3 py-1.5 font-medium">Key</th>
-                          <th class="px-3 py-1.5 font-medium">Summary</th>
-                          <th class="px-3 py-1.5 font-medium">Status</th>
-                          <th class="px-3 py-1.5 font-medium">Type</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr v-for="child in si.children" :key="child.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
-                          <td class="px-3 py-1.5 whitespace-nowrap">
-                            <a :href="child.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ child.key }}</a>
-                          </td>
-                          <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ child.summary }}</span></td>
-                          <td class="px-3 py-1.5 whitespace-nowrap">
-                            <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(child.statusBucket)">
-                              <span class="h-1 w-1 rounded-full" :class="statusDotClass(child.statusBucket)" />
-                              {{ child.status }}
-                            </span>
-                          </td>
-                          <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ child.issueType || '—' }}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-                <div v-else-if="expandedStrategic.has(strategicId(comp.name, si.key)) && !si.children.length" class="px-4 pb-2 pl-14">
-                  <p class="text-[10px] text-gray-400 dark:text-gray-500 italic">No child issues in this release.</p>
-                </div>
-              </div>
-
-              <!-- Other items -->
-              <div v-if="comp.otherItems.length" class="border-t border-gray-100/60 dark:border-gray-800/60">
-                <button
-                  class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
-                  @click.stop="toggleStrategicExpand(comp.name, '__other__')"
-                >
-                  <div class="flex items-center gap-2 min-w-0">
-                    <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, '__other__')) }">&#9654;</span>
-                    <span class="font-medium text-gray-500 dark:text-gray-400 text-xs italic">Other items</span>
-                    <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ comp.otherItems.length }}</span>
-                  </div>
-                  <div class="grid grid-cols-3 gap-1.5 text-[10px] shrink-0">
-                    <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1 w-1 rounded-full bg-emerald-500" />{{ comp.otherCounts.done }}</span>
-                    <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1 w-1 rounded-full bg-blue-500" />{{ comp.otherCounts.doing }}</span>
-                    <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1 w-1 rounded-full bg-gray-400" />{{ comp.otherCounts.to_do }}</span>
-                  </div>
-                </button>
-
-                <div v-if="expandedStrategic.has(strategicId(comp.name, '__other__'))" class="px-4 pb-2 pl-14">
-                  <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
-                    <table class="min-w-full text-sm">
-                      <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                        <tr>
-                          <th class="px-3 py-1.5 font-medium">Key</th>
-                          <th class="px-3 py-1.5 font-medium">Summary</th>
-                          <th class="px-3 py-1.5 font-medium">Status</th>
-                          <th class="px-3 py-1.5 font-medium">Type</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr v-for="issue in comp.otherItems" :key="issue.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
-                          <td class="px-3 py-1.5 whitespace-nowrap">
-                            <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ issue.key }}</a>
-                          </td>
-                          <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ issue.summary }}</span></td>
-                          <td class="px-3 py-1.5 whitespace-nowrap">
-                            <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(issue.statusBucket)">
-                              <span class="h-1 w-1 rounded-full" :class="statusDotClass(issue.statusBucket)" />
-                              {{ issue.status }}
-                            </span>
-                          </td>
-                          <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType || '—' }}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+            <ComponentDetailRow v-for="comp in nonRiskComponents" :key="comp.name" :comp="comp" />
           </div>
         </div>
       </div>
@@ -631,8 +266,9 @@
 </template>
 
 <script setup>
-import { computed, ref, reactive } from 'vue'
+import { computed, ref } from 'vue'
 import MonteCarloChart from './MonteCarloChart.vue'
+import ComponentDetailRow from './ComponentDetailRow.vue'
 import { extractProduct } from '../composables/useReleaseFilter'
 import { gammaSample } from '../utils/monteCarlo'
 
@@ -668,27 +304,6 @@ const props = defineProps({
 defineEmits(['set-mc-target'])
 
 const expanded = ref(props.defaultExpanded)
-const expandedComponents = reactive(new Set())
-const expandedStrategic = reactive(new Set())
-
-function toggleComponentExpand(name) {
-  if (expandedComponents.has(name)) {
-    expandedComponents.delete(name)
-    for (const k of [...expandedStrategic]) {
-      if (k.startsWith(name + '::')) expandedStrategic.delete(k)
-    }
-  } else {
-    expandedComponents.add(name)
-  }
-}
-
-function strategicId(compName, itemKey) { return `${compName}::${itemKey}` }
-
-function toggleStrategicExpand(compName, itemKey) {
-  const k = strategicId(compName, itemKey)
-  if (expandedStrategic.has(k)) expandedStrategic.delete(k)
-  else expandedStrategic.add(k)
-}
 
 const productLabel = computed(() => extractProduct(props.release.releaseNumber).toUpperCase())
 
@@ -851,7 +466,13 @@ const nonRiskComponents = computed(() => componentList.value.filter(c => c.forec
 
 const releaseForecast = computed(() => {
   const allNames = componentList.value.map(c => c.name)
-  const totalRemaining = componentList.value.reduce((s, c) => s + c.issues_to_do + c.issues_doing, 0)
+  const seen = new Set()
+  let totalRemaining = 0
+  for (const issue of projectFilteredIssues.value) {
+    if (seen.has(issue.key)) continue
+    seen.add(issue.key)
+    if (issue.statusBucket !== 'done') totalRemaining++
+  }
   const forecast = computeForecast(totalRemaining, allNames)
 
   const atRisk = componentList.value.filter(c => c.forecast.paceStatus === 'At Risk')
@@ -926,39 +547,6 @@ function confidenceBadgeClass(level) {
 function confidenceDotClass(level) {
   if (level === 'High') return 'bg-emerald-500'
   return 'bg-red-500'
-}
-
-function issueTypePillClass(type) {
-  const t = normalizeType(type)
-  if (t === 'feature') return 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300'
-  if (t === 'initiative') return 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300'
-  if (t === 'spike') return 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300'
-  return 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
-}
-
-function statusBadgeClass(bucket) {
-  if (bucket === 'done') return 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
-  if (bucket === 'doing') return 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
-  return 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
-}
-
-function statusDotClass(bucket) {
-  if (bucket === 'done') return 'bg-emerald-500'
-  if (bucket === 'doing') return 'bg-blue-500'
-  return 'bg-gray-400'
-}
-
-function childProgressColor(counts) {
-  const total = counts.done + counts.doing + counts.to_do
-  if (total === 0) return 'text-gray-400 dark:text-gray-500'
-  if (counts.done === total) return 'text-emerald-600 dark:text-emerald-400'
-  if (counts.done / total > 0.5) return 'text-blue-600 dark:text-blue-400'
-  return 'text-gray-500 dark:text-gray-400'
-}
-
-function compIssueSum(comp) {
-  if (!comp) return 0
-  return (comp.issues_to_do || 0) + (comp.issues_doing || 0) + (comp.issues_done || 0)
 }
 
 function pct(part, total) {

--- a/modules/release-analysis/client/components/ProductReleaseCard.vue
+++ b/modules/release-analysis/client/components/ProductReleaseCard.vue
@@ -77,7 +77,7 @@
         <div class="min-w-0">
           <p class="text-xs text-gray-500 dark:text-gray-400">{{ release.productName }}</p>
           <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            {{ releaseTeamsList.length }} project(s)
+            {{ componentList.length }} component(s) across {{ releaseTeamsList.length }} project(s)
             <span v-if="release.riskDriver"> · Driver: {{ release.riskDriver }}</span>
           </p>
           <p
@@ -103,124 +103,447 @@
         </div>
       </div>
 
-      <div v-if="!releaseTeamsList.length" class="text-sm text-gray-500 dark:text-gray-400">
+      <!-- Release-level capacity forecast -->
+      <div v-if="componentList.length" class="rounded-lg bg-gray-50/60 dark:bg-gray-800/30 border border-gray-200/60 dark:border-gray-700/40 px-4 py-2.5">
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1.5 text-[11px]">
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Feature Velocity (V) — 6mo avg</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ releaseForecast.velocity }} <span class="font-normal text-gray-400 dark:text-gray-500">issues / 14d</span></p>
+          </div>
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Remaining Issues (RI)</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ releaseForecast.remaining }} <span class="font-normal text-gray-400 dark:text-gray-500">not done</span></p>
+          </div>
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Sprint (14d window) Remaining (W)</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ releaseForecast.windowsRemaining }} <span class="font-normal text-gray-400 dark:text-gray-500">({{ releaseForecast.T }}d ÷ 14)</span></p>
+          </div>
+          <div>
+            <span class="text-gray-400 dark:text-gray-500">Capacity (C = V x W)</span>
+            <p class="font-semibold text-gray-700 dark:text-gray-300">{{ releaseForecast.totalCapacity }} <span class="font-normal text-gray-400 dark:text-gray-500">projected</span></p>
+          </div>
+        </div>
+        <div class="mt-2 text-xs space-y-1">
+          <div class="flex items-center gap-3 flex-wrap">
+            <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-semibold" :class="confidenceBadgeClass(releaseForecast.level)">
+              <span class="h-2 w-2 rounded-full" :class="confidenceDotClass(releaseForecast.level)" />
+              {{ releaseForecast.paceStatus }}
+            </span>
+            <span v-if="releaseForecast.riskSource === 'components'" class="text-red-600 dark:text-red-400">
+              At Risk Due To: {{ releaseForecast.atRiskComponents.join(', ') }}
+            </span>
+            <span v-else-if="releaseForecast.remaining > 0 && releaseForecast.delta < 0" class="text-red-600 dark:text-red-400">
+              Capacity Required: {{ releaseForecast.remaining }} but Projected {{ releaseForecast.totalCapacity }}
+            </span>
+            <span v-else-if="releaseForecast.remaining > 0" class="text-emerald-600 dark:text-emerald-400">
+              Capacity Required: {{ releaseForecast.remaining }}; Projected {{ releaseForecast.totalCapacity }}
+            </span>
+            <span v-else class="text-emerald-600 dark:text-emerald-400 font-medium">All issues resolved</span>
+          </div>
+          <div v-if="releaseForecast.riskSource === 'components' && releaseForecast.remaining > 0" class="pl-[calc(2.5rem+0.75rem)] text-gray-500 dark:text-gray-400">
+            Overall Capacity: Required {{ releaseForecast.remaining }}; Projected {{ releaseForecast.totalCapacity }}
+            <span class="font-semibold" :class="releaseForecast.delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
+              ({{ releaseForecast.delta >= 0 ? '+' : '' }}{{ releaseForecast.delta }})
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="!componentList.length" class="text-sm text-gray-500 dark:text-gray-400">
         No issues mapped to this release yet.
       </div>
 
-      <div v-else class="space-y-3">
-        <div
-          v-for="team in releaseTeamsList"
-          :key="team.projectKey"
-          class="space-y-1.5"
-        >
-          <div class="flex items-center justify-between gap-2 flex-wrap">
-            <span class="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
-              {{ team.projectKey }}
-            </span>
-            <div
-              class="inline-flex items-center gap-1.5 rounded-full border border-gray-200/80 dark:border-gray-600 bg-gray-50/80 dark:bg-gray-800/50 px-2 py-0.5"
-            >
-              <span class="text-[9px] font-bold uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400 select-none">Risk</span>
-              <span class="h-2.5 w-px shrink-0 bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
-              <span
-                class="inline-flex h-2 w-2 shrink-0 rounded-full ring-1 ring-white dark:ring-gray-900"
-                :class="riskDotClass(team.risk)"
-              />
+      <!-- Component rows -->
+      <div v-else class="flex flex-col gap-3">
+        <!-- At Risk block -->
+        <div v-if="atRiskComponents.length" class="rounded-lg bg-red-50/60 dark:bg-red-950/20 border border-red-200/80 dark:border-red-800/50 overflow-hidden">
+          <div class="flex items-center gap-2 px-4 py-2 border-b border-red-200/60 dark:border-red-800/40">
+            <span class="h-2 w-2 rounded-full bg-red-500" />
+            <span class="text-xs font-semibold text-red-700 dark:text-red-300 uppercase tracking-wide">At Risk</span>
+            <span class="text-[10px] text-red-500/70 dark:text-red-400/60">{{ atRiskComponents.length }} component{{ atRiskComponents.length !== 1 ? 's' : '' }}</span>
+          </div>
+          <div class="divide-y divide-red-100 dark:divide-red-900/30">
+            <div v-for="comp in atRiskComponents" :key="comp.name">
+              <button
+                class="w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-red-100/40 dark:hover:bg-red-900/20 transition-colors"
+                @click="toggleComponentExpand(comp.name)"
+              >
+                <div class="flex items-center gap-2.5 min-w-0 flex-wrap">
+                  <span class="text-red-400 dark:text-red-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedComponents.has(comp.name) }">&#9654;</span>
+                  <span class="font-medium text-gray-700 dark:text-gray-200 text-sm">{{ comp.name }}</span>
+                  <span class="text-xs text-gray-400 dark:text-gray-500">{{ compIssueSum(comp) }} issue{{ compIssueSum(comp) !== 1 ? 's' : '' }}</span>
+                  <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
+                    <span class="h-1.5 w-1.5 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
+                    {{ comp.forecast.paceStatus }}
+                  </span>
+                  <span
+                    v-for="proj in comp.projects"
+                    :key="proj"
+                    class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/40 border border-indigo-200/70 dark:border-indigo-700/50 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-indigo-600 dark:text-indigo-300"
+                  >{{ proj }}</span>
+                </div>
+                <div class="flex items-center gap-3 shrink-0">
+                  <div class="grid grid-cols-3 gap-1.5 text-[10px]">
+                    <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(comp.issues_done) }}</span>
+                    <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(comp.issues_doing) }}</span>
+                    <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(comp.issues_to_do) }}</span>
+                  </div>
+                  <div class="flex h-2 w-24 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
+                    <div class="h-full bg-emerald-500" :style="{ width: pct(comp.issues_done, compIssueSum(comp)) }" />
+                    <div class="h-full bg-blue-500" :style="{ width: pct(comp.issues_doing, compIssueSum(comp)) }" />
+                    <div class="h-full bg-gray-400" :style="{ width: pct(comp.issues_to_do, compIssueSum(comp)) }" />
+                  </div>
+                </div>
+              </button>
+
+              <!-- Expanded component detail -->
+              <div v-if="expandedComponents.has(comp.name)" class="border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900/50">
+                <!-- Capacity strip -->
+                <div class="px-4 py-2.5 bg-gray-50/40 dark:bg-gray-800/20 border-b border-gray-100 dark:border-gray-800">
+                  <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1.5 text-[11px]">
+                    <div>
+                      <span class="text-gray-400 dark:text-gray-500">Feature Velocity (V) — 6mo avg</span>
+                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.velocity }} <span class="font-normal text-gray-400 dark:text-gray-500">issues / 14d</span></p>
+                    </div>
+                    <div>
+                      <span class="text-gray-400 dark:text-gray-500">Remaining Issues (RI)</span>
+                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.remaining }} <span class="font-normal text-gray-400 dark:text-gray-500">not done</span></p>
+                    </div>
+                    <div>
+                      <span class="text-gray-400 dark:text-gray-500">Sprint (14d window) Remaining (W)</span>
+                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.windowsRemaining }} <span class="font-normal text-gray-400 dark:text-gray-500">({{ comp.forecast.T }}d ÷ 14)</span></p>
+                    </div>
+                    <div>
+                      <span class="text-gray-400 dark:text-gray-500">Capacity (C = V x W)</span>
+                      <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.totalCapacity }} <span class="font-normal text-gray-400 dark:text-gray-500">projected</span></p>
+                    </div>
+                  </div>
+                  <div class="mt-2 flex items-center gap-3 text-xs flex-wrap">
+                    <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
+                      <span class="h-2 w-2 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
+                      {{ comp.forecast.paceStatus }}
+                    </span>
+                    <span v-if="comp.forecast.remaining > 0" class="text-gray-500 dark:text-gray-400">
+                      Needs {{ comp.forecast.remaining }}; Projected {{ comp.forecast.totalCapacity }}
+                      <span class="font-semibold" :class="comp.forecast.delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
+                        ({{ comp.forecast.delta >= 0 ? '+' : '' }}{{ comp.forecast.delta }})
+                      </span>
+                    </span>
+                    <span v-else class="text-emerald-600 dark:text-emerald-400 font-medium">All issues resolved</span>
+                  </div>
+                </div>
+
+                <!-- Strategic items -->
+                <div
+                  v-for="si in comp.strategicItems"
+                  :key="si.key"
+                  class="border-b border-gray-100/60 dark:border-gray-800/60 last:border-b-0"
+                >
+                  <button
+                    class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
+                    @click.stop="toggleStrategicExpand(comp.name, si.key)"
+                  >
+                    <div class="flex items-center gap-2 min-w-0 flex-wrap">
+                      <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, si.key)) }">&#9654;</span>
+                      <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider" :class="issueTypePillClass(si.issueType)">{{ si.issueType }}</span>
+                      <a :href="si.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline text-xs font-medium" @click.stop>{{ si.key }}</a>
+                      <span class="text-xs text-gray-700 dark:text-gray-300 truncate">{{ si.summary }}</span>
+                    </div>
+                    <div class="flex items-center gap-3 shrink-0">
+                      <span class="inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full font-medium" :class="statusBadgeClass(si.statusBucket)">
+                        <span class="h-1.5 w-1.5 rounded-full" :class="statusDotClass(si.statusBucket)" />
+                        {{ si.status }}
+                      </span>
+                      <span class="text-xs font-medium tabular-nums" :class="childProgressColor(si.childCounts)">
+                        {{ si.childCounts.done }}/{{ si.children.length }} Done
+                      </span>
+                    </div>
+                  </button>
+
+                  <!-- Children table -->
+                  <div v-if="expandedStrategic.has(strategicId(comp.name, si.key)) && si.children.length" class="px-4 pb-2 pl-14">
+                    <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
+                      <table class="min-w-full text-sm">
+                        <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                          <tr>
+                            <th class="px-3 py-1.5 font-medium">Key</th>
+                            <th class="px-3 py-1.5 font-medium">Summary</th>
+                            <th class="px-3 py-1.5 font-medium">Status</th>
+                            <th class="px-3 py-1.5 font-medium">Type</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr v-for="child in si.children" :key="child.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
+                            <td class="px-3 py-1.5 whitespace-nowrap">
+                              <a :href="child.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ child.key }}</a>
+                            </td>
+                            <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ child.summary }}</span></td>
+                            <td class="px-3 py-1.5 whitespace-nowrap">
+                              <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(child.statusBucket)">
+                                <span class="h-1 w-1 rounded-full" :class="statusDotClass(child.statusBucket)" />
+                                {{ child.status }}
+                              </span>
+                            </td>
+                            <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ child.issueType || '—' }}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                  <div v-else-if="expandedStrategic.has(strategicId(comp.name, si.key)) && !si.children.length" class="px-4 pb-2 pl-14">
+                    <p class="text-[10px] text-gray-400 dark:text-gray-500 italic">No child issues in this release.</p>
+                  </div>
+                </div>
+
+                <!-- Other items -->
+                <div v-if="comp.otherItems.length" class="border-t border-gray-100/60 dark:border-gray-800/60">
+                  <button
+                    class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
+                    @click.stop="toggleStrategicExpand(comp.name, '__other__')"
+                  >
+                    <div class="flex items-center gap-2 min-w-0">
+                      <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, '__other__')) }">&#9654;</span>
+                      <span class="font-medium text-gray-500 dark:text-gray-400 text-xs italic">Other items</span>
+                      <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ comp.otherItems.length }}</span>
+                    </div>
+                    <div class="grid grid-cols-3 gap-1.5 text-[10px] shrink-0">
+                      <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1 w-1 rounded-full bg-emerald-500" />{{ comp.otherCounts.done }}</span>
+                      <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1 w-1 rounded-full bg-blue-500" />{{ comp.otherCounts.doing }}</span>
+                      <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1 w-1 rounded-full bg-gray-400" />{{ comp.otherCounts.to_do }}</span>
+                    </div>
+                  </button>
+
+                  <div v-if="expandedStrategic.has(strategicId(comp.name, '__other__'))" class="px-4 pb-2 pl-14">
+                    <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
+                      <table class="min-w-full text-sm">
+                        <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                          <tr>
+                            <th class="px-3 py-1.5 font-medium">Key</th>
+                            <th class="px-3 py-1.5 font-medium">Summary</th>
+                            <th class="px-3 py-1.5 font-medium">Status</th>
+                            <th class="px-3 py-1.5 font-medium">Type</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr v-for="issue in comp.otherItems" :key="issue.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
+                            <td class="px-3 py-1.5 whitespace-nowrap">
+                              <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ issue.key }}</a>
+                            </td>
+                            <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ issue.summary }}</span></td>
+                            <td class="px-3 py-1.5 whitespace-nowrap">
+                              <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(issue.statusBucket)">
+                                <span class="h-1 w-1 rounded-full" :class="statusDotClass(issue.statusBucket)" />
+                                {{ issue.status }}
+                              </span>
+                            </td>
+                            <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType || '—' }}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-          <div
-            class="flex h-2 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60"
-          >
-            <template v-if="teamIssueSum(team) > 0">
-              <div class="h-full bg-emerald-500 dark:bg-emerald-600" :style="{ width: pct(team.issues_done, teamIssueSum(team)) }" />
-              <div class="h-full bg-blue-500 dark:bg-blue-600" :style="{ width: pct(team.issues_doing, teamIssueSum(team)) }" />
-              <div class="h-full bg-gray-400 dark:bg-gray-500" :style="{ width: pct(team.issues_to_do, teamIssueSum(team)) }" />
-            </template>
+        </div>
+
+        <!-- On Track / Complete block -->
+        <div v-if="nonRiskComponents.length" class="rounded-lg border border-emerald-200/80 dark:border-emerald-800/50 overflow-hidden">
+          <div class="flex items-center gap-2 px-4 py-2 border-b border-emerald-200/60 dark:border-emerald-800/40 bg-emerald-50/60 dark:bg-emerald-950/20">
+            <span class="h-2 w-2 rounded-full bg-emerald-500" />
+            <span class="text-xs font-semibold text-emerald-700 dark:text-emerald-300 uppercase tracking-wide">On Track</span>
+            <span class="text-[10px] text-emerald-500/70 dark:text-emerald-400/60">{{ nonRiskComponents.length }} component{{ nonRiskComponents.length !== 1 ? 's' : '' }}</span>
           </div>
-          <div class="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-gray-600 dark:text-gray-300">
-            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Done {{ fmtCount(team.issues_done) }}</span>
-            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" /> Doing {{ fmtCount(team.issues_doing) }}</span>
-            <span class="inline-flex items-center gap-1"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" /> To do {{ fmtCount(team.issues_to_do) }}</span>
-            <span class="text-gray-500 dark:text-gray-400">· {{ teamIssueSum(team) }} issues</span>
+          <div class="divide-y divide-gray-100 dark:divide-gray-800">
+          <div
+            v-for="comp in nonRiskComponents"
+            :key="comp.name"
+          >
+            <button
+              class="w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-gray-50/60 dark:hover:bg-gray-800/30 transition-colors"
+              @click="toggleComponentExpand(comp.name)"
+            >
+              <div class="flex items-center gap-2.5 min-w-0 flex-wrap">
+                <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedComponents.has(comp.name) }">&#9654;</span>
+                <span class="font-medium text-gray-700 dark:text-gray-200 text-sm">{{ comp.name }}</span>
+                <span class="text-xs text-gray-400 dark:text-gray-500">{{ compIssueSum(comp) }} issue{{ compIssueSum(comp) !== 1 ? 's' : '' }}</span>
+                <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
+                  <span class="h-1.5 w-1.5 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
+                  {{ comp.forecast.paceStatus }}
+                </span>
+                <span
+                  v-for="proj in comp.projects"
+                  :key="proj"
+                  class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/40 border border-indigo-200/70 dark:border-indigo-700/50 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-indigo-600 dark:text-indigo-300"
+                >{{ proj }}</span>
+              </div>
+              <div class="flex items-center gap-3 shrink-0">
+                <div class="grid grid-cols-3 gap-1.5 text-[10px]">
+                  <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />{{ fmtCount(comp.issues_done) }}</span>
+                  <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1.5 w-1.5 rounded-full bg-blue-500" />{{ fmtCount(comp.issues_doing) }}</span>
+                  <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1.5 w-1.5 rounded-full bg-gray-400" />{{ fmtCount(comp.issues_to_do) }}</span>
+                </div>
+                <div class="flex h-2 w-24 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800 ring-1 ring-inset ring-gray-200/60 dark:ring-gray-700/60">
+                  <div class="h-full bg-emerald-500" :style="{ width: pct(comp.issues_done, compIssueSum(comp)) }" />
+                  <div class="h-full bg-blue-500" :style="{ width: pct(comp.issues_doing, compIssueSum(comp)) }" />
+                  <div class="h-full bg-gray-400" :style="{ width: pct(comp.issues_to_do, compIssueSum(comp)) }" />
+                </div>
+              </div>
+            </button>
+
+            <!-- Expanded component detail -->
+            <div v-if="expandedComponents.has(comp.name)" class="border-t border-gray-100 dark:border-gray-800">
+              <!-- Capacity strip -->
+              <div class="px-4 py-2.5 bg-gray-50/40 dark:bg-gray-800/20 border-b border-gray-100 dark:border-gray-800">
+                <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1.5 text-[11px]">
+                  <div>
+                    <span class="text-gray-400 dark:text-gray-500">Feature Velocity (V) — 6mo avg</span>
+                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.velocity }} <span class="font-normal text-gray-400 dark:text-gray-500">issues / 14d</span></p>
+                  </div>
+                  <div>
+                    <span class="text-gray-400 dark:text-gray-500">Remaining Issues (RI)</span>
+                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.remaining }} <span class="font-normal text-gray-400 dark:text-gray-500">not done</span></p>
+                  </div>
+                  <div>
+                    <span class="text-gray-400 dark:text-gray-500">Sprint (14d window) Remaining (W)</span>
+                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.windowsRemaining }} <span class="font-normal text-gray-400 dark:text-gray-500">({{ comp.forecast.T }}d ÷ 14)</span></p>
+                  </div>
+                  <div>
+                    <span class="text-gray-400 dark:text-gray-500">Capacity (C = V x W)</span>
+                    <p class="font-semibold text-gray-700 dark:text-gray-300">{{ comp.forecast.totalCapacity }} <span class="font-normal text-gray-400 dark:text-gray-500">projected</span></p>
+                  </div>
+                </div>
+                <div class="mt-2 flex items-center gap-3 text-xs flex-wrap">
+                  <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-semibold" :class="confidenceBadgeClass(comp.forecast.level)">
+                    <span class="h-2 w-2 rounded-full" :class="confidenceDotClass(comp.forecast.level)" />
+                    {{ comp.forecast.paceStatus }}
+                  </span>
+                  <span v-if="comp.forecast.remaining > 0" class="text-gray-500 dark:text-gray-400">
+                    Needs {{ comp.forecast.remaining }}; Projected {{ comp.forecast.totalCapacity }}
+                    <span class="font-semibold" :class="comp.forecast.delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
+                      ({{ comp.forecast.delta >= 0 ? '+' : '' }}{{ comp.forecast.delta }})
+                    </span>
+                  </span>
+                  <span v-else class="text-emerald-600 dark:text-emerald-400 font-medium">All issues resolved</span>
+                </div>
+              </div>
+
+              <!-- Strategic items -->
+              <div
+                v-for="si in comp.strategicItems"
+                :key="si.key"
+                class="border-b border-gray-100/60 dark:border-gray-800/60 last:border-b-0"
+              >
+                <button
+                  class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
+                  @click.stop="toggleStrategicExpand(comp.name, si.key)"
+                >
+                  <div class="flex items-center gap-2 min-w-0 flex-wrap">
+                    <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, si.key)) }">&#9654;</span>
+                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider" :class="issueTypePillClass(si.issueType)">{{ si.issueType }}</span>
+                    <a :href="si.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline text-xs font-medium" @click.stop>{{ si.key }}</a>
+                    <span class="text-xs text-gray-700 dark:text-gray-300 truncate">{{ si.summary }}</span>
+                  </div>
+                  <div class="flex items-center gap-3 shrink-0">
+                    <span class="inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full font-medium" :class="statusBadgeClass(si.statusBucket)">
+                      <span class="h-1.5 w-1.5 rounded-full" :class="statusDotClass(si.statusBucket)" />
+                      {{ si.status }}
+                    </span>
+                    <span class="text-xs font-medium tabular-nums" :class="childProgressColor(si.childCounts)">
+                      {{ si.childCounts.done }}/{{ si.children.length }} Done
+                    </span>
+                  </div>
+                </button>
+
+                <!-- Children table -->
+                <div v-if="expandedStrategic.has(strategicId(comp.name, si.key)) && si.children.length" class="px-4 pb-2 pl-14">
+                  <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
+                    <table class="min-w-full text-sm">
+                      <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                        <tr>
+                          <th class="px-3 py-1.5 font-medium">Key</th>
+                          <th class="px-3 py-1.5 font-medium">Summary</th>
+                          <th class="px-3 py-1.5 font-medium">Status</th>
+                          <th class="px-3 py-1.5 font-medium">Type</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr v-for="child in si.children" :key="child.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
+                          <td class="px-3 py-1.5 whitespace-nowrap">
+                            <a :href="child.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ child.key }}</a>
+                          </td>
+                          <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ child.summary }}</span></td>
+                          <td class="px-3 py-1.5 whitespace-nowrap">
+                            <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(child.statusBucket)">
+                              <span class="h-1 w-1 rounded-full" :class="statusDotClass(child.statusBucket)" />
+                              {{ child.status }}
+                            </span>
+                          </td>
+                          <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ child.issueType || '—' }}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+                <div v-else-if="expandedStrategic.has(strategicId(comp.name, si.key)) && !si.children.length" class="px-4 pb-2 pl-14">
+                  <p class="text-[10px] text-gray-400 dark:text-gray-500 italic">No child issues in this release.</p>
+                </div>
+              </div>
+
+              <!-- Other items -->
+              <div v-if="comp.otherItems.length" class="border-t border-gray-100/60 dark:border-gray-800/60">
+                <button
+                  class="w-full flex items-center justify-between gap-3 px-4 py-2 pl-8 text-left hover:bg-gray-50/40 dark:hover:bg-gray-800/20 transition-colors"
+                  @click.stop="toggleStrategicExpand(comp.name, '__other__')"
+                >
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="text-gray-400 dark:text-gray-500 transition-transform text-[10px]" :class="{ 'rotate-90': expandedStrategic.has(strategicId(comp.name, '__other__')) }">&#9654;</span>
+                    <span class="font-medium text-gray-500 dark:text-gray-400 text-xs italic">Other items</span>
+                    <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ comp.otherItems.length }}</span>
+                  </div>
+                  <div class="grid grid-cols-3 gap-1.5 text-[10px] shrink-0">
+                    <span class="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400"><span class="h-1 w-1 rounded-full bg-emerald-500" />{{ comp.otherCounts.done }}</span>
+                    <span class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400"><span class="h-1 w-1 rounded-full bg-blue-500" />{{ comp.otherCounts.doing }}</span>
+                    <span class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400"><span class="h-1 w-1 rounded-full bg-gray-400" />{{ comp.otherCounts.to_do }}</span>
+                  </div>
+                </button>
+
+                <div v-if="expandedStrategic.has(strategicId(comp.name, '__other__'))" class="px-4 pb-2 pl-14">
+                  <div class="overflow-x-auto rounded-lg border border-gray-200/80 dark:border-gray-700/80">
+                    <table class="min-w-full text-sm">
+                      <thead class="bg-gray-50 dark:bg-gray-800/60 text-left text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                        <tr>
+                          <th class="px-3 py-1.5 font-medium">Key</th>
+                          <th class="px-3 py-1.5 font-medium">Summary</th>
+                          <th class="px-3 py-1.5 font-medium">Status</th>
+                          <th class="px-3 py-1.5 font-medium">Type</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr v-for="issue in comp.otherItems" :key="issue.key" class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/20">
+                          <td class="px-3 py-1.5 whitespace-nowrap">
+                            <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-medium text-xs">{{ issue.key }}</a>
+                          </td>
+                          <td class="px-3 py-1.5 max-w-xs"><span class="line-clamp-1 text-xs text-gray-700 dark:text-gray-300">{{ issue.summary }}</span></td>
+                          <td class="px-3 py-1.5 whitespace-nowrap">
+                            <span class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full font-medium" :class="statusBadgeClass(issue.statusBucket)">
+                              <span class="h-1 w-1 rounded-full" :class="statusDotClass(issue.statusBucket)" />
+                              {{ issue.status }}
+                            </span>
+                          </td>
+                          <td class="px-3 py-1.5 text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType || '—' }}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
           </div>
         </div>
       </div>
-
-      <!-- Capacity table -->
-      <details class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30">
-        <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
-          <span class="text-gray-400 group-open:rotate-90 transition-transform">&#9656;</span>
-          Capacity &amp; throughput
-        </summary>
-        <div class="px-3 pb-3 overflow-x-auto border-t border-gray-100 dark:border-gray-800">
-          <table class="min-w-full text-sm mt-2">
-            <thead class="text-left text-gray-600 dark:text-gray-300">
-              <tr>
-                <th class="pr-3 py-1">Team</th>
-                <th class="pr-3 py-1">Remaining</th>
-                <th class="pr-3 py-1">Done</th>
-                <th class="pr-3 py-1">Expected to due</th>
-                <th class="pr-3 py-1">Required/day</th>
-                <th class="pr-3 py-1">Available/day</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="team in releaseTeamsList"
-                :key="`cap-${team.projectKey}`"
-                class="border-t border-gray-100 dark:border-gray-800"
-              >
-                <td class="py-2 pr-3 font-medium">{{ team.projectKey }}</td>
-                <td class="py-2 pr-3">{{ fmt(team.remaining) }}</td>
-                <td class="py-2 pr-3">{{ fmt(team.actualDoneThisRelease) }}</td>
-                <td class="py-2 pr-3">{{ fmt(team.expectedThroughputToDue) }}</td>
-                <td class="py-2 pr-3">{{ fmt(team.requiredRatePerDay) }}</td>
-                <td class="py-2 pr-3">{{ fmt(team.availableRatePerDay) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </details>
-
-      <!-- Issues table -->
-      <details class="group rounded-lg border border-gray-200 dark:border-gray-700 open:bg-gray-50/50 dark:open:bg-gray-800/30">
-        <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 list-none flex items-center gap-2">
-          <span class="text-gray-400 group-open:rotate-90 transition-transform">&#9656;</span>
-          Issues ({{ releaseIssues.length }})
-        </summary>
-        <div class="overflow-x-auto max-h-[min(440px,50vh)] border-t border-gray-100 dark:border-gray-800">
-          <table class="min-w-full text-sm">
-            <thead class="bg-white dark:bg-gray-900 sticky top-0 text-left text-gray-600 dark:text-gray-300">
-              <tr>
-                <th class="px-3 py-2">Issue</th>
-                <th class="px-3 py-2">Type</th>
-                <th class="px-3 py-2">Team</th>
-                <th class="px-3 py-2">Status</th>
-                <th class="px-3 py-2">Weight</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="issue in releaseIssues"
-                :key="issue.key"
-                class="border-b border-gray-100 dark:border-gray-800"
-              >
-                <td class="px-3 py-2">
-                  <a :href="issue.link" target="_blank" rel="noopener" class="text-blue-600 hover:underline">{{ issue.key }}</a>
-                  <div class="text-xs text-gray-500 dark:text-gray-400 max-w-[320px] truncate">{{ issue.summary }}</div>
-                </td>
-                <td class="px-3 py-2">{{ issue.issueType || '—' }}</td>
-                <td class="px-3 py-2">{{ issue.projectKey }}</td>
-                <td class="px-3 py-2">
-                  <span class="text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700">{{ issue.statusBucket }}</span>
-                  <span class="text-xs text-gray-500 ml-1">{{ issue.status }}</span>
-                </td>
-                <td class="px-3 py-2">{{ fmt(issue.weight) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </details>
 
       <!-- Monte Carlo -->
       <details
@@ -308,27 +631,237 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, reactive } from 'vue'
 import MonteCarloChart from './MonteCarloChart.vue'
 import { extractProduct } from '../composables/useReleaseFilter'
 import { gammaSample } from '../utils/monteCarlo'
+
+const FORECAST_WINDOW = 14
+const STRATEGIC_TYPES = new Set(['feature', 'initiative', 'spike'])
+const BUCKET_ORDER = { to_do: 0, doing: 1, done: 2 }
+
+function normalizeType(t) { return (t || '').toLowerCase().trim() }
+
+function countByBucket(issues) {
+  const counts = { done: 0, doing: 0, to_do: 0 }
+  for (const i of issues) {
+    if (i.statusBucket === 'done') counts.done++
+    else if (i.statusBucket === 'doing') counts.doing++
+    else counts.to_do++
+  }
+  return counts
+}
+
+function sortRemainingFirst(issues) {
+  return [...issues].sort((a, b) => (BUCKET_ORDER[a.statusBucket] ?? 1) - (BUCKET_ORDER[b.statusBucket] ?? 1))
+}
 
 const props = defineProps({
   release: { type: Object, required: true },
   mcInputs: { type: Object, default: null },
   activeMcTarget: { type: String, default: 'codeFreeze' },
+  componentVelocity: { type: Object, default: () => ({}) },
+  selectedProjects: { type: Set, default: () => new Set() },
   defaultExpanded: { type: Boolean, default: false }
 })
 
 defineEmits(['set-mc-target'])
 
 const expanded = ref(props.defaultExpanded)
+const expandedComponents = reactive(new Set())
+const expandedStrategic = reactive(new Set())
+
+function toggleComponentExpand(name) {
+  if (expandedComponents.has(name)) {
+    expandedComponents.delete(name)
+    for (const k of [...expandedStrategic]) {
+      if (k.startsWith(name + '::')) expandedStrategic.delete(k)
+    }
+  } else {
+    expandedComponents.add(name)
+  }
+}
+
+function strategicId(compName, itemKey) { return `${compName}::${itemKey}` }
+
+function toggleStrategicExpand(compName, itemKey) {
+  const k = strategicId(compName, itemKey)
+  if (expandedStrategic.has(k)) expandedStrategic.delete(k)
+  else expandedStrategic.add(k)
+}
 
 const productLabel = computed(() => extractProduct(props.release.releaseNumber).toUpperCase())
 
 const releaseTeamsList = computed(() => {
   if (!props.release?.teams) return []
   return Object.values(props.release.teams).sort((a, b) => a.projectKey.localeCompare(b.projectKey))
+})
+
+function daysUntilDeadline() {
+  const deadline = props.release?.codeFreezeDate || props.release?.dueDate
+  if (!deadline) return 0
+  const target = new Date(deadline + 'T00:00:00')
+  if (isNaN(target.getTime())) return 0
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return Math.max(0, Math.ceil((target - today) / (1000 * 60 * 60 * 24)))
+}
+
+function lookupVelocity(componentNames) {
+  const cv = props.componentVelocity || {}
+  let total = 0
+  const seen = new Set()
+  for (const name of componentNames) {
+    if (seen.has(name)) continue
+    seen.add(name)
+    const entry = cv[name]
+    if (entry) total += entry.velocity
+  }
+  return Math.round(total * 10) / 10
+}
+
+function computeForecast(remaining, componentNames) {
+  const velocity = lookupVelocity(componentNames)
+  const T = daysUntilDeadline()
+  const windowsRemaining = T / FORECAST_WINDOW
+  const totalCapacity = velocity * windowsRemaining
+  const delta = totalCapacity - remaining
+
+  let paceStatus, level
+  if (remaining === 0) {
+    paceStatus = 'Complete'
+    level = 'High'
+  } else if (totalCapacity >= remaining) {
+    paceStatus = 'On Track'
+    level = 'High'
+  } else {
+    paceStatus = 'At Risk'
+    level = 'Low'
+  }
+
+  return {
+    velocity,
+    remaining,
+    windowsRemaining: +windowsRemaining.toFixed(1),
+    totalCapacity: +totalCapacity.toFixed(1),
+    delta: +delta.toFixed(1),
+    paceStatus,
+    level,
+    T
+  }
+}
+
+const projectFilteredIssues = computed(() => {
+  const all = releaseIssues.value
+  if (!props.selectedProjects.size) return all
+  return all.filter(i => props.selectedProjects.has(i.projectKey))
+})
+
+const componentList = computed(() => {
+  const issues = projectFilteredIssues.value
+  if (!issues.length) return []
+
+  const strategicMap = {}
+  for (const issue of issues) {
+    if (STRATEGIC_TYPES.has(normalizeType(issue.issueType))) {
+      strategicMap[issue.key] = issue
+    }
+  }
+
+  const childKeySet = new Set()
+  const childrenByParent = {}
+  for (const issue of issues) {
+    if (issue.parentKey && strategicMap[issue.parentKey]) {
+      childKeySet.add(issue.key)
+      if (!childrenByParent[issue.parentKey]) childrenByParent[issue.parentKey] = []
+      childrenByParent[issue.parentKey].push(issue)
+    }
+  }
+
+  const map = {}
+  for (const issue of issues) {
+    const names = issue.components?.length ? issue.components : ['(No component)']
+    for (const name of names) {
+      if (!map[name]) {
+        map[name] = { name, projects: new Set(), issues_to_do: 0, issues_doing: 0, issues_done: 0, allIssues: [] }
+      }
+      const entry = map[name]
+      entry.projects.add(issue.projectKey)
+      entry.allIssues.push(issue)
+      if (issue.statusBucket === 'to_do') entry.issues_to_do++
+      else if (issue.statusBucket === 'doing') entry.issues_doing++
+      else entry.issues_done++
+    }
+  }
+
+  return Object.values(map)
+    .map(c => {
+      const remaining = c.issues_to_do + c.issues_doing
+
+      const compStrategic = c.allIssues.filter(i => strategicMap[i.key])
+      const compStrategicKeys = new Set(compStrategic.map(i => i.key))
+
+      const TYPE_ORDER = { Feature: 0, Initiative: 1, Spike: 2 }
+      const strategicItems = compStrategic
+        .map(si => {
+          const children = sortRemainingFirst(childrenByParent[si.key] || [])
+          return {
+            key: si.key, summary: si.summary, issueType: si.issueType,
+            status: si.status, statusBucket: si.statusBucket, link: si.link,
+            children,
+            childCounts: countByBucket(children)
+          }
+        })
+        .sort((a, b) => {
+          const ta = TYPE_ORDER[a.issueType] ?? 3
+          const tb = TYPE_ORDER[b.issueType] ?? 3
+          if (ta !== tb) return ta - tb
+          return a.key.localeCompare(b.key)
+        })
+
+      const otherItems = sortRemainingFirst(
+        c.allIssues.filter(i => !compStrategicKeys.has(i.key) && !childKeySet.has(i.key))
+      )
+
+      return {
+        name: c.name,
+        projects: [...c.projects].sort(),
+        issues_to_do: c.issues_to_do,
+        issues_doing: c.issues_doing,
+        issues_done: c.issues_done,
+        forecast: computeForecast(remaining, [c.name]),
+        strategicItems,
+        otherItems,
+        otherCounts: countByBucket(otherItems)
+      }
+    })
+    .sort((a, b) => {
+      if (a.name === '(No component)') return 1
+      if (b.name === '(No component)') return -1
+      const riskOrder = { Low: 0, High: 1 }
+      const ra = riskOrder[a.forecast.level] ?? 0
+      const rb = riskOrder[b.forecast.level] ?? 0
+      if (ra !== rb) return ra - rb
+      return a.name.localeCompare(b.name)
+    })
+})
+
+const atRiskComponents = computed(() => componentList.value.filter(c => c.forecast.paceStatus === 'At Risk'))
+const nonRiskComponents = computed(() => componentList.value.filter(c => c.forecast.paceStatus !== 'At Risk'))
+
+const releaseForecast = computed(() => {
+  const allNames = componentList.value.map(c => c.name)
+  const totalRemaining = componentList.value.reduce((s, c) => s + c.issues_to_do + c.issues_doing, 0)
+  const forecast = computeForecast(totalRemaining, allNames)
+
+  const atRisk = componentList.value.filter(c => c.forecast.paceStatus === 'At Risk')
+  if (atRisk.length > 0 && forecast.paceStatus !== 'At Risk') {
+    forecast.paceStatus = 'At Risk'
+    forecast.level = 'Low'
+    forecast.riskSource = 'components'
+  }
+  forecast.atRiskComponents = atRisk.map(c => c.name)
+  return forecast
 })
 
 const releaseIssues = computed(() => {
@@ -376,6 +909,8 @@ const releaseRiskTitle = computed(() => {
   return props.release?.riskSummary || 'Schedule risk from open issue count vs days to due date.'
 })
 
+// ── Styling helpers ──
+
 function riskDotClass(risk) {
   if (risk === 'red') return 'bg-red-500 dark:bg-red-600'
   if (risk === 'yellow') return 'bg-amber-400 dark:bg-amber-500'
@@ -383,9 +918,47 @@ function riskDotClass(risk) {
   return 'bg-emerald-500 dark:bg-emerald-600'
 }
 
-function teamIssueSum(team) {
-  if (!team) return 0
-  return (team.issues_to_do || 0) + (team.issues_doing || 0) + (team.issues_done || 0)
+function confidenceBadgeClass(level) {
+  if (level === 'High') return 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+  return 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300'
+}
+
+function confidenceDotClass(level) {
+  if (level === 'High') return 'bg-emerald-500'
+  return 'bg-red-500'
+}
+
+function issueTypePillClass(type) {
+  const t = normalizeType(type)
+  if (t === 'feature') return 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300'
+  if (t === 'initiative') return 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300'
+  if (t === 'spike') return 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300'
+  return 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
+}
+
+function statusBadgeClass(bucket) {
+  if (bucket === 'done') return 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+  if (bucket === 'doing') return 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+  return 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
+}
+
+function statusDotClass(bucket) {
+  if (bucket === 'done') return 'bg-emerald-500'
+  if (bucket === 'doing') return 'bg-blue-500'
+  return 'bg-gray-400'
+}
+
+function childProgressColor(counts) {
+  const total = counts.done + counts.doing + counts.to_do
+  if (total === 0) return 'text-gray-400 dark:text-gray-500'
+  if (counts.done === total) return 'text-emerald-600 dark:text-emerald-400'
+  if (counts.done / total > 0.5) return 'text-blue-600 dark:text-blue-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+function compIssueSum(comp) {
+  if (!comp) return 0
+  return (comp.issues_to_do || 0) + (comp.issues_doing || 0) + (comp.issues_done || 0)
 }
 
 function pct(part, total) {
@@ -398,10 +971,6 @@ function fmtCount(n) {
   return String(Math.round(Number(n)))
 }
 
-function fmt(n) {
-  if (!Number.isFinite(Number(n))) return String(n)
-  return Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 })
-}
 
 function formatDate(iso) {
   const d = new Date(iso)

--- a/modules/release-analysis/client/components/ReleaseFilterBar.vue
+++ b/modules/release-analysis/client/components/ReleaseFilterBar.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex flex-wrap items-center gap-3">
     <div
-      v-if="versionOpen"
+      v-if="versionOpen || projectOpen"
       class="fixed inset-0 z-10"
-      @click="versionOpen = false"
+      @click="versionOpen = false; projectOpen = false"
     />
 
     <!-- Version Filter -->
@@ -13,7 +13,7 @@
         :class="selectedVersions.size
           ? 'border-violet-300 dark:border-violet-600 bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300'
           : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'"
-        @click="versionOpen = !versionOpen"
+        @click="versionOpen = !versionOpen; projectOpen = false"
       >
         <svg class="h-4 w-4 shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z" />
@@ -58,11 +58,62 @@
       </div>
     </div>
 
+    <!-- Project Filter -->
+    <div class="relative z-20">
+      <button
+        class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+        :class="selectedProjects.size
+          ? 'border-sky-300 dark:border-sky-600 bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300'
+          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'"
+        @click="projectOpen = !projectOpen; versionOpen = false"
+      >
+        <svg class="h-4 w-4 shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+        </svg>
+        <span>Project</span>
+        <span
+          v-if="selectedProjects.size"
+          class="inline-flex items-center justify-center h-5 min-w-[1.25rem] rounded-full bg-sky-600 dark:bg-sky-500 text-white text-[10px] font-bold px-1.5"
+        >{{ selectedProjects.size }}</span>
+        <svg class="h-3.5 w-3.5 text-gray-400 transition-transform" :class="{ 'rotate-180': projectOpen }" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+        </svg>
+      </button>
+      <div
+        v-if="projectOpen"
+        class="absolute left-0 top-full mt-1.5 w-56 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg ring-1 ring-black/5 dark:ring-white/5 overflow-hidden"
+      >
+        <div class="flex items-center justify-between px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+          <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Projects</span>
+          <button
+            v-if="selectedProjects.size"
+            class="text-[11px] font-medium text-sky-600 dark:text-sky-400 hover:text-sky-800 dark:hover:text-sky-300"
+            @click="clearProjects"
+          >Clear All</button>
+        </div>
+        <div class="max-h-52 overflow-y-auto py-1">
+          <label
+            v-for="project in visibleProjects"
+            :key="project"
+            class="flex items-center gap-2.5 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+          >
+            <input
+              type="checkbox"
+              :checked="selectedProjects.has(project)"
+              class="h-3.5 w-3.5 rounded border-gray-300 dark:border-gray-600 text-sky-600 focus:ring-sky-500"
+              @change="toggleProject(project)"
+            />
+            <span class="text-sm font-bold uppercase tracking-wide text-gray-700 dark:text-gray-300">{{ project }}</span>
+          </label>
+        </div>
+      </div>
+    </div>
+
     <!-- Active filter pills + summary -->
     <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
       <span>{{ filteredCount }} of {{ totalCount }} releases</span>
       <button
-        v-if="selectedVersions.size"
+        v-if="selectedVersions.size || selectedProjects.size"
         class="text-xs font-medium text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
         @click="resetFilters"
       >Reset filters</button>
@@ -76,12 +127,17 @@ import { ref } from 'vue'
 defineProps({
   selectedVersions: { type: Set, required: true },
   visibleVersions: { type: Array, required: true },
+  selectedProjects: { type: Set, required: true },
+  visibleProjects: { type: Array, required: true },
   filteredCount: { type: Number, required: true },
   totalCount: { type: Number, required: true },
   toggleVersion: { type: Function, required: true },
   clearVersions: { type: Function, required: true },
+  toggleProject: { type: Function, required: true },
+  clearProjects: { type: Function, required: true },
   resetFilters: { type: Function, required: true }
 })
 
 const versionOpen = ref(false)
+const projectOpen = ref(false)
 </script>

--- a/modules/release-analysis/client/components/ReleaseVersionGroup.vue
+++ b/modules/release-analysis/client/components/ReleaseVersionGroup.vue
@@ -153,6 +153,8 @@
             :release="release"
             :mc-inputs="mcInputsMap.get(release.releaseNumber) || null"
             :active-mc-target="getMcTarget(release.releaseNumber)"
+            :component-velocity="componentVelocity"
+            :selected-projects="selectedProjects"
             @set-mc-target="(rn, target) => $emit('set-mc-target', rn, target)"
           />
         </div>
@@ -174,6 +176,8 @@ const props = defineProps({
   group: { type: Object, required: true },
   mcInputsMap: { type: Map, required: true },
   getMcTarget: { type: Function, required: true },
+  componentVelocity: { type: Object, default: () => ({}) },
+  selectedProjects: { type: Set, default: () => new Set() },
   defaultOpen: { type: Boolean, default: true }
 })
 

--- a/modules/release-analysis/client/views/MainView.vue
+++ b/modules/release-analysis/client/views/MainView.vue
@@ -61,11 +61,15 @@
             class="mt-4"
             :selected-versions="selectedVersions"
             :visible-versions="visibleVersions"
+            :selected-projects="selectedProjects"
+            :visible-projects="visibleProjects"
             :filtered-count="filteredReleases.length"
             :total-count="allReleases.length"
             :toggle-version="toggleVersion"
             :clear-versions="clearVersions"
-            :reset-filters="resetFilters"
+            :toggle-project="toggleProject"
+            :clear-projects="clearProjects"
+            :reset-filters="resetAllFilters"
           />
         </div>
 
@@ -81,6 +85,8 @@
               :group="group"
               :mc-inputs-map="mcInputsMap"
               :get-mc-target="getMcTarget"
+              :component-velocity="analysis?.componentVelocity || {}"
+              :selected-projects="selectedProjects"
               :default-open="false"
               @set-mc-target="setMcTarget"
             />
@@ -111,6 +117,32 @@ const {
   clearVersions,
   resetFilters
 } = useReleaseFilter(allReleases)
+
+// ── Jira project key filter ──
+
+const selectedProjects = reactive(new Set())
+
+const visibleProjects = computed(() => {
+  const keys = new Set()
+  for (const r of filteredReleases.value) {
+    if (r.teams) {
+      for (const pk of Object.keys(r.teams)) keys.add(pk)
+    }
+  }
+  return [...keys].sort()
+})
+
+function toggleProject(pk) {
+  if (selectedProjects.has(pk)) selectedProjects.delete(pk)
+  else selectedProjects.add(pk)
+}
+
+function clearProjects() { selectedProjects.clear() }
+
+function resetAllFilters() {
+  resetFilters()
+  selectedProjects.clear()
+}
 
 // ── Monte Carlo state ──
 


### PR DESCRIPTION
## Summary
- **Flatten component hierarchy**: Replaces nested project-based groupings (AIPCC, INFERENG, etc.) with a flat list of Jira components, each tagged with contributing project key badges.
- **Per-component capacity forecast**: Each component row shows Feature Velocity, Remaining Issues, Sprint Windows Remaining, Capacity, and a pace status (On Track / At Risk / Complete), ported from the Component Breakdown view.
- **Visual risk grouping**: At Risk components are grouped in a red-bordered block with a header; On Track / Complete components in a green-bordered block. Expanded detail areas use clean white backgrounds for readability.
- **Issue hierarchy per component**: Strategic items (Feature, Initiative, Spike) render with expandable children and completion counts, plus an "Other Items" collapsible section for non-strategic work.
- **Project picker filter**: New sky-blue "Project" dropdown alongside the existing "Version" picker allows filtering by Jira project key (AIPCC, INFERENG, etc.).
- **Remove flat issues table**: The redundant "Issues (N)" collapsible widget is removed from release cards since the component hierarchy already surfaces all issues.

## Test plan
- [ ] Verify Release Analysis tab loads and shows components in a flat list with project key badges
- [ ] Expand a component and confirm capacity metrics and issue hierarchy render correctly
- [ ] Confirm At Risk components appear in the red block, On Track/Complete in the green block
- [ ] Test the Project picker filter: selecting a project filters components accordingly
- [ ] Test Version + Project filters together and the Reset button clears both
- [ ] Verify the "Issues" collapsible widget is no longer shown on any release card
- [ ] Check dark mode rendering for both risk group blocks

Made with [Cursor](https://cursor.com)