### PR TITLE
fix: handle product manager names not in roster for smart chip splitting

### DIFF
--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -6,7 +6,7 @@
 
 const { runSync, calculateHeadcountByRole, parseTeamBoardsTab } = require('../org-sync');
 const { fetchAllRfeBacklog } = require('../rfe');
-const { getAllPeople, getTeamRollup } = require('../../../../shared/server/roster');
+const { getAllPeople, getTeamRollup, collectRoleNames } = require('../../../../shared/server/roster');
 const { getOrgDisplayNames } = require('../../../../shared/server/roster-sync/config');
 const { fetchRawSheet } = require('../../../../shared/server/google-sheets');
 
@@ -82,7 +82,8 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
     const orgKeyToDisplay = buildOrgKeyToDisplayName();
     const orgTeamPeopleMap = groupPeopleByOrgTeam(allPeople, orgKeyToDisplay);
 
-    const allNames = new Set(allPeople.map(p => p.name).filter(Boolean));
+    const rosterNames = new Set(allPeople.map(p => p.name).filter(Boolean));
+    const allNames = collectRoleNames(allPeople, ['engineeringLead', 'productManager'], rosterNames);
 
     const teams = [];
     for (const [compositeKey, teamPeople] of Object.entries(orgTeamPeopleMap)) {

--- a/shared/server/__tests__/roster.test.js
+++ b/shared/server/__tests__/roster.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-const { splitByKnownNames, getTeamRollup } = require('../roster')
+const { splitByKnownNames, getTeamRollup, collectRoleNames } = require('../roster')
 
 describe('splitByKnownNames', () => {
   const knownNames = new Set([
@@ -113,5 +113,105 @@ describe('getTeamRollup with knownNames', () => {
     ]
     const result = getTeamRollup(people, 'engineeringLead', knownNames)
     expect(result).toEqual([])
+  })
+})
+
+describe('collectRoleNames', () => {
+  it('discovers PM names not in the roster from field values', () => {
+    const people = [
+      { name: 'Alice', productManager: 'Adam Bellusci' },
+      { name: 'Bob', productManager: 'Adam Bellusci Naina Singh' },
+      { name: 'Carol', productManager: 'Naina Singh' }
+    ]
+    const rosterNames = new Set(['Alice', 'Bob', 'Carol'])
+    const result = collectRoleNames(people, ['productManager'], rosterNames)
+    expect(result.has('Adam Bellusci')).toBe(true)
+    expect(result.has('Naina Singh')).toBe(true)
+    expect(result.has('Adam Bellusci Naina Singh')).toBe(false)
+  })
+
+  it('discovers names from three-name concatenations', () => {
+    const people = [
+      { name: 'Alice', productManager: 'Adam Bellusci' },
+      { name: 'Bob', productManager: 'Naina Singh' },
+      { name: 'Carol', productManager: 'Adam Bellusci Naina Singh Jonathan Zarecki' },
+      { name: 'Dave', productManager: 'Jonathan Zarecki' }
+    ]
+    const result = collectRoleNames(people, ['productManager'], new Set())
+    expect(result.has('Adam Bellusci')).toBe(true)
+    expect(result.has('Naina Singh')).toBe(true)
+    expect(result.has('Jonathan Zarecki')).toBe(true)
+    expect(result.has('Adam Bellusci Naina Singh Jonathan Zarecki')).toBe(false)
+  })
+
+  it('preserves multi-word names that cannot be decomposed', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: 'Pierangelo Di Pilato' },
+      { name: 'Bob', engineeringLead: 'Pierangelo Di Pilato Yuan Tang' }
+    ]
+    const rosterNames = new Set(['Alice', 'Bob', 'Yuan Tang'])
+    const result = collectRoleNames(people, ['engineeringLead'], rosterNames)
+    expect(result.has('Pierangelo Di Pilato')).toBe(true)
+    expect(result.has('Yuan Tang')).toBe(true)
+  })
+
+  it('includes existing roster names in the result', () => {
+    const people = [{ name: 'Alice', productManager: 'Some PM' }]
+    const rosterNames = new Set(['Alice', 'Bob'])
+    const result = collectRoleNames(people, ['productManager'], rosterNames)
+    expect(result.has('Alice')).toBe(true)
+    expect(result.has('Bob')).toBe(true)
+    expect(result.has('Some PM')).toBe(true)
+  })
+
+  it('handles comma-separated values correctly', () => {
+    const people = [
+      { name: 'Alice', productManager: 'Adam Bellusci, Naina Singh' },
+      { name: 'Bob', productManager: 'Adam Bellusci Naina Singh' }
+    ]
+    const result = collectRoleNames(people, ['productManager'], new Set())
+    expect(result.has('Adam Bellusci')).toBe(true)
+    expect(result.has('Naina Singh')).toBe(true)
+  })
+
+  it('scans multiple fields', () => {
+    const people = [
+      { name: 'Alice', engineeringLead: 'Lead One', productManager: 'PM One' },
+      { name: 'Bob', engineeringLead: 'Lead One Lead Two', productManager: 'PM One PM Two' },
+      { name: 'Carol', engineeringLead: 'Lead Two', productManager: 'PM Two' }
+    ]
+    const result = collectRoleNames(people, ['engineeringLead', 'productManager'], new Set())
+    expect(result.has('Lead One')).toBe(true)
+    expect(result.has('Lead Two')).toBe(true)
+    expect(result.has('PM One')).toBe(true)
+    expect(result.has('PM Two')).toBe(true)
+  })
+
+  it('cannot discover names that only appear concatenated', () => {
+    const people = [
+      { name: 'Alice', productManager: 'Adam Bellusci Naina Singh' }
+    ]
+    const result = collectRoleNames(people, ['productManager'], new Set())
+    expect(result.has('Adam Bellusci Naina Singh')).toBe(true)
+    expect(result.has('Adam Bellusci')).toBe(false)
+    expect(result.has('Naina Singh')).toBe(false)
+  })
+
+  it('handles empty field values gracefully', () => {
+    const people = [
+      { name: 'Alice', productManager: '' },
+      { name: 'Bob', productManager: null },
+      { name: 'Carol' }
+    ]
+    const result = collectRoleNames(people, ['productManager'], new Set())
+    expect(result.size).toBe(0)
+  })
+
+  it('reads from customFields fallback', () => {
+    const people = [
+      { name: 'Alice', customFields: { productManager: 'Custom PM' } }
+    ]
+    const result = collectRoleNames(people, ['productManager'], new Set())
+    expect(result.has('Custom PM')).toBe(true)
   })
 })

