### PR TITLE
feat(release-planning): ETag-based conditional caching

### DIFF
--- a/modules/release-planning/__tests__/server/routes.test.js
+++ b/modules/release-planning/__tests__/server/routes.test.js
@@ -77,14 +77,26 @@ function makeRes() {
   const res = {
     _status: 200,
     _json: null,
+    _headers: {},
+    _ended: false,
     status: function(code) { res._status = code; return res },
-    json: function(data) { res._json = data; return res }
+    json: function(data) { res._json = data; return res },
+    set: function(key, value) { res._headers[key] = value; return res },
+    end: function() { res._ended = true; return res },
+    send: function(body) {
+      if (typeof body === 'string') {
+        try { res._json = JSON.parse(body) } catch { res._json = body }
+      } else {
+        res._json = body
+      }
+      return res
+    }
   }
   return res
 }
 
 function makeReq(overrides) {
-  return Object.assign({ isAdmin: true, userEmail: 'admin@test.com', body: {}, params: {}, query: {} }, overrides)
+  return Object.assign({ isAdmin: true, userEmail: 'admin@test.com', body: {}, params: {}, query: {}, headers: {} }, overrides)
 }
 
 function callRoute(routes, method, path, req) {
@@ -231,6 +243,45 @@ describe('release-planning routes', function() {
       const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._status).toBe(202)
       expect(res._json._noCache).toBe(true)
+    })
+
+    it('returns ETag header with cached response', function() {
+      storage._store['release-planning/candidates-cache-3.5.json'] = {
+        cachedAt: new Date().toISOString(),
+        data: { features: [], rfes: [], bigRocks: [], summary: null }
+      }
+      const req = makeReq({ params: { version: '3.5' }, query: {} })
+      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      expect(res._headers['ETag']).toBeDefined()
+      expect(res._headers['ETag']).toMatch(/^"[a-f0-9]+"$/)
+    })
+
+    it('returns 304 when If-None-Match matches ETag', function() {
+      storage._store['release-planning/candidates-cache-3.5.json'] = {
+        cachedAt: new Date().toISOString(),
+        data: { features: [], rfes: [], bigRocks: [], summary: null }
+      }
+      // First request to get the ETag
+      const req1 = makeReq({ params: { version: '3.5' }, query: {} })
+      const res1 = callRoute(router._routes, 'GET', '/releases/:version/candidates', req1)
+      const etag = res1._headers['ETag']
+
+      // Second request with matching If-None-Match
+      const req2 = makeReq({ params: { version: '3.5' }, query: {}, headers: { 'if-none-match': etag } })
+      const res2 = callRoute(router._routes, 'GET', '/releases/:version/candidates', req2)
+      expect(res2._status).toBe(304)
+      expect(res2._ended).toBe(true)
+    })
+
+    it('returns 200 when If-None-Match does not match', function() {
+      storage._store['release-planning/candidates-cache-3.5.json'] = {
+        cachedAt: new Date().toISOString(),
+        data: { features: [{ issueKey: 'TEST-1' }], rfes: [], bigRocks: [], summary: null }
+      }
+      const req = makeReq({ params: { version: '3.5' }, query: {}, headers: { 'if-none-match': '"stale-etag"' } })
+      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      expect(res._status).toBe(200)
+      expect(res._json.features).toHaveLength(1)
     })
   })
 

--- a/modules/release-planning/client/composables/useReleasePlanning.js
+++ b/modules/release-planning/client/composables/useReleasePlanning.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue'
-import { apiRequest } from '@shared/client/services/api'
+import { apiRequest, getApiBase } from '@shared/client/services/api'
 
 const API_BASE = '/modules/release-planning'
 
@@ -10,6 +10,7 @@ const error = ref(null)
 const refreshing = ref(false)
 const cacheStale = ref(false)
 const permissions = ref(null)
