### PR TITLE
feat: admin seed endpoint for release-planning bootstrap

### DIFF
--- a/modules/release-planning/client/composables/useReleasePlanning.js
+++ b/modules/release-planning/client/composables/useReleasePlanning.js
@@ -169,6 +169,15 @@ export function useReleasePlanning() {
     )
   }
 
+  async function seedFromFixture() {
+    var fixture = await apiRequest(`${API_BASE}/admin/seed/fixture`)
+    return apiRequest(`${API_BASE}/admin/seed`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(fixture)
+    })
+  }
+
   async function fetchSmartSheetReleases() {
     try {
       var data = await apiRequest(`${API_BASE}/smartsheet/releases`)
@@ -198,6 +207,7 @@ export function useReleasePlanning() {
     reorderBigRocks,
     createRelease,
     deleteRelease,
+    seedFromFixture,
     fetchSmartSheetReleases
   }
 }

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -17,7 +17,7 @@ const {
   candidates, loading, error, refreshing, cacheStale, permissions,
   loadCandidates, triggerRefresh, loadPermissions,
   saveBigRock, deleteBigRock: deleteBigRockApi, updateBigRocksInPlace,
-  reorderBigRocks
+  reorderBigRocks, seedFromFixture
 } = useReleasePlanning()
 
 const { releases, loadReleases } = useReleases()
@@ -38,6 +38,9 @@ const deleting = ref(false)
 
 // New release dialog state
 const newReleaseDialogOpen = ref(false)
+
+// Seed state
+const seeding = ref(false)
 
 const features = computed(() => candidates.value ? candidates.value.features || [] : [])
 const rfes = computed(() => candidates.value ? candidates.value.rfes || [] : [])
@@ -198,6 +201,24 @@ async function handleReleaseCreated(result) {
   }
 }
 
+// ─── Seed handler ───
+
+async function handleSeedFixture() {
+  seeding.value = true
+  error.value = null
+  try {
+    var result = await seedFromFixture()
+    await loadReleases()
+    if (result.seeded && result.seeded.length > 0) {
+      selectedVersion.value = result.seeded[0].version
+    }
+  } catch (err) {
+    error.value = err.message || 'Failed to load fixture data'
+  } finally {
+    seeding.value = false
+  }
+}
+
 watch(selectedVersion, function(newVersion) {
   if (newVersion) {
     loadCandidates(newVersion)
@@ -336,6 +357,23 @@ onMounted(async function() {
     <div v-else-if="!loading && releases.length === 0" class="text-center py-12">
       <p class="text-gray-500 dark:text-gray-400">No releases configured.</p>
       <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Add Big Rocks configuration to get started.</p>
+      <div class="flex items-center justify-center gap-3 mt-4">
+        <button
+          v-if="canEdit"
+          @click="handleNewRelease"
+          class="px-4 py-2 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700"
+        >
+          New Release
+        </button>
+        <button
+          v-if="canEdit"
+          @click="handleSeedFixture"
+          :disabled="seeding"
+          class="px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ seeding ? 'Loading...' : 'Load Fixture Data' }}
+        </button>
+      </div>
     </div>
 
     <!-- Edit panel -->

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -629,6 +629,58 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
+  // ─── Admin Seed / Bootstrap ───
+
+  router.post('/admin/seed', requireAdmin, async function(req, res) {
+    var config = req.body
+    if (!config || typeof config !== 'object' || !config.releases) {
+      return res.status(400).json({ error: 'Request body must include a "releases" object' })
+    }
+
+    var versions = Object.keys(config.releases)
+    for (var i = 0; i < versions.length; i++) {
+      if (!VERSION_RE.test(versions[i]) || RESERVED_VERSIONS.includes(versions[i])) {
+        return res.status(400).json({ error: 'Invalid version: ' + versions[i] })
+      }
+    }
+
+    try {
+      var result = await withConfigLock(function() {
+        backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+
+        var existing = getConfig(readFromStorage)
+        var merged = {
+          ...existing,
+          ...config,
+          releases: { ...existing.releases, ...config.releases },
+          fieldMapping: { ...existing.fieldMapping, ...(config.fieldMapping || {}) },
+          customFieldIds: { ...existing.customFieldIds, ...(config.customFieldIds || {}) }
+        }
+
+        writeToStorage('release-planning/config.json', merged)
+
+        var seededVersions = versions.map(function(v) {
+          return { version: v, bigRockCount: (merged.releases[v].bigRocks || []).length }
+        })
+
+        return { seeded: seededVersions, totalReleases: Object.keys(merged.releases).length }
+      })
+
+      res.json(result)
+    } catch (err) {
+      var status = err.statusCode || 500
+      res.status(status).json({ error: err.message })
+    }
+  })
+
+  router.get('/admin/seed/fixture', requireAdmin, function(req, res) {
+    var fixture = loadFixture('config.json')
+    if (!fixture) {
+      return res.status(404).json({ error: 'No fixture data found' })
+    }
+    res.json(fixture)
+  })
+
   // Diagnostics
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -651,7 +651,6 @@ module.exports = function registerRoutes(router, context) {
         var existing = getConfig(readFromStorage)
         var merged = {
           ...existing,
-          ...config,
           releases: { ...existing.releases, ...config.releases },
           fieldMapping: { ...existing.fieldMapping, ...(config.fieldMapping || {}) },
           customFieldIds: { ...existing.customFieldIds, ...(config.customFieldIds || {}) }


### PR DESCRIPTION
## Summary
- Adds `POST /admin/seed` endpoint that accepts a full release-planning config JSON and merges it into storage (creates a backup first, validates all version strings)
- Adds `GET /admin/seed/fixture` endpoint that returns the bundled fixture data (14 Big Rocks for 3.5) so the client can fetch and POST it in one flow
- Updates the dashboard empty state ("No releases configured") to show **New Release** and **Load Fixture Data** buttons for admin users

## Why
New deployments (or redeployments with a fresh PVC) start with no `release-planning/config.json`, leaving the dashboard empty with no way to populate it from the UI. This gives admins a one-click path to bootstrap from the bundled fixture data, and a reusable API for seeding from any JSON payload.

## Test plan
- [ ] Verify `GET /admin/seed/fixture` returns the fixture config with 14 Big Rocks
- [ ] Verify `POST /admin/seed` writes config to storage and returns seeded versions
- [ ] Verify non-admin users get 403 on both endpoints
- [ ] Verify the "Load Fixture Data" button appears on the empty-state dashboard for admins
- [ ] Verify clicking it populates releases and navigates to the first version
- [ ] Verify existing config is preserved (merged, not replaced) when seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)