### PR TITLE
fix(release-planning): eliminate doc import write amplification

### DIFF
--- a/modules/release-planning/__tests__/server/doc-import.test.js
+++ b/modules/release-planning/__tests__/server/doc-import.test.js
@@ -188,6 +188,44 @@ describe('executeDocImport', () => {
     expect(result.validationErrors[0].name).toBe(longName)
   })
 
+  it('writes config exactly once in replace mode', () => {
+    const config = makeConfig([
+      makeRock('Old A', ['RHAISTRAT-100']),
+      makeRock('Old B', ['RHAISTRAT-200']),
+      makeRock('Old C', ['RHAISTRAT-300'])
+    ])
+    const storage = createStorageWithConfig(config)
+    const parsedDoc = makeParsedDoc([
+      makeRock('New 1', ['RHAISTRAT-400']),
+      makeRock('New 2', ['RHAISTRAT-500'])
+    ])
+
+    executeDocImport(
+      storage.readFromStorage, storage.writeToStorage,
+      '3.5', 'test-doc-id', 'replace', parsedDoc
+    )
+
+    expect(storage.writeToStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes config exactly once in append mode', () => {
+    const config = makeConfig([
+      makeRock('Existing', ['RHAISTRAT-100'])
+    ])
+    const storage = createStorageWithConfig(config)
+    const parsedDoc = makeParsedDoc([
+      makeRock('New A', ['RHAISTRAT-200']),
+      makeRock('New B', ['RHAISTRAT-300'])
+    ])
+
+    executeDocImport(
+      storage.readFromStorage, storage.writeToStorage,
+      '3.5', 'test-doc-id', 'append', parsedDoc
+    )
+
+    expect(storage.writeToStorage).toHaveBeenCalledTimes(1)
+  })
+
   it('renumbers priorities sequentially', () => {
     const config = makeConfig([])
     const storage = createStorageWithConfig(config)

--- a/modules/release-planning/server/doc-import.js
+++ b/modules/release-planning/server/doc-import.js
@@ -59,18 +59,6 @@ async function previewDocImport(docIdOrUrl) {
   }
 }
 
-/**
- * Execute the import: validate each rock via validateBigRock, then batch-write
- * all changes in a single config read-modify-write cycle.
- *
- * @param {Function} readFromStorage
- * @param {Function} writeToStorage
- * @param {string} version - Release version
- * @param {string} docIdOrUrl - Google Doc URL or ID (retained for logging/audit)
- * @param {string} mode - "replace" or "append"
- * @param {object} parsedDoc - Pre-fetched parse result from previewDocImport
- * @returns {object} { imported, skipped, skippedNames, validationErrors, mode, bigRocks }
- */
 function normalizeRock(data, priority) {
   return {
     priority: priority,
@@ -86,6 +74,18 @@ function normalizeRock(data, priority) {
   }
 }
 
+/**
+ * Execute the import: validate each rock via validateBigRock, then batch-write
+ * all changes in a single config read-modify-write cycle.
+ *
+ * @param {Function} readFromStorage
+ * @param {Function} writeToStorage
+ * @param {string} version - Release version
+ * @param {string} docIdOrUrl - Google Doc URL or ID (retained for logging/audit)
+ * @param {string} mode - "replace" or "append"
+ * @param {object} parsedDoc - Pre-fetched parse result from previewDocImport
+ * @returns {object} { imported, skipped, skippedNames, validationErrors, mode, bigRocks }
+ */
 function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, mode, parsedDoc) {
   const parsedRocks = parsedDoc.bigRocks
 

--- a/modules/release-planning/server/doc-import.js
+++ b/modules/release-planning/server/doc-import.js
@@ -7,7 +7,7 @@
 
 const googleDocs = require('../../../shared/server/google-docs')
 const { validateBigRock } = require('./validation')
-const { getConfig, saveBigRock, deleteBigRock } = require('./config')
+const { getConfig } = require('./config')
 
 /**
  * Parse a Google Doc URL or ID to extract the document ID.
@@ -60,11 +60,8 @@ async function previewDocImport(docIdOrUrl) {
 }
 
 /**
- * Execute the import: validate each rock via validateBigRock, and persist
- * through saveBigRock / deleteBigRock CRUD functions.
- *
- * This ensures all imported data passes through the same validation and
- * persistence code path as manual CRUD operations.
+ * Execute the import: validate each rock via validateBigRock, then batch-write
+ * all changes in a single config read-modify-write cycle.
  *
  * @param {Function} readFromStorage
  * @param {Function} writeToStorage
@@ -74,6 +71,21 @@ async function previewDocImport(docIdOrUrl) {
  * @param {object} parsedDoc - Pre-fetched parse result from previewDocImport
  * @returns {object} { imported, skipped, skippedNames, validationErrors, mode, bigRocks }
  */
+function normalizeRock(data, priority) {
+  return {
+    priority: priority,
+    name: (data.name || '').trim(),
+    fullName: data.fullName || '',
+    pillar: data.pillar || '',
+    state: data.state || '',
+    owner: data.owner || '',
+    architect: data.architect || '',
+    outcomeKeys: data.outcomeKeys || [],
+    notes: data.notes || '',
+    description: data.description || ''
+  }
+}
+
 function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, mode, parsedDoc) {
   const parsedRocks = parsedDoc.bigRocks
 
@@ -89,34 +101,23 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
     throw Object.assign(new Error('Release ' + version + ' not found'), { statusCode: 404 })
   }
 
-  const existingRocks = config.releases[version].bigRocks || []
+  const bigRocks = mode === 'replace' ? [] : (config.releases[version].bigRocks || []).slice()
+  const existingNames = new Set(bigRocks.map(function(r) { return r.name }))
+
   let imported = 0
   let skipped = 0
   const skippedNames = []
   const validationErrors = []
 
-  if (mode === 'replace') {
-    // Delete all existing rocks first (reverse order to avoid index shift)
-    for (let i = existingRocks.length - 1; i >= 0; i--) {
-      deleteBigRock(readFromStorage, writeToStorage, version, existingRocks[i].name)
-    }
-  }
-
-  // Build the set of names already present (for duplicate + uniqueness checks)
-  const currentRocks = getConfig(readFromStorage).releases[version].bigRocks || []
-  const existingNames = new Set(currentRocks.map(function(r) { return r.name }))
-
   for (let j = 0; j < parsedRocks.length; j++) {
     const rock = parsedRocks[j]
 
-    // Skip duplicates in append mode
     if (mode === 'append' && existingNames.has(rock.name)) {
       skipped++
       skippedNames.push(rock.name)
       continue
     }
 
-    // Validate through the same validator used by CRUD endpoints
     const validation = validateBigRock(rock, {
       existingNames: Array.from(existingNames)
     })
@@ -127,15 +128,17 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
       continue
     }
 
-    // Persist through the standard CRUD function
-    saveBigRock(readFromStorage, writeToStorage, version, null, rock)
+    bigRocks.push(normalizeRock(rock, bigRocks.length + 1))
     existingNames.add(rock.name)
     imported++
   }
 
-  // Read back the final state (authoritative)
-  const finalConfig = getConfig(readFromStorage)
-  const finalRocks = finalConfig.releases[version].bigRocks || []
+  for (let i = 0; i < bigRocks.length; i++) {
+    bigRocks[i].priority = i + 1
+  }
+
+  config.releases[version].bigRocks = bigRocks
+  writeToStorage('release-planning/config.json', config)
 
   return {
     imported: imported,
@@ -143,7 +146,7 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
     skippedNames: skippedNames.length > 0 ? skippedNames : undefined,
     validationErrors: validationErrors.length > 0 ? validationErrors : undefined,
     mode: mode,
-    bigRocks: finalRocks
+    bigRocks: bigRocks
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace mode previously called `deleteBigRock()` N times then `saveBigRock()` M times, each doing a full config.json read-modify-write cycle — O(N+M) disk I/O operations
- Refactored to a single read-modify-write: read config once, clear the array in memory, validate and append new rocks, renumber priorities once, write config once — O(1) disk I/O
- Example: replacing 10 rocks with 15 new ones drops from 52 I/O operations to 2 (one read, one write)

## Details
The `executeDocImport()` function no longer calls `saveBigRock()` or `deleteBigRock()` from `config.js`. Instead it:
1. Reads config once via `getConfig()`
2. In replace mode: starts with an empty array; in append mode: copies existing rocks
3. Validates each parsed rock via `validateBigRock()` and pushes normalized rocks to the array
4. Renumbers priorities once at the end
5. Writes config once via `writeToStorage()`

A new `normalizeRock()` helper replicates the field normalization that `saveBigRock()` does (trimming name, defaulting empty strings for optional fields).

## Test plan
- [x] All 15 doc-import tests pass (including 2 new ones)
- [x] All 250 release-planning tests pass
- [x] New test: `writeToStorage` called exactly once in replace mode
- [x] New test: `writeToStorage` called exactly once in append mode
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)