### PR TITLE
chore(release-planning): replace var with const/let

### DIFF
--- a/modules/release-planning/__tests__/server/cache-reader.test.js
+++ b/modules/release-planning/__tests__/server/cache-reader.test.js
@@ -92,14 +92,14 @@ function makeRfeDetail(key, overrides) {
 }
 
 function createMockStorage(featureDetails, rfeDetails) {
-  var store = {}
+  const store = {}
   if (featureDetails) {
-    for (var i = 0; i < featureDetails.length; i++) {
+    for (let i = 0; i < featureDetails.length; i++) {
       store['feature-traffic/features/' + featureDetails[i].key + '.json'] = featureDetails[i]
     }
   }
   if (rfeDetails) {
-    for (var j = 0; j < rfeDetails.length; j++) {
+    for (let j = 0; j < rfeDetails.length; j++) {
       store['feature-traffic/rfes/' + rfeDetails[j].key + '.json'] = rfeDetails[j]
     }
   }
@@ -110,13 +110,13 @@ function createMockStorage(featureDetails, rfeDetails) {
 
 describe('mapToCandidate', () => {
   it('maps an index-level feature (string fields)', () => {
-    var feature = makeFeatureIndex('RHAISTRAT-100', {
+    const feature = makeFeatureIndex('RHAISTRAT-100', {
       targetVersions: ['rhoai-3.5'],
       pm: 'Jane PM',
       architect: 'Bob Arch',
       assignee: 'John Smith'
     })
-    var candidate = mapToCandidate(feature, 'MaaS', 'outcome')
+    const candidate = mapToCandidate(feature, 'MaaS', 'outcome')
     expect(candidate.issueKey).toBe('RHAISTRAT-100')
     expect(candidate.bigRock).toBe('MaaS')
     expect(candidate.targetRelease).toBe('rhoai-3.5')
@@ -128,13 +128,13 @@ describe('mapToCandidate', () => {
   })
 
   it('maps a detail-level feature (object fields)', () => {
-    var feature = makeFeatureDetail('RHAISTRAT-200', {
+    const feature = makeFeatureDetail('RHAISTRAT-200', {
       targetVersions: ['rhoai-3.5'],
       pm: { displayName: 'Jane PM', accountId: 'pm123' },
       architect: { displayName: 'Bob Arch', accountId: 'arch456' },
       components: ['Serving', 'Platform']
     })
-    var candidate = mapToCandidate(feature, 'Training', 'tier2')
+    const candidate = mapToCandidate(feature, 'Training', 'tier2')
     expect(candidate.pm).toBe('Jane PM')
     expect(candidate.architect).toBe('Bob Arch')
     expect(candidate.components).toBe('Serving, Platform')
@@ -142,19 +142,19 @@ describe('mapToCandidate', () => {
   })
 
   it('identifies RHAIRFE keys as rfe source', () => {
-    var rfe = makeRfeDetail('RHAIRFE-100')
-    var candidate = mapToCandidate(rfe, '', 'tier2')
+    const rfe = makeRfeDetail('RHAIRFE-100')
+    const candidate = mapToCandidate(rfe, '', 'tier2')
     expect(candidate.source).toBe('rfe')
   })
 
   it('handles null/missing fields gracefully', () => {
-    var feature = makeFeatureIndex('RHAISTRAT-300', {
+    const feature = makeFeatureIndex('RHAISTRAT-300', {
       targetVersions: null,
       pm: null,
       architect: null,
       assignee: null
     })
-    var candidate = mapToCandidate(feature, '', 'tier3')
+    const candidate = mapToCandidate(feature, '', 'tier3')
     expect(candidate.targetRelease).toBe('')
     expect(candidate.pm).toBe('')
     expect(candidate.architect).toBe('')
@@ -168,14 +168,14 @@ describe('findRfeFromLinks', () => {
   })
 
   it('finds RHAIRFE link', () => {
-    var links = [
+    const links = [
       { type: 'Dependency', direction: 'inward', linkedKey: 'RHAIRFE-100', linkedSummary: 'Test', linkedStatus: 'Approved' }
     ]
     expect(findRfeFromLinks(links)).toEqual({ key: 'RHAIRFE-100', status: 'Approved' })
   })
 
   it('ignores non-RHAIRFE links', () => {
-    var links = [
+    const links = [
       { type: 'Dependency', direction: 'inward', linkedKey: 'RHAISTRAT-100', linkedSummary: 'Test', linkedStatus: 'New' }
     ]
     expect(findRfeFromLinks(links)).toEqual({ key: '', status: '' })
@@ -184,7 +184,7 @@ describe('findRfeFromLinks', () => {
 
 describe('findTier1Features', () => {
   it('finds features whose parentKey matches outcome keys', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'In Progress' }),
         makeFeatureIndex('RHAISTRAT-101', { parentKey: 'KEY-2', targetVersions: ['rhoai-3.5'], status: 'New' }),
@@ -192,54 +192,54 @@ describe('findTier1Features', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] }),
       makeFeatureDetail('RHAISTRAT-101', { parentKey: 'KEY-2', targetVersions: ['rhoai-3.5'] })
     ]
-    var readFromStorage = createMockStorage(details)
+    const readFromStorage = createMockStorage(details)
 
-    var results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-100')
   })
 
   it('excludes closed statuses', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Closed' })
       ],
       rfes: []
     }
-    var readFromStorage = createMockStorage([])
+    const readFromStorage = createMockStorage([])
 
-    var results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(0)
   })
 
   it('excludes features without target versions', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: null, status: 'In Progress' })
       ],
       rfes: []
     }
-    var readFromStorage = createMockStorage([])
+    const readFromStorage = createMockStorage([])
 
-    var results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(0)
   })
 })
 
 describe('findTier1Rfes', () => {
   it('finds RFEs linked to outcome keys with candidate label', () => {
-    var index = {
+    const index = {
       features: [],
       rfes: [
         makeRfeIndex('RHAIRFE-100', { labels: ['3.5-candidate'], status: 'New' }),
         makeRfeIndex('RHAIRFE-101', { labels: ['3.5-candidate'], status: 'New' })
       ]
     }
-    var rfeDetails = [
+    const rfeDetails = [
       makeRfeDetail('RHAIRFE-100', {
         labels: ['3.5-candidate'],
         issueLinks: [{ type: 'Dependency', direction: 'inward', linkedKey: 'KEY-1', linkedSummary: 'Outcome', linkedStatus: 'In Progress' }]
@@ -249,43 +249,43 @@ describe('findTier1Rfes', () => {
         issueLinks: []
       })
     ]
-    var readFromStorage = createMockStorage([], rfeDetails)
+    const readFromStorage = createMockStorage([], rfeDetails)
 
-    var results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
+    const results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAIRFE-100')
   })
 
   it('excludes Approved RFEs', () => {
-    var index = {
+    const index = {
       features: [],
       rfes: [
         makeRfeIndex('RHAIRFE-100', { labels: ['3.5-candidate'], status: 'Approved' })
       ]
     }
-    var readFromStorage = createMockStorage([], [])
+    const readFromStorage = createMockStorage([], [])
 
-    var results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
+    const results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
     expect(results).toHaveLength(0)
   })
 
   it('excludes closed RFEs', () => {
-    var index = {
+    const index = {
       features: [],
       rfes: [
         makeRfeIndex('RHAIRFE-100', { labels: ['3.5-candidate'], status: 'Closed' })
       ]
     }
-    var readFromStorage = createMockStorage([], [])
+    const readFromStorage = createMockStorage([], [])
 
-    var results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
+    const results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
     expect(results).toHaveLength(0)
   })
 })
 
 describe('findOutcomeSummaries', () => {
   it('returns summaries for outcome keys found in features', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome A' }),
         makeFeatureIndex('KEY-2', { summary: 'Outcome B' }),
@@ -294,7 +294,7 @@ describe('findOutcomeSummaries', () => {
       rfes: []
     }
 
-    var result = findOutcomeSummaries(index, ['KEY-1', 'KEY-2'])
+    const result = findOutcomeSummaries(index, ['KEY-1', 'KEY-2'])
     expect(result).toEqual({
       'KEY-1': 'Outcome A',
       'KEY-2': 'Outcome B'
@@ -302,20 +302,20 @@ describe('findOutcomeSummaries', () => {
   })
 
   it('returns empty for missing keys', () => {
-    var index = { features: [], rfes: [] }
-    var result = findOutcomeSummaries(index, ['KEY-999'])
+    const index = { features: [], rfes: [] }
+    const result = findOutcomeSummaries(index, ['KEY-999'])
     expect(result).toEqual({})
   })
 
   it('returns empty for empty input', () => {
-    var result = findOutcomeSummaries({ features: [] }, [])
+    const result = findOutcomeSummaries({ features: [] }, [])
     expect(result).toEqual({})
   })
 })
 
 describe('findTier2Features', () => {
   it('finds features with matching target version, excluding Tier 1', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { targetVersions: ['rhoai-3.5'] }),
         makeFeatureIndex('RHAISTRAT-101', { targetVersions: ['rhoai-3.5'] }),
@@ -323,34 +323,34 @@ describe('findTier2Features', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-101', { targetVersions: ['rhoai-3.5'] })
     ]
-    var readFromStorage = createMockStorage(details)
-    var excludeKeys = new Set(['RHAISTRAT-100'])
+    const readFromStorage = createMockStorage(details)
+    const excludeKeys = new Set(['RHAISTRAT-100'])
 
-    var results = findTier2Features(readFromStorage, index, '3.5', excludeKeys)
+    const results = findTier2Features(readFromStorage, index, '3.5', excludeKeys)
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-101')
   })
 
   it('excludes closed statuses', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { targetVersions: ['rhoai-3.5'], status: 'Done' })
       ],
       rfes: []
     }
-    var readFromStorage = createMockStorage([])
+    const readFromStorage = createMockStorage([])
 
-    var results = findTier2Features(readFromStorage, index, '3.5', new Set())
+    const results = findTier2Features(readFromStorage, index, '3.5', new Set())
     expect(results).toHaveLength(0)
   })
 })
 
 describe('findTier2Rfes', () => {
   it('finds RFEs with candidate label, excluding Tier 1', () => {
-    var index = {
+    const index = {
       features: [],
       rfes: [
         makeRfeIndex('RHAIRFE-100', { labels: ['3.5-candidate'], status: 'New' }),
@@ -358,13 +358,13 @@ describe('findTier2Rfes', () => {
         makeRfeIndex('RHAIRFE-102', { labels: [], status: 'New' })
       ]
     }
-    var rfeDetails = [
+    const rfeDetails = [
       makeRfeDetail('RHAIRFE-101', { labels: ['3.5-candidate'] })
     ]
-    var readFromStorage = createMockStorage([], rfeDetails)
-    var excludeKeys = new Set(['RHAIRFE-100'])
+    const readFromStorage = createMockStorage([], rfeDetails)
+    const excludeKeys = new Set(['RHAIRFE-100'])
 
-    var results = findTier2Rfes(readFromStorage, index, '3.5', excludeKeys)
+    const results = findTier2Rfes(readFromStorage, index, '3.5', excludeKeys)
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAIRFE-101')
   })
@@ -372,7 +372,7 @@ describe('findTier2Rfes', () => {
 
 describe('findTier3Features', () => {
   it('finds In Progress features without target version or fix version', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { status: 'In Progress', targetVersions: null, fixVersions: [] }),
         makeFeatureIndex('RHAISTRAT-101', { status: 'New', targetVersions: null, fixVersions: [] }),
@@ -381,38 +381,38 @@ describe('findTier3Features', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { status: 'In Progress' })
     ]
-    var readFromStorage = createMockStorage(details)
+    const readFromStorage = createMockStorage(details)
 
-    var results = findTier3Features(readFromStorage, index, new Set())
+    const results = findTier3Features(readFromStorage, index, new Set())
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-100')
   })
 
   it('excludes already-discovered keys', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { status: 'In Progress', targetVersions: null, fixVersions: [] })
       ],
       rfes: []
     }
-    var readFromStorage = createMockStorage([])
+    const readFromStorage = createMockStorage([])
 
-    var results = findTier3Features(readFromStorage, index, new Set(['RHAISTRAT-100']))
+    const results = findTier3Features(readFromStorage, index, new Set(['RHAISTRAT-100']))
     expect(results).toHaveLength(0)
   })
 })
 
 describe('validateKeysFromCache', () => {
   it('validates keys found in features and rfes', () => {
-    var index = {
+    const index = {
       features: [makeFeatureIndex('RHAISTRAT-100', { summary: 'Feature A' })],
       rfes: [makeRfeIndex('RHAIRFE-100', { summary: 'RFE B' })]
     }
 
-    var results = validateKeysFromCache(index, ['RHAISTRAT-100', 'RHAIRFE-100', 'MISSING-1'])
+    const results = validateKeysFromCache(index, ['RHAISTRAT-100', 'RHAIRFE-100', 'MISSING-1'])
     expect(results['RHAISTRAT-100']).toEqual({ valid: true, summary: 'Feature A' })
     expect(results['RHAIRFE-100']).toEqual({ valid: true, summary: 'RFE B' })
     expect(results['MISSING-1'].valid).toBe(false)

--- a/modules/release-planning/__tests__/server/doc-import.test.js
+++ b/modules/release-planning/__tests__/server/doc-import.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 const { parseDocId, executeDocImport } = require('../../server/doc-import')
 
 function createStorageWithConfig(config) {
-  var stored = JSON.parse(JSON.stringify(config))
+  let stored = JSON.parse(JSON.stringify(config))
   return {
     readFromStorage: vi.fn(function() { return stored }),
     writeToStorage: vi.fn(function(key, data) {
@@ -13,7 +13,7 @@ function createStorageWithConfig(config) {
 
 function makeConfig(bigRocks, version) {
   version = version || '3.5'
-  var releases = {}
+  const releases = {}
   releases[version] = { release: version, bigRocks: bigRocks || [] }
   return { releases: releases }
 }
@@ -74,17 +74,17 @@ describe('parseDocId', () => {
 describe('executeDocImport', () => {
   describe('replace mode', () => {
     it('replaces all existing Big Rocks', () => {
-      var config = makeConfig([
+      const config = makeConfig([
         makeRock('Old Rock A', ['RHAISTRAT-100']),
         makeRock('Old Rock B', ['RHAISTRAT-200'])
       ])
-      var storage = createStorageWithConfig(config)
-      var parsedDoc = makeParsedDoc([
+      const storage = createStorageWithConfig(config)
+      const parsedDoc = makeParsedDoc([
         makeRock('New Rock 1', ['RHAISTRAT-300']),
         makeRock('New Rock 2', ['RHAISTRAT-400'])
       ])
 
-      var result = executeDocImport(
+      const result = executeDocImport(
         storage.readFromStorage, storage.writeToStorage,
         '3.5', 'test-doc-id', 'replace', parsedDoc
       )
@@ -100,15 +100,15 @@ describe('executeDocImport', () => {
 
   describe('append mode', () => {
     it('adds new rocks after existing ones', () => {
-      var config = makeConfig([
+      const config = makeConfig([
         makeRock('Existing', ['RHAISTRAT-100'])
       ])
-      var storage = createStorageWithConfig(config)
-      var parsedDoc = makeParsedDoc([
+      const storage = createStorageWithConfig(config)
+      const parsedDoc = makeParsedDoc([
         makeRock('New Rock', ['RHAISTRAT-200'])
       ])
 
-      var result = executeDocImport(
+      const result = executeDocImport(
         storage.readFromStorage, storage.writeToStorage,
         '3.5', 'test-doc-id', 'append', parsedDoc
       )
@@ -120,16 +120,16 @@ describe('executeDocImport', () => {
     })
 
     it('skips duplicate names', () => {
-      var config = makeConfig([
+      const config = makeConfig([
         makeRock('MaaS', ['RHAISTRAT-100'])
       ])
-      var storage = createStorageWithConfig(config)
-      var parsedDoc = makeParsedDoc([
+      const storage = createStorageWithConfig(config)
+      const parsedDoc = makeParsedDoc([
         makeRock('MaaS', ['RHAISTRAT-200']),
         makeRock('New Rock', ['RHAISTRAT-300'])
       ])
 
-      var result = executeDocImport(
+      const result = executeDocImport(
         storage.readFromStorage, storage.writeToStorage,
         '3.5', 'test-doc-id', 'append', parsedDoc
       )
@@ -142,9 +142,9 @@ describe('executeDocImport', () => {
   })
 
   it('throws when no Big Rocks are parsed', () => {
-    var config = makeConfig([])
-    var storage = createStorageWithConfig(config)
-    var parsedDoc = makeParsedDoc([])
+    const config = makeConfig([])
+    const storage = createStorageWithConfig(config)
+    const parsedDoc = makeParsedDoc([])
 
     expect(function() {
       executeDocImport(
@@ -155,9 +155,9 @@ describe('executeDocImport', () => {
   })
 
   it('throws when release version not found', () => {
-    var config = makeConfig([], '3.5')
-    var storage = createStorageWithConfig(config)
-    var parsedDoc = makeParsedDoc([makeRock('Test')])
+    const config = makeConfig([], '3.5')
+    const storage = createStorageWithConfig(config)
+    const parsedDoc = makeParsedDoc([makeRock('Test')])
 
     expect(function() {
       executeDocImport(
@@ -168,16 +168,16 @@ describe('executeDocImport', () => {
   })
 
   it('skips rocks that fail validation', () => {
-    var config = makeConfig([])
-    var storage = createStorageWithConfig(config)
+    const config = makeConfig([])
+    const storage = createStorageWithConfig(config)
     // Name exceeding 100 chars
-    var longName = 'A'.repeat(101)
-    var parsedDoc = makeParsedDoc([
+    const longName = 'A'.repeat(101)
+    const parsedDoc = makeParsedDoc([
       makeRock(longName),
       makeRock('Valid Rock', ['RHAISTRAT-100'])
     ])
 
-    var result = executeDocImport(
+    const result = executeDocImport(
       storage.readFromStorage, storage.writeToStorage,
       '3.5', 'test-doc-id', 'replace', parsedDoc
     )
@@ -189,15 +189,15 @@ describe('executeDocImport', () => {
   })
 
   it('renumbers priorities sequentially', () => {
-    var config = makeConfig([])
-    var storage = createStorageWithConfig(config)
-    var parsedDoc = makeParsedDoc([
+    const config = makeConfig([])
+    const storage = createStorageWithConfig(config)
+    const parsedDoc = makeParsedDoc([
       makeRock('Rock A'),
       makeRock('Rock B'),
       makeRock('Rock C')
     ])
 
-    var result = executeDocImport(
+    const result = executeDocImport(
       storage.readFromStorage, storage.writeToStorage,
       '3.5', 'test-doc-id', 'replace', parsedDoc
     )

--- a/modules/release-planning/__tests__/server/google-docs.test.js
+++ b/modules/release-planning/__tests__/server/google-docs.test.js
@@ -181,7 +181,7 @@ describe('extractBigRocksFromDoc', () => {
 
   it('assigns sequential priorities', () => {
     const result = extractBigRocksFromDoc(fixture)
-    for (var i = 0; i < result.bigRocks.length; i++) {
+    for (let i = 0; i < result.bigRocks.length; i++) {
       expect(result.bigRocks[i].priority).toBe(i + 1)
     }
   })
@@ -200,7 +200,7 @@ describe('extractBigRocksFromDoc', () => {
   it('generates warnings for all rocks without outcome keys', () => {
     const result = extractBigRocksFromDoc(fixture)
     // Expected: Big Rocks #3, #4, #12, #13, #14 have no outcome keys
-    var noKeyRocks = result.bigRocks.filter(function(r) { return r.outcomeKeys.length === 0 })
+    const noKeyRocks = result.bigRocks.filter(function(r) { return r.outcomeKeys.length === 0 })
     expect(noKeyRocks.length).toBe(result.warnings.length)
   })
 

--- a/modules/release-planning/__tests__/server/pipeline.test.js
+++ b/modules/release-planning/__tests__/server/pipeline.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 const { runPipeline, buildCandidateResponse } = require('../../server/pipeline')
 
 function makeFeatureIndex(key, opts) {
-  var o = opts || {}
+  const o = opts || {}
   return {
     key: key,
     summary: o.summary || 'Summary for ' + key,
@@ -26,7 +26,7 @@ function makeFeatureIndex(key, opts) {
 }
 
 function makeFeatureDetail(key, opts) {
-  var o = opts || {}
+  const o = opts || {}
   return {
     key: key,
     summary: o.summary || 'Summary for ' + key,
@@ -52,7 +52,7 @@ function makeFeatureDetail(key, opts) {
 }
 
 function makeRfeIndex(key, opts) {
-  var o = opts || {}
+  const o = opts || {}
   return {
     key: key,
     summary: o.summary || 'RFE ' + key,
@@ -67,7 +67,7 @@ function makeRfeIndex(key, opts) {
 }
 
 function makeRfeDetail(key, opts) {
-  var o = opts || {}
+  const o = opts || {}
   return {
     key: key,
     summary: o.summary || 'RFE ' + key,
@@ -86,16 +86,16 @@ function makeRfeDetail(key, opts) {
 }
 
 function createMockStorage(index, featureDetails, rfeDetails) {
-  var store = {
+  const store = {
     'feature-traffic/index.json': index
   }
   if (featureDetails) {
-    for (var i = 0; i < featureDetails.length; i++) {
+    for (let i = 0; i < featureDetails.length; i++) {
       store['feature-traffic/features/' + featureDetails[i].key + '.json'] = featureDetails[i]
     }
   }
   if (rfeDetails) {
-    for (var j = 0; j < rfeDetails.length; j++) {
+    for (let j = 0; j < rfeDetails.length; j++) {
       store['feature-traffic/rfes/' + rfeDetails[j].key + '.json'] = rfeDetails[j]
     }
   }
@@ -121,7 +121,7 @@ function makeConfig() {
 
 describe('runPipeline', () => {
   it('discovers Tier 1 features from outcome children', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-1513', { summary: 'MaaS Outcome', status: 'New' }),
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'RHAISTRAT-1513', targetVersions: ['rhoai-3.5'], status: 'In Progress' }),
@@ -129,18 +129,18 @@ describe('runPipeline', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'RHAISTRAT-1513', targetVersions: ['rhoai-3.5'] }),
       makeFeatureDetail('RHAISTRAT-101', { parentKey: 'RHAISTRAT-1513', targetVersions: ['rhoai-3.5'], status: 'New' })
     ]
-    var readFromStorage = createMockStorage(index, details)
+    const readFromStorage = createMockStorage(index, details)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'MaaS', outcomeKeys: ['RHAISTRAT-1513'], pillar: 'Inference' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(2)
     expect(result.tier1Features).toBe(2)
@@ -149,7 +149,7 @@ describe('runPipeline', () => {
   })
 
   it('filters features without matching target release', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.4'], status: 'In Progress' }),
@@ -157,18 +157,18 @@ describe('runPipeline', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.4'] }),
       makeFeatureDetail('RHAISTRAT-101', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'New' })
     ]
-    var readFromStorage = createMockStorage(index, details)
+    const readFromStorage = createMockStorage(index, details)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].issueKey).toBe('RHAISTRAT-101')
@@ -176,7 +176,7 @@ describe('runPipeline', () => {
   })
 
   it('filters terminal status features', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Review' }),
@@ -184,18 +184,18 @@ describe('runPipeline', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Review' }),
       makeFeatureDetail('RHAISTRAT-101', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
     ]
-    var readFromStorage = createMockStorage(index, details)
+    const readFromStorage = createMockStorage(index, details)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     // Terminal feature is discovered and filtered in both Tier 1 and Tier 2 scans
@@ -203,59 +203,59 @@ describe('runPipeline', () => {
   })
 
   it('deduplicates features across multiple rocks sharing an outcome', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome 1', status: 'New' }),
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
     ]
-    var readFromStorage = createMockStorage(index, details)
+    const readFromStorage = createMockStorage(index, details)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'Rock A', outcomeKeys: ['KEY-1'], pillar: 'Inference' },
       { priority: 2, name: 'Rock B', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].bigRock).toBe('Rock A, Rock B')
   })
 
   it('applies rockFilter', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
     ]
-    var readFromStorage = createMockStorage(index, details)
+    const readFromStorage = createMockStorage(index, details)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'MaaS', outcomeKeys: ['KEY-1'], pillar: 'Inference' },
       { priority: 2, name: 'Other', outcomeKeys: ['KEY-2'], pillar: 'Platform' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage, { rockFilter: 'MaaS' })
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage, { rockFilter: 'MaaS' })
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].bigRock).toBe('MaaS')
   })
 
   it('throws for invalid rockFilter', () => {
-    var readFromStorage = createMockStorage({ features: [], rfes: [] })
-    var config = makeConfig()
-    var bigRocks = [
+    const readFromStorage = createMockStorage({ features: [], rfes: [] })
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'MaaS', outcomeKeys: ['KEY-1'], pillar: 'Inference' }
     ]
 
@@ -265,22 +265,22 @@ describe('runPipeline', () => {
   })
 
   it('skips rocks without outcome keys', () => {
-    var index = { features: [], rfes: [] }
-    var readFromStorage = createMockStorage(index)
+    const index = { features: [], rfes: [] }
+    const readFromStorage = createMockStorage(index)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'NoOutcome', outcomeKeys: [], pillar: 'Platform' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(0)
     expect(result.rocksWithoutOutcomes).toContain('NoOutcome')
   })
 
   it('discovers RFEs linked to outcomes', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' })
       ],
@@ -288,20 +288,20 @@ describe('runPipeline', () => {
         makeRfeIndex('RHAIRFE-100', { labels: ['3.5-candidate'], status: 'New' })
       ]
     }
-    var rfeDetails = [
+    const rfeDetails = [
       makeRfeDetail('RHAIRFE-100', {
         labels: ['3.5-candidate'],
         issueLinks: [{ type: 'Dependency', direction: 'inward', linkedKey: 'KEY-1', linkedSummary: 'Outcome', linkedStatus: 'In Progress' }]
       })
     ]
-    var readFromStorage = createMockStorage(index, [], rfeDetails)
+    const readFromStorage = createMockStorage(index, [], rfeDetails)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Data' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.rfes).toHaveLength(1)
     expect(result.rfes[0].issueKey).toBe('RHAIRFE-100')
@@ -309,7 +309,7 @@ describe('runPipeline', () => {
   })
 
   it('excludes Approved RFEs', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' })
       ],
@@ -317,19 +317,19 @@ describe('runPipeline', () => {
         makeRfeIndex('RHAIRFE-100', { labels: ['3.5-candidate'], status: 'Approved' })
       ]
     }
-    var readFromStorage = createMockStorage(index, [], [])
+    const readFromStorage = createMockStorage(index, [], [])
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Data' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
     expect(result.rfes).toHaveLength(0)
   })
 
   it('discovers Tier 2 and Tier 3 features', () => {
-    var index = {
+    const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] }),
@@ -338,19 +338,19 @@ describe('runPipeline', () => {
       ],
       rfes: []
     }
-    var details = [
+    const details = [
       makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] }),
       makeFeatureDetail('RHAISTRAT-200', { targetVersions: ['rhoai-3.5'], status: 'New' }),
       makeFeatureDetail('RHAISTRAT-300', { status: 'In Progress' })
     ]
-    var readFromStorage = createMockStorage(index, details)
+    const readFromStorage = createMockStorage(index, details)
 
-    var config = makeConfig()
-    var bigRocks = [
+    const config = makeConfig()
+    const bigRocks = [
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    var result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.tier1Features).toBe(1)
     expect(result.tier2Features).toBe(1)
@@ -364,7 +364,7 @@ describe('runPipeline', () => {
 
 describe('buildCandidateResponse', () => {
   it('builds a complete response object', () => {
-    var pipelineResult = {
+    const pipelineResult = {
       features: [
         { issueKey: 'RHAISTRAT-100', status: 'In Progress', priority: 'Major', components: 'Serving', bigRock: 'MaaS', tier: 1, labels: '' },
         { issueKey: 'RHAISTRAT-200', status: 'New', priority: 'Normal', components: 'Platform', bigRock: '', tier: 2, labels: '' }
@@ -382,7 +382,7 @@ describe('buildCandidateResponse', () => {
       release: '3.5'
     }
 
-    var bigRocks = [
+    const bigRocks = [
       {
         priority: 1,
         name: 'MaaS',
@@ -395,7 +395,7 @@ describe('buildCandidateResponse', () => {
       }
     ]
 
-    var response = buildCandidateResponse(pipelineResult, '3.5', bigRocks, false)
+    const response = buildCandidateResponse(pipelineResult, '3.5', bigRocks, false)
 
     expect(response.version).toBe('3.5')
     expect(response.demoMode).toBe(false)

--- a/modules/release-planning/__tests__/server/pm-auth.test.js
+++ b/modules/release-planning/__tests__/server/pm-auth.test.js
@@ -14,11 +14,11 @@ function createMockStorage(data) {
 
 describe('createRequirePM', () => {
   it('allows admin users through', () => {
-    var storage = createMockStorage({})
-    var requirePM = createRequirePM(storage.readFromStorage)
-    var req = { isAdmin: true, userEmail: 'admin@redhat.com' }
-    var res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
-    var next = vi.fn()
+    const storage = createMockStorage({})
+    const requirePM = createRequirePM(storage.readFromStorage)
+    const req = { isAdmin: true, userEmail: 'admin@redhat.com' }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+    const next = vi.fn()
 
     requirePM(req, res, next)
 
@@ -27,13 +27,13 @@ describe('createRequirePM', () => {
   })
 
   it('allows listed PM users through', () => {
-    var storage = createMockStorage({
+    const storage = createMockStorage({
       'release-planning/pm-users.json': { emails: ['pm@redhat.com'] }
     })
-    var requirePM = createRequirePM(storage.readFromStorage)
-    var req = { isAdmin: false, userEmail: 'pm@redhat.com' }
-    var res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
-    var next = vi.fn()
+    const requirePM = createRequirePM(storage.readFromStorage)
+    const req = { isAdmin: false, userEmail: 'pm@redhat.com' }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+    const next = vi.fn()
 
     requirePM(req, res, next)
 
@@ -41,13 +41,13 @@ describe('createRequirePM', () => {
   })
 
   it('blocks non-admin, non-PM users', () => {
-    var storage = createMockStorage({
+    const storage = createMockStorage({
       'release-planning/pm-users.json': { emails: ['pm@redhat.com'] }
     })
-    var requirePM = createRequirePM(storage.readFromStorage)
-    var req = { isAdmin: false, userEmail: 'nobody@redhat.com' }
-    var res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
-    var next = vi.fn()
+    const requirePM = createRequirePM(storage.readFromStorage)
+    const req = { isAdmin: false, userEmail: 'nobody@redhat.com' }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+    const next = vi.fn()
 
     requirePM(req, res, next)
 
@@ -56,11 +56,11 @@ describe('createRequirePM', () => {
   })
 
   it('handles missing pm-users.json gracefully', () => {
-    var storage = createMockStorage({})
-    var requirePM = createRequirePM(storage.readFromStorage)
-    var req = { isAdmin: false, userEmail: 'pm@redhat.com' }
-    var res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
-    var next = vi.fn()
+    const storage = createMockStorage({})
+    const requirePM = createRequirePM(storage.readFromStorage)
+    const req = { isAdmin: false, userEmail: 'pm@redhat.com' }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+    const next = vi.fn()
 
     requirePM(req, res, next)
 
@@ -71,33 +71,33 @@ describe('createRequirePM', () => {
 
 describe('getPMUsers', () => {
   it('returns emails from storage', () => {
-    var storage = createMockStorage({
+    const storage = createMockStorage({
       'release-planning/pm-users.json': { emails: ['a@redhat.com', 'b@redhat.com'] }
     })
     expect(getPMUsers(storage.readFromStorage)).toEqual(['a@redhat.com', 'b@redhat.com'])
   })
 
   it('returns empty array when no file exists', () => {
-    var storage = createMockStorage({})
+    const storage = createMockStorage({})
     expect(getPMUsers(storage.readFromStorage)).toEqual([])
   })
 })
 
 describe('addPMUser', () => {
   it('adds a new email', () => {
-    var data = {}
-    var storage = createMockStorage(data)
-    var result = addPMUser(storage.readFromStorage, storage.writeToStorage, 'new@redhat.com')
+    const data = {}
+    const storage = createMockStorage(data)
+    const result = addPMUser(storage.readFromStorage, storage.writeToStorage, 'new@redhat.com')
     expect(result).toContain('new@redhat.com')
     expect(storage.writeToStorage).toHaveBeenCalled()
   })
 
   it('does not duplicate existing email', () => {
-    var data = {
+    const data = {
       'release-planning/pm-users.json': { emails: ['existing@redhat.com'] }
     }
-    var storage = createMockStorage(data)
-    var result = addPMUser(storage.readFromStorage, storage.writeToStorage, 'existing@redhat.com')
+    const storage = createMockStorage(data)
+    const result = addPMUser(storage.readFromStorage, storage.writeToStorage, 'existing@redhat.com')
     expect(result).toEqual(['existing@redhat.com'])
     expect(storage.writeToStorage).not.toHaveBeenCalled()
   })
@@ -105,21 +105,21 @@ describe('addPMUser', () => {
 
 describe('removePMUser', () => {
   it('removes an existing email', () => {
-    var data = {
+    const data = {
       'release-planning/pm-users.json': { emails: ['a@redhat.com', 'b@redhat.com'] }
     }
-    var storage = createMockStorage(data)
-    var result = removePMUser(storage.readFromStorage, storage.writeToStorage, 'a@redhat.com')
+    const storage = createMockStorage(data)
+    const result = removePMUser(storage.readFromStorage, storage.writeToStorage, 'a@redhat.com')
     expect(result).toEqual(['b@redhat.com'])
     expect(storage.writeToStorage).toHaveBeenCalled()
   })
 
   it('handles removing non-existent email gracefully', () => {
-    var data = {
+    const data = {
       'release-planning/pm-users.json': { emails: ['a@redhat.com'] }
     }
-    var storage = createMockStorage(data)
-    var result = removePMUser(storage.readFromStorage, storage.writeToStorage, 'nonexistent@redhat.com')
+    const storage = createMockStorage(data)
+    const result = removePMUser(storage.readFromStorage, storage.writeToStorage, 'nonexistent@redhat.com')
     expect(result).toEqual(['a@redhat.com'])
   })
 })

--- a/modules/release-planning/__tests__/server/routes.test.js
+++ b/modules/release-planning/__tests__/server/routes.test.js
@@ -35,12 +35,12 @@ vi.mock('../../server/cache-reader', () => ({
   validateKeysFromCache: vi.fn().mockReturnValue({})
 }))
 
-var registerRoutes = require('../../server/index')
+const registerRoutes = require('../../server/index')
 
 function makeStorage(data) {
-  var store = {}
+  const store = {}
   if (data) {
-    for (var k in data) store[k] = data[k]
+    for (const k in data) store[k] = data[k]
   }
   return {
     readFromStorage: function(key) {
@@ -56,10 +56,10 @@ function makeStorage(data) {
 }
 
 function makeRouter() {
-  var routes = {}
+  const routes = {}
   function reg(method) {
     return function(path) {
-      var handlers = Array.prototype.slice.call(arguments, 1)
+      const handlers = Array.prototype.slice.call(arguments, 1)
       routes[method + ' ' + path] = handlers
     }
   }
@@ -74,7 +74,7 @@ function makeRouter() {
 }
 
 function makeRes() {
-  var res = {
+  const res = {
     _status: 200,
     _json: null,
     status: function(code) { res._status = code; return res },
@@ -88,12 +88,12 @@ function makeReq(overrides) {
 }
 
 function callRoute(routes, method, path, req) {
-  var key = method + ' ' + path
-  var handlers = routes[key]
+  const key = method + ' ' + path
+  const handlers = routes[key]
   if (!handlers) throw new Error('No route registered: ' + key)
-  var handler = handlers[handlers.length - 1]
-  var res = makeRes()
-  var result = handler(req || makeReq(), res)
+  const handler = handlers[handlers.length - 1]
+  const res = makeRes()
+  const result = handler(req || makeReq(), res)
   if (result && typeof result.then === 'function') {
     return result.then(function() { return res })
   }
@@ -101,12 +101,12 @@ function callRoute(routes, method, path, req) {
 }
 
 function makeConfig(version, bigRocks) {
-  var releases = {}
+  const releases = {}
   releases[version] = { release: version, bigRocks: bigRocks || [] }
   return { releases: releases }
 }
 
-var VALID_ROCK = {
+const VALID_ROCK = {
   name: 'Test Rock',
   fullName: 'Test Rock Full',
   pillar: 'Platform',
@@ -119,7 +119,7 @@ var VALID_ROCK = {
 }
 
 describe('release-planning routes', function() {
-  var router, storage, context
+  let router, storage, context
 
   beforeEach(function() {
     vi.clearAllMocks()
@@ -141,7 +141,7 @@ describe('release-planning routes', function() {
 
   describe('route registration', function() {
     it('registers all expected routes', function() {
-      var expected = [
+      const expected = [
         'GET /releases',
         'GET /releases/:version/candidates',
         'POST /releases/:version/refresh',
@@ -160,7 +160,7 @@ describe('release-planning routes', function() {
         'DELETE /pm-users/:email',
         'GET /audit-log'
       ]
-      for (var i = 0; i < expected.length; i++) {
+      for (let i = 0; i < expected.length; i++) {
         expect(router._routes[expected[i]], 'Missing route: ' + expected[i]).toBeDefined()
       }
     })
@@ -170,7 +170,7 @@ describe('release-planning routes', function() {
 
   describe('auth guards', function() {
     it('uses requireAuth on GET /releases', function() {
-      var handlers = router._routes['GET /releases']
+      const handlers = router._routes['GET /releases']
       expect(handlers.length).toBeGreaterThan(1)
     })
 
@@ -195,13 +195,13 @@ describe('release-planning routes', function() {
 
   describe('GET /releases', function() {
     it('returns configured releases', function() {
-      var res = callRoute(router._routes, 'GET', '/releases')
+      const res = callRoute(router._routes, 'GET', '/releases')
       expect(res._json).toEqual([{ version: '3.5', bigRockCount: 0 }])
     })
 
     it('returns empty array when no releases configured', function() {
       storage._store['release-planning/config.json'] = { releases: {} }
-      var res = callRoute(router._routes, 'GET', '/releases')
+      const res = callRoute(router._routes, 'GET', '/releases')
       expect(res._json).toEqual([])
     })
   })
@@ -210,8 +210,8 @@ describe('release-planning routes', function() {
 
   describe('GET /releases/:version/candidates', function() {
     it('rejects invalid version format', function() {
-      var req = makeReq({ params: { version: '../etc/passwd' } })
-      var res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const req = makeReq({ params: { version: '../etc/passwd' } })
+      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._status).toBe(400)
       expect(res._json.error).toMatch(/Invalid version/)
     })
@@ -221,14 +221,14 @@ describe('release-planning routes', function() {
         cachedAt: new Date().toISOString(),
         data: { features: [{ issueKey: 'TEST-1' }], rfes: [], bigRocks: [], summary: null }
       }
-      var req = makeReq({ params: { version: '3.5' }, query: {} })
-      var res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const req = makeReq({ params: { version: '3.5' }, query: {} })
+      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._json.features).toHaveLength(1)
     })
 
     it('returns 202 when no cache exists', function() {
-      var req = makeReq({ params: { version: '3.5' }, query: {} })
-      var res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const req = makeReq({ params: { version: '3.5' }, query: {} })
+      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._status).toBe(202)
       expect(res._json._noCache).toBe(true)
     })
@@ -238,20 +238,20 @@ describe('release-planning routes', function() {
 
   describe('version validation', function() {
     it('rejects reserved version names', async function() {
-      var req = makeReq({ params: { version: '__proto__' } })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
+      const req = makeReq({ params: { version: '__proto__' } })
+      const res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
       expect(res._status).toBe(400)
     })
 
     it('rejects versions with special characters', async function() {
-      var req = makeReq({ params: { version: 'v1;rm -rf' } })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
+      const req = makeReq({ params: { version: 'v1;rm -rf' } })
+      const res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
       expect(res._status).toBe(400)
     })
 
     it('accepts valid version formats', async function() {
-      var req = makeReq({ params: { version: '3.5' } })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
+      const req = makeReq({ params: { version: '3.5' } })
+      const res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
       expect(res._status).toBe(200)
     })
   })
@@ -260,39 +260,39 @@ describe('release-planning routes', function() {
 
   describe('POST /releases/:version/big-rocks', function() {
     it('creates a new big rock', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '3.5' },
         body: VALID_ROCK
       })
-      var res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
       expect(res._status).toBe(201)
     })
 
     it('rejects invalid version', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '../../bad' },
         body: VALID_ROCK
       })
-      var res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
       expect(res._status).toBe(400)
     })
 
     it('rejects missing name', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '3.5' },
         body: { pillar: 'Test' }
       })
-      var res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
       expect(res._status).toBe(400)
     })
 
     it('writes audit log entry on success', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '3.5' },
         body: VALID_ROCK
       })
       await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log).toBeDefined()
       expect(log.entries).toHaveLength(1)
       expect(log.entries[0].action).toBe('create_rock')
@@ -308,30 +308,30 @@ describe('release-planning routes', function() {
     })
 
     it('updates an existing big rock', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '3.5', name: 'Test Rock' },
         body: Object.assign({}, VALID_ROCK, { notes: 'Updated' })
       })
-      var res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', req)
+      const res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', req)
       expect(res._status).toBe(200)
     })
 
     it('writes audit log on update', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '3.5', name: 'Test Rock' },
         body: Object.assign({}, VALID_ROCK, { notes: 'Updated' })
       })
       await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('update_rock')
     })
 
     it('handles malformed URI encoding', async function() {
-      var req = makeReq({
+      const req = makeReq({
         params: { version: '3.5', name: '%E0%A4%A' },
         body: VALID_ROCK
       })
-      var res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', req)
+      const res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', req)
       expect(res._status).toBe(400)
       expect(res._json.error).toMatch(/Invalid parameter encoding/)
     })
@@ -345,21 +345,21 @@ describe('release-planning routes', function() {
     })
 
     it('deletes a big rock', async function() {
-      var req = makeReq({ params: { version: '3.5', name: 'Test Rock' } })
-      var res = await callRoute(router._routes, 'DELETE', '/releases/:version/big-rocks/:name', req)
+      const req = makeReq({ params: { version: '3.5', name: 'Test Rock' } })
+      const res = await callRoute(router._routes, 'DELETE', '/releases/:version/big-rocks/:name', req)
       expect(res._status).toBe(200)
     })
 
     it('returns 404 for nonexistent rock', async function() {
-      var req = makeReq({ params: { version: '3.5', name: 'Nonexistent' } })
-      var res = await callRoute(router._routes, 'DELETE', '/releases/:version/big-rocks/:name', req)
+      const req = makeReq({ params: { version: '3.5', name: 'Nonexistent' } })
+      const res = await callRoute(router._routes, 'DELETE', '/releases/:version/big-rocks/:name', req)
       expect(res._status).toBe(404)
     })
 
     it('writes audit log on delete', async function() {
-      var req = makeReq({ params: { version: '3.5', name: 'Test Rock' } })
+      const req = makeReq({ params: { version: '3.5', name: 'Test Rock' } })
       await callRoute(router._routes, 'DELETE', '/releases/:version/big-rocks/:name', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('delete_rock')
     })
   })
@@ -368,34 +368,34 @@ describe('release-planning routes', function() {
 
   describe('POST /releases', function() {
     it('creates a new release', async function() {
-      var req = makeReq({ body: { version: '3.6' } })
-      var res = await callRoute(router._routes, 'POST', '/releases', req)
+      const req = makeReq({ body: { version: '3.6' } })
+      const res = await callRoute(router._routes, 'POST', '/releases', req)
       expect(res._status).toBe(201)
     })
 
     it('rejects missing version', async function() {
-      var req = makeReq({ body: {} })
-      var res = await callRoute(router._routes, 'POST', '/releases', req)
+      const req = makeReq({ body: {} })
+      const res = await callRoute(router._routes, 'POST', '/releases', req)
       expect(res._status).toBe(400)
     })
 
     it('rejects invalid version format', async function() {
-      var req = makeReq({ body: { version: 'a'.repeat(51) } })
-      var res = await callRoute(router._routes, 'POST', '/releases', req)
+      const req = makeReq({ body: { version: 'a'.repeat(51) } })
+      const res = await callRoute(router._routes, 'POST', '/releases', req)
       expect(res._status).toBe(400)
     })
 
     it('writes audit log for create', async function() {
-      var req = makeReq({ body: { version: '3.6' } })
+      const req = makeReq({ body: { version: '3.6' } })
       await callRoute(router._routes, 'POST', '/releases', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('create_release')
     })
 
     it('writes audit log for clone', async function() {
-      var req = makeReq({ body: { version: '3.6', cloneFrom: '3.5' } })
+      const req = makeReq({ body: { version: '3.6', cloneFrom: '3.5' } })
       await callRoute(router._routes, 'POST', '/releases', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('clone_release')
     })
   })
@@ -404,15 +404,15 @@ describe('release-planning routes', function() {
 
   describe('DELETE /releases/:version', function() {
     it('deletes a release', async function() {
-      var req = makeReq({ params: { version: '3.5' } })
-      var res = await callRoute(router._routes, 'DELETE', '/releases/:version', req)
+      const req = makeReq({ params: { version: '3.5' } })
+      const res = await callRoute(router._routes, 'DELETE', '/releases/:version', req)
       expect(res._status).toBe(200)
     })
 
     it('writes audit log on delete', async function() {
-      var req = makeReq({ params: { version: '3.5' } })
+      const req = makeReq({ params: { version: '3.5' } })
       await callRoute(router._routes, 'DELETE', '/releases/:version', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('delete_release')
     })
   })
@@ -421,20 +421,20 @@ describe('release-planning routes', function() {
 
   describe('GET /permissions', function() {
     it('returns canEdit true for admin', function() {
-      var req = makeReq({ isAdmin: true, userEmail: 'admin@test.com' })
-      var res = callRoute(router._routes, 'GET', '/permissions', req)
+      const req = makeReq({ isAdmin: true, userEmail: 'admin@test.com' })
+      const res = callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
     })
 
     it('returns canEdit true for PM user', function() {
-      var req = makeReq({ isAdmin: false, userEmail: 'pm@test.com' })
-      var res = callRoute(router._routes, 'GET', '/permissions', req)
+      const req = makeReq({ isAdmin: false, userEmail: 'pm@test.com' })
+      const res = callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
     })
 
     it('returns canEdit false for regular user', function() {
-      var req = makeReq({ isAdmin: false, userEmail: 'user@test.com' })
-      var res = callRoute(router._routes, 'GET', '/permissions', req)
+      const req = makeReq({ isAdmin: false, userEmail: 'user@test.com' })
+      const res = callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(false)
     })
   })
@@ -443,39 +443,39 @@ describe('release-planning routes', function() {
 
   describe('PM user management', function() {
     it('GET /pm-users returns PM list', function() {
-      var res = callRoute(router._routes, 'GET', '/pm-users')
+      const res = callRoute(router._routes, 'GET', '/pm-users')
       expect(res._json.emails).toEqual(['pm@test.com'])
     })
 
     it('POST /pm-users adds a PM', function() {
-      var req = makeReq({ body: { email: 'new@test.com' } })
-      var res = callRoute(router._routes, 'POST', '/pm-users', req)
+      const req = makeReq({ body: { email: 'new@test.com' } })
+      const res = callRoute(router._routes, 'POST', '/pm-users', req)
       expect(res._json.emails).toContain('new@test.com')
     })
 
     it('POST /pm-users rejects empty email', function() {
-      var req = makeReq({ body: { email: '' } })
-      var res = callRoute(router._routes, 'POST', '/pm-users', req)
+      const req = makeReq({ body: { email: '' } })
+      const res = callRoute(router._routes, 'POST', '/pm-users', req)
       expect(res._status).toBe(400)
     })
 
     it('POST /pm-users writes audit log', function() {
-      var req = makeReq({ body: { email: 'new@test.com' } })
+      const req = makeReq({ body: { email: 'new@test.com' } })
       callRoute(router._routes, 'POST', '/pm-users', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('add_pm')
     })
 
     it('DELETE /pm-users/:email removes a PM', function() {
-      var req = makeReq({ params: { email: 'pm@test.com' } })
-      var res = callRoute(router._routes, 'DELETE', '/pm-users/:email', req)
+      const req = makeReq({ params: { email: 'pm@test.com' } })
+      const res = callRoute(router._routes, 'DELETE', '/pm-users/:email', req)
       expect(res._json.emails).not.toContain('pm@test.com')
     })
 
     it('DELETE /pm-users/:email writes audit log', function() {
-      var req = makeReq({ params: { email: 'pm@test.com' } })
+      const req = makeReq({ params: { email: 'pm@test.com' } })
       callRoute(router._routes, 'DELETE', '/pm-users/:email', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('remove_pm')
     })
   })
@@ -484,8 +484,8 @@ describe('release-planning routes', function() {
 
   describe('GET /audit-log', function() {
     it('returns empty entries when no log exists', function() {
-      var req = makeReq({ query: {} })
-      var res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const req = makeReq({ query: {} })
+      const res = callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toEqual([])
       expect(res._json.total).toBe(0)
     })
@@ -497,8 +497,8 @@ describe('release-planning routes', function() {
           { id: '2', timestamp: '2026-01-02T00:00:00Z', version: '3.6', action: 'create_rock', user: 'a@b.com', summary: 'test2' }
         ]
       }
-      var req = makeReq({ query: { version: '3.5' } })
-      var res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const req = makeReq({ query: { version: '3.5' } })
+      const res = callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toHaveLength(1)
       expect(res._json.total).toBe(1)
     })
@@ -510,27 +510,27 @@ describe('release-planning routes', function() {
           { id: '2', timestamp: '2026-01-02T00:00:00Z', version: '3.5', action: 'delete_rock', user: 'a@b.com', summary: 'test2' }
         ]
       }
-      var req = makeReq({ query: { action: 'delete_rock' } })
-      var res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const req = makeReq({ query: { action: 'delete_rock' } })
+      const res = callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toHaveLength(1)
       expect(res._json.entries[0].action).toBe('delete_rock')
     })
 
     it('respects limit and offset', function() {
-      var entries = []
-      for (var i = 0; i < 10; i++) {
+      const entries = []
+      for (let i = 0; i < 10; i++) {
         entries.push({ id: String(i), timestamp: '2026-01-0' + (i + 1) + 'T00:00:00Z', version: '3.5', action: 'create_rock', user: 'a@b.com', summary: 'entry ' + i })
       }
       storage._store['release-planning/audit-log.json'] = { entries: entries }
-      var req = makeReq({ query: { limit: '3', offset: '2' } })
-      var res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const req = makeReq({ query: { limit: '3', offset: '2' } })
+      const res = callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toHaveLength(3)
       expect(res._json.total).toBe(10)
     })
 
     it('clamps limit to max 500', function() {
-      var req = makeReq({ query: { limit: '1000' } })
-      var res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const req = makeReq({ query: { limit: '1000' } })
+      const res = callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json).toBeDefined()
     })
   })
@@ -546,21 +546,21 @@ describe('release-planning routes', function() {
     })
 
     it('rejects non-array order', async function() {
-      var req = makeReq({ params: { version: '3.5' }, body: { order: 'not-array' } })
-      var res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/reorder', req)
+      const req = makeReq({ params: { version: '3.5' }, body: { order: 'not-array' } })
+      const res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/reorder', req)
       expect(res._status).toBe(400)
     })
 
     it('reorders big rocks', async function() {
-      var req = makeReq({ params: { version: '3.5' }, body: { order: ['Rock B', 'Rock A'] } })
-      var res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/reorder', req)
+      const req = makeReq({ params: { version: '3.5' }, body: { order: ['Rock B', 'Rock A'] } })
+      const res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/reorder', req)
       expect(res._status).toBe(200)
     })
 
     it('writes audit log on reorder', async function() {
-      var req = makeReq({ params: { version: '3.5' }, body: { order: ['Rock B', 'Rock A'] } })
+      const req = makeReq({ params: { version: '3.5' }, body: { order: ['Rock B', 'Rock A'] } })
       await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/reorder', req)
-      var log = storage._store['release-planning/audit-log.json']
+      const log = storage._store['release-planning/audit-log.json']
       expect(log.entries[0].action).toBe('reorder_rocks')
     })
   })
@@ -569,7 +569,7 @@ describe('release-planning routes', function() {
 
   describe('GET /refresh/status', function() {
     it('returns initial refresh state', function() {
-      var res = callRoute(router._routes, 'GET', '/refresh/status')
+      const res = callRoute(router._routes, 'GET', '/refresh/status')
       expect(res._json.running).toBe(false)
     })
   })

--- a/modules/release-planning/__tests__/server/smartsheet.test.js
+++ b/modules/release-planning/__tests__/server/smartsheet.test.js
@@ -10,7 +10,7 @@ describe('isConfigured', () => {
     // Default in the module is '' when env var is not set
     // Since we can't easily reset module-level vars, we verify the function exists
     // and returns a boolean. In CI, the token is not set, so this should be false.
-    var result = isConfigured()
+    const result = isConfigured()
     expect(typeof result).toBe('boolean')
   })
 })
@@ -18,42 +18,42 @@ describe('isConfigured', () => {
 // Test the regex patterns used by discoverReleases by extracting them.
 // These mirror the Python client's patterns.
 describe('SmartSheet regex patterns', () => {
-  var EA_FREEZE_RE = /^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?Code\s+Freeze/i
-  var EA_RELEASE_RE = /^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?RELEASE/i
-  var GA_FREEZE_RE = /^(\d+\.\d+)\s+(?:RHOAI\s+)?Code\s+Freeze$/i
-  var GA_RELEASE_RE = /^(\d+\.\d+)\s+(?:RHOAI\s+)?GA$/i
+  const EA_FREEZE_RE = /^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?Code\s+Freeze/i
+  const EA_RELEASE_RE = /^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?RELEASE/i
+  const GA_FREEZE_RE = /^(\d+\.\d+)\s+(?:RHOAI\s+)?Code\s+Freeze$/i
+  const GA_RELEASE_RE = /^(\d+\.\d+)\s+(?:RHOAI\s+)?GA$/i
 
   describe('EA Code Freeze pattern', () => {
     it('matches "3.4.EA1 RHOAI Code Freeze"', () => {
-      var m = '3.4.EA1 RHOAI Code Freeze'.match(EA_FREEZE_RE)
+      const m = '3.4.EA1 RHOAI Code Freeze'.match(EA_FREEZE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.4')
       expect(m[2]).toBe('EA1')
     })
 
     it('matches "3.5.EA2 Code Freeze" (without RHOAI)', () => {
-      var m = '3.5.EA2 Code Freeze'.match(EA_FREEZE_RE)
+      const m = '3.5.EA2 Code Freeze'.match(EA_FREEZE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.5')
       expect(m[2]).toBe('EA2')
     })
 
     it('does not match GA code freeze', () => {
-      var m = '3.4 RHOAI Code Freeze'.match(EA_FREEZE_RE)
+      const m = '3.4 RHOAI Code Freeze'.match(EA_FREEZE_RE)
       expect(m).toBeNull()
     })
   })
 
   describe('EA Release pattern', () => {
     it('matches "3.5.EA1 RHOAI RELEASE"', () => {
-      var m = '3.5.EA1 RHOAI RELEASE'.match(EA_RELEASE_RE)
+      const m = '3.5.EA1 RHOAI RELEASE'.match(EA_RELEASE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.5')
       expect(m[2]).toBe('EA1')
     })
 
     it('matches "3.4.EA2 RELEASE" (without RHOAI)', () => {
-      var m = '3.4.EA2 RELEASE'.match(EA_RELEASE_RE)
+      const m = '3.4.EA2 RELEASE'.match(EA_RELEASE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.4')
       expect(m[2]).toBe('EA2')
@@ -62,53 +62,53 @@ describe('SmartSheet regex patterns', () => {
 
   describe('GA Code Freeze pattern', () => {
     it('matches "3.4 RHOAI Code Freeze"', () => {
-      var m = '3.4 RHOAI Code Freeze'.match(GA_FREEZE_RE)
+      const m = '3.4 RHOAI Code Freeze'.match(GA_FREEZE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.4')
     })
 
     it('matches "3.5 Code Freeze" (without RHOAI)', () => {
-      var m = '3.5 Code Freeze'.match(GA_FREEZE_RE)
+      const m = '3.5 Code Freeze'.match(GA_FREEZE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.5')
     })
 
     it('does not match EA code freeze', () => {
-      var m = '3.4.EA1 RHOAI Code Freeze'.match(GA_FREEZE_RE)
+      const m = '3.4.EA1 RHOAI Code Freeze'.match(GA_FREEZE_RE)
       expect(m).toBeNull()
     })
 
     it('does not match Feature Freeze', () => {
-      var m = '3.4 RHOAI Feature Freeze'.match(GA_FREEZE_RE)
+      const m = '3.4 RHOAI Feature Freeze'.match(GA_FREEZE_RE)
       expect(m).toBeNull()
     })
   })
 
   describe('GA Release pattern', () => {
     it('matches "3.5 RHOAI GA"', () => {
-      var m = '3.5 RHOAI GA'.match(GA_RELEASE_RE)
+      const m = '3.5 RHOAI GA'.match(GA_RELEASE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.5')
     })
 
     it('matches "3.4 GA" (without RHOAI)', () => {
-      var m = '3.4 GA'.match(GA_RELEASE_RE)
+      const m = '3.4 GA'.match(GA_RELEASE_RE)
       expect(m).not.toBeNull()
       expect(m[1]).toBe('3.4')
     })
 
     it('does not match "3.4 RHOAI GA Prep"', () => {
-      var m = '3.4 RHOAI GA Prep'.match(GA_RELEASE_RE)
+      const m = '3.4 RHOAI GA Prep'.match(GA_RELEASE_RE)
       expect(m).toBeNull()
     })
   })
 
   describe('version sorting', () => {
     it('sorts versions numerically', () => {
-      var versions = ['3.5', '3.4', '4.0', '3.10']
-      var sorted = versions.sort(function(a, b) {
-        var ap = a.split('.').map(Number)
-        var bp = b.split('.').map(Number)
+      const versions = ['3.5', '3.4', '4.0', '3.10']
+      const sorted = versions.sort(function(a, b) {
+        const ap = a.split('.').map(Number)
+        const bp = b.split('.').map(Number)
         return ap[0] - bp[0] || ap[1] - bp[1]
       })
       expect(sorted).toEqual(['3.4', '3.5', '3.10', '4.0'])

--- a/modules/release-planning/client/components/BigRocksTable.vue
+++ b/modules/release-planning/client/components/BigRocksTable.vue
@@ -29,7 +29,7 @@ function handleDeleteClick(event, rock) {
 }
 
 function onDragEnd() {
-  var orderedNames = localRocks.value.map(function(r) { return r.name })
+  const orderedNames = localRocks.value.map(function(r) { return r.name })
   emit('reorder', orderedNames)
 }
 </script>

--- a/modules/release-planning/client/components/FilterBar.vue
+++ b/modules/release-planning/client/components/FilterBar.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 
-var props = defineProps({
+const props = defineProps({
   filterOptions: { type: Object, default: () => ({}) },
   activeTab: { type: String, default: 'big-rocks' },
   selectedPillar: { type: String, default: '' },
@@ -13,7 +13,7 @@ var props = defineProps({
   hasActiveFilters: { type: Boolean, default: false }
 })
 
-var emit = defineEmits([
+const emit = defineEmits([
   'update:selectedPillar',
   'update:selectedRock',
   'update:selectedStatus',
@@ -23,20 +23,20 @@ var emit = defineEmits([
   'clearFilters'
 ])
 
-var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500'
+const selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500'
 
-var teamsOpen = ref(false)
-var teamsDropdownRef = ref(null)
+const teamsOpen = ref(false)
+const teamsDropdownRef = ref(null)
 
-var teamsLabel = computed(function() {
+const teamsLabel = computed(function() {
   if (props.selectedTeams.length === 0) return 'Component Teams'
   if (props.selectedTeams.length === 1) return props.selectedTeams[0]
   return props.selectedTeams.length + ' teams selected'
 })
 
 function toggleTeam(team) {
-  var current = props.selectedTeams.slice()
-  var idx = current.indexOf(team)
+  const current = props.selectedTeams.slice()
+  const idx = current.indexOf(team)
   if (idx >= 0) {
     current.splice(idx, 1)
   } else {

--- a/modules/release-planning/client/components/NewReleaseDialog.vue
+++ b/modules/release-planning/client/components/NewReleaseDialog.vue
@@ -34,8 +34,8 @@ const unconfiguredSmartSheetReleases = computed(function() {
 })
 
 const docId = computed(function() {
-  var input = docUrl.value.trim()
-  var urlMatch = input.match(/docs\.google\.com\/document\/d\/([a-zA-Z0-9_-]+)/)
+  const input = docUrl.value.trim()
+  const urlMatch = input.match(/docs\.google\.com\/document\/d\/([a-zA-Z0-9_-]+)/)
   if (urlMatch) return urlMatch[1]
   if (/^[a-zA-Z0-9_-]{10,}$/.test(input)) return input
   return null
@@ -85,7 +85,7 @@ watch(mode, function(newMode) {
 async function loadSmartSheetReleases() {
   smartSheetLoading.value = true
   try {
-    var data = await fetchSmartSheetReleases()
+    const data = await fetchSmartSheetReleases()
     if (data && data.available && data.available.length > 0) {
       smartSheetReleases.value = data.available
       smartSheetAvailable.value = true
@@ -117,7 +117,7 @@ async function loadPreview() {
   previewData.value = null
 
   try {
-    var data = await previewDocImport(version.value.trim(), docId.value)
+    const data = await previewDocImport(version.value.trim(), docId.value)
     previewData.value = data
   } catch (err) {
     previewError.value = err.message || 'Failed to load preview'
@@ -132,9 +132,9 @@ async function handleCreate() {
   errorMsg.value = ''
 
   try {
-    var result
+    let result
     if (!releaseCreated.value) {
-      var cloneSource = mode.value === 'clone' ? cloneFrom.value : null
+      const cloneSource = mode.value === 'clone' ? cloneFrom.value : null
       result = await createRelease(version.value.trim(), cloneSource)
 
       if (result.status === 'skipped') {

--- a/modules/release-planning/client/components/RecentActivity.vue
+++ b/modules/release-planning/client/components/RecentActivity.vue
@@ -2,15 +2,15 @@
 import { ref, computed, watch, inject } from 'vue'
 import { useAuditLog } from '../composables/useAuditLog'
 
-var props = defineProps({
+const props = defineProps({
   version: { type: String, default: '' }
 })
 
-var moduleNav = inject('moduleNav')
-var { entries, loading, loadAuditLog } = useAuditLog()
-var collapsed = ref(true)
+const moduleNav = inject('moduleNav')
+const { entries, loading, loadAuditLog } = useAuditLog()
+const collapsed = ref(true)
 
-var ACTION_META = {
+const ACTION_META = {
   create_rock: { icon: 'plus', label: 'Created', color: 'text-green-600 dark:text-green-400' },
   update_rock: { icon: 'pencil', label: 'Updated', color: 'text-blue-600 dark:text-blue-400' },
   delete_rock: { icon: 'trash', label: 'Deleted', color: 'text-red-600 dark:text-red-400' },
@@ -29,38 +29,38 @@ function actionMeta(action) {
 }
 
 function formatRelativeTime(iso) {
-  var now = Date.now()
-  var then = new Date(iso).getTime()
-  var diff = now - then
-  var minutes = Math.floor(diff / 60000)
+  const now = Date.now()
+  const then = new Date(iso).getTime()
+  const diff = now - then
+  const minutes = Math.floor(diff / 60000)
   if (minutes < 1) return 'just now'
   if (minutes < 60) return minutes + 'm ago'
-  var hours = Math.floor(minutes / 60)
+  const hours = Math.floor(minutes / 60)
   if (hours < 24) return hours + 'h ago'
-  var days = Math.floor(hours / 24)
+  const days = Math.floor(hours / 24)
   if (days < 7) return days + 'd ago'
   return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 function shortUser(email) {
   if (!email) return 'System'
-  var at = email.indexOf('@')
+  const at = email.indexOf('@')
   return at > 0 ? email.substring(0, at) : email
 }
 
-var recentEntries = computed(function() {
+const recentEntries = computed(function() {
   return entries.value.slice(0, 5)
 })
 
-var hasEntries = computed(function() {
+const hasEntries = computed(function() {
   return entries.value.length > 0
 })
 
-var activitySummary = computed(function() {
-  var count = entries.value.length
+const activitySummary = computed(function() {
+  const count = entries.value.length
   if (count === 0) return ''
-  var recent = entries.value[0]
-  var age = formatRelativeTime(recent.timestamp)
+  const recent = entries.value[0]
+  const age = formatRelativeTime(recent.timestamp)
   return count + ' change' + (count !== 1 ? 's' : '') + ' · latest ' + age
 })
 

--- a/modules/release-planning/client/composables/useAuditLog.js
+++ b/modules/release-planning/client/composables/useAuditLog.js
@@ -1,29 +1,29 @@
 import { ref } from 'vue'
 import { apiRequest } from '@shared/client/services/api'
 
-var API_BASE = '/modules/release-planning'
+const API_BASE = '/modules/release-planning'
 
 export function useAuditLog() {
-  var entries = ref([])
-  var total = ref(0)
-  var loading = ref(false)
-  var error = ref(null)
+  const entries = ref([])
+  const total = ref(0)
+  const loading = ref(false)
+  const error = ref(null)
 
   async function loadAuditLog(options) {
     loading.value = true
     error.value = null
 
-    var params = new URLSearchParams()
+    const params = new URLSearchParams()
     if (options && options.version) params.set('version', options.version)
     if (options && options.action) params.set('action', options.action)
     if (options && options.limit) params.set('limit', String(options.limit))
     if (options && options.offset) params.set('offset', String(options.offset))
 
-    var qs = params.toString()
-    var url = API_BASE + '/audit-log' + (qs ? '?' + qs : '')
+    const qs = params.toString()
+    const url = API_BASE + '/audit-log' + (qs ? '?' + qs : '')
 
     try {
-      var data = await apiRequest(url)
+      const data = await apiRequest(url)
       entries.value = data.entries || []
       total.value = data.total || 0
     } catch (err) {

--- a/modules/release-planning/client/composables/useFilters.js
+++ b/modules/release-planning/client/composables/useFilters.js
@@ -24,10 +24,10 @@ export function useFilters(features, rfes, bigRocks) {
     if (selectedPriority.value && item.priority !== selectedPriority.value) return false
 
     if (selectedTeams.value.length > 0) {
-      var itemComponents = item.components
+      const itemComponents = item.components
         ? item.components.split(', ').map(function(c) { return c.trim() })
         : []
-      var hasMatch = selectedTeams.value.some(function(team) {
+      const hasMatch = selectedTeams.value.some(function(team) {
         return itemComponents.includes(team)
       })
       if (!hasMatch) return false

--- a/modules/release-planning/client/composables/useReleasePlanning.js
+++ b/modules/release-planning/client/composables/useReleasePlanning.js
@@ -150,7 +150,7 @@ export function useReleasePlanning() {
   }
 
   async function createRelease(version, cloneFrom) {
-    var body = { version: version }
+    const body = { version: version }
     if (cloneFrom) {
       body.cloneFrom = cloneFrom
     }
@@ -169,7 +169,7 @@ export function useReleasePlanning() {
   }
 
   async function seedFromFixture() {
-    var fixture = await apiRequest(`${API_BASE}/admin/seed/fixture`)
+    const fixture = await apiRequest(`${API_BASE}/admin/seed/fixture`)
     return apiRequest(`${API_BASE}/admin/seed`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -179,7 +179,7 @@ export function useReleasePlanning() {
 
   async function fetchSmartSheetReleases() {
     try {
-      var data = await apiRequest(`${API_BASE}/smartsheet/releases`)
+      const data = await apiRequest(`${API_BASE}/smartsheet/releases`)
       return data
     } catch {
       return { available: [], configured: [] }

--- a/modules/release-planning/client/constants.js
+++ b/modules/release-planning/client/constants.js
@@ -1,4 +1,4 @@
-export var PRIORITY_STYLES = {
+export const PRIORITY_STYLES = {
   'Blocker': 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400',
   'Critical': 'bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400',
   'Major': 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400',

--- a/modules/release-planning/client/views/AuditLogView.vue
+++ b/modules/release-planning/client/views/AuditLogView.vue
@@ -3,16 +3,16 @@ import { ref, computed, watch, onMounted, inject } from 'vue'
 import { useAuditLog } from '../composables/useAuditLog'
 import { useReleases } from '../composables/useReleasePlanning'
 
-var moduleNav = inject('moduleNav')
-var { entries, total, loading, error, loadAuditLog } = useAuditLog()
-var { releases, loadReleases } = useReleases()
+const moduleNav = inject('moduleNav')
+const { entries, total, loading, error, loadAuditLog } = useAuditLog()
+const { releases, loadReleases } = useReleases()
 
-var selectedVersion = ref('')
-var selectedAction = ref('')
-var currentPage = ref(1)
-var pageSize = 25
+const selectedVersion = ref('')
+const selectedAction = ref('')
+const currentPage = ref(1)
+const pageSize = 25
 
-var ACTION_OPTIONS = [
+const ACTION_OPTIONS = [
   { value: '', label: 'All actions' },
   { value: 'create_rock', label: 'Created Big Rock' },
   { value: 'update_rock', label: 'Updated Big Rock' },
@@ -27,7 +27,7 @@ var ACTION_OPTIONS = [
   { value: 'seed', label: 'Seeded data' }
 ]
 
-var ACTION_COLORS = {
+const ACTION_COLORS = {
   create_rock: 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400',
   update_rock: 'bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400',
   delete_rock: 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400',
@@ -46,13 +46,13 @@ function actionColor(action) {
 }
 
 function actionLabel(action) {
-  var opt = ACTION_OPTIONS.find(function(o) { return o.value === action })
+  const opt = ACTION_OPTIONS.find(function(o) { return o.value === action })
   return opt ? opt.label : action
 }
 
 function shortUser(email) {
   if (!email) return 'System'
-  var at = email.indexOf('@')
+  const at = email.indexOf('@')
   return at > 0 ? email.substring(0, at) : email
 }
 
@@ -67,7 +67,7 @@ function formatTimestamp(iso) {
   })
 }
 
-var totalPages = computed(function() {
+const totalPages = computed(function() {
   return Math.max(1, Math.ceil(total.value / pageSize))
 })
 
@@ -76,7 +76,7 @@ function goBack() {
 }
 
 function fetchPage() {
-  var opts = {
+  const opts = {
     limit: pageSize,
     offset: (currentPage.value - 1) * pageSize
   }
@@ -94,7 +94,7 @@ watch(currentPage, fetchPage)
 
 onMounted(async function() {
   await loadReleases()
-  var params = moduleNav ? moduleNav.params : {}
+  const params = moduleNav ? moduleNav.params : {}
   if (params && params.version) {
     selectedVersion.value = params.version
   } else {

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -44,12 +44,12 @@ const newReleaseDialogOpen = ref(false)
 const seeding = ref(false)
 
 // Refresh polling
-var refreshPollTimer = null
+let refreshPollTimer = null
 
 function startRefreshPolling() {
   stopRefreshPolling()
   refreshPollTimer = setInterval(async function() {
-    var status = await checkRefreshStatus()
+    const status = await checkRefreshStatus()
     if (!status.running) {
       stopRefreshPolling()
       if (selectedVersion.value) {
@@ -117,7 +117,7 @@ function escapeCell(val) {
 }
 
 function escapeCsv(val) {
-  var s = String(val)
+  const s = String(val)
   if (s.indexOf(',') !== -1 || s.indexOf('"') !== -1 || s.indexOf('\n') !== -1 || s.indexOf('\r') !== -1) {
     return '"' + s.replace(/"/g, '""') + '"'
   }
@@ -135,15 +135,15 @@ function toggleExportMenu() {
 }
 
 function exportMarkdown() {
-  var lines = []
-  var filename
+  const lines = []
+  let filename
 
   if (activeTab.value === 'big-rocks') {
     lines.push('# Big Rocks - ' + selectedVersion.value)
     lines.push('')
     lines.push('| **Priority** | **Pillar** | **Big Rock** | **Owner** | **Architect** | **Features** | **RFEs** | **Notes** |')
     lines.push('|:--------:|--------|----------|-------|-----------|:--------:|:----:|-------|')
-    for (var rock of bigRocks.value) {
+    for (const rock of bigRocks.value) {
       lines.push('| ' + [
         rock.priority,
         escapeCell(rock.pillar || '-'),
@@ -161,7 +161,7 @@ function exportMarkdown() {
     lines.push('')
     lines.push('| **Big Rock** | **Feature** | **Status** | **Priority** | **Phase** | **Title** | **Components** | **Target Release** | **PM** | **Delivery Owner** | **RFE** | **Fix Version** |')
     lines.push('|----------|---------|--------|----------|-------|-------|------------|----------------|-----|----------------|-----|-------------|')
-    for (var f of filteredFeatures.value) {
+    for (const f of filteredFeatures.value) {
       lines.push('| ' + [
         escapeCell(f.bigRock || '-'),
         f.issueKey,
@@ -183,7 +183,7 @@ function exportMarkdown() {
     lines.push('')
     lines.push('| **Big Rock** | **RFE** | **Status** | **Priority** | **Title** | **Components** | **PM** | **Labels** |')
     lines.push('|----------|-----|--------|----------|-------|------------|-----|--------|')
-    for (var r of filteredRfes.value) {
+    for (const r of filteredRfes.value) {
       lines.push('| ' + [
         escapeCell(r.bigRock || '-'),
         r.issueKey,
@@ -198,9 +198,9 @@ function exportMarkdown() {
     filename = 'rfes-' + selectedVersion.value + '.md'
   }
 
-  var blob = new Blob([lines.join('\n') + '\n'], { type: 'text/markdown' })
-  var url = URL.createObjectURL(blob)
-  var a = document.createElement('a')
+  const blob = new Blob([lines.join('\n') + '\n'], { type: 'text/markdown' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
   a.href = url
   a.download = filename
   a.click()
@@ -209,12 +209,12 @@ function exportMarkdown() {
 
 function exportCsv() {
   closeExportMenu()
-  var rows = []
-  var filename
+  const rows = []
+  let filename
 
   if (activeTab.value === 'big-rocks') {
     rows.push(['Priority', 'Pillar', 'Big Rock', 'Owner', 'Architect', 'Features', 'RFEs', 'Notes'])
-    for (var rock of bigRocks.value) {
+    for (const rock of bigRocks.value) {
       rows.push([
         rock.priority,
         rock.pillar || '',
@@ -229,7 +229,7 @@ function exportCsv() {
     filename = 'big-rocks-' + selectedVersion.value + '.csv'
   } else if (activeTab.value === 'features') {
     rows.push(['Big Rock', 'Feature', 'Status', 'Priority', 'Phase', 'Title', 'Components', 'Target Release', 'PM', 'Delivery Owner', 'RFE', 'Fix Version'])
-    for (var f of filteredFeatures.value) {
+    for (const f of filteredFeatures.value) {
       rows.push([
         f.bigRock || '',
         f.issueKey,
@@ -248,7 +248,7 @@ function exportCsv() {
     filename = 'features-' + selectedVersion.value + '.csv'
   } else {
     rows.push(['Big Rock', 'RFE', 'Status', 'Priority', 'Title', 'Components', 'PM', 'Labels'])
-    for (var r of filteredRfes.value) {
+    for (const r of filteredRfes.value) {
       rows.push([
         r.bigRock || '',
         r.issueKey,
@@ -263,10 +263,10 @@ function exportCsv() {
     filename = 'rfes-' + selectedVersion.value + '.csv'
   }
 
-  var csv = rows.map(function(row) { return row.map(escapeCsv).join(',') }).join('\n')
-  var blob = new Blob([csv + '\n'], { type: 'text/csv' })
-  var url = URL.createObjectURL(blob)
-  var a = document.createElement('a')
+  const csv = rows.map(function(row) { return row.map(escapeCsv).join(',') }).join('\n')
+  const blob = new Blob([csv + '\n'], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
   a.href = url
   a.download = filename
   a.click()
@@ -407,7 +407,7 @@ async function handleSeedFixture() {
   seeding.value = true
   error.value = null
   try {
-    var result = await seedFromFixture()
+    const result = await seedFromFixture()
     await loadReleases()
     if (result.seeded && result.seeded.length > 0) {
       selectedVersion.value = result.seeded[0].version

--- a/modules/release-planning/server/audit-log.js
+++ b/modules/release-planning/server/audit-log.js
@@ -1,7 +1,7 @@
-var crypto = require('crypto')
+const crypto = require('crypto')
 
-var STORAGE_KEY = 'release-planning/audit-log.json'
-var MAX_ENTRIES = 5000
+const STORAGE_KEY = 'release-planning/audit-log.json'
+const MAX_ENTRIES = 5000
 
 function generateId() {
   return 'audit-' + Date.now().toString(36) + '-' + crypto.randomBytes(4).toString('hex')
@@ -9,7 +9,7 @@ function generateId() {
 
 function logAudit(readFromStorage, writeToStorage, entry) {
   try {
-    var log = readFromStorage(STORAGE_KEY) || { entries: [] }
+    const log = readFromStorage(STORAGE_KEY) || { entries: [] }
 
     log.entries.push({
       id: generateId(),
@@ -32,8 +32,8 @@ function logAudit(readFromStorage, writeToStorage, entry) {
 }
 
 function getAuditLog(readFromStorage, options) {
-  var log = readFromStorage(STORAGE_KEY) || { entries: [] }
-  var entries = log.entries
+  const log = readFromStorage(STORAGE_KEY) || { entries: [] }
+  let entries = log.entries
 
   if (options && options.version) {
     entries = entries.filter(function(e) { return e.version === options.version })
@@ -43,13 +43,13 @@ function getAuditLog(readFromStorage, options) {
     entries = entries.filter(function(e) { return e.action === options.action })
   }
 
-  var total = entries.length
+  const total = entries.length
 
   // Newest first
   entries = entries.slice().reverse()
 
-  var limit = (options && options.limit) || 100
-  var offset = (options && options.offset) || 0
+  const limit = (options && options.limit) || 100
+  const offset = (options && options.offset) || 0
   entries = entries.slice(offset, offset + limit)
 
   return { entries: entries, total: total }

--- a/modules/release-planning/server/cache-reader.js
+++ b/modules/release-planning/server/cache-reader.js
@@ -59,7 +59,7 @@ function getComponents(item) {
 
 // ─── Phase Extraction ───
 
-var RELEASE_TYPE_MAP = {
+const RELEASE_TYPE_MAP = {
   'Tech Preview': 'TP',
   'Developer Preview': 'DP',
   'General Availability': 'GA',
@@ -71,16 +71,16 @@ var RELEASE_TYPE_MAP = {
 function getPhase(item, fixVersions) {
   // Prefer explicit releaseType field from Jira (customfield_10851)
   if (item.releaseType) {
-    var mapped = RELEASE_TYPE_MAP[item.releaseType]
+    const mapped = RELEASE_TYPE_MAP[item.releaseType]
     if (mapped) return mapped
   }
   // Fall back to deriving from fixVersions
-  for (var i = 0; i < fixVersions.length; i++) {
-    var v = fixVersions[i].toUpperCase()
+  for (let i = 0; i < fixVersions.length; i++) {
+    const v = fixVersions[i].toUpperCase()
     if (v.indexOf('GA') !== -1) return 'GA'
   }
-  for (var j = 0; j < fixVersions.length; j++) {
-    var v2 = fixVersions[j].toUpperCase().replace(/[^A-Z0-9]/g, '')
+  for (let j = 0; j < fixVersions.length; j++) {
+    const v2 = fixVersions[j].toUpperCase().replace(/[^A-Z0-9]/g, '')
     if (v2.indexOf('EA2') !== -1 || v2.indexOf('DP2') !== -1) return 'DP'
     if (v2.indexOf('EA1') !== -1 || v2.indexOf('DP1') !== -1 || v2.indexOf('TP') !== -1) return 'TP'
   }
@@ -95,10 +95,10 @@ function getPhase(item, fixVersions) {
  * detail files (objects with displayName).
  */
 function mapToCandidate(item, bigRockName, sourcePass) {
-  var components = getComponents(item)
-  var targetVersions = getTargetVersions(item)
-  var fixVersions = getFixVersions(item)
-  var labels = getLabels(item)
+  const components = getComponents(item)
+  const targetVersions = getTargetVersions(item)
+  const fixVersions = getFixVersions(item)
+  const labels = getLabels(item)
 
   return {
     bigRock: bigRockName,
@@ -129,8 +129,8 @@ function mapToCandidate(item, bigRockName, sourcePass) {
  */
 function findRfeFromLinks(issueLinks) {
   if (!Array.isArray(issueLinks)) return { key: '', status: '' }
-  for (var i = 0; i < issueLinks.length; i++) {
-    var link = issueLinks[i]
+  for (let i = 0; i < issueLinks.length; i++) {
+    const link = issueLinks[i]
     if (link.linkedKey && link.linkedKey.startsWith('RHAIRFE-')) {
       return { key: link.linkedKey, status: link.linkedStatus || '' }
     }
@@ -143,7 +143,7 @@ function findRfeFromLinks(issueLinks) {
  */
 function rfeLinksToOutcome(issueLinks, outcomeSet) {
   if (!Array.isArray(issueLinks)) return false
-  for (var i = 0; i < issueLinks.length; i++) {
+  for (let i = 0; i < issueLinks.length; i++) {
     if (outcomeSet.has(issueLinks[i].linkedKey)) return true
   }
   return false
@@ -156,22 +156,22 @@ function rfeLinksToOutcome(issueLinks, outcomeSet) {
  * Uses parentKey from the index to identify outcome children.
  */
 function findTier1Features(readFromStorage, index, outcomeKeys) {
-  var outcomeSet = new Set(outcomeKeys)
-  var results = []
+  const outcomeSet = new Set(outcomeKeys)
+  const results = []
 
-  var features = index.features || []
-  for (var i = 0; i < features.length; i++) {
-    var f = features[i]
+  const features = index.features || []
+  for (let i = 0; i < features.length; i++) {
+    const f = features[i]
     if (!f.parentKey || !outcomeSet.has(f.parentKey)) continue
 
-    var versions = getTargetVersions(f)
+    const versions = getTargetVersions(f)
     if (versions.length === 0) continue
 
-    var status = f.status || ''
+    const status = f.status || ''
     if (CLOSED_STATUSES.indexOf(status) !== -1) continue
 
     // Load detail for components and issueLinks
-    var detail = loadFeatureDetail(readFromStorage, f.key)
+    const detail = loadFeatureDetail(readFromStorage, f.key)
     if (detail) {
       detail._indexEntry = f
     }
@@ -189,22 +189,22 @@ function findTier1Features(readFromStorage, index, outcomeKeys) {
  * issueLinks to find connections to outcome keys.
  */
 function findTier1Rfes(readFromStorage, index, outcomeKeys, release) {
-  var outcomeSet = new Set(outcomeKeys)
-  var results = []
-  var candidateLabel = release + '-candidate'
+  const outcomeSet = new Set(outcomeKeys)
+  const results = []
+  const candidateLabel = release + '-candidate'
 
-  var rfes = index.rfes || []
-  for (var i = 0; i < rfes.length; i++) {
-    var r = rfes[i]
-    var status = r.status || ''
+  const rfes = index.rfes || []
+  for (let i = 0; i < rfes.length; i++) {
+    const r = rfes[i]
+    const status = r.status || ''
     if (CLOSED_STATUSES.indexOf(status) !== -1) continue
     if (status === 'Approved') continue
 
-    var labels = getLabels(r)
+    const labels = getLabels(r)
     if (labels.indexOf(candidateLabel) === -1) continue
 
     // Need detail file to check issueLinks
-    var detail = loadRfeDetail(readFromStorage, r.key)
+    const detail = loadRfeDetail(readFromStorage, r.key)
     if (!detail) continue
 
     if (!rfeLinksToOutcome(detail.issueLinks, outcomeSet)) continue
@@ -220,12 +220,12 @@ function findTier1Rfes(readFromStorage, index, outcomeKeys, release) {
  * Outcomes are RHAISTRAT issues that may appear in the features list.
  */
 function findOutcomeSummaries(index, outcomeKeys) {
-  var summaries = {}
+  const summaries = {}
   if (!outcomeKeys || outcomeKeys.length === 0) return summaries
 
-  var keySet = new Set(outcomeKeys)
-  var features = index.features || []
-  for (var i = 0; i < features.length; i++) {
+  const keySet = new Set(outcomeKeys)
+  const features = index.features || []
+  for (let i = 0; i < features.length; i++) {
     if (keySet.has(features[i].key)) {
       summaries[features[i].key] = features[i].summary || ''
     }
@@ -239,16 +239,16 @@ function findOutcomeSummaries(index, outcomeKeys) {
  * excluding already-discovered Tier 1 keys.
  */
 function findTier2Features(readFromStorage, index, release, excludeKeys) {
-  var results = []
-  var features = index.features || []
+  const results = []
+  const features = index.features || []
 
-  for (var i = 0; i < features.length; i++) {
-    var f = features[i]
+  for (let i = 0; i < features.length; i++) {
+    const f = features[i]
     if (excludeKeys.has(f.key)) continue
 
-    var versions = getTargetVersions(f)
-    var matchesRelease = false
-    for (var j = 0; j < versions.length; j++) {
+    const versions = getTargetVersions(f)
+    let matchesRelease = false
+    for (let j = 0; j < versions.length; j++) {
       if (versions[j].indexOf(release) !== -1) {
         matchesRelease = true
         break
@@ -256,10 +256,10 @@ function findTier2Features(readFromStorage, index, release, excludeKeys) {
     }
     if (!matchesRelease) continue
 
-    var status = f.status || ''
+    const status = f.status || ''
     if (CLOSED_STATUSES.indexOf(status) !== -1) continue
 
-    var detail = loadFeatureDetail(readFromStorage, f.key)
+    const detail = loadFeatureDetail(readFromStorage, f.key)
     results.push(detail || f)
   }
 
@@ -271,22 +271,22 @@ function findTier2Features(readFromStorage, index, release, excludeKeys) {
  * not closed, not Approved, excluding Tier 1 keys.
  */
 function findTier2Rfes(readFromStorage, index, release, excludeKeys) {
-  var results = []
-  var candidateLabel = release + '-candidate'
-  var rfes = index.rfes || []
+  const results = []
+  const candidateLabel = release + '-candidate'
+  const rfes = index.rfes || []
 
-  for (var i = 0; i < rfes.length; i++) {
-    var r = rfes[i]
+  for (let i = 0; i < rfes.length; i++) {
+    const r = rfes[i]
     if (excludeKeys.has(r.key)) continue
 
-    var status = r.status || ''
+    const status = r.status || ''
     if (CLOSED_STATUSES.indexOf(status) !== -1) continue
     if (status === 'Approved') continue
 
-    var labels = getLabels(r)
+    const labels = getLabels(r)
     if (labels.indexOf(candidateLabel) === -1) continue
 
-    var detail = loadRfeDetail(readFromStorage, r.key)
+    const detail = loadRfeDetail(readFromStorage, r.key)
     results.push(detail || r)
   }
 
@@ -297,22 +297,22 @@ function findTier2Rfes(readFromStorage, index, release, excludeKeys) {
  * Find Tier 3 features: In Progress, no target version, no fix version.
  */
 function findTier3Features(readFromStorage, index, excludeKeys) {
-  var results = []
-  var features = index.features || []
+  const results = []
+  const features = index.features || []
 
-  for (var i = 0; i < features.length; i++) {
-    var f = features[i]
+  for (let i = 0; i < features.length; i++) {
+    const f = features[i]
     if (excludeKeys.has(f.key)) continue
 
     if (f.status !== 'In Progress') continue
 
-    var versions = getTargetVersions(f)
+    const versions = getTargetVersions(f)
     if (versions.length > 0) continue
 
-    var fixVersions = getFixVersions(f)
+    const fixVersions = getFixVersions(f)
     if (fixVersions.length > 0) continue
 
-    var detail = loadFeatureDetail(readFromStorage, f.key)
+    const detail = loadFeatureDetail(readFromStorage, f.key)
     results.push(detail || f)
   }
 
@@ -324,21 +324,21 @@ function findTier3Features(readFromStorage, index, excludeKeys) {
  * Returns { key: { valid, summary?, error? } } for each key.
  */
 function validateKeysFromCache(index, keys) {
-  var results = {}
-  var keyMap = {}
+  const results = {}
+  const keyMap = {}
 
-  var features = index.features || []
-  for (var i = 0; i < features.length; i++) {
+  const features = index.features || []
+  for (let i = 0; i < features.length; i++) {
     keyMap[features[i].key] = features[i].summary || ''
   }
 
-  var rfes = index.rfes || []
-  for (var j = 0; j < rfes.length; j++) {
+  const rfes = index.rfes || []
+  for (let j = 0; j < rfes.length; j++) {
     keyMap[rfes[j].key] = rfes[j].summary || ''
   }
 
-  for (var k = 0; k < keys.length; k++) {
-    var key = keys[k]
+  for (let k = 0; k < keys.length; k++) {
+    const key = keys[k]
     if (keyMap[key] !== undefined) {
       results[key] = { valid: true, summary: keyMap[key] }
     } else {

--- a/modules/release-planning/server/config.js
+++ b/modules/release-planning/server/config.js
@@ -163,14 +163,14 @@ function deleteBigRock(readFromStorage, writeToStorage, version, name) {
  * @returns {object} { bigRocks } - The reordered list with new priorities
  */
 function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames) {
-  var config = getConfig(readFromStorage)
+  const config = getConfig(readFromStorage)
 
   if (!config.releases[version]) {
     throw new Error('Release ' + version + ' not found')
   }
 
-  var bigRocks = config.releases[version].bigRocks || []
-  var currentNames = bigRocks.map(function(r) { return r.name })
+  const bigRocks = config.releases[version].bigRocks || []
+  const currentNames = bigRocks.map(function(r) { return r.name })
 
   // Validate: orderedNames must be an array
   if (!Array.isArray(orderedNames)) {
@@ -186,12 +186,12 @@ function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames)
   }
 
   // Validate: same set of names (no duplicates, no extras, no missing)
-  var currentSet = Object.create(null)
-  for (var i = 0; i < currentNames.length; i++) {
+  const currentSet = Object.create(null)
+  for (let i = 0; i < currentNames.length; i++) {
     currentSet[currentNames[i]] = true
   }
-  var submittedSet = Object.create(null)
-  for (var j = 0; j < orderedNames.length; j++) {
+  const submittedSet = Object.create(null)
+  for (let j = 0; j < orderedNames.length; j++) {
     if (submittedSet[orderedNames[j]]) {
       throw Object.assign(
         new Error('Order list contains duplicate name: ' + orderedNames[j] + '. Expected names: ' + JSON.stringify(currentNames)),
@@ -208,13 +208,13 @@ function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames)
   }
 
   // Build a lookup map for fast access
-  var rockByName = Object.create(null)
-  for (var k = 0; k < bigRocks.length; k++) {
+  const rockByName = Object.create(null)
+  for (let k = 0; k < bigRocks.length; k++) {
     rockByName[bigRocks[k].name] = bigRocks[k]
   }
 
   // Reorder
-  var reordered = orderedNames.map(function(name) { return rockByName[name] })
+  const reordered = orderedNames.map(function(name) { return rockByName[name] })
 
   // Renumber priorities
   renumberPriorities(reordered)
@@ -238,7 +238,7 @@ function createRelease(readFromStorage, writeToStorage, version) {
     throw new Error('Version is required')
   }
 
-  var config = getConfig(readFromStorage)
+  const config = getConfig(readFromStorage)
 
   if (config.releases[version]) {
     throw Object.assign(
@@ -267,7 +267,7 @@ function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
     throw new Error('Version is required')
   }
 
-  var config = getConfig(readFromStorage)
+  const config = getConfig(readFromStorage)
 
   if (config.releases[version]) {
     throw Object.assign(
@@ -284,8 +284,8 @@ function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
   }
 
   // Deep-copy the bigRocks array so edits to the clone don't affect the source
-  var sourceBigRocks = config.releases[cloneFrom].bigRocks || []
-  var clonedBigRocks = JSON.parse(JSON.stringify(sourceBigRocks))
+  const sourceBigRocks = config.releases[cloneFrom].bigRocks || []
+  const clonedBigRocks = JSON.parse(JSON.stringify(sourceBigRocks))
 
   config.releases[version] = { release: version, bigRocks: clonedBigRocks }
   writeToStorage('release-planning/config.json', config)
@@ -302,7 +302,7 @@ function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
  * @returns {object} { deleted }
  */
 function deleteRelease(readFromStorage, writeToStorage, version) {
-  var config = getConfig(readFromStorage)
+  const config = getConfig(readFromStorage)
 
   if (!config.releases[version]) {
     throw Object.assign(
@@ -322,7 +322,7 @@ function deleteRelease(readFromStorage, writeToStorage, version) {
  * Modifies the array in place.
  */
 function renumberPriorities(bigRocks) {
-  for (var i = 0; i < bigRocks.length; i++) {
+  for (let i = 0; i < bigRocks.length; i++) {
     bigRocks[i].priority = i + 1
   }
 }

--- a/modules/release-planning/server/doc-import.js
+++ b/modules/release-planning/server/doc-import.js
@@ -5,9 +5,9 @@
  * and config persistence (config.js) for the import flow.
  */
 
-var googleDocs = require('../../../shared/server/google-docs')
-var { validateBigRock } = require('./validation')
-var { getConfig, saveBigRock, deleteBigRock } = require('./config')
+const googleDocs = require('../../../shared/server/google-docs')
+const { validateBigRock } = require('./validation')
+const { getConfig, saveBigRock, deleteBigRock } = require('./config')
 
 /**
  * Parse a Google Doc URL or ID to extract the document ID.
@@ -17,7 +17,7 @@ function parseDocId(input) {
   input = input.trim()
 
   // Full URL: https://docs.google.com/document/d/{ID}/...
-  var urlMatch = input.match(/docs\.google\.com\/document\/d\/([a-zA-Z0-9_-]+)/)
+  const urlMatch = input.match(/docs\.google\.com\/document\/d\/([a-zA-Z0-9_-]+)/)
   if (urlMatch) return urlMatch[1]
 
   // Raw ID (alphanumeric + hyphens + underscores, typical length 44)
@@ -30,20 +30,20 @@ function parseDocId(input) {
  * Fetch and parse a Google Doc, returning Big Rocks for preview.
  */
 async function previewDocImport(docIdOrUrl) {
-  var docId = parseDocId(docIdOrUrl)
+  const docId = parseDocId(docIdOrUrl)
   if (!docId) {
     throw Object.assign(new Error('Invalid Google Doc URL or ID'), { statusCode: 400 })
   }
 
   try {
-    var doc = await googleDocs.fetchDocument(docId)
+    const doc = await googleDocs.fetchDocument(docId)
     return googleDocs.extractBigRocksFromDoc(doc)
   } catch (err) {
     if (err.statusCode) throw err
 
     // Google API errors
     if (err.code === 403 || err.code === 404) {
-      var email = googleDocs.getServiceAccountEmail()
+      const email = googleDocs.getServiceAccountEmail()
       if (email) {
         console.error('[release-planning] Document access denied. Share with:', email)
       }
@@ -75,7 +75,7 @@ async function previewDocImport(docIdOrUrl) {
  * @returns {object} { imported, skipped, skippedNames, validationErrors, mode, bigRocks }
  */
 function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, mode, parsedDoc) {
-  var parsedRocks = parsedDoc.bigRocks
+  const parsedRocks = parsedDoc.bigRocks
 
   if (parsedRocks.length === 0) {
     throw Object.assign(
@@ -84,30 +84,30 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
     )
   }
 
-  var config = getConfig(readFromStorage)
+  const config = getConfig(readFromStorage)
   if (!config.releases[version]) {
     throw Object.assign(new Error('Release ' + version + ' not found'), { statusCode: 404 })
   }
 
-  var existingRocks = config.releases[version].bigRocks || []
-  var imported = 0
-  var skipped = 0
-  var skippedNames = []
-  var validationErrors = []
+  const existingRocks = config.releases[version].bigRocks || []
+  let imported = 0
+  let skipped = 0
+  const skippedNames = []
+  const validationErrors = []
 
   if (mode === 'replace') {
     // Delete all existing rocks first (reverse order to avoid index shift)
-    for (var i = existingRocks.length - 1; i >= 0; i--) {
+    for (let i = existingRocks.length - 1; i >= 0; i--) {
       deleteBigRock(readFromStorage, writeToStorage, version, existingRocks[i].name)
     }
   }
 
   // Build the set of names already present (for duplicate + uniqueness checks)
-  var currentRocks = getConfig(readFromStorage).releases[version].bigRocks || []
-  var existingNames = new Set(currentRocks.map(function(r) { return r.name }))
+  const currentRocks = getConfig(readFromStorage).releases[version].bigRocks || []
+  const existingNames = new Set(currentRocks.map(function(r) { return r.name }))
 
-  for (var j = 0; j < parsedRocks.length; j++) {
-    var rock = parsedRocks[j]
+  for (let j = 0; j < parsedRocks.length; j++) {
+    const rock = parsedRocks[j]
 
     // Skip duplicates in append mode
     if (mode === 'append' && existingNames.has(rock.name)) {
@@ -117,7 +117,7 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
     }
 
     // Validate through the same validator used by CRUD endpoints
-    var validation = validateBigRock(rock, {
+    const validation = validateBigRock(rock, {
       existingNames: Array.from(existingNames)
     })
     if (!validation.valid) {
@@ -134,8 +134,8 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
   }
 
   // Read back the final state (authoritative)
-  var finalConfig = getConfig(readFromStorage)
-  var finalRocks = finalConfig.releases[version].bigRocks || []
+  const finalConfig = getConfig(readFromStorage)
+  const finalRocks = finalConfig.releases[version].bigRocks || []
 
   return {
     imported: imported,

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -243,17 +243,17 @@ module.exports = function registerRoutes(router, context) {
   // Must be registered BEFORE the :name route so Express doesn't match "reorder" as a name param.
 
   router.put('/releases/:version/big-rocks/reorder', requirePM, async function(req, res) {
-    var version = req.params.version
+    const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
     }
-    var order = req.body && req.body.order
+    const order = req.body && req.body.order
     if (!Array.isArray(order)) {
       return res.status(400).json({ error: 'order must be an array of Big Rock names' })
     }
 
     try {
-      var result = await withConfigLock(function() {
+      const result = await withConfigLock(function() {
         return reorderBigRocks(readFromStorage, writeToStorage, version, order)
       })
       logAudit(readFromStorage, writeToStorage, {
@@ -265,7 +265,7 @@ module.exports = function registerRoutes(router, context) {
       invalidateCache(version)
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
@@ -277,7 +277,7 @@ module.exports = function registerRoutes(router, context) {
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
     }
-    var name
+    let name
     try {
       name = decodeURIComponent(req.params.name)
     } catch {
@@ -316,8 +316,8 @@ module.exports = function registerRoutes(router, context) {
       invalidateCache(version)
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
-      var response = { error: err.message }
+      const status = err.statusCode || 500
+      const response = { error: err.message }
       if (err.fields) response.fields = err.fields
       res.status(status).json(response)
     }
@@ -352,7 +352,7 @@ module.exports = function registerRoutes(router, context) {
         return saveBigRock(readFromStorage, writeToStorage, version, null, req.body)
       })
 
-      var newName = req.body && req.body.name
+      const newName = req.body && req.body.name
       logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'create_rock',
@@ -363,8 +363,8 @@ module.exports = function registerRoutes(router, context) {
       invalidateCache(version)
       res.status(201).json(result)
     } catch (err) {
-      var status = err.statusCode || 500
-      var response = { error: err.message }
+      const status = err.statusCode || 500
+      const response = { error: err.message }
       if (err.fields) response.fields = err.fields
       res.status(status).json(response)
     }
@@ -377,7 +377,7 @@ module.exports = function registerRoutes(router, context) {
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
     }
-    var name
+    let name
     try {
       name = decodeURIComponent(req.params.name)
     } catch {
@@ -414,7 +414,7 @@ module.exports = function registerRoutes(router, context) {
       invalidateCache(version)
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
@@ -422,8 +422,8 @@ module.exports = function registerRoutes(router, context) {
   // ─── POST /releases ───
 
   router.post('/releases', requirePM, async function(req, res) {
-    var version = req.body && req.body.version
-    var cloneFrom = req.body && req.body.cloneFrom
+    const version = req.body && req.body.version
+    const cloneFrom = req.body && req.body.cloneFrom
 
     if (!version || typeof version !== 'string') {
       return res.status(400).json({ error: 'version is required' })
@@ -436,7 +436,7 @@ module.exports = function registerRoutes(router, context) {
     }
 
     try {
-      var result = await withConfigLock(function() {
+      const result = await withConfigLock(function() {
         if (cloneFrom) {
           backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
           return cloneRelease(readFromStorage, writeToStorage, version, cloneFrom)
@@ -453,7 +453,7 @@ module.exports = function registerRoutes(router, context) {
       })
       res.status(201).json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
@@ -461,13 +461,13 @@ module.exports = function registerRoutes(router, context) {
   // ─── DELETE /releases/:version ───
 
   router.delete('/releases/:version', requireAdmin, async function(req, res) {
-    var version = req.params.version
+    const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
     }
 
     try {
-      var result = await withConfigLock(function() {
+      const result = await withConfigLock(function() {
         backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
         return deleteRelease(readFromStorage, writeToStorage, version)
       })
@@ -486,7 +486,7 @@ module.exports = function registerRoutes(router, context) {
 
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
@@ -506,7 +506,7 @@ module.exports = function registerRoutes(router, context) {
     const keysToValidate = []
 
     // Mark invalid-format keys immediately
-    for (var i = 0; i < keys.length; i++) {
+    for (let i = 0; i < keys.length; i++) {
       if (typeof keys[i] !== 'string' || !/^[A-Z]+-\d+$/.test(keys[i])) {
         results[keys[i]] = { valid: false, error: 'Invalid key format' }
       } else {
@@ -515,8 +515,8 @@ module.exports = function registerRoutes(router, context) {
     }
 
     if (keysToValidate.length > 0) {
-      var index = loadIndex(readFromStorage)
-      var cacheResults = validateKeysFromCache(index, keysToValidate)
+      const index = loadIndex(readFromStorage)
+      const cacheResults = validateKeysFromCache(index, keysToValidate)
       Object.assign(results, cacheResults)
     }
 
@@ -526,16 +526,16 @@ module.exports = function registerRoutes(router, context) {
   // ─── PM User Management ───
 
   router.get('/pm-users', requireAdmin, function(req, res) {
-    var emails = getPMUsers(readFromStorage)
+    const emails = getPMUsers(readFromStorage)
     res.json({ emails: emails })
   })
 
   router.post('/pm-users', requireAdmin, function(req, res) {
-    var email = req.body && req.body.email
+    const email = req.body && req.body.email
     if (!email || typeof email !== 'string' || !email.trim()) {
       return res.status(400).json({ error: 'email is required' })
     }
-    var emails = addPMUser(readFromStorage, writeToStorage, email.trim())
+    const emails = addPMUser(readFromStorage, writeToStorage, email.trim())
     logAudit(readFromStorage, writeToStorage, {
       action: 'add_pm',
       user: req.userEmail,
@@ -545,13 +545,13 @@ module.exports = function registerRoutes(router, context) {
   })
 
   router.delete('/pm-users/:email', requireAdmin, function(req, res) {
-    var email
+    let email
     try {
       email = decodeURIComponent(req.params.email)
     } catch {
       return res.status(400).json({ error: 'Invalid parameter encoding' })
     }
-    var emails = removePMUser(readFromStorage, writeToStorage, email)
+    const emails = removePMUser(readFromStorage, writeToStorage, email)
     logAudit(readFromStorage, writeToStorage, {
       action: 'remove_pm',
       user: req.userEmail,
@@ -563,29 +563,29 @@ module.exports = function registerRoutes(router, context) {
   // ─── Google Doc Import ───
 
   router.post('/releases/:version/import/doc/preview', requirePM, async function(req, res) {
-    var version = req.params.version
+    const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
     }
-    var docId = req.body && req.body.docId
+    const docId = req.body && req.body.docId
     if (!docId) {
       return res.status(400).json({ error: 'docId is required' })
     }
 
     try {
-      var result = await previewDocImport(docId)
+      const result = await previewDocImport(docId)
 
       // Annotate each rock with duplicate/validation status for the target release
-      var config = getConfig(readFromStorage)
-      var existingRocks = (config.releases[version] && config.releases[version].bigRocks) || []
-      var existingNames = new Set(existingRocks.map(function(r) { return r.name }))
+      const config = getConfig(readFromStorage)
+      const existingRocks = (config.releases[version] && config.releases[version].bigRocks) || []
+      const existingNames = new Set(existingRocks.map(function(r) { return r.name }))
 
-      for (var i = 0; i < result.bigRocks.length; i++) {
-        var rock = result.bigRocks[i]
+      for (let i = 0; i < result.bigRocks.length; i++) {
+        const rock = result.bigRocks[i]
         if (existingNames.has(rock.name)) {
           rock.status = 'duplicate'
         } else {
-          var validation = validateBigRock(rock, {
+          const validation = validateBigRock(rock, {
             existingNames: Array.from(existingNames)
           })
           rock.status = validation.valid ? 'new' : 'validation_error'
@@ -595,18 +595,18 @@ module.exports = function registerRoutes(router, context) {
 
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message, shareWith: err.shareWith })
     }
   })
 
   router.post('/releases/:version/import/doc', requirePM, async function(req, res) {
-    var version = req.params.version
+    const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
     }
-    var docId = req.body && req.body.docId
-    var mode = req.body && req.body.mode
+    const docId = req.body && req.body.docId
+    const mode = req.body && req.body.mode
     if (!docId) {
       return res.status(400).json({ error: 'docId is required' })
     }
@@ -618,10 +618,10 @@ module.exports = function registerRoutes(router, context) {
       // Fetch and parse the Google Doc OUTSIDE the config lock.
       // The network call can take up to 30s; holding the lock during that
       // time would starve all CRUD operations (lock starvation).
-      var parsedDoc = await previewDocImport(docId)
+      const parsedDoc = await previewDocImport(docId)
 
       // Only hold the lock for the fast, synchronous config read-modify-write.
-      var result = await withConfigLock(function() {
+      const result = await withConfigLock(function() {
         if (mode === 'replace') {
           backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
         }
@@ -640,7 +640,7 @@ module.exports = function registerRoutes(router, context) {
       invalidateCache(version)
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
@@ -655,11 +655,11 @@ module.exports = function registerRoutes(router, context) {
         })
       }
 
-      var releases = await smartsheetClient.discoverReleases()
-      var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
-      var configuredSet = new Set(configuredVersions)
+      const releases = await smartsheetClient.discoverReleases()
+      const configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
+      const configuredSet = new Set(configuredVersions)
 
-      var available = releases.map(function(rel) {
+      const available = releases.map(function(rel) {
         return {
           version: rel.version,
           ea1Target: rel.ea1Target,
@@ -675,7 +675,7 @@ module.exports = function registerRoutes(router, context) {
         cachedAt: new Date().toISOString()
       })
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
@@ -683,29 +683,29 @@ module.exports = function registerRoutes(router, context) {
   // ─── Admin Seed / Bootstrap ───
 
   router.post('/admin/seed', requireAdmin, async function(req, res) {
-    var config = req.body
+    const config = req.body
     if (!config || typeof config !== 'object' || !config.releases) {
       return res.status(400).json({ error: 'Request body must include a "releases" object' })
     }
 
-    var versions = Object.keys(config.releases)
-    for (var i = 0; i < versions.length; i++) {
+    const versions = Object.keys(config.releases)
+    for (let i = 0; i < versions.length; i++) {
       if (!VERSION_RE.test(versions[i]) || RESERVED_VERSIONS.includes(versions[i])) {
         return res.status(400).json({ error: 'Invalid version: ' + versions[i] })
       }
     }
 
     // Validate each Big Rock in each release
-    for (var vi = 0; vi < versions.length; vi++) {
-      var ver = versions[vi]
-      var rocks = config.releases[ver].bigRocks
+    for (let vi = 0; vi < versions.length; vi++) {
+      const ver = versions[vi]
+      const rocks = config.releases[ver].bigRocks
       if (!rocks) continue
       if (!Array.isArray(rocks)) {
         return res.status(400).json({ error: 'bigRocks must be an array for release ' + ver })
       }
-      var namesInRelease = []
-      for (var ri = 0; ri < rocks.length; ri++) {
-        var validation = validateBigRock(rocks[ri], { existingNames: namesInRelease })
+      const namesInRelease = []
+      for (let ri = 0; ri < rocks.length; ri++) {
+        const validation = validateBigRock(rocks[ri], { existingNames: namesInRelease })
         if (!validation.valid) {
           return res.status(400).json({
             error: 'Invalid Big Rock at index ' + ri + ' in release ' + ver,
@@ -717,11 +717,11 @@ module.exports = function registerRoutes(router, context) {
     }
 
     try {
-      var result = await withConfigLock(function() {
+      const result = await withConfigLock(function() {
         backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
-        var existing = getConfig(readFromStorage)
-        var merged = {
+        const existing = getConfig(readFromStorage)
+        const merged = {
           ...existing,
           ...config,
           releases: { ...existing.releases, ...config.releases },
@@ -731,7 +731,7 @@ module.exports = function registerRoutes(router, context) {
 
         writeToStorage('release-planning/config.json', merged)
 
-        var seededVersions = versions.map(function(v) {
+        const seededVersions = versions.map(function(v) {
           return { version: v, bigRockCount: (merged.releases[v].bigRocks || []).length }
         })
 
@@ -745,13 +745,13 @@ module.exports = function registerRoutes(router, context) {
       })
       res.json(result)
     } catch (err) {
-      var status = err.statusCode || 500
+      const status = err.statusCode || 500
       res.status(status).json({ error: err.message })
     }
   })
 
   router.get('/admin/seed/fixture', requireAdmin, function(req, res) {
-    var fixture = loadFixture('config.json')
+    const fixture = loadFixture('config.json')
     if (!fixture) {
       return res.status(404).json({ error: 'No fixture data found' })
     }
@@ -761,12 +761,12 @@ module.exports = function registerRoutes(router, context) {
   // ─── Audit Log ───
 
   router.get('/audit-log', requireAuth, function(req, res) {
-    var version = req.query.version || null
-    var action = req.query.action || null
-    var limit = Math.min(Math.max(parseInt(req.query.limit) || 50, 1), 500)
-    var offset = Math.max(parseInt(req.query.offset) || 0, 0)
+    const version = req.query.version || null
+    const action = req.query.action || null
+    const limit = Math.min(Math.max(parseInt(req.query.limit) || 50, 1), 500)
+    const offset = Math.max(parseInt(req.query.offset) || 0, 0)
 
-    var result = getAuditLog(readFromStorage, {
+    const result = getAuditLog(readFromStorage, {
       version: version,
       action: action,
       limit: limit,

--- a/modules/release-planning/server/pipeline.js
+++ b/modules/release-planning/server/pipeline.js
@@ -12,16 +12,16 @@ const {
 } = require('./cache-reader')
 
 function sortByPriority(a, b) {
-  var pa = PRIORITY_ORDER[a.priority] !== undefined ? PRIORITY_ORDER[a.priority] : 99
-  var pb = PRIORITY_ORDER[b.priority] !== undefined ? PRIORITY_ORDER[b.priority] : 99
+  const pa = PRIORITY_ORDER[a.priority] !== undefined ? PRIORITY_ORDER[a.priority] : 99
+  const pb = PRIORITY_ORDER[b.priority] !== undefined ? PRIORITY_ORDER[b.priority] : 99
   if (pa !== pb) return pa - pb
   return a.issueKey.localeCompare(b.issueKey)
 }
 
 function runPipeline(config, bigRocks, release, readFromStorage, opts) {
-  var rockFilter = opts && opts.rockFilter
+  const rockFilter = opts && opts.rockFilter
 
-  var rocksToProcess = rockFilter
+  const rocksToProcess = rockFilter
     ? bigRocks.filter(function(r) { return r.name === rockFilter })
     : bigRocks
 
@@ -29,41 +29,41 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     throw new Error('No matching rock found for filter: ' + rockFilter + '. Available: ' + bigRocks.map(function(r) { return r.name }).join(', '))
   }
 
-  var rocksWithOutcomes = rocksToProcess.filter(function(r) { return r.outcomeKeys && r.outcomeKeys.length > 0 })
-  var rocksWithout = rocksToProcess.filter(function(r) { return !r.outcomeKeys || r.outcomeKeys.length === 0 })
+  const rocksWithOutcomes = rocksToProcess.filter(function(r) { return r.outcomeKeys && r.outcomeKeys.length > 0 })
+  const rocksWithout = rocksToProcess.filter(function(r) { return !r.outcomeKeys || r.outcomeKeys.length === 0 })
 
-  for (var w = 0; w < rocksWithout.length; w++) {
+  for (let w = 0; w < rocksWithout.length; w++) {
     console.warn('[release-planning] Skipping ' + rocksWithout[w].name + ': no outcomeKeys defined')
   }
 
   // Load the feature-traffic index once
-  var index = loadIndex(readFromStorage)
+  const index = loadIndex(readFromStorage)
 
   // Collect all outcome keys
-  var allOutcomeKeys = []
-  for (var r = 0; r < rocksWithOutcomes.length; r++) {
+  const allOutcomeKeys = []
+  for (let r = 0; r < rocksWithOutcomes.length; r++) {
     allOutcomeKeys.push.apply(allOutcomeKeys, rocksWithOutcomes[r].outcomeKeys)
   }
 
   // Fetch outcome summaries from cache
-  var outcomeSummaries = findOutcomeSummaries(index, allOutcomeKeys)
+  const outcomeSummaries = findOutcomeSummaries(index, allOutcomeKeys)
 
   // Phase A: Discover children for each rock's outcomes
   // Maps: issueKey -> { candidate, rockSet: Set<"priority:name"> }
-  var featureMap = new Map()
-  var rfeMap = new Map()
-  var skippedCount = 0
-  var terminalFilteredCount = 0
+  const featureMap = new Map()
+  const rfeMap = new Map()
+  let skippedCount = 0
+  let terminalFilteredCount = 0
 
-  for (var ri = 0; ri < rocksWithOutcomes.length; ri++) {
-    var rock = rocksWithOutcomes[ri]
-    var rockChildCount = 0
+  for (let ri = 0; ri < rocksWithOutcomes.length; ri++) {
+    const rock = rocksWithOutcomes[ri]
+    let rockChildCount = 0
 
     // Find Tier 1 features for this rock's outcomes
-    var rawFeatures = findTier1Features(readFromStorage, index, rock.outcomeKeys)
-    for (var fi = 0; fi < rawFeatures.length; fi++) {
-      var feat = rawFeatures[fi]
-      var candidate = mapToCandidate(feat, rock.name, 'outcome')
+    const rawFeatures = findTier1Features(readFromStorage, index, rock.outcomeKeys)
+    for (let fi = 0; fi < rawFeatures.length; fi++) {
+      const feat = rawFeatures[fi]
+      const candidate = mapToCandidate(feat, rock.name, 'outcome')
 
       // Filter by release match
       if (!candidate.targetRelease.includes(release)) {
@@ -78,14 +78,14 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
       }
 
       // Enrich with RFE link from issueLinks
-      var issueLinks = feat.issueLinks || feat._indexEntry && feat._indexEntry.issueLinks || []
-      var rfeLink = findRfeFromLinks(issueLinks)
+      const issueLinks = feat.issueLinks || feat._indexEntry && feat._indexEntry.issueLinks || []
+      const rfeLink = findRfeFromLinks(issueLinks)
       if (rfeLink.key) {
         candidate.rfe = rfeLink.key
         candidate.rfeStatus = rfeLink.status
       }
 
-      var key = candidate.issueKey
+      const key = candidate.issueKey
       if (featureMap.has(key)) {
         featureMap.get(key).rockSet.add(rock.priority + ':' + rock.name)
       } else {
@@ -95,12 +95,12 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     }
 
     // Find Tier 1 RFEs for this rock's outcomes
-    var rawRfes = findTier1Rfes(readFromStorage, index, rock.outcomeKeys, release)
-    for (var rfi = 0; rfi < rawRfes.length; rfi++) {
-      var rfe = rawRfes[rfi]
-      var rfeCandidate = mapToCandidate(rfe, rock.name, 'outcome')
+    const rawRfes = findTier1Rfes(readFromStorage, index, rock.outcomeKeys, release)
+    for (let rfi = 0; rfi < rawRfes.length; rfi++) {
+      const rfe = rawRfes[rfi]
+      const rfeCandidate = mapToCandidate(rfe, rock.name, 'outcome')
 
-      var rfeKey = rfeCandidate.issueKey
+      const rfeKey = rfeCandidate.issueKey
       if (rfeMap.has(rfeKey)) {
         rfeMap.get(rfeKey).rockSet.add(rock.priority + ':' + rock.name)
       } else {
@@ -115,59 +115,59 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   }
 
   // Phase B: Merge Big Rock names and build Tier 1 lists
-  var rockPriority = {}
-  for (var bp = 0; bp < bigRocks.length; bp++) {
+  const rockPriority = {}
+  for (let bp = 0; bp < bigRocks.length; bp++) {
     rockPriority[bigRocks[bp].name] = bigRocks[bp].priority
   }
 
   function mergeRockNames(rockSet) {
-    var pairs = []
+    const pairs = []
     rockSet.forEach(function(s) {
-      var idx = s.indexOf(':')
+      const idx = s.indexOf(':')
       pairs.push([parseInt(s.slice(0, idx), 10), s.slice(idx + 1)])
     })
     pairs.sort(function(a, b) { return a[0] - b[0] })
     return pairs.map(function(p) { return p[1] }).join(', ')
   }
 
-  var tier1Features = []
+  const tier1Features = []
   featureMap.forEach(function(entry) {
-    var merged = mergeRockNames(entry.rockSet)
+    const merged = mergeRockNames(entry.rockSet)
     tier1Features.push(Object.assign({}, entry.candidate, { bigRock: merged, tier: 1 }))
   })
 
-  var tier1Rfes = []
+  const tier1Rfes = []
   rfeMap.forEach(function(entry) {
-    var merged = mergeRockNames(entry.rockSet)
+    const merged = mergeRockNames(entry.rockSet)
     tier1Rfes.push(Object.assign({}, entry.candidate, { bigRock: merged, tier: 1 }))
   })
 
   // Sort Tier 1
   tier1Features.sort(function(a, b) {
-    var ra = rockPriority[a.bigRock.split(', ')[0]] || 999
-    var rb = rockPriority[b.bigRock.split(', ')[0]] || 999
+    const ra = rockPriority[a.bigRock.split(', ')[0]] || 999
+    const rb = rockPriority[b.bigRock.split(', ')[0]] || 999
     if (ra !== rb) return ra - rb
     return sortByPriority(a, b)
   })
   tier1Rfes.sort(function(a, b) {
-    var ra = rockPriority[a.bigRock.split(', ')[0]] || 999
-    var rb = rockPriority[b.bigRock.split(', ')[0]] || 999
+    const ra = rockPriority[a.bigRock.split(', ')[0]] || 999
+    const rb = rockPriority[b.bigRock.split(', ')[0]] || 999
     if (ra !== rb) return ra - rb
     return sortByPriority(a, b)
   })
 
   // Phase C: Tier 2 discovery
-  var tier1FeatureKeys = new Set(tier1Features.map(function(c) { return c.issueKey }))
-  var tier1RfeKeys = new Set(tier1Rfes.map(function(c) { return c.issueKey }))
+  const tier1FeatureKeys = new Set(tier1Features.map(function(c) { return c.issueKey }))
+  const tier1RfeKeys = new Set(tier1Rfes.map(function(c) { return c.issueKey }))
 
-  var rawTier2Features = findTier2Features(readFromStorage, index, release, tier1FeatureKeys)
-  var rawTier2Rfes = findTier2Rfes(readFromStorage, index, release, tier1RfeKeys)
+  const rawTier2Features = findTier2Features(readFromStorage, index, release, tier1FeatureKeys)
+  const rawTier2Rfes = findTier2Rfes(readFromStorage, index, release, tier1RfeKeys)
 
   // Post-filter terminal statuses on Tier 2 features
-  var tier2Features = []
-  for (var t2i = 0; t2i < rawTier2Features.length; t2i++) {
-    var t2f = rawTier2Features[t2i]
-    var t2candidate = mapToCandidate(t2f, '', 'tier2')
+  const tier2Features = []
+  for (let t2i = 0; t2i < rawTier2Features.length; t2i++) {
+    const t2f = rawTier2Features[t2i]
+    const t2candidate = mapToCandidate(t2f, '', 'tier2')
 
     if (TERMINAL_STATUSES.indexOf(t2candidate.status) !== -1) {
       terminalFilteredCount++
@@ -175,8 +175,8 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     }
 
     // Enrich with RFE link
-    var t2links = t2f.issueLinks || []
-    var t2rfeLink = findRfeFromLinks(t2links)
+    const t2links = t2f.issueLinks || []
+    const t2rfeLink = findRfeFromLinks(t2links)
     if (t2rfeLink.key) {
       t2candidate.rfe = t2rfeLink.key
       t2candidate.rfeStatus = t2rfeLink.status
@@ -186,23 +186,23 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   }
   tier2Features.sort(sortByPriority)
 
-  var tier2RfesTagged = rawTier2Rfes.map(function(rfe) {
+  const tier2RfesTagged = rawTier2Rfes.map(function(rfe) {
     return Object.assign({}, mapToCandidate(rfe, '', 'tier2'), { tier: 2 })
   })
   tier2RfesTagged.sort(sortByPriority)
 
   // Phase D: Tier 3 discovery
-  var tier2FeatureKeys = new Set(tier2Features.map(function(c) { return c.issueKey }))
-  var tier3Exclude = new Set()
+  const tier2FeatureKeys = new Set(tier2Features.map(function(c) { return c.issueKey }))
+  const tier3Exclude = new Set()
   tier1FeatureKeys.forEach(function(k) { tier3Exclude.add(k) })
   tier2FeatureKeys.forEach(function(k) { tier3Exclude.add(k) })
 
-  var rawTier3Features = findTier3Features(readFromStorage, index, tier3Exclude)
+  const rawTier3Features = findTier3Features(readFromStorage, index, tier3Exclude)
 
-  var tier3Features = []
-  for (var t3i = 0; t3i < rawTier3Features.length; t3i++) {
-    var t3f = rawTier3Features[t3i]
-    var t3candidate = mapToCandidate(t3f, '', 'tier3')
+  const tier3Features = []
+  for (let t3i = 0; t3i < rawTier3Features.length; t3i++) {
+    const t3f = rawTier3Features[t3i]
+    const t3candidate = mapToCandidate(t3f, '', 'tier3')
 
     if (TERMINAL_STATUSES.indexOf(t3candidate.status) !== -1) {
       terminalFilteredCount++
@@ -212,8 +212,8 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     if (t3candidate.targetRelease || t3candidate.fixVersion) continue
 
     // Enrich with RFE link
-    var t3links = t3f.issueLinks || []
-    var t3rfeLink = findRfeFromLinks(t3links)
+    const t3links = t3f.issueLinks || []
+    const t3rfeLink = findRfeFromLinks(t3links)
     if (t3rfeLink.key) {
       t3candidate.rfe = t3rfeLink.key
       t3candidate.rfeStatus = t3rfeLink.status
@@ -223,15 +223,15 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   }
   tier3Features.sort(sortByPriority)
 
-  var allFeatures = tier1Features.concat(tier2Features, tier3Features)
-  var allRfes = tier1Rfes.concat(tier2RfesTagged)
+  const allFeatures = tier1Features.concat(tier2Features, tier3Features)
+  const allRfes = tier1Rfes.concat(tier2RfesTagged)
 
   // Per-rock stats
-  var perRockStats = {}
-  for (var si = 0; si < rocksWithOutcomes.length; si++) {
-    var statRock = rocksWithOutcomes[si]
-    var rockFeatures = tier1Features.filter(function(c) { return c.bigRock.split(', ')[0] === statRock.name }).length
-    var rockRfes = tier1Rfes.filter(function(c) { return c.bigRock.split(', ')[0] === statRock.name }).length
+  const perRockStats = {}
+  for (let si = 0; si < rocksWithOutcomes.length; si++) {
+    const statRock = rocksWithOutcomes[si]
+    const rockFeatures = tier1Features.filter(function(c) { return c.bigRock.split(', ')[0] === statRock.name }).length
+    const rockRfes = tier1Rfes.filter(function(c) { return c.bigRock.split(', ')[0] === statRock.name }).length
     perRockStats[statRock.name] = { features: rockFeatures, rfes: rockRfes }
   }
 
@@ -253,36 +253,36 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
 }
 
 function buildCandidateResponse(pipelineResult, version, bigRocks, demoMode) {
-  var features = pipelineResult.features
-  var rfes = pipelineResult.rfes
-  var outcomeSummaries = pipelineResult.outcomeSummaries
-  var perRockStats = pipelineResult.perRockStats
+  const features = pipelineResult.features
+  const rfes = pipelineResult.rfes
+  const outcomeSummaries = pipelineResult.outcomeSummaries
+  const perRockStats = pipelineResult.perRockStats
 
-  var allStatuses = new Set()
-  var allTeams = new Set()
-  var allPriorities = new Set()
-  var allPillars = new Set()
+  const allStatuses = new Set()
+  const allTeams = new Set()
+  const allPriorities = new Set()
+  const allPillars = new Set()
 
-  for (var fi = 0; fi < features.length; fi++) {
+  for (let fi = 0; fi < features.length; fi++) {
     if (features[fi].status) allStatuses.add(features[fi].status)
     if (features[fi].components) {
-      var parts = features[fi].components.split(', ')
-      for (var pi = 0; pi < parts.length; pi++) {
-        var trimmed = parts[pi].trim()
+      const parts = features[fi].components.split(', ')
+      for (let pi = 0; pi < parts.length; pi++) {
+        const trimmed = parts[pi].trim()
         if (trimmed) allTeams.add(trimmed)
       }
     }
     if (features[fi].priority) allPriorities.add(features[fi].priority)
   }
-  for (var ri = 0; ri < rfes.length; ri++) {
+  for (let ri = 0; ri < rfes.length; ri++) {
     if (rfes[ri].status) allStatuses.add(rfes[ri].status)
     if (rfes[ri].priority) allPriorities.add(rfes[ri].priority)
   }
-  for (var bi = 0; bi < bigRocks.length; bi++) {
+  for (let bi = 0; bi < bigRocks.length; bi++) {
     if (bigRocks[bi].pillar) allPillars.add(bigRocks[bi].pillar)
   }
 
-  var rockSummaries = bigRocks.map(function(rock) {
+  const rockSummaries = bigRocks.map(function(rock) {
     return {
       priority: rock.priority,
       name: rock.name,
@@ -299,10 +299,10 @@ function buildCandidateResponse(pipelineResult, version, bigRocks, demoMode) {
   })
 
   // Fill in outcome descriptions
-  for (var si = 0; si < rockSummaries.length; si++) {
-    var rockSum = rockSummaries[si]
-    for (var ki = 0; ki < rockSum.outcomeKeys.length; ki++) {
-      var oKey = rockSum.outcomeKeys[ki]
+  for (let si = 0; si < rockSummaries.length; si++) {
+    const rockSum = rockSummaries[si]
+    for (let ki = 0; ki < rockSum.outcomeKeys.length; ki++) {
+      const oKey = rockSum.outcomeKeys[ki]
       if (outcomeSummaries[oKey]) {
         rockSum.outcomeDescriptions[oKey] = outcomeSummaries[oKey]
       }

--- a/modules/release-planning/server/pm-auth.js
+++ b/modules/release-planning/server/pm-auth.js
@@ -7,7 +7,7 @@
 
 function createRequirePM(readFromStorage) {
   function isPM(email) {
-    var pmList = readFromStorage('release-planning/pm-users.json')
+    const pmList = readFromStorage('release-planning/pm-users.json')
     return pmList && pmList.emails && pmList.emails.includes(email.toLowerCase())
   }
 
@@ -20,13 +20,13 @@ function createRequirePM(readFromStorage) {
 }
 
 function getPMUsers(readFromStorage) {
-  var data = readFromStorage('release-planning/pm-users.json')
+  const data = readFromStorage('release-planning/pm-users.json')
   return (data && data.emails) || []
 }
 
 function addPMUser(readFromStorage, writeToStorage, email) {
-  var normalized = email.toLowerCase()
-  var data = readFromStorage('release-planning/pm-users.json') || { emails: [] }
+  const normalized = email.toLowerCase()
+  const data = readFromStorage('release-planning/pm-users.json') || { emails: [] }
   if (!data.emails.includes(normalized)) {
     data.emails.push(normalized)
     writeToStorage('release-planning/pm-users.json', data)
@@ -35,15 +35,15 @@ function addPMUser(readFromStorage, writeToStorage, email) {
 }
 
 function removePMUser(readFromStorage, writeToStorage, email) {
-  var normalized = email.toLowerCase()
-  var data = readFromStorage('release-planning/pm-users.json') || { emails: [] }
+  const normalized = email.toLowerCase()
+  const data = readFromStorage('release-planning/pm-users.json') || { emails: [] }
   data.emails = data.emails.filter(function(e) { return e !== normalized })
   writeToStorage('release-planning/pm-users.json', data)
   return data.emails
 }
 
 function isPM(email, readFromStorage) {
-  var pmList = readFromStorage('release-planning/pm-users.json')
+  const pmList = readFromStorage('release-planning/pm-users.json')
   return !!(pmList && pmList.emails && pmList.emails.includes(email.toLowerCase()))
 }
 

--- a/modules/release-planning/server/validation.js
+++ b/modules/release-planning/server/validation.js
@@ -54,7 +54,7 @@ function validateBigRock(data, options) {
   }
 
   // String fields: max length
-  var field
+  let field
   for (field of ['fullName', 'pillar', 'state', 'owner', 'architect', 'notes', 'description']) {
     if (data[field] && typeof data[field] === 'string' && data[field].length > FIELD_LIMITS[field]) {
       errors[field] = `${field} must be ${FIELD_LIMITS[field]} characters or fewer`


### PR DESCRIPTION
## Summary
- Convert all 673 `var` declarations to `const`/`let` across the release-planning module (25 files)
- ESLint `no-var` + `prefer-const` auto-fix handled the bulk; 3 edge cases fixed manually
- Zero functional changes — pure mechanical modernization

## Test plan
- [x] All 1475 tests pass
- [x] ESLint clean (no errors/warnings)
- [x] `git diff --stat` confirms exact 673:673 replacement ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)