### PR TITLE
fix: handle concatenated names from Google Sheets smart chips

### DIFF
--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -82,6 +82,8 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
     const orgKeyToDisplay = buildOrgKeyToDisplayName();
     const orgTeamPeopleMap = groupPeopleByOrgTeam(allPeople, orgKeyToDisplay);
 
+    const allNames = new Set(allPeople.map(p => p.name).filter(Boolean));
+
     const teams = [];
     for (const [compositeKey, teamPeople] of Object.entries(orgTeamPeopleMap)) {
       const sepIdx = compositeKey.indexOf('::');
@@ -90,8 +92,8 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
       if (orgFilter && org !== orgFilter) continue;
 
       const counts = calculateHeadcountByRole(teamPeople);
-      const engLeads = getTeamRollup(teamPeople, 'engineeringLead');
-      const productManagers = getTeamRollup(teamPeople, 'productManager');
+      const engLeads = getTeamRollup(teamPeople, 'engineeringLead', allNames);
+      const productManagers = getTeamRollup(teamPeople, 'productManager', allNames);
 
       const filterCounts = {};
       for (const p of teamPeople) {

--- a/shared/server/__tests__/roster.test.js
+++ b/shared/server/__tests__/roster.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+
+const { splitByKnownNames, getTeamRollup } = require('../roster')
+
+describe('splitByKnownNames', () => {
+  const knownNames = new Set([
+    'Yuan Tang',
+    'Pierangelo Di Pilato',
+    'Lindani Phiri',
+    'Steven Grubb',
+    'Adam Bellusci',
+    'Naina Singh',
+    'Jonathan Zarecki'
+  ])
+
+  it('returns a single known name unchanged', () => {
+    expect(splitByKnownNames('Yuan Tang', knownNames)).toEqual(['Yuan Tang'])
+  })
+
+  it('splits two concatenated names', () => {
+    expect(splitByKnownNames('Pierangelo Di Pilato Yuan Tang', knownNames))
+      .toEqual(['Pierangelo Di Pilato', 'Yuan Tang'])
+  })
+
+  it('splits three concatenated names', () => {
+    expect(splitByKnownNames('Adam Bellusci Naina Singh Jonathan Zarecki', knownNames))
+      .toEqual(['Adam Bellusci', 'Naina Singh', 'Jonathan Zarecki'])
+  })
+
+  it('returns unknown names as-is', () => {
+    expect(splitByKnownNames('Someone Unknown', knownNames))
+      .toEqual(['Someone Unknown'])
+  })
+
+  it('returns original string when only partial match at start', () => {
+    expect(splitByKnownNames('Yuan Tang Unknown Person', knownNames))
+      .toEqual(['Yuan Tang Unknown Person'])
+  })
+
+  it('handles empty knownNames set', () => {
+    expect(splitByKnownNames('Yuan Tang', new Set())).toEqual(['Yuan Tang'])
+  })
+
+  it('prefers longer name match (greedy longest-first)', () => {
+    const names = new Set(['John', 'John Smith', 'Anna Brown'])
+    expect(splitByKnownNames('John Smith Anna Brown', names))
+      .toEqual(['John Smith', 'Anna Brown'])
+  })
+
+  it('handles extra whitespace between names', () => {
+    expect(splitByKnownNames('Yuan Tang  Lindani Phiri', knownNames))
+      .toEqual(['Yuan Tang', 'Lindani Phiri'])
+  })
+})
+
+describe('getTeamRollup with knownNames', () => {
+  const knownNames = new Set([
+    'Yuan Tang',
+    'Pierangelo Di Pilato',
+    'Adam Bellusci',
+    'Naina Singh'
+  ])
+
+  it('splits concatenated names when knownNames provided', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: 'Pierangelo Di Pilato Yuan Tang' },
+      { name: 'Bob', engineeringLead: 'Yuan Tang' }
+    ]
+    const result = getTeamRollup(people, 'engineeringLead', knownNames)
+    expect(result).toEqual(['Pierangelo Di Pilato', 'Yuan Tang'])
+  })
+
+  it('handles mix of comma-separated and concatenated names', () => {
+    const people = [
+      { name: 'Alice', productManager: 'Adam Bellusci, Naina Singh' },
+      { name: 'Bob', productManager: 'Adam Bellusci Naina Singh' }
+    ]
+    const result = getTeamRollup(people, 'productManager', knownNames)
+    expect(result).toEqual(['Adam Bellusci', 'Naina Singh'])
+  })
+
+  it('works without knownNames (backward compatible)', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: 'Pierangelo Di Pilato Yuan Tang' }
+    ]
+    const result = getTeamRollup(people, 'engineeringLead')
+    expect(result).toEqual(['Pierangelo Di Pilato Yuan Tang'])
+  })
+
+  it('deduplicates across people', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: 'Yuan Tang' },
+      { name: 'Bob', engineeringLead: 'Yuan Tang' },
+      { name: 'Carol', engineeringLead: 'Adam Bellusci Yuan Tang' }
+    ]
+    const result = getTeamRollup(people, 'engineeringLead', knownNames)
+    expect(result).toEqual(['Adam Bellusci', 'Yuan Tang'])
+  })
+
+  it('returns sorted results', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: 'Yuan Tang Adam Bellusci' }
+    ]
+    const result = getTeamRollup(people, 'engineeringLead', knownNames)
+    expect(result).toEqual(['Adam Bellusci', 'Yuan Tang'])
+  })
+
+  it('skips empty and null values', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: '' },
+      { name: 'Bob', engineeringLead: null },
+      { name: 'Carol' }
+    ]
+    const result = getTeamRollup(people, 'engineeringLead', knownNames)
+    expect(result).toEqual([])
+  })
+})

