### PR TITLE
feat: add Story Points / Issue Count toggle to Allocation Tracker

### DIFF
--- a/modules/allocation-tracker/client/components/AllocationBar.vue
+++ b/modules/allocation-tracker/client/components/AllocationBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full">
-    <div v-if="totalPoints === 0" data-testid="no-data" class="h-6 bg-gray-100 rounded text-center text-xs text-gray-400 leading-6">
-      No points
+    <div v-if="total === 0" data-testid="no-data" class="h-6 bg-gray-100 rounded text-center text-xs text-gray-400 leading-6">
+      {{ metricMode === 'counts' ? 'No issues' : 'No points' }}
     </div>
     <div v-else class="relative h-6 rounded overflow-visible flex">
       <div
@@ -10,7 +10,7 @@
         class="group/seg relative bg-amber-400 h-full flex items-center justify-center text-xs font-medium text-amber-900 rounded-l cursor-default "
         :class="{ 'rounded-r': featurePercent === 0 && learningPercent === 0 && uncategorizedPercent === 0 }"
         :style="{ width: techDebtPercent + '%' }"
-        :title="`Tech Debt & Quality: ${buckets['tech-debt-quality']?.points || 0} pts (${techDebtPercent}%)`"
+        :title="`Tech Debt & Quality: ${bucketValue('tech-debt-quality')} ${unitLabel} (${techDebtPercent}%)`"
       >
         <span v-if="techDebtPercent >= 10">{{ techDebtPercent }}%</span>
         <div data-testid="tooltip" class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded shadow-lg whitespace-nowrap opacity-0 group-hover/seg:opacity-100 pointer-events-none transition-opacity z-10">
@@ -24,7 +24,7 @@
         class="group/seg relative bg-blue-400 h-full flex items-center justify-center text-xs font-medium text-blue-900 cursor-default"
         :class="{ 'rounded-r': learningPercent === 0 && uncategorizedPercent === 0 }"
         :style="{ width: featurePercent + '%' }"
-        :title="`New Features: ${buckets['new-features']?.points || 0} pts (${featurePercent}%)`"
+        :title="`New Features: ${bucketValue('new-features')} ${unitLabel} (${featurePercent}%)`"
       >
         <span v-if="featurePercent >= 10">{{ featurePercent }}%</span>
         <div data-testid="tooltip" class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded shadow-lg whitespace-nowrap opacity-0 group-hover/seg:opacity-100 pointer-events-none transition-opacity z-10">
@@ -38,7 +38,7 @@
         class="group/seg relative bg-green-400 h-full flex items-center justify-center text-xs font-medium text-green-900 cursor-default"
         :class="{ 'rounded-r': uncategorizedPercent === 0 }"
         :style="{ width: learningPercent + '%' }"
-        :title="`Learning & Enablement: ${buckets['learning-enablement']?.points || 0} pts (${learningPercent}%)`"
+        :title="`Learning & Enablement: ${bucketValue('learning-enablement')} ${unitLabel} (${learningPercent}%)`"
       >
         <span v-if="learningPercent >= 10">{{ learningPercent }}%</span>
         <div data-testid="tooltip" class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded shadow-lg whitespace-nowrap opacity-0 group-hover/seg:opacity-100 pointer-events-none transition-opacity z-10">
@@ -51,7 +51,7 @@
         data-testid="segment-uncategorized"
         class="group/seg relative bg-gray-400 h-full flex items-center justify-center text-xs font-medium text-gray-900 rounded-r cursor-default"
         :style="{ width: uncategorizedPercent + '%' }"
-        :title="`Uncategorized: ${buckets['uncategorized']?.points || 0} pts (${uncategorizedPercent}%)`"
+        :title="`Uncategorized: ${bucketValue('uncategorized')} ${unitLabel} (${uncategorizedPercent}%)`"
       >
         <span v-if="uncategorizedPercent >= 10">{{ uncategorizedPercent }}%</span>
         <div data-testid="tooltip" class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded shadow-lg whitespace-nowrap opacity-0 group-hover/seg:opacity-100 pointer-events-none transition-opacity z-10">
@@ -86,26 +86,46 @@ const props = defineProps({
   totalPoints: {
     type: Number,
     required: true
+  },
+  metricMode: {
+    type: String,
+    default: 'points'
   }
 })
 
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
+
+const total = computed(() => {
+  if (props.metricMode === 'counts') {
+    return Object.values(props.buckets).reduce((sum, b) => sum + (b.count || b.issueCount || 0), 0)
+  }
+  return props.totalPoints
+})
+
+function bucketValue(key) {
+  const bucket = props.buckets[key]
+  if (!bucket) return 0
+  if (props.metricMode === 'counts') return bucket.count || bucket.issueCount || 0
+  return bucket.points || 0
+}
+
 const techDebtPercent = computed(() => {
-  if (props.totalPoints === 0) return 0
-  return Math.round((props.buckets['tech-debt-quality']?.points || 0) / props.totalPoints * 100)
+  if (total.value === 0) return 0
+  return Math.round(bucketValue('tech-debt-quality') / total.value * 100)
 })
 
 const featurePercent = computed(() => {
-  if (props.totalPoints === 0) return 0
-  return Math.round((props.buckets['new-features']?.points || 0) / props.totalPoints * 100)
+  if (total.value === 0) return 0
+  return Math.round(bucketValue('new-features') / total.value * 100)
 })
 
 const learningPercent = computed(() => {
-  if (props.totalPoints === 0) return 0
-  return Math.round((props.buckets['learning-enablement']?.points || 0) / props.totalPoints * 100)
+  if (total.value === 0) return 0
+  return Math.round(bucketValue('learning-enablement') / total.value * 100)
 })
 
 const uncategorizedPercent = computed(() => {
-  if (props.totalPoints === 0) return 0
-  return Math.round((props.buckets['uncategorized']?.points || 0) / props.totalPoints * 100)
+  if (total.value === 0) return 0
+  return Math.round(bucketValue('uncategorized') / total.value * 100)
 })
 </script>

