### PR TITLE
feat: add roster-to-upstream-pulse sync in upstream-pulse module

### DIFF
--- a/modules/upstream-pulse/__tests__/server/index.test.js
+++ b/modules/upstream-pulse/__tests__/server/index.test.js
@@ -15,7 +15,7 @@ describe('upstream-pulse server module', () => {
       get: vi.fn((...args) => registered.push({ method: 'get', path: args[0] })),
       post: vi.fn(),
     }
-    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn() }
+    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn(), storage: { readFromStorage: vi.fn() } }
 
     registerRoutes(router, context)
 
@@ -31,31 +31,33 @@ describe('upstream-pulse server module', () => {
     expect(paths).toHaveLength(8)
   })
 
-  it('registers admin POST route for projects', () => {
+  it('registers admin POST routes for projects and roster-push', () => {
     const postCalls = []
     const router = {
       get: vi.fn(),
       post: vi.fn((...args) => postCalls.push({ path: args[0] })),
     }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin, storage: { readFromStorage: vi.fn() } })
 
-    expect(postCalls).toHaveLength(1)
-    expect(postCalls[0].path).toBe('/projects')
+    expect(postCalls).toHaveLength(2)
+    expect(postCalls.map(c => c.path)).toContain('/projects')
+    expect(postCalls.map(c => c.path)).toContain('/roster-push')
     expect(router.post).toHaveBeenCalledWith('/projects', requireAdmin, expect.any(Function))
+    expect(router.post).toHaveBeenCalledWith('/roster-push', requireAdmin, expect.any(Function))
   })
 
   it('gates repo-info behind requireAdmin', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin, storage: { readFromStorage: vi.fn() } })
 
     expect(router.get).toHaveBeenCalledWith('/repo-info', requireAdmin, expect.any(Function))
   })
 
   it('registers diagnostics hook when available', () => {
     const router = { get: vi.fn(), post: vi.fn() }
-    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn() }
+    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn(), storage: { readFromStorage: vi.fn() } }
 
     registerRoutes(router, context)
     expect(context.registerDiagnostics).toHaveBeenCalledWith(expect.any(Function))
