### PR TITLE
add weekly preprod sync workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -199,6 +199,64 @@ jobs:
           docker push ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
           docker push ${{ env.FRONTEND_IMAGE }}:${BRANCH_TAG}
 
+  update-preprod-image:
+    name: Update Preprod Image Tags
+    needs: [detect-changes, build-backend, build-frontend]
+    if: |
+      always() &&
+      github.ref == 'refs/heads/preprod' &&
+      (needs.build-backend.result == 'success' || needs.build-frontend.result == 'success') &&
+      needs.build-backend.result != 'failure' &&
+      needs.build-frontend.result != 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: preprod
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Update backend image tag
+        if: needs.build-backend.result == 'success'
+        working-directory: deploy/openshift/overlays/preprod
+        run: |
+          kustomize edit set image ${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+
+      - name: Update frontend image tag
+        if: needs.build-frontend.result == 'success'
+        working-directory: deploy/openshift/overlays/preprod
+        run: |
+          kustomize edit set image ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
+
+      - name: Validate kustomize build
+        run: kustomize build deploy/openshift/overlays/preprod > /dev/null
+
+      - name: Push deploy commit
+        run: |
+          PARTS=""
+          if [ "${{ needs.build-backend.result }}" = "success" ]; then
+            PARTS="backend"
+          fi
+          if [ "${{ needs.build-frontend.result }}" = "success" ]; then
+            [ -n "$PARTS" ] && PARTS="$PARTS + "
+            PARTS="${PARTS}frontend"
+          fi
+
+          git config user.name "rhai-org-pulse[bot]"
+          git config user.email "rhai-org-pulse[bot]@users.noreply.github.com"
+          git add deploy/openshift/overlays/preprod/kustomization.yaml
+          git commit -m "deploy: update ${PARTS} image to ${{ github.sha }}"
+          git push origin preprod
+
   update-prod-image:
     name: Update Prod Image Tags
     needs: [detect-changes, build-backend, build-frontend]

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -251,9 +251,10 @@ jobs:
             PARTS="${PARTS}frontend"
           fi
 
-          git config user.name "rhai-org-pulse[bot]"
-          git config user.email "rhai-org-pulse[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add deploy/openshift/overlays/preprod/kustomization.yaml
+          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
           git commit -m "deploy: update ${PARTS} image to ${{ github.sha }}"
           git push origin preprod
 

--- a/.github/workflows/sync-preprod.yml
+++ b/.github/workflows/sync-preprod.yml
@@ -49,10 +49,10 @@ jobs:
         if: steps.check.outputs.commits_behind != '0' && steps.existing.outputs.existing_pr == ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMITS_BEHIND: ${{ steps.check.outputs.commits_behind }}
         run: |
-          BEHIND=${{ steps.check.outputs.commits_behind }}
           BODY="Automated sync of \`main\` into \`preprod\`."
-          BODY="$BODY"$'\n\n'"**$BEHIND commits** to promote. Merge when ready to deploy to preprod."
+          BODY="$BODY"$'\n\n'"**${COMMITS_BEHIND} commits** to promote. Merge when ready to deploy to preprod."
           gh pr create \
             --base preprod \
             --head main \

--- a/.github/workflows/sync-preprod.yml
+++ b/.github/workflows/sync-preprod.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * 1'  # Weekly: Monday 6 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: Create sync PR

--- a/.github/workflows/sync-preprod.yml
+++ b/.github/workflows/sync-preprod.yml
@@ -1,0 +1,58 @@
+name: Sync Preprod with Main
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly: Monday 6 AM UTC
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Create sync PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Check if sync needed
+        id: check
+        run: |
+          git fetch origin main preprod
+          BEHIND=$(git rev-list --count origin/preprod..origin/main)
+          echo "commits_behind=$BEHIND" >> "$GITHUB_OUTPUT"
+          echo "Preprod is $BEHIND commits behind main"
+
+      - name: Check for existing PR
+        if: steps.check.outputs.commits_behind != '0'
+        id: existing
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          EXISTING=$(gh pr list --base preprod --head main --state open --json number --jq '.[0].number // empty')
+          echo "existing_pr=$EXISTING" >> "$GITHUB_OUTPUT"
+          if [ -n "$EXISTING" ]; then
+            echo "Sync PR #$EXISTING already exists, skipping"
+          fi
+
+      - name: Create sync PR
+        if: steps.check.outputs.commits_behind != '0' && steps.existing.outputs.existing_pr == ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BEHIND=${{ steps.check.outputs.commits_behind }}
+          BODY="Automated sync of \`main\` into \`preprod\`."
+          BODY="$BODY"$'\n\n'"**$BEHIND commits** to promote. Merge when ready to deploy to preprod."
+          gh pr create \
+            --base preprod \
+            --head main \
+            --title "Release: main → preprod" \
+            --body "$BODY" \
+            --label automated


### PR DESCRIPTION
Adds a scheduled GitHub Action that creates a PR to merge main into preprod every Monday at 6 AM UTC. Skips if preprod is already up to date or a sync PR already exists. Also supports manual trigger via workflow_dispatch.