### PR TITLE
feat: add Claude issue assistant GitHub Action

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -1,0 +1,183 @@
+name: Claude Issue Assistant
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: claude-issues-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude-issue:
+    name: Claude Issue Assistant
+    timeout-minutes: 30
+    if: |
+      (github.event_name == 'issues' &&
+       github.actor != 'github-actions[bot]') ||
+      (github.event_name == 'issue_comment' &&
+       !github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.author_association != 'NONE' &&
+       github.event.comment.author_association != 'FIRST_TIMER' &&
+       github.event.comment.author_association != 'FIRST_TIME_CONTRIBUTOR')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config user.name "claude-issue-assistant[bot]"
+          git config user.email "claude-issue-assistant[bot]@users.noreply.github.com"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Claude Issue Assistant
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        with:
+          use_vertex: "true"
+          track_progress: true
+          display_report: "true"
+          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh issue view:*),Bash(gh pr create:*),Bash(gh label create:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(npm test:*),Bash(npm run lint:*),Read,Glob,Grep,Edit,Write"'
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            EVENT: ${{ github.event_name }}
+            TRIGGER: ${{ github.event_name == 'issue_comment' && 'comment' || 'new_issue' }}
+            AUTHOR: ${{ github.event_name == 'issue_comment' && github.event.comment.user.login || github.event.issue.user.login }}
+            AUTHOR_ASSOCIATION: ${{ github.event_name == 'issue_comment' && github.event.comment.author_association || github.event.issue.author_association }}
+
+            You are an AI assistant helping with GitHub issues for this project.
+            Read the project's CLAUDE.md, AGENTS.md, and relevant documentation to
+            understand the codebase before responding.
+
+            ## Your role
+
+            You help with issues by:
+            1. Triaging and labeling new issues
+            2. Answering questions about the codebase
+            3. Fixing bugs by opening pull requests
+            4. Implementing feature requests (only after explicit approval)
+            5. Facilitating discussion when you can't resolve something yourself
+
+            ## Step 1: Understand the context
+
+            Run `gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments`
+            to read the full issue and all comments.
+
+            If this was triggered by a comment (TRIGGER=comment), pay close attention to
+            what the commenter is asking you to do.
+
+            ## Step 2: Categorize and respond
+
+            Based on the issue content, determine the category:
+
+            ### Question / Help Request
+            - Read the relevant code and documentation
+            - Post a clear, helpful answer as an issue comment
+            - Apply the `question` label if not already present
+
+            ### Bug Report
+            - Investigate the bug by reading relevant source code
+            - If you can identify the root cause with HIGH confidence:
+              - Post a comment explaining what you found and your proposed fix
+              - Implement the fix, run tests (`npm test`) and lint (`npm run lint`)
+              - If tests pass, create a branch, commit, and open a PR:
+                ```
+                git checkout -b fix/issue-${{ github.event.issue.number }}-<short-description>
+                git add -u
+                git commit -m "fix: <description>
+
+                Fixes #${{ github.event.issue.number }}"
+                git push origin HEAD
+                gh pr create --title "fix: <description>" --body "Fixes #${{ github.event.issue.number }}
+
+                <explanation of the fix>"
+                ```
+              - Comment on the issue linking to the PR
+            - If you canNOT confidently fix it:
+              - Post your analysis: what you found, what you suspect, what's unclear
+              - Ask specific clarifying questions
+              - Apply the `needs-clarification` label
+            - Apply the `bug` label if not already present
+
+            ### Feature Request
+            - Analyze the request and the relevant parts of the codebase
+            - Post a comment with:
+              - Your understanding of the request
+              - A proposed implementation approach (which files to change, how)
+              - Any concerns, trade-offs, or questions
+              - A clear ask telling the user to reply and mention you with their approval if they'd like you to implement it. IMPORTANT: Do NOT write the literal string "@claude" anywhere in your comment — this will re-trigger the workflow. Instead, say "mention me" or "tag me" when telling users how to respond.
+            - Apply the `enhancement` label if not already present
+            - **Do NOT start implementation** unless the user has explicitly approved
+              your approach by commenting and mentioning you with some form of approval
+              (e.g., "go ahead", "implement this", "approved", "looks good, build it")
+            - When you DO have approval to implement:
+              - Create a feature branch, implement the changes, run tests and lint
+              - Open a PR linking back to the issue
+              - Comment on the issue linking to the PR
+
+            ### Unclear / Insufficient Information
+            - Ask specific clarifying questions (not generic "can you provide more info")
+            - Apply the `needs-clarification` label
+
+            ## Step 3: Apply labels
+
+            Use `gh issue edit` to apply appropriate labels. Create labels if they
+            don't exist yet (use `gh label create` with sensible colors).
+
+            Standard labels to use:
+            - `bug` (color: d73a4a) — confirmed bug reports
+            - `enhancement` (color: a2eeef) — feature requests
+            - `question` (color: d876e3) — questions about the codebase
+            - `needs-clarification` (color: fbca04) — waiting for more info from author
+
+            ## Important rules
+
+            - **Never force push.** Only push new branches via `git push origin HEAD`.
+            - **Use `git add -u`** (not `git add -A`) to avoid staging untracked files.
+            - **Never implement features without explicit approval.** Always propose
+              your approach first and wait for the user to approve.
+            - **Be concise.** Don't write walls of text. Be direct and helpful.
+            - **Read before you write.** Always read relevant files before proposing
+              or making changes.
+            - **Test your changes.** Always run `npm test` and `npm run lint` before
+              committing. If tests fail, fix the issue or revert and explain.
+            - **Follow project conventions.** Read AGENTS.md and .claude/CLAUDE.md
+              for code style and patterns.
+            - **Don't over-engineer.** Keep fixes and implementations minimal and
+              focused on what was asked.
+            - When you lack confidence or the issue is too complex, say so honestly.
+              Provide whatever analysis you can to help a human pick up the work.
+            - **PR branch naming:** `fix/issue-<number>-<short-desc>` for bugs,
+              `feat/issue-<number>-<short-desc>` for features.
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
+          CLOUD_ML_REGION: "us-east5"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
+          GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that lets Claude automatically respond to and help with GitHub issues
- Triages new issues with labels (`bug`, `enhancement`, `question`, `needs-clarification`)
- Answers questions, investigates bugs, proposes feature implementations
- Opens fix PRs for bugs when confident; waits for explicit `@claude` approval before implementing features
- Security: anyone can open an issue and get a response, but `@claude` comment interactions require collaborator/member association

## Design decisions

- Single workflow with two triggers (`issues: opened` + `issue_comment: created`) rather than multiple workflows, matching the pattern in `claude-review.yml`
- Uses `GH_PAT` so PRs created by Claude trigger CI (the "Test & Build" required check)
- Concurrency groups by issue number — concurrent comments queue rather than cancel in-progress work
- Excludes PR comments (`!github.event.issue.pull_request`) to avoid conflicting with the review workflow

## Test plan

- [ ] Open a test issue with a question about the codebase — verify Claude responds with a helpful answer and applies the `question` label
- [ ] Open a test issue reporting a bug — verify Claude investigates and either opens a fix PR or asks clarifying questions
- [ ] Open a test issue with a feature request — verify Claude proposes an approach and waits for approval before implementing
- [ ] Comment `@claude` on an issue as a collaborator — verify Claude responds
- [ ] Verify the workflow does NOT trigger on PR comments (those go to `claude-review.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)