@@ -63,7 +65,7 @@ describe('upstream-pulse server module', () => {
 
   it('does not fail when registerDiagnostics is absent', () => {
     const router = { get: vi.fn(), post: vi.fn() }
-    const context = { requireAdmin: vi.fn() }
+    const context = { requireAdmin: vi.fn(), storage: { readFromStorage: vi.fn() } }
 
     expect(() => registerRoutes(router, context)).not.toThrow()
   })

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -126,6 +126,100 @@ async function checkConnection() {
   }
 }
 
+const ROSTER_PUSH_SOURCE = 'org_pulse_roster';
+const ROSTER_PUSH_REPLACES = ['github_org_sync'];
+const ROSTER_PUSH_INTERVAL = 2 * 60 * 60 * 1000; // 2 hours
+const ROSTER_PUSH_STARTUP_DELAY = 2 * 60 * 1000; // 2 minutes
+
+var _lastPushGeneratedAt = null;
+
+function getServiceIdentityHeaders() {
+  var serviceUser = process.env.UPSTREAM_SYNC_SERVICE_USER || 'roster-sync-service';
+  return {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'x-forwarded-user': serviceUser,
+    'x-forwarded-email': serviceUser + '@internal'
+  };
+}
+
+async function pushRosterToUpstream(storage) {
+  var { getAllPeople } = require('../../../shared/server/roster');
+  var allPeople = getAllPeople(storage);
+
+  var people = [];
+  for (var i = 0; i < allPeople.length; i++) {
+    var p = allPeople[i];
+    if (!p.github || !p.github.username) continue;
+    people.push({
+      name: p.name,
+      email: p.email || null,
+      githubUsername: p.github.username,
+      employeeId: p.uid || null,
+      department: p._teamGrouping || p.miroTeam || null,
+      role: p.title || null
+    });
+  }
+
+  if (people.length === 0) {
+    console.log('[upstream-pulse] Roster push skipped: no people with GitHub usernames');
+    return { skipped: true, reason: 'no_people' };
+  }
+
+  var base = getBaseUrl();
+  var url = base + '/api/admin/team-members/sync';
+  var body = {
+    source: ROSTER_PUSH_SOURCE,
+    replacesSources: ROSTER_PUSH_REPLACES,
+    people: people
+  };
+
+  console.log('[upstream-pulse] Pushing ' + people.length + ' roster members to ' + url);
+  var response = await fetch(url, {
+    method: 'POST',
+    timeout: PROXY_TIMEOUT,
+    headers: getServiceIdentityHeaders(),
+    body: JSON.stringify(body)
+  });
+
+  var data = await response.json().catch(function() { return {}; });
+  if (!response.ok) {
+    throw new Error('Roster push failed (' + response.status + '): ' + (data.error || 'unknown'));
+  }
+
+  console.log('[upstream-pulse] Roster push complete:', JSON.stringify(data));
+  return data;
+}
+
+function startPeriodicRosterPush(storage) {
+  var DEMO_MODE = process.env.DEMO_MODE === 'true';
+  if (DEMO_MODE) return;
+
+  function checkAndPush() {
+    try {
+      var registry = storage.readFromStorage('team-data/registry.json');
+      if (!registry || !registry.meta || !registry.meta.generatedAt) return;
+
+      var generatedAt = registry.meta.generatedAt;
+      if (_lastPushGeneratedAt === generatedAt) return;
+
+      pushRosterToUpstream(storage).then(function(result) {
+        if (!result.skipped) {
+          _lastPushGeneratedAt = generatedAt;
+        }
+      }).catch(function(err) {
+        console.warn('[upstream-pulse] Periodic roster push failed:', err.message);
+      });
+    } catch (err) {
+      console.warn('[upstream-pulse] Periodic roster push check failed:', err.message);
+    }
+  }
+
+  setTimeout(checkAndPush, ROSTER_PUSH_STARTUP_DELAY);
+  var timer = setInterval(checkAndPush, ROSTER_PUSH_INTERVAL);
+  if (timer.unref) timer.unref();
+}
+
 module.exports = function registerRoutes(router, context) {
 
   function handleProxyError(res, err) {
@@ -271,13 +365,36 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
+  // ── Roster push (sync org-pulse team data to upstream-pulse) ──
+
+  router.post('/roster-push', requireAdmin, async function(req, res) {
+    try {
+      var result = await pushRosterToUpstream(context.storage);
+      if (!result.skipped) {
+        var registry = context.storage.readFromStorage('team-data/registry.json');
+        if (registry && registry.meta) _lastPushGeneratedAt = registry.meta.generatedAt;
+      }
+      res.json(result);
+    } catch (err) {
+      console.error('[upstream-pulse] Manual roster push failed:', err.message);
+      res.status(502).json({ error: 'Roster push failed', message: err.message });
+    }
+  });
+
+  // Start periodic roster push (checks registry.json for changes)
+  startPeriodicRosterPush(context.storage);
+
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
       const connection = await checkConnection();
       return {
         baseUrl: getBaseUrl(),
         configured: !!process.env.UPSTREAM_PULSE_API_URL,
-        connection
+        connection,
+        rosterPush: {
+          lastPushGeneratedAt: _lastPushGeneratedAt,
+          serviceUser: process.env.UPSTREAM_SYNC_SERVICE_USER || 'roster-sync-service'
+        }
       };
     });
   }

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -126,15 +126,17 @@ async function checkConnection() {
   }
 }
 
+const { getAllPeople } = require('../../../shared/server/roster');
+
 const ROSTER_PUSH_SOURCE = 'org_pulse_roster';
 const ROSTER_PUSH_REPLACES = ['github_org_sync'];
 const ROSTER_PUSH_INTERVAL = 2 * 60 * 60 * 1000; // 2 hours
 const ROSTER_PUSH_STARTUP_DELAY = 2 * 60 * 1000; // 2 minutes
 