+const etagCache = {}
 
 export function useReleasePlanning() {
   async function loadCandidates(version, opts) {
@@ -22,8 +23,32 @@ export function useReleasePlanning() {
     const qs = params.toString()
     const url = `${API_BASE}/releases/${encodeURIComponent(version)}/candidates${qs ? '?' + qs : ''}`
 
+    const cacheKey = version + (opts && opts.rockFilter ? ':' + opts.rockFilter : '')
+    const headers = {}
+    if (etagCache[cacheKey]) {
+      headers['If-None-Match'] = etagCache[cacheKey]
+    }
+
     try {
-      const data = await apiRequest(url)
+      const response = await fetch(`${getApiBase()}${url}`, { headers })
+
+      if (response.status === 304) {
+        // Data unchanged — keep existing candidates
+        loading.value = false
+        return
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(function() { return {} })
+        throw new Error(errorData.error || 'HTTP ' + response.status)
+      }
+
+      const etag = response.headers.get('etag')
+      if (etag) {
+        etagCache[cacheKey] = etag
+      }
+
+      const data = await response.json()
       candidates.value = data
       refreshing.value = !!data._refreshing
       cacheStale.value = !!data._cacheStale

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto')
 const { getConfig, loadBigRocks, getConfiguredReleases, saveBigRock, deleteBigRock, reorderBigRocks, createRelease, cloneRelease, deleteRelease } = require('./config')
 const { runPipeline, buildCandidateResponse } = require('./pipeline')
 const { loadIndex, validateKeysFromCache } = require('./cache-reader')
@@ -29,6 +30,16 @@ module.exports = function registerRoutes(router, context) {
   const requirePM = createRequirePM(readFromStorage)
 
   let refreshState = { running: false, lastResult: null }
+
+  function sendJsonWithETag(req, res, data, statusCode) {
+    const body = JSON.stringify(data)
+    const etag = '"' + crypto.createHash('md5').update(body).digest('hex') + '"'
+    res.set('ETag', etag)
+    if (req.headers['if-none-match'] === etag) {
+      return res.status(304).end()
+    }
+    res.status(statusCode || 200).set('Content-Type', 'application/json').send(body)
+  }
 
   // Demo mode guard: block all non-GET requests when DEMO_MODE is true
   if (DEMO_MODE) {
@@ -173,7 +184,7 @@ module.exports = function registerRoutes(router, context) {
         }
       }
 
-      return res.json({
+      return sendJsonWithETag(req, res, {
         ...data,
         _cacheStale: isStale,
         _refreshing: refreshState.running
@@ -181,7 +192,7 @@ module.exports = function registerRoutes(router, context) {
     }
 
     triggerBackgroundRefresh(version)
-    res.status(202).json({
+    sendJsonWithETag(req, res, {
       _cacheStale: true,
       _refreshing: true,
       _noCache: true,
@@ -190,7 +201,7 @@ module.exports = function registerRoutes(router, context) {
       bigRocks: [],
       summary: null,
       warning: 'Pipeline is running for the first time. This may take a few minutes.'
-    })
+    }, 202)
   })
 
   // POST /releases/:version/refresh


### PR DESCRIPTION
## Summary
- Adds ETag support to the candidates GET endpoint — server computes MD5 hash of the JSON response body and returns it as the `ETag` header
- Client stores ETags per version+filter key and sends `If-None-Match` on subsequent requests
- Server returns `304 Not Modified` when the ETag matches, saving bandwidth during the 3-second refresh polling cycle

## Details
During background pipeline refreshes, the dashboard polls every 3 seconds. Previously every poll returned the full JSON response (~hundreds of KB for large releases) even when nothing changed. With ETag caching, repeated polls during the same cache state return 304 with an empty body.

**Server** (`modules/release-planning/server/index.js`):
- New `sendJsonWithETag()` helper computes MD5 hash of serialized JSON and sets `ETag` header
- Checks `If-None-Match` request header and returns 304 when matched
- Applied to both the 200 (cached data) and 202 (no cache) response paths

**Client** (`modules/release-planning/client/composables/useReleasePlanning.js`):
- Module-level `etagCache` object stores ETags keyed by `version:rockFilter`
- `loadCandidates()` uses `fetch()` directly (instead of `apiRequest()`) to handle 304 responses
- On 304: skips JSON parsing and keeps existing `candidates` data unchanged

**Tests** (`modules/release-planning/__tests__/server/routes.test.js`):
- Updated mock response helper with `set()`, `end()`, and `send()` methods
- Added 3 new tests: ETag header presence, 304 on matching If-None-Match, 200 on mismatched ETag

## Test plan
- [x] All 1478 existing tests pass
- [x] 3 new ETag-specific tests pass
- [x] ESLint clean
- [ ] Manual: load dashboard, observe network tab during background refresh polling — should see 304 responses after first fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)