### PR TITLE
feat(release-planning): optimistic Big Rock reorder

### DIFF
--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -19,6 +19,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/team-tracker-backend
-  newTag: 4898588d7f6618d7f81700d9cd0f6d4cb4d8bd6f
+  newTag: d6777051dfa8249a79740f27ddc2776c60f1105c
 - name: quay.io/org-pulse/team-tracker-frontend
-  newTag: 4898588d7f6618d7f81700d9cd0f6d4cb4d8bd6f
+  newTag: d6777051dfa8249a79740f27ddc2776c60f1105c

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -372,14 +372,9 @@ function handleCancelDelete() {
 // ─── Reorder handler ───
 
 async function handleReorder(orderedNames) {
-  var previousBigRocks = bigRocks.value.slice()
-  var rocksByName = {}
-  for (var i = 0; i < previousBigRocks.length; i++) {
-    rocksByName[previousBigRocks[i].name] = previousBigRocks[i]
-  }
-  var optimistic = orderedNames.map(function(name, idx) {
-    return Object.assign({}, rocksByName[name], { priority: idx + 1 })
-  })
+  const previousBigRocks = bigRocks.value.slice()
+  const rocksByName = Object.fromEntries(previousBigRocks.map(r => [r.name, r]))
+  const optimistic = orderedNames.map((name, idx) => ({ ...rocksByName[name], priority: idx + 1 }))
   updateBigRocksInPlace(optimistic)
 
   try {

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -383,7 +383,7 @@ async function handleReorder(orderedNames) {
   updateBigRocksInPlace(optimistic)
 
   try {
-    var result = await reorderBigRocks(selectedVersion.value, orderedNames)
+    const result = await reorderBigRocks(selectedVersion.value, orderedNames)
     if (result && result.bigRocks) {
       updateBigRocksInPlace(result.bigRocks)
     }

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -372,15 +372,24 @@ function handleCancelDelete() {
 // ─── Reorder handler ───
 
 async function handleReorder(orderedNames) {
+  var previousBigRocks = bigRocks.value.slice()
+  var rocksByName = {}
+  for (var i = 0; i < previousBigRocks.length; i++) {
+    rocksByName[previousBigRocks[i].name] = previousBigRocks[i]
+  }
+  var optimistic = orderedNames.map(function(name, idx) {
+    return Object.assign({}, rocksByName[name], { priority: idx + 1 })
+  })
+  updateBigRocksInPlace(optimistic)
+
   try {
-    const result = await reorderBigRocks(selectedVersion.value, orderedNames)
+    var result = await reorderBigRocks(selectedVersion.value, orderedNames)
     if (result && result.bigRocks) {
       updateBigRocksInPlace(result.bigRocks)
     }
   } catch (err) {
     error.value = err.message || 'Reorder failed'
-    // Refetch to restore correct state
-    loadCandidates(selectedVersion.value)
+    updateBigRocksInPlace(previousBigRocks)
   }
 }
 


### PR DESCRIPTION
## Summary

- Apply the new row order to the UI immediately on drag-end instead of waiting for the API round-trip
- On success, the server response replaces the optimistic state (no visible change)
- On error, the previous order is restored and an error message is shown

Eliminates the visual snap-back that occurs when dragging a row while the API call is in flight.

## Test plan

- [x] All 245 release-planning tests pass
- [ ] Drag a Big Rock to a new position — row should stay in place without flickering
- [ ] Simulate API failure (e.g. disconnect network) — row should revert to original position with error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)