### PR TITLE
feat: update autofix dashboard for granular pipeline labels

### DIFF
--- a/fixtures/ai-impact/autofix-data.json
+++ b/fixtures/ai-impact/autofix-data.json
@@ -11,13 +11,13 @@
       "updated": "2026-04-20T19:33:19.957+0000",
       "labels": [
         "aicp-team-forge",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Platform"
       ],
       "assignee": "Davide Bianchi",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58983",
@@ -30,13 +30,13 @@
       "labels": [
         "dashboard-area-infrastructure",
         "dashboard-monarch-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Christian Vogt",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58933",
@@ -48,13 +48,13 @@
       "updated": "2026-04-20T19:31:46.645+0000",
       "labels": [
         "devtestops-service",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Platform"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58847",
@@ -66,13 +66,13 @@
       "updated": "2026-04-20T15:49:04.059+0000",
       "labels": [
         "dashboard-area-mcp",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Manaswini Das",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58830",
@@ -84,13 +84,13 @@
       "updated": "2026-04-18T19:32:59.375+0000",
       "labels": [
         "dashboard-area-maas",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58829",
@@ -102,14 +102,14 @@
       "updated": "2026-04-18T19:34:11.323+0000",
       "labels": [
         "dashboard-area-maas",
-        "jira-triage-needs-info",
+        "jira-triage-missing-info",
         "needs-ux"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "AIPCC-14469",
@@ -139,14 +139,14 @@
       "updated": "2026-04-20T18:04:22.620+0000",
       "labels": [
         "dashboard-crimson-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard",
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58747",
@@ -160,13 +160,13 @@
         "ai-reviewed",
         "dashboard-area-maas",
         "dashboard-zaffre-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58734",
@@ -180,13 +180,13 @@
         "ai-reviewed",
         "dashboard-area-observability",
         "dashboard-monarch-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "AIPCC-14461",
@@ -198,14 +198,14 @@
       "updated": "2026-04-20T10:39:14.230+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14460",
@@ -217,14 +217,14 @@
       "updated": "2026-04-20T10:39:14.034+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14459",
@@ -236,14 +236,14 @@
       "updated": "2026-04-20T06:10:53.893+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14458",
@@ -255,14 +255,14 @@
       "updated": "2026-04-20T10:39:13.975+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14457",
@@ -274,14 +274,14 @@
       "updated": "2026-04-20T06:10:58.412+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14456",
@@ -293,14 +293,14 @@
       "updated": "2026-04-20T06:10:45.565+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-needs-info"
+        "jira-autofix-blocked"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-needs-info"
+      "pipelineState": "autofix-blocked"
     },
     {
       "key": "AIPCC-14455",
@@ -312,14 +312,14 @@
       "updated": "2026-04-20T10:39:14.180+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14454",
@@ -331,14 +331,14 @@
       "updated": "2026-04-20T10:39:14.364+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-needs-info"
+        "jira-autofix-blocked"
       ],
       "components": [
         "Development Platform",
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-needs-info"
+      "pipelineState": "autofix-blocked"
     },
     {
       "key": "RHOAIENG-58730",
@@ -350,14 +350,14 @@
       "updated": "2026-04-20T18:04:31.549+0000",
       "labels": [
         "dashboard-crimson-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard",
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58729",
@@ -369,14 +369,14 @@
       "updated": "2026-04-20T18:04:49.001+0000",
       "labels": [
         "dashboard-crimson-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard",
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58728",
@@ -388,14 +388,14 @@
       "updated": "2026-04-20T18:04:59.878+0000",
       "labels": [
         "dashboard-crimson-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard",
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58724",
@@ -409,13 +409,13 @@
         "ai-reviewed",
         "dashboard-area-infrastructure",
         "dashboard-monarch-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Moulali Shikalwadi",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58678",
@@ -427,13 +427,13 @@
       "updated": "2026-04-17T15:37:30.425+0000",
       "labels": [
         "dashboard-tangerine-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58677",
@@ -445,13 +445,13 @@
       "updated": "2026-04-17T15:37:12.252+0000",
       "labels": [
         "dashboard-tangerine-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58676",
@@ -463,13 +463,13 @@
       "updated": "2026-04-17T15:37:49.388+0000",
       "labels": [
         "dashboard-tangerine-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58655",
@@ -481,13 +481,13 @@
       "updated": "2026-04-17T15:38:08.954+0000",
       "labels": [
         "dashboard-razzmatazz-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "AIPCC-14433",
@@ -499,14 +499,14 @@
       "updated": "2026-04-17T00:54:05.296+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-needs-info",
+        "jira-autofix-blocked",
         "support"
       ],
       "components": [
         "Development Platform"
       ],
       "assignee": "Sean Johnston",
-      "pipelineState": "autofix-needs-info"
+      "pipelineState": "autofix-blocked"
     },
     {
       "key": "RHOAIENG-58577",
@@ -518,14 +518,14 @@
       "updated": "2026-04-20T18:06:11.084+0000",
       "labels": [
         "dashboard-crimson-scrum",
-        "jira-triage-needs-info",
+        "jira-triage-missing-info",
         "needs-advisor"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58544",
@@ -537,13 +537,13 @@
       "updated": "2026-04-17T15:35:58.110+0000",
       "labels": [
         "dashboard-area-model-serving",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58513",
@@ -555,14 +555,14 @@
       "updated": "2026-04-20T12:14:01.591+0000",
       "labels": [
         "dashboard-area-maas",
-        "jira-triage-needs-info",
+        "jira-triage-missing-info",
         "maas-3.4-extension"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Claudia Alphonse",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "AIPCC-14345",
@@ -574,13 +574,13 @@
       "updated": "2026-04-16T10:34:58.135+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Accelerator Enablement"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14342",
@@ -592,13 +592,13 @@
       "updated": "2026-04-18T19:10:43.152+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Accelerator Enablement"
       ],
       "assignee": "Lance Barto",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "AIPCC-14341",
@@ -610,13 +610,13 @@
       "updated": "2026-04-15T20:11:12.091+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Accelerator Enablement"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "RHOAIENG-58426",
@@ -628,14 +628,14 @@
       "updated": "2026-04-20T18:05:04.963+0000",
       "labels": [
         "dashboard-crimson-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard",
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "RHOAIENG-58425",
@@ -783,13 +783,13 @@
       "updated": "2026-04-17T13:47:34.251+0000",
       "labels": [
         "autorag",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AutoRAG"
       ],
       "assignee": "Jakub Walaszczyk",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "AIPCC-14329",
@@ -819,13 +819,13 @@
       "updated": "2026-04-15T11:22:57.603+0000",
       "labels": [
         "jira-autofix",
-        "jira-autofix-done"
+        "jira-autofix-merged"
       ],
       "components": [
         "Accelerator Enablement"
       ],
       "assignee": "Anu Oguntayo",
-      "pipelineState": "autofix-done"
+      "pipelineState": "autofix-merged"
     },
     {
       "key": "RHOAIENG-58326",
@@ -839,13 +839,13 @@
         "ai-reviewed",
         "dashboard-area-applications",
         "dashboard-monarch-scrum",
-        "jira-triage-needs-info"
+        "jira-triage-missing-info"
       ],
       "components": [
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-needs-info"
+      "pipelineState": "triage-missing-info"
     },
     {
       "key": "AIPCC-14318",
@@ -876,7 +876,7 @@
       "labels": [
         "devtestops-service",
         "jira-autofix",
-        "jira-autofix-needs-info"
+        "jira-autofix-blocked"
       ],
       "components": [
         "Build and Release",
@@ -884,7 +884,7 @@
         "Notebooks Images"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-needs-info"
+      "pipelineState": "autofix-blocked"
     }
   ]
 }

--- a/modules/ai-impact/__tests__/client/AutofixContent.test.js
+++ b/modules/ai-impact/__tests__/client/AutofixContent.test.js
@@ -7,16 +7,16 @@ const MOCK_DATA = {
   jiraHost: 'https://redhat.atlassian.net',
   metrics: {
     triageTotal: 10,
-    triageVerdicts: { ready: 6, needsInfo: 2, notFixable: 1, stale: 1, pending: 0 },
-    autofixStates: { ready: 1, pending: 1, review: 2, done: 2, needsInfo: 0 },
+    triageVerdicts: { ready: 6, missingInfo: 2, notFixable: 1, stale: 1, pending: 0 },
+    autofixStates: { ready: 1, pending: 1, review: 1, ciFailing: 0, merged: 2, rejected: 0, maxRetries: 0, researched: 0, blocked: 1 },
     autofixTotal: 6,
-    successRate: 33,
+    successRate: 100,
     windowTotal: 10,
     totalIssues: 10
   },
   trendData: [
-    { date: '2026-04-11', triaged: 3, autofixed: 2, done: 1, total: 3 },
-    { date: '2026-04-18', triaged: 7, autofixed: 4, done: 1, total: 7 }
+    { date: '2026-04-11', triaged: 3, autofixed: 2, merged: 1, total: 3 },
+    { date: '2026-04-18', triaged: 7, autofixed: 4, merged: 1, total: 7 }
   ],
   componentBreakdown: [
     { component: 'Model Server', triaged: 5, autofixed: 3, done: 1 },
@@ -56,7 +56,7 @@ describe('AutofixContent', () => {
       props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
     })
     expect(wrapper.text()).toContain('10')
-    expect(wrapper.text()).toContain('33%')
+    expect(wrapper.text()).toContain('100%')
   })
 
   it('renders triage outcomes panel', () => {
@@ -65,7 +65,7 @@ describe('AutofixContent', () => {
     })
     expect(wrapper.text()).toContain('Triage Outcomes')
     expect(wrapper.text()).toContain('Ready for AI')
-    expect(wrapper.text()).toContain('Needs Info')
+    expect(wrapper.text()).toContain('Missing Info')
     expect(wrapper.text()).toContain('Not AI-Fixable')
   })
 
@@ -74,7 +74,7 @@ describe('AutofixContent', () => {
       props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
     })
     expect(wrapper.text()).toContain('Autofix Progress')
-    expect(wrapper.text()).toContain('AI Completed')
+    expect(wrapper.text()).toContain('AI Fix Merged')
     expect(wrapper.text()).toContain('AI Fix Under Review')
   })
 

--- a/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
+++ b/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
@@ -8,8 +8,24 @@ const {
 } = require('../../server/jira/autofix-fetcher')
 
 describe('classifyIssue', () => {
-  it('returns autofix-done when jira-autofix-done is present', () => {
-    expect(classifyIssue(['jira-autofix-done', 'jira-autofix'])).toBe('autofix-done')
+  it('returns autofix-merged for jira-autofix-merged', () => {
+    expect(classifyIssue(['jira-autofix-merged', 'jira-autofix'])).toBe('autofix-merged')
+  })
+
+  it('returns autofix-rejected for jira-autofix-rejected', () => {
+    expect(classifyIssue(['jira-autofix-rejected'])).toBe('autofix-rejected')
+  })
+
+  it('returns autofix-max-retries for jira-autofix-max-retries', () => {
+    expect(classifyIssue(['jira-autofix-max-retries'])).toBe('autofix-max-retries')
+  })
+
+  it('returns autofix-researched for jira-autofix-researched', () => {
+    expect(classifyIssue(['jira-autofix-researched'])).toBe('autofix-researched')
+  })
+
+  it('returns autofix-ci-failing for jira-autofix-ci-failing', () => {
+    expect(classifyIssue(['jira-autofix-ci-failing'])).toBe('autofix-ci-failing')
   })
 
   it('returns autofix-review when jira-autofix-review is present', () => {
@@ -20,8 +36,8 @@ describe('classifyIssue', () => {
     expect(classifyIssue(['jira-autofix-pending'])).toBe('autofix-pending')
   })
 
-  it('returns autofix-needs-info when jira-autofix-needs-info is present', () => {
-    expect(classifyIssue(['jira-autofix-needs-info'])).toBe('autofix-needs-info')
+  it('returns autofix-blocked for jira-autofix-blocked', () => {
+    expect(classifyIssue(['jira-autofix-blocked'])).toBe('autofix-blocked')
   })
 
   it('returns autofix-ready when only jira-autofix is present', () => {
@@ -36,8 +52,8 @@ describe('classifyIssue', () => {
     expect(classifyIssue(['jira-triage-stale'])).toBe('triage-stale')
   })
 
-  it('returns triage-needs-info for jira-triage-needs-info', () => {
-    expect(classifyIssue(['jira-triage-needs-info'])).toBe('triage-needs-info')
+  it('returns triage-missing-info for jira-triage-missing-info', () => {
+    expect(classifyIssue(['jira-triage-missing-info'])).toBe('triage-missing-info')
   })
 
   it('returns triage-pending for jira-triage-pending', () => {
@@ -48,8 +64,8 @@ describe('classifyIssue', () => {
     expect(classifyIssue(['some-other-label'])).toBe('unknown')
   })
 
-  it('prioritizes autofix-done over other labels', () => {
-    expect(classifyIssue(['jira-autofix-done', 'jira-autofix-review', 'jira-autofix'])).toBe('autofix-done')
+  it('prioritizes autofix-merged over other labels', () => {
+    expect(classifyIssue(['jira-autofix-merged', 'jira-autofix-review', 'jira-autofix'])).toBe('autofix-merged')
   })
 })
 
@@ -108,49 +124,49 @@ describe('computeAutofixMetrics', () => {
   const old = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString()
 
   const issues = [
-    { created: recent, pipelineState: 'autofix-done', components: ['A'] },
+    { created: recent, pipelineState: 'autofix-merged', components: ['A'] },
     { created: recent, pipelineState: 'autofix-review', components: ['A'] },
-    { created: recent, pipelineState: 'triage-needs-info', components: ['B'] },
+    { created: recent, pipelineState: 'autofix-rejected', components: ['A'] },
+    { created: recent, pipelineState: 'triage-missing-info', components: ['B'] },
     { created: recent, pipelineState: 'triage-not-fixable', components: ['B'] },
-    { created: old, pipelineState: 'autofix-done', components: ['A'] }
+    { created: old, pipelineState: 'autofix-merged', components: ['A'] }
   ]
 
   it('computes metrics for a week window', () => {
     const m = computeAutofixMetrics(issues, 'week')
-    expect(m.windowTotal).toBe(4)
-    expect(m.triageVerdicts.ready).toBe(2)
-    expect(m.triageVerdicts.needsInfo).toBe(1)
+    expect(m.windowTotal).toBe(5)
+    expect(m.triageVerdicts.ready).toBe(3)
+    expect(m.triageVerdicts.missingInfo).toBe(1)
     expect(m.triageVerdicts.notFixable).toBe(1)
-    expect(m.autofixStates.done).toBe(1)
+    expect(m.autofixStates.merged).toBe(1)
     expect(m.autofixStates.review).toBe(1)
-    expect(m.totalIssues).toBe(5)
+    expect(m.autofixStates.rejected).toBe(1)
+    expect(m.totalIssues).toBe(6)
   })
 
-  it('computes success rate from terminal states only (done + blocked)', () => {
+  it('computes success rate from terminal states (merged / (merged + rejected + maxRetries))', () => {
     const m = computeAutofixMetrics(issues, 'week')
-    expect(m.autofixTotal).toBe(2)
-    // done=1, needsInfo=0 → terminal=1, successRate = 1/1 = 100%
-    // in-review issues don't count against the rate
-    expect(m.successRate).toBe(100)
+    // merged=1, rejected=1, maxRetries=0 → terminal=2, successRate = 1/2 = 50%
+    expect(m.successRate).toBe(50)
   })
 
-  it('returns zero success rate when no autofix issues in window', () => {
+  it('returns zero success rate when no terminal autofix issues in window', () => {
     const m = computeAutofixMetrics([], 'week')
     expect(m.successRate).toBe(0)
   })
 })
 
 describe('buildTrendData', () => {
-  it('returns weekly data points', () => {
+  it('returns weekly data points with merged field', () => {
     const issues = [
-      { created: new Date().toISOString(), pipelineState: 'autofix-done', components: [] }
+      { created: new Date().toISOString(), pipelineState: 'autofix-merged', components: [] }
     ]
     const trend = buildTrendData(issues, 'week')
     expect(trend).toHaveLength(4)
     expect(trend[0]).toHaveProperty('date')
     expect(trend[0]).toHaveProperty('triaged')
     expect(trend[0]).toHaveProperty('autofixed')
-    expect(trend[0]).toHaveProperty('done')
+    expect(trend[0]).toHaveProperty('merged')
   })
 
   it('returns 13 points for 3months window', () => {
@@ -158,4 +174,3 @@ describe('buildTrendData', () => {
     expect(trend).toHaveLength(13)
   })
 })
-

--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -86,9 +86,6 @@ const hasActiveFilter = computed(() =>
 
 // Client-side metrics recomputation when filters are active.
 // Mirrors computeAutofixMetrics() in autofix-fetcher.js (server).
-// Uses startsWith('autofix-') for triageVerdicts.ready which includes
-// autofix-needs-info — matches the server's enumerated list in practice
-// since both count all autofix-* states as "passed triage."
 const metrics = computed(() => {
   if (!props.autofixData?.metrics) return null
   if (!hasActiveFilter.value) return props.autofixData.metrics
@@ -104,7 +101,7 @@ const metrics = computed(() => {
 
   const triageVerdicts = {
     ready: windowIssues.filter(i => i.pipelineState.startsWith('autofix-')).length,
-    needsInfo: windowIssues.filter(i => i.pipelineState === 'triage-needs-info').length,
+    missingInfo: windowIssues.filter(i => i.pipelineState === 'triage-missing-info').length,
     notFixable: windowIssues.filter(i => i.pipelineState === 'triage-not-fixable').length,
     stale: windowIssues.filter(i => i.pipelineState === 'triage-stale').length,
     pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length
@@ -114,12 +111,16 @@ const metrics = computed(() => {
     ready: windowIssues.filter(i => i.pipelineState === 'autofix-ready').length,
     pending: windowIssues.filter(i => i.pipelineState === 'autofix-pending').length,
     review: windowIssues.filter(i => i.pipelineState === 'autofix-review').length,
-    done: windowIssues.filter(i => i.pipelineState === 'autofix-done').length,
-    needsInfo: windowIssues.filter(i => i.pipelineState === 'autofix-needs-info').length
+    ciFailing: windowIssues.filter(i => i.pipelineState === 'autofix-ci-failing').length,
+    merged: windowIssues.filter(i => i.pipelineState === 'autofix-merged').length,
+    rejected: windowIssues.filter(i => i.pipelineState === 'autofix-rejected').length,
+    maxRetries: windowIssues.filter(i => i.pipelineState === 'autofix-max-retries').length,
+    researched: windowIssues.filter(i => i.pipelineState === 'autofix-researched').length,
+    blocked: windowIssues.filter(i => i.pipelineState === 'autofix-blocked').length
   }
 
-  const terminalTotal = autofixStates.done + autofixStates.needsInfo
-  const successRate = terminalTotal > 0 ? Math.round((autofixStates.done / terminalTotal) * 100) : 0
+  const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries
+  const successRate = terminalTotal > 0 ? Math.round((autofixStates.merged / terminalTotal) * 100) : 0
 
   return { triageTotal, triageVerdicts, autofixStates, autofixTotal: triageVerdicts.ready, successRate, windowTotal: windowIssues.length, totalIssues: issues.length }
 })
@@ -137,8 +138,8 @@ const trendData = computed(() => {
     const weekIssues = issues.filter(i => { const d = new Date(i.created); return d >= weekStart && d < weekEnd })
     const triaged = weekIssues.filter(i => i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')).length
     const autofixed = weekIssues.filter(i => i.pipelineState.startsWith('autofix-')).length
-    const done = weekIssues.filter(i => i.pipelineState === 'autofix-done').length
-    points.push({ date: weekEnd.toISOString().slice(0, 10), triaged, autofixed, done, total: weekIssues.length })
+    const merged = weekIssues.filter(i => i.pipelineState === 'autofix-merged').length
+    points.push({ date: weekEnd.toISOString().slice(0, 10), triaged, autofixed, merged, total: weekIssues.length })
   }
   return points
 })
@@ -146,14 +147,18 @@ const trendData = computed(() => {
 const STATE_OPTIONS = [
   { value: 'all', label: 'All' },
   { value: 'triage-pending', label: 'AI Assessing' },
-  { value: 'triage-needs-info', label: 'Needs Info' },
+  { value: 'triage-missing-info', label: 'Missing Info' },
   { value: 'triage-not-fixable', label: 'Not AI-Fixable' },
   { value: 'triage-stale', label: 'Stale' },
   { value: 'autofix-ready', label: 'Queued for AI' },
   { value: 'autofix-pending', label: 'AI Working' },
   { value: 'autofix-review', label: 'AI Fix Under Review' },
-  { value: 'autofix-done', label: 'AI Completed' },
-  { value: 'autofix-needs-info', label: 'AI Blocked' }
+  { value: 'autofix-ci-failing', label: 'AI Fix CI Failing' },
+  { value: 'autofix-merged', label: 'AI Fix Merged' },
+  { value: 'autofix-rejected', label: 'AI Fix Rejected' },
+  { value: 'autofix-max-retries', label: 'AI Max Retries' },
+  { value: 'autofix-researched', label: 'AI Researched' },
+  { value: 'autofix-blocked', label: 'AI Blocked' }
 ]
 
 const timeFilteredIssues = computed(() => {
@@ -183,9 +188,9 @@ const trendStatus = computed(() => {
   const firstHalf = trendData.value.slice(0, mid)
   const secondHalf = trendData.value.slice(mid)
   const firstTotal = firstHalf.reduce((s, p) => s + p.triaged, 0)
-  const firstDone = firstHalf.reduce((s, p) => s + p.done, 0)
+  const firstDone = firstHalf.reduce((s, p) => s + p.merged, 0)
   const secondTotal = secondHalf.reduce((s, p) => s + p.triaged, 0)
-  const secondDone = secondHalf.reduce((s, p) => s + p.done, 0)
+  const secondDone = secondHalf.reduce((s, p) => s + p.merged, 0)
   const firstRate = firstTotal > 0 ? firstDone / firstTotal : 0
   const secondRate = secondTotal > 0 ? secondDone / secondTotal : 0
   const diff = secondRate - firstRate
@@ -211,8 +216,8 @@ const comboChartData = computed(() => ({
       borderWidth: 2
     },
     {
-      label: 'Completed',
-      data: trendData.value.map(p => p.done),
+      label: 'Merged',
+      data: trendData.value.map(p => p.merged),
       backgroundColor: 'rgba(99, 102, 241, 0.5)',
       type: 'bar',
       yAxisID: 'y'
@@ -233,7 +238,7 @@ const comboChartOptions = {
 }
 
 const totalFixesLanded = computed(() => {
-  return trendData.value.reduce((s, p) => s + p.done, 0)
+  return trendData.value.reduce((s, p) => s + p.merged, 0)
 })
 
 const hasTrendActivity = computed(() => {
@@ -246,10 +251,14 @@ function stateLabel(state) {
 }
 
 function stateColorClass(state) {
-  if (state === 'autofix-done') return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  if (state === 'autofix-merged') return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  if (state === 'autofix-researched') return 'bg-teal-100 dark:bg-teal-500/20 text-teal-700 dark:text-teal-400'
   if (state === 'autofix-review') return 'bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400'
+  if (state === 'autofix-ci-failing') return 'bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400'
   if (state === 'autofix-pending' || state === 'autofix-ready') return 'bg-indigo-100 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-400'
-  if (state.includes('needs-info')) return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
+  if (state === 'autofix-rejected') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+  if (state === 'autofix-max-retries') return 'bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400'
+  if (state === 'autofix-blocked' || state === 'triage-missing-info') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
   if (state === 'triage-not-fixable') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
   if (state === 'triage-stale') return 'bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400'
   return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
@@ -264,8 +273,8 @@ const triageSegments = computed(() => {
   if (!metrics.value) return []
   const v = metrics.value.triageVerdicts
   return [
-    { label: 'Ready for AI', count: v.ready || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix', 'jira-autofix-pending', 'jira-autofix-review', 'jira-autofix-done', 'jira-autofix-needs-info'] },
-    { label: 'Needs Info', count: v.needsInfo || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-triage-needs-info'] },
+    { label: 'Ready for AI', count: v.ready || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix', 'jira-autofix-pending', 'jira-autofix-review', 'jira-autofix-ci-failing', 'jira-autofix-merged', 'jira-autofix-rejected', 'jira-autofix-max-retries', 'jira-autofix-researched', 'jira-autofix-blocked'] },
+    { label: 'Missing Info', count: v.missingInfo || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-triage-missing-info'] },
     { label: 'Not AI-Fixable', count: v.notFixable || 0, color: 'bg-red-500', textClass: 'text-red-600 dark:text-red-400', jiraLabels: ['jira-triage-not-fixable'] },
     { label: 'Stale', count: v.stale || 0, color: 'bg-gray-400', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-triage-stale'] },
     { label: 'AI Assessing', count: v.pending || 0, color: 'bg-gray-300 dark:bg-gray-600', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-triage-pending'] }
@@ -278,11 +287,15 @@ const autofixSegments = computed(() => {
   if (!metrics.value) return []
   const a = metrics.value.autofixStates
   return [
-    { label: 'AI Completed', count: a.done || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix-done'] },
+    { label: 'AI Fix Merged', count: a.merged || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix-merged'] },
+    { label: 'AI Researched', count: a.researched || 0, color: 'bg-teal-500', textClass: 'text-teal-600 dark:text-teal-400', jiraLabels: ['jira-autofix-researched'] },
     { label: 'AI Fix Under Review', count: a.review || 0, color: 'bg-blue-500', textClass: 'text-blue-600 dark:text-blue-400', jiraLabels: ['jira-autofix-review'] },
+    { label: 'AI Fix CI Failing', count: a.ciFailing || 0, color: 'bg-orange-500', textClass: 'text-orange-600 dark:text-orange-400', jiraLabels: ['jira-autofix-ci-failing'] },
     { label: 'AI Working', count: a.pending || 0, color: 'bg-indigo-500', textClass: 'text-indigo-600 dark:text-indigo-400', jiraLabels: ['jira-autofix-pending'] },
     { label: 'Queued for AI', count: a.ready || 0, color: 'bg-gray-400', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-autofix'] },
-    { label: 'AI Blocked', count: a.needsInfo || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-autofix-needs-info'] }
+    { label: 'AI Fix Rejected', count: a.rejected || 0, color: 'bg-red-500', textClass: 'text-red-600 dark:text-red-400', jiraLabels: ['jira-autofix-rejected'] },
+    { label: 'AI Max Retries', count: a.maxRetries || 0, color: 'bg-orange-500', textClass: 'text-orange-600 dark:text-orange-400', jiraLabels: ['jira-autofix-max-retries'] },
+    { label: 'AI Blocked', count: a.blocked || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-autofix-blocked'] }
   ].filter(s => s.count > 0)
 })
 
@@ -334,14 +347,18 @@ function buildJiraLabelUrl(jiraLabels) {
                 <tbody>
                   <tr><td colspan="2" class="font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide text-[10px] pb-1 pt-0">Triage</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Assessing</td><td class="text-gray-400 py-0.5">Bot is evaluating the ticket</td></tr>
-                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Needs Info</td><td class="text-gray-400 py-0.5">Ticket incomplete, waiting on reporter</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Missing Info</td><td class="text-gray-400 py-0.5">Ticket incomplete, waiting on reporter</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Not AI-Fixable</td><td class="text-gray-400 py-0.5">Not suitable for automated fixing</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Stale</td><td class="text-gray-400 py-0.5">No response for 14+ days</td></tr>
                   <tr><td colspan="2" class="font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide text-[10px] pb-1 pt-3">Autofix</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Queued for AI</td><td class="text-gray-400 py-0.5">Waiting for bot pickup</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Working</td><td class="text-gray-400 py-0.5">Bot is generating a fix</td></tr>
-                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Fix Under Review</td><td class="text-gray-400 py-0.5">MR/PR created, iterating on feedback</td></tr>
-                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Completed</td><td class="text-gray-400 py-0.5">Bot finished (merged, rejected, or max retries)</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Fix Under Review</td><td class="text-gray-400 py-0.5">MR/PR created, human reviewing</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Fix CI Failing</td><td class="text-gray-400 py-0.5">MR/PR exists, CI is red</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Fix Merged</td><td class="text-gray-400 py-0.5">Fix landed successfully</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Fix Rejected</td><td class="text-gray-400 py-0.5">MR/PR closed without merge</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Max Retries</td><td class="text-gray-400 py-0.5">Bot hit iteration limit, needs human</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Researched</td><td class="text-gray-400 py-0.5">Spike completed, findings posted</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Blocked</td><td class="text-gray-400 py-0.5">Bot stuck, needs human intervention</td></tr>
                 </tbody>
               </table>
@@ -430,7 +447,7 @@ function buildJiraLabelUrl(jiraLabels) {
             <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.totalIssues }} all time</div>
           </div>
           <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center"
-            :title="`Percentage of triaged bugs that qualified for autofix. ${metrics.triageVerdicts.ready || 0} out of ${metrics.triageTotal} triaged issues were deemed fixable by the AI triage bot.`"
+            :title="`Percentage of triaged issues that qualified for autofix. ${metrics.triageVerdicts.ready || 0} out of ${metrics.triageTotal} triaged issues were deemed fixable by the AI triage bot.`"
           >
             <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
               {{ metrics.triageTotal > 0 ? Math.round((metrics.triageVerdicts.ready || 0) / metrics.triageTotal * 100) : 0 }}%
@@ -439,13 +456,13 @@ function buildJiraLabelUrl(jiraLabels) {
             <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.triageVerdicts.ready || 0 }} of {{ metrics.triageTotal }} triaged</div>
           </div>
           <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center"
-            :title="`Percentage of completed autofixes out of all terminal outcomes. Calculated as: AI Completed / (AI Completed + AI Blocked). In-progress issues are excluded. Note: AI Completed currently includes merged, rejected, and max-retries — accuracy improves once pipeline labels are split. ${metrics.autofixStates.done || 0} completed, ${metrics.autofixStates.needsInfo || 0} blocked.`"
+            :title="`Percentage of successfully merged autofixes out of all terminal outcomes. Calculated as: merged / (merged + rejected + max-retries). In-progress issues are excluded. Researched spikes are excluded (they don't produce MRs). ${metrics.autofixStates.merged || 0} merged, ${metrics.autofixStates.rejected || 0} rejected, ${metrics.autofixStates.maxRetries || 0} max retries.`"
           >
             <div class="text-2xl font-bold" :class="metrics.successRate >= 50 ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400'">
               {{ metrics.successRate }}%
             </div>
             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">Success Rate</div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.autofixStates.done || 0 }} of {{ (metrics.autofixStates.done || 0) + (metrics.autofixStates.needsInfo || 0) }} resolved</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.autofixStates.merged || 0 }} of {{ (metrics.autofixStates.merged || 0) + (metrics.autofixStates.rejected || 0) + (metrics.autofixStates.maxRetries || 0) }} resolved</div>
           </div>
           <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center"
             :title="`Issues where the autofix bot has created an MR/PR and is iterating on review feedback and CI failures. ${metrics.autofixStates.review || 0} issues currently in review.`"
@@ -454,13 +471,13 @@ function buildJiraLabelUrl(jiraLabels) {
             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">In Review</div>
           </div>
           <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center"
-            :title="`Issues requiring human intervention. Includes tickets with incomplete information (missing info: ${metrics.triageVerdicts.needsInfo || 0}) and autofix attempts that hit a blocker (blocked: ${metrics.autofixStates.needsInfo || 0}).`"
+            :title="`Issues requiring human intervention. Includes tickets with incomplete information (missing info: ${metrics.triageVerdicts.missingInfo || 0}) and autofix attempts that hit a blocker (blocked: ${metrics.autofixStates.blocked || 0}).`"
           >
             <div class="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
-              {{ (metrics.autofixStates.needsInfo || 0) + (metrics.triageVerdicts.needsInfo || 0) }}
+              {{ (metrics.autofixStates.blocked || 0) + (metrics.triageVerdicts.missingInfo || 0) }}
             </div>
             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">Needs Attention</div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.triageVerdicts.needsInfo || 0 }} needs info · {{ metrics.autofixStates.needsInfo || 0 }} AI blocked</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ metrics.triageVerdicts.missingInfo || 0 }} missing info · {{ metrics.autofixStates.blocked || 0 }} AI blocked</div>
           </div>
           <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center"
             title="Trend compares autofix completion rate between the first and second half of the selected time window."
@@ -493,7 +510,7 @@ function buildJiraLabelUrl(jiraLabels) {
                   <div class="absolute left-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300">
                     <div class="space-y-1">
                       <div class="flex justify-between"><span class="font-medium">Ready for AI</span><span class="text-gray-400">Qualified for autofix</span></div>
-                      <div class="flex justify-between"><span class="font-medium">Needs Info</span><span class="text-gray-400">Waiting on reporter</span></div>
+                      <div class="flex justify-between"><span class="font-medium">Missing Info</span><span class="text-gray-400">Waiting on reporter</span></div>
                       <div class="flex justify-between"><span class="font-medium">Not AI-Fixable</span><span class="text-gray-400">Not suitable for AI</span></div>
                       <div class="flex justify-between"><span class="font-medium">Stale</span><span class="text-gray-400">No response 14+ days</span></div>
                       <div class="flex justify-between"><span class="font-medium">AI Assessing</span><span class="text-gray-400">Bot is evaluating</span></div>
@@ -547,10 +564,14 @@ function buildJiraLabelUrl(jiraLabels) {
                   </svg>
                   <div class="absolute left-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300">
                     <div class="space-y-1">
-                      <div class="flex justify-between"><span class="font-medium">AI Completed</span><span class="text-gray-400">Bot finished</span></div>
-                      <div class="flex justify-between"><span class="font-medium">AI Fix Under Review</span><span class="text-gray-400">MR/PR iterating</span></div>
+                      <div class="flex justify-between"><span class="font-medium">AI Fix Merged</span><span class="text-gray-400">Fix landed</span></div>
+                      <div class="flex justify-between"><span class="font-medium">AI Researched</span><span class="text-gray-400">Spike completed</span></div>
+                      <div class="flex justify-between"><span class="font-medium">AI Fix Under Review</span><span class="text-gray-400">Human reviewing</span></div>
+                      <div class="flex justify-between"><span class="font-medium">AI Fix CI Failing</span><span class="text-gray-400">CI is red</span></div>
                       <div class="flex justify-between"><span class="font-medium">AI Working</span><span class="text-gray-400">Generating fix</span></div>
                       <div class="flex justify-between"><span class="font-medium">Queued for AI</span><span class="text-gray-400">Waiting for bot</span></div>
+                      <div class="flex justify-between"><span class="font-medium">AI Fix Rejected</span><span class="text-gray-400">MR closed</span></div>
+                      <div class="flex justify-between"><span class="font-medium">AI Max Retries</span><span class="text-gray-400">Bot gave up</span></div>
                       <div class="flex justify-between"><span class="font-medium">AI Blocked</span><span class="text-gray-400">Needs human help</span></div>
                     </div>
                   </div>
@@ -634,7 +655,7 @@ function buildJiraLabelUrl(jiraLabels) {
                     <p class="font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide text-[10px]">Triage</p>
                     <div class="space-y-1 mb-3">
                       <div class="flex justify-between"><span>AI Assessing</span><span class="text-gray-400">Bot is evaluating</span></div>
-                      <div class="flex justify-between"><span>Needs Info</span><span class="text-gray-400">Waiting on reporter</span></div>
+                      <div class="flex justify-between"><span>Missing Info</span><span class="text-gray-400">Waiting on reporter</span></div>
                       <div class="flex justify-between"><span>Not AI-Fixable</span><span class="text-gray-400">Not suitable for AI</span></div>
                       <div class="flex justify-between"><span>Stale</span><span class="text-gray-400">No response 14+ days</span></div>
                     </div>
@@ -642,8 +663,12 @@ function buildJiraLabelUrl(jiraLabels) {
                     <div class="space-y-1">
                       <div class="flex justify-between"><span>Queued for AI</span><span class="text-gray-400">Waiting for bot</span></div>
                       <div class="flex justify-between"><span>AI Working</span><span class="text-gray-400">Generating fix</span></div>
-                      <div class="flex justify-between"><span>AI Fix Under Review</span><span class="text-gray-400">MR/PR iterating</span></div>
-                      <div class="flex justify-between"><span>AI Completed</span><span class="text-gray-400">Bot finished</span></div>
+                      <div class="flex justify-between"><span>AI Fix Under Review</span><span class="text-gray-400">Human reviewing</span></div>
+                      <div class="flex justify-between"><span>AI Fix CI Failing</span><span class="text-gray-400">CI is red</span></div>
+                      <div class="flex justify-between"><span>AI Fix Merged</span><span class="text-gray-400">Fix landed</span></div>
+                      <div class="flex justify-between"><span>AI Fix Rejected</span><span class="text-gray-400">MR closed</span></div>
+                      <div class="flex justify-between"><span>AI Max Retries</span><span class="text-gray-400">Bot gave up</span></div>
+                      <div class="flex justify-between"><span>AI Researched</span><span class="text-gray-400">Spike completed</span></div>
                       <div class="flex justify-between"><span>AI Blocked</span><span class="text-gray-400">Needs human help</span></div>
                     </div>
                   </div>

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -4,7 +4,7 @@ const { validateJqlSafeString } = require('../config');
 // All labels from the jira-autofix triage + autofix pipelines
 const TRIAGE_LABELS = [
   'jira-triage-pending',
-  'jira-triage-needs-info',
+  'jira-triage-missing-info',
   'jira-triage-not-fixable',
   'jira-triage-stale'
 ];
@@ -13,8 +13,12 @@ const AUTOFIX_LABELS = [
   'jira-autofix',
   'jira-autofix-pending',
   'jira-autofix-review',
-  'jira-autofix-done',
-  'jira-autofix-needs-info'
+  'jira-autofix-ci-failing',
+  'jira-autofix-merged',
+  'jira-autofix-rejected',
+  'jira-autofix-max-retries',
+  'jira-autofix-researched',
+  'jira-autofix-blocked'
 ];
 
 const ALL_PIPELINE_LABELS = [...TRIAGE_LABELS, ...AUTOFIX_LABELS];
@@ -22,14 +26,21 @@ const ALL_PIPELINE_LABELS = [...TRIAGE_LABELS, ...AUTOFIX_LABELS];
 function classifyIssue(labels) {
   const labelSet = new Set(labels);
 
-  if (labelSet.has('jira-autofix-done')) return 'autofix-done';
+  // Terminal autofix states (check first — most specific)
+  if (labelSet.has('jira-autofix-merged')) return 'autofix-merged';
+  if (labelSet.has('jira-autofix-rejected')) return 'autofix-rejected';
+  if (labelSet.has('jira-autofix-max-retries')) return 'autofix-max-retries';
+  if (labelSet.has('jira-autofix-researched')) return 'autofix-researched';
+  // Active autofix states
+  if (labelSet.has('jira-autofix-ci-failing')) return 'autofix-ci-failing';
   if (labelSet.has('jira-autofix-review')) return 'autofix-review';
   if (labelSet.has('jira-autofix-pending')) return 'autofix-pending';
-  if (labelSet.has('jira-autofix-needs-info')) return 'autofix-needs-info';
+  if (labelSet.has('jira-autofix-blocked')) return 'autofix-blocked';
   if (labelSet.has('jira-autofix')) return 'autofix-ready';
+  // Triage states
   if (labelSet.has('jira-triage-not-fixable')) return 'triage-not-fixable';
   if (labelSet.has('jira-triage-stale')) return 'triage-stale';
-  if (labelSet.has('jira-triage-needs-info')) return 'triage-needs-info';
+  if (labelSet.has('jira-triage-missing-info')) return 'triage-missing-info';
   if (labelSet.has('jira-triage-pending')) return 'triage-pending';
 
   return 'unknown';
@@ -64,14 +75,8 @@ function computeAutofixMetrics(issues, timeWindow) {
   ).length;
 
   const triageVerdicts = {
-    ready: windowIssues.filter(i =>
-      i.pipelineState === 'autofix-ready' ||
-      i.pipelineState === 'autofix-pending' ||
-      i.pipelineState === 'autofix-review' ||
-      i.pipelineState === 'autofix-done' ||
-      i.pipelineState === 'autofix-needs-info'
-    ).length,
-    needsInfo: windowIssues.filter(i => i.pipelineState === 'triage-needs-info').length,
+    ready: windowIssues.filter(i => i.pipelineState.startsWith('autofix-')).length,
+    missingInfo: windowIssues.filter(i => i.pipelineState === 'triage-missing-info').length,
     notFixable: windowIssues.filter(i => i.pipelineState === 'triage-not-fixable').length,
     stale: windowIssues.filter(i => i.pipelineState === 'triage-stale').length,
     pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length
@@ -81,15 +86,18 @@ function computeAutofixMetrics(issues, timeWindow) {
     ready: windowIssues.filter(i => i.pipelineState === 'autofix-ready').length,
     pending: windowIssues.filter(i => i.pipelineState === 'autofix-pending').length,
     review: windowIssues.filter(i => i.pipelineState === 'autofix-review').length,
-    done: windowIssues.filter(i => i.pipelineState === 'autofix-done').length,
-    needsInfo: windowIssues.filter(i => i.pipelineState === 'autofix-needs-info').length
+    ciFailing: windowIssues.filter(i => i.pipelineState === 'autofix-ci-failing').length,
+    merged: windowIssues.filter(i => i.pipelineState === 'autofix-merged').length,
+    rejected: windowIssues.filter(i => i.pipelineState === 'autofix-rejected').length,
+    maxRetries: windowIssues.filter(i => i.pipelineState === 'autofix-max-retries').length,
+    researched: windowIssues.filter(i => i.pipelineState === 'autofix-researched').length,
+    blocked: windowIssues.filter(i => i.pipelineState === 'autofix-blocked').length
   };
 
-  const autofixTotal = autofixStates.ready + autofixStates.pending +
-    autofixStates.review + autofixStates.done + autofixStates.needsInfo;
-  const terminalTotal = autofixStates.done + autofixStates.needsInfo;
+  const autofixTotal = Object.values(autofixStates).reduce((s, v) => s + v, 0);
+  const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries;
   const successRate = terminalTotal > 0
-    ? Math.round((autofixStates.done / terminalTotal) * 100)
+    ? Math.round((autofixStates.merged / terminalTotal) * 100)
     : 0;
 
   return {
@@ -104,8 +112,8 @@ function computeAutofixMetrics(issues, timeWindow) {
 }
 
 // Buckets issues by created date but uses current pipelineState. An issue
-// created 3 weeks ago that later moved to autofix-done appears as "done"
-// in the week it was created, not when it completed. This is a known
+// created 3 weeks ago that later moved to autofix-merged appears as "merged"
+// in the week it was created, not when it was merged. This is a known
 // limitation — Jira labels don't carry timestamps for state transitions.
 function buildTrendData(issues, timeWindow) {
   const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13;
@@ -129,13 +137,13 @@ function buildTrendData(issues, timeWindow) {
       i.pipelineState.startsWith('autofix-')
     ).length;
 
-    const done = weekIssues.filter(i => i.pipelineState === 'autofix-done').length;
+    const merged = weekIssues.filter(i => i.pipelineState === 'autofix-merged').length;
 
     points.push({
       date: weekEnd.toISOString().slice(0, 10),
       triaged,
       autofixed,
-      done,
+      merged,
       total: weekIssues.length
     });
   }


### PR DESCRIPTION
## Summary

Update the Jira AutoFix dashboard to consume the granular pipeline labels from the label renaming MR (gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/213).

**Depends on:** The pipeline label rename MR must merge first. This PR should be merged after that.

## What changed

**Pipeline labels consumed:**
- `jira-autofix-done` split into `jira-autofix-merged` / `jira-autofix-rejected` / `jira-autofix-max-retries` / `jira-autofix-researched`
- `jira-autofix-needs-info` renamed to `jira-autofix-blocked`
- `jira-triage-needs-info` renamed to `jira-triage-missing-info`
- `jira-autofix-ci-failing` added as transient active state (swaps with review)

**Dashboard updates:**
- `classifyIssue()` recognizes all new labels
- Success rate is now accurate: `merged / (merged + rejected + max-retries)` instead of `done / (done + needs-info)`
- Autofix Progress panel shows 9 distinct states: AI Fix Merged (green), AI Researched (teal), AI Fix Under Review (blue), AI Fix CI Failing (orange), AI Working (indigo), Queued for AI (gray), AI Fix Rejected (red), AI Max Retries (orange), AI Blocked (yellow)
- Combo chart label: "Completed" -> "Merged"
- Success rate tooltip explains researched spike exclusion
- All legends and info popups updated
- Fixture data migrated to new labels for demo mode
- Tests updated

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` -- 1061 tests pass (88 files)
- [x] `npm run build` succeeds
- [x] `npm run validate:modules` passes
- [ ] Verify with live data after pipeline label MR merges