### PR TITLE
feat: Big Rocks dashboard improvements

### DIFF
--- a/modules/release-planning/client/components/BigRocksTable.vue
+++ b/modules/release-planning/client/components/BigRocksTable.vue
@@ -1,7 +1,6 @@
 <script setup>
-import { ref, toRef, watch } from 'vue'
+import { ref, watch } from 'vue'
 import draggable from 'vuedraggable'
-import { useRockColors } from '../composables/useRockColors'
 
 const props = defineProps({
   bigRocks: { type: Array, default: () => [] },
@@ -10,8 +9,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['editRock', 'addRock', 'deleteRock', 'reorder'])
-
-const { rockRowClass } = useRockColors(toRef(props, 'bigRocks'))
 
 // Local copy for draggable to mutate
 const localRocks = ref([...props.bigRocks])
@@ -56,17 +53,17 @@ function onDragEnd() {
       <table class="w-full text-sm border-collapse">
         <thead>
           <tr>
-            <th v-if="canEdit" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50"></th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium w-8 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Priority</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Pillar</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Big Rock</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Outcome(s)</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Owner</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Architect</th>
-            <th class="px-3 py-2 text-center text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Features</th>
-            <th class="px-3 py-2 text-center text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">RFEs</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Notes</th>
-            <th v-if="canEdit" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50"></th>
+            <th v-if="canEdit" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"></th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Priority</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Pillar</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Big Rock</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Outcome(s)</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Owner</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Architect</th>
+            <th class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Features</th>
+            <th class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">RFEs</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Notes</th>
+            <th v-if="canEdit" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"></th>
           </tr>
         </thead>
         <draggable
@@ -79,7 +76,7 @@ function onDragEnd() {
         >
           <template #item="{ element: rock }">
             <tr
-              :class="[rockRowClass(rock.name).bg, 'cursor-pointer hover:ring-2 hover:ring-primary-400 hover:ring-inset']"
+              class="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
               @click="handleRowClick(rock)"
             >
               <td class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
@@ -139,7 +136,7 @@ function onDragEnd() {
           <tr
             v-for="rock in bigRocks"
             :key="rock.name"
-            :class="[rockRowClass(rock.name).bg]"
+            class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
           >
             <td class="px-3 py-2 text-gray-400 dark:text-gray-500 font-mono text-xs border border-gray-300 dark:border-gray-600">{{ rock.priority }}</td>
             <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">

--- a/modules/release-planning/client/components/FeaturesTable.vue
+++ b/modules/release-planning/client/components/FeaturesTable.vue
@@ -1,8 +1,7 @@
 <script setup>
 import StatusBadge from './StatusBadge.vue'
 import TierSeparator from './TierSeparator.vue'
-import { computed, toRef } from 'vue'
-import { useRockColors } from '../composables/useRockColors'
+import { computed } from 'vue'
 
 const props = defineProps({
   features: { type: Array, default: () => [] },
@@ -10,8 +9,6 @@ const props = defineProps({
   jiraBaseUrl: { type: String, default: '' },
   summary: { type: Object, default: null }
 })
-
-const { rockRowClass } = useRockColors(toRef(props, 'bigRocks'))
 
 const PRIORITY_STYLES = {
   'Blocker': 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400',
@@ -55,18 +52,18 @@ const groupedFeatures = computed(() => {
       <table class="w-full text-sm border-collapse">
         <thead>
           <tr>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Big Rock</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Feature</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Status</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Priority</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Phase</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Title</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Components</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Target Release</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">PM</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Delivery Owner</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">RFE</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Fix Version</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Big Rock</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Feature</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Status</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Priority</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Phase</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Title</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Components</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Target Release</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">PM</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Delivery Owner</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">RFE</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Fix Version</th>
           </tr>
         </thead>
         <tbody>
@@ -79,7 +76,7 @@ const groupedFeatures = computed(() => {
             />
             <tr
               v-else
-              :class="rockRowClass(item.data.bigRock).bg"
+              class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
             >
               <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 max-w-[120px] truncate border border-gray-300 dark:border-gray-600">{{ item.data.bigRock || '-' }}</td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">

--- a/modules/release-planning/client/components/FilterBar.vue
+++ b/modules/release-planning/client/components/FilterBar.vue
@@ -1,6 +1,7 @@
 <script setup>
 defineProps({
   filterOptions: { type: Object, default: () => ({}) },
+  activeTab: { type: String, default: 'big-rocks' },
   selectedPillar: { type: String, default: '' },
   selectedRock: { type: String, default: '' },
   selectedStatus: { type: String, default: '' },
@@ -34,6 +35,7 @@ const selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:borde
     />
 
     <select
+      v-if="activeTab === 'big-rocks'"
       :value="selectedPillar"
       @change="$emit('update:selectedPillar', $event.target.value)"
       :class="selectClass"
@@ -43,6 +45,7 @@ const selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:borde
     </select>
 
     <select
+      v-if="activeTab !== 'big-rocks'"
       :value="selectedRock"
       @change="$emit('update:selectedRock', $event.target.value)"
       :class="selectClass"
@@ -52,6 +55,7 @@ const selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:borde
     </select>
 
     <select
+      v-if="activeTab !== 'big-rocks'"
       :value="selectedStatus"
       @change="$emit('update:selectedStatus', $event.target.value)"
       :class="selectClass"
@@ -61,6 +65,7 @@ const selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:borde
     </select>
 
     <select
+      v-if="activeTab !== 'big-rocks'"
       :value="selectedPriority"
       @change="$emit('update:selectedPriority', $event.target.value)"
       :class="selectClass"
@@ -70,7 +75,7 @@ const selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:borde
     </select>
 
     <select
-      v-if="filterOptions.teams && filterOptions.teams.length > 0"
+      v-if="activeTab === 'features' && filterOptions.teams && filterOptions.teams.length > 0"
       :value="selectedTeam"
       @change="$emit('update:selectedTeam', $event.target.value)"
       :class="selectClass"

--- a/modules/release-planning/client/components/RfesTable.vue
+++ b/modules/release-planning/client/components/RfesTable.vue
@@ -1,8 +1,7 @@
 <script setup>
 import StatusBadge from './StatusBadge.vue'
 import TierSeparator from './TierSeparator.vue'
-import { computed, toRef } from 'vue'
-import { useRockColors } from '../composables/useRockColors'
+import { computed } from 'vue'
 
 const props = defineProps({
   rfes: { type: Array, default: () => [] },
@@ -10,8 +9,6 @@ const props = defineProps({
   jiraBaseUrl: { type: String, default: '' },
   summary: { type: Object, default: null }
 })
-
-const { rockRowClass } = useRockColors(toRef(props, 'bigRocks'))
 
 const PRIORITY_STYLES = {
   'Blocker': 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400',
@@ -55,14 +52,14 @@ const groupedRfes = computed(() => {
       <table class="w-full text-sm border-collapse">
         <thead>
           <tr>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Big Rock</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">RFE</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Status</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Priority</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Title</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Components</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">PM</th>
-            <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400 font-medium border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/50">Labels</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Big Rock</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">RFE</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Status</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Priority</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Title</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Components</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">PM</th>
+            <th class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Labels</th>
           </tr>
         </thead>
         <tbody>
@@ -75,7 +72,7 @@ const groupedRfes = computed(() => {
             />
             <tr
               v-else
-              :class="rockRowClass(item.data.bigRock).bg"
+              class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
             >
               <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 max-w-[120px] truncate border border-gray-300 dark:border-gray-600">{{ item.data.bigRock || '-' }}</td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">

--- a/modules/release-planning/client/components/SummaryCards.vue
+++ b/modules/release-planning/client/components/SummaryCards.vue
@@ -39,17 +39,17 @@ defineProps({
     </div>
 
     <!-- Tier 3 -->
-    <div class="p-4 rounded-lg bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700">
-      <div class="text-sm font-semibold text-gray-700 dark:text-gray-300">Tier 3: Collaborative Support</div>
-      <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 leading-snug">Cross-team priorities</div>
+    <div class="p-4 rounded-lg bg-violet-50 dark:bg-violet-500/10 border border-violet-200 dark:border-violet-500/30">
+      <div class="text-sm font-semibold text-violet-700 dark:text-violet-400">Tier 3: Collaborative Support</div>
+      <div class="text-xs text-violet-600/70 dark:text-violet-400/70 mt-0.5 leading-snug">Cross-team priorities</div>
       <div class="flex items-baseline gap-4 mt-3">
         <div>
-          <span class="text-2xl font-bold text-gray-700 dark:text-gray-300">{{ summary.tier3 ? summary.tier3.features : 0 }}</span>
-          <span class="text-xs text-gray-500 dark:text-gray-400 ml-1">Features</span>
+          <span class="text-2xl font-bold text-violet-700 dark:text-violet-400">{{ summary.tier3 ? summary.tier3.features : 0 }}</span>
+          <span class="text-xs text-violet-600/70 dark:text-violet-400/70 ml-1">Features</span>
         </div>
         <div>
-          <span class="text-2xl font-bold text-gray-700 dark:text-gray-300">{{ summary.tier3 ? summary.tier3.rfes : 0 }}</span>
-          <span class="text-xs text-gray-500 dark:text-gray-400 ml-1">RFEs</span>
+          <span class="text-2xl font-bold text-violet-700 dark:text-violet-400">{{ summary.tier3 ? summary.tier3.rfes : 0 }}</span>
+          <span class="text-xs text-violet-600/70 dark:text-violet-400/70 ml-1">RFEs</span>
         </div>
       </div>
     </div>

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -82,6 +82,79 @@ function tabCount(tabId) {
   return 0
 }
 
+function exportMarkdown() {
+  var lines = []
+  var filename
+
+  if (activeTab.value === 'big-rocks') {
+    lines.push('# Big Rocks - ' + selectedVersion.value)
+    lines.push('')
+    lines.push('| **Priority** | **Pillar** | **Big Rock** | **Owner** | **Architect** | **Features** | **RFEs** | **Notes** |')
+    lines.push('|:--------:|--------|----------|-------|-----------|:--------:|:----:|-------|')
+    for (var rock of bigRocks.value) {
+      lines.push('| ' + [
+        rock.priority,
+        rock.pillar || '-',
+        rock.name,
+        rock.owner || '-',
+        rock.architect || '-',
+        rock.featureCount,
+        rock.rfeCount,
+        rock.notes || '-'
+      ].join(' | ') + ' |')
+    }
+    filename = 'big-rocks-' + selectedVersion.value + '.md'
+  } else if (activeTab.value === 'features') {
+    lines.push('# Features - ' + selectedVersion.value)
+    lines.push('')
+    lines.push('| **Big Rock** | **Feature** | **Status** | **Priority** | **Phase** | **Title** | **Components** | **Target Release** | **PM** | **Delivery Owner** | **RFE** | **Fix Version** |')
+    lines.push('|----------|---------|--------|----------|-------|-------|------------|----------------|-----|----------------|-----|-------------|')
+    for (var f of filteredFeatures.value) {
+      lines.push('| ' + [
+        f.bigRock || '-',
+        f.issueKey,
+        f.status || '-',
+        f.priority || '-',
+        f.phase || '-',
+        f.summary || '-',
+        f.components || '-',
+        f.targetRelease || '-',
+        f.pm || '-',
+        f.deliveryOwner || '-',
+        f.rfe || '-',
+        f.fixVersion || '-'
+      ].join(' | ') + ' |')
+    }
+    filename = 'features-' + selectedVersion.value + '.md'
+  } else {
+    lines.push('# RFEs - ' + selectedVersion.value)
+    lines.push('')
+    lines.push('| **Big Rock** | **RFE** | **Status** | **Priority** | **Title** | **Components** | **PM** | **Labels** |')
+    lines.push('|----------|-----|--------|----------|-------|------------|-----|--------|')
+    for (var r of filteredRfes.value) {
+      lines.push('| ' + [
+        r.bigRock || '-',
+        r.issueKey,
+        r.status || '-',
+        r.priority || '-',
+        r.summary || '-',
+        r.components || '-',
+        r.pm || '-',
+        (r.labels || []).join(', ') || '-'
+      ].join(' | ') + ' |')
+    }
+    filename = 'rfes-' + selectedVersion.value + '.md'
+  }
+
+  var blob = new Blob([lines.join('\n') + '\n'], { type: 'text/markdown' })
+  var url = URL.createObjectURL(blob)
+  var a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 function formatDate(iso) {
   if (!iso) return 'Never'
   return new Date(iso).toLocaleString()
@@ -239,7 +312,7 @@ onMounted(async function() {
     <!-- Header -->
     <div class="flex items-center justify-between flex-wrap gap-4">
       <div>
-        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Release Planning Dashboard</h1>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Big Rocks Planning Dashboard</h1>
         <p v-if="candidates && candidates.lastRefreshed" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Data from {{ formatDate(candidates.lastRefreshed) }}
         </p>
@@ -295,6 +368,7 @@ onMounted(async function() {
       <!-- Filters -->
       <FilterBar
         :filterOptions="filterOptions"
+        :activeTab="activeTab"
         v-model:selectedPillar="selectedPillar"
         v-model:selectedRock="selectedRock"
         v-model:selectedStatus="selectedStatus"
@@ -306,6 +380,7 @@ onMounted(async function() {
       />
 
       <!-- Tabs -->
+      <div class="flex items-center gap-3">
       <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-0.5 w-fit">
         <button
           v-for="tab in tabs"
@@ -324,6 +399,16 @@ onMounted(async function() {
               : 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400'"
           >{{ tabCount(tab.id) }}</span>
         </button>
+      </div>
+      <button
+        @click="exportMarkdown"
+        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        Export
+      </button>
       </div>
 
       <!-- Tab content -->

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -82,6 +82,10 @@ function tabCount(tabId) {
   return 0
 }
 
+function escapeCell(val) {
+  return String(val).replace(/\|/g, '\\|').replace(/\n/g, ' ')
+}
+
 function exportMarkdown() {
   var lines = []
   var filename
@@ -94,13 +98,13 @@ function exportMarkdown() {
     for (var rock of bigRocks.value) {
       lines.push('| ' + [
         rock.priority,
-        rock.pillar || '-',
-        rock.name,
-        rock.owner || '-',
-        rock.architect || '-',
+        escapeCell(rock.pillar || '-'),
+        escapeCell(rock.name),
+        escapeCell(rock.owner || '-'),
+        escapeCell(rock.architect || '-'),
         rock.featureCount,
         rock.rfeCount,
-        rock.notes || '-'
+        escapeCell(rock.notes || '-')
       ].join(' | ') + ' |')
     }
     filename = 'big-rocks-' + selectedVersion.value + '.md'
@@ -111,18 +115,18 @@ function exportMarkdown() {
     lines.push('|----------|---------|--------|----------|-------|-------|------------|----------------|-----|----------------|-----|-------------|')
     for (var f of filteredFeatures.value) {
       lines.push('| ' + [
-        f.bigRock || '-',
+        escapeCell(f.bigRock || '-'),
         f.issueKey,
-        f.status || '-',
-        f.priority || '-',
-        f.phase || '-',
-        f.summary || '-',
-        f.components || '-',
-        f.targetRelease || '-',
-        f.pm || '-',
-        f.deliveryOwner || '-',
+        escapeCell(f.status || '-'),
+        escapeCell(f.priority || '-'),
+        escapeCell(f.phase || '-'),
+        escapeCell(f.summary || '-'),
+        escapeCell(f.components || '-'),
+        escapeCell(f.targetRelease || '-'),
+        escapeCell(f.pm || '-'),
+        escapeCell(f.deliveryOwner || '-'),
         f.rfe || '-',
-        f.fixVersion || '-'
+        escapeCell(f.fixVersion || '-')
       ].join(' | ') + ' |')
     }
     filename = 'features-' + selectedVersion.value + '.md'
@@ -133,14 +137,14 @@ function exportMarkdown() {
     lines.push('|----------|-----|--------|----------|-------|------------|-----|--------|')
     for (var r of filteredRfes.value) {
       lines.push('| ' + [
-        r.bigRock || '-',
+        escapeCell(r.bigRock || '-'),
         r.issueKey,
-        r.status || '-',
-        r.priority || '-',
-        r.summary || '-',
-        r.components || '-',
-        r.pm || '-',
-        (r.labels || []).join(', ') || '-'
+        escapeCell(r.status || '-'),
+        escapeCell(r.priority || '-'),
+        escapeCell(r.summary || '-'),
+        escapeCell(r.components || '-'),
+        escapeCell(r.pm || '-'),
+        escapeCell((r.labels || []).join(', ') || '-')
       ].join(' | ') + ' |')
     }
     filename = 'rfes-' + selectedVersion.value + '.md'

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -83,7 +83,7 @@ function tabCount(tabId) {
 }
 
 function escapeCell(val) {
-  return String(val).replace(/\|/g, '\\|').replace(/\n/g, ' ')
+  return String(val).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
 }
 
 function exportMarkdown() {

--- a/modules/release-planning/module.json
+++ b/modules/release-planning/module.json
@@ -8,7 +8,7 @@
   "client": {
     "entry": "./client/index.js",
     "navItems": [
-      { "id": "main", "label": "Release Planning", "icon": "ClipboardList", "default": true }
+      { "id": "main", "label": "Big Rocks Planning", "icon": "ClipboardList", "default": true }
     ]
   },
   "server": {

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -258,6 +258,7 @@ module.exports = function registerRoutes(router, context) {
       var result = await withConfigLock(function() {
         return reorderBigRocks(readFromStorage, writeToStorage, version, order)
       })
+      invalidateCache(version)
       res.json(result)
     } catch (err) {
       var status = err.statusCode || 500


### PR DESCRIPTION
## Summary
- Rename sidebar sub-item to "Big Rocks Planning" and page title to "Big Rocks Planning Dashboard"
- Add tab-specific filters: Big Rocks shows Pillar + Search; Features shows Rock, Status, Priority, Team + Search; RFEs shows Rock, Status, Priority + Search
- Add Markdown export button that downloads tab-specific `.md` files with filtered data
- Remove per-rock row coloring from Big Rocks, Features, and RFE tables — all rows are now plain with hover highlight
- Enhance table header rows with stronger background, semibold uppercase text
- Style Tier 3 summary card with violet theme to match other tier cards
- Fix reorder not persisting: invalidate candidates cache after reorder save

## Test plan
- [ ] Sidebar shows "Release Planning" top-level, "Big Rocks Planning" sub-item
- [ ] Page title reads "Big Rocks Planning Dashboard"
- [ ] Switching tabs changes which filters appear
- [ ] Export button downloads correct `.md` file for each tab
- [ ] Table rows are plain (no per-rock coloring), headers are visually distinct
- [ ] Tier 3 card is violet
- [ ] Drag-to-reorder persists after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)