--- a/shared/server/roster.js
+++ b/shared/server/roster.js
@@ -99,20 +99,76 @@ function getOrgKeys(storage) {
 }
 
 /**
- * Collect unique non-empty values of a given field across a list of people.
- * Useful for rolling up fields like engineeringLead or productManager per team.
- * @param {object[]} people
- * @param {string} fieldName
+ * Split a string that may contain multiple concatenated names (from Google Sheets
+ * smart chips entered without commas) into individual names by matching against
+ * a set of known roster names.
+ *
+ * Uses greedy longest-first matching from left to right. Falls back to returning
+ * the original string if no roster names match.
+ *
+ * @param {string} text - The possibly-concatenated name string
+ * @param {Set<string>} knownNames - Set of all known roster names
  * @returns {string[]}
  */
-function getTeamRollup(people, fieldName) {
+function splitByKnownNames(text, knownNames) {
+  if (knownNames.has(text)) return [text];
+
+  const candidates = [...knownNames]
+    .filter(name => text.includes(name))
+    .sort((a, b) => b.length - a.length);
+
+  if (candidates.length === 0) return [text];
+
+  const result = [];
+  let remaining = text.trim();
+
+  while (remaining.length > 0) {
+    let found = false;
+    for (const name of candidates) {
+      if (remaining.startsWith(name)) {
+        result.push(name);
+        remaining = remaining.substring(name.length).trim();
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return [text];
+    }
+  }
+
+  return result.length > 0 ? result : [text];
+}
+
+/**
+ * Collect unique non-empty values of a given field across a list of people.
+ * Useful for rolling up fields like engineeringLead or productManager per team.
+ *
+ * When knownNames is provided, comma-separated tokens that don't match a known
+ * name are further split by matching against roster names (handles Google Sheets
+ * smart chip concatenation without commas).
+ *
+ * @param {object[]} people
+ * @param {string} fieldName
+ * @param {Set<string>} [knownNames] - Optional set of all roster names for smart-chip splitting
+ * @returns {string[]}
+ */
+function getTeamRollup(people, fieldName, knownNames) {
   const values = new Set();
   for (const person of people) {
     const val = person[fieldName] || person.customFields?.[fieldName];
     if (val && typeof val === 'string') {
       for (const v of val.split(',')) {
         const trimmed = v.trim();
-        if (trimmed) values.add(trimmed);
+        if (trimmed) {
+          if (knownNames && knownNames.size > 0) {
+            for (const name of splitByKnownNames(trimmed, knownNames)) {
+              values.add(name);
+            }
+          } else {
+            values.add(trimmed);
+          }
+        }
       }
     }
   }
@@ -125,5 +181,6 @@ module.exports = {
   getPeopleByOrg,
   getOrgKeys,
   getTeamRollup,
+  splitByKnownNames,
   getOrgDisplayNames
 };


### PR DESCRIPTION
When Google Sheets smart chips are used to @-mention people without commas between them, names get concatenated (e.g., "Adam Bellusci Naina Singh" instead of "Adam Bellusci, Naina Singh"). This adds roster-aware name splitting to `getTeamRollup()` so it can decompose these concatenated strings by matching against known roster names.

Fixes #268

Generated with [Claude Code](https://claude.ai/code)