--- a/modules/allocation-tracker/client/components/AllocationBar.vue
+++ b/modules/allocation-tracker/client/components/AllocationBar.vue
@@ -87,6 +87,10 @@ const props = defineProps({
     type: Number,
     required: true
   },
+  totalCount: {
+    type: Number,
+    default: 0
+  },
   metricMode: {
     type: String,
     default: 'points'
@@ -96,16 +100,13 @@ const props = defineProps({
 const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
 
 const total = computed(() => {
-  if (props.metricMode === 'counts') {
-    return Object.values(props.buckets).reduce((sum, b) => sum + (b.count || b.issueCount || 0), 0)
-  }
-  return props.totalPoints
+  return props.metricMode === 'counts' ? props.totalCount : props.totalPoints
 })
 
 function bucketValue(key) {
   const bucket = props.buckets[key]
   if (!bucket) return 0
-  if (props.metricMode === 'counts') return bucket.count || bucket.issueCount || 0
+  if (props.metricMode === 'counts') return bucket.count || 0
   return bucket.points || 0
 }
 

--- a/modules/allocation-tracker/client/components/BucketBreakdown.vue
+++ b/modules/allocation-tracker/client/components/BucketBreakdown.vue
@@ -12,12 +12,12 @@
     </div>
 
     <div class="flex items-baseline gap-2 mb-1">
-      <span class="text-2xl font-bold text-gray-900">{{ points }} pts</span>
+      <span class="text-2xl font-bold text-gray-900">{{ displayValue }} {{ unitLabel }}</span>
       <span class="text-sm text-gray-500">({{ percentage }}%)</span>
     </div>
 
     <div class="text-xs text-gray-500 mb-3">
-      Target: {{ targetPercentage }}% · {{ completedPoints }} completed · {{ issues.length }} issues
+      Target: {{ targetPercentage }}% · {{ displayCompleted }} completed · {{ issues.length }} issues
     </div>
 
     <IssueList :issues="issues" :expandable="true" />
@@ -32,12 +32,19 @@ const props = defineProps({
   name: { type: String, required: true },
   bucketKey: { type: String, required: true },
   points: { type: Number, required: true },
+  count: { type: Number, default: 0 },
   percentage: { type: Number, required: true },
   targetPercentage: { type: Number, required: true },
   issues: { type: Array, required: true },
   completedPoints: { type: Number, required: true },
-  color: { type: String, required: true }
+  completedCount: { type: Number, default: 0 },
+  color: { type: String, required: true },
+  metricMode: { type: String, default: 'points' }
 })
+
+const displayValue = computed(() => props.metricMode === 'counts' ? props.count : props.points)
+const displayCompleted = computed(() => props.metricMode === 'counts' ? props.completedCount : props.completedPoints)
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
 
 const borderClass = computed(() => {
   const map = {

--- a/modules/allocation-tracker/client/components/CompletionSummary.vue
+++ b/modules/allocation-tracker/client/components/CompletionSummary.vue
@@ -4,7 +4,7 @@
 
     <div class="mb-4">
       <div class="flex justify-between text-sm text-gray-700 mb-1">
-        <span>{{ summary.completedPoints }}/{{ summary.totalPoints }} pts completed</span>
+        <span>{{ displayCompleted }}/{{ displayTotal }} {{ unitLabel }} completed</span>
         <span class="font-medium">{{ completionPercent }}%</span>
       </div>
       <div class="w-full bg-gray-200 rounded-full h-3">
@@ -23,7 +23,7 @@
         class="flex justify-between text-sm"
       >
         <span class="text-gray-600">{{ bucket.label }}</span>
-        <span class="text-gray-900 font-medium">{{ bucket.completedPoints }}/{{ bucket.points }} pts</span>
+        <span class="text-gray-900 font-medium">{{ bucket.displayCompleted }}/{{ bucket.displayValue }} {{ unitLabel }}</span>
       </div>
     </div>
   </div>
@@ -40,12 +40,31 @@ const props = defineProps({
   sprintState: {
     type: String,
     required: true
+  },
+  metricMode: {
+    type: String,
+    default: 'points'
   }
 })
 
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
+
+const displayTotal = computed(() => {
+  if (props.metricMode === 'counts') return props.summary.totalCount || 0
+  return props.summary.totalPoints || 0
+})
+
+const displayCompleted = computed(() => {
+  if (props.metricMode === 'counts') {
+    return Object.values(props.summary.buckets)
+      .reduce((sum, b) => sum + (b.completedCount || 0), 0)
+  }
+  return props.summary.completedPoints || 0
+})
+
 const completionPercent = computed(() => {
-  if (props.summary.totalPoints === 0) return 0
-  return Math.round((props.summary.completedPoints / props.summary.totalPoints) * 100)
+  if (displayTotal.value === 0) return 0
+  return Math.round((displayCompleted.value / displayTotal.value) * 100)
 })
 
 const bucketLabels = {
@@ -56,13 +75,15 @@ const bucketLabels = {
 }
 
 const visibleBuckets = computed(() => {
+  const valueField = props.metricMode === 'counts' ? 'count' : 'points'
+  const completedField = props.metricMode === 'counts' ? 'completedCount' : 'completedPoints'
   return Object.entries(props.summary.buckets)
-    .filter(([, data]) => data.points > 0)
+    .filter(([, data]) => (data[valueField] || data.issueCount || 0) > 0)
     .map(([key, data]) => ({
       key,
       label: bucketLabels[key] || key,
-      points: data.points,
-      completedPoints: data.completedPoints
+      displayValue: props.metricMode === 'counts' ? (data.count || data.issueCount || 0) : (data.points || 0),
+      displayCompleted: data[completedField] || 0
     }))
 })
 </script>

--- a/modules/allocation-tracker/client/components/CompletionSummary.vue
+++ b/modules/allocation-tracker/client/components/CompletionSummary.vue
@@ -78,11 +78,11 @@ const visibleBuckets = computed(() => {
   const valueField = props.metricMode === 'counts' ? 'count' : 'points'
   const completedField = props.metricMode === 'counts' ? 'completedCount' : 'completedPoints'
   return Object.entries(props.summary.buckets)
-    .filter(([, data]) => (data[valueField] || data.issueCount || 0) > 0)
+    .filter(([, data]) => (data[valueField] || 0) > 0)
     .map(([key, data]) => ({
       key,
       label: bucketLabels[key] || key,
-      displayValue: props.metricMode === 'counts' ? (data.count || data.issueCount || 0) : (data.points || 0),
+      displayValue: data[valueField] || 0,
       displayCompleted: data[completedField] || 0
     }))
 })

--- a/modules/allocation-tracker/client/components/MetricToggle.vue
+++ b/modules/allocation-tracker/client/components/MetricToggle.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="inline-flex rounded-md shadow-sm">
+    <button
+      @click="$emit('update:modelValue', 'points')"
+      class="px-3 py-1.5 text-sm font-medium rounded-l-md border"
+      :class="modelValue === 'points'
+        ? 'bg-primary-600 text-white border-primary-600'
+        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'"
+      data-testid="metric-toggle-points"
+    >
+      Story Points
+    </button>
+    <button
+      @click="$emit('update:modelValue', 'counts')"
+      class="px-3 py-1.5 text-sm font-medium rounded-r-md border border-l-0"
+      :class="modelValue === 'counts'
+        ? 'bg-primary-600 text-white border-primary-600'
+        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'"
+      data-testid="metric-toggle-counts"
+    >
+      Issue Count
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  modelValue: { type: String, required: true }
+})
+defineEmits(['update:modelValue'])
+</script>

--- a/modules/allocation-tracker/client/components/OrgDashboard.vue
+++ b/modules/allocation-tracker/client/components/OrgDashboard.vue
@@ -15,7 +15,7 @@
           </span>
         </div>
         <p class="text-xs text-gray-400 mb-2">Aggregated from each board's currently active sprint</p>
-        <AllocationBar :buckets="orgSummary.buckets" :totalPoints="orgSummary.totalPoints" :metricMode="metricMode" />
+        <AllocationBar :buckets="orgSummary.buckets" :totalPoints="orgSummary.totalPoints" :totalCount="orgSummary.totalCount || 0" :metricMode="metricMode" />
       </div>
     </div>
 

--- a/modules/allocation-tracker/client/components/OrgDashboard.vue
+++ b/modules/allocation-tracker/client/components/OrgDashboard.vue
@@ -1,16 +1,21 @@
 <template>
   <div class="container mx-auto px-6 py-6">
+    <!-- Metric toggle -->
+    <div class="flex items-center justify-end mb-4">
+      <MetricToggle :modelValue="metricMode" @update:modelValue="$emit('update:metricMode', $event)" />
+    </div>
+
     <!-- Org-wide allocation bar -->
-    <div v-if="orgSummary && orgSummary.totalPoints > 0" class="mb-6">
+    <div v-if="orgSummary && orgTotal > 0" class="mb-6">
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
         <div class="flex items-center justify-between mb-2">
           <h2 class="text-lg font-semibold text-gray-900">{{ orgName }} — Organization Overview</h2>
           <span class="text-sm text-gray-500">
-            {{ orgSummary.totalPoints }} pts across {{ orgSummary.boardCount }} {{ orgSummary.boardCount === 1 ? 'board' : 'boards' }}
+            {{ orgTotal }} {{ unitLabel }} across {{ orgSummary.boardCount }} {{ orgSummary.boardCount === 1 ? 'board' : 'boards' }}
           </span>
         </div>
         <p class="text-xs text-gray-400 mb-2">Aggregated from each board's currently active sprint</p>
-        <AllocationBar :buckets="orgSummary.buckets" :totalPoints="orgSummary.totalPoints" />
+        <AllocationBar :buckets="orgSummary.buckets" :totalPoints="orgSummary.totalPoints" :metricMode="metricMode" />
       </div>
     </div>
 
@@ -53,6 +58,7 @@
         :key="project.key"
         :project="project"
         :summary="projectSummaries[project.key] || null"
+        :metricMode="metricMode"
         @select-project="$emit('select-project', $event)"
       />
     </div>
@@ -60,10 +66,12 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import AllocationBar from './AllocationBar.vue'
+import MetricToggle from './MetricToggle.vue'
 import ProjectCard from './ProjectCard.vue'
 
-defineProps({
+const props = defineProps({
   orgName: {
     type: String,
     default: 'AI Engineering'
@@ -79,8 +87,20 @@ defineProps({
   projectSummaries: {
     type: Object,
     default: () => ({})
+  },
+  metricMode: {
+    type: String,
+    default: 'points'
   }
 })
 
-defineEmits(['select-project'])
+defineEmits(['select-project', 'update:metricMode'])
+
+const orgTotal = computed(() => {
+  if (!props.orgSummary) return 0
+  if (props.metricMode === 'counts') return props.orgSummary.totalCount || 0
+  return props.orgSummary.totalPoints || 0
+})
+
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
 </script>

--- a/modules/allocation-tracker/client/components/ProjectCard.vue
+++ b/modules/allocation-tracker/client/components/ProjectCard.vue
@@ -16,7 +16,7 @@
 
     <template v-if="displayTotal > 0">
       <div class="mt-3">
-        <AllocationBar :buckets="aggregatedBuckets" :totalPoints="totalPoints" :metricMode="metricMode" />
+        <AllocationBar :buckets="aggregatedBuckets" :totalPoints="totalPoints" :totalCount="totalCount" :metricMode="metricMode" />
       </div>
 
       <div class="flex items-center justify-between mt-2 text-sm">
@@ -36,6 +36,9 @@
 <script setup>
 import { computed } from 'vue'
 import AllocationBar from './AllocationBar.vue'
+import { useAllocationData } from '../composables/useAllocationData.js'
+
+const { aggregateBuckets } = useAllocationData()
 
 const props = defineProps({
   project: {
@@ -59,41 +62,15 @@ const boardCount = computed(() => {
   return Object.keys(props.summary.boards).length
 })
 
-const totalPoints = computed(() => {
-  if (!props.summary?.boards) return 0
-  return Object.values(props.summary.boards)
-    .reduce((sum, b) => sum + (b?.summary?.totalPoints || 0), 0)
+const aggregated = computed(() => {
+  if (!props.summary?.boards) return { buckets: {}, totalPoints: 0, totalCount: 0 }
+  return aggregateBuckets(props.summary.boards)
 })
 
-const totalCount = computed(() => {
-  if (!props.summary?.boards) return 0
-  return Object.values(props.summary.boards)
-    .reduce((sum, b) => sum + (b?.summary?.totalCount || b?.summary?.estimatedIssueCount || 0), 0)
-})
+const aggregatedBuckets = computed(() => aggregated.value.buckets)
+const totalPoints = computed(() => aggregated.value.totalPoints)
+const totalCount = computed(() => aggregated.value.totalCount)
 
 const displayTotal = computed(() => props.metricMode === 'counts' ? totalCount.value : totalPoints.value)
 const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
-
-const aggregatedBuckets = computed(() => {
-  if (!props.summary?.boards) return {}
-  const buckets = {
-    'tech-debt-quality': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
-    'new-features': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
-    'learning-enablement': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
-    'uncategorized': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 }
-  }
-  for (const boardData of Object.values(props.summary.boards)) {
-    if (!boardData?.summary?.buckets) continue
-    for (const [key, bucket] of Object.entries(boardData.summary.buckets)) {
-      if (buckets[key]) {
-        buckets[key].points += bucket.points || 0
-        buckets[key].count += bucket.count || bucket.issueCount || 0
-        buckets[key].issueCount += bucket.issueCount || 0
-        buckets[key].completedPoints += bucket.completedPoints || 0
-        buckets[key].completedCount += bucket.completedCount || 0
-      }
-    }
-  }
-  return buckets
-})
 </script>

--- a/modules/allocation-tracker/client/components/ProjectCard.vue
+++ b/modules/allocation-tracker/client/components/ProjectCard.vue
@@ -14,14 +14,14 @@
       </svg>
     </div>
 
-    <template v-if="totalPoints > 0">
+    <template v-if="displayTotal > 0">
       <div class="mt-3">
-        <AllocationBar :buckets="aggregatedBuckets" :totalPoints="totalPoints" />
+        <AllocationBar :buckets="aggregatedBuckets" :totalPoints="totalPoints" :metricMode="metricMode" />
       </div>
 
       <div class="flex items-center justify-between mt-2 text-sm">
         <span class="text-gray-600">
-          <span class="font-medium">{{ totalPoints }}</span> pts
+          <span class="font-medium">{{ displayTotal }}</span> {{ unitLabel }}
         </span>
         <span class="text-gray-500">
           {{ boardCount }} {{ boardCount === 1 ? 'board' : 'boards' }}
@@ -45,6 +45,10 @@ const props = defineProps({
   summary: {
     type: Object,
     default: null
+  },
+  metricMode: {
+    type: String,
+    default: 'points'
   }
 })
 
@@ -61,21 +65,32 @@ const totalPoints = computed(() => {
     .reduce((sum, b) => sum + (b?.summary?.totalPoints || 0), 0)
 })
 
+const totalCount = computed(() => {
+  if (!props.summary?.boards) return 0
+  return Object.values(props.summary.boards)
+    .reduce((sum, b) => sum + (b?.summary?.totalCount || b?.summary?.estimatedIssueCount || 0), 0)
+})
+
+const displayTotal = computed(() => props.metricMode === 'counts' ? totalCount.value : totalPoints.value)
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
+
 const aggregatedBuckets = computed(() => {
   if (!props.summary?.boards) return {}
   const buckets = {
-    'tech-debt-quality': { points: 0, issueCount: 0, completedPoints: 0 },
-    'new-features': { points: 0, issueCount: 0, completedPoints: 0 },
-    'learning-enablement': { points: 0, issueCount: 0, completedPoints: 0 },
-    'uncategorized': { points: 0, issueCount: 0, completedPoints: 0 }
+    'tech-debt-quality': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
+    'new-features': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
+    'learning-enablement': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
+    'uncategorized': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 }
   }
   for (const boardData of Object.values(props.summary.boards)) {
     if (!boardData?.summary?.buckets) continue
     for (const [key, bucket] of Object.entries(boardData.summary.buckets)) {
       if (buckets[key]) {
         buckets[key].points += bucket.points || 0
+        buckets[key].count += bucket.count || bucket.issueCount || 0
         buckets[key].issueCount += bucket.issueCount || 0
         buckets[key].completedPoints += bucket.completedPoints || 0
+        buckets[key].completedCount += bucket.completedCount || 0
       }
     }
   }

--- a/modules/allocation-tracker/client/components/ProjectDetail.vue
+++ b/modules/allocation-tracker/client/components/ProjectDetail.vue
@@ -13,17 +13,22 @@
       </button>
     </div>
 
+    <!-- Metric toggle -->
+    <div class="flex items-center justify-end mb-4">
+      <MetricToggle :modelValue="metricMode" @update:modelValue="$emit('update:metricMode', $event)" />
+    </div>
+
     <!-- Project allocation bar -->
     <div v-if="projectSummary && projectSummary.lastUpdated" class="mb-6">
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
         <div class="flex items-center justify-between mb-2">
           <h2 class="text-lg font-semibold text-gray-900">{{ project.name }} — Project Overview</h2>
-          <span v-if="totalPoints > 0" class="text-sm text-gray-500">
-            {{ totalPoints }} pts across {{ boardCount }} {{ boardCount === 1 ? 'board' : 'boards' }}
+          <span v-if="displayTotal > 0" class="text-sm text-gray-500">
+            {{ displayTotal }} {{ unitLabel }} across {{ boardCount }} {{ boardCount === 1 ? 'board' : 'boards' }}
           </span>
         </div>
         <p class="text-xs text-gray-400 mb-2">Aggregated from each board's currently active sprint</p>
-        <AllocationBar v-if="aggregatedBuckets && totalPoints > 0" :buckets="aggregatedBuckets" :totalPoints="totalPoints" />
+        <AllocationBar v-if="aggregatedBuckets && displayTotal > 0" :buckets="aggregatedBuckets" :totalPoints="totalPoints" :metricMode="metricMode" />
       </div>
     </div>
 
@@ -78,6 +83,7 @@
         :key="board.id"
         :board="board"
         :sprintData="boardSprintData[board.id] || null"
+        :metricMode="metricMode"
         @select-team="$emit('select-team', $event)"
       />
     </div>
@@ -90,6 +96,7 @@
 import { computed } from 'vue'
 import AllocationBar from './AllocationBar.vue'
 import FilterSelector from './FilterSelector.vue'
+import MetricToggle from './MetricToggle.vue'
 import LoadingOverlay from '@shared/client/components/LoadingOverlay.vue'
 import TeamCard from './TeamCard.vue'
 
@@ -125,10 +132,14 @@ const props = defineProps({
   activeFilter: {
     type: Object,
     default: null
+  },
+  metricMode: {
+    type: String,
+    default: 'points'
   }
 })
 
-defineEmits(['back', 'select-team', 'select-filter', 'create-filter', 'edit-filter', 'delete-filter'])
+defineEmits(['back', 'select-team', 'select-filter', 'create-filter', 'edit-filter', 'delete-filter', 'update:metricMode'])
 
 const filteredBoards = computed(() => {
   const boards = props.activeFilter
@@ -145,10 +156,10 @@ const boardCount = computed(() => {
 const aggregatedBuckets = computed(() => {
   if (!props.projectSummary?.boards) return null
   const buckets = {
-    'tech-debt-quality': { points: 0, issueCount: 0, completedPoints: 0 },
-    'new-features': { points: 0, issueCount: 0, completedPoints: 0 },
-    'learning-enablement': { points: 0, issueCount: 0, completedPoints: 0 },
-    'uncategorized': { points: 0, issueCount: 0, completedPoints: 0 }
+    'tech-debt-quality': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
+    'new-features': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
+    'learning-enablement': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
+    'uncategorized': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 }
   }
 
   for (const boardData of Object.values(props.projectSummary.boards)) {
@@ -156,8 +167,10 @@ const aggregatedBuckets = computed(() => {
     for (const [key, bucket] of Object.entries(boardData.summary.buckets)) {
       if (buckets[key]) {
         buckets[key].points += bucket.points || 0
+        buckets[key].count += bucket.count || bucket.issueCount || 0
         buckets[key].issueCount += bucket.issueCount || 0
         buckets[key].completedPoints += bucket.completedPoints || 0
+        buckets[key].completedCount += bucket.completedCount || 0
       }
     }
   }
@@ -170,4 +183,13 @@ const totalPoints = computed(() => {
   return Object.values(props.projectSummary.boards)
     .reduce((sum, b) => sum + (b?.summary?.totalPoints || 0), 0)
 })
+
+const totalCount = computed(() => {
+  if (!props.projectSummary?.boards) return 0
+  return Object.values(props.projectSummary.boards)
+    .reduce((sum, b) => sum + (b?.summary?.totalCount || b?.summary?.estimatedIssueCount || 0), 0)
+})
+
+const displayTotal = computed(() => props.metricMode === 'counts' ? totalCount.value : totalPoints.value)
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
 </script>

--- a/modules/allocation-tracker/client/components/ProjectDetail.vue
+++ b/modules/allocation-tracker/client/components/ProjectDetail.vue
@@ -28,7 +28,7 @@
           </span>
         </div>
         <p class="text-xs text-gray-400 mb-2">Aggregated from each board's currently active sprint</p>
-        <AllocationBar v-if="aggregatedBuckets && displayTotal > 0" :buckets="aggregatedBuckets" :totalPoints="totalPoints" :metricMode="metricMode" />
+        <AllocationBar v-if="aggregatedBuckets && displayTotal > 0" :buckets="aggregatedBuckets" :totalPoints="totalPoints" :totalCount="totalCount" :metricMode="metricMode" />
       </div>
     </div>
 
@@ -99,6 +99,9 @@ import FilterSelector from './FilterSelector.vue'
 import MetricToggle from './MetricToggle.vue'
 import LoadingOverlay from '@shared/client/components/LoadingOverlay.vue'
 import TeamCard from './TeamCard.vue'
+import { useAllocationData } from '../composables/useAllocationData.js'
+
+const { aggregateBuckets } = useAllocationData()
 
 const props = defineProps({
   project: {
@@ -153,42 +156,14 @@ const boardCount = computed(() => {
   return Object.keys(props.projectSummary.boards).length
 })
 
-const aggregatedBuckets = computed(() => {
+const aggregated = computed(() => {
   if (!props.projectSummary?.boards) return null
-  const buckets = {
-    'tech-debt-quality': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
-    'new-features': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
-    'learning-enablement': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 },
-    'uncategorized': { points: 0, count: 0, issueCount: 0, completedPoints: 0, completedCount: 0 }
-  }
-
-  for (const boardData of Object.values(props.projectSummary.boards)) {
-    if (!boardData?.summary?.buckets) continue
-    for (const [key, bucket] of Object.entries(boardData.summary.buckets)) {
-      if (buckets[key]) {
-        buckets[key].points += bucket.points || 0
-        buckets[key].count += bucket.count || bucket.issueCount || 0
-        buckets[key].issueCount += bucket.issueCount || 0
-        buckets[key].completedPoints += bucket.completedPoints || 0
-        buckets[key].completedCount += bucket.completedCount || 0
-      }
-    }
-  }
-
-  return buckets
+  return aggregateBuckets(props.projectSummary.boards)
 })
 
-const totalPoints = computed(() => {
-  if (!props.projectSummary?.boards) return 0
-  return Object.values(props.projectSummary.boards)
-    .reduce((sum, b) => sum + (b?.summary?.totalPoints || 0), 0)
-})
-
-const totalCount = computed(() => {
-  if (!props.projectSummary?.boards) return 0
-  return Object.values(props.projectSummary.boards)
-    .reduce((sum, b) => sum + (b?.summary?.totalCount || b?.summary?.estimatedIssueCount || 0), 0)
-})
+const aggregatedBuckets = computed(() => aggregated.value?.buckets || null)
+const totalPoints = computed(() => aggregated.value?.totalPoints || 0)
+const totalCount = computed(() => aggregated.value?.totalCount || 0)
 
 const displayTotal = computed(() => props.metricMode === 'counts' ? totalCount.value : totalPoints.value)
 const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')

--- a/modules/allocation-tracker/client/components/TeamCard.vue
+++ b/modules/allocation-tracker/client/components/TeamCard.vue
@@ -21,12 +21,12 @@
       </div>
 
       <div class="mt-3">
-        <AllocationBar :buckets="sprintData.summary.buckets" :totalPoints="sprintData.summary.totalPoints" />
+        <AllocationBar :buckets="sprintData.summary.buckets" :totalPoints="sprintData.summary.totalPoints" :metricMode="metricMode" />
       </div>
 
       <div class="flex items-center justify-between mt-2 text-sm">
         <span class="text-gray-600">
-          <span class="font-medium">{{ sprintData.summary.totalPoints }}</span> pts
+          <span class="font-medium">{{ displayTotal }}</span> {{ unitLabel }}
         </span>
         <span
           v-if="sprintData.summary.unestimatedIssueCount > 0"
@@ -38,7 +38,7 @@
         <span v-else class="text-gray-400 text-xs">All estimated</span>
       </div>
 
-      <div v-if="sprintData.sprint.state === 'closed' && sprintData.summary.totalPoints > 0" class="mt-1 text-xs text-gray-500">
+      <div v-if="sprintData.sprint.state === 'closed' && displayTotal > 0" class="mt-1 text-xs text-gray-500">
         Completed: {{ completionPercent }}%
       </div>
     </template>
@@ -60,13 +60,33 @@ const props = defineProps({
   sprintData: {
     type: Object,
     default: null
+  },
+  metricMode: {
+    type: String,
+    default: 'points'
   }
 })
 
 defineEmits(['select-team'])
 
+const displayTotal = computed(() => {
+  if (!props.sprintData) return 0
+  if (props.metricMode === 'counts') return props.sprintData.summary.totalCount || 0
+  return props.sprintData.summary.totalPoints || 0
+})
+
+const unitLabel = computed(() => props.metricMode === 'counts' ? 'issues' : 'pts')
+
 const completionPercent = computed(() => {
-  if (!props.sprintData || props.sprintData.summary.totalPoints === 0) return 0
+  if (!props.sprintData) return 0
+  if (props.metricMode === 'counts') {
+    const total = props.sprintData.summary.totalCount || 0
+    if (total === 0) return 0
+    const completed = Object.values(props.sprintData.summary.buckets)
+      .reduce((sum, b) => sum + (b.completedCount || 0), 0)
+    return Math.round((completed / total) * 100)
+  }
+  if (props.sprintData.summary.totalPoints === 0) return 0
   const completedPoints = Object.values(props.sprintData.summary.buckets)
     .reduce((sum, b) => sum + (b.completedPoints || 0), 0)
   return Math.round((completedPoints / props.sprintData.summary.totalPoints) * 100)

--- a/modules/allocation-tracker/client/components/TeamCard.vue
+++ b/modules/allocation-tracker/client/components/TeamCard.vue
@@ -21,7 +21,7 @@
       </div>
 
       <div class="mt-3">
-        <AllocationBar :buckets="sprintData.summary.buckets" :totalPoints="sprintData.summary.totalPoints" :metricMode="metricMode" />
+        <AllocationBar :buckets="sprintData.summary.buckets" :totalPoints="sprintData.summary.totalPoints" :totalCount="sprintData.summary.totalCount || 0" :metricMode="metricMode" />
       </div>
 
       <div class="flex items-center justify-between mt-2 text-sm">

--- a/modules/allocation-tracker/client/components/TeamDetail.vue
+++ b/modules/allocation-tracker/client/components/TeamDetail.vue
@@ -54,6 +54,7 @@
         <AllocationBar
           :buckets="sprintData.summary.buckets"
           :totalPoints="sprintData.summary.totalPoints"
+          :totalCount="sprintData.summary.totalCount || 0"
           :metricMode="metricMode"
           class="h-8"
         />
@@ -134,14 +135,18 @@ const displayTotal = computed(() => {
 
 function getBucketData(key) {
   const bucket = props.sprintData?.summary?.buckets?.[key]
-  const total = displayTotal.value
-  const value = props.metricMode === 'counts'
-    ? (bucket?.count || bucket?.issueCount || 0)
-    : (bucket?.points || 0)
+  let percentage
+  if (props.metricMode === 'counts') {
+    const total = displayTotal.value
+    const count = bucket?.count || 0
+    percentage = total > 0 ? Math.round((count / total) * 100) : 0
+  } else {
+    percentage = bucket?.percentage || 0
+  }
   return {
     points: bucket?.points || 0,
-    count: bucket?.count || bucket?.issueCount || 0,
-    percentage: total > 0 ? Math.round((value / total) * 100) : 0,
+    count: bucket?.count || 0,
+    percentage,
     completedPoints: bucket?.completedPoints || 0,
     completedCount: bucket?.completedCount || 0
   }

--- a/modules/allocation-tracker/client/components/TeamDetail.vue
+++ b/modules/allocation-tracker/client/components/TeamDetail.vue
@@ -44,18 +44,24 @@
         </span>
       </div>
 
+      <!-- Metric toggle -->
+      <div class="flex items-center justify-end mb-4">
+        <MetricToggle :modelValue="metricMode" @update:modelValue="$emit('update:metricMode', $event)" />
+      </div>
+
       <!-- Allocation bar -->
       <div class="mb-4">
         <AllocationBar
           :buckets="sprintData.summary.buckets"
           :totalPoints="sprintData.summary.totalPoints"
+          :metricMode="metricMode"
           class="h-8"
         />
       </div>
 
-      <!-- Total points summary -->
+      <!-- Total summary -->
       <div class="text-sm text-gray-600 mb-4">
-        <span class="font-semibold text-gray-900">{{ sprintData.summary.totalPoints }}</span> total points
+        <span class="font-semibold text-gray-900">{{ displayTotal }}</span> total {{ metricMode === 'counts' ? 'issues' : 'points' }}
       </div>
 
       <!-- Unestimated panel -->
@@ -71,11 +77,14 @@
           :name="bucket.name"
           :bucketKey="bucket.key"
           :points="getBucketData(bucket.key).points"
+          :count="getBucketData(bucket.key).count"
           :percentage="getBucketData(bucket.key).percentage"
           :targetPercentage="bucket.target"
           :completedPoints="getBucketData(bucket.key).completedPoints"
+          :completedCount="getBucketData(bucket.key).completedCount"
           :color="bucket.color"
           :issues="sprintData.issues[bucket.key] || []"
+          :metricMode="metricMode"
         />
       </div>
 
@@ -83,6 +92,7 @@
       <CompletionSummary
         :summary="sprintData.summary"
         :sprintState="selectedSprint.state"
+        :metricMode="metricMode"
       />
     </template>
   </div>
@@ -94,6 +104,7 @@ import SprintSelector from './SprintSelector.vue'
 import SprintStatusBadge from './SprintStatusBadge.vue'
 import AllocationBar from './AllocationBar.vue'
 import BucketBreakdown from './BucketBreakdown.vue'
+import MetricToggle from './MetricToggle.vue'
 import UnestimatedPanel from './UnestimatedPanel.vue'
 import CompletionSummary from './CompletionSummary.vue'
 
@@ -102,10 +113,11 @@ const props = defineProps({
   sprints: { type: Array, default: () => [] },
   selectedSprint: { type: Object, default: null },
   sprintData: { type: Object, default: null },
-  isLoading: { type: Boolean, default: false }
+  isLoading: { type: Boolean, default: false },
+  metricMode: { type: String, default: 'points' }
 })
 
-defineEmits(['select-sprint', 'back'])
+defineEmits(['select-sprint', 'back', 'update:metricMode'])
 
 const bucketConfigs = [
   { key: 'tech-debt-quality', name: 'Tech Debt & Quality', target: 40, color: 'amber' },
@@ -114,12 +126,24 @@ const bucketConfigs = [
   { key: 'uncategorized', name: 'Uncategorized', target: 0, color: 'gray' }
 ]
 
+const displayTotal = computed(() => {
+  if (!props.sprintData) return 0
+  if (props.metricMode === 'counts') return props.sprintData.summary.totalCount || 0
+  return props.sprintData.summary.totalPoints || 0
+})
+
 function getBucketData(key) {
   const bucket = props.sprintData?.summary?.buckets?.[key]
+  const total = displayTotal.value
+  const value = props.metricMode === 'counts'
+    ? (bucket?.count || bucket?.issueCount || 0)
+    : (bucket?.points || 0)
   return {
     points: bucket?.points || 0,
-    percentage: bucket?.percentage || 0,
-    completedPoints: bucket?.completedPoints || 0
+    count: bucket?.count || bucket?.issueCount || 0,
+    percentage: total > 0 ? Math.round((value / total) * 100) : 0,
+    completedPoints: bucket?.completedPoints || 0,
+    completedCount: bucket?.completedCount || 0
   }
 }
 

--- a/modules/allocation-tracker/client/composables/useAllocationData.js
+++ b/modules/allocation-tracker/client/composables/useAllocationData.js
@@ -36,6 +36,8 @@ const selectedSprint = ref(null)
 const teamSprintData = ref(null)
 const isTeamDetailLoading = ref(false)
 
+const metricMode = ref('points')
+
 const isLoading = ref(false)
 const isRefreshing = ref(false)
 const lastUpdated = ref(null)
@@ -273,6 +275,7 @@ export function useAllocationData() {
     isTeamDetailLoading,
 
     // UI state
+    metricMode,
     isLoading,
     isRefreshing,
     lastUpdated,

--- a/modules/allocation-tracker/client/composables/useAllocationData.js
+++ b/modules/allocation-tracker/client/composables/useAllocationData.js
@@ -188,17 +188,49 @@ async function handleRefreshData(hardRefresh) {
   }
 }
 
+// ─── Shared bucket helpers ───
+
+const BUCKET_KEYS = ['tech-debt-quality', 'new-features', 'learning-enablement', 'uncategorized']
+
+function emptyBucket() {
+  return { points: 0, count: 0, completedPoints: 0, completedCount: 0 }
+}
+
+/**
+ * Aggregate bucket data across boards from a project/org summary.
+ * Normalizes server fields (count/issueCount) into a single `count` field.
+ * Returns { buckets, totalPoints, totalCount }.
+ */
+function aggregateBuckets(boards) {
+  const buckets = Object.fromEntries(BUCKET_KEYS.map(k => [k, emptyBucket()]))
+  let totalPoints = 0
+  let totalCount = 0
+
+  for (const boardData of Object.values(boards)) {
+    if (!boardData?.summary?.buckets) continue
+    totalPoints += boardData.summary.totalPoints || 0
+    totalCount += boardData.summary.totalCount || 0
+    for (const [key, bucket] of Object.entries(boardData.summary.buckets)) {
+      if (!buckets[key]) continue
+      buckets[key].points += bucket.points || 0
+      buckets[key].count += bucket.count || bucket.issueCount || 0
+      buckets[key].completedPoints += bucket.completedPoints || 0
+      buckets[key].completedCount += bucket.completedCount || 0
+    }
+  }
+
+  return { buckets, totalPoints, totalCount }
+}
+
 // ─── transformSprintData ───
 
 function transformSprintData(data) {
-  // Group flat issues array by bucket
-  const issuesByBucket = { 'tech-debt-quality': [], 'new-features': [], 'learning-enablement': [], 'uncategorized': [] }
+  const issuesByBucket = Object.fromEntries(BUCKET_KEYS.map(k => [k, []]))
   for (const issue of (data.issues || [])) {
     const bucket = issuesByBucket[issue.bucket]
     if (bucket) bucket.push(issue)
   }
 
-  // Add percentage and completedPoints to summary
   const summary = { ...data.summary }
   const totalPoints = summary.totalPoints || 0
 
@@ -209,6 +241,8 @@ function transformSprintData(data) {
         completedPoints += bucket.completedPoints || 0
         return [key, {
           ...bucket,
+          count: bucket.count || bucket.issueCount || 0,
+          completedCount: bucket.completedCount || 0,
           percentage: totalPoints > 0 ? Math.round((bucket.points / totalPoints) * 100) : 0
         }]
       })
@@ -289,6 +323,7 @@ export function useAllocationData() {
     loadTeamSprints,
     handleSelectSprint,
     handleRefreshData,
-    transformSprintData
+    transformSprintData,
+    aggregateBuckets
   }
 }

--- a/modules/allocation-tracker/client/views/OrgDashboardView.vue
+++ b/modules/allocation-tracker/client/views/OrgDashboardView.vue
@@ -18,7 +18,9 @@
         :orgSummary="orgSummary"
         :projects="projects"
         :projectSummaries="projectSummaries"
+        :metricMode="metricMode"
         @select-project="onSelectProject"
+        @update:metricMode="metricMode = $event"
       />
       <LoadingOverlay v-if="isLoading" />
     </div>
@@ -39,6 +41,7 @@ const {
   projects,
   projectSummaries,
   configError,
+  metricMode,
   isLoading,
   loadInitialData,
   handleSelectProject

--- a/modules/allocation-tracker/client/views/ProjectDetailView.vue
+++ b/modules/allocation-tracker/client/views/ProjectDetailView.vue
@@ -9,12 +9,14 @@
       :filters="filters"
       :activeFilterId="activeFilterId"
       :activeFilter="activeFilter"
+      :metricMode="metricMode"
       @back="onBack"
       @select-team="onSelectTeam"
       @select-filter="setActiveFilter"
       @create-filter="openCreateFilter"
       @edit-filter="openEditFilter"
       @delete-filter="handleDeleteFilter"
+      @update:metricMode="metricMode = $event"
     />
 
     <FilterEditorModal
@@ -41,6 +43,7 @@ const {
   selectedProjectSummary,
   boards,
   boardSprintData,
+  metricMode,
   isLoading,
   projects,
   handleSelectProject

--- a/modules/allocation-tracker/client/views/TeamDetailView.vue
+++ b/modules/allocation-tracker/client/views/TeamDetailView.vue
@@ -5,8 +5,10 @@
     :selectedSprint="selectedSprint"
     :sprintData="teamSprintData"
     :isLoading="isTeamDetailLoading"
+    :metricMode="metricMode"
     @select-sprint="handleSelectSprint"
     @back="onBack"
+    @update:metricMode="metricMode = $event"
   />
 </template>
 
@@ -24,6 +26,7 @@ const {
   selectedSprint,
   teamSprintData,
   isTeamDetailLoading,
+  metricMode,
   handleSelectTeam,
   handleSelectSprint
 } = useAllocationData()


### PR DESCRIPTION
## Summary
- Adds a segmented toggle switch (Story Points | Issue Count) to the top-right of the Allocation Tracker dashboard, project detail, and team detail views
- When toggled, all allocation bars, bucket breakdowns, completion summaries, and project/team cards dynamically recalculate using the selected metric
- Defaults to "Story Points"; selection persists across view navigation via shared composable state

## Changes
- **New component:** `MetricToggle.vue` — reusable two-option segmented control
- **Composable:** Added `metricMode` ref to `useAllocationData.js` (module-level, shared across views)
- **Updated components:** `AllocationBar`, `OrgDashboard`, `ProjectCard`, `ProjectDetail`, `TeamCard`, `TeamDetail`, `BucketBreakdown`, `CompletionSummary` — all accept `metricMode` and switch between `points`/`count` fields from server data
- **Updated views:** `OrgDashboardView`, `ProjectDetailView`, `TeamDetailView` — wire `metricMode` from composable to components

## Test plan
- [ ] Verify toggle renders in top-right on org dashboard, project detail, and team detail views
- [ ] Confirm default state is "Story Points" (active/highlighted)
- [ ] Toggle to "Issue Count" and verify all allocation bars recalculate using issue counts
- [ ] Check project cards show "X issues" instead of "X pts" when in Issue Count mode
- [ ] Verify bucket breakdown cards show issue counts and correct percentages
- [ ] Verify completion summary uses issue counts when toggled
- [ ] Navigate between views (org → project → team) and confirm toggle selection persists
- [ ] Toggle back to "Story Points" and confirm all values revert correctly
- [ ] All 315 existing tests pass (`npm test`)
- [ ] Lint passes clean (`npm run lint`)

Made with [Cursor](https://cursor.com)