### PR TITLE
ci: auto-update preprod image tags after build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -199,6 +199,64 @@ jobs:
           docker push ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
           docker push ${{ env.FRONTEND_IMAGE }}:${BRANCH_TAG}
 
+  update-preprod-image:
+    name: Update Preprod Image Tags
+    needs: [detect-changes, build-backend, build-frontend]
+    if: |
+      always() &&
+      github.ref == 'refs/heads/preprod' &&
+      (needs.build-backend.result == 'success' || needs.build-frontend.result == 'success') &&
+      needs.build-backend.result != 'failure' &&
+      needs.build-frontend.result != 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: preprod
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Update backend image tag
+        if: needs.build-backend.result == 'success'
+        working-directory: deploy/openshift/overlays/preprod
+        run: |
+          kustomize edit set image ${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+
+      - name: Update frontend image tag
+        if: needs.build-frontend.result == 'success'
+        working-directory: deploy/openshift/overlays/preprod
+        run: |
+          kustomize edit set image ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
+
+      - name: Validate kustomize build
+        run: kustomize build deploy/openshift/overlays/preprod > /dev/null
+
+      - name: Push deploy commit
+        run: |
+          PARTS=""
+          if [ "${{ needs.build-backend.result }}" = "success" ]; then
+            PARTS="backend"
+          fi
+          if [ "${{ needs.build-frontend.result }}" = "success" ]; then
+            [ -n "$PARTS" ] && PARTS="$PARTS + "
+            PARTS="${PARTS}frontend"
+          fi
+
+          git config user.name "rhai-org-pulse[bot]"
+          git config user.email "rhai-org-pulse[bot]@users.noreply.github.com"
+          git add deploy/openshift/overlays/preprod/kustomization.yaml
+          git commit -m "deploy: update ${PARTS} image to ${{ github.sha }}"
+          git push origin preprod
+
   update-prod-image:
     name: Update Prod Image Tags
     needs: [detect-changes, build-backend, build-frontend]


### PR DESCRIPTION
Add update-preprod-image job to the Build & Push Images workflow. When images are built on the preprod branch, this job automatically updates deploy/openshift/overlays/preprod/kustomization.yaml with the new image SHA and pushes directly to preprod, matching the pattern used by prod's PR-based update.