-var _lastPushGeneratedAt = null;
+let _lastPushGeneratedAt = null;
 
 function getServiceIdentityHeaders() {
-  var serviceUser = process.env.UPSTREAM_SYNC_SERVICE_USER || 'roster-sync-service';
+  const serviceUser = process.env.UPSTREAM_SYNC_SERVICE_USER || 'roster-sync-service';
   return {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
@@ -144,12 +146,10 @@ function getServiceIdentityHeaders() {
 }
 
 async function pushRosterToUpstream(storage) {
-  var { getAllPeople } = require('../../../shared/server/roster');
-  var allPeople = getAllPeople(storage);
+  const allPeople = getAllPeople(storage);
 
-  var people = [];
-  for (var i = 0; i < allPeople.length; i++) {
-    var p = allPeople[i];
+  const people = [];
+  for (const p of allPeople) {
     if (!p.github || !p.github.username) continue;
     people.push({
       name: p.name,
@@ -166,23 +166,23 @@ async function pushRosterToUpstream(storage) {
     return { skipped: true, reason: 'no_people' };
   }
 
-  var base = getBaseUrl();
-  var url = base + '/api/admin/team-members/sync';
-  var body = {
+  const base = getBaseUrl();
+  const url = base + '/api/admin/team-members/sync';
+  const body = {
     source: ROSTER_PUSH_SOURCE,
     replacesSources: ROSTER_PUSH_REPLACES,
     people: people
   };
 
   console.log('[upstream-pulse] Pushing ' + people.length + ' roster members to ' + url);
-  var response = await fetch(url, {
+  const response = await fetch(url, {
     method: 'POST',
     timeout: PROXY_TIMEOUT,
     headers: getServiceIdentityHeaders(),
     body: JSON.stringify(body)
   });
 
-  var data = await response.json().catch(function() { return {}; });
+  const data = await response.json().catch(function() { return {}; });
   if (!response.ok) {
     throw new Error('Roster push failed (' + response.status + '): ' + (data.error || 'unknown'));
   }
@@ -192,15 +192,14 @@ async function pushRosterToUpstream(storage) {
 }
 
 function startPeriodicRosterPush(storage) {
-  var DEMO_MODE = process.env.DEMO_MODE === 'true';
-  if (DEMO_MODE) return;
+  if (process.env.DEMO_MODE === 'true') return;
 
   function checkAndPush() {
     try {
-      var registry = storage.readFromStorage('team-data/registry.json');
+      const registry = storage.readFromStorage('team-data/registry.json');
       if (!registry || !registry.meta || !registry.meta.generatedAt) return;
 
-      var generatedAt = registry.meta.generatedAt;
+      const generatedAt = registry.meta.generatedAt;
       if (_lastPushGeneratedAt === generatedAt) return;
 
       pushRosterToUpstream(storage).then(function(result) {
@@ -216,7 +215,7 @@ function startPeriodicRosterPush(storage) {
   }
 
   setTimeout(checkAndPush, ROSTER_PUSH_STARTUP_DELAY);
-  var timer = setInterval(checkAndPush, ROSTER_PUSH_INTERVAL);
+  const timer = setInterval(checkAndPush, ROSTER_PUSH_INTERVAL);
   if (timer.unref) timer.unref();
 }
 
@@ -369,9 +368,9 @@ module.exports = function registerRoutes(router, context) {
 
   router.post('/roster-push', requireAdmin, async function(req, res) {
     try {
-      var result = await pushRosterToUpstream(context.storage);
+      const result = await pushRosterToUpstream(context.storage);
       if (!result.skipped) {
-        var registry = context.storage.readFromStorage('team-data/registry.json');
+        const registry = context.storage.readFromStorage('team-data/registry.json');
         if (registry && registry.meta) _lastPushGeneratedAt = registry.meta.generatedAt;
       }
       res.json(result);


### PR DESCRIPTION
Push org-pulse LDAP roster data to the upstream-pulse backend via the generic bulk team member sync API. Maps LDAP fields (uid, name, email, github.username, title, teamGrouping) to the generic payload format.

- pushRosterToUpstream() reads roster, filters people with GitHub usernames, POSTs to upstream-pulse with service identity headers
- Periodic push on startup + 2-hour interval, skips if registry.json hasn't changed (compares generatedAt timestamp)
- POST /roster-push admin route for manual trigger
- Guarded by DEMO_MODE (no push in demo)
- Sends replacesSources: ['github_org_sync'] to clean up old sync data