--- a/shared/server/roster.js
+++ b/shared/server/roster.js
@@ -175,6 +175,49 @@ function getTeamRollup(people, fieldName, knownNames) {
   return [...values].sort();
 }
 
+/**
+ * Discover real names from role field values (e.g. engineeringLead, productManager)
+ * by iteratively building a known-names set. Handles the case where role holders
+ * (like PMs) aren't in the LDAP roster but their names appear in field values.
+ *
+ * Sorts comma-separated tokens by length (shortest first) so atomic names are
+ * discovered before concatenations. A token that can be decomposed into already-known
+ * names is a concatenation; one that can't is a new name.
+ *
+ * @param {object[]} allPeople
+ * @param {string[]} fieldNames - Fields to scan (e.g. ['engineeringLead', 'productManager'])
+ * @param {Set<string>} existingNames - Seed names (e.g. roster names)
+ * @returns {Set<string>} Union of existing + discovered names
+ */
+function collectRoleNames(allPeople, fieldNames, existingNames) {
+  const allTokens = new Set();
+
+  for (const p of allPeople) {
+    for (const field of fieldNames) {
+      const val = p[field] || p.customFields?.[field];
+      if (val && typeof val === 'string') {
+        for (const v of val.split(',')) {
+          const trimmed = v.trim();
+          if (trimmed) allTokens.add(trimmed);
+        }
+      }
+    }
+  }
+
+  const sorted = [...allTokens].sort((a, b) => a.length - b.length);
+  const discovered = new Set(existingNames);
+
+  for (const token of sorted) {
+    if (discovered.has(token)) continue;
+    const result = splitByKnownNames(token, discovered);
+    if (result.length <= 1) {
+      discovered.add(token);
+    }
+  }
+
+  return discovered;
+}
+
 module.exports = {
   readRosterFull,
   getAllPeople,
@@ -182,5 +225,6 @@ module.exports = {
   getOrgKeys,
   getTeamRollup,
   splitByKnownNames,
+  collectRoleNames,
   getOrgDisplayNames
 };


### PR DESCRIPTION
The previous fix for concatenated Google Sheets smart chip names only worked for engineering leads (whose names are in the LDAP roster). Product managers often report through a different org tree and aren't in the roster, so their concatenated names couldn't be split.

Adds `collectRoleNames()` that bootstraps known names from field values themselves by sorting tokens shortest-first and iteratively discovering atomic names before concatenations.

Fixes #268

Generated with [Claude Code](https://claude.ai/code)