### PR TITLE
feat(release-planning): Release Plan Health dashboard

### DIFF
--- a/fixtures/release-planning/health-cache-demo.json
+++ b/fixtures/release-planning/health-cache-demo.json
@@ -1,0 +1,415 @@
+{
+  "cachedAt": "2026-04-25T14:30:00.000Z",
+  "version": "3.5",
+  "milestones": {
+    "ea1Freeze": "2026-05-01",
+    "ea1Target": "2026-05-15",
+    "ea2Freeze": "2026-06-15",
+    "ea2Target": "2026-07-01",
+    "gaFreeze": "2026-08-01",
+    "gaTarget": "2026-08-15"
+  },
+  "phase": "all",
+  "summary": {
+    "totalFeatures": 8,
+    "byRisk": { "green": 2, "yellow": 3, "red": 3 },
+    "dorCompletionRate": 62,
+    "averageRiceScore": 310,
+    "blockedCount": 1,
+    "unestimatedCount": 2,
+    "currentPhase": "Pre-EA1",
+    "daysToNextMilestone": 5,
+    "nextMilestone": "EA1 Code Freeze",
+    "planningDeadline": { "date": "2026-04-24", "daysRemaining": -2 }
+  },
+  "features": [
+    {
+      "key": "RHOAIENG-1001",
+      "summary": "MaaS: Multi-model serving with shared GPU",
+      "status": "In Progress",
+      "priority": "Critical",
+      "phase": "GA",
+      "bigRock": "MaaS",
+      "tier": 1,
+      "pm": "Sarah Chen",
+      "deliveryOwner": "David Kim",
+      "components": ["Model Serving"],
+      "completionPct": 75,
+      "epicCount": 4,
+      "issueCount": 28,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "green",
+        "score": 0,
+        "flags": [],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 12,
+        "totalCount": 13,
+        "completionPct": 92,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": { "reach": 2000, "impact": 3, "confidence": 90, "effort": 8, "score": 675, "complete": true },
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1001"
+    },
+    {
+      "key": "RHOAIENG-1002",
+      "summary": "Gen AI Studio: Notebook-based agent builder",
+      "status": "In Progress",
+      "priority": "Major",
+      "phase": "GA",
+      "bigRock": "Gen AI Studio",
+      "tier": 1,
+      "pm": "Maria Lopez",
+      "deliveryOwner": "James Park",
+      "components": ["Workbenches"],
+      "completionPct": 80,
+      "epicCount": 3,
+      "issueCount": 22,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "green",
+        "score": 0,
+        "flags": [],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 11,
+        "totalCount": 13,
+        "completionPct": 85,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": { "reach": 1500, "impact": 2, "confidence": 85, "effort": 5, "score": 510, "complete": true },
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1002"
+    },
+    {
+      "key": "RHOAIENG-1003",
+      "summary": "llm-d: Disaggregated serving with KV cache routing",
+      "status": "In Progress",
+      "priority": "Major",
+      "phase": "DP",
+      "bigRock": "llm-d / xKS",
+      "tier": 1,
+      "pm": "Alex Nguyen",
+      "deliveryOwner": "Priya Sharma",
+      "components": ["Model Serving"],
+      "completionPct": 55,
+      "epicCount": 5,
+      "issueCount": 35,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "yellow",
+        "score": 2,
+        "flags": [
+          { "category": "DOR_INCOMPLETE", "severity": "medium", "message": "DoR completion at 54% (below 80% threshold)" },
+          { "category": "UNESTIMATED", "severity": "medium", "message": "No story point estimate" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 7,
+        "totalCount": 13,
+        "completionPct": 54,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": null,
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1003"
+    },
+    {
+      "key": "RHOAIENG-1004",
+      "summary": "Observability: Distributed tracing for inference pipelines",
+      "status": "In Progress",
+      "priority": "Major",
+      "phase": "GA",
+      "bigRock": "Observability",
+      "tier": 2,
+      "pm": "Tom Wilson",
+      "deliveryOwner": "Rachel Green",
+      "components": ["Dashboard"],
+      "completionPct": 40,
+      "epicCount": 2,
+      "issueCount": 14,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "yellow",
+        "score": 1,
+        "flags": [
+          { "category": "DOR_INCOMPLETE", "severity": "medium", "message": "DoR completion at 62% (below 80% threshold)" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 8,
+        "totalCount": 13,
+        "completionPct": 62,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": { "reach": 800, "impact": 2, "confidence": 70, "effort": 3, "score": 373, "complete": true },
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1004"
+    },
+    {
+      "key": "RHOAIENG-1005",
+      "summary": "Tool Calling: MCP server integration for agent workflows",
+      "status": "Refinement",
+      "priority": "Major",
+      "phase": "GA",
+      "bigRock": "Tool Calling",
+      "tier": 1,
+      "pm": "Linda Zhang",
+      "deliveryOwner": "",
+      "components": ["Agents"],
+      "completionPct": 20,
+      "epicCount": 1,
+      "issueCount": 6,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "yellow",
+        "score": 3,
+        "flags": [
+          { "category": "UNESTIMATED", "severity": "medium", "message": "No story point estimate" },
+          { "category": "DOR_INCOMPLETE", "severity": "medium", "message": "DoR completion at 46% (below 80% threshold)" },
+          { "category": "MISSING_OWNER", "severity": "medium", "message": "No delivery owner assigned" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 6,
+        "totalCount": 13,
+        "completionPct": 46,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": null,
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1005"
+    },
+    {
+      "key": "RHOAIENG-1006",
+      "summary": "Upgrade Support: In-place upgrade from 3.4 to 3.5",
+      "status": "New",
+      "priority": "Critical",
+      "phase": "GA",
+      "bigRock": "Upgrade Support",
+      "tier": 1,
+      "pm": "Tom Wilson",
+      "deliveryOwner": "Chris Evans",
+      "components": ["Operator"],
+      "completionPct": 0,
+      "epicCount": 0,
+      "issueCount": 2,
+      "blockerCount": 1,
+      "health": "",
+      "risk": {
+        "level": "red",
+        "score": 3,
+        "flags": [
+          { "category": "DOR_INCOMPLETE", "severity": "high", "message": "DoR completion at 31% (below 50% threshold)" },
+          { "category": "UNESTIMATED", "severity": "medium", "message": "No story point estimate" },
+          { "category": "BLOCKED", "severity": "high", "message": "Blocked by RHOAIENG-998 (In Progress)" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 4,
+        "totalCount": 13,
+        "completionPct": 31,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": { "reach": 3000, "impact": 3, "confidence": 60, "effort": 12, "score": 450, "complete": true },
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1006"
+    },
+    {
+      "key": "RHOAIENG-1007",
+      "summary": "Eval Hub: Centralized evaluation framework",
+      "status": "New",
+      "priority": "Major",
+      "phase": "TP",
+      "bigRock": "Eval Hub",
+      "tier": 2,
+      "pm": "",
+      "deliveryOwner": "",
+      "components": [],
+      "completionPct": 0,
+      "epicCount": 0,
+      "issueCount": 1,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "red",
+        "score": 4,
+        "flags": [
+          { "category": "DOR_INCOMPLETE", "severity": "high", "message": "DoR completion at 15% (below 50% threshold)" },
+          { "category": "UNESTIMATED", "severity": "medium", "message": "No story point estimate" },
+          { "category": "MISSING_OWNER", "severity": "medium", "message": "No delivery owner assigned" },
+          { "category": "VELOCITY_LAG", "severity": "medium", "message": "Completion at 0% vs expected 30% for TP at Pre-EA1" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 2,
+        "totalCount": 13,
+        "completionPct": 15,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": null,
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1007"
+    },
+    {
+      "key": "RHOAIENG-1008",
+      "summary": "Multitenancy: Namespace-scoped model serving isolation",
+      "status": "Refinement",
+      "priority": "Critical",
+      "phase": "GA",
+      "bigRock": "Multitenancy",
+      "tier": 1,
+      "pm": "Sarah Chen",
+      "deliveryOwner": "Priya Sharma",
+      "components": ["Model Serving", "Dashboard"],
+      "completionPct": 15,
+      "epicCount": 3,
+      "issueCount": 18,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "red",
+        "score": 2,
+        "flags": [
+          { "category": "DOR_INCOMPLETE", "severity": "high", "message": "DoR completion at 38% (below 50% threshold)" },
+          { "category": "VELOCITY_LAG", "severity": "high", "message": "Completion at 15% vs expected 70% for GA at Pre-EA1" }
+        ],
+        "override": { "riskOverride": "yellow", "reason": "Team confirmed design is complete, implementation sprint starting next week", "updatedBy": "sarah@redhat.com", "updatedAt": "2026-04-24T09:15:00.000Z" }
+      },
+      "dor": {
+        "checkedCount": 5,
+        "totalCount": 13,
+        "completionPct": 38,
+        "items": [
+          { "id": "F-1", "label": "Summary and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target version set", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-3", "label": "Stakeholders identified", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-6", "label": "Component assigned", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-7", "label": "Story points estimated", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blockers", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-9", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-10", "label": "Release type set", "type": "automated", "checked": false, "source": "jira" },
+          { "id": "F-11", "label": "Test plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Documentation plan exists", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Security review completed", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": { "reach": 1200, "impact": 3, "confidence": 75, "effort": 10, "score": 270, "complete": true },
+      "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1008"
+    }
+  ],
+  "enrichmentStatus": {
+    "jiraQueriesRun": 3,
+    "featuresEnriched": 8,
+    "featuresSkipped": 0,
+    "riceAvailable": true,
+    "warnings": []
+  }
+}

--- a/modules/release-planning/__tests__/client/health-components.test.js
+++ b/modules/release-planning/__tests__/client/health-components.test.js
@@ -1,0 +1,406 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RiskBadge from '../../client/components/RiskBadge.vue'
+import HealthSummaryCards from '../../client/components/HealthSummaryCards.vue'
+import DorChecklist from '../../client/components/DorChecklist.vue'
+import RiceScoreDisplay from '../../client/components/RiceScoreDisplay.vue'
+import HealthFilterBar from '../../client/components/HealthFilterBar.vue'
+import MilestoneTimeline from '../../client/components/MilestoneTimeline.vue'
+import FeatureHealthTable from '../../client/components/FeatureHealthTable.vue'
+import PhaseSelector from '../../client/components/PhaseSelector.vue'
+
+// ─── RiskBadge ───
+
+describe('RiskBadge', function() {
+  it('renders Green label by default', function() {
+    var wrapper = mount(RiskBadge)
+    expect(wrapper.text()).toContain('Green')
+  })
+
+  it('renders Red label for level red', function() {
+    var wrapper = mount(RiskBadge, { props: { level: 'red' } })
+    expect(wrapper.text()).toContain('Red')
+  })
+
+  it('renders Yellow label for level yellow', function() {
+    var wrapper = mount(RiskBadge, { props: { level: 'yellow' } })
+    expect(wrapper.text()).toContain('Yellow')
+  })
+
+  it('applies red color classes for red level', function() {
+    var wrapper = mount(RiskBadge, { props: { level: 'red' } })
+    expect(wrapper.find('span').classes().join(' ')).toContain('red')
+  })
+
+  it('shows flag count superscript when flagCount > 0', function() {
+    var wrapper = mount(RiskBadge, { props: { level: 'yellow', flagCount: 3 } })
+    var sup = wrapper.find('sup')
+    expect(sup.exists()).toBe(true)
+    expect(sup.text()).toBe('3')
+  })
+
+  it('does not show superscript when flagCount is 0', function() {
+    var wrapper = mount(RiskBadge, { props: { level: 'green', flagCount: 0 } })
+    expect(wrapper.find('sup').exists()).toBe(false)
+  })
+
+  it('shows override indicator when override is present', function() {
+    var wrapper = mount(RiskBadge, {
+      props: { level: 'red', override: { riskOverride: 'green', reason: 'PM approved' } }
+    })
+    expect(wrapper.text()).toContain('M')
+  })
+
+  it('displays override level instead of original level', function() {
+    var wrapper = mount(RiskBadge, {
+      props: { level: 'red', override: { riskOverride: 'green', reason: 'PM approved' } }
+    })
+    expect(wrapper.text()).toContain('Green')
+  })
+})
+
+// ─── HealthSummaryCards ───
+
+describe('HealthSummaryCards', function() {
+  var summary = {
+    totalFeatures: 10,
+    byRisk: { green: 5, yellow: 3, red: 2 },
+    dorCompletionRate: 65,
+    averageRiceScore: 200
+  }
+
+  it('renders nothing when summary is null', function() {
+    var wrapper = mount(HealthSummaryCards, { props: { summary: null } })
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('renders risk count cards', function() {
+    var wrapper = mount(HealthSummaryCards, { props: { summary: summary } })
+    expect(wrapper.text()).toContain('5')
+    expect(wrapper.text()).toContain('3')
+    expect(wrapper.text()).toContain('2')
+  })
+
+  it('renders DoR completion percentage', function() {
+    var wrapper = mount(HealthSummaryCards, { props: { summary: summary } })
+    expect(wrapper.text()).toContain('65')
+  })
+
+  it('emits filterByRisk when a risk card is clicked', async function() {
+    var wrapper = mount(HealthSummaryCards, { props: { summary: summary } })
+    var buttons = wrapper.findAll('button')
+    await buttons[0].trigger('click')
+    expect(wrapper.emitted('filterByRisk')).toBeDefined()
+  })
+
+  it('renders planning deadline card when planningDeadline is present', function() {
+    var summaryWithDeadline = Object.assign({}, summary, {
+      planningDeadline: { date: '2026-05-01', daysRemaining: 5 }
+    })
+    var wrapper = mount(HealthSummaryCards, { props: { summary: summaryWithDeadline } })
+    expect(wrapper.text()).toContain('Planning Deadline')
+    expect(wrapper.text()).toContain('2026-05-01')
+  })
+
+  it('does not render planning deadline card when planningDeadline is null', function() {
+    var wrapper = mount(HealthSummaryCards, { props: { summary: summary } })
+    expect(wrapper.text()).not.toContain('Planning Deadline')
+  })
+
+  it('shows days remaining for planning deadline', function() {
+    var summaryWithDeadline = Object.assign({}, summary, {
+      planningDeadline: { date: '2026-05-01', daysRemaining: 10 }
+    })
+    var wrapper = mount(HealthSummaryCards, { props: { summary: summaryWithDeadline } })
+    expect(wrapper.text()).toContain('10')
+  })
+})
+
+// ─── DorChecklist ───
+
+describe('DorChecklist', function() {
+  var items = [
+    { id: 'F-1', label: 'Description exists', type: 'automated', checked: true, source: 'jira' },
+    { id: 'F-2', label: 'Target version set', type: 'automated', checked: false, source: 'jira' },
+    { id: 'F-3', label: 'Stakeholders identified', type: 'manual', checked: false, source: 'manual' }
+  ]
+
+  it('renders all items', function() {
+    var wrapper = mount(DorChecklist, { props: { items: items, canEdit: false } })
+    expect(wrapper.text()).toContain('Description exists')
+    expect(wrapper.text()).toContain('Target version set')
+    expect(wrapper.text()).toContain('Stakeholders identified')
+  })
+
+  it('displays checked count in header', function() {
+    var wrapper = mount(DorChecklist, { props: { items: items, canEdit: false } })
+    expect(wrapper.text()).toContain('1/3')
+  })
+
+  it('shows lock icon for automated items', function() {
+    var wrapper = mount(DorChecklist, { props: { items: items, canEdit: true } })
+    var automatedRows = wrapper.findAll('[data-automated]').length
+    || wrapper.findAll('svg').length
+    expect(automatedRows).toBeGreaterThan(0)
+  })
+
+  it('emits toggleItem when manual item row is clicked and canEdit is true', async function() {
+    var wrapper = mount(DorChecklist, { props: { items: items, canEdit: true, featureKey: 'T-1' } })
+    var checkboxes = wrapper.findAll('input[type="checkbox"]')
+    if (checkboxes.length > 0) {
+      await checkboxes[0].trigger('click')
+      expect(wrapper.emitted('toggleItem')).toBeDefined()
+    }
+  })
+
+  it('shows textarea when canEdit is true', function() {
+    var wrapper = mount(DorChecklist, { props: { items: items, canEdit: true, notes: '' } })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  it('shows read-only notes when canEdit is false and notes exist', function() {
+    var wrapper = mount(DorChecklist, { props: { items: items, canEdit: false, notes: 'Some notes here' } })
+    expect(wrapper.text()).toContain('Some notes here')
+  })
+})
+
+// ─── RiceScoreDisplay ───
+
+describe('RiceScoreDisplay', function() {
+  it('shows N/A when rice is null', function() {
+    var wrapper = mount(RiceScoreDisplay, { props: { rice: null } })
+    expect(wrapper.text()).toContain('N/A')
+  })
+
+  it('shows score when rice data is complete', function() {
+    var wrapper = mount(RiceScoreDisplay, {
+      props: { rice: { reach: 1000, impact: 2, confidence: 80, effort: 4, score: 400, complete: true } }
+    })
+    expect(wrapper.text()).toContain('400')
+  })
+
+  it('shows N/A when rice has no score', function() {
+    var wrapper = mount(RiceScoreDisplay, {
+      props: { rice: { reach: 1000, impact: null, confidence: 80, effort: 4, score: null, complete: false } }
+    })
+    expect(wrapper.text()).toContain('N/A')
+  })
+
+  it('expands breakdown on click when score exists', async function() {
+    var wrapper = mount(RiceScoreDisplay, {
+      props: { rice: { reach: 1000, impact: 2, confidence: 80, effort: 4, score: 400, complete: true } }
+    })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.text()).toContain('Reach')
+    expect(wrapper.text()).toContain('1000')
+    expect(wrapper.text()).toContain('Impact')
+    expect(wrapper.text()).toContain('Confidence')
+    expect(wrapper.text()).toContain('Effort')
+  })
+
+  it('does not expand on click when score is null', async function() {
+    var wrapper = mount(RiceScoreDisplay, { props: { rice: null } })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.text()).not.toContain('Reach')
+  })
+})
+
+// ─── PhaseSelector ───
+
+describe('PhaseSelector', function() {
+  var phases = [
+    { value: 'EA1', label: 'RHOAI 3.5 EA1' },
+    { value: 'EA2', label: 'RHOAI 3.5 EA2' },
+    { value: 'GA', label: 'RHOAI 3.5 GA' }
+  ]
+
+  it('renders select with All Phases option', function() {
+    var wrapper = mount(PhaseSelector, { props: { phases: phases, modelValue: '' } })
+    expect(wrapper.find('select').exists()).toBe(true)
+    expect(wrapper.text()).toContain('All Phases')
+  })
+
+  it('renders all provided phase options', function() {
+    var wrapper = mount(PhaseSelector, { props: { phases: phases, modelValue: '' } })
+    expect(wrapper.text()).toContain('RHOAI 3.5 EA1')
+    expect(wrapper.text()).toContain('RHOAI 3.5 EA2')
+    expect(wrapper.text()).toContain('RHOAI 3.5 GA')
+  })
+
+  it('emits update:modelValue on change', async function() {
+    var wrapper = mount(PhaseSelector, { props: { phases: phases, modelValue: '' } })
+    await wrapper.find('select').setValue('EA2')
+    expect(wrapper.emitted('update:modelValue')).toBeDefined()
+    expect(wrapper.emitted('update:modelValue')[0][0]).toBe('EA2')
+  })
+
+  it('renders empty when no phases provided', function() {
+    var wrapper = mount(PhaseSelector, { props: { phases: [], modelValue: '' } })
+    var options = wrapper.findAll('option')
+    expect(options.length).toBe(1)
+    expect(options[0].text()).toContain('All Phases')
+  })
+})
+
+// ─── HealthFilterBar ───
+
+describe('HealthFilterBar', function() {
+  it('renders search input', function() {
+    var wrapper = mount(HealthFilterBar)
+    expect(wrapper.find('input').exists()).toBe(true)
+  })
+
+  it('renders risk filter select', function() {
+    var wrapper = mount(HealthFilterBar)
+    var selects = wrapper.findAll('select')
+    expect(selects.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders big rocks select when bigRocks provided', function() {
+    var wrapper = mount(HealthFilterBar, { props: { bigRocks: ['Rock A', 'Rock B'] } })
+    expect(wrapper.text()).toContain('Rock A')
+    expect(wrapper.text()).toContain('Rock B')
+  })
+
+  it('renders components select when components provided', function() {
+    var wrapper = mount(HealthFilterBar, { props: { components: ['Model Serving', 'Pipelines'] } })
+    expect(wrapper.text()).toContain('Model Serving')
+    expect(wrapper.text()).toContain('Pipelines')
+  })
+
+  it('renders tier filter select', function() {
+    var wrapper = mount(HealthFilterBar)
+    expect(wrapper.text()).toContain('All Tiers')
+    expect(wrapper.text()).toContain('Tier 1')
+    expect(wrapper.text()).toContain('Tier 2')
+    expect(wrapper.text()).toContain('Tier 3')
+  })
+
+  it('emits update:tierFilter on tier select change', async function() {
+    var wrapper = mount(HealthFilterBar)
+    var tierSelect = wrapper.findAll('select').filter(function(s) {
+      return s.text().includes('All Tiers')
+    })
+    if (tierSelect.length > 0) {
+      await tierSelect[0].setValue('2')
+      expect(wrapper.emitted('update:tierFilter')).toBeDefined()
+      expect(wrapper.emitted('update:tierFilter')[0][0]).toBe('2')
+    }
+  })
+
+  it('shows clear button when hasActiveFilters is true', function() {
+    var wrapper = mount(HealthFilterBar, { props: { hasActiveFilters: true } })
+    var clearBtn = wrapper.findAll('button').filter(function(b) { return b.text().toLowerCase().includes('clear') })
+    expect(clearBtn.length).toBeGreaterThan(0)
+  })
+
+  it('hides clear button when hasActiveFilters is false', function() {
+    var wrapper = mount(HealthFilterBar, { props: { hasActiveFilters: false } })
+    var clearBtn = wrapper.findAll('button').filter(function(b) { return b.text().toLowerCase().includes('clear') })
+    expect(clearBtn.length).toBe(0)
+  })
+
+  it('emits clearFilters when clear button is clicked', async function() {
+    var wrapper = mount(HealthFilterBar, { props: { hasActiveFilters: true } })
+    var clearBtn = wrapper.findAll('button').filter(function(b) { return b.text().toLowerCase().includes('clear') })
+    if (clearBtn.length > 0) {
+      await clearBtn[0].trigger('click')
+      expect(wrapper.emitted('clearFilters')).toBeDefined()
+    }
+  })
+
+  it('emits update:searchQuery on input', async function() {
+    var wrapper = mount(HealthFilterBar)
+    await wrapper.find('input').setValue('test query')
+    expect(wrapper.emitted('update:searchQuery')).toBeDefined()
+    expect(wrapper.emitted('update:searchQuery')[0][0]).toBe('test query')
+  })
+})
+
+// ─── MilestoneTimeline ───
+
+describe('MilestoneTimeline', function() {
+  var milestones = {
+    ea1Freeze: '2026-05-01',
+    ea1Target: '2026-05-15',
+    ea2Freeze: '2026-06-15',
+    ea2Target: '2026-07-01',
+    gaFreeze: '2026-08-01',
+    gaTarget: '2026-08-15'
+  }
+
+  it('shows fallback when milestones is null', function() {
+    var wrapper = mount(MilestoneTimeline, { props: { milestones: null } })
+    expect(wrapper.text()).toContain('Milestone')
+  })
+
+  it('renders milestone labels when data provided', function() {
+    var wrapper = mount(MilestoneTimeline, { props: { milestones: milestones } })
+    expect(wrapper.text()).toContain('EA1')
+    expect(wrapper.text()).toContain('GA')
+  })
+
+  it('shows next milestone countdown', function() {
+    var wrapper = mount(MilestoneTimeline, { props: { milestones: milestones } })
+    var text = wrapper.text()
+    if (text.includes('day')) {
+      expect(text).toMatch(/\d+\s*day/)
+    }
+  })
+
+  it('renders milestone points', function() {
+    var wrapper = mount(MilestoneTimeline, { props: { milestones: milestones } })
+    expect(wrapper.findAll('[class*="rounded-full"]').length || wrapper.findAll('div').length).toBeGreaterThan(0)
+  })
+})
+
+// ─── FeatureHealthTable ───
+
+describe('FeatureHealthTable', function() {
+  var features = [
+    {
+      key: 'T-1', summary: 'Feature 1', status: 'In Progress',
+      risk: { level: 'green', flags: [], riskScore: 0 },
+      dor: { checkedCount: 10, totalCount: 13, completionPct: 77, items: [] },
+      rice: null, components: ['Model Serving'], phase: 'GA', bigRock: 'MaaS'
+    },
+    {
+      key: 'T-2', summary: 'Feature 2', status: 'New',
+      risk: { level: 'red', flags: [{ category: 'MILESTONE_MISS', severity: 'high' }], riskScore: 1 },
+      dor: { checkedCount: 3, totalCount: 13, completionPct: 23, items: [] },
+      rice: { score: 250, complete: true }, components: ['Pipelines'], phase: 'TP', bigRock: null
+    }
+  ]
+
+  it('renders table headers', function() {
+    var wrapper = mount(FeatureHealthTable, { props: { features: features } })
+    expect(wrapper.text()).toContain('Feature')
+    expect(wrapper.text()).toContain('Summary')
+    expect(wrapper.text()).toContain('Risk')
+  })
+
+  it('shows empty state when features array is empty', function() {
+    var wrapper = mount(FeatureHealthTable, { props: { features: [] } })
+    expect(wrapper.text()).toContain('No features')
+  })
+
+  it('renders feature rows', function() {
+    var wrapper = mount(FeatureHealthTable, { props: { features: features } })
+    expect(wrapper.text()).toContain('T-1')
+    expect(wrapper.text()).toContain('T-2')
+    expect(wrapper.text()).toContain('Feature 1')
+    expect(wrapper.text()).toContain('Feature 2')
+  })
+
+  it('does not show pagination for small feature lists', function() {
+    var wrapper = mount(FeatureHealthTable, { props: { features: features } })
+    expect(wrapper.text()).not.toContain('Next')
+  })
+
+  it('sorts features by risk by default (red first)', function() {
+    var wrapper = mount(FeatureHealthTable, { props: { features: features } })
+    var rows = wrapper.findAll('tr')
+    var firstDataRow = rows.length > 1 ? rows[1].text() : ''
+    expect(firstDataRow).toContain('T-2')
+  })
+})

--- a/modules/release-planning/__tests__/server/dor-checker.test.js
+++ b/modules/release-planning/__tests__/server/dor-checker.test.js
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest'
+
+const { DOR_ITEMS, evaluateDor } = require('../../server/health/dor-checker')
+
+describe('DOR_ITEMS', function() {
+  it('has 13 items', function() {
+    expect(DOR_ITEMS).toHaveLength(13)
+  })
+
+  it('has 8 automated items', function() {
+    var automated = DOR_ITEMS.filter(function(i) { return i.type === 'automated' })
+    expect(automated).toHaveLength(8)
+  })
+
+  it('has 5 manual items', function() {
+    var manual = DOR_ITEMS.filter(function(i) { return i.type === 'manual' })
+    expect(manual).toHaveLength(5)
+  })
+
+  it('has unique ids', function() {
+    var ids = DOR_ITEMS.map(function(i) { return i.id })
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('evaluateDor', function() {
+  it('returns all 13 items', function() {
+    var result = evaluateDor({}, null, null)
+    expect(result.items).toHaveLength(13)
+    expect(result.totalCount).toBe(13)
+  })
+
+  it('F-1 passes when summary exists and enrichment has description', function() {
+    var feature = { summary: 'A feature' }
+    var enrichment = { hasDescription: true }
+    var result = evaluateDor(feature, enrichment, null)
+    var f1 = result.items.find(function(i) { return i.id === 'F-1' })
+    expect(f1.checked).toBe(true)
+  })
+
+  it('F-1 fails when enrichment has no description', function() {
+    var feature = { summary: 'A feature' }
+    var enrichment = { hasDescription: false }
+    var result = evaluateDor(feature, enrichment, null)
+    var f1 = result.items.find(function(i) { return i.id === 'F-1' })
+    expect(f1.checked).toBe(false)
+  })
+
+  it('F-1 fails when summary is empty', function() {
+    var result = evaluateDor({ summary: '' }, { hasDescription: true }, null)
+    var f1 = result.items.find(function(i) { return i.id === 'F-1' })
+    expect(f1.checked).toBe(false)
+  })
+
+  it('F-2 passes when targetVersions is non-empty', function() {
+    var result = evaluateDor({ targetVersions: ['3.5'] }, null, null)
+    var f2 = result.items.find(function(i) { return i.id === 'F-2' })
+    expect(f2.checked).toBe(true)
+  })
+
+  it('F-2 fails when targetVersions is empty', function() {
+    var result = evaluateDor({ targetVersions: [] }, null, null)
+    var f2 = result.items.find(function(i) { return i.id === 'F-2' })
+    expect(f2.checked).toBe(false)
+  })
+
+  it('F-4 passes when pm is a non-empty string', function() {
+    var result = evaluateDor({ pm: 'Jane Doe' }, null, null)
+    var f4 = result.items.find(function(i) { return i.id === 'F-4' })
+    expect(f4.checked).toBe(true)
+  })
+
+  it('F-4 passes when pm is an object with displayName', function() {
+    var result = evaluateDor({ pm: { displayName: 'Jane Doe' } }, null, null)
+    var f4 = result.items.find(function(i) { return i.id === 'F-4' })
+    expect(f4.checked).toBe(true)
+  })
+
+  it('F-4 fails when pm is null', function() {
+    var result = evaluateDor({ pm: null }, null, null)
+    var f4 = result.items.find(function(i) { return i.id === 'F-4' })
+    expect(f4.checked).toBe(false)
+  })
+
+  it('F-5 passes when assignee is a non-empty string', function() {
+    var result = evaluateDor({ assignee: 'John Smith' }, null, null)
+    var f5 = result.items.find(function(i) { return i.id === 'F-5' })
+    expect(f5.checked).toBe(true)
+  })
+
+  it('F-5 passes when assignee has displayName', function() {
+    var result = evaluateDor({ assignee: { displayName: 'John' } }, null, null)
+    var f5 = result.items.find(function(i) { return i.id === 'F-5' })
+    expect(f5.checked).toBe(true)
+  })
+
+  it('F-5 fails when assignee is null', function() {
+    var result = evaluateDor({ assignee: null }, null, null)
+    var f5 = result.items.find(function(i) { return i.id === 'F-5' })
+    expect(f5.checked).toBe(false)
+  })
+
+  it('F-6 passes when components is a non-empty array', function() {
+    var result = evaluateDor({ components: ['Model Serving'] }, null, null)
+    var f6 = result.items.find(function(i) { return i.id === 'F-6' })
+    expect(f6.checked).toBe(true)
+  })
+
+  it('F-6 fails when components is empty', function() {
+    var result = evaluateDor({ components: [] }, null, null)
+    var f6 = result.items.find(function(i) { return i.id === 'F-6' })
+    expect(f6.checked).toBe(false)
+  })
+
+  it('F-7 passes when enrichment has storyPoints > 0', function() {
+    var result = evaluateDor({}, { storyPoints: 5 }, null)
+    var f7 = result.items.find(function(i) { return i.id === 'F-7' })
+    expect(f7.checked).toBe(true)
+  })
+
+  it('F-7 fails when storyPoints is null', function() {
+    var result = evaluateDor({}, { storyPoints: null }, null)
+    var f7 = result.items.find(function(i) { return i.id === 'F-7' })
+    expect(f7.checked).toBe(false)
+  })
+
+  it('F-8 passes by default when no dependency links', function() {
+    var result = evaluateDor({}, null, null)
+    var f8 = result.items.find(function(i) { return i.id === 'F-8' })
+    expect(f8.checked).toBe(true)
+  })
+
+  it('F-8 fails when unresolved inward Blocks link exists', function() {
+    var enrichment = {
+      dependencyLinks: [
+        { type: 'Blocks', direction: 'inward', linkedKey: 'X-1', linkedStatus: 'In Progress' }
+      ]
+    }
+    var result = evaluateDor({}, enrichment, null)
+    var f8 = result.items.find(function(i) { return i.id === 'F-8' })
+    expect(f8.checked).toBe(false)
+  })
+
+  it('F-8 passes when Blocks link is Closed', function() {
+    var enrichment = {
+      dependencyLinks: [
+        { type: 'Blocks', direction: 'inward', linkedKey: 'X-1', linkedStatus: 'Closed' }
+      ]
+    }
+    var result = evaluateDor({}, enrichment, null)
+    var f8 = result.items.find(function(i) { return i.id === 'F-8' })
+    expect(f8.checked).toBe(true)
+  })
+
+  it('F-10 passes when releaseType is set', function() {
+    var result = evaluateDor({ releaseType: 'General Availability' }, null, null)
+    var f10 = result.items.find(function(i) { return i.id === 'F-10' })
+    expect(f10.checked).toBe(true)
+  })
+
+  it('F-10 fails when releaseType is falsy', function() {
+    var result = evaluateDor({ releaseType: '' }, null, null)
+    var f10 = result.items.find(function(i) { return i.id === 'F-10' })
+    expect(f10.checked).toBe(false)
+  })
+
+  it('reads manual checks from manualChecks parameter', function() {
+    var manualChecks = { 'F-3': { checked: true }, 'F-9': { checked: false } }
+    var result = evaluateDor({}, null, manualChecks)
+    var f3 = result.items.find(function(i) { return i.id === 'F-3' })
+    var f9 = result.items.find(function(i) { return i.id === 'F-9' })
+    expect(f3.checked).toBe(true)
+    expect(f9.checked).toBe(false)
+  })
+
+  it('calculates completionPct correctly', function() {
+    var feature = {
+      summary: 'Test',
+      targetVersions: ['3.5'],
+      pm: 'PM',
+      assignee: 'Owner',
+      components: ['Comp'],
+      releaseType: 'GA'
+    }
+    var enrichment = { hasDescription: true, storyPoints: 5, dependencyLinks: [] }
+    var manualChecks = {
+      'F-3': { checked: true },
+      'F-9': { checked: true },
+      'F-11': { checked: true },
+      'F-12': { checked: true },
+      'F-13': { checked: true }
+    }
+    var result = evaluateDor(feature, enrichment, manualChecks)
+    expect(result.checkedCount).toBe(13)
+    expect(result.completionPct).toBe(100)
+  })
+
+  it('returns ~8% for empty feature with no enrichment or manual checks', function() {
+    var result = evaluateDor({}, null, null)
+    // Only F-8 passes by default
+    expect(result.checkedCount).toBe(1)
+    expect(result.completionPct).toBe(Math.round((1 / 13) * 100))
+  })
+
+  it('items have correct structure', function() {
+    var result = evaluateDor({}, null, null)
+    for (var i = 0; i < result.items.length; i++) {
+      var item = result.items[i]
+      expect(item).toHaveProperty('id')
+      expect(item).toHaveProperty('label')
+      expect(item).toHaveProperty('type')
+      expect(item).toHaveProperty('checked')
+      expect(item).toHaveProperty('source')
+      expect(typeof item.checked).toBe('boolean')
+    }
+  })
+})

--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -1,0 +1,438 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const {
+  runHealthPipeline,
+  loadFeaturesForRelease,
+  loadFeaturesFromCandidates,
+  computeMilestoneInfo,
+  computePlanningDeadline,
+  getFeaturePhase,
+  buildEmptyCache,
+  splitCommaString,
+  passesPhaseFilter
+} = require('../../server/health/health-pipeline')
+
+function makeStorage(data) {
+  var store = {}
+  if (data) {
+    for (var k in data) store[k] = data[k]
+  }
+  return {
+    readFromStorage: function(key) {
+      return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
+    },
+    writeToStorage: function(key, value) {
+      store[key] = value
+    },
+    _store: store
+  }
+}
+
+describe('getFeaturePhase', function() {
+  it('maps Tech Preview to TP', function() {
+    expect(getFeaturePhase({ releaseType: 'Tech Preview' })).toBe('TP')
+  })
+
+  it('maps Developer Preview to DP', function() {
+    expect(getFeaturePhase({ releaseType: 'Developer Preview' })).toBe('DP')
+  })
+
+  it('maps General Availability to GA', function() {
+    expect(getFeaturePhase({ releaseType: 'General Availability' })).toBe('GA')
+  })
+
+  it('maps TP shorthand to TP', function() {
+    expect(getFeaturePhase({ releaseType: 'TP' })).toBe('TP')
+  })
+
+  it('infers GA from fixVersions containing GA', function() {
+    expect(getFeaturePhase({ fixVersions: ['rhoai-3.5 GA'] })).toBe('GA')
+  })
+
+  it('infers TP from fixVersions containing EA1', function() {
+    expect(getFeaturePhase({ fixVersions: ['rhoai-3.5-EA1'] })).toBe('TP')
+  })
+
+  it('infers DP from fixVersions containing EA2', function() {
+    expect(getFeaturePhase({ fixVersions: ['rhoai-3.5-EA2'] })).toBe('DP')
+  })
+
+  it('returns empty string when no releaseType or matching fixVersions', function() {
+    expect(getFeaturePhase({ fixVersions: [] })).toBe('')
+    expect(getFeaturePhase({})).toBe('')
+  })
+})
+
+describe('computeMilestoneInfo', function() {
+  var milestones = {
+    ea1Freeze: '2026-05-01',
+    ea1Target: '2026-05-15',
+    ea2Freeze: '2026-06-15',
+    ea2Target: '2026-07-01',
+    gaFreeze: '2026-08-01',
+    gaTarget: '2026-08-15'
+  }
+
+  it('returns Unknown when milestones is null', function() {
+    var result = computeMilestoneInfo(null, new Date())
+    expect(result.currentPhase).toBe('Unknown')
+    expect(result.daysToNextMilestone).toBeNull()
+    expect(result.nextMilestone).toBeNull()
+  })
+
+  it('returns Pre-EA1 for dates before ea1Freeze', function() {
+    var result = computeMilestoneInfo(milestones, new Date('2026-04-15T12:00:00Z'))
+    expect(result.currentPhase).toBe('Pre-EA1')
+    expect(result.nextMilestone).toBe('EA1 Code Freeze')
+  })
+
+  it('returns EA1 Freeze when today is after ea1Freeze', function() {
+    var result = computeMilestoneInfo(milestones, new Date('2026-05-05T12:00:00Z'))
+    expect(result.currentPhase).toBe('EA1 Freeze')
+    expect(result.nextMilestone).toBe('EA1 Release')
+  })
+
+  it('returns Post-GA when after gaTarget', function() {
+    var result = computeMilestoneInfo(milestones, new Date('2026-09-01T12:00:00Z'))
+    expect(result.currentPhase).toBe('Post-GA')
+    expect(result.nextMilestone).toBeNull()
+  })
+
+  it('computes correct daysToNextMilestone', function() {
+    var result = computeMilestoneInfo(milestones, new Date('2026-04-28T12:00:00Z'))
+    expect(result.daysToNextMilestone).toBe(3)
+    expect(result.nextMilestone).toBe('EA1 Code Freeze')
+  })
+})
+
+describe('buildEmptyCache', function() {
+  it('returns correct structure with zero counts', function() {
+    var cache = buildEmptyCache('3.5', ['some warning'])
+    expect(cache.version).toBe('3.5')
+    expect(cache.cachedAt).toBeDefined()
+    expect(cache.milestones).toBeNull()
+    expect(cache.summary.totalFeatures).toBe(0)
+    expect(cache.summary.byRisk).toEqual({ green: 0, yellow: 0, red: 0 })
+    expect(cache.summary.dorCompletionRate).toBe(0)
+    expect(cache.summary.averageRiceScore).toBeNull()
+    expect(cache.features).toEqual([])
+    expect(cache.enrichmentStatus.warnings).toContain('some warning')
+  })
+})
+
+describe('splitCommaString', function() {
+  it('returns empty array for null', function() {
+    expect(splitCommaString(null)).toEqual([])
+  })
+
+  it('returns empty array for empty string', function() {
+    expect(splitCommaString('')).toEqual([])
+  })
+
+  it('splits and trims comma-separated values', function() {
+    expect(splitCommaString('A, B, C')).toEqual(['A', 'B', 'C'])
+  })
+
+  it('filters out empty segments', function() {
+    expect(splitCommaString('A,,B')).toEqual(['A', 'B'])
+  })
+
+  it('returns single item for no comma', function() {
+    expect(splitCommaString('OnlyOne')).toEqual(['OnlyOne'])
+  })
+})
+
+describe('passesPhaseFilter', function() {
+  it('passes all features when phase is null', function() {
+    expect(passesPhaseFilter({ fixVersion: 'rhoai-3.5-EA2' }, '3.5', null)).toBe(true)
+  })
+
+  it('passes features without phase-specific fixVersion', function() {
+    expect(passesPhaseFilter({ fixVersion: 'rhoai-3.5' }, '3.5', 'EA2')).toBe(true)
+  })
+
+  it('passes features with matching phase fixVersion', function() {
+    expect(passesPhaseFilter({ fixVersion: 'rhoai-3.5-EA2' }, '3.5', 'EA2')).toBe(true)
+  })
+
+  it('rejects features with different phase fixVersion', function() {
+    expect(passesPhaseFilter({ fixVersion: 'rhoai-3.5-EA1' }, '3.5', 'EA2')).toBe(false)
+  })
+
+  it('handles empty fixVersion', function() {
+    expect(passesPhaseFilter({ fixVersion: '' }, '3.5', 'EA1')).toBe(true)
+  })
+})
+
+describe('computePlanningDeadline', function() {
+  var milestones = {
+    ea1Freeze: '2026-05-01',
+    ea2Freeze: '2026-06-18',
+    gaFreeze: '2026-08-01'
+  }
+
+  it('returns null when milestones is null', function() {
+    expect(computePlanningDeadline(null, 'EA1')).toBeNull()
+  })
+
+  it('returns null when phase is null', function() {
+    expect(computePlanningDeadline(milestones, null)).toBeNull()
+  })
+
+  it('computes deadline as freeze minus 7 days for EA1', function() {
+    var result = computePlanningDeadline(milestones, 'EA1')
+    expect(result.date).toBe('2026-04-24')
+  })
+
+  it('computes deadline as freeze minus 7 days for EA2', function() {
+    var result = computePlanningDeadline(milestones, 'EA2')
+    expect(result.date).toBe('2026-06-11')
+  })
+
+  it('computes deadline as freeze minus 7 days for GA', function() {
+    var result = computePlanningDeadline(milestones, 'GA')
+    expect(result.date).toBe('2026-07-25')
+  })
+
+  it('returns null for unknown phase', function() {
+    expect(computePlanningDeadline(milestones, 'XYZ')).toBeNull()
+  })
+})
+
+describe('loadFeaturesFromCandidates', function() {
+  it('returns warning when candidates cache is empty', function() {
+    var storage = makeStorage({})
+    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
+    expect(result.features).toEqual([])
+    expect(result.warnings[0]).toContain('No candidates found')
+  })
+
+  it('maps candidate fields to health feature shape', function() {
+    var storage = makeStorage({
+      'release-planning/candidates-cache-3.5.json': {
+        cachedAt: '2026-04-26T00:00:00Z',
+        data: {
+          features: [{
+            issueKey: 'RHOAIENG-1001',
+            summary: 'Feature 1',
+            status: 'In Progress',
+            priority: 'Major',
+            phase: 'GA',
+            components: 'Backend, API',
+            fixVersion: 'rhoai-3.5',
+            targetRelease: 'rhoai-3.5',
+            deliveryOwner: 'Jane',
+            pm: 'Bob',
+            bigRock: 'MaaS',
+            tier: 1,
+            labels: 'test, feature',
+            rfe: 'RHAIRFE-100'
+          }]
+        }
+      }
+    })
+    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
+    expect(result.features).toHaveLength(1)
+    var f = result.features[0]
+    expect(f.key).toBe('RHOAIENG-1001')
+    expect(f.components).toEqual(['Backend', 'API'])
+    expect(f.fixVersions).toEqual(['rhoai-3.5'])
+    expect(f.targetVersions).toEqual(['rhoai-3.5'])
+    expect(f.assignee).toBe('Jane')
+    expect(f.deliveryOwner).toBe('Jane')
+    expect(f.tier).toBe(1)
+    expect(f.bigRock).toBe('MaaS')
+    expect(f.labels).toEqual(['test', 'feature'])
+  })
+
+  it('excludes closed features', function() {
+    var storage = makeStorage({
+      'release-planning/candidates-cache-3.5.json': {
+        cachedAt: '2026-04-26T00:00:00Z',
+        data: {
+          features: [
+            { issueKey: 'T-1', status: 'Closed', components: '', fixVersion: '', tier: 1 },
+            { issueKey: 'T-2', status: 'In Progress', components: '', fixVersion: '', tier: 1 }
+          ]
+        }
+      }
+    })
+    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
+    expect(result.features).toHaveLength(1)
+    expect(result.features[0].key).toBe('T-2')
+  })
+
+  it('applies phase filter', function() {
+    var storage = makeStorage({
+      'release-planning/candidates-cache-3.5.json': {
+        cachedAt: '2026-04-26T00:00:00Z',
+        data: {
+          features: [
+            { issueKey: 'T-1', status: 'In Progress', components: '', fixVersion: 'rhoai-3.5-EA1', tier: 1 },
+            { issueKey: 'T-2', status: 'In Progress', components: '', fixVersion: 'rhoai-3.5-EA2', tier: 1 },
+            { issueKey: 'T-3', status: 'In Progress', components: '', fixVersion: 'rhoai-3.5', tier: 1 }
+          ]
+        }
+      }
+    })
+    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', 'EA2')
+    expect(result.features).toHaveLength(2)
+    var keys = result.features.map(function(f) { return f.key })
+    expect(keys).toContain('T-2')
+    expect(keys).toContain('T-3')
+    expect(keys).not.toContain('T-1')
+  })
+})
+
+describe('loadFeaturesForRelease', function() {
+  it('returns warning when index is empty', function() {
+    var storage = makeStorage({})
+    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    expect(result.features).toEqual([])
+    expect(result.warnings).toContain('Feature-traffic index is empty -- run a feature-traffic refresh first')
+  })
+
+  it('filters features by targetVersions match', function() {
+    var storage = makeStorage({
+      'feature-traffic/index.json': {
+        features: [
+          { key: 'T-1', targetVersions: ['rhoai-3.5'], fixVersions: [], status: 'In Progress' },
+          { key: 'T-2', targetVersions: ['rhoai-3.6'], fixVersions: [], status: 'In Progress' }
+        ]
+      }
+    })
+    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    expect(result.features).toHaveLength(1)
+    expect(result.features[0].key).toBe('T-1')
+  })
+
+  it('filters features by fixVersions match', function() {
+    var storage = makeStorage({
+      'feature-traffic/index.json': {
+        features: [
+          { key: 'T-1', targetVersions: [], fixVersions: ['rhoai-3.5 EA1'], status: 'In Progress' }
+        ]
+      }
+    })
+    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    expect(result.features).toHaveLength(1)
+  })
+
+  it('excludes closed features', function() {
+    var storage = makeStorage({
+      'feature-traffic/index.json': {
+        features: [
+          { key: 'T-1', targetVersions: ['rhoai-3.5'], fixVersions: [], status: 'Closed' }
+        ]
+      }
+    })
+    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    expect(result.features).toHaveLength(0)
+  })
+
+  it('merges detail data onto features', function() {
+    var storage = makeStorage({
+      'feature-traffic/index.json': {
+        features: [
+          { key: 'T-1', targetVersions: ['rhoai-3.5'], fixVersions: [], status: 'In Progress' }
+        ]
+      },
+      'feature-traffic/features/T-1.json': {
+        pm: { displayName: 'Jane PM' },
+        components: ['Model Serving'],
+        releaseType: 'General Availability'
+      }
+    })
+    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    expect(result.features[0].pm).toEqual({ displayName: 'Jane PM' })
+    expect(result.features[0].components).toEqual(['Model Serving'])
+    expect(result.features[0].releaseType).toBe('General Availability')
+  })
+})
+
+describe('runHealthPipeline', function() {
+  function makeCandidatesCache(features) {
+    return {
+      'release-planning/candidates-cache-3.5.json': {
+        cachedAt: '2026-04-26T00:00:00Z',
+        data: { features: features }
+      }
+    }
+  }
+
+  it('writes empty cache when no candidates found', async function() {
+    var storage = makeStorage({})
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.features).toEqual([])
+    expect(result.summary.totalFeatures).toBe(0)
+    expect(storage._store['release-planning/health-cache-3.5-all.json']).toBeDefined()
+  })
+
+  it('writes cache with assessed features to storage', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'Feature 1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.features).toHaveLength(1)
+    expect(result.features[0].key).toBe('T-1')
+    expect(result.summary.totalFeatures).toBe(1)
+    expect(storage._store['release-planning/health-cache-3.5-all.json']).toBeDefined()
+  })
+
+  it('uses phase-specific cache key when phase is provided', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn(), 'EA2')
+    expect(storage._store['release-planning/health-cache-3.5-EA2.json']).toBeDefined()
+  })
+
+  it('aggregates risk counts correctly', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 },
+      { issueKey: 'T-2', summary: 'F2', status: 'New', components: '', fixVersion: '', deliveryOwner: 'Bob', tier: 2 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.summary.totalFeatures).toBe(2)
+    var total = result.summary.byRisk.green + result.summary.byRisk.yellow + result.summary.byRisk.red
+    expect(total).toBe(2)
+  })
+
+  it('includes enrichmentStatus in result', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.enrichmentStatus).toBeDefined()
+    expect(typeof result.enrichmentStatus.jiraQueriesRun).toBe('number')
+    expect(typeof result.enrichmentStatus.featuresEnriched).toBe('number')
+    expect(Array.isArray(result.enrichmentStatus.warnings)).toBe(true)
+  })
+
+  it('returns null milestones when Smartsheet is unavailable', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.milestones).toBeNull()
+    expect(result.enrichmentStatus.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Smartsheet')])
+    )
+  })
+
+  it('produces correct cache structure', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.version).toBe('3.5')
+    expect(result.cachedAt).toBeDefined()
+    expect(result.phase).toBe('all')
+    expect(result.summary).toBeDefined()
+    expect(result.summary.byRisk).toBeDefined()
+    expect(typeof result.summary.dorCompletionRate).toBe('number')
+    expect(result.features[0]).toHaveProperty('key')
+    expect(result.features[0]).toHaveProperty('risk')
+    expect(result.features[0]).toHaveProperty('dor')
+  })
+})

--- a/modules/release-planning/__tests__/server/health-routes.test.js
+++ b/modules/release-planning/__tests__/server/health-routes.test.js
@@ -1,0 +1,592 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../server/config', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    healthConfig: {},
+    customFieldIds: {}
+  })
+}))
+
+vi.mock('../../server/health/health-pipeline', () => ({
+  runHealthPipeline: vi.fn().mockResolvedValue({
+    version: '3.5',
+    cachedAt: new Date().toISOString(),
+    features: [],
+    summary: { totalFeatures: 0, byRisk: { green: 0, yellow: 0, red: 0 }, dorCompletionRate: 0, averageRiceScore: null },
+    milestones: null,
+    enrichmentStatus: { jiraQueriesRun: 0, featuresEnriched: 0, warnings: [] }
+  })
+}))
+
+vi.mock('../../../../shared/server/jira', () => ({
+  jiraRequest: vi.fn(),
+  fetchAllJqlResults: vi.fn()
+}))
+
+const healthRoutes = require('../../server/health/health-routes')
+
+function makeStorage(data) {
+  var store = {}
+  if (data) {
+    for (var k in data) store[k] = data[k]
+  }
+  return {
+    readFromStorage: function(key) {
+      return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
+    },
+    writeToStorage: function(key, value) {
+      store[key] = value
+    },
+    _store: store
+  }
+}
+
+function makeRouter() {
+  var routes = {}
+  function reg(method) {
+    return function(path) {
+      var handlers = Array.prototype.slice.call(arguments, 1)
+      routes[method + ' ' + path] = handlers
+    }
+  }
+  return {
+    get: vi.fn(reg('GET')),
+    post: vi.fn(reg('POST')),
+    put: vi.fn(reg('PUT')),
+    delete: vi.fn(reg('DELETE')),
+    use: vi.fn(),
+    _routes: routes
+  }
+}
+
+function makeRes() {
+  var res = {
+    _status: 200,
+    _json: null,
+    _headers: {},
+    status: function(code) { res._status = code; return res },
+    json: function(data) { res._json = data; return res },
+    set: function(key, value) { res._headers[key] = value; return res },
+    end: function() { return res },
+    send: function(body) {
+      if (typeof body === 'string') {
+        try { res._json = JSON.parse(body) } catch { res._json = body }
+      } else {
+        res._json = body
+      }
+      return res
+    }
+  }
+  return res
+}
+
+function makeReq(overrides) {
+  return Object.assign({
+    isAdmin: true,
+    userEmail: 'admin@test.com',
+    body: {},
+    params: {},
+    query: {},
+    headers: {}
+  }, overrides)
+}
+
+function callRoute(routes, method, path, req) {
+  var key = method + ' ' + path
+  var handlers = routes[key]
+  if (!handlers) throw new Error('No route registered: ' + key)
+  var handler = handlers[handlers.length - 1]
+  var res = makeRes()
+  var result = handler(req || makeReq(), res)
+  if (result && typeof result.then === 'function') {
+    return result.then(function() { return res })
+  }
+  return res
+}
+
+function freshCache(version, overrides) {
+  return Object.assign({
+    version: version,
+    cachedAt: new Date().toISOString(),
+    milestones: null,
+    summary: { totalFeatures: 2, byRisk: { green: 1, yellow: 1, red: 0 }, dorCompletionRate: 50, averageRiceScore: null },
+    features: [
+      { key: 'T-1', summary: 'Feature 1', risk: { level: 'green', flags: [] }, dor: { checkedCount: 10, totalCount: 13, completionPct: 77, items: [] } },
+      { key: 'T-2', summary: 'Feature 2', risk: { level: 'yellow', flags: [{ category: 'UNESTIMATED' }] }, dor: { checkedCount: 5, totalCount: 13, completionPct: 38, items: [] } }
+    ],
+    enrichmentStatus: { jiraQueriesRun: 1, featuresEnriched: 2, warnings: [] }
+  }, overrides)
+}
+
+describe('health routes', function() {
+  var router, storage, context, refreshStates
+
+  beforeEach(function() {
+    vi.clearAllMocks()
+    refreshStates = new Map()
+    storage = makeStorage({})
+    router = makeRouter()
+    context = {
+      storage: storage,
+      requireAuth: function(req, res, next) { next() },
+      requirePM: function(req, res, next) { next() },
+      refreshStates: refreshStates,
+      MAX_CONCURRENT_REFRESHES: 2,
+      sendJsonWithETag: function(req, res, data, statusCode) {
+        if (statusCode) res.status(statusCode)
+        res.json(data)
+      }
+    }
+    healthRoutes(router, context)
+  })
+
+  // ─── Route Registration ───
+
+  describe('route registration', function() {
+    it('registers all expected health routes', function() {
+      var expected = [
+        'GET /releases/:version/health',
+        'GET /releases/:version/health/summary',
+        'GET /releases/:version/health/feature/:key',
+        'PUT /releases/:version/health/dor/:featureKey',
+        'PUT /releases/:version/health/override/:featureKey',
+        'DELETE /releases/:version/health/override/:featureKey',
+        'POST /releases/:version/health/refresh',
+        'GET /releases/:version/health/refresh/status'
+      ]
+      for (var i = 0; i < expected.length; i++) {
+        expect(router._routes[expected[i]]).toBeDefined()
+      }
+    })
+  })
+
+  // ─── GET /releases/:version/health ───
+
+  describe('GET /releases/:version/health', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '../evil' } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('Invalid version')
+    })
+
+    it('returns 400 for __proto__ version', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '__proto__' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 202 with _noCache when no cache exists', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._status).toBe(202)
+      expect(res._json._noCache).toBe(true)
+      expect(res._json.features).toEqual([])
+    })
+
+    it('returns cached data when available', function() {
+      var cached = freshCache('3.5')
+      storage._store['release-planning/health-cache-3.5-all.json'] = cached
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.version).toBe('3.5')
+      expect(res._json.features).toHaveLength(2)
+    })
+
+    it('sets _cacheStale true for old cache', function() {
+      var cached = freshCache('3.5', { cachedAt: new Date(Date.now() - 20 * 60 * 1000).toISOString() })
+      storage._store['release-planning/health-cache-3.5-all.json'] = cached
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._json._cacheStale).toBe(true)
+    })
+
+    it('sets _cacheStale false for fresh cache', function() {
+      var cached = freshCache('3.5')
+      storage._store['release-planning/health-cache-3.5-all.json'] = cached
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._json._cacheStale).toBe(false)
+    })
+  })
+
+  // ─── Phase validation ───
+
+  describe('phase query param validation', function() {
+    it('returns 400 for invalid phase on GET health', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'INVALID' } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('phase')
+    })
+
+    it('accepts valid EA1 phase on GET health', function() {
+      storage._store['release-planning/health-cache-3.5-EA1.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'EA1' } }))
+      expect(res._status).toBe(200)
+    })
+
+    it('accepts valid EA2 phase on GET health', function() {
+      storage._store['release-planning/health-cache-3.5-EA2.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'EA2' } }))
+      expect(res._status).toBe(200)
+    })
+
+    it('accepts valid GA phase on GET health', function() {
+      storage._store['release-planning/health-cache-3.5-GA.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'GA' } }))
+      expect(res._status).toBe(200)
+    })
+
+    it('uses phase-specific cache key', function() {
+      storage._store['release-planning/health-cache-3.5-EA2.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'EA2' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.features).toHaveLength(2)
+    })
+
+    it('returns 202 when phase-specific cache does not exist', function() {
+      storage._store['release-planning/health-cache-3.5-all.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'EA1' } }))
+      expect(res._status).toBe(202)
+      expect(res._json._noCache).toBe(true)
+    })
+
+    it('returns 400 for invalid phase on GET summary', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'WRONG' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 for invalid phase on POST refresh', function() {
+      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'BAD' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 for invalid phase on GET refresh status', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'XYZ' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('uses phase-specific refresh state key', function() {
+      refreshStates.set('health:3.5:EA1', { running: true, startedAt: '2026-04-26T12:00:00Z', lastResult: null })
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+        makeReq({ params: { version: '3.5' }, query: { phase: 'EA1' } }))
+      expect(res._json.running).toBe(true)
+    })
+  })
+
+  // ─── GET /releases/:version/health/summary ───
+
+  describe('GET /releases/:version/health/summary', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+        makeReq({ params: { version: '!bad!' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 404 when no cache exists', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._status).toBe(404)
+    })
+
+    it('returns summary from cached data', function() {
+      storage._store['release-planning/health-cache-3.5-all.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.version).toBe('3.5')
+      expect(res._json.summary).toBeDefined()
+      expect(res._json.summary.totalFeatures).toBe(2)
+      expect(res._json.milestones).toBeNull()
+    })
+  })
+
+  // ─── GET /releases/:version/health/feature/:key ───
+
+  describe('GET /releases/:version/health/feature/:key', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+        makeReq({ params: { version: '!bad', key: 'T-1' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 for invalid feature key', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+        makeReq({ params: { version: '3.5', key: 'not-valid' } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('Invalid feature key')
+    })
+
+    it('returns 404 when no cache exists', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+        makeReq({ params: { version: '3.5', key: 'T-1' } }))
+      expect(res._status).toBe(404)
+    })
+
+    it('returns 404 when feature not found in cache', function() {
+      storage._store['release-planning/health-cache-3.5-all.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+        makeReq({ params: { version: '3.5', key: 'T-999' } }))
+      expect(res._status).toBe(404)
+      expect(res._json.error).toContain('T-999')
+    })
+
+    it('returns feature data when found', function() {
+      storage._store['release-planning/health-cache-3.5-all.json'] = freshCache('3.5')
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+        makeReq({ params: { version: '3.5', key: 'T-1' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.key).toBe('T-1')
+      expect(res._json.summary).toBe('Feature 1')
+    })
+  })
+
+  // ─── PUT /releases/:version/health/dor/:featureKey ───
+
+  describe('PUT /releases/:version/health/dor/:featureKey', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '!bad', featureKey: 'T-1' }, body: { items: {} } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 for invalid feature key', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'bad' }, body: { items: {} } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 when items is missing', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: {} }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('items must be an object')
+    })
+
+    it('returns 400 when items is an array', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: [] } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 for unknown DoR item ID', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: { 'F-999': true } } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('Unknown DoR item ID')
+    })
+
+    it('returns 400 for automated DoR item', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: { 'F-1': true } } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('automated')
+    })
+
+    it('returns 400 for non-boolean item value', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: { 'F-3': 'yes' } } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('booleans')
+    })
+
+    it('returns 400 for notes exceeding max length', function() {
+      var longNotes = 'x'.repeat(2001)
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: { 'F-3': true }, notes: longNotes } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('2000')
+    })
+
+    it('writes DoR state and returns completion info on success', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: { 'F-3': true, 'F-9': false }, notes: 'Test note' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.featureKey).toBe('T-1')
+      expect(res._json.dor).toBeDefined()
+      expect(res._json.dor.totalCount).toBe(13)
+      expect(res._json.updatedBy).toBe('admin@test.com')
+
+      var dorState = storage._store['release-planning/dor-state-3.5.json']
+      expect(dorState).toBeDefined()
+      expect(dorState.features['T-1'].manualChecks['F-3'].checked).toBe(true)
+      expect(dorState.features['T-1'].manualChecks['F-9'].checked).toBe(false)
+      expect(dorState.features['T-1'].notes).toBe('Test note')
+    })
+
+    it('writes audit log entry', function() {
+      callRoute(router._routes, 'PUT', '/releases/:version/health/dor/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { items: { 'F-3': true } } }))
+      var auditLog = storage._store['release-planning/audit-log.json']
+      expect(auditLog).toBeDefined()
+      expect(auditLog.entries).toBeDefined()
+      var entry = auditLog.entries[auditLog.entries.length - 1]
+      expect(entry.action).toBe('update_dor')
+      expect(entry.summary).toContain('T-1')
+    })
+  })
+
+  // ─── PUT /releases/:version/health/override/:featureKey ───
+
+  describe('PUT /releases/:version/health/override/:featureKey', function() {
+    it('returns 400 for invalid risk level', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'purple', reason: 'test' } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('riskOverride')
+    })
+
+    it('returns 400 when reason is missing', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green' } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('reason')
+    })
+
+    it('returns 400 when reason is empty string', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green', reason: '   ' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 400 when reason exceeds max length', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green', reason: 'x'.repeat(501) } }))
+      expect(res._status).toBe(400)
+      expect(res._json.error).toContain('500')
+    })
+
+    it('writes override and returns confirmation on success', function() {
+      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green', reason: 'PM verified' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.featureKey).toBe('T-1')
+      expect(res._json.riskOverride).toBe('green')
+      expect(res._json.reason).toBe('PM verified')
+
+      var overrides = storage._store['release-planning/health-overrides-3.5.json']
+      expect(overrides.overrides['T-1'].riskOverride).toBe('green')
+      expect(overrides.overrides['T-1'].reason).toBe('PM verified')
+    })
+
+    it('writes audit log entry', function() {
+      callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'yellow', reason: 'Under review' } }))
+      var auditLog = storage._store['release-planning/audit-log.json']
+      expect(auditLog).toBeDefined()
+      var entry = auditLog.entries[auditLog.entries.length - 1]
+      expect(entry.action).toBe('set_risk_override')
+      expect(entry.summary).toContain('yellow')
+    })
+  })
+
+  // ─── DELETE /releases/:version/health/override/:featureKey ───
+
+  describe('DELETE /releases/:version/health/override/:featureKey', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '!bad', featureKey: 'T-1' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 404 when no override exists', function() {
+      var res = callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' } }))
+      expect(res._status).toBe(404)
+    })
+
+    it('removes override and returns confirmation', function() {
+      storage._store['release-planning/health-overrides-3.5.json'] = {
+        version: '3.5',
+        overrides: { 'T-1': { riskOverride: 'green', reason: 'old reason' } }
+      }
+      var res = callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.removed).toBe(true)
+
+      var overrides = storage._store['release-planning/health-overrides-3.5.json']
+      expect(overrides.overrides['T-1']).toBeUndefined()
+    })
+
+    it('writes audit log entry', function() {
+      storage._store['release-planning/health-overrides-3.5.json'] = {
+        version: '3.5',
+        overrides: { 'T-1': { riskOverride: 'green', reason: 'test' } }
+      }
+      callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+        makeReq({ params: { version: '3.5', featureKey: 'T-1' } }))
+      var auditLog = storage._store['release-planning/audit-log.json']
+      expect(auditLog).toBeDefined()
+      var entry = auditLog.entries[auditLog.entries.length - 1]
+      expect(entry.action).toBe('remove_risk_override')
+    })
+  })
+
+  // ─── POST /releases/:version/health/refresh ───
+
+  describe('POST /releases/:version/health/refresh', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+        makeReq({ params: { version: '../bad' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns already_running when refresh in progress', function() {
+      refreshStates.set('health:3.5:all', { running: true, startedAt: new Date().toISOString() })
+      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._json.status).toBe('already_running')
+    })
+
+    it('returns 429 when max concurrent refreshes reached', function() {
+      refreshStates.set('health:3.4:all', { running: true })
+      refreshStates.set('health:3.3:all', { running: true })
+      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._status).toBe(429)
+    })
+
+    it('returns started on success', function() {
+      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._json.status).toBe('started')
+    })
+  })
+
+  // ─── GET /releases/:version/health/refresh/status ───
+
+  describe('GET /releases/:version/health/refresh/status', function() {
+    it('returns 400 for invalid version', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+        makeReq({ params: { version: '!bad' } }))
+      expect(res._status).toBe(400)
+    })
+
+    it('returns initial state when no refresh has run', function() {
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._status).toBe(200)
+      expect(res._json.running).toBe(false)
+      expect(res._json.lastResult).toBeNull()
+    })
+
+    it('returns running state during refresh', function() {
+      refreshStates.set('health:3.5:all', { running: true, startedAt: '2026-04-26T12:00:00Z', lastResult: null })
+      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+        makeReq({ params: { version: '3.5' } }))
+      expect(res._json.running).toBe(true)
+      expect(res._json.startedAt).toBe('2026-04-26T12:00:00Z')
+    })
+  })
+})

--- a/modules/release-planning/__tests__/server/jira-enrichment.test.js
+++ b/modules/release-planning/__tests__/server/jira-enrichment.test.js
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const {
+  parseIssueLinks,
+  hasDescriptionContent,
+  parseChangelog,
+  identifyChangelogTargets,
+  runPass1,
+  runPass2,
+  enrichFeatures
+} = require('../../server/health/jira-enrichment')
+
+describe('parseIssueLinks', function() {
+  it('returns empty array for null', function() {
+    expect(parseIssueLinks(null)).toEqual([])
+  })
+
+  it('returns empty array for undefined', function() {
+    expect(parseIssueLinks(undefined)).toEqual([])
+  })
+
+  it('parses inward issue links', function() {
+    var links = parseIssueLinks([{
+      type: { name: 'Blocks' },
+      inwardIssue: {
+        key: 'TEST-1',
+        fields: { status: { name: 'In Progress' } }
+      }
+    }])
+    expect(links).toEqual([{
+      type: 'Blocks',
+      direction: 'inward',
+      linkedKey: 'TEST-1',
+      linkedStatus: 'In Progress'
+    }])
+  })
+
+  it('parses outward issue links', function() {
+    var links = parseIssueLinks([{
+      type: { name: 'is required by' },
+      outwardIssue: {
+        key: 'RFE-5',
+        fields: { status: { name: 'Closed' } }
+      }
+    }])
+    expect(links).toEqual([{
+      type: 'is required by',
+      direction: 'outward',
+      linkedKey: 'RFE-5',
+      linkedStatus: 'Closed'
+    }])
+  })
+
+  it('handles missing type and status fields', function() {
+    var links = parseIssueLinks([{
+      type: null,
+      inwardIssue: { key: 'X-1', fields: {} }
+    }])
+    expect(links[0].type).toBe('')
+    expect(links[0].linkedStatus).toBe('')
+  })
+
+  it('parses both inward and outward from a single link', function() {
+    var links = parseIssueLinks([{
+      type: { name: 'Relates' },
+      inwardIssue: { key: 'A-1', fields: { status: { name: 'New' } } },
+      outwardIssue: { key: 'A-2', fields: { status: { name: 'Done' } } }
+    }])
+    expect(links).toHaveLength(2)
+  })
+})
+
+describe('hasDescriptionContent', function() {
+  it('returns false for null', function() {
+    expect(hasDescriptionContent(null)).toBe(false)
+  })
+
+  it('returns false for undefined', function() {
+    expect(hasDescriptionContent(undefined)).toBe(false)
+  })
+
+  it('returns false for empty string', function() {
+    expect(hasDescriptionContent('')).toBe(false)
+  })
+
+  it('returns false for whitespace-only string', function() {
+    expect(hasDescriptionContent('   ')).toBe(false)
+  })
+
+  it('returns true for non-empty string', function() {
+    expect(hasDescriptionContent('Feature description')).toBe(true)
+  })
+
+  it('returns true for ADF doc with content', function() {
+    expect(hasDescriptionContent({ type: 'doc', content: [{ type: 'paragraph' }] })).toBe(true)
+  })
+
+  it('returns false for ADF doc with empty content', function() {
+    expect(hasDescriptionContent({ type: 'doc', content: [] })).toBe(false)
+  })
+
+  it('returns true for non-string non-ADF truthy value', function() {
+    expect(hasDescriptionContent({ someField: true })).toBe(true)
+  })
+})
+
+describe('parseChangelog', function() {
+  it('returns empty array when no changelog', function() {
+    expect(parseChangelog({})).toEqual([])
+  })
+
+  it('returns empty array when histories is not an array', function() {
+    expect(parseChangelog({ changelog: { histories: null } })).toEqual([])
+  })
+
+  it('extracts Target Version changes', function() {
+    var issue = {
+      changelog: {
+        histories: [{
+          created: '2026-03-15T10:00:00Z',
+          items: [{
+            field: 'Target Version',
+            fromString: 'rhoai-3.4',
+            toString: 'rhoai-3.5'
+          }]
+        }]
+      }
+    }
+    var result = parseChangelog(issue)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      field: 'Target Version',
+      from: 'rhoai-3.4',
+      to: 'rhoai-3.5',
+      date: '2026-03-15T10:00:00Z'
+    })
+  })
+
+  it('also matches by fieldId customfield_10855', function() {
+    var issue = {
+      changelog: {
+        histories: [{
+          created: '2026-04-01T10:00:00Z',
+          items: [{
+            fieldId: 'customfield_10855',
+            field: 'some display name',
+            fromString: null,
+            toString: 'rhoai-3.5'
+          }]
+        }]
+      }
+    }
+    var result = parseChangelog(issue)
+    expect(result).toHaveLength(1)
+    expect(result[0].to).toBe('rhoai-3.5')
+  })
+
+  it('ignores non-Target-Version changelog items', function() {
+    var issue = {
+      changelog: {
+        histories: [{
+          created: '2026-03-15T10:00:00Z',
+          items: [
+            { field: 'Status', fromString: 'New', toString: 'In Progress' },
+            { field: 'Target Version', fromString: null, toString: 'rhoai-3.5' }
+          ]
+        }]
+      }
+    }
+    var result = parseChangelog(issue)
+    expect(result).toHaveLength(1)
+    expect(result[0].field).toBe('Target Version')
+  })
+})
+
+describe('identifyChangelogTargets', function() {
+  it('flags features with empty targetVersions', function() {
+    var features = [{ key: 'A-1', status: 'In Progress', targetVersions: [] }]
+    var enrichmentMap = new Map([['A-1', { storyPoints: 5 }]])
+    var result = identifyChangelogTargets(['A-1'], enrichmentMap, features)
+    expect(result).toContain('A-1')
+  })
+
+  it('flags features in EARLY_STATUSES', function() {
+    var features = [{ key: 'A-1', status: 'New', targetVersions: ['3.5'] }]
+    var enrichmentMap = new Map([['A-1', { storyPoints: 5 }]])
+    var result = identifyChangelogTargets(['A-1'], enrichmentMap, features)
+    expect(result).toContain('A-1')
+  })
+
+  it('flags features with no storyPoints in enrichment', function() {
+    var features = [{ key: 'A-1', status: 'In Progress', targetVersions: ['3.5'] }]
+    var enrichmentMap = new Map([['A-1', { storyPoints: null }]])
+    var result = identifyChangelogTargets(['A-1'], enrichmentMap, features)
+    expect(result).toContain('A-1')
+  })
+
+  it('does not flag healthy features', function() {
+    var features = [{ key: 'A-1', status: 'In Progress', targetVersions: ['3.5'] }]
+    var enrichmentMap = new Map([['A-1', { storyPoints: 8 }]])
+    var result = identifyChangelogTargets(['A-1'], enrichmentMap, features)
+    expect(result).not.toContain('A-1')
+  })
+})
+
+describe('runPass1', function() {
+  it('populates enrichmentMap from fetchAllJqlResults', async function() {
+    var mockFetch = vi.fn().mockResolvedValue([{
+      key: 'TEST-1',
+      fields: {
+        description: 'A desc',
+        customfield_10028: 5,
+        issuelinks: []
+      }
+    }])
+    var result = await runPass1(vi.fn(), mockFetch, ['TEST-1'], { batchSize: 40, throttleMs: 0 })
+    expect(result.get('TEST-1')).toBeDefined()
+    expect(result.get('TEST-1').hasDescription).toBe(true)
+    expect(result.get('TEST-1').storyPoints).toBe(5)
+  })
+
+  it('batches keys correctly', async function() {
+    var keys = []
+    for (var i = 1; i <= 5; i++) keys.push('T-' + i)
+    var mockFetch = vi.fn().mockResolvedValue([])
+    await runPass1(vi.fn(), mockFetch, keys, { batchSize: 2, throttleMs: 0 })
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('marks failed keys with _error on batch failure', async function() {
+    var mockFetch = vi.fn().mockRejectedValue(new Error('Jira down'))
+    var result = await runPass1(vi.fn(), mockFetch, ['T-1', 'T-2'], { batchSize: 40, throttleMs: 0 })
+    expect(result.get('T-1')._error).toBe(true)
+    expect(result.get('T-2')._error).toBe(true)
+  })
+
+  it('returns empty map for empty keys', async function() {
+    var result = await runPass1(vi.fn(), vi.fn(), [], { throttleMs: 0 })
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('runPass2', function() {
+  it('updates enrichmentMap with refinementHistory', async function() {
+    var enrichmentMap = new Map([['T-1', { hasDescription: true, storyPoints: 5 }]])
+    var mockFetch = vi.fn().mockResolvedValue([{
+      key: 'T-1',
+      changelog: {
+        histories: [{
+          created: '2026-04-01T10:00:00Z',
+          items: [{ field: 'Target Version', fromString: null, toString: '3.5' }]
+        }]
+      }
+    }])
+    await runPass2(vi.fn(), mockFetch, ['T-1'], enrichmentMap, { batchSize: 40, throttleMs: 0 })
+    expect(enrichmentMap.get('T-1').refinementHistory).toHaveLength(1)
+  })
+
+  it('handles empty targetKeys', async function() {
+    var enrichmentMap = new Map()
+    var mockFetch = vi.fn()
+    await runPass2(vi.fn(), mockFetch, [], enrichmentMap, { throttleMs: 0 })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('enrichFeatures', function() {
+  var origToken, origEmail
+
+  beforeEach(function() {
+    origToken = process.env.JIRA_TOKEN
+    origEmail = process.env.JIRA_EMAIL
+  })
+
+  afterEach(function() {
+    if (origToken !== undefined) process.env.JIRA_TOKEN = origToken
+    else delete process.env.JIRA_TOKEN
+    if (origEmail !== undefined) process.env.JIRA_EMAIL = origEmail
+    else delete process.env.JIRA_EMAIL
+  })
+
+  it('returns warning when Jira credentials not configured', async function() {
+    delete process.env.JIRA_TOKEN
+    delete process.env.JIRA_EMAIL
+    var result = await enrichFeatures(vi.fn(), vi.fn(), [], {})
+    expect(result.warnings).toContain('Jira credentials not configured -- enrichment skipped')
+    expect(result.enrichments.size).toBe(0)
+  })
+
+  it('returns warning when enrichment disabled in config', async function() {
+    process.env.JIRA_TOKEN = 'test'
+    process.env.JIRA_EMAIL = 'test@test.com'
+    var result = await enrichFeatures(vi.fn(), vi.fn(), [], {
+      healthConfig: { enableJiraEnrichment: false }
+    })
+    expect(result.warnings).toContain('Jira enrichment disabled in config')
+  })
+
+  it('runs pass1 and pass2 when configured', async function() {
+    process.env.JIRA_TOKEN = 'test'
+    process.env.JIRA_EMAIL = 'test@test.com'
+    var features = [{ key: 'T-1', status: 'New', targetVersions: [] }]
+    var mockFetch = vi.fn().mockResolvedValue([{
+      key: 'T-1',
+      fields: { description: 'desc', customfield_10028: 3, issuelinks: [] }
+    }])
+    var result = await enrichFeatures(vi.fn(), mockFetch, features, {
+      healthConfig: { enrichmentThrottleMs: 0 }
+    })
+    expect(result.enrichments.has('T-1')).toBe(true)
+    expect(result.stats.pass1).toBe(1)
+  })
+
+  it('fetches RICE from parents when enabled and configured', async function() {
+    process.env.JIRA_TOKEN = 'test'
+    process.env.JIRA_EMAIL = 'test@test.com'
+    var features = [{ key: 'T-1', status: 'In Progress', targetVersions: ['3.5'], parentKey: 'STRAT-1' }]
+    var mockFetch = vi.fn().mockImplementation(function(jiraReq, jql) {
+      if (jql.indexOf('STRAT-1') !== -1) {
+        return Promise.resolve([{
+          key: 'STRAT-1',
+          fields: { cf_reach: 1000, cf_impact: 2, cf_conf: 80, cf_effort: 4 }
+        }])
+      }
+      return Promise.resolve([{
+        key: 'T-1',
+        fields: { description: 'desc', customfield_10028: 3, issuelinks: [] }
+      }])
+    })
+    var result = await enrichFeatures(vi.fn(), mockFetch, features, {
+      healthConfig: { enableRice: true, enrichmentThrottleMs: 0 },
+      customFieldIds: {
+        riceReach: 'cf_reach',
+        riceImpact: 'cf_impact',
+        riceConfidence: 'cf_conf',
+        riceEffort: 'cf_effort'
+      }
+    })
+    var enrichment = result.enrichments.get('T-1')
+    expect(enrichment.rice).toBeDefined()
+    expect(enrichment.rice.reach).toBe(1000)
+  })
+})

--- a/modules/release-planning/__tests__/server/rice-scorer.test.js
+++ b/modules/release-planning/__tests__/server/rice-scorer.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+
+const { computeRiceScore, buildRiceResult } = require('../../server/health/rice-scorer')
+
+describe('computeRiceScore', function() {
+  it('computes correct RICE score for valid inputs', function() {
+    var result = computeRiceScore({ reach: 1000, impact: 2, confidence: 80, effort: 4 })
+    expect(result).toBe(Math.round((1000 * 2 * 0.80) / 4))
+    expect(result).toBe(400)
+  })
+
+  it('returns null when rice is null', function() {
+    expect(computeRiceScore(null)).toBeNull()
+  })
+
+  it('returns null when rice is undefined', function() {
+    expect(computeRiceScore(undefined)).toBeNull()
+  })
+
+  it('returns null when reach is missing', function() {
+    expect(computeRiceScore({ impact: 2, confidence: 80, effort: 4 })).toBeNull()
+  })
+
+  it('returns null when impact is missing', function() {
+    expect(computeRiceScore({ reach: 1000, confidence: 80, effort: 4 })).toBeNull()
+  })
+
+  it('returns null when confidence is missing', function() {
+    expect(computeRiceScore({ reach: 1000, impact: 2, effort: 4 })).toBeNull()
+  })
+
+  it('returns null when effort is missing', function() {
+    expect(computeRiceScore({ reach: 1000, impact: 2, confidence: 80 })).toBeNull()
+  })
+
+  it('returns null when effort is zero', function() {
+    expect(computeRiceScore({ reach: 1000, impact: 2, confidence: 80, effort: 0 })).toBeNull()
+  })
+
+  it('returns null when a field is NaN', function() {
+    expect(computeRiceScore({ reach: 'abc', impact: 2, confidence: 80, effort: 4 })).toBeNull()
+  })
+
+  it('handles fractional impact values', function() {
+    var result = computeRiceScore({ reach: 500, impact: 0.25, confidence: 100, effort: 1 })
+    expect(result).toBe(Math.round(500 * 0.25 * 1.0 / 1))
+    expect(result).toBe(125)
+  })
+
+  it('rounds result to nearest integer', function() {
+    var result = computeRiceScore({ reach: 100, impact: 1, confidence: 33, effort: 1 })
+    expect(result).toBe(33)
+    expect(Number.isInteger(result)).toBe(true)
+  })
+})
+
+describe('buildRiceResult', function() {
+  it('returns null when rice is null', function() {
+    expect(buildRiceResult(null)).toBeNull()
+  })
+
+  it('returns null when rice is undefined', function() {
+    expect(buildRiceResult(undefined)).toBeNull()
+  })
+
+  it('returns complete result with score for valid data', function() {
+    var result = buildRiceResult({ reach: 1000, impact: 2, confidence: 80, effort: 4 })
+    expect(result).toEqual({
+      reach: 1000,
+      impact: 2,
+      confidence: 80,
+      effort: 4,
+      score: 400,
+      complete: true
+    })
+  })
+
+  it('returns incomplete result when data is missing', function() {
+    var result = buildRiceResult({ reach: 1000, impact: null, confidence: 80, effort: 4 })
+    expect(result.score).toBeNull()
+    expect(result.complete).toBe(false)
+    expect(result.reach).toBe(1000)
+    expect(result.confidence).toBe(80)
+  })
+
+  it('preserves original field values in result', function() {
+    var rice = { reach: 500, impact: 3, confidence: 90, effort: 2 }
+    var result = buildRiceResult(rice)
+    expect(result.reach).toBe(500)
+    expect(result.impact).toBe(3)
+    expect(result.confidence).toBe(90)
+    expect(result.effort).toBe(2)
+  })
+})

--- a/modules/release-planning/__tests__/server/risk-engine.test.js
+++ b/modules/release-planning/__tests__/server/risk-engine.test.js
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest'
+
+const {
+  computeFeatureRisk,
+  determineExpectedPhase,
+  isFeatureBehindPhase,
+  expectedCompletionForPhase
+} = require('../../server/health/risk-engine')
+
+const MILESTONES = {
+  ea1Freeze: '2026-05-01',
+  ea1Target: '2026-05-15',
+  ea2Freeze: '2026-06-15',
+  ea2Target: '2026-07-01',
+  gaFreeze: '2026-08-01',
+  gaTarget: '2026-08-15'
+}
+
+function dateOf(str) {
+  return new Date(str + 'T12:00:00Z')
+}
+
+describe('determineExpectedPhase', function() {
+  it('returns null when milestones is null', function() {
+    expect(determineExpectedPhase(null, new Date())).toBeNull()
+  })
+
+  it('returns null when today is before all milestones', function() {
+    expect(determineExpectedPhase(MILESTONES, dateOf('2026-04-01'))).toBeNull()
+  })
+
+  it('returns ea1_freeze when today is on ea1Freeze', function() {
+    expect(determineExpectedPhase(MILESTONES, dateOf('2026-05-01'))).toBe('ea1_freeze')
+  })
+
+  it('returns ea1_target when today is between ea1Target and ea2Freeze', function() {
+    expect(determineExpectedPhase(MILESTONES, dateOf('2026-05-20'))).toBe('ea1_target')
+  })
+
+  it('returns ea2_freeze when today is on ea2Freeze', function() {
+    expect(determineExpectedPhase(MILESTONES, dateOf('2026-06-15'))).toBe('ea2_freeze')
+  })
+
+  it('returns ga_target when today is past gaTarget', function() {
+    expect(determineExpectedPhase(MILESTONES, dateOf('2026-09-01'))).toBe('ga_target')
+  })
+
+  it('walks reverse chronologically to find the most recent', function() {
+    expect(determineExpectedPhase(MILESTONES, dateOf('2026-08-10'))).toBe('ga_freeze')
+  })
+
+  it('skips milestones with null dates', function() {
+    var partial = { ea1Freeze: null, ea1Target: '2026-05-15', ea2Freeze: '2026-06-15' }
+    expect(determineExpectedPhase(partial, dateOf('2026-05-01'))).toBeNull()
+    expect(determineExpectedPhase(partial, dateOf('2026-05-20'))).toBe('ea1_target')
+  })
+})
+
+describe('isFeatureBehindPhase', function() {
+  it('returns false when currentMilestone is null', function() {
+    expect(isFeatureBehindPhase({ status: 'New' }, null)).toBe(false)
+  })
+
+  it('returns true when feature in New status after freeze', function() {
+    expect(isFeatureBehindPhase({ status: 'New' }, 'ea1_freeze')).toBe(true)
+  })
+
+  it('returns true when feature in Refinement status after target', function() {
+    expect(isFeatureBehindPhase({ status: 'Refinement' }, 'ea1_target')).toBe(true)
+  })
+
+  it('returns false when feature is In Progress', function() {
+    expect(isFeatureBehindPhase({ status: 'In Progress' }, 'ea1_freeze')).toBe(false)
+  })
+
+  it('returns false for empty status', function() {
+    expect(isFeatureBehindPhase({ status: '' }, 'ea1_freeze')).toBe(false)
+  })
+})
+
+describe('expectedCompletionForPhase', function() {
+  it('returns 0 when currentMilestone is null', function() {
+    expect(expectedCompletionForPhase(null, 'EA1')).toBe(0)
+  })
+
+  it('returns 0 when featurePhase is null', function() {
+    expect(expectedCompletionForPhase('ea1_freeze', null)).toBe(0)
+  })
+
+  it('returns correct expectation for known phase and milestone', function() {
+    var result = expectedCompletionForPhase('ea1_freeze', 'EA1')
+    expect(typeof result).toBe('number')
+    expect(result).toBeGreaterThan(0)
+  })
+
+  it('falls back to GA expectations for unknown phase', function() {
+    var gaResult = expectedCompletionForPhase('ea1_freeze', 'GA')
+    var unknownResult = expectedCompletionForPhase('ea1_freeze', 'UNKNOWN_PHASE')
+    expect(unknownResult).toBe(gaResult)
+  })
+
+  it('uses custom expectations when provided', function() {
+    var custom = { ea1_freeze: { EA1: 99, GA: 10 } }
+    expect(expectedCompletionForPhase('ea1_freeze', 'EA1', custom)).toBe(99)
+  })
+
+  it('returns 0 when milestone not in expectations', function() {
+    expect(expectedCompletionForPhase('unknown_milestone', 'EA1')).toBe(0)
+  })
+})
+
+describe('computeFeatureRisk', function() {
+  var healthyFeature = { status: 'In Progress', completionPct: 80, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1 }
+  var healthyDor = { completionPct: 100, totalCount: 13 }
+  var healthyEnrichment = { storyPoints: 8, dependencyLinks: [] }
+
+  it('returns green with no flags for a healthy feature', function() {
+    var result = computeFeatureRisk(healthyFeature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    expect(result.risk).toBe('green')
+    expect(result.flags).toHaveLength(0)
+    expect(result.riskScore).toBe(0)
+  })
+
+  it('flags MILESTONE_MISS when feature in New status after freeze', function() {
+    var feature = { status: 'New', completionPct: 0, phase: 'EA1' }
+    var result = computeFeatureRisk(feature, MILESTONES, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-05-10')
+    })
+    var milestoneFlag = result.flags.find(function(f) { return f.category === 'MILESTONE_MISS' })
+    expect(milestoneFlag).toBeDefined()
+    expect(milestoneFlag.severity).toBe('high')
+    expect(result.risk).toBe('red')
+  })
+
+  it('flags VELOCITY_LAG medium when behind but above velocityYellowMin', function() {
+    var feature = { status: 'In Progress', completionPct: 60, phase: 'GA' }
+    var result = computeFeatureRisk(feature, MILESTONES, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-08-01'),
+      riskThresholds: { velocityYellowMin: 50 }
+    })
+    var velocityFlag = result.flags.find(function(f) { return f.category === 'VELOCITY_LAG' })
+    if (velocityFlag) {
+      expect(velocityFlag.severity).toBe('medium')
+    }
+  })
+
+  it('flags VELOCITY_LAG high when below velocityYellowMin', function() {
+    var feature = { status: 'In Progress', completionPct: 10, phase: 'GA' }
+    var result = computeFeatureRisk(feature, MILESTONES, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-08-01'),
+      riskThresholds: { velocityYellowMin: 50 }
+    })
+    var velocityFlag = result.flags.find(function(f) { return f.category === 'VELOCITY_LAG' })
+    if (velocityFlag) {
+      expect(velocityFlag.severity).toBe('high')
+    }
+  })
+
+  it('flags DOR_INCOMPLETE high when below 50%', function() {
+    var dor = { completionPct: 30, totalCount: 13 }
+    var result = computeFeatureRisk(healthyFeature, null, dor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var dorFlag = result.flags.find(function(f) { return f.category === 'DOR_INCOMPLETE' })
+    expect(dorFlag).toBeDefined()
+    expect(dorFlag.severity).toBe('high')
+  })
+
+  it('flags DOR_INCOMPLETE medium when between 50-80%', function() {
+    var dor = { completionPct: 65, totalCount: 13 }
+    var result = computeFeatureRisk(healthyFeature, null, dor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var dorFlag = result.flags.find(function(f) { return f.category === 'DOR_INCOMPLETE' })
+    expect(dorFlag).toBeDefined()
+    expect(dorFlag.severity).toBe('medium')
+  })
+
+  it('does not flag DOR_INCOMPLETE when above 80%', function() {
+    var dor = { completionPct: 85, totalCount: 13 }
+    var result = computeFeatureRisk(healthyFeature, null, dor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var dorFlag = result.flags.find(function(f) { return f.category === 'DOR_INCOMPLETE' })
+    expect(dorFlag).toBeUndefined()
+  })
+
+  it('flags BLOCKED when unresolved inward Blocks link exists', function() {
+    var enrichment = {
+      storyPoints: 8,
+      dependencyLinks: [
+        { type: 'Blocks', direction: 'inward', linkedKey: 'TEST-999', linkedStatus: 'In Progress' }
+      ]
+    }
+    var result = computeFeatureRisk(healthyFeature, null, healthyDor, enrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var blockedFlag = result.flags.find(function(f) { return f.category === 'BLOCKED' })
+    expect(blockedFlag).toBeDefined()
+    expect(blockedFlag.severity).toBe('high')
+    expect(blockedFlag.message).toContain('TEST-999')
+  })
+
+  it('does not flag BLOCKED when linked status is Closed', function() {
+    var enrichment = {
+      storyPoints: 8,
+      dependencyLinks: [
+        { type: 'Blocks', direction: 'inward', linkedKey: 'TEST-999', linkedStatus: 'Closed' }
+      ]
+    }
+    var result = computeFeatureRisk(healthyFeature, null, healthyDor, enrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var blockedFlag = result.flags.find(function(f) { return f.category === 'BLOCKED' })
+    expect(blockedFlag).toBeUndefined()
+  })
+
+  it('flags UNESTIMATED when no story points', function() {
+    var enrichment = { storyPoints: null, dependencyLinks: [] }
+    var result = computeFeatureRisk(healthyFeature, null, healthyDor, enrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var unestFlag = result.flags.find(function(f) { return f.category === 'UNESTIMATED' })
+    expect(unestFlag).toBeDefined()
+    expect(unestFlag.severity).toBe('medium')
+  })
+
+  it('sets risk to red when any flag has high severity', function() {
+    var dor = { completionPct: 30, totalCount: 13 }
+    var result = computeFeatureRisk(healthyFeature, null, dor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    expect(result.risk).toBe('red')
+  })
+
+  it('sets risk to yellow when worst severity is medium', function() {
+    var enrichment = { storyPoints: null, dependencyLinks: [] }
+    var dor = { completionPct: 85, totalCount: 13 }
+    var result = computeFeatureRisk(healthyFeature, null, dor, enrichment, {
+      today: dateOf('2026-04-01')
+    })
+    expect(result.risk).toBe('yellow')
+  })
+
+  it('riskScore equals the number of flags', function() {
+    var dor = { completionPct: 30, totalCount: 13 }
+    var enrichment = { storyPoints: null, dependencyLinks: [] }
+    var result = computeFeatureRisk(healthyFeature, null, dor, enrichment, {
+      today: dateOf('2026-04-01')
+    })
+    expect(result.riskScore).toBe(result.flags.length)
+  })
+
+  // ─── Planning risk categories ───
+
+  it('flags MISSING_OWNER when no deliveryOwner or assignee', function() {
+    var feature = { status: 'In Progress', completionPct: 80, phase: 'GA', tier: 1 }
+    var result = computeFeatureRisk(feature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'MISSING_OWNER' })
+    expect(flag).toBeDefined()
+    expect(flag.severity).toBe('medium')
+  })
+
+  it('does not flag MISSING_OWNER when deliveryOwner is set', function() {
+    var result = computeFeatureRisk(healthyFeature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'MISSING_OWNER' })
+    expect(flag).toBeUndefined()
+  })
+
+  it('flags NO_BIG_ROCK when tier is 3', function() {
+    var feature = { status: 'In Progress', completionPct: 80, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 3 }
+    var result = computeFeatureRisk(feature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'NO_BIG_ROCK' })
+    expect(flag).toBeDefined()
+    expect(flag.severity).toBe('low')
+  })
+
+  it('NO_BIG_ROCK low severity does not escalate to yellow by itself', function() {
+    var feature = { status: 'In Progress', completionPct: 80, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 3 }
+    var result = computeFeatureRisk(feature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    expect(result.risk).toBe('green')
+    expect(result.flags.length).toBe(1)
+  })
+
+  it('does not flag NO_BIG_ROCK for tier 1 or 2', function() {
+    var result = computeFeatureRisk(healthyFeature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01')
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'NO_BIG_ROCK' })
+    expect(flag).toBeUndefined()
+  })
+
+  it('flags LATE_COMMITMENT when past planning deadline and no fixVersion', function() {
+    var feature = { status: 'In Progress', completionPct: 80, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1, fixVersions: [] }
+    var result = computeFeatureRisk(feature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01'),
+      planningDeadline: { date: '2026-03-25', daysRemaining: -7 },
+      version: '3.5'
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'LATE_COMMITMENT' })
+    expect(flag).toBeDefined()
+    expect(flag.severity).toBe('high')
+    expect(flag.message).toContain('7 days')
+  })
+
+  it('does not flag LATE_COMMITMENT when feature has a matching fixVersion', function() {
+    var feature = { status: 'In Progress', completionPct: 80, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1, fixVersions: ['rhoai-3.5'] }
+    var result = computeFeatureRisk(feature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01'),
+      planningDeadline: { date: '2026-03-25', daysRemaining: -7 },
+      version: '3.5'
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'LATE_COMMITMENT' })
+    expect(flag).toBeUndefined()
+  })
+
+  it('does not flag LATE_COMMITMENT when before planning deadline', function() {
+    var feature = { status: 'In Progress', completionPct: 80, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1, fixVersions: [] }
+    var result = computeFeatureRisk(feature, null, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-04-01'),
+      planningDeadline: { date: '2026-04-15', daysRemaining: 14 },
+      version: '3.5'
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'LATE_COMMITMENT' })
+    expect(flag).toBeUndefined()
+  })
+
+  // ─── Execution category suppression ───
+
+  it('suppresses MILESTONE_MISS when before planning deadline', function() {
+    var feature = { status: 'New', completionPct: 0, phase: 'EA1', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1 }
+    var result = computeFeatureRisk(feature, MILESTONES, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-05-10'),
+      planningDeadline: { date: '2026-06-01', daysRemaining: 22 }
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'MILESTONE_MISS' })
+    expect(flag).toBeUndefined()
+  })
+
+  it('suppresses VELOCITY_LAG when before planning deadline', function() {
+    var feature = { status: 'In Progress', completionPct: 10, phase: 'GA', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1 }
+    var result = computeFeatureRisk(feature, MILESTONES, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-08-01'),
+      planningDeadline: { date: '2026-09-01', daysRemaining: 31 }
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'VELOCITY_LAG' })
+    expect(flag).toBeUndefined()
+  })
+
+  it('does not suppress execution categories when past planning deadline', function() {
+    var feature = { status: 'New', completionPct: 0, phase: 'EA1', deliveryOwner: 'Jane', assignee: 'Jane', tier: 1 }
+    var result = computeFeatureRisk(feature, MILESTONES, healthyDor, healthyEnrichment, {
+      today: dateOf('2026-05-10'),
+      planningDeadline: { date: '2026-04-01', daysRemaining: -39 }
+    })
+    var flag = result.flags.find(function(f) { return f.category === 'MILESTONE_MISS' })
+    expect(flag).toBeDefined()
+  })
+})

--- a/modules/release-planning/client/components/BigRockRow.vue
+++ b/modules/release-planning/client/components/BigRockRow.vue
@@ -1,7 +1,19 @@
 <script setup>
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   rock: { type: Object, required: true },
-  jiraBaseUrl: { type: String, default: '' }
+  jiraBaseUrl: { type: String, default: '' },
+  health: { type: Object, default: null },
+  hasHealth: { type: Boolean, default: false }
+})
+
+const healthBadgeClass = computed(function() {
+  if (!props.health) return ''
+  var level = props.health.worstLevel
+  if (level === 'red') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+  if (level === 'yellow') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
+  return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
 })
 </script>
 
@@ -40,4 +52,13 @@ defineProps({
     <span class="font-semibold text-gray-700 dark:text-gray-300">{{ rock.rfeCount }}</span>
   </td>
   <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 max-w-xs truncate border border-gray-300 dark:border-gray-600">{{ rock.notes }}</td>
+  <td v-if="hasHealth" class="px-3 py-2 text-center border border-gray-300 dark:border-gray-600">
+    <span
+      v-if="health"
+      class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
+      :class="healthBadgeClass"
+      :title="health.totalFlags + ' risk flag(s) across ' + health.featureCount + ' feature(s)'"
+    >{{ health.worstLevel === 'green' ? 'OK' : health.worstLevel === 'yellow' ? 'At Risk' : 'Critical' }}</span>
+    <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
+  </td>
 </template>

--- a/modules/release-planning/client/components/BigRocksTable.vue
+++ b/modules/release-planning/client/components/BigRocksTable.vue
@@ -1,12 +1,43 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import draggable from 'vuedraggable'
 import BigRockRow from './BigRockRow.vue'
 
 const props = defineProps({
   bigRocks: { type: Array, default: () => [] },
   jiraBaseUrl: { type: String, default: '' },
-  canEdit: { type: Boolean, default: false }
+  canEdit: { type: Boolean, default: false },
+  healthByKey: { type: Object, default: () => ({}) },
+  features: { type: Array, default: () => [] }
+})
+
+const RISK_SEVERITY = { red: 0, yellow: 1, green: 2 }
+
+const hasHealth = computed(function() {
+  return Object.keys(props.healthByKey).length > 0
+})
+
+const rockHealth = computed(function() {
+  if (!hasHealth.value) return {}
+  var result = {}
+  for (var i = 0; i < props.features.length; i++) {
+    var f = props.features[i]
+    var rockName = f.bigRock
+    if (!rockName) continue
+    var h = props.healthByKey[f.issueKey]
+    if (!h || !h.risk) continue
+
+    if (!result[rockName]) {
+      result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0 }
+    }
+    result[rockName].featureCount++
+    result[rockName].totalFlags += (h.risk.score || 0)
+    var level = h.risk.override ? (h.risk.override.riskOverride || h.risk.level) : h.risk.level
+    if ((RISK_SEVERITY[level] || 2) < (RISK_SEVERITY[result[rockName].worstLevel] || 2)) {
+      result[rockName].worstLevel = level
+    }
+  }
+  return result
 })
 
 const emit = defineEmits(['editRock', 'addRock', 'deleteRock', 'reorder'])
@@ -64,6 +95,7 @@ function onDragEnd() {
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Architect</th>
             <th scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Features</th>
             <th scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">RFEs</th>
+            <th v-if="hasHealth" scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Health</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Notes</th>
             <th v-if="canEdit" scope="col" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"><span class="sr-only">Actions</span></th>
           </tr>
@@ -86,7 +118,7 @@ function onDragEnd() {
                   &#x2807;
                 </span>
               </td>
-              <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" />
+              <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" />
               <td class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
                 <button
                   @click="handleDeleteClick($event, rock)"
@@ -107,10 +139,10 @@ function onDragEnd() {
             :key="rock.name"
             class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
           >
-            <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" />
+            <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" />
           </tr>
           <tr v-if="!bigRocks || bigRocks.length === 0">
-            <td colspan="9" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
+            <td :colspan="hasHealth ? 10 : 9" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
               No Big Rocks configured.
             </td>
           </tr>

--- a/modules/release-planning/client/components/DorChecklist.vue
+++ b/modules/release-planning/client/components/DorChecklist.vue
@@ -1,0 +1,156 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  items: { type: Array, default: () => [] },
+  notes: { type: String, default: '' },
+  featureKey: { type: String, default: '' },
+  canEdit: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['toggleItem', 'updateNotes'])
+
+var localNotes = ref(props.notes || '')
+
+watch(function() { return props.notes }, function(val) {
+  localNotes.value = val || ''
+})
+
+var checkedCount = computed(function() {
+  var count = 0
+  for (var i = 0; i < props.items.length; i++) {
+    if (props.items[i].checked) count++
+  }
+  return count
+})
+
+var totalCount = computed(function() {
+  return props.items.length
+})
+
+var completionPct = computed(function() {
+  if (totalCount.value === 0) return 0
+  return Math.round((checkedCount.value / totalCount.value) * 100)
+})
+
+function handleToggle(item) {
+  if (item.type !== 'manual' || !props.canEdit) return
+  emit('toggleItem', item.id, !item.checked)
+}
+
+function handleNotesInput(event) {
+  localNotes.value = event.target.value
+  emit('updateNotes', event.target.value)
+}
+
+function itemStatusClass(item) {
+  if (item.checked) return 'text-green-600 dark:text-green-400'
+  return 'text-gray-400 dark:text-gray-500'
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <!-- Header with completion -->
+    <div class="flex items-center justify-between">
+      <div class="text-xs font-semibold text-gray-700 dark:text-gray-300">
+        Definition of Ready
+        <span class="ml-1 font-normal text-gray-500 dark:text-gray-400">({{ checkedCount }}/{{ totalCount }})</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <div class="w-20 bg-gray-200 dark:bg-gray-600 rounded-full h-1.5">
+          <div
+            class="h-1.5 rounded-full transition-all"
+            :class="completionPct >= 80 ? 'bg-green-500' : completionPct >= 50 ? 'bg-yellow-500' : 'bg-red-500'"
+            :style="{ width: Math.min(completionPct, 100) + '%' }"
+          ></div>
+        </div>
+        <span class="text-[10px] font-medium text-gray-500 dark:text-gray-400">{{ completionPct }}%</span>
+      </div>
+    </div>
+
+    <!-- Checklist items -->
+    <div class="space-y-1">
+      <div
+        v-for="item in items"
+        :key="item.id"
+        class="flex items-start gap-2 py-1 px-2 rounded text-xs"
+        :class="item.type === 'manual' && canEdit ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer' : ''"
+        @click="handleToggle(item)"
+      >
+        <!-- Checkbox / Lock icon -->
+        <div class="flex-shrink-0 mt-0.5">
+          <template v-if="item.type === 'automated'">
+            <!-- Lock icon for automated items -->
+            <svg
+              class="w-3.5 h-3.5"
+              :class="itemStatusClass(item)"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+          </template>
+          <template v-else>
+            <!-- Checkbox for manual items -->
+            <input
+              type="checkbox"
+              :checked="item.checked"
+              :disabled="!canEdit"
+              class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+              @click.stop="handleToggle(item)"
+              @change.stop
+            />
+          </template>
+        </div>
+
+        <!-- Label -->
+        <div class="flex-1 min-w-0">
+          <span
+            class="text-gray-700 dark:text-gray-300"
+            :class="item.checked ? '' : 'opacity-80'"
+          >{{ item.label }}</span>
+          <span
+            class="ml-1 text-[10px] text-gray-400 dark:text-gray-500"
+          >({{ item.type === 'automated' ? 'auto' : 'manual' }})</span>
+        </div>
+
+        <!-- Status indicator -->
+        <div class="flex-shrink-0">
+          <svg
+            v-if="item.checked"
+            class="w-3.5 h-3.5 text-green-500 dark:text-green-400"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          <svg
+            v-else
+            class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+      </div>
+    </div>
+
+    <!-- Notes -->
+    <div class="pt-2 border-t border-gray-100 dark:border-gray-700">
+      <label class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Notes</label>
+      <textarea
+        v-if="canEdit"
+        :value="localNotes"
+        @input="handleNotesInput"
+        rows="2"
+        maxlength="2000"
+        placeholder="Add readiness notes..."
+        class="mt-1 w-full text-xs bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 resize-none"
+      ></textarea>
+      <p v-else-if="localNotes" class="mt-1 text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap">{{ localNotes }}</p>
+      <p v-else class="mt-1 text-xs text-gray-400 dark:text-gray-500 italic">No notes</p>
+    </div>
+  </div>
+</template>

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -1,0 +1,270 @@
+<script setup>
+import { computed } from 'vue'
+import RiskBadge from './RiskBadge.vue'
+import RiceScoreDisplay from './RiceScoreDisplay.vue'
+import DorChecklist from './DorChecklist.vue'
+import StatusBadge from './StatusBadge.vue'
+
+const props = defineProps({
+  feature: { type: Object, required: true },
+  expanded: { type: Boolean, default: false },
+  canEdit: { type: Boolean, default: false },
+  jiraBaseUrl: { type: String, default: '' }
+})
+
+const emit = defineEmits(['toggle', 'toggleDorItem', 'updateNotes', 'setOverride', 'removeOverride'])
+
+var dorItems = computed(function() {
+  if (!props.feature.dor || !props.feature.dor.items) return []
+  return props.feature.dor.items
+})
+
+var dorNotes = computed(function() {
+  if (!props.feature.dor) return ''
+  return props.feature.dor.notes || ''
+})
+
+var riskFlags = computed(function() {
+  if (!props.feature.risk || !props.feature.risk.flags) return []
+  return props.feature.risk.flags
+})
+
+var riskLevel = computed(function() {
+  if (!props.feature.risk) return 'green'
+  return props.feature.risk.level || 'green'
+})
+
+var riskOverride = computed(function() {
+  if (!props.feature.risk) return null
+  return props.feature.risk.override || null
+})
+
+var dorPct = computed(function() {
+  if (!props.feature.dor) return 0
+  return props.feature.dor.completionPct || 0
+})
+
+var featureUrl = computed(function() {
+  if (props.feature.jiraUrl) return props.feature.jiraUrl
+  if (props.jiraBaseUrl && props.feature.key) return props.jiraBaseUrl + '/' + props.feature.key
+  return ''
+})
+
+function handleToggle() {
+  emit('toggle', props.feature.key)
+}
+
+function handleDorToggle(itemId, checked) {
+  emit('toggleDorItem', props.feature.key, itemId, checked)
+}
+
+function handleNotesUpdate(notes) {
+  emit('updateNotes', props.feature.key, notes)
+}
+
+var flagSeverityClass = {
+  high: 'bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400 border-red-200 dark:border-red-500/30',
+  medium: 'bg-yellow-50 dark:bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 border-yellow-200 dark:border-yellow-500/30'
+}
+</script>
+
+<template>
+  <!-- Main row -->
+  <tr
+    class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
+    @click="handleToggle"
+  >
+    <!-- Expand toggle -->
+    <td class="px-2 py-2 border border-gray-300 dark:border-gray-600 w-8 text-center">
+      <svg
+        class="w-3.5 h-3.5 text-gray-400 transition-transform inline-block"
+        :class="expanded ? 'rotate-90' : ''"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+    </td>
+    <!-- Feature key -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+      <div class="flex items-center gap-1">
+        <a
+          v-if="featureUrl"
+          :href="featureUrl"
+          target="_blank"
+          rel="noopener"
+          class="text-primary-600 dark:text-blue-400 font-mono text-xs hover:underline"
+          @click.stop
+        >{{ feature.key }}</a>
+        <span v-else class="font-mono text-xs text-gray-700 dark:text-gray-300">{{ feature.key }}</span>
+        <a
+          :href="'#/feature-traffic/feature-detail?key=' + feature.key"
+          class="text-gray-400 hover:text-primary-600 dark:hover:text-blue-400"
+          title="View in Feature Traffic"
+          @click.stop
+        >
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
+      </div>
+    </td>
+    <!-- Summary -->
+    <td class="px-3 py-2 text-gray-900 dark:text-gray-100 max-w-[200px] truncate border border-gray-300 dark:border-gray-600 text-xs">{{ feature.summary }}</td>
+    <!-- Status -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+      <StatusBadge :status="feature.status" />
+    </td>
+    <!-- Risk -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+      <RiskBadge
+        :level="riskLevel"
+        :flagCount="feature.risk ? feature.risk.score : 0"
+        :flags="riskFlags"
+        :override="riskOverride"
+      />
+    </td>
+    <!-- DoR -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-center">
+      <span
+        class="font-medium"
+        :class="dorPct >= 80 ? 'text-green-600 dark:text-green-400' : dorPct >= 50 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'"
+      >{{ dorPct }}%</span>
+    </td>
+    <!-- RICE -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center" @click.stop>
+      <RiceScoreDisplay :rice="feature.rice" :jiraUrl="featureUrl" />
+    </td>
+    <!-- Component -->
+    <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.components || '-' }}</td>
+    <!-- Phase -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+      <span
+        v-if="feature.phase"
+        class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
+        :class="{
+          'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400': feature.phase === 'TP' || feature.phase === 'EA1',
+          'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400': feature.phase === 'DP' || feature.phase === 'EA2',
+          'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400': feature.phase === 'GA'
+        }"
+      >{{ feature.phase }}</span>
+      <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
+    </td>
+    <!-- Tier -->
+    <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.tier || '-' }}</td>
+  </tr>
+
+  <!-- Expanded detail row -->
+  <tr v-if="expanded">
+    <td colspan="10" class="border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/50 p-0">
+      <div class="p-4 space-y-4">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <!-- DoR Checklist -->
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+            <DorChecklist
+              :items="dorItems"
+              :notes="dorNotes"
+              :featureKey="feature.key"
+              :canEdit="canEdit"
+              @toggleItem="handleDorToggle"
+              @updateNotes="handleNotesUpdate"
+            />
+          </div>
+
+          <!-- Risk Flags & Details -->
+          <div class="space-y-3">
+            <!-- Risk flags -->
+            <div v-if="riskFlags.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+              <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Risk Flags</div>
+              <div class="space-y-1.5">
+                <div
+                  v-for="(flag, idx) in riskFlags"
+                  :key="idx"
+                  class="flex items-start gap-2 text-xs px-2 py-1.5 rounded border"
+                  :class="flagSeverityClass[flag.severity] || flagSeverityClass.medium"
+                >
+                  <svg
+                    class="w-3.5 h-3.5 flex-shrink-0 mt-0.5"
+                    fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                  </svg>
+                  <div>
+                    <span class="font-semibold">{{ flag.category }}</span>
+                    <span class="ml-1">{{ flag.message }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Override section -->
+            <div v-if="riskOverride" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+              <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">Risk Override</div>
+              <div class="text-xs text-gray-600 dark:text-gray-400">
+                <span class="font-medium">Level:</span> {{ riskOverride.riskOverride }}
+              </div>
+              <div class="text-xs text-gray-600 dark:text-gray-400">
+                <span class="font-medium">Reason:</span> {{ riskOverride.reason }}
+              </div>
+              <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+                Set by {{ riskOverride.updatedBy }} on {{ riskOverride.updatedAt ? new Date(riskOverride.updatedAt).toLocaleDateString() : '' }}
+              </div>
+              <button
+                v-if="canEdit"
+                @click.stop="$emit('removeOverride', feature.key)"
+                class="mt-2 text-[10px] text-red-600 dark:text-red-400 hover:underline"
+              >Remove override</button>
+            </div>
+
+            <!-- Feature metadata -->
+            <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+              <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Feature Details</div>
+              <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400">PM:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.pm || '-' }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400">Owner:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.deliveryOwner || '-' }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400">Epics:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.epicCount != null ? feature.epicCount : '-' }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400">Issues:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.issueCount != null ? feature.issueCount : '-' }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400">Completion:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.completionPct != null ? feature.completionPct + '%' : '-' }}</span>
+                </div>
+                <div>
+                  <span class="text-gray-500 dark:text-gray-400">Blockers:</span>
+                  <span
+                    class="ml-1"
+                    :class="feature.blockerCount > 0 ? 'text-red-600 dark:text-red-400 font-semibold' : 'text-gray-900 dark:text-gray-100'"
+                  >{{ feature.blockerCount != null ? feature.blockerCount : '-' }}</span>
+                </div>
+                <div v-if="feature.bigRock">
+                  <span class="text-gray-500 dark:text-gray-400">Big Rock:</span>
+                  <a
+                    :href="'#/release-planning/main?bigRock=' + encodeURIComponent(feature.bigRock)"
+                    class="ml-1 text-primary-600 dark:text-blue-400 hover:underline"
+                    @click.stop
+                  >{{ feature.bigRock }}</a>
+                </div>
+                <div v-if="feature.tier">
+                  <span class="text-gray-500 dark:text-gray-400">Tier:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.tier }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </td>
+  </tr>
+</template>

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -98,7 +98,7 @@ var flagSeverityClass = {
         >{{ feature.key }}</a>
         <span v-else class="font-mono text-xs text-gray-700 dark:text-gray-300">{{ feature.key }}</span>
         <a
-          :href="'#/feature-traffic/feature-detail?key=' + feature.key"
+          :href="'#/feature-traffic/feature-detail?key=' + encodeURIComponent(feature.key)"
           class="text-gray-400 hover:text-primary-600 dark:hover:text-blue-400"
           title="View in Feature Traffic"
           @click.stop

--- a/modules/release-planning/client/components/FeatureHealthTable.vue
+++ b/modules/release-planning/client/components/FeatureHealthTable.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { ref, computed } from 'vue'
+import FeatureHealthRow from './FeatureHealthRow.vue'
+
+const props = defineProps({
+  features: { type: Array, default: () => [] },
+  canEdit: { type: Boolean, default: false },
+  jiraBaseUrl: { type: String, default: '' }
+})
+
+const emit = defineEmits(['toggleDorItem', 'updateNotes', 'setOverride', 'removeOverride'])
+
+var PAGE_SIZE = 50
+var expandedRows = ref({})
+var sortKey = ref('risk')
+var sortAsc = ref(true)
+var currentPage = ref(1)
+
+var columns = [
+  { key: 'expand', label: '', sortable: false },
+  { key: 'key', label: 'Feature', sortable: true },
+  { key: 'summary', label: 'Summary', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'risk', label: 'Risk', sortable: true },
+  { key: 'dor', label: 'DoR', sortable: true },
+  { key: 'rice', label: 'RICE', sortable: true },
+  { key: 'components', label: 'Component', sortable: true },
+  { key: 'phase', label: 'Phase', sortable: true },
+  { key: 'tier', label: 'Tier', sortable: true }
+]
+
+var RISK_ORDER = { red: 0, yellow: 1, green: 2 }
+
+function getRiskLevel(feature) {
+  if (!feature.risk) return 'green'
+  if (feature.risk.override) return feature.risk.override.riskOverride || feature.risk.level
+  return feature.risk.level || 'green'
+}
+
+var sortedFeatures = computed(function() {
+  var list = props.features.slice()
+  var key = sortKey.value
+  var asc = sortAsc.value
+
+  list.sort(function(a, b) {
+    var va, vb
+
+    if (key === 'key') {
+      va = a.key || ''
+      vb = b.key || ''
+    } else if (key === 'summary') {
+      va = (a.summary || '').toLowerCase()
+      vb = (b.summary || '').toLowerCase()
+    } else if (key === 'status') {
+      va = a.status || ''
+      vb = b.status || ''
+    } else if (key === 'risk') {
+      va = RISK_ORDER[getRiskLevel(a)]
+      vb = RISK_ORDER[getRiskLevel(b)]
+      if (va == null) va = 3
+      if (vb == null) vb = 3
+    } else if (key === 'dor') {
+      va = a.dor ? a.dor.completionPct : 0
+      vb = b.dor ? b.dor.completionPct : 0
+    } else if (key === 'rice') {
+      va = a.rice && a.rice.score != null ? a.rice.score : -1
+      vb = b.rice && b.rice.score != null ? b.rice.score : -1
+    } else if (key === 'components') {
+      va = (a.components || '').toLowerCase()
+      vb = (b.components || '').toLowerCase()
+    } else if (key === 'phase') {
+      va = a.phase || ''
+      vb = b.phase || ''
+    } else if (key === 'tier') {
+      va = a.tier || ''
+      vb = b.tier || ''
+    } else {
+      return 0
+    }
+
+    var cmp = (typeof va === 'number' && typeof vb === 'number')
+      ? va - vb
+      : String(va).localeCompare(String(vb))
+
+    return asc ? cmp : -cmp
+  })
+
+  return list
+})
+
+var totalPages = computed(function() {
+  return Math.max(1, Math.ceil(sortedFeatures.value.length / PAGE_SIZE))
+})
+
+var paginatedFeatures = computed(function() {
+  var start = (currentPage.value - 1) * PAGE_SIZE
+  return sortedFeatures.value.slice(start, start + PAGE_SIZE)
+})
+
+var needsPagination = computed(function() {
+  return sortedFeatures.value.length > PAGE_SIZE
+})
+
+function handleSort(key) {
+  if (key === 'expand') return
+  if (sortKey.value === key) {
+    sortAsc.value = !sortAsc.value
+  } else {
+    sortKey.value = key
+    sortAsc.value = true
+  }
+  currentPage.value = 1
+}
+
+function toggleRow(featureKey) {
+  var updated = Object.assign({}, expandedRows.value)
+  if (updated[featureKey]) {
+    delete updated[featureKey]
+  } else {
+    updated[featureKey] = true
+  }
+  expandedRows.value = updated
+}
+
+function handleDorToggle(featureKey, itemId, checked) {
+  emit('toggleDorItem', featureKey, itemId, checked)
+}
+
+function handleNotesUpdate(featureKey, notes) {
+  emit('updateNotes', featureKey, notes)
+}
+
+function handleRemoveOverride(featureKey) {
+  emit('removeOverride', featureKey)
+}
+
+function goToPage(page) {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page
+  }
+}
+
+function sortIndicator(key) {
+  if (sortKey.value !== key) return ''
+  return sortAsc.value ? ' ↑' : ' ↓'
+}
+</script>
+
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm border-collapse">
+        <caption class="sr-only">Feature health assessment</caption>
+        <thead>
+          <tr>
+            <th
+              v-for="col in columns"
+              :key="col.key"
+              scope="col"
+              class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"
+              :class="col.sortable ? 'cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 select-none' : ''"
+              @click="col.sortable ? handleSort(col.key) : null"
+            >
+              {{ col.label }}{{ sortIndicator(col.key) }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="feature in paginatedFeatures" :key="feature.key">
+            <FeatureHealthRow
+              :feature="feature"
+              :expanded="!!expandedRows[feature.key]"
+              :canEdit="canEdit"
+              :jiraBaseUrl="jiraBaseUrl"
+              @toggle="toggleRow"
+              @toggleDorItem="handleDorToggle"
+              @updateNotes="handleNotesUpdate"
+              @removeOverride="handleRemoveOverride"
+            />
+          </template>
+          <tr v-if="!features || features.length === 0">
+            <td colspan="10" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
+              No features found matching the current filters.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="needsPagination" class="flex items-center justify-between px-4 py-3 border-t border-gray-200 dark:border-gray-600">
+      <div class="text-xs text-gray-500 dark:text-gray-400">
+        Showing {{ (currentPage - 1) * PAGE_SIZE + 1 }}-{{ Math.min(currentPage * PAGE_SIZE, sortedFeatures.length) }}
+        of {{ sortedFeatures.length }} features
+      </div>
+      <div class="flex items-center gap-1">
+        <button
+          :disabled="currentPage <= 1"
+          @click="goToPage(currentPage - 1)"
+          class="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >Prev</button>
+        <span class="text-xs text-gray-600 dark:text-gray-400 px-2">
+          Page {{ currentPage }} of {{ totalPages }}
+        </span>
+        <button
+          :disabled="currentPage >= totalPages"
+          @click="goToPage(currentPage + 1)"
+          class="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >Next</button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/modules/release-planning/client/components/FeaturesTable.vue
+++ b/modules/release-planning/client/components/FeaturesTable.vue
@@ -1,5 +1,6 @@
 <script setup>
 import StatusBadge from './StatusBadge.vue'
+import RiskBadge from './RiskBadge.vue'
 import TierSeparator from './TierSeparator.vue'
 import { computed } from 'vue'
 import { PRIORITY_STYLES } from '../constants'
@@ -8,10 +9,17 @@ const props = defineProps({
   features: { type: Array, default: () => [] },
   bigRocks: { type: Array, default: () => [] },
   jiraBaseUrl: { type: String, default: '' },
-  summary: { type: Object, default: null }
+  summary: { type: Object, default: null },
+  healthByKey: { type: Object, default: () => ({}) }
 })
 
-const COL_COUNT = 11
+const hasHealth = computed(function() {
+  return Object.keys(props.healthByKey).length > 0
+})
+
+const COL_COUNT = computed(function() {
+  return hasHealth.value ? 13 : 11
+})
 
 const tierCounts = computed(() => {
   const counts = {}
@@ -49,6 +57,8 @@ const groupedFeatures = computed(() => {
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Big Rock</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Feature</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Status</th>
+            <th v-if="hasHealth" scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Risk</th>
+            <th v-if="hasHealth" scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">DoR</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Priority</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Phase</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Title</th>
@@ -81,6 +91,24 @@ const groupedFeatures = computed(() => {
                 >{{ item.data.issueKey }}</a>
               </td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600"><StatusBadge :status="item.data.status" /></td>
+              <td v-if="hasHealth" class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+                <RiskBadge
+                  v-if="healthByKey[item.data.issueKey]"
+                  :level="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.level : 'green'"
+                  :flagCount="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.score : 0"
+                  :flags="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.flags : []"
+                  :override="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.override : null"
+                />
+                <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
+              </td>
+              <td v-if="hasHealth" class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-center">
+                <span
+                  v-if="healthByKey[item.data.issueKey] && healthByKey[item.data.issueKey].dor"
+                  class="font-medium"
+                  :class="healthByKey[item.data.issueKey].dor.completionPct >= 80 ? 'text-green-600 dark:text-green-400' : healthByKey[item.data.issueKey].dor.completionPct >= 50 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'"
+                >{{ healthByKey[item.data.issueKey].dor.completionPct }}%</span>
+                <span v-else class="text-gray-400 dark:text-gray-600">-</span>
+              </td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
                 <span
                   v-if="item.data.priority"

--- a/modules/release-planning/client/components/HealthFilterBar.vue
+++ b/modules/release-planning/client/components/HealthFilterBar.vue
@@ -1,0 +1,104 @@
+<script setup>
+defineProps({
+  riskFilter: { type: String, default: '' },
+  dorFilter: { type: String, default: '' },
+  bigRockFilter: { type: String, default: '' },
+  componentFilter: { type: String, default: '' },
+  tierFilter: { type: String, default: '' },
+  searchQuery: { type: String, default: '' },
+  bigRocks: { type: Array, default: () => [] },
+  components: { type: Array, default: () => [] },
+  hasActiveFilters: { type: Boolean, default: false }
+})
+
+defineEmits([
+  'update:riskFilter',
+  'update:dorFilter',
+  'update:bigRockFilter',
+  'update:componentFilter',
+  'update:tierFilter',
+  'update:searchQuery',
+  'clearFilters'
+])
+
+var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500'
+</script>
+
+<template>
+  <div class="flex flex-wrap gap-3 items-center">
+    <input
+      :value="searchQuery"
+      @input="$emit('update:searchQuery', $event.target.value)"
+      type="text"
+      placeholder="Search features..."
+      aria-label="Search features"
+      class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+    />
+
+    <select
+      :value="riskFilter"
+      @change="$emit('update:riskFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by risk level"
+    >
+      <option value="">All Risk Levels</option>
+      <option value="green">Green - On Track</option>
+      <option value="yellow">Yellow - At Risk</option>
+      <option value="red">Red - Critical</option>
+    </select>
+
+    <select
+      :value="dorFilter"
+      @change="$emit('update:dorFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by DoR status"
+    >
+      <option value="">All DoR Status</option>
+      <option value="complete">DoR Complete (80%+)</option>
+      <option value="partial">DoR Partial (50-79%)</option>
+      <option value="incomplete">DoR Incomplete (&lt;50%)</option>
+    </select>
+
+    <select
+      v-if="bigRocks.length > 0"
+      :value="bigRockFilter"
+      @change="$emit('update:bigRockFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by Big Rock"
+    >
+      <option value="">All Big Rocks</option>
+      <option v-for="rock in bigRocks" :key="rock" :value="rock">{{ rock }}</option>
+    </select>
+
+    <select
+      v-if="components.length > 0"
+      :value="componentFilter"
+      @change="$emit('update:componentFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by component"
+    >
+      <option value="">All Components</option>
+      <option v-for="comp in components" :key="comp" :value="comp">{{ comp }}</option>
+    </select>
+
+    <select
+      :value="tierFilter"
+      @change="$emit('update:tierFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by tier"
+    >
+      <option value="">All Tiers</option>
+      <option value="1">Tier 1</option>
+      <option value="2">Tier 2</option>
+      <option value="3">Tier 3</option>
+    </select>
+
+    <button
+      v-if="hasActiveFilters"
+      class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+      @click="$emit('clearFilters')"
+    >
+      Clear Filters
+    </button>
+  </div>
+</template>

--- a/modules/release-planning/client/components/HealthSummaryCards.vue
+++ b/modules/release-planning/client/components/HealthSummaryCards.vue
@@ -1,0 +1,123 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  summary: { type: Object, default: null }
+})
+
+const emit = defineEmits(['filterByRisk'])
+
+const greenCount = computed(function() {
+  if (!props.summary || !props.summary.byRisk) return 0
+  return props.summary.byRisk.green || 0
+})
+
+const yellowCount = computed(function() {
+  if (!props.summary || !props.summary.byRisk) return 0
+  return props.summary.byRisk.yellow || 0
+})
+
+const redCount = computed(function() {
+  if (!props.summary || !props.summary.byRisk) return 0
+  return props.summary.byRisk.red || 0
+})
+
+const dorPct = computed(function() {
+  if (!props.summary) return 0
+  return props.summary.dorCompletionRate || 0
+})
+
+const planningDeadline = computed(function() {
+  if (!props.summary || !props.summary.planningDeadline) return null
+  return props.summary.planningDeadline
+})
+
+const deadlineColorClass = computed(function() {
+  if (!planningDeadline.value) return ''
+  var days = planningDeadline.value.daysRemaining
+  if (days < 0) return 'bg-red-50 dark:bg-red-500/10 border-red-200 dark:border-red-500/30 text-red-700 dark:text-red-400'
+  if (days <= 14) return 'bg-yellow-50 dark:bg-yellow-500/10 border-yellow-200 dark:border-yellow-500/30 text-yellow-700 dark:text-yellow-400'
+  return 'bg-green-50 dark:bg-green-500/10 border-green-200 dark:border-green-500/30 text-green-700 dark:text-green-400'
+})
+
+function handleCardClick(level) {
+  emit('filterByRisk', level)
+}
+</script>
+
+<template>
+  <div v-if="summary" class="grid grid-cols-2 lg:grid-cols-5 gap-4">
+    <!-- Green -->
+    <button
+      type="button"
+      class="p-4 rounded-lg bg-green-50 dark:bg-green-500/10 border border-green-200 dark:border-green-500/30 text-left hover:bg-green-100 dark:hover:bg-green-500/20 transition-colors cursor-pointer"
+      @click="handleCardClick('green')"
+    >
+      <div class="flex items-center gap-2">
+        <span class="w-2.5 h-2.5 rounded-full bg-green-500 dark:bg-green-400 flex-shrink-0"></span>
+        <span class="text-sm font-semibold text-green-700 dark:text-green-400">On Track</span>
+      </div>
+      <div class="mt-2">
+        <span class="text-2xl font-bold text-green-700 dark:text-green-400">{{ greenCount }}</span>
+        <span class="text-xs text-green-600/70 dark:text-green-400/70 ml-1">feature{{ greenCount !== 1 ? 's' : '' }}</span>
+      </div>
+    </button>
+
+    <!-- Yellow -->
+    <button
+      type="button"
+      class="p-4 rounded-lg bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/30 text-left hover:bg-yellow-100 dark:hover:bg-yellow-500/20 transition-colors cursor-pointer"
+      @click="handleCardClick('yellow')"
+    >
+      <div class="flex items-center gap-2">
+        <span class="w-2.5 h-2.5 rounded-full bg-yellow-500 dark:bg-yellow-400 flex-shrink-0"></span>
+        <span class="text-sm font-semibold text-yellow-700 dark:text-yellow-400">At Risk</span>
+      </div>
+      <div class="mt-2">
+        <span class="text-2xl font-bold text-yellow-700 dark:text-yellow-400">{{ yellowCount }}</span>
+        <span class="text-xs text-yellow-600/70 dark:text-yellow-400/70 ml-1">feature{{ yellowCount !== 1 ? 's' : '' }}</span>
+      </div>
+    </button>
+
+    <!-- Red -->
+    <button
+      type="button"
+      class="p-4 rounded-lg bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 text-left hover:bg-red-100 dark:hover:bg-red-500/20 transition-colors cursor-pointer"
+      @click="handleCardClick('red')"
+    >
+      <div class="flex items-center gap-2">
+        <span class="w-2.5 h-2.5 rounded-full bg-red-500 dark:bg-red-400 flex-shrink-0"></span>
+        <span class="text-sm font-semibold text-red-700 dark:text-red-400">Critical</span>
+      </div>
+      <div class="mt-2">
+        <span class="text-2xl font-bold text-red-700 dark:text-red-400">{{ redCount }}</span>
+        <span class="text-xs text-red-600/70 dark:text-red-400/70 ml-1">feature{{ redCount !== 1 ? 's' : '' }}</span>
+      </div>
+    </button>
+
+    <!-- DoR completion -->
+    <div class="p-4 rounded-lg bg-indigo-50 dark:bg-indigo-500/10 border border-indigo-200 dark:border-indigo-500/30">
+      <div class="text-sm font-semibold text-indigo-700 dark:text-indigo-400">Definition of Ready</div>
+      <div class="mt-2">
+        <span class="text-2xl font-bold text-indigo-700 dark:text-indigo-400">{{ dorPct }}%</span>
+        <span class="text-xs text-indigo-600/70 dark:text-indigo-400/70 ml-1">complete</span>
+      </div>
+      <div class="mt-2 w-full bg-indigo-200 dark:bg-indigo-500/20 rounded-full h-1.5">
+        <div
+          class="h-1.5 rounded-full bg-indigo-500 dark:bg-indigo-400 transition-all"
+          :style="{ width: Math.min(dorPct, 100) + '%' }"
+        ></div>
+      </div>
+    </div>
+
+    <!-- Planning Deadline -->
+    <div v-if="planningDeadline" class="p-4 rounded-lg border" :class="deadlineColorClass">
+      <div class="text-sm font-semibold">Planning Deadline</div>
+      <div class="mt-2">
+        <span class="text-2xl font-bold">{{ planningDeadline.daysRemaining }}</span>
+        <span class="text-xs ml-1">{{ planningDeadline.daysRemaining === 1 ? 'day' : 'days' }} {{ planningDeadline.daysRemaining >= 0 ? 'remaining' : 'overdue' }}</span>
+      </div>
+      <div class="mt-1 text-xs opacity-70">{{ planningDeadline.date }}</div>
+    </div>
+  </div>
+</template>

--- a/modules/release-planning/client/components/MilestoneTimeline.vue
+++ b/modules/release-planning/client/components/MilestoneTimeline.vue
@@ -1,0 +1,204 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  milestones: { type: Object, default: null }
+})
+
+const MILESTONE_ORDER = [
+  { key: 'ea1Freeze', label: 'EA1 Freeze', color: 'bg-blue-500 dark:bg-blue-400' },
+  { key: 'ea1Target', label: 'EA1 Release', color: 'bg-blue-600 dark:bg-blue-500' },
+  { key: 'ea2Freeze', label: 'EA2 Freeze', color: 'bg-amber-500 dark:bg-amber-400' },
+  { key: 'ea2Target', label: 'EA2 Release', color: 'bg-amber-600 dark:bg-amber-500' },
+  { key: 'gaFreeze', label: 'GA Freeze', color: 'bg-green-500 dark:bg-green-400' },
+  { key: 'gaTarget', label: 'GA Release', color: 'bg-green-600 dark:bg-green-500' }
+]
+
+function parseDate(val) {
+  if (!val) return null
+  var d = new Date(val)
+  return isNaN(d.getTime()) ? null : d
+}
+
+function formatShort(date) {
+  if (!date) return ''
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+const milestonePoints = computed(function() {
+  if (!props.milestones) return []
+  var points = []
+  for (var i = 0; i < MILESTONE_ORDER.length; i++) {
+    var m = MILESTONE_ORDER[i]
+    var date = parseDate(props.milestones[m.key])
+    if (date) {
+      points.push({
+        key: m.key,
+        label: m.label,
+        color: m.color,
+        date: date,
+        dateStr: formatShort(date)
+      })
+    }
+  }
+  return points
+})
+
+const hasMilestones = computed(function() {
+  return milestonePoints.value.length > 0
+})
+
+const timelineRange = computed(function() {
+  if (!hasMilestones.value) return { start: 0, end: 1 }
+  var dates = milestonePoints.value.map(function(p) { return p.date.getTime() })
+  var min = Math.min.apply(null, dates)
+  var max = Math.max.apply(null, dates)
+  // Add 5% padding on each side
+  var padding = (max - min) * 0.05 || 86400000
+  return { start: min - padding, end: max + padding }
+})
+
+function positionPct(date) {
+  var range = timelineRange.value
+  var span = range.end - range.start
+  if (span <= 0) return 50
+  return ((date.getTime() - range.start) / span) * 100
+}
+
+const todayPosition = computed(function() {
+  if (!hasMilestones.value) return null
+  var now = new Date()
+  var pct = positionPct(now)
+  if (pct < 0 || pct > 100) return null
+  return pct
+})
+
+const nextMilestone = computed(function() {
+  if (!hasMilestones.value) return null
+  var now = Date.now()
+  for (var i = 0; i < milestonePoints.value.length; i++) {
+    if (milestonePoints.value[i].date.getTime() > now) {
+      var diff = milestonePoints.value[i].date.getTime() - now
+      var days = Math.ceil(diff / 86400000)
+      return {
+        label: milestonePoints.value[i].label,
+        days: days
+      }
+    }
+  }
+  return null
+})
+
+const STEM_HEIGHT = 28
+const OVERLAP_THRESHOLD = 10
+
+const staggeredPoints = computed(function() {
+  var points = milestonePoints.value
+  if (points.length === 0) return []
+
+  var result = []
+  for (var i = 0; i < points.length; i++) {
+    var pct = positionPct(points[i].date)
+    var above = true
+
+    if (i > 0) {
+      var prevPct = positionPct(points[i - 1].date)
+      if (Math.abs(pct - prevPct) < OVERLAP_THRESHOLD) {
+        above = !result[i - 1].above
+      }
+    }
+
+    result.push(Object.assign({}, points[i], { pct: pct, above: above }))
+  }
+  return result
+})
+</script>
+
+<template>
+  <div v-if="hasMilestones" class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Release Timeline</h3>
+      <span v-if="nextMilestone" class="text-xs text-gray-500 dark:text-gray-400">
+        {{ nextMilestone.days }} day{{ nextMilestone.days !== 1 ? 's' : '' }} to {{ nextMilestone.label }}
+      </span>
+    </div>
+
+    <!-- Desktop horizontal timeline -->
+    <div class="hidden sm:block relative mx-4" style="height: 120px">
+      <!-- Track line — centered vertically -->
+      <div class="absolute left-0 right-0 h-0.5 bg-gray-300 dark:bg-gray-600" style="top: 50%"></div>
+
+      <!-- Today marker -->
+      <div
+        v-if="todayPosition != null"
+        class="absolute -translate-x-1/2 z-10"
+        :style="{ left: todayPosition + '%', top: '10%', height: '80%' }"
+      >
+        <div class="w-px h-full bg-red-400/40 dark:bg-red-400/30 mx-auto"></div>
+        <div class="text-[10px] font-medium text-red-600 dark:text-red-400 mt-0.5 whitespace-nowrap text-center -translate-x-1/4">Today</div>
+      </div>
+
+      <!-- Milestone points -->
+      <template v-for="point in staggeredPoints" :key="point.key">
+        <!-- Dot — always on the track -->
+        <div
+          class="absolute -translate-x-1/2 -translate-y-1/2 z-[5]"
+          :style="{ left: point.pct + '%', top: '50%' }"
+        >
+          <div
+            class="w-3 h-3 rounded-full border-2 border-white dark:border-gray-800"
+            :class="point.color"
+          ></div>
+        </div>
+
+        <!-- Stem + label above -->
+        <div
+          v-if="point.above"
+          class="absolute -translate-x-1/2 text-center flex flex-col items-center"
+          :style="{ left: point.pct + '%', bottom: '50%' }"
+        >
+          <div class="text-[10px] text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ point.label }}</div>
+          <div class="text-[10px] font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ point.dateStr }}</div>
+          <div class="w-px bg-gray-300 dark:bg-gray-500 mt-0.5" :style="{ height: STEM_HEIGHT + 'px' }"></div>
+        </div>
+
+        <!-- Stem + label below -->
+        <div
+          v-else
+          class="absolute -translate-x-1/2 text-center flex flex-col items-center"
+          :style="{ left: point.pct + '%', top: '50%' }"
+        >
+          <div class="w-px bg-gray-300 dark:bg-gray-500 mb-0.5" :style="{ height: STEM_HEIGHT + 'px' }"></div>
+          <div class="text-[10px] text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ point.label }}</div>
+          <div class="text-[10px] font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ point.dateStr }}</div>
+        </div>
+      </template>
+    </div>
+
+    <!-- Mobile vertical timeline -->
+    <div class="sm:hidden space-y-2">
+      <div
+        v-for="point in milestonePoints"
+        :key="point.key"
+        class="flex items-center gap-3"
+      >
+        <div
+          class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+          :class="point.color"
+        ></div>
+        <div class="flex-1 flex justify-between items-center">
+          <span class="text-xs text-gray-600 dark:text-gray-400">{{ point.label }}</span>
+          <span class="text-xs font-medium text-gray-900 dark:text-gray-100">{{ point.dateStr }}</span>
+        </div>
+      </div>
+      <div v-if="nextMilestone" class="text-xs text-center text-red-600 dark:text-red-400 pt-1 border-t border-gray-100 dark:border-gray-700">
+        {{ nextMilestone.days }} day{{ nextMilestone.days !== 1 ? 's' : '' }} to {{ nextMilestone.label }}
+      </div>
+    </div>
+  </div>
+
+  <!-- No milestones fallback -->
+  <div v-else class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-3 text-center">
+    <p class="text-xs text-gray-400 dark:text-gray-500">Milestone dates unavailable. Configure Smartsheet integration for timeline display.</p>
+  </div>
+</template>

--- a/modules/release-planning/client/components/PhaseSelector.vue
+++ b/modules/release-planning/client/components/PhaseSelector.vue
@@ -1,0 +1,24 @@
+<script setup>
+defineProps({
+  phases: { type: Array, default: () => [] },
+  modelValue: { type: String, default: '' }
+})
+
+defineEmits(['update:modelValue'])
+</script>
+
+<template>
+  <div class="flex items-center gap-2">
+    <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Phase:</label>
+    <select
+      :value="modelValue"
+      @change="$emit('update:modelValue', $event.target.value)"
+      class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+    >
+      <option value="">All Phases</option>
+      <option v-for="p in phases" :key="p.value" :value="p.value">
+        {{ p.label }}
+      </option>
+    </select>
+  </div>
+</template>

--- a/modules/release-planning/client/components/RiceScoreDisplay.vue
+++ b/modules/release-planning/client/components/RiceScoreDisplay.vue
@@ -1,0 +1,78 @@
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  rice: { type: Object, default: null },
+  jiraUrl: { type: String, default: '' }
+})
+
+const expanded = ref(false)
+
+const hasScore = computed(function() {
+  return props.rice && props.rice.score != null
+})
+
+const scoreLabel = computed(function() {
+  if (!hasScore.value) return 'N/A'
+  return String(props.rice.score)
+})
+
+function toggle() {
+  if (hasScore.value) {
+    expanded.value = !expanded.value
+  }
+}
+</script>
+
+<template>
+  <div class="inline-block relative">
+    <button
+      type="button"
+      class="text-xs font-mono font-semibold px-1.5 py-0.5 rounded"
+      :class="hasScore
+        ? 'text-indigo-700 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10 hover:bg-indigo-100 dark:hover:bg-indigo-500/20 cursor-pointer'
+        : 'text-gray-400 dark:text-gray-500 cursor-default'"
+      :title="hasScore ? 'Click to see RICE breakdown' : 'RICE scoring not configured or data incomplete'"
+      @click="toggle"
+    >
+      {{ scoreLabel }}
+    </button>
+
+    <!-- Expanded breakdown popover -->
+    <div
+      v-if="expanded && hasScore"
+      class="absolute z-20 mt-1 left-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-3 w-48"
+    >
+      <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">RICE Breakdown</div>
+      <div class="space-y-1 text-xs">
+        <div class="flex justify-between">
+          <span class="text-gray-500 dark:text-gray-400">Reach</span>
+          <span class="font-mono text-gray-900 dark:text-gray-100">{{ rice.reach != null ? rice.reach : '-' }}</span>
+        </div>
+        <div class="flex justify-between">
+          <span class="text-gray-500 dark:text-gray-400">Impact</span>
+          <span class="font-mono text-gray-900 dark:text-gray-100">{{ rice.impact != null ? rice.impact : '-' }}</span>
+        </div>
+        <div class="flex justify-between">
+          <span class="text-gray-500 dark:text-gray-400">Confidence</span>
+          <span class="font-mono text-gray-900 dark:text-gray-100">{{ rice.confidence != null ? rice.confidence + '%' : '-' }}</span>
+        </div>
+        <div class="flex justify-between">
+          <span class="text-gray-500 dark:text-gray-400">Effort</span>
+          <span class="font-mono text-gray-900 dark:text-gray-100">{{ rice.effort != null ? rice.effort : '-' }}</span>
+        </div>
+        <div class="border-t border-gray-200 dark:border-gray-600 pt-1 mt-1 flex justify-between font-semibold">
+          <span class="text-gray-700 dark:text-gray-300">Score</span>
+          <span class="font-mono text-indigo-700 dark:text-indigo-400">{{ rice.score }}</span>
+        </div>
+      </div>
+      <a
+        v-if="jiraUrl"
+        :href="jiraUrl"
+        target="_blank"
+        rel="noopener"
+        class="block mt-2 text-[10px] text-primary-600 dark:text-primary-400 hover:underline"
+      >View in Jira</a>
+    </div>
+  </div>
+</template>

--- a/modules/release-planning/client/components/RiskBadge.vue
+++ b/modules/release-planning/client/components/RiskBadge.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  level: { type: String, default: 'green' },
+  flagCount: { type: Number, default: 0 },
+  flags: { type: Array, default: () => [] },
+  override: { type: Object, default: null }
+})
+
+const displayLevel = computed(function() {
+  if (props.override) return props.override.riskOverride || props.level
+  return props.level
+})
+
+const badgeClasses = computed(function() {
+  var level = displayLevel.value
+  if (level === 'red') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400 border-red-300 dark:border-red-500/30'
+  if (level === 'yellow') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border-yellow-300 dark:border-yellow-500/30'
+  return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400 border-green-300 dark:border-green-500/30'
+})
+
+const levelLabel = computed(function() {
+  var level = displayLevel.value
+  if (level === 'red') return 'Red'
+  if (level === 'yellow') return 'Yellow'
+  return 'Green'
+})
+
+const tooltipText = computed(function() {
+  var lines = []
+  if (props.override) {
+    lines.push('Manual override: ' + props.override.riskOverride)
+    if (props.override.reason) lines.push('Reason: ' + props.override.reason)
+  }
+  if (props.flags && props.flags.length > 0) {
+    for (var i = 0; i < props.flags.length; i++) {
+      lines.push(props.flags[i].category + ': ' + props.flags[i].message)
+    }
+  }
+  return lines.join('\n')
+})
+</script>
+
+<template>
+  <span
+    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs font-medium relative"
+    :class="badgeClasses"
+    :title="tooltipText"
+  >
+    {{ levelLabel }}
+    <sup
+      v-if="flagCount > 0"
+      class="text-[9px] font-bold -mt-1"
+    >{{ flagCount }}</sup>
+    <span
+      v-if="override"
+      class="ml-0.5 text-[9px] opacity-70"
+      title="Manually overridden"
+    >M</span>
+  </span>
+</template>

--- a/modules/release-planning/client/components/SummaryCards.vue
+++ b/modules/release-planning/client/components/SummaryCards.vue
@@ -1,6 +1,13 @@
 <script setup>
-defineProps({
-  summary: { type: Object, default: null }
+import { computed } from 'vue'
+
+const props = defineProps({
+  summary: { type: Object, default: null },
+  healthSummary: { type: Object, default: null }
+})
+
+const hasHealth = computed(function() {
+  return props.healthSummary && props.healthSummary.byRisk
 })
 </script>
 
@@ -66,6 +73,21 @@ defineProps({
         <div>
           <span class="text-2xl font-bold text-green-700 dark:text-green-400">{{ summary.totalRfes }}</span>
           <span class="text-xs text-green-600/70 dark:text-green-400/70 ml-1">RFEs</span>
+        </div>
+      </div>
+      <!-- Health indicator -->
+      <div v-if="hasHealth" class="flex items-center gap-2 mt-3 pt-2 border-t border-green-200/50 dark:border-green-500/20">
+        <span class="text-[10px] text-green-600/70 dark:text-green-400/70 uppercase tracking-wide">Health</span>
+        <div class="flex items-center gap-1.5">
+          <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-green-700 dark:text-green-400">
+            <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>{{ healthSummary.byRisk.green || 0 }}
+          </span>
+          <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-yellow-700 dark:text-yellow-400">
+            <span class="w-1.5 h-1.5 rounded-full bg-yellow-500"></span>{{ healthSummary.byRisk.yellow || 0 }}
+          </span>
+          <span class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-red-700 dark:text-red-400">
+            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>{{ healthSummary.byRisk.red || 0 }}
+          </span>
         </div>
       </div>
     </div>

--- a/modules/release-planning/client/composables/useDorChecklist.js
+++ b/modules/release-planning/client/composables/useDorChecklist.js
@@ -1,0 +1,126 @@
+import { ref } from 'vue'
+import { useReleaseHealth } from './useReleaseHealth'
+
+/**
+ * Manages local DoR checklist toggle state with debounced save.
+ *
+ * Each feature's manual checks are buffered locally and flushed
+ * to the server after 250ms of inactivity, batching rapid toggles
+ * into a single PUT request.
+ */
+export function useDorChecklist() {
+  var { updateDorItem } = useReleaseHealth()
+  var pendingUpdates = ref({})
+  var saving = ref(false)
+  var saveError = ref(null)
+  var debounceTimers = {}
+
+  /**
+   * Toggle a manual DoR item and schedule a debounced save.
+   *
+   * @param {string} version - Release version
+   * @param {string} featureKey - Jira feature key
+   * @param {string} itemId - DoR item ID (e.g. 'F-3')
+   * @param {boolean} checked - New checked state
+   * @param {string} [notes] - Optional notes text
+   */
+  function toggleItem(version, featureKey, itemId, checked, notes) {
+    var key = version + ':' + featureKey
+
+    if (!pendingUpdates.value[key]) {
+      pendingUpdates.value[key] = { items: {}, notes: undefined }
+    }
+    pendingUpdates.value[key].items[itemId] = checked
+    if (notes !== undefined) {
+      pendingUpdates.value[key].notes = notes
+    }
+
+    // Clear any existing timer for this feature
+    if (debounceTimers[key]) {
+      clearTimeout(debounceTimers[key])
+    }
+
+    // Set new debounced save
+    debounceTimers[key] = setTimeout(function() {
+      flush(version, featureKey)
+    }, 250)
+  }
+
+  /**
+   * Save notes for a feature with debounced save.
+   */
+  function updateNotes(version, featureKey, notes) {
+    var key = version + ':' + featureKey
+
+    if (!pendingUpdates.value[key]) {
+      pendingUpdates.value[key] = { items: {}, notes: undefined }
+    }
+    pendingUpdates.value[key].notes = notes
+
+    if (debounceTimers[key]) {
+      clearTimeout(debounceTimers[key])
+    }
+
+    debounceTimers[key] = setTimeout(function() {
+      flush(version, featureKey)
+    }, 250)
+  }
+
+  /**
+   * Flush pending updates for a specific feature.
+   */
+  async function flush(version, featureKey) {
+    var key = version + ':' + featureKey
+    var pending = pendingUpdates.value[key]
+    if (!pending) return
+
+    // Clear pending before sending so new toggles during save start a fresh batch
+    delete pendingUpdates.value[key]
+    pendingUpdates.value = Object.assign({}, pendingUpdates.value)
+
+    // Only send if there are actual items or notes to update
+    var hasItems = Object.keys(pending.items).length > 0
+    var hasNotes = pending.notes !== undefined
+    if (!hasItems && !hasNotes) return
+
+    saving.value = true
+    saveError.value = null
+
+    try {
+      var result = await updateDorItem(
+        version,
+        featureKey,
+        hasItems ? pending.items : {},
+        pending.notes
+      )
+      return result
+    } catch (err) {
+      saveError.value = err.message
+      throw err
+    } finally {
+      saving.value = false
+    }
+  }
+
+  /**
+   * Cancel all pending debounced saves.
+   */
+  function cancelAll() {
+    var keys = Object.keys(debounceTimers)
+    for (var i = 0; i < keys.length; i++) {
+      clearTimeout(debounceTimers[keys[i]])
+      delete debounceTimers[keys[i]]
+    }
+    pendingUpdates.value = {}
+  }
+
+  return {
+    pendingUpdates: pendingUpdates,
+    saving: saving,
+    saveError: saveError,
+    toggleItem: toggleItem,
+    updateNotes: updateNotes,
+    flush: flush,
+    cancelAll: cancelAll
+  }
+}

--- a/modules/release-planning/client/composables/useReleaseHealth.js
+++ b/modules/release-planning/client/composables/useReleaseHealth.js
@@ -1,0 +1,132 @@
+import { ref } from 'vue'
+import { apiRequest, getApiBase } from '@shared/client/services/api'
+
+const API_BASE = '/modules/release-planning'
+
+// Module-level refs -- singleton pattern so all components share state
+const healthData = ref(null)
+const healthLoading = ref(false)
+const healthError = ref(null)
+const healthRefreshing = ref(false)
+const healthCacheStale = ref(false)
+const etagCache = {}
+
+export function useReleaseHealth() {
+  async function loadHealth(version, phase) {
+    healthLoading.value = true
+    healthError.value = null
+
+    var url = API_BASE + '/releases/' + encodeURIComponent(version) + '/health'
+    if (phase) {
+      url += '?phase=' + encodeURIComponent(phase)
+    }
+
+    var cacheKey = version + ':' + (phase || 'all')
+    var headers = {}
+    if (etagCache[cacheKey]) {
+      headers['If-None-Match'] = etagCache[cacheKey]
+    }
+
+    try {
+      var response = await fetch(getApiBase() + url, { headers: headers })
+
+      if (response.status === 304) {
+        healthLoading.value = false
+        return
+      }
+
+      if (!response.ok) {
+        var errorData = await response.json().catch(function() { return {} })
+        throw new Error(errorData.error || 'HTTP ' + response.status)
+      }
+
+      var etag = response.headers.get('etag')
+      if (etag) {
+        etagCache[cacheKey] = etag
+      }
+
+      var data = await response.json()
+      healthData.value = data
+      healthRefreshing.value = !!data._refreshing
+      healthCacheStale.value = !!data._cacheStale
+    } catch (err) {
+      healthError.value = err.message
+    } finally {
+      healthLoading.value = false
+    }
+  }
+
+  async function updateDorItem(version, featureKey, items, notes) {
+    var body = { items: items }
+    if (notes !== undefined) {
+      body.notes = notes
+    }
+    return apiRequest(
+      API_BASE + '/releases/' + encodeURIComponent(version) + '/health/dor/' + encodeURIComponent(featureKey),
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }
+    )
+  }
+
+  async function setRiskOverride(version, featureKey, level, reason) {
+    return apiRequest(
+      API_BASE + '/releases/' + encodeURIComponent(version) + '/health/override/' + encodeURIComponent(featureKey),
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ riskOverride: level, reason: reason })
+      }
+    )
+  }
+
+  async function removeRiskOverride(version, featureKey) {
+    return apiRequest(
+      API_BASE + '/releases/' + encodeURIComponent(version) + '/health/override/' + encodeURIComponent(featureKey),
+      { method: 'DELETE' }
+    )
+  }
+
+  async function triggerHealthRefresh(version, phase) {
+    try {
+      var url = API_BASE + '/releases/' + encodeURIComponent(version) + '/health/refresh'
+      if (phase) {
+        url += '?phase=' + encodeURIComponent(phase)
+      }
+      await apiRequest(url, { method: 'POST' })
+      healthRefreshing.value = true
+    } catch (err) {
+      healthError.value = err.message
+    }
+  }
+
+  async function checkHealthRefreshStatus(version, phase) {
+    try {
+      var url = API_BASE + '/releases/' + encodeURIComponent(version) + '/health/refresh/status'
+      if (phase) {
+        url += '?phase=' + encodeURIComponent(phase)
+      }
+      var status = await apiRequest(url)
+      healthRefreshing.value = status.running
+      return status
+    } catch {
+      return { running: false }
+    }
+  }
+
+  return {
+    healthData: healthData,
+    healthLoading: healthLoading,
+    healthError: healthError,
+    healthRefreshing: healthRefreshing,
+    healthCacheStale: healthCacheStale,
+    loadHealth: loadHealth,
+    updateDorItem: updateDorItem,
+    setRiskOverride: setRiskOverride,
+    removeRiskOverride: removeRiskOverride,
+    triggerHealthRefresh: triggerHealthRefresh,
+    checkHealthRefreshStatus: checkHealthRefreshStatus
+  }
+}

--- a/modules/release-planning/client/index.js
+++ b/modules/release-planning/client/index.js
@@ -2,5 +2,6 @@ import { defineAsyncComponent } from 'vue'
 
 export const routes = {
   'main': defineAsyncComponent(() => import('./views/DashboardView.vue')),
+  'health': defineAsyncComponent(() => import('./views/HealthDashboardView.vue')),
   'audit-log': defineAsyncComponent(() => import('./views/AuditLogView.vue')),
 }

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, inject, onMounted, onUnmounted, watch } from 'vue'
 import { useReleasePlanning, useReleases } from '../composables/useReleasePlanning'
+import { useReleaseHealth } from '../composables/useReleaseHealth'
 import { useBigRockEditor } from '../composables/useBigRockEditor'
 import { useFilters } from '../composables/useFilters'
 import SummaryCards from '../components/SummaryCards.vue'
@@ -22,6 +23,8 @@ const {
 } = useReleasePlanning()
 
 const { releases, loadReleases } = useReleases()
+
+const { healthData, loadHealth } = useReleaseHealth()
 
 const {
   formData, editingRock, isNewRock,
@@ -79,6 +82,20 @@ const summary = computed(() => candidates.value ? candidates.value.summary : nul
 const filterOptions = computed(() => candidates.value ? candidates.value.filterOptions || {} : {})
 const jiraBaseUrl = computed(() => candidates.value ? candidates.value.jiraBaseUrl || '' : '')
 const demoMode = computed(() => candidates.value ? candidates.value.demoMode : false)
+
+const healthByKey = computed(function() {
+  if (!healthData.value || !healthData.value.features) return {}
+  var map = {}
+  for (var i = 0; i < healthData.value.features.length; i++) {
+    var f = healthData.value.features[i]
+    map[f.key] = f
+  }
+  return map
+})
+
+const healthSummary = computed(function() {
+  return healthData.value ? healthData.value.summary : null
+})
 const warning = computed(() => candidates.value ? candidates.value.warning : null)
 const pipelineWarnings = computed(() => candidates.value ? candidates.value.pipelineWarnings || [] : [])
 const canEdit = computed(() => !demoMode.value && permissions.value && permissions.value.canEdit)
@@ -95,6 +112,8 @@ const {
   hasActiveFilters,
   clearFilters
 } = useFilters(features, rfes, bigRocks)
+
+const moduleNav = inject('moduleNav', null)
 
 const tabs = [
   { id: 'big-rocks', label: 'Big Rocks' },
@@ -424,6 +443,7 @@ watch(selectedVersion, function(newVersion) {
   error.value = null
   if (newVersion) {
     loadCandidates(newVersion)
+    loadHealth(newVersion)
   }
 })
 
@@ -441,6 +461,13 @@ onMounted(async function() {
   await loadReleases()
   if (releases.value.length > 0) {
     selectedVersion.value = releases.value[0].version
+  }
+  if (moduleNav && moduleNav.params && moduleNav.params.value) {
+    var p = moduleNav.params.value
+    if (p.bigRock) {
+      selectedRock.value = p.bigRock
+      activeTab.value = 'features'
+    }
   }
 })
 
@@ -516,7 +543,7 @@ onUnmounted(function() {
 
     <template v-else-if="candidates">
       <!-- Summary -->
-      <SummaryCards :summary="summary" />
+      <SummaryCards :summary="summary" :healthSummary="healthSummary" />
 
       <!-- Recent Activity -->
       <RecentActivity :version="selectedVersion" />
@@ -606,6 +633,8 @@ onUnmounted(function() {
           :bigRocks="bigRocks"
           :jiraBaseUrl="jiraBaseUrl"
           :canEdit="canEdit"
+          :healthByKey="healthByKey"
+          :features="features"
           @editRock="handleEditRock"
           @addRock="handleAddRock"
           @deleteRock="handleDeleteRock"
@@ -618,6 +647,7 @@ onUnmounted(function() {
           :bigRocks="bigRocks"
           :jiraBaseUrl="jiraBaseUrl"
           :summary="summary"
+          :healthByKey="healthByKey"
         />
       </div>
       <div v-if="activeTab === 'rfes'" id="panel-rfes" role="tabpanel" aria-labelledby="tab-rfes">

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -177,12 +177,16 @@ function handleFilterByRisk(level) {
 function startRefreshPolling() {
   stopRefreshPolling()
   refreshPollTimer = setInterval(async function() {
-    var status = await checkHealthRefreshStatus(selectedVersion.value, selectedPhase.value || undefined)
-    if (!status.running) {
-      stopRefreshPolling()
-      if (selectedVersion.value) {
-        loadHealth(selectedVersion.value, selectedPhase.value || undefined)
+    try {
+      var status = await checkHealthRefreshStatus(selectedVersion.value, selectedPhase.value || undefined)
+      if (!status.running) {
+        stopRefreshPolling()
+        if (selectedVersion.value) {
+          loadHealth(selectedVersion.value, selectedPhase.value || undefined)
+        }
       }
+    } catch {
+      stopRefreshPolling()
     }
   }, 3000)
 }

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -1,0 +1,548 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useReleaseHealth } from '../composables/useReleaseHealth'
+import { useDorChecklist } from '../composables/useDorChecklist'
+import { useReleases } from '../composables/useReleasePlanning'
+import { useAuth } from '@shared/client'
+import ReleaseSelector from '../components/ReleaseSelector.vue'
+import PhaseSelector from '../components/PhaseSelector.vue'
+import MilestoneTimeline from '../components/MilestoneTimeline.vue'
+import HealthSummaryCards from '../components/HealthSummaryCards.vue'
+import HealthFilterBar from '../components/HealthFilterBar.vue'
+import FeatureHealthTable from '../components/FeatureHealthTable.vue'
+
+var {
+  healthData, healthLoading, healthError, healthRefreshing, healthCacheStale,
+  loadHealth, triggerHealthRefresh, checkHealthRefreshStatus,
+  removeRiskOverride: removeRiskOverrideApi
+} = useReleaseHealth()
+
+var { toggleItem, updateNotes, cancelAll: cancelDorPending } = useDorChecklist()
+var { releases, loadReleases } = useReleases()
+var { isAdmin } = useAuth()
+
+var selectedVersion = ref('')
+var selectedPhase = ref('')
+
+// Filter state
+var riskFilter = ref('')
+var dorFilter = ref('')
+var bigRockFilter = ref('')
+var componentFilter = ref('')
+var tierFilter = ref('')
+var searchQuery = ref('')
+
+// Export menu
+var exportMenuOpen = ref(false)
+
+// Refresh polling
+var refreshPollTimer = null
+
+// ─── Permissions ───
+
+var canEdit = computed(function() {
+  if (healthData.value && healthData.value.demoMode) return false
+  // PM/admin check -- the health routes enforce requirePM on the server,
+  // but for the UI we check the permissions from the main composable.
+  // For now, we use isAdmin as a proxy. The server will reject if not PM.
+  return isAdmin.value
+})
+
+var demoMode = computed(function() {
+  return healthData.value ? !!healthData.value.demoMode : false
+})
+
+// ─── Derived data ───
+
+var features = computed(function() {
+  return healthData.value ? healthData.value.features || [] : []
+})
+
+var summary = computed(function() {
+  return healthData.value ? healthData.value.summary : null
+})
+
+var milestones = computed(function() {
+  return healthData.value ? healthData.value.milestones : null
+})
+
+var warning = computed(function() {
+  return healthData.value ? healthData.value.warning : null
+})
+
+var jiraBaseUrl = computed(function() {
+  return 'https://redhat.atlassian.net/browse'
+})
+
+var enrichmentStatus = computed(function() {
+  return healthData.value ? healthData.value.enrichmentStatus : null
+})
+
+var availablePhases = computed(function() {
+  var ms = milestones.value
+  if (!ms) return []
+  var phases = []
+  var ver = selectedVersion.value || ''
+  if (ms.ea1Freeze) phases.push({ value: 'EA1', label: 'RHOAI ' + ver + ' EA1' })
+  if (ms.ea2Freeze) phases.push({ value: 'EA2', label: 'RHOAI ' + ver + ' EA2' })
+  if (ms.gaFreeze) phases.push({ value: 'GA', label: 'RHOAI ' + ver + ' GA' })
+  return phases
+})
+
+// ─── Filter options ───
+
+var bigRockOptions = computed(function() {
+  var rocks = {}
+  for (var i = 0; i < features.value.length; i++) {
+    var rock = features.value[i].bigRock
+    if (rock) rocks[rock] = true
+  }
+  return Object.keys(rocks).sort()
+})
+
+var componentOptions = computed(function() {
+  var comps = {}
+  for (var i = 0; i < features.value.length; i++) {
+    var comp = features.value[i].components
+    if (comp) comps[comp] = true
+  }
+  return Object.keys(comps).sort()
+})
+
+// ─── Filtered features ───
+
+var filteredFeatures = computed(function() {
+  var list = features.value
+  if (!list || list.length === 0) return []
+
+  return list.filter(function(f) {
+    // Risk filter
+    if (riskFilter.value) {
+      var featureRisk = f.risk ? f.risk.level : 'green'
+      if (f.risk && f.risk.override) featureRisk = f.risk.override.riskOverride || featureRisk
+      if (featureRisk !== riskFilter.value) return false
+    }
+
+    // DoR filter
+    if (dorFilter.value) {
+      var dorPct = f.dor ? f.dor.completionPct : 0
+      if (dorFilter.value === 'complete' && dorPct < 80) return false
+      if (dorFilter.value === 'partial' && (dorPct < 50 || dorPct >= 80)) return false
+      if (dorFilter.value === 'incomplete' && dorPct >= 50) return false
+    }
+
+    // Big Rock filter
+    if (bigRockFilter.value && f.bigRock !== bigRockFilter.value) return false
+
+    // Component filter
+    if (componentFilter.value && f.components !== componentFilter.value) return false
+
+    // Tier filter
+    if (tierFilter.value && String(f.tier) !== tierFilter.value) return false
+
+    // Search
+    if (searchQuery.value) {
+      var q = searchQuery.value.toLowerCase()
+      var searchFields = [f.key, f.summary, f.status, f.pm, f.deliveryOwner, f.components, f.bigRock].join(' ').toLowerCase()
+      if (searchFields.indexOf(q) === -1) return false
+    }
+
+    return true
+  })
+})
+
+var hasActiveFilters = computed(function() {
+  return !!(riskFilter.value || dorFilter.value || bigRockFilter.value || componentFilter.value || tierFilter.value || searchQuery.value)
+})
+
+function clearFilters() {
+  riskFilter.value = ''
+  dorFilter.value = ''
+  bigRockFilter.value = ''
+  componentFilter.value = ''
+  tierFilter.value = ''
+  searchQuery.value = ''
+}
+
+function handleFilterByRisk(level) {
+  if (riskFilter.value === level) {
+    riskFilter.value = ''
+  } else {
+    riskFilter.value = level
+  }
+}
+
+// ─── Data refresh ───
+
+function startRefreshPolling() {
+  stopRefreshPolling()
+  refreshPollTimer = setInterval(async function() {
+    var status = await checkHealthRefreshStatus(selectedVersion.value, selectedPhase.value || undefined)
+    if (!status.running) {
+      stopRefreshPolling()
+      if (selectedVersion.value) {
+        loadHealth(selectedVersion.value, selectedPhase.value || undefined)
+      }
+    }
+  }, 3000)
+}
+
+function stopRefreshPolling() {
+  if (refreshPollTimer) {
+    clearInterval(refreshPollTimer)
+    refreshPollTimer = null
+  }
+}
+
+watch(healthRefreshing, function(isRefreshing) {
+  if (isRefreshing) {
+    startRefreshPolling()
+  }
+})
+
+function handleRefresh() {
+  if (selectedVersion.value && !demoMode.value) {
+    triggerHealthRefresh(selectedVersion.value, selectedPhase.value || undefined)
+  }
+}
+
+// ─── DoR interactions ───
+
+function handleDorToggle(featureKey, itemId, checked) {
+  // Optimistic UI update
+  if (healthData.value && healthData.value.features) {
+    for (var i = 0; i < healthData.value.features.length; i++) {
+      if (healthData.value.features[i].key === featureKey && healthData.value.features[i].dor) {
+        var items = healthData.value.features[i].dor.items
+        for (var j = 0; j < items.length; j++) {
+          if (items[j].id === itemId) {
+            items[j].checked = checked
+            break
+          }
+        }
+        // Recount
+        var checkedCount = 0
+        for (var k = 0; k < items.length; k++) {
+          if (items[k].checked) checkedCount++
+        }
+        healthData.value.features[i].dor.checkedCount = checkedCount
+        healthData.value.features[i].dor.completionPct = items.length > 0
+          ? Math.round((checkedCount / items.length) * 100) : 0
+        break
+      }
+    }
+  }
+
+  // Debounced save
+  toggleItem(selectedVersion.value, featureKey, itemId, checked)
+}
+
+function handleNotesUpdate(featureKey, notes) {
+  updateNotes(selectedVersion.value, featureKey, notes)
+}
+
+function handleRemoveOverride(featureKey) {
+  removeRiskOverrideApi(selectedVersion.value, featureKey).then(function() {
+    loadHealth(selectedVersion.value, selectedPhase.value || undefined)
+  }).catch(function(err) {
+    healthError.value = err.message || 'Failed to remove override'
+  })
+}
+
+// ─── Export ───
+
+function escapeCsv(val) {
+  var s = String(val)
+  if (s.indexOf(',') !== -1 || s.indexOf('"') !== -1 || s.indexOf('\n') !== -1 || s.indexOf('\r') !== -1) {
+    return '"' + s.replace(/"/g, '""') + '"'
+  }
+  return s
+}
+
+function exportCsv() {
+  exportMenuOpen.value = false
+  var rows = []
+  rows.push(['Feature', 'Summary', 'Status', 'Risk', 'DoR %', 'RICE', 'Component', 'Phase', 'Tier', 'PM', 'Owner', 'Epics', 'Issues', 'Completion %', 'Blockers'])
+
+  for (var i = 0; i < filteredFeatures.value.length; i++) {
+    var f = filteredFeatures.value[i]
+    rows.push([
+      f.key || '',
+      f.summary || '',
+      f.status || '',
+      f.risk ? f.risk.level : '',
+      f.dor ? f.dor.completionPct : '',
+      f.rice && f.rice.score != null ? f.rice.score : '',
+      f.components || '',
+      f.phase || '',
+      f.tier || '',
+      f.pm || '',
+      f.deliveryOwner || '',
+      f.epicCount != null ? f.epicCount : '',
+      f.issueCount != null ? f.issueCount : '',
+      f.completionPct != null ? f.completionPct : '',
+      f.blockerCount != null ? f.blockerCount : ''
+    ])
+  }
+
+  var csv = rows.map(function(row) { return row.map(escapeCsv).join(',') }).join('\n')
+  var blob = new Blob([csv + '\n'], { type: 'text/csv' })
+  var url = URL.createObjectURL(blob)
+  var a = document.createElement('a')
+  a.href = url
+  a.download = 'plan-health-' + selectedVersion.value + '-' + (selectedPhase.value || 'all') + '.csv'
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function escapeCell(val) {
+  return String(val).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
+}
+
+function exportMarkdown() {
+  exportMenuOpen.value = false
+  var lines = []
+  lines.push('# Release Plan Health - ' + selectedVersion.value + (selectedPhase.value ? ' ' + selectedPhase.value : ''))
+  lines.push('')
+  lines.push('| **Feature** | **Summary** | **Status** | **Risk** | **DoR %** | **RICE** | **Component** | **Phase** |')
+  lines.push('|---------|---------|--------|------|-------|------|-----------|-------|')
+
+  for (var i = 0; i < filteredFeatures.value.length; i++) {
+    var f = filteredFeatures.value[i]
+    lines.push('| ' + [
+      f.key || '-',
+      escapeCell(f.summary || '-'),
+      escapeCell(f.status || '-'),
+      f.risk ? f.risk.level : '-',
+      f.dor ? f.dor.completionPct + '%' : '-',
+      f.rice && f.rice.score != null ? f.rice.score : '-',
+      escapeCell(f.components || '-'),
+      f.phase || '-'
+    ].join(' | ') + ' |')
+  }
+
+  var blob = new Blob([lines.join('\n') + '\n'], { type: 'text/markdown' })
+  var url = URL.createObjectURL(blob)
+  var a = document.createElement('a')
+  a.href = url
+  a.download = 'plan-health-' + selectedVersion.value + '-' + (selectedPhase.value || 'all') + '.md'
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function toggleExportMenu() {
+  exportMenuOpen.value = !exportMenuOpen.value
+}
+
+function closeExportMenu() {
+  exportMenuOpen.value = false
+}
+
+function handleClickOutside() {
+  exportMenuOpen.value = false
+}
+
+// ─── Format helpers ───
+
+function formatDate(iso) {
+  if (!iso) return 'Never'
+  return new Date(iso).toLocaleString()
+}
+
+// ─── Lifecycle ───
+
+watch(selectedVersion, function(newVersion) {
+  healthError.value = null
+  selectedPhase.value = ''
+  clearFilters()
+  if (newVersion) {
+    loadHealth(newVersion)
+  }
+})
+
+watch(selectedPhase, function(newPhase) {
+  if (selectedVersion.value) {
+    loadHealth(selectedVersion.value, newPhase || undefined)
+  }
+})
+
+onMounted(async function() {
+  document.addEventListener('click', handleClickOutside)
+  await loadReleases()
+  if (releases.value.length > 0) {
+    selectedVersion.value = releases.value[0].version
+  }
+})
+
+onUnmounted(function() {
+  document.removeEventListener('click', handleClickOutside)
+  stopRefreshPolling()
+  cancelDorPending()
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between flex-wrap gap-4">
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Release Plan Health</h1>
+        <p v-if="healthData && healthData.cachedAt" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Data from {{ formatDate(healthData.cachedAt) }}
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <ReleaseSelector
+          v-if="releases.length > 0"
+          :releases="releases"
+          v-model="selectedVersion"
+        />
+        <PhaseSelector
+          v-if="availablePhases.length > 0"
+          :phases="availablePhases"
+          v-model="selectedPhase"
+        />
+        <button
+          v-if="selectedVersion && !demoMode"
+          @click="handleRefresh"
+          :disabled="healthRefreshing"
+          class="px-3 py-1.5 text-xs font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ healthRefreshing ? 'Refreshing...' : 'Refresh' }}
+        </button>
+        <div class="relative" @click.stop @keydown.escape="closeExportMenu">
+          <button
+            v-if="features.length > 0"
+            @click="toggleExportMenu"
+            :aria-expanded="exportMenuOpen"
+            aria-haspopup="menu"
+            aria-label="Export data"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+            Export
+          </button>
+          <div
+            v-if="exportMenuOpen"
+            role="menu"
+            class="absolute right-0 mt-1 w-40 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-600 py-1 z-10"
+          >
+            <button
+              role="menuitem"
+              @click="exportMarkdown"
+              class="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >Markdown (.md)</button>
+            <button
+              role="menuitem"
+              @click="exportCsv"
+              class="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >CSV (.csv)</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Demo mode banner -->
+    <div v-if="demoMode" class="bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg px-4 py-2 text-sm text-amber-700 dark:text-amber-400">
+      Demo mode -- displaying sample health data. Configure Jira credentials and run a health refresh for live data.
+    </div>
+
+    <!-- Warning -->
+    <div v-if="warning" class="bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/30 rounded-lg px-4 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+      {{ warning }}
+    </div>
+
+    <!-- Cache stale / refreshing indicator -->
+    <div v-if="healthCacheStale && healthRefreshing" role="status" class="bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/30 rounded-lg px-4 py-2 text-sm text-blue-700 dark:text-blue-400">
+      Refreshing health data in the background...
+    </div>
+
+    <!-- Enrichment status -->
+    <details v-if="enrichmentStatus && enrichmentStatus.warnings && enrichmentStatus.warnings.length > 0" class="bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg text-sm text-amber-700 dark:text-amber-400">
+      <summary class="px-4 py-2 cursor-pointer select-none">
+        {{ enrichmentStatus.warnings.length }} enrichment warning{{ enrichmentStatus.warnings.length !== 1 ? 's' : '' }} -- data may be incomplete
+      </summary>
+      <ul class="px-4 pb-2 ml-4 list-disc space-y-0.5">
+        <li v-for="(w, i) in enrichmentStatus.warnings" :key="i">{{ w }}</li>
+      </ul>
+    </details>
+
+    <!-- Error -->
+    <div v-if="healthError" role="alert" class="bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-lg p-4 text-red-700 dark:text-red-400 text-sm">
+      {{ healthError }}
+    </div>
+
+    <!-- Loading -->
+    <div v-if="healthLoading && !healthData" class="text-center py-12 text-gray-500">
+      Loading release health data...
+    </div>
+
+    <template v-else-if="healthData && features.length > 0">
+      <!-- Milestone Timeline -->
+      <MilestoneTimeline :milestones="milestones" />
+
+      <!-- Summary Cards -->
+      <HealthSummaryCards :summary="summary" @filterByRisk="handleFilterByRisk" />
+
+      <!-- Filters -->
+      <HealthFilterBar
+        v-model:riskFilter="riskFilter"
+        v-model:dorFilter="dorFilter"
+        v-model:bigRockFilter="bigRockFilter"
+        v-model:componentFilter="componentFilter"
+        v-model:tierFilter="tierFilter"
+        v-model:searchQuery="searchQuery"
+        :bigRocks="bigRockOptions"
+        :components="componentOptions"
+        :hasActiveFilters="hasActiveFilters"
+        @clearFilters="clearFilters"
+      />
+
+      <!-- Feature Health Table -->
+      <FeatureHealthTable
+        :features="filteredFeatures"
+        :canEdit="canEdit"
+        :jiraBaseUrl="jiraBaseUrl"
+        @toggleDorItem="handleDorToggle"
+        @updateNotes="handleNotesUpdate"
+        @removeOverride="handleRemoveOverride"
+      />
+    </template>
+
+    <!-- Empty state: data exists but no features -->
+    <template v-else-if="healthData && features.length === 0 && !healthData._noCache">
+      <div class="text-center py-12">
+        <p class="text-gray-500 dark:text-gray-400">No features found in the health data for this release.</p>
+        <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">This may mean the Big Rocks candidates cache is empty. Try running a Big Rocks refresh first.</p>
+      </div>
+    </template>
+
+    <!-- No cache state: first load -->
+    <template v-else-if="healthData && healthData._noCache">
+      <div class="text-center py-12">
+        <div class="inline-flex items-center gap-2 text-gray-500 dark:text-gray-400 mb-4">
+          <svg class="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <span>Health pipeline is running...</span>
+        </div>
+        <p class="text-sm text-gray-400 dark:text-gray-500">This may take several minutes on the first run. The page will update automatically when ready.</p>
+      </div>
+    </template>
+
+    <!-- No releases configured -->
+    <div v-else-if="!healthLoading && releases.length === 0" class="text-center py-12">
+      <p class="text-gray-500 dark:text-gray-400">No releases configured.</p>
+      <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Configure releases in the Big Rocks Planning view first.</p>
+    </div>
+
+    <!-- No data yet, not loading -->
+    <div v-else-if="!healthLoading && selectedVersion && !healthData" class="text-center py-12">
+      <p class="text-gray-500 dark:text-gray-400">No health data available for this release.</p>
+      <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Click "Refresh" to generate a health assessment.</p>
+    </div>
+  </div>
+</template>

--- a/modules/release-planning/module.json
+++ b/modules/release-planning/module.json
@@ -9,6 +9,7 @@
     "entry": "./client/index.js",
     "navItems": [
       { "id": "main", "label": "Big Rocks Planning", "icon": "ClipboardList", "default": true },
+      { "id": "health", "label": "Release Plan Health", "icon": "HeartPulse" },
       { "id": "audit-log", "label": "Audit Log", "icon": "History" }
     ]
   },

--- a/modules/release-planning/server/config.js
+++ b/modules/release-planning/server/config.js
@@ -11,7 +11,25 @@ const DEFAULT_CONFIG = {
   customFieldIds: {
     targetVersion: 'customfield_10855',
     productManager: 'customfield_10469',
-    releaseType: 'customfield_10851'
+    releaseType: 'customfield_10851',
+    riceReach: '',
+    riceImpact: '',
+    riceConfidence: '',
+    riceEffort: ''
+  },
+  healthConfig: {
+    enableRice: false,
+    enableJiraEnrichment: true,
+    enrichmentBatchSize: 40,
+    enrichmentThrottleMs: 1000,
+    healthRefreshTimeoutMs: 480000,
+    riskThresholds: {
+      velocityGreenMin: 80,
+      velocityYellowMin: 50,
+      dorGreenMin: 80,
+      dorYellowMin: 50
+    },
+    phaseCompletionExpectations: null
   }
 }
 
@@ -22,11 +40,20 @@ function releaseFilePath(version) {
 function getConfig(readFromStorage) {
   const stored = readFromStorage('release-planning/config.json')
   if (stored && typeof stored === 'object') {
+    const storedHealth = stored.healthConfig || {}
     return {
       ...DEFAULT_CONFIG,
       ...stored,
       fieldMapping: { ...DEFAULT_CONFIG.fieldMapping, ...(stored.fieldMapping || {}) },
-      customFieldIds: { ...DEFAULT_CONFIG.customFieldIds, ...(stored.customFieldIds || {}) }
+      customFieldIds: { ...DEFAULT_CONFIG.customFieldIds, ...(stored.customFieldIds || {}) },
+      healthConfig: {
+        ...DEFAULT_CONFIG.healthConfig,
+        ...storedHealth,
+        riskThresholds: {
+          ...DEFAULT_CONFIG.healthConfig.riskThresholds,
+          ...(storedHealth.riskThresholds || {})
+        }
+      }
     }
   }
   return { ...DEFAULT_CONFIG }

--- a/modules/release-planning/server/constants.js
+++ b/modules/release-planning/server/constants.js
@@ -43,6 +43,59 @@ const PRIORITY_STYLES = {
   'Minor': 'bg-gray-100 dark:bg-gray-500/20 text-gray-600 dark:text-gray-400'
 }
 
+// ─── Risk Categories ───
+
+const RISK_CATEGORIES = {
+  MILESTONE_MISS: 'MILESTONE_MISS',
+  VELOCITY_LAG: 'VELOCITY_LAG',
+  DOR_INCOMPLETE: 'DOR_INCOMPLETE',
+  BLOCKED: 'BLOCKED',
+  UNESTIMATED: 'UNESTIMATED',
+  MISSING_OWNER: 'MISSING_OWNER',
+  NO_BIG_ROCK: 'NO_BIG_ROCK',
+  LATE_COMMITMENT: 'LATE_COMMITMENT'
+}
+
+const EXECUTION_RISK_CATEGORIES = ['MILESTONE_MISS', 'VELOCITY_LAG']
+const PLANNING_RISK_CATEGORIES = ['MISSING_OWNER', 'NO_BIG_ROCK', 'LATE_COMMITMENT']
+const VALID_PHASES = ['EA1', 'EA2', 'GA']
+const PLANNING_DEADLINE_OFFSET_DAYS = 7
+
+// ─── DoR Item IDs ───
+
+const DOR_ITEM_IDS = [
+  'F-1', 'F-2', 'F-3', 'F-4', 'F-5', 'F-6',
+  'F-7', 'F-8', 'F-9', 'F-10', 'F-11', 'F-12', 'F-13'
+]
+
+const MANUAL_DOR_IDS = ['F-3', 'F-9', 'F-11', 'F-12', 'F-13']
+
+// ─── Health-related Status Sets ───
+
+// Statuses considered "early" in the workflow -- features in these states
+// after a code freeze are flagged as MILESTONE_MISS
+const EARLY_STATUSES = ['New', 'Refinement']
+
+// Default phase-completion expectations by milestone.
+// Keys are milestone names; values map release phase (EA1/EA2/GA/TP/DP)
+// to the expected completion percentage at that milestone.
+const DEFAULT_PHASE_COMPLETION_EXPECTATIONS = {
+  ea1_freeze: { EA1: 90, EA2: 30, GA: 10, TP: 90, DP: 30 },
+  ea1_target: { EA1: 100, EA2: 50, GA: 20, TP: 100, DP: 50 },
+  ea2_freeze: { EA1: 100, EA2: 90, GA: 40, TP: 100, DP: 90 },
+  ea2_target: { EA1: 100, EA2: 100, GA: 60, TP: 100, DP: 100 },
+  ga_freeze:  { EA1: 100, EA2: 100, GA: 90, TP: 100, DP: 100 },
+  ga_target:  { EA1: 100, EA2: 100, GA: 100, TP: 100, DP: 100 }
+}
+
+// ─── Health Enrichment Fields ───
+
+// Lightweight fields fetched in Pass 1 for ALL features
+const ENRICHMENT_FIELDS = 'description,customfield_10028,issuelinks'
+
+// Minimal fields fetched in Pass 2 (changelog comes via expand param)
+const CHANGELOG_FIELDS = 'summary'
+
 module.exports = {
   JIRA_BROWSE_URL,
   CLOSED_STATUSES,
@@ -54,5 +107,16 @@ module.exports = {
   RFE_COLUMNS,
   BIG_ROCK_COLUMNS,
   STATUS_STYLES,
-  PRIORITY_STYLES
+  PRIORITY_STYLES,
+  RISK_CATEGORIES,
+  EXECUTION_RISK_CATEGORIES,
+  PLANNING_RISK_CATEGORIES,
+  VALID_PHASES,
+  PLANNING_DEADLINE_OFFSET_DAYS,
+  DOR_ITEM_IDS,
+  MANUAL_DOR_IDS,
+  EARLY_STATUSES,
+  DEFAULT_PHASE_COMPLETION_EXPECTATIONS,
+  ENRICHMENT_FIELDS,
+  CHANGELOG_FIELDS
 }

--- a/modules/release-planning/server/health/dor-checker.js
+++ b/modules/release-planning/server/health/dor-checker.js
@@ -1,0 +1,218 @@
+/**
+ * Definition of Ready (DoR) checker.
+ *
+ * Defines all 13 DoR criteria and evaluates them per-feature,
+ * combining automated checks (from feature-traffic data + Jira enrichment)
+ * with manual toggles (persisted in dor-state-{version}.json).
+ *
+ * IMPORTANT: Automated checks operate on RAW data from loadIndex() and
+ * loadFeatureDetail(), NOT on mapToCandidate() output. mapToCandidate()
+ * stringifies labels and components via .join(', '), which breaks array
+ * methods like .includes() and .length checks.
+ */
+
+const { CLOSED_STATUSES } = require('../constants')
+
+/**
+ * DoR checklist items.
+ *
+ * Each item has:
+ *   - id: unique identifier (F-1 through F-13)
+ *   - label: human-readable description
+ *   - type: 'automated' (evaluated from data) or 'manual' (toggled by PM)
+ *   - source: where the data comes from ('index', 'detail', 'jira', 'manual')
+ *   - check: function(feature, enrichment) => boolean (automated items only)
+ *
+ * Feature objects are RAW data from loadIndex()/loadFeatureDetail():
+ *   - feature.summary (string)
+ *   - feature.targetVersions (array)
+ *   - feature.assignee (string or object)
+ *   - feature.pm (object with displayName, from detail files)
+ *   - feature.components (array, from detail files)
+ *   - feature.releaseType (string, from detail files)
+ *   - feature.labels (array, from detail files)
+ *
+ * Enrichment objects come from jira-enrichment.js:
+ *   - enrichment.hasDescription (boolean)
+ *   - enrichment.storyPoints (number or null)
+ *   - enrichment.dependencyLinks (array)
+ */
+const DOR_ITEMS = [
+  // Automated checks
+  {
+    id: 'F-1',
+    label: 'Clear title and description',
+    type: 'automated',
+    source: 'jira',
+    check: function(feature, enrichment) {
+      return !!feature.summary && !!(enrichment && enrichment.hasDescription)
+    }
+  },
+  {
+    id: 'F-2',
+    label: 'Target release version set',
+    type: 'automated',
+    source: 'index',
+    check: function(feature) {
+      var versions = feature.targetVersions
+      return Array.isArray(versions) && versions.length > 0
+    }
+  },
+  {
+    id: 'F-4',
+    label: 'PM assigned',
+    type: 'automated',
+    source: 'detail',
+    check: function(feature) {
+      if (!feature.pm) return false
+      if (typeof feature.pm === 'string') return feature.pm.length > 0
+      if (feature.pm.displayName) return true
+      return false
+    }
+  },
+  {
+    id: 'F-5',
+    label: 'Delivery owner assigned',
+    type: 'automated',
+    source: 'index',
+    check: function(feature) {
+      if (!feature.assignee) return false
+      if (typeof feature.assignee === 'string') return feature.assignee.length > 0
+      if (feature.assignee.displayName) return true
+      return false
+    }
+  },
+  {
+    id: 'F-6',
+    label: 'Component/team assignment',
+    type: 'automated',
+    source: 'detail',
+    check: function(feature) {
+      return Array.isArray(feature.components) && feature.components.length > 0
+    }
+  },
+  {
+    id: 'F-7',
+    label: 'Estimated scope (story points)',
+    type: 'automated',
+    source: 'jira',
+    check: function(feature, enrichment) {
+      return !!(enrichment && enrichment.storyPoints && enrichment.storyPoints > 0)
+    }
+  },
+  {
+    id: 'F-8',
+    label: 'No unresolved blocking dependencies',
+    type: 'automated',
+    source: 'jira',
+    // Inverted logic: passes by DEFAULT, fails only if there are
+    // unresolved inward "Blocks" links. Most features have no blocking
+    // dependencies, so the default is "passing."
+    check: function(feature, enrichment) {
+      if (!enrichment || !enrichment.dependencyLinks) return true
+      var blocking = enrichment.dependencyLinks.filter(function(d) {
+        return d.direction === 'inward' &&
+          d.type === 'Blocks' &&
+          CLOSED_STATUSES.indexOf(d.linkedStatus) === -1
+      })
+      return blocking.length === 0
+    }
+  },
+  {
+    id: 'F-10',
+    label: 'Release type/phase specified',
+    type: 'automated',
+    source: 'detail',
+    check: function(feature) {
+      return !!feature.releaseType
+    }
+  },
+
+  // Manual checks -- toggled by PM in the UI
+  {
+    id: 'F-3',
+    label: 'Acceptance criteria defined',
+    type: 'manual',
+    source: 'manual'
+  },
+  {
+    id: 'F-9',
+    label: 'RFE linkage (if customer-driven)',
+    type: 'manual',
+    source: 'manual'
+  },
+  {
+    id: 'F-11',
+    label: 'Architectural alignment reviewed',
+    type: 'manual',
+    source: 'manual'
+  },
+  {
+    id: 'F-12',
+    label: 'Cross-functional engagement confirmed',
+    type: 'manual',
+    source: 'manual'
+  },
+  {
+    id: 'F-13',
+    label: 'Licensing review complete',
+    type: 'manual',
+    source: 'manual'
+  }
+]
+
+/**
+ * Evaluate the DoR checklist for a single feature.
+ *
+ * @param {object} feature - Raw feature data from loadIndex()/loadFeatureDetail().
+ *   Must include: summary, targetVersions, assignee, pm, components, releaseType
+ * @param {object|null} enrichment - Jira enrichment data from jira-enrichment.js.
+ *   May be null if Jira enrichment was skipped.
+ * @param {object|null} manualChecks - Persisted manual check state from dor-state file.
+ *   Format: { "F-3": { checked: true, ... }, "F-9": { checked: false, ... }, ... }
+ * @returns {{ checkedCount: number, totalCount: number, completionPct: number, items: Array<object> }}
+ */
+function evaluateDor(feature, enrichment, manualChecks) {
+  var safeEnrichment = enrichment || {}
+  var safeManual = manualChecks || {}
+  var items = []
+  var checkedCount = 0
+  var totalCount = DOR_ITEMS.length
+
+  for (var i = 0; i < DOR_ITEMS.length; i++) {
+    var item = DOR_ITEMS[i]
+    var checked = false
+
+    if (item.type === 'automated') {
+      checked = item.check(feature, safeEnrichment)
+    } else {
+      // Manual check -- read from persisted state
+      var manualEntry = safeManual[item.id]
+      if (manualEntry && manualEntry.checked) checked = true
+    }
+
+    if (checked) checkedCount++
+
+    items.push({
+      id: item.id,
+      label: item.label,
+      type: item.type,
+      checked: checked,
+      source: item.source
+    })
+  }
+
+  var completionPct = totalCount > 0 ? Math.round((checkedCount / totalCount) * 100) : 0
+
+  return {
+    checkedCount: checkedCount,
+    totalCount: totalCount,
+    completionPct: completionPct,
+    items: items
+  }
+}
+
+module.exports = {
+  DOR_ITEMS: DOR_ITEMS,
+  evaluateDor: evaluateDor
+}

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -1,0 +1,604 @@
+/**
+ * Health pipeline orchestrator.
+ *
+ * Coordinates the full health assessment flow:
+ *   1. Load feature-traffic index and detail files
+ *   2. Load Smartsheet milestone dates (with freeze dates)
+ *   3. Run Jira enrichment (two-pass)
+ *   4. Evaluate DoR for each feature
+ *   5. Compute risk for each feature
+ *   6. Compute RICE scores (if enabled)
+ *   7. Build and write health cache
+ *
+ * Graceful degradation at every step -- if any data source is unavailable,
+ * the pipeline continues with reduced accuracy rather than failing entirely.
+ */
+
+const { loadIndex, loadFeatureDetail } = require('../cache-reader')
+const { getConfig } = require('../config')
+const { JIRA_BROWSE_URL, CLOSED_STATUSES, PLANNING_DEADLINE_OFFSET_DAYS, VALID_PHASES } = require('../constants')
+const { enrichFeatures } = require('./jira-enrichment')
+const { evaluateDor } = require('./dor-checker')
+const { computeFeatureRisk } = require('./risk-engine')
+const { buildRiceResult } = require('./rice-scorer')
+const smartsheetClient = require('../../../../shared/server/smartsheet')
+
+var DATA_PREFIX = 'release-planning'
+
+/**
+ * Get a display name from an assignee/pm field that may be a string or object.
+ * @param {*} field
+ * @returns {string}
+ */
+function getDisplayName(field) {
+  if (!field) return ''
+  if (typeof field === 'string') return field
+  if (field.displayName) return field.displayName
+  if (field.name) return field.name
+  return ''
+}
+
+/**
+ * Split a comma-separated string into a trimmed array.
+ * @param {string} str
+ * @returns {Array<string>}
+ */
+function splitCommaString(str) {
+  if (!str || typeof str !== 'string') return []
+  return str.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+}
+
+/**
+ * Check whether a candidate feature passes the phase filter.
+ * If no phase is specified, all features pass.
+ * If a feature has a phase-specific fixVersion (e.g., rhoai-3.5-EA2),
+ * it only appears in the matching phase view.
+ * Features without phase-specific fixVersions appear in all views.
+ *
+ * @param {object} candidate - Candidate feature from pipeline
+ * @param {string} version - Release version (e.g., '3.5')
+ * @param {string|null} phase - Selected phase (EA1/EA2/GA) or null
+ * @returns {boolean}
+ */
+function passesPhaseFilter(candidate, version, phase) {
+  if (!phase) return true
+
+  var fixVersionStr = candidate.fixVersion || ''
+  var fixVersions = splitCommaString(fixVersionStr)
+
+  var hasPhaseSpecific = false
+  var matchesRequestedPhase = false
+
+  for (var i = 0; i < fixVersions.length; i++) {
+    var fv = fixVersions[i].toUpperCase()
+    for (var j = 0; j < VALID_PHASES.length; j++) {
+      if (fv.indexOf('-' + VALID_PHASES[j]) !== -1) {
+        hasPhaseSpecific = true
+        if (VALID_PHASES[j] === phase.toUpperCase()) {
+          matchesRequestedPhase = true
+        }
+      }
+    }
+  }
+
+  if (!hasPhaseSpecific) return true
+  return matchesRequestedPhase
+}
+
+/**
+ * Map a candidate feature from the Big Rocks pipeline to the shape
+ * expected by the health pipeline.
+ *
+ * @param {object} candidate
+ * @returns {object}
+ */
+function mapCandidateToHealthFeature(candidate) {
+  return {
+    key: candidate.issueKey,
+    summary: candidate.summary || '',
+    status: candidate.status || '',
+    priority: candidate.priority || '',
+    releaseType: candidate.phase || '',
+    components: splitCommaString(candidate.components),
+    fixVersions: splitCommaString(candidate.fixVersion),
+    targetVersions: candidate.targetRelease ? [candidate.targetRelease] : [],
+    assignee: candidate.deliveryOwner || '',
+    deliveryOwner: candidate.deliveryOwner || '',
+    pm: candidate.pm || '',
+    bigRock: candidate.bigRock || '',
+    tier: candidate.tier || null,
+    rfe: candidate.rfe || '',
+    labels: splitCommaString(candidate.labels),
+    parentKey: candidate.rfe || ''
+  }
+}
+
+/**
+ * Load features from the Big Rocks candidates pipeline cache.
+ *
+ * @param {Function} readFromStorage
+ * @param {string} version - Release version (e.g., '3.5')
+ * @param {string|null} phase - Phase filter (EA1/EA2/GA) or null for all
+ * @returns {{ features: Array<object>, warnings: Array<string> }}
+ */
+function loadFeaturesFromCandidates(readFromStorage, version, phase) {
+  var warnings = []
+  var cacheKey = DATA_PREFIX + '/candidates-cache-' + version + '.json'
+  var cached = readFromStorage(cacheKey)
+
+  if (!cached || !cached.data || !cached.data.features) {
+    warnings.push('No candidates found -- run a Big Rocks refresh first')
+    return { features: [], warnings: warnings }
+  }
+
+  var candidates = cached.data.features
+  var features = []
+
+  for (var i = 0; i < candidates.length; i++) {
+    var candidate = candidates[i]
+
+    if (!passesPhaseFilter(candidate, version, phase)) continue
+
+    var status = candidate.status || ''
+    if (CLOSED_STATUSES.indexOf(status) !== -1) continue
+
+    features.push(mapCandidateToHealthFeature(candidate))
+  }
+
+  return { features: features, warnings: warnings }
+}
+
+/**
+ * Compute the planning deadline for a given phase.
+ * The planning deadline is the code freeze date minus PLANNING_DEADLINE_OFFSET_DAYS.
+ *
+ * @param {object|null} milestones - Milestone dates from Smartsheet
+ * @param {string|null} phase - Selected phase (EA1/EA2/GA)
+ * @returns {{ date: string, daysRemaining: number }|null}
+ */
+function computePlanningDeadline(milestones, phase) {
+  if (!milestones || !phase) return null
+
+  var freezeMap = {
+    'EA1': milestones.ea1Freeze,
+    'EA2': milestones.ea2Freeze,
+    'GA': milestones.gaFreeze
+  }
+
+  var freezeDate = freezeMap[phase.toUpperCase()]
+  if (!freezeDate) return null
+
+  var freeze = new Date(freezeDate + 'T00:00:00Z')
+  var deadline = new Date(freeze.getTime() - PLANNING_DEADLINE_OFFSET_DAYS * 24 * 60 * 60 * 1000)
+  var deadlineStr = deadline.toISOString().split('T')[0]
+
+  var today = new Date()
+  var todayStr = today.toISOString().split('T')[0]
+  var todayDate = new Date(todayStr + 'T00:00:00Z')
+  var daysRemaining = Math.ceil((deadline - todayDate) / (1000 * 60 * 60 * 24))
+
+  return { date: deadlineStr, daysRemaining: daysRemaining }
+}
+
+/**
+ * Get the release phase from a feature's releaseType or fixVersions.
+ * Simplified version -- just returns the raw releaseType or infers from data.
+ * @param {object} feature
+ * @returns {string}
+ */
+function getFeaturePhase(feature) {
+  var RELEASE_TYPE_MAP = {
+    'Tech Preview': 'TP',
+    'Developer Preview': 'DP',
+    'General Availability': 'GA',
+    'TP': 'TP',
+    'DP': 'DP',
+    'GA': 'GA'
+  }
+
+  if (feature.releaseType) {
+    var mapped = RELEASE_TYPE_MAP[feature.releaseType]
+    if (mapped) return mapped
+  }
+
+  var fixVersions = feature.fixVersions || []
+  for (var i = 0; i < fixVersions.length; i++) {
+    var v = fixVersions[i].toUpperCase()
+    if (v.indexOf('GA') !== -1) return 'GA'
+  }
+  for (var j = 0; j < fixVersions.length; j++) {
+    var v2 = fixVersions[j].toUpperCase().replace(/[^A-Z0-9]/g, '')
+    if (v2.indexOf('EA2') !== -1 || v2.indexOf('DP2') !== -1) return 'DP'
+    if (v2.indexOf('EA1') !== -1 || v2.indexOf('DP1') !== -1 || v2.indexOf('TP') !== -1) return 'TP'
+  }
+  return ''
+}
+
+/**
+ * Load milestone data from Smartsheet.
+ * Returns milestones for the requested version, or null if unavailable.
+ *
+ * @param {string} version - Release version (e.g., '3.5')
+ * @returns {Promise<object|null>} Milestone dates or null
+ */
+async function loadMilestones(version) {
+  if (!smartsheetClient.isConfigured()) {
+    return null
+  }
+
+  try {
+    var releases = await smartsheetClient.discoverReleasesWithFreezes()
+    for (var i = 0; i < releases.length; i++) {
+      if (releases[i].version === version) {
+        return releases[i]
+      }
+    }
+    return null
+  } catch (err) {
+    console.warn('[health] Failed to load Smartsheet milestones:', err.message)
+    return null
+  }
+}
+
+/**
+ * Load features for a release version from the feature-traffic cache.
+ * Filters features by target version match and excludes closed statuses.
+ * Loads detail files for each feature to get pm, components, releaseType, etc.
+ *
+ * @param {Function} readFromStorage
+ * @param {string} version - Release version (e.g., '3.5')
+ * @returns {{ features: Array<object>, warnings: Array<string> }}
+ */
+function loadFeaturesForRelease(readFromStorage, version) {
+  var index = loadIndex(readFromStorage)
+  var warnings = []
+
+  if (!index.features || index.features.length === 0) {
+    warnings.push('Feature-traffic index is empty -- run a feature-traffic refresh first')
+    return { features: [], warnings: warnings }
+  }
+
+  var features = []
+  var allFeatures = index.features || []
+
+  for (var i = 0; i < allFeatures.length; i++) {
+    var f = allFeatures[i]
+
+    // Check if feature targets or is committed to this version
+    var targetVersions = f.targetVersions || []
+    var fixVersions = f.fixVersions || []
+    var matchesVersion = false
+    for (var j = 0; j < targetVersions.length; j++) {
+      if (targetVersions[j].indexOf(version) !== -1) {
+        matchesVersion = true
+        break
+      }
+    }
+    if (!matchesVersion) {
+      for (var j2 = 0; j2 < fixVersions.length; j2++) {
+        if (fixVersions[j2].indexOf(version) !== -1) {
+          matchesVersion = true
+          break
+        }
+      }
+    }
+    if (!matchesVersion) continue
+
+    // Skip closed features
+    var status = f.status || ''
+    if (CLOSED_STATUSES.indexOf(status) !== -1) continue
+
+    // Load detail file for additional fields
+    var detail = loadFeatureDetail(readFromStorage, f.key)
+
+    // Merge index + detail data, preferring detail where available
+    var merged = Object.assign({}, f)
+    if (detail) {
+      // Preserve raw arrays from detail -- do NOT use mapToCandidate
+      if (detail.pm !== undefined) merged.pm = detail.pm
+      if (detail.components !== undefined) merged.components = detail.components
+      if (detail.releaseType !== undefined) merged.releaseType = detail.releaseType
+      if (detail.labels !== undefined) merged.labels = detail.labels
+      if (detail.issueLinks !== undefined) merged.issueLinks = detail.issueLinks
+    }
+
+    features.push(merged)
+  }
+
+  return { features: features, warnings: warnings }
+}
+
+/**
+ * Compute next milestone info for the release summary.
+ *
+ * @param {object|null} milestones - Milestone dates
+ * @param {Date} today
+ * @returns {{ currentPhase: string, daysToNextMilestone: number|null, nextMilestone: string|null }}
+ */
+function computeMilestoneInfo(milestones, today) {
+  if (!milestones) {
+    return { currentPhase: 'Unknown', daysToNextMilestone: null, nextMilestone: null }
+  }
+
+  var todayStr = today.toISOString().split('T')[0]
+  var milestoneList = [
+    { key: 'ea1Freeze', label: 'EA1 Code Freeze', date: milestones.ea1Freeze },
+    { key: 'ea1Target', label: 'EA1 Release', date: milestones.ea1Target },
+    { key: 'ea2Freeze', label: 'EA2 Code Freeze', date: milestones.ea2Freeze },
+    { key: 'ea2Target', label: 'EA2 Release', date: milestones.ea2Target },
+    { key: 'gaFreeze', label: 'GA Code Freeze', date: milestones.gaFreeze },
+    { key: 'gaTarget', label: 'GA Release', date: milestones.gaTarget }
+  ]
+
+  // Find the next upcoming milestone
+  var nextMilestone = null
+  var daysToNext = null
+  for (var i = 0; i < milestoneList.length; i++) {
+    var ms = milestoneList[i]
+    if (ms.date && ms.date > todayStr) {
+      nextMilestone = ms.label
+      var msDate = new Date(ms.date + 'T00:00:00Z')
+      var todayDate = new Date(todayStr + 'T00:00:00Z')
+      daysToNext = Math.ceil((msDate - todayDate) / (1000 * 60 * 60 * 24))
+      break
+    }
+  }
+
+  // Determine current phase based on what's passed
+  var currentPhase = 'Pre-EA1'
+  if (milestones.gaTarget && todayStr >= milestones.gaTarget) currentPhase = 'Post-GA'
+  else if (milestones.gaFreeze && todayStr >= milestones.gaFreeze) currentPhase = 'GA Freeze'
+  else if (milestones.ea2Target && todayStr >= milestones.ea2Target) currentPhase = 'Post-EA2'
+  else if (milestones.ea2Freeze && todayStr >= milestones.ea2Freeze) currentPhase = 'EA2 Freeze'
+  else if (milestones.ea1Target && todayStr >= milestones.ea1Target) currentPhase = 'Post-EA1'
+  else if (milestones.ea1Freeze && todayStr >= milestones.ea1Freeze) currentPhase = 'EA1 Freeze'
+
+  return {
+    currentPhase: currentPhase,
+    daysToNextMilestone: daysToNext,
+    nextMilestone: nextMilestone
+  }
+}
+
+/**
+ * Run the health pipeline for a release version.
+ *
+ * @param {string} version - Release version (e.g., '3.5')
+ * @param {Function} readFromStorage
+ * @param {Function} writeToStorage
+ * @param {Function} jiraRequest - From shared/server/jira.js
+ * @param {Function} fetchAllJqlResults - From shared/server/jira.js
+ * @param {string|null} phase - Phase filter (EA1/EA2/GA) or null for all
+ * @returns {Promise<object>} Health cache data
+ */
+async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraRequest, fetchAllJqlResults, phase) {
+  var config = getConfig(readFromStorage)
+  var healthConfig = config.healthConfig || {}
+  var warnings = []
+  var today = new Date()
+  var phaseKey = phase || 'all'
+
+  console.log('[health] Starting health pipeline for version ' + version + ' phase ' + phaseKey)
+
+  // Step 1: Load features from Big Rocks candidates cache
+  var featureResult = loadFeaturesFromCandidates(readFromStorage, version, phase)
+  var features = featureResult.features
+  warnings = warnings.concat(featureResult.warnings)
+
+  if (features.length === 0) {
+    console.warn('[health] No features found for version ' + version + ' phase ' + phaseKey)
+    var emptyCache = buildEmptyCache(version, warnings)
+    writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', emptyCache)
+    return emptyCache
+  }
+
+  console.log('[health] Found ' + features.length + ' features for version ' + version + ' phase ' + phaseKey)
+
+  // Step 2: Load milestone dates from Smartsheet
+  var milestones = await loadMilestones(version)
+  if (!milestones) {
+    warnings.push('Smartsheet milestone dates not available -- milestone risk checks will be skipped')
+  }
+
+  // Step 3: Run Jira enrichment
+  var enrichResult = { enrichments: new Map(), riceData: new Map(), warnings: [], stats: { pass1: 0, pass2: 0, rice: 0 } }
+  try {
+    enrichResult = await enrichFeatures(jiraRequest, fetchAllJqlResults, features, config)
+    warnings = warnings.concat(enrichResult.warnings)
+  } catch (err) {
+    console.error('[health] Jira enrichment failed:', err.message)
+    warnings.push('Jira enrichment failed: ' + err.message)
+  }
+
+  // Step 4: Load manual DoR state and overrides
+  var dorState = readFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json') || { features: {} }
+  var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || { overrides: {} }
+
+  // Step 5: Build per-feature health assessments
+  var planningDeadline = computePlanningDeadline(milestones, phase)
+  var milestoneInfo = computeMilestoneInfo(milestones, today)
+  var healthFeatures = []
+  var riskCounts = { green: 0, yellow: 0, red: 0 }
+  var totalDorChecked = 0
+  var totalDorItems = 0
+  var totalRiceScore = 0
+  var riceCount = 0
+  var blockedCount = 0
+  var unestimatedCount = 0
+
+  for (var i = 0; i < features.length; i++) {
+    var feature = features[i]
+    var key = feature.key
+    var enrichment = enrichResult.enrichments.get(key) || null
+    var manualChecks = (dorState.features && dorState.features[key] && dorState.features[key].manualChecks) || null
+
+    // Evaluate DoR
+    var dorStatus = evaluateDor(feature, enrichment, manualChecks)
+    totalDorChecked += dorStatus.checkedCount
+    totalDorItems += dorStatus.totalCount
+
+    // Derive phase for risk engine
+    var featurePhase = getFeaturePhase(feature)
+
+    // Build a feature object with phase for risk engine
+    var featureForRisk = Object.assign({}, feature, { phase: featurePhase })
+
+    // Compute risk
+    var riskResult = computeFeatureRisk(featureForRisk, milestones, dorStatus, enrichment, {
+      riskThresholds: healthConfig.riskThresholds,
+      phaseCompletionExpectations: healthConfig.phaseCompletionExpectations,
+      today: today,
+      planningDeadline: planningDeadline,
+      version: version
+    })
+
+    // Apply manual override if present
+    var override = (overrides.overrides && overrides.overrides[key]) || null
+    var effectiveRisk = riskResult.risk
+    if (override && override.riskOverride) {
+      effectiveRisk = override.riskOverride
+    }
+
+    riskCounts[effectiveRisk] = (riskCounts[effectiveRisk] || 0) + 1
+
+    // Count specific risk types
+    for (var fi = 0; fi < riskResult.flags.length; fi++) {
+      if (riskResult.flags[fi].category === 'BLOCKED') blockedCount++
+      if (riskResult.flags[fi].category === 'UNESTIMATED') unestimatedCount++
+    }
+
+    // RICE score
+    var riceResult = null
+    if (enrichment && enrichment.rice) {
+      riceResult = buildRiceResult(enrichment.rice)
+      if (riceResult && riceResult.score !== null) {
+        totalRiceScore += riceResult.score
+        riceCount++
+      }
+    }
+
+    // Build health feature entry
+    var components = Array.isArray(feature.components)
+      ? feature.components.join(', ')
+      : ''
+
+    healthFeatures.push({
+      key: key,
+      summary: feature.summary || '',
+      status: feature.status || '',
+      priority: feature.priority || '',
+      phase: phase,
+      bigRock: feature.bigRock || '',
+      tier: feature.tier || null,
+      pm: getDisplayName(feature.pm),
+      deliveryOwner: getDisplayName(feature.assignee),
+      components: components,
+      completionPct: typeof feature.completionPct === 'number' ? feature.completionPct : 0,
+      epicCount: feature.epicCount || 0,
+      issueCount: feature.issueCount || 0,
+      blockerCount: feature.blockerCount || 0,
+      health: feature.health || '',
+      risk: {
+        level: effectiveRisk,
+        score: riskResult.riskScore,
+        flags: riskResult.flags,
+        override: override
+      },
+      dor: dorStatus,
+      rice: riceResult,
+      jiraUrl: JIRA_BROWSE_URL + '/' + key
+    })
+  }
+
+  // Step 6: Build summary
+  var averageRice = riceCount > 0 ? Math.round(totalRiceScore / riceCount) : null
+  var dorCompletionRate = totalDorItems > 0 ? Math.round((totalDorChecked / totalDorItems) * 100) : 0
+
+  var cache = {
+    cachedAt: today.toISOString(),
+    version: version,
+    milestones: milestones ? {
+      ea1Freeze: milestones.ea1Freeze,
+      ea1Target: milestones.ea1Target,
+      ea2Freeze: milestones.ea2Freeze,
+      ea2Target: milestones.ea2Target,
+      gaFreeze: milestones.gaFreeze,
+      gaTarget: milestones.gaTarget
+    } : null,
+    phase: phaseKey,
+    summary: {
+      totalFeatures: features.length,
+      byRisk: riskCounts,
+      dorCompletionRate: dorCompletionRate,
+      averageRiceScore: averageRice,
+      blockedCount: blockedCount,
+      unestimatedCount: unestimatedCount,
+      currentPhase: milestoneInfo.currentPhase,
+      daysToNextMilestone: milestoneInfo.daysToNextMilestone,
+      nextMilestone: milestoneInfo.nextMilestone,
+      planningDeadline: planningDeadline
+    },
+    features: healthFeatures,
+    enrichmentStatus: {
+      jiraQueriesRun: enrichResult.stats.pass1 + enrichResult.stats.pass2,
+      featuresEnriched: enrichResult.enrichments.size,
+      featuresSkipped: features.length - enrichResult.enrichments.size,
+      riceAvailable: riceCount > 0,
+      warnings: warnings
+    }
+  }
+
+  // Step 7: Write health cache
+  writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', cache)
+  console.log('[health] Health pipeline completed for version ' + version + ' phase ' + phaseKey + ': ' + features.length + ' features assessed')
+
+  return cache
+}
+
+/**
+ * Build an empty health cache for when no features are found.
+ * @param {string} version
+ * @param {Array<string>} warnings
+ * @returns {object}
+ */
+function buildEmptyCache(version, warnings) {
+  return {
+    cachedAt: new Date().toISOString(),
+    version: version,
+    milestones: null,
+    summary: {
+      totalFeatures: 0,
+      byRisk: { green: 0, yellow: 0, red: 0 },
+      dorCompletionRate: 0,
+      averageRiceScore: null,
+      blockedCount: 0,
+      unestimatedCount: 0,
+      currentPhase: 'Unknown',
+      daysToNextMilestone: null,
+      nextMilestone: null
+    },
+    features: [],
+    enrichmentStatus: {
+      jiraQueriesRun: 0,
+      featuresEnriched: 0,
+      featuresSkipped: 0,
+      riceAvailable: false,
+      warnings: warnings
+    }
+  }
+}
+
+module.exports = {
+  runHealthPipeline: runHealthPipeline,
+  // Exported for testing
+  loadFeaturesForRelease: loadFeaturesForRelease,
+  loadFeaturesFromCandidates: loadFeaturesFromCandidates,
+  loadMilestones: loadMilestones,
+  computeMilestoneInfo: computeMilestoneInfo,
+  computePlanningDeadline: computePlanningDeadline,
+  getFeaturePhase: getFeaturePhase,
+  buildEmptyCache: buildEmptyCache,
+  splitCommaString: splitCommaString,
+  passesPhaseFilter: passesPhaseFilter,
+  mapCandidateToHealthFeature: mapCandidateToHealthFeature
+}

--- a/modules/release-planning/server/health/health-routes.js
+++ b/modules/release-planning/server/health/health-routes.js
@@ -1,0 +1,581 @@
+/**
+ * Health API route handlers.
+ *
+ * Registers all health-related endpoints under /releases/:version/health/*.
+ * Read endpoints use requireAuth; write endpoints use requirePM.
+ *
+ * Shares the refreshStates Map and MAX_CONCURRENT_REFRESHES limit with the
+ * candidates pipeline to prevent concurrent Jira-heavy operations from
+ * exceeding rate limits.
+ */
+
+const { getConfig } = require('../config')
+const { CACHE_MAX_AGE_MS, MANUAL_DOR_IDS, DOR_ITEM_IDS, VALID_PHASES } = require('../constants')
+const { runHealthPipeline } = require('./health-pipeline')
+const { DOR_ITEMS } = require('./dor-checker')
+const { logAudit } = require('../audit-log')
+const { jiraRequest, fetchAllJqlResults } = require('../../../../shared/server/jira')
+
+var DATA_PREFIX = 'release-planning'
+var VERSION_RE = /^[a-zA-Z0-9._-]{1,50}$/
+var FEATURE_KEY_RE = /^[A-Z]+-\d+$/
+var VALID_RISK_LEVELS = ['green', 'yellow', 'red']
+var MAX_NOTES_LENGTH = 2000
+var MAX_REASON_LENGTH = 500
+
+var DEMO_MODE = process.env.DEMO_MODE === 'true'
+
+/**
+ * Register health routes on the module router.
+ *
+ * @param {object} router - Express router (already mounted at /api/modules/release-planning/)
+ * @param {object} context - Module context with storage, auth, refreshStates, etc.
+ */
+function healthRoutes(router, context) {
+  var storage = context.storage
+  var readFromStorage = storage.readFromStorage
+  var writeToStorage = storage.writeToStorage
+  var requireAuth = context.requireAuth
+  var requirePM = context.requirePM
+  var refreshStates = context.refreshStates
+  var MAX_CONCURRENT_REFRESHES = context.MAX_CONCURRENT_REFRESHES
+  var sendJsonWithETag = context.sendJsonWithETag
+
+  function isValidVersion(version) {
+    return VERSION_RE.test(version) && ['__proto__', 'constructor', 'prototype'].indexOf(version) === -1
+  }
+
+  function parsePhase(req) {
+    var phase = req.query && req.query.phase
+    return phase || null
+  }
+
+  function isValidPhase(phase) {
+    return !phase || VALID_PHASES.indexOf(phase) !== -1
+  }
+
+  function phaseKey(phase) {
+    return phase || 'all'
+  }
+
+  function getHealthRefreshState(version, phase) {
+    return refreshStates.get('health:' + version + ':' + phaseKey(phase)) || { running: false, lastResult: null }
+  }
+
+  function loadFixture(name) {
+    var fs = require('fs')
+    var fixturePath = require('path').join(__dirname, '..', '..', '..', '..', 'fixtures', DATA_PREFIX, name)
+    try {
+      return JSON.parse(fs.readFileSync(fixturePath, 'utf-8'))
+    } catch {
+      return null
+    }
+  }
+
+  // ─── GET /releases/:version/health ───
+
+  router.get('/releases/:version/health', requireAuth, function(req, res) {
+    var version = req.params.version
+    var phase = parsePhase(req)
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!isValidPhase(phase)) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + VALID_PHASES.join(', ') })
+    }
+
+    if (DEMO_MODE) {
+      var demoData = loadFixture('health-cache-demo.json')
+      if (demoData) {
+        return res.json(Object.assign({}, demoData, { demoMode: true }))
+      }
+      return res.status(404).json({ error: 'Demo health data not available' })
+    }
+
+    var pk = phaseKey(phase)
+    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    var hasCachedData = cached && cached.cachedAt
+
+    if (hasCachedData) {
+      var age = Date.now() - new Date(cached.cachedAt).getTime()
+      var isStale = age >= CACHE_MAX_AGE_MS
+
+      if (isStale) {
+        triggerHealthRefresh(version, phase)
+      }
+
+      return sendJsonWithETag(req, res, Object.assign({}, cached, {
+        _cacheStale: isStale,
+        _refreshing: getHealthRefreshState(version, phase).running
+      }))
+    }
+
+    // No cache exists -- trigger refresh and return 202
+    triggerHealthRefresh(version, phase)
+    sendJsonWithETag(req, res, {
+      version: version,
+      phase: pk,
+      _cacheStale: true,
+      _refreshing: getHealthRefreshState(version, phase).running,
+      _noCache: true,
+      milestones: null,
+      summary: null,
+      features: [],
+      enrichmentStatus: null,
+      warning: 'Health pipeline is running for the first time. This may take several minutes.'
+    }, 202)
+  })
+
+  // ─── GET /releases/:version/health/summary ───
+
+  router.get('/releases/:version/health/summary', requireAuth, function(req, res) {
+    var version = req.params.version
+    var phase = parsePhase(req)
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!isValidPhase(phase)) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + VALID_PHASES.join(', ') })
+    }
+
+    if (DEMO_MODE) {
+      var demoData = loadFixture('health-cache-demo.json')
+      if (demoData) {
+        return res.json({
+          version: demoData.version,
+          generatedAt: demoData.cachedAt,
+          milestones: demoData.milestones,
+          summary: demoData.summary,
+          _cacheStale: false,
+          demoMode: true
+        })
+      }
+      return res.status(404).json({ error: 'Demo health data not available' })
+    }
+
+    var pk = phaseKey(phase)
+    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    if (!cached || !cached.cachedAt) {
+      return res.status(404).json({ error: 'No health data available for version ' + version + '. Trigger a health refresh first.' })
+    }
+
+    var age = Date.now() - new Date(cached.cachedAt).getTime()
+    var isStale = age >= CACHE_MAX_AGE_MS
+
+    sendJsonWithETag(req, res, {
+      version: cached.version,
+      generatedAt: cached.cachedAt,
+      milestones: cached.milestones,
+      summary: cached.summary,
+      _cacheStale: isStale,
+      _refreshing: getHealthRefreshState(version, phase).running
+    })
+  })
+
+  // ─── GET /releases/:version/health/feature/:key ───
+
+  router.get('/releases/:version/health/feature/:key', requireAuth, function(req, res) {
+    var version = req.params.version
+    var key = req.params.key
+    var phase = parsePhase(req)
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!FEATURE_KEY_RE.test(key)) {
+      return res.status(400).json({ error: 'Invalid feature key format' })
+    }
+    if (!isValidPhase(phase)) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + VALID_PHASES.join(', ') })
+    }
+
+    if (DEMO_MODE) {
+      var demoData = loadFixture('health-cache-demo.json')
+      if (demoData && demoData.features) {
+        var demoFeature = null
+        for (var di = 0; di < demoData.features.length; di++) {
+          if (demoData.features[di].key === key) {
+            demoFeature = demoData.features[di]
+            break
+          }
+        }
+        if (demoFeature) {
+          return res.json(Object.assign({}, demoFeature, { demoMode: true }))
+        }
+        return res.status(404).json({ error: 'Feature ' + key + ' not found in demo data' })
+      }
+      return res.status(404).json({ error: 'Demo health data not available' })
+    }
+
+    var pk = phaseKey(phase)
+    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    if (!cached || !cached.features) {
+      return res.status(404).json({ error: 'No health data available for version ' + version })
+    }
+
+    var feature = null
+    for (var i = 0; i < cached.features.length; i++) {
+      if (cached.features[i].key === key) {
+        feature = cached.features[i]
+        break
+      }
+    }
+
+    if (!feature) {
+      return res.status(404).json({ error: 'Feature ' + key + ' not found in health data for version ' + version })
+    }
+
+    sendJsonWithETag(req, res, feature)
+  })
+
+  // ─── PUT /releases/:version/health/dor/:featureKey ───
+
+  router.put('/releases/:version/health/dor/:featureKey', requirePM, function(req, res) {
+    var version = req.params.version
+    var featureKey = req.params.featureKey
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!FEATURE_KEY_RE.test(featureKey)) {
+      return res.status(400).json({ error: 'Invalid feature key format. Expected pattern like PROJ-123.' })
+    }
+
+    var items = req.body && req.body.items
+    var notes = req.body && req.body.notes
+
+    // Validate items
+    if (!items || typeof items !== 'object' || Array.isArray(items)) {
+      return res.status(400).json({ error: 'items must be an object mapping DoR item IDs to booleans' })
+    }
+
+    var itemKeys = Object.keys(items)
+    for (var i = 0; i < itemKeys.length; i++) {
+      var itemId = itemKeys[i]
+
+      // Validate item ID exists
+      if (DOR_ITEM_IDS.indexOf(itemId) === -1) {
+        return res.status(400).json({ error: 'Unknown DoR item ID: ' + itemId })
+      }
+
+      // Only manual items can be toggled
+      if (MANUAL_DOR_IDS.indexOf(itemId) === -1) {
+        return res.status(400).json({ error: 'DoR item ' + itemId + ' is automated and cannot be toggled manually' })
+      }
+
+      // Values must be booleans
+      if (typeof items[itemId] !== 'boolean') {
+        return res.status(400).json({ error: 'DoR item values must be booleans. Got ' + typeof items[itemId] + ' for ' + itemId })
+      }
+    }
+
+    // Validate notes
+    if (notes !== undefined && notes !== null) {
+      if (typeof notes !== 'string') {
+        return res.status(400).json({ error: 'notes must be a string' })
+      }
+      if (notes.length > MAX_NOTES_LENGTH) {
+        return res.status(400).json({ error: 'notes must be at most ' + MAX_NOTES_LENGTH + ' characters' })
+      }
+    }
+
+    // Read existing DoR state
+    var dorState = readFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json') || {
+      version: version,
+      updatedAt: null,
+      features: {}
+    }
+
+    if (!dorState.features) dorState.features = {}
+    if (!dorState.features[featureKey]) {
+      dorState.features[featureKey] = { manualChecks: {}, notes: '' }
+    }
+    if (!dorState.features[featureKey].manualChecks) {
+      dorState.features[featureKey].manualChecks = {}
+    }
+
+    var now = new Date().toISOString()
+    var userEmail = req.userEmail || 'unknown'
+
+    // Apply updates
+    for (var j = 0; j < itemKeys.length; j++) {
+      var id = itemKeys[j]
+      dorState.features[featureKey].manualChecks[id] = {
+        checked: items[id],
+        updatedBy: userEmail,
+        updatedAt: now
+      }
+    }
+
+    if (notes !== undefined && notes !== null) {
+      dorState.features[featureKey].notes = notes
+    }
+
+    dorState.updatedAt = now
+
+    // Write updated state
+    writeToStorage(DATA_PREFIX + '/dor-state-' + version + '.json', dorState)
+
+    // Count manual checks for response
+    var manualChecks = dorState.features[featureKey].manualChecks
+    var checkedCount = 0
+    var totalCount = DOR_ITEMS.length
+    // Count automated checks from cache (if available)
+    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '.json')
+    var cachedFeature = null
+    if (cached && cached.features) {
+      for (var ci = 0; ci < cached.features.length; ci++) {
+        if (cached.features[ci].key === featureKey) {
+          cachedFeature = cached.features[ci]
+          break
+        }
+      }
+    }
+
+    if (cachedFeature && cachedFeature.dor && cachedFeature.dor.items) {
+      // Use cached automated check results and updated manual checks
+      for (var k = 0; k < cachedFeature.dor.items.length; k++) {
+        var dorItem = cachedFeature.dor.items[k]
+        if (dorItem.type === 'automated') {
+          if (dorItem.checked) checkedCount++
+        } else {
+          // Manual -- use the updated state
+          var entry = manualChecks[dorItem.id]
+          if (entry && entry.checked) checkedCount++
+        }
+      }
+    } else {
+      // No cached data -- just count manual checks
+      var allManualIds = MANUAL_DOR_IDS
+      for (var m = 0; m < allManualIds.length; m++) {
+        var mc = manualChecks[allManualIds[m]]
+        if (mc && mc.checked) checkedCount++
+      }
+    }
+
+    var completionPct = totalCount > 0 ? Math.round((checkedCount / totalCount) * 100) : 0
+
+    // Audit log
+    logAudit(readFromStorage, writeToStorage, {
+      version: version,
+      action: 'update_dor',
+      user: userEmail,
+      summary: 'Updated DoR checklist for ' + featureKey,
+      details: { featureKey: featureKey, items: items }
+    })
+
+    res.json({
+      featureKey: featureKey,
+      dor: { checkedCount: checkedCount, totalCount: totalCount, completionPct: completionPct },
+      updatedAt: now,
+      updatedBy: userEmail
+    })
+  })
+
+  // ─── PUT /releases/:version/health/override/:featureKey ───
+
+  router.put('/releases/:version/health/override/:featureKey', requirePM, function(req, res) {
+    var version = req.params.version
+    var featureKey = req.params.featureKey
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!FEATURE_KEY_RE.test(featureKey)) {
+      return res.status(400).json({ error: 'Invalid feature key format. Expected pattern like PROJ-123.' })
+    }
+
+    var riskOverride = req.body && req.body.riskOverride
+    var reason = req.body && req.body.reason
+
+    // Validate riskOverride
+    if (!riskOverride || VALID_RISK_LEVELS.indexOf(riskOverride) === -1) {
+      return res.status(400).json({ error: 'riskOverride must be one of: ' + VALID_RISK_LEVELS.join(', ') })
+    }
+
+    // Validate reason
+    if (!reason || typeof reason !== 'string' || reason.trim().length === 0) {
+      return res.status(400).json({ error: 'reason is required' })
+    }
+    if (reason.length > MAX_REASON_LENGTH) {
+      return res.status(400).json({ error: 'reason must be at most ' + MAX_REASON_LENGTH + ' characters' })
+    }
+
+    var now = new Date().toISOString()
+    var userEmail = req.userEmail || 'unknown'
+
+    // Read existing overrides
+    var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || {
+      version: version,
+      overrides: {}
+    }
+
+    if (!overrides.overrides) overrides.overrides = {}
+
+    overrides.overrides[featureKey] = {
+      riskOverride: riskOverride,
+      reason: reason.trim(),
+      updatedBy: userEmail,
+      updatedAt: now
+    }
+
+    writeToStorage(DATA_PREFIX + '/health-overrides-' + version + '.json', overrides)
+
+    // Audit log
+    logAudit(readFromStorage, writeToStorage, {
+      version: version,
+      action: 'set_risk_override',
+      user: userEmail,
+      summary: 'Set risk override to ' + riskOverride + ' for ' + featureKey,
+      details: { featureKey: featureKey, riskOverride: riskOverride, reason: reason.trim() }
+    })
+
+    res.json({
+      featureKey: featureKey,
+      riskOverride: riskOverride,
+      reason: reason.trim(),
+      updatedAt: now,
+      updatedBy: userEmail
+    })
+  })
+
+  // ─── DELETE /releases/:version/health/override/:featureKey ───
+
+  router.delete('/releases/:version/health/override/:featureKey', requirePM, function(req, res) {
+    var version = req.params.version
+    var featureKey = req.params.featureKey
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!FEATURE_KEY_RE.test(featureKey)) {
+      return res.status(400).json({ error: 'Invalid feature key format. Expected pattern like PROJ-123.' })
+    }
+
+    var userEmail = req.userEmail || 'unknown'
+
+    var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || {
+      version: version,
+      overrides: {}
+    }
+
+    if (!overrides.overrides || !overrides.overrides[featureKey]) {
+      return res.status(404).json({ error: 'No risk override found for ' + featureKey })
+    }
+
+    delete overrides.overrides[featureKey]
+    writeToStorage(DATA_PREFIX + '/health-overrides-' + version + '.json', overrides)
+
+    logAudit(readFromStorage, writeToStorage, {
+      version: version,
+      action: 'remove_risk_override',
+      user: userEmail,
+      summary: 'Removed risk override for ' + featureKey,
+      details: { featureKey: featureKey }
+    })
+
+    res.json({ featureKey: featureKey, removed: true })
+  })
+
+  // ─── POST /releases/:version/health/refresh ───
+
+  router.post('/releases/:version/health/refresh', requirePM, function(req, res) {
+    var version = req.params.version
+    var phase = parsePhase(req)
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!isValidPhase(phase)) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + VALID_PHASES.join(', ') })
+    }
+    if (DEMO_MODE) {
+      return res.json({ status: 'skipped', message: 'Health refresh disabled in demo mode' })
+    }
+
+    var state = getHealthRefreshState(version, phase)
+    if (state.running) {
+      return res.json({ status: 'already_running', startedAt: state.startedAt })
+    }
+
+    var runningCount = 0
+    refreshStates.forEach(function(s) { if (s.running) runningCount++ })
+    if (runningCount >= MAX_CONCURRENT_REFRESHES) {
+      return res.status(429).json({ error: 'Maximum concurrent refreshes reached. Please try again shortly.' })
+    }
+
+    triggerHealthRefresh(version, phase)
+    res.json({ status: 'started' })
+  })
+
+  // ─── GET /releases/:version/health/refresh/status ───
+
+  router.get('/releases/:version/health/refresh/status', requireAuth, function(req, res) {
+    var version = req.params.version
+    var phase = parsePhase(req)
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (!isValidPhase(phase)) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + VALID_PHASES.join(', ') })
+    }
+
+    res.json(getHealthRefreshState(version, phase))
+  })
+
+  // ─── Health refresh helper ───
+
+  function triggerHealthRefresh(version, phase) {
+    var pk = phaseKey(phase)
+    var stateKey = 'health:' + version + ':' + pk
+    var state = getHealthRefreshState(version, phase)
+    if (state.running) return
+
+    var runningCount = 0
+    refreshStates.forEach(function(s) { if (s.running) runningCount++ })
+    if (runningCount >= MAX_CONCURRENT_REFRESHES) return
+
+    var config = getConfig(readFromStorage)
+    var healthConfig = config.healthConfig || {}
+    var timeoutMs = healthConfig.healthRefreshTimeoutMs || 480000
+
+    refreshStates.set(stateKey, {
+      running: true,
+      version: version,
+      phase: pk,
+      startedAt: new Date().toISOString(),
+      lastResult: state.lastResult
+    })
+
+    var pipeline = new Promise(function(resolve) {
+      resolve(runHealthPipeline(version, readFromStorage, writeToStorage, jiraRequest, fetchAllJqlResults, phase))
+    })
+    var timeout = new Promise(function(_, reject) {
+      setTimeout(function() { reject(new Error('Health refresh timed out after ' + Math.round(timeoutMs / 1000) + ' seconds')) }, timeoutMs)
+    })
+
+    Promise.race([pipeline, timeout])
+      .then(function(result) {
+        refreshStates.set(stateKey, {
+          running: false,
+          lastResult: {
+            status: 'success',
+            version: version,
+            phase: pk,
+            message: 'Health pipeline completed: ' + (result.features ? result.features.length : 0) + ' features assessed',
+            completedAt: new Date().toISOString()
+          }
+        })
+      })
+      .catch(function(err) {
+        console.error('[health] Background health refresh failed for ' + version + ' phase ' + pk + ':', err)
+        refreshStates.set(stateKey, {
+          running: false,
+          lastResult: {
+            status: 'error',
+            version: version,
+            phase: pk,
+            message: 'Health pipeline refresh failed. Check server logs for details.',
+            completedAt: new Date().toISOString()
+          }
+        })
+      })
+  }
+}
+
+module.exports = healthRoutes

--- a/modules/release-planning/server/health/jira-enrichment.js
+++ b/modules/release-planning/server/health/jira-enrichment.js
@@ -1,0 +1,417 @@
+/**
+ * Jira enrichment for the release health pipeline.
+ *
+ * Two-pass strategy:
+ *   Pass 1 (lightweight, all features): description, story points, issuelinks
+ *   Pass 2 (targeted): changelog for at-risk features only
+ *
+ * Optionally fetches RICE fields from parent (RHAISTRAT outcome) issues.
+ *
+ * Uses shared/server/jira.js for API calls, with batching and throttling
+ * to respect Jira Cloud rate limits.
+ */
+
+const { ENRICHMENT_FIELDS, CHANGELOG_FIELDS, EARLY_STATUSES } = require('../constants')
+
+/**
+ * Check whether Jira credentials are configured.
+ * @returns {boolean}
+ */
+function hasJiraCredentials() {
+  return !!(process.env.JIRA_TOKEN && process.env.JIRA_EMAIL)
+}
+
+/**
+ * Split an array into batches of a given size.
+ * @param {Array} arr
+ * @param {number} size
+ * @returns {Array<Array>}
+ */
+function batch(arr, size) {
+  const batches = []
+  for (let i = 0; i < arr.length; i += size) {
+    batches.push(arr.slice(i, i + size))
+  }
+  return batches
+}
+
+/**
+ * Sleep for the given number of milliseconds.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise(function(resolve) { setTimeout(resolve, ms) })
+}
+
+/**
+ * Parse issue links from the Jira issuelinks field into a normalized format.
+ * @param {Array} issuelinks - Raw issuelinks array from Jira API
+ * @returns {Array<{ type: string, direction: string, linkedKey: string, linkedStatus: string }>}
+ */
+function parseIssueLinks(issuelinks) {
+  if (!Array.isArray(issuelinks)) return []
+
+  var links = []
+  for (var i = 0; i < issuelinks.length; i++) {
+    var link = issuelinks[i]
+    var typeName = link.type ? link.type.name : ''
+
+    if (link.inwardIssue) {
+      links.push({
+        type: typeName,
+        direction: 'inward',
+        linkedKey: link.inwardIssue.key,
+        linkedStatus: link.inwardIssue.fields && link.inwardIssue.fields.status
+          ? link.inwardIssue.fields.status.name || ''
+          : ''
+      })
+    }
+    if (link.outwardIssue) {
+      links.push({
+        type: typeName,
+        direction: 'outward',
+        linkedKey: link.outwardIssue.key,
+        linkedStatus: link.outwardIssue.fields && link.outwardIssue.fields.status
+          ? link.outwardIssue.fields.status.name || ''
+          : ''
+      })
+    }
+  }
+  return links
+}
+
+/**
+ * Check whether a Jira description field has content.
+ * The v3 API returns ADF (Atlassian Document Format) as an object.
+ * A non-empty description has content nodes beyond the empty doc wrapper.
+ * @param {*} description - The description field value from Jira
+ * @returns {boolean}
+ */
+function hasDescriptionContent(description) {
+  if (!description) return false
+  if (typeof description === 'string') return description.trim().length > 0
+  // ADF format: { type: 'doc', content: [...] }
+  if (description.type === 'doc' && Array.isArray(description.content)) {
+    return description.content.length > 0
+  }
+  return true
+}
+
+/**
+ * Parse changelog entries to extract refinement history.
+ * Looks for Target Version changes in the changelog.
+ * @param {object} issue - Jira issue with changelog expansion
+ * @returns {Array<{ field: string, from: string|null, to: string|null, date: string }>}
+ */
+function parseChangelog(issue) {
+  if (!issue.changelog || !Array.isArray(issue.changelog.histories)) return []
+
+  var history = []
+  var histories = issue.changelog.histories
+  for (var i = 0; i < histories.length; i++) {
+    var items = histories[i].items || []
+    var created = histories[i].created || ''
+    for (var j = 0; j < items.length; j++) {
+      var item = items[j]
+      if (item.field === 'Target Version' || item.fieldId === 'customfield_10855') {
+        history.push({
+          field: 'Target Version',
+          from: item.fromString || null,
+          to: item.toString || null,
+          date: created
+        })
+      }
+    }
+  }
+  return history
+}
+
+/**
+ * Determine which features need changelog enrichment (Pass 2).
+ * Targets features that lack a Target Version, are in early workflow states,
+ * or have no story points.
+ * @param {Array<string>} featureKeys - All feature keys
+ * @param {Map<string, object>} enrichmentMap - Pass 1 enrichment data
+ * @param {Array<object>} features - Feature data from index/detail
+ * @returns {Array<string>} Keys needing changelog
+ */
+function identifyChangelogTargets(featureKeys, enrichmentMap, features) {
+  var featureByKey = {}
+  for (var i = 0; i < features.length; i++) {
+    featureByKey[features[i].key] = features[i]
+  }
+
+  var targets = []
+  for (var k = 0; k < featureKeys.length; k++) {
+    var key = featureKeys[k]
+    var feature = featureByKey[key]
+    var enrichment = enrichmentMap.get(key)
+
+    if (!feature) continue
+
+    var status = feature.status || ''
+    var targetVersions = feature.targetVersions || []
+    var needsChangelog = false
+
+    // No target version
+    if (!targetVersions.length) needsChangelog = true
+    // Early workflow state
+    if (EARLY_STATUSES.indexOf(status) !== -1) needsChangelog = true
+    // No story points from enrichment
+    if (enrichment && !enrichment.storyPoints) needsChangelog = true
+
+    if (needsChangelog) targets.push(key)
+  }
+  return targets
+}
+
+/**
+ * Run Pass 1 enrichment: fetch description, story points, and issuelinks
+ * for all features in batches.
+ *
+ * @param {Function} jiraRequest - The shared jiraRequest function
+ * @param {Function} fetchAllJqlResults - The shared fetchAllJqlResults function
+ * @param {Array<string>} featureKeys - Jira issue keys to enrich
+ * @param {object} opts - Options: { batchSize, throttleMs }
+ * @returns {Promise<Map<string, object>>} Map of key -> enrichment data
+ */
+async function runPass1(jiraRequest, fetchAllJqlResults, featureKeys, opts) {
+  var batchSize = (opts && opts.batchSize) || 40
+  var throttleMs = (opts && opts.throttleMs) || 1000
+  var enrichmentMap = new Map()
+
+  if (!featureKeys.length) return enrichmentMap
+
+  var batches = batch(featureKeys, batchSize)
+
+  for (var bi = 0; bi < batches.length; bi++) {
+    if (bi > 0) await sleep(throttleMs)
+
+    var keys = batches[bi]
+    var jql = 'key in (' + keys.join(', ') + ')'
+
+    try {
+      var issues = await fetchAllJqlResults(jiraRequest, jql, ENRICHMENT_FIELDS)
+
+      for (var ii = 0; ii < issues.length; ii++) {
+        var issue = issues[ii]
+        var fields = issue.fields || {}
+
+        enrichmentMap.set(issue.key, {
+          hasDescription: hasDescriptionContent(fields.description),
+          storyPoints: fields.customfield_10028 || null,
+          dependencyLinks: parseIssueLinks(fields.issuelinks),
+          refinementHistory: null,
+          rice: null
+        })
+      }
+    } catch (err) {
+      console.warn('[health] Pass 1 batch ' + (bi + 1) + '/' + batches.length + ' failed:', err.message)
+      // Mark missing keys with empty enrichment so the pipeline can continue
+      for (var ei = 0; ei < keys.length; ei++) {
+        if (!enrichmentMap.has(keys[ei])) {
+          enrichmentMap.set(keys[ei], {
+            hasDescription: false,
+            storyPoints: null,
+            dependencyLinks: [],
+            refinementHistory: null,
+            rice: null,
+            _error: true
+          })
+        }
+      }
+    }
+  }
+
+  return enrichmentMap
+}
+
+/**
+ * Run Pass 2 enrichment: fetch changelog for targeted features.
+ *
+ * @param {Function} jiraRequest - The shared jiraRequest function
+ * @param {Function} fetchAllJqlResults - The shared fetchAllJqlResults function
+ * @param {Array<string>} targetKeys - Keys needing changelog enrichment
+ * @param {Map<string, object>} enrichmentMap - Existing enrichment map to update
+ * @param {object} opts - Options: { batchSize, throttleMs }
+ * @returns {Promise<void>} Updates enrichmentMap in place
+ */
+async function runPass2(jiraRequest, fetchAllJqlResults, targetKeys, enrichmentMap, opts) {
+  var batchSize = (opts && opts.batchSize) || 40
+  var throttleMs = (opts && opts.throttleMs) || 1000
+
+  if (!targetKeys.length) return
+
+  var batches = batch(targetKeys, batchSize)
+
+  for (var bi = 0; bi < batches.length; bi++) {
+    if (bi > 0) await sleep(throttleMs)
+
+    var keys = batches[bi]
+    var jql = 'key in (' + keys.join(', ') + ')'
+
+    try {
+      var issues = await fetchAllJqlResults(jiraRequest, jql, CHANGELOG_FIELDS, { expand: 'changelog' })
+
+      for (var ii = 0; ii < issues.length; ii++) {
+        var issue = issues[ii]
+        var existing = enrichmentMap.get(issue.key) || {}
+        existing.refinementHistory = parseChangelog(issue)
+        enrichmentMap.set(issue.key, existing)
+      }
+    } catch (err) {
+      console.warn('[health] Pass 2 batch ' + (bi + 1) + '/' + batches.length + ' failed:', err.message)
+    }
+  }
+}
+
+/**
+ * Fetch RICE fields from RHAISTRAT parent issues.
+ *
+ * @param {Function} jiraRequest - The shared jiraRequest function
+ * @param {Function} fetchAllJqlResults - The shared fetchAllJqlResults function
+ * @param {Array<string>} parentKeys - Unique parent (outcome) keys
+ * @param {object} riceFieldIds - { riceReach, riceImpact, riceConfidence, riceEffort }
+ * @param {object} opts - Options: { batchSize, throttleMs }
+ * @returns {Promise<Map<string, object>>} Map of parentKey -> { reach, impact, confidence, effort }
+ */
+async function fetchRiceFields(jiraRequest, fetchAllJqlResults, parentKeys, riceFieldIds, opts) {
+  var batchSize = (opts && opts.batchSize) || 40
+  var throttleMs = (opts && opts.throttleMs) || 1000
+  var riceMap = new Map()
+
+  if (!parentKeys.length) return riceMap
+
+  var fields = [
+    riceFieldIds.riceReach,
+    riceFieldIds.riceImpact,
+    riceFieldIds.riceConfidence,
+    riceFieldIds.riceEffort
+  ].filter(Boolean).join(',')
+
+  if (!fields) return riceMap
+
+  var batches = batch(parentKeys, batchSize)
+
+  for (var bi = 0; bi < batches.length; bi++) {
+    if (bi > 0) await sleep(throttleMs)
+
+    var keys = batches[bi]
+    var jql = 'key in (' + keys.join(', ') + ')'
+
+    try {
+      var issues = await fetchAllJqlResults(jiraRequest, jql, fields)
+
+      for (var ii = 0; ii < issues.length; ii++) {
+        var issue = issues[ii]
+        var f = issue.fields || {}
+        riceMap.set(issue.key, {
+          reach: f[riceFieldIds.riceReach] || null,
+          impact: f[riceFieldIds.riceImpact] || null,
+          confidence: f[riceFieldIds.riceConfidence] || null,
+          effort: f[riceFieldIds.riceEffort] || null
+        })
+      }
+    } catch (err) {
+      console.warn('[health] RICE field fetch batch ' + (bi + 1) + '/' + batches.length + ' failed:', err.message)
+    }
+  }
+
+  return riceMap
+}
+
+/**
+ * Run the full Jira enrichment pipeline.
+ *
+ * @param {Function} jiraRequest - The shared jiraRequest function
+ * @param {Function} fetchAllJqlResults - The shared fetchAllJqlResults function
+ * @param {Array<object>} features - Feature objects (must have .key, .status, .targetVersions)
+ * @param {object} config - Release-planning config with healthConfig and customFieldIds
+ * @returns {Promise<{ enrichments: Map<string, object>, riceData: Map<string, object>, warnings: Array<string>, stats: object }>}
+ */
+async function enrichFeatures(jiraRequest, fetchAllJqlResults, features, config) {
+  var warnings = []
+  var healthConfig = config.healthConfig || {}
+  var customFieldIds = config.customFieldIds || {}
+  var enableJira = healthConfig.enableJiraEnrichment !== false
+  var enableRice = !!healthConfig.enableRice
+  var batchSize = healthConfig.enrichmentBatchSize || 40
+  var throttleMs = healthConfig.enrichmentThrottleMs || 1000
+  var opts = { batchSize: batchSize, throttleMs: throttleMs }
+
+  var emptyMap = new Map()
+
+  // Check Jira credentials
+  if (!hasJiraCredentials()) {
+    warnings.push('Jira credentials not configured -- enrichment skipped')
+    return { enrichments: emptyMap, riceData: emptyMap, warnings: warnings, stats: { pass1: 0, pass2: 0, rice: 0 } }
+  }
+
+  if (!enableJira) {
+    warnings.push('Jira enrichment disabled in config')
+    return { enrichments: emptyMap, riceData: emptyMap, warnings: warnings, stats: { pass1: 0, pass2: 0, rice: 0 } }
+  }
+
+  var featureKeys = features.map(function(f) { return f.key }).filter(Boolean)
+
+  // Pass 1: Lightweight enrichment for all features
+  var enrichmentMap = await runPass1(jiraRequest, fetchAllJqlResults, featureKeys, opts)
+
+  // Pass 2: Changelog for at-risk features
+  var changelogTargets = identifyChangelogTargets(featureKeys, enrichmentMap, features)
+  await runPass2(jiraRequest, fetchAllJqlResults, changelogTargets, enrichmentMap, opts)
+
+  // RICE: Fetch from parent keys if enabled
+  var riceData = new Map()
+  if (enableRice) {
+    var hasRiceFields = customFieldIds.riceReach && customFieldIds.riceImpact &&
+      customFieldIds.riceConfidence && customFieldIds.riceEffort
+
+    if (hasRiceFields) {
+      // Collect unique parentKeys
+      var parentKeySet = new Set()
+      for (var pi = 0; pi < features.length; pi++) {
+        if (features[pi].parentKey) parentKeySet.add(features[pi].parentKey)
+      }
+      var uniqueParentKeys = Array.from(parentKeySet)
+
+      if (uniqueParentKeys.length > 0) {
+        riceData = await fetchRiceFields(jiraRequest, fetchAllJqlResults, uniqueParentKeys, customFieldIds, opts)
+
+        // Map RICE data back to child features via parentKey
+        for (var ri = 0; ri < features.length; ri++) {
+          var feat = features[ri]
+          if (feat.parentKey && riceData.has(feat.parentKey)) {
+            var enrichment = enrichmentMap.get(feat.key) || {}
+            enrichment.rice = riceData.get(feat.parentKey)
+            enrichmentMap.set(feat.key, enrichment)
+          }
+        }
+      }
+    } else {
+      warnings.push('RICE scoring enabled but field IDs not configured')
+    }
+  }
+
+  var stats = {
+    pass1: featureKeys.length,
+    pass2: changelogTargets.length,
+    rice: riceData.size
+  }
+
+  return { enrichments: enrichmentMap, riceData: riceData, warnings: warnings, stats: stats }
+}
+
+module.exports = {
+  enrichFeatures: enrichFeatures,
+  hasJiraCredentials: hasJiraCredentials,
+  // Exported for testing
+  parseIssueLinks: parseIssueLinks,
+  hasDescriptionContent: hasDescriptionContent,
+  parseChangelog: parseChangelog,
+  identifyChangelogTargets: identifyChangelogTargets,
+  runPass1: runPass1,
+  runPass2: runPass2,
+  fetchRiceFields: fetchRiceFields
+}

--- a/modules/release-planning/server/health/rice-scorer.js
+++ b/modules/release-planning/server/health/rice-scorer.js
@@ -1,0 +1,65 @@
+/**
+ * RICE score computation.
+ *
+ * RICE = (Reach * Impact * Confidence%) / Effort
+ *
+ * RICE fields are read from RHAISTRAT parent features (outcome keys).
+ * The field IDs must be discovered and configured before RICE scoring
+ * can be enabled (see healthConfig.enableRice).
+ *
+ * Returns null for features with incomplete RICE data -- this is not
+ * an error condition, just means the data is not available yet.
+ */
+
+/**
+ * Compute the RICE score from component values.
+ *
+ * @param {object|null} rice - { reach, impact, confidence, effort }
+ *   - reach: number of users/quarter affected
+ *   - impact: 0.25 (minimal), 0.5 (low), 1 (medium), 2 (high), 3 (massive)
+ *   - confidence: percentage (0-100)
+ *   - effort: person-months
+ * @returns {number|null} Computed RICE score, or null if data is incomplete
+ */
+function computeRiceScore(rice) {
+  if (!rice) return null
+  if (!rice.reach || !rice.impact || !rice.confidence || !rice.effort) return null
+
+  var reach = Number(rice.reach)
+  var impact = Number(rice.impact)
+  var confidence = Number(rice.confidence)
+  var effort = Number(rice.effort)
+
+  if (isNaN(reach) || isNaN(impact) || isNaN(confidence) || isNaN(effort)) return null
+  if (effort === 0) return null
+
+  var confidencePct = confidence / 100
+  return Math.round((reach * impact * confidencePct) / effort)
+}
+
+/**
+ * Build a complete RICE result object for inclusion in the health cache.
+ *
+ * @param {object|null} rice - Raw RICE values from Jira enrichment
+ * @returns {object|null} RICE result with score, or null if incomplete
+ */
+function buildRiceResult(rice) {
+  if (!rice) return null
+
+  var score = computeRiceScore(rice)
+  var complete = score !== null
+
+  return {
+    reach: rice.reach || null,
+    impact: rice.impact || null,
+    confidence: rice.confidence || null,
+    effort: rice.effort || null,
+    score: score,
+    complete: complete
+  }
+}
+
+module.exports = {
+  computeRiceScore: computeRiceScore,
+  buildRiceResult: buildRiceResult
+}

--- a/modules/release-planning/server/health/risk-engine.js
+++ b/modules/release-planning/server/health/risk-engine.js
@@ -1,0 +1,265 @@
+/**
+ * Risk assessment engine for release health.
+ *
+ * Hybrid model combining execution and planning risk checks:
+ *
+ * Execution-phase (suppressed pre-planning-deadline):
+ *   1. MILESTONE_MISS -- feature behind expected phase progress
+ *   2. VELOCITY_LAG -- completion % below threshold for current phase
+ *
+ * Always active:
+ *   3. DOR_INCOMPLETE -- DoR criteria below threshold
+ *   4. BLOCKED -- unresolved blocking dependencies
+ *   5. UNESTIMATED -- no story point estimate
+ *
+ * Planning-phase:
+ *   6. MISSING_OWNER -- no delivery owner assigned
+ *   7. NO_BIG_ROCK -- not associated with any Big Rock (tier 3)
+ *   8. LATE_COMMITMENT -- past planning deadline with no committed fix version
+ */
+
+const {
+  RISK_CATEGORIES,
+  CLOSED_STATUSES,
+  EARLY_STATUSES,
+  DEFAULT_PHASE_COMPLETION_EXPECTATIONS
+} = require('../constants')
+
+/**
+ * Determine the current expected phase based on milestone dates.
+ *
+ * Walks through milestones in chronological order and returns the most
+ * recent milestone that has passed. Returns null if no milestones have
+ * passed (i.e., we are before EA1 freeze).
+ *
+ * @param {object} milestones - { ea1Freeze, ea1Target, ea2Freeze, ea2Target, gaFreeze, gaTarget }
+ * @param {Date} today - Current date
+ * @returns {string|null} The current milestone key (e.g., 'ea1_freeze', 'ea2_target') or null
+ */
+function determineExpectedPhase(milestones, today) {
+  if (!milestones) return null
+
+  var todayStr = today.toISOString().split('T')[0]
+
+  // Walk milestones in reverse chronological order
+  var orderedMilestones = [
+    { key: 'ga_target', date: milestones.gaTarget },
+    { key: 'ga_freeze', date: milestones.gaFreeze },
+    { key: 'ea2_target', date: milestones.ea2Target },
+    { key: 'ea2_freeze', date: milestones.ea2Freeze },
+    { key: 'ea1_target', date: milestones.ea1Target },
+    { key: 'ea1_freeze', date: milestones.ea1Freeze }
+  ]
+
+  for (var i = 0; i < orderedMilestones.length; i++) {
+    var ms = orderedMilestones[i]
+    if (ms.date && todayStr >= ms.date) {
+      return ms.key
+    }
+  }
+
+  return null
+}
+
+/**
+ * Check if a feature is behind the expected phase progress.
+ *
+ * A feature is "behind" if it is still in an early workflow state (New,
+ * Refinement) after the relevant code freeze has passed for its phase.
+ *
+ * @param {object} feature - Feature data (must have .status)
+ * @param {string} currentMilestone - The current milestone key
+ * @returns {boolean}
+ */
+function isFeatureBehindPhase(feature, currentMilestone) {
+  if (!currentMilestone) return false
+
+  var status = feature.status || ''
+
+  // Features in early statuses after any freeze has passed are behind
+  if (EARLY_STATUSES.indexOf(status) !== -1) {
+    // Any freeze milestone has passed
+    if (currentMilestone.indexOf('freeze') !== -1 || currentMilestone.indexOf('target') !== -1) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Get the expected completion percentage for a feature's phase at the
+ * current milestone.
+ *
+ * @param {string} currentMilestone - The current milestone key (e.g., 'ea1_freeze')
+ * @param {string} featurePhase - The feature's release phase (e.g., 'EA1', 'GA', 'TP', 'DP')
+ * @param {object|null} customExpectations - Override expectations from config
+ * @returns {number} Expected completion percentage (0-100)
+ */
+function expectedCompletionForPhase(currentMilestone, featurePhase, customExpectations) {
+  if (!currentMilestone || !featurePhase) return 0
+
+  var expectations = customExpectations || DEFAULT_PHASE_COMPLETION_EXPECTATIONS
+  var milestoneExpectations = expectations[currentMilestone]
+  if (!milestoneExpectations) return 0
+
+  var phase = featurePhase.toUpperCase()
+  if (milestoneExpectations[phase] !== undefined) {
+    return milestoneExpectations[phase]
+  }
+
+  // Default: if phase not found, use GA expectations as a fallback
+  return milestoneExpectations['GA'] || 0
+}
+
+/**
+ * Compute risk assessment for a single feature.
+ *
+ * @param {object} feature - Feature data with status, completionPct, etc.
+ * @param {object|null} milestones - Smartsheet milestone dates
+ * @param {object} dorStatus - DoR evaluation result from evaluateDor()
+ * @param {object|null} enrichment - Jira enrichment data
+ * @param {object} opts - Options: { riskThresholds, phaseCompletionExpectations, today, planningDeadline, phase, version }
+ * @returns {{ risk: string, flags: Array<object>, riskScore: number }}
+ */
+function computeFeatureRisk(feature, milestones, dorStatus, enrichment, opts) {
+  var options = opts || {}
+  var thresholds = options.riskThresholds || {}
+  var today = options.today || new Date()
+  var customExpectations = options.phaseCompletionExpectations || null
+  var planningDeadline = options.planningDeadline || null
+  var version = options.version || ''
+  var flags = []
+
+  var suppressExecution = planningDeadline && planningDeadline.daysRemaining > 0
+
+  var currentMilestone = determineExpectedPhase(milestones, today)
+
+  // 1. Milestone Risk (suppressed pre-planning-deadline)
+  if (!suppressExecution && isFeatureBehindPhase(feature, currentMilestone)) {
+    var milestoneName = currentMilestone
+      ? currentMilestone.replace(/_/g, ' ').toUpperCase()
+      : 'unknown'
+    flags.push({
+      category: RISK_CATEGORIES.MILESTONE_MISS,
+      severity: 'high',
+      message: 'Feature still in "' + (feature.status || 'unknown') + '" but ' + milestoneName + ' has passed'
+    })
+  }
+
+  // 2. Velocity Risk (suppressed pre-planning-deadline)
+  var featurePhase = feature.phase || feature.releaseType || ''
+  var completionPct = typeof feature.completionPct === 'number' ? feature.completionPct : 0
+  if (!suppressExecution && currentMilestone && featurePhase) {
+    var expected = expectedCompletionForPhase(currentMilestone, featurePhase, customExpectations)
+    if (expected > 0 && completionPct < expected) {
+      var severity = completionPct < (thresholds.velocityYellowMin || 50) ? 'high' : 'medium'
+      flags.push({
+        category: RISK_CATEGORIES.VELOCITY_LAG,
+        severity: severity,
+        message: completionPct + '% complete, expected ' + expected + '% by now'
+      })
+    }
+  }
+
+  // 3. DoR Readiness
+  if (dorStatus && dorStatus.totalCount > 0) {
+    var dorPct = dorStatus.completionPct
+    var dorGreenMin = thresholds.dorGreenMin || 80
+    var dorYellowMin = thresholds.dorYellowMin || 50
+
+    if (dorPct < dorYellowMin) {
+      flags.push({
+        category: RISK_CATEGORIES.DOR_INCOMPLETE,
+        severity: 'high',
+        message: 'Only ' + dorPct + '% of DoR criteria met'
+      })
+    } else if (dorPct < dorGreenMin) {
+      flags.push({
+        category: RISK_CATEGORIES.DOR_INCOMPLETE,
+        severity: 'medium',
+        message: dorPct + '% of DoR criteria met (target: ' + dorGreenMin + '%)'
+      })
+    }
+  }
+
+  // 4. Dependency Risk
+  var safeEnrichment = enrichment || {}
+  var dependencyLinks = safeEnrichment.dependencyLinks || []
+  var blocking = dependencyLinks.filter(function(d) {
+    return d.direction === 'inward' &&
+      d.type === 'Blocks' &&
+      CLOSED_STATUSES.indexOf(d.linkedStatus) === -1
+  })
+  if (blocking.length > 0) {
+    var blockerKeys = blocking.map(function(b) { return b.linkedKey }).join(', ')
+    flags.push({
+      category: RISK_CATEGORIES.BLOCKED,
+      severity: 'high',
+      message: 'Blocked by ' + blocking.length + ' unresolved issue(s): ' + blockerKeys
+    })
+  }
+
+  // 5. Scope Risk
+  if (!safeEnrichment.storyPoints) {
+    flags.push({
+      category: RISK_CATEGORIES.UNESTIMATED,
+      severity: 'medium',
+      message: 'No story point estimate'
+    })
+  }
+
+  // 6. Missing Owner (planning)
+  if (!feature.deliveryOwner && !feature.assignee) {
+    flags.push({
+      category: RISK_CATEGORIES.MISSING_OWNER,
+      severity: 'medium',
+      message: 'No delivery owner assigned'
+    })
+  }
+
+  // 7. No Big Rock (planning)
+  if (feature.tier === 3) {
+    flags.push({
+      category: RISK_CATEGORIES.NO_BIG_ROCK,
+      severity: 'low',
+      message: 'Not associated with any Big Rock'
+    })
+  }
+
+  // 8. Late Commitment (planning, post-deadline only)
+  if (planningDeadline && planningDeadline.daysRemaining < 0 && version) {
+    var fixVersions = feature.fixVersions || []
+    var hasCommittedVersion = false
+    for (var fvi = 0; fvi < fixVersions.length; fvi++) {
+      if (fixVersions[fvi].indexOf(version) !== -1) {
+        hasCommittedVersion = true
+        break
+      }
+    }
+    if (!hasCommittedVersion) {
+      flags.push({
+        category: RISK_CATEGORIES.LATE_COMMITMENT,
+        severity: 'high',
+        message: 'No committed fix version ' + Math.abs(planningDeadline.daysRemaining) + ' days after planning deadline'
+      })
+    }
+  }
+
+  // Composite risk level: high → red, medium → yellow, low alone → green
+  var risk = 'green'
+  if (flags.some(function(f) { return f.severity === 'high' })) {
+    risk = 'red'
+  } else if (flags.some(function(f) { return f.severity === 'medium' })) {
+    risk = 'yellow'
+  }
+
+  return { risk: risk, flags: flags, riskScore: flags.length }
+}
+
+module.exports = {
+  computeFeatureRisk: computeFeatureRisk,
+  determineExpectedPhase: determineExpectedPhase,
+  isFeatureBehindPhase: isFeatureBehindPhase,
+  expectedCompletionForPhase: expectedCompletionForPhase
+}

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -306,8 +306,11 @@ module.exports = function registerRoutes(router, context) {
     // Delete the candidates cache file so next GET re-fetches
     if (deleteFromStorage) {
       deleteFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
-      // Also delete health cache -- rebuilt lazily on next GET /health request
-      deleteFromStorage(`${DATA_PREFIX}/health-cache-${version}.json`)
+      // Delete all phase-specific health caches -- rebuilt lazily on next GET /health request
+      var healthPhases = ['all', 'EA1', 'EA2', 'GA']
+      for (var hp = 0; hp < healthPhases.length; hp++) {
+        deleteFromStorage(`${DATA_PREFIX}/health-cache-${version}-${healthPhases[hp]}.json`)
+      }
     }
     // Trigger background refresh to rebuild the candidates cache
     triggerBackgroundRefresh(version)
@@ -557,8 +560,11 @@ module.exports = function registerRoutes(router, context) {
       if (deleteFromStorage) {
         deleteFromStorage(releaseFilePath(version))
         deleteFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
-        // Clean up health-related files
-        deleteFromStorage(DATA_PREFIX + '/health-cache-' + version + '.json')
+        // Clean up all phase-specific health caches
+        var delPhases = ['all', 'EA1', 'EA2', 'GA']
+        for (var dp = 0; dp < delPhases.length; dp++) {
+          deleteFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + delPhases[dp] + '.json')
+        }
         deleteFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json')
         deleteFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json')
       }

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -10,6 +10,7 @@ const { createRequirePM, getPMUsers, addPMUser, removePMUser, isPM } = require('
 const { previewDocImport, executeDocImport } = require('./doc-import')
 const { logAudit, getAuditLog } = require('./audit-log')
 const smartsheetClient = require('../../../shared/server/smartsheet')
+const healthRoutes = require('./health/health-routes')
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true'
 const DATA_PREFIX = 'release-planning'
@@ -147,6 +148,16 @@ module.exports = function registerRoutes(router, context) {
 
     doRefresh(1)
   }
+
+  // Mount health routes
+  healthRoutes(router, {
+    storage: storage,
+    requireAuth: requireAuth,
+    requirePM: requirePM,
+    refreshStates: refreshStates,
+    MAX_CONCURRENT_REFRESHES: MAX_CONCURRENT_REFRESHES,
+    sendJsonWithETag: sendJsonWithETag
+  })
 
   // GET /releases
   router.get('/releases', requireAuth, function(req, res) {
@@ -295,8 +306,10 @@ module.exports = function registerRoutes(router, context) {
     // Delete the candidates cache file so next GET re-fetches
     if (deleteFromStorage) {
       deleteFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
+      // Also delete health cache -- rebuilt lazily on next GET /health request
+      deleteFromStorage(`${DATA_PREFIX}/health-cache-${version}.json`)
     }
-    // Trigger background refresh to rebuild the cache
+    // Trigger background refresh to rebuild the candidates cache
     triggerBackgroundRefresh(version)
   }
 
@@ -544,6 +557,10 @@ module.exports = function registerRoutes(router, context) {
       if (deleteFromStorage) {
         deleteFromStorage(releaseFilePath(version))
         deleteFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
+        // Clean up health-related files
+        deleteFromStorage(DATA_PREFIX + '/health-cache-' + version + '.json')
+        deleteFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json')
+        deleteFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json')
       }
 
       res.json(result)

--- a/shared/server/smartsheet.js
+++ b/shared/server/smartsheet.js
@@ -174,4 +174,110 @@ function httpGet(url, headers) {
   })
 }
 
-module.exports = { discoverReleases: discoverReleases, isConfigured: isConfigured, SMARTSHEET_SHEET_ID: SMARTSHEET_SHEET_ID }
+/**
+ * Extended version of discoverReleases that includes freeze dates.
+ *
+ * Returns all 6 milestones per release (ea1Freeze, ea1Target, ea2Freeze,
+ * ea2Target, gaFreeze, gaTarget) for use by the health pipeline's risk
+ * engine, which needs freeze dates for phase-completion checks.
+ *
+ * The existing discoverReleases() is left unchanged for backward compatibility.
+ *
+ * @returns {Array<{ version: string, ea1Freeze: string|null, ea1Target: string|null, ea2Freeze: string|null, ea2Target: string|null, gaFreeze: string|null, gaTarget: string|null }>}
+ */
+async function discoverReleasesWithFreezes() {
+  var sheet = await fetchSheet()
+
+  var colMap = {}
+  for (var c = 0; c < sheet.columns.length; c++) {
+    colMap[sheet.columns[c].title] = sheet.columns[c].id
+  }
+  var taskCol = colMap['Task Name']
+  var startCol = colMap['Start']
+
+  var milestones = {}
+
+  for (var r = 0; r < sheet.rows.length; r++) {
+    var row = sheet.rows[r]
+    var cells = {}
+    for (var ci = 0; ci < row.cells.length; ci++) {
+      cells[row.cells[ci].columnId] = row.cells[ci].value
+    }
+    var task = cells[taskCol]
+    var startVal = cells[startCol]
+    if (!task || !startVal) continue
+
+    var dateStr = String(startVal).split('T')[0]
+    var m
+
+    // EA1/EA2 Code Freeze
+    m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?Code\s+Freeze/i)
+    if (m) {
+      var ver = m[1]
+      var phase = m[2].toLowerCase()
+      if (!milestones[ver]) milestones[ver] = {}
+      milestones[ver][phase + '_freeze'] = dateStr
+      continue
+    }
+
+    // EA1/EA2 Release
+    m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?RELEASE/i)
+    if (m) {
+      var ver2 = m[1]
+      var phase2 = m[2].toLowerCase()
+      if (!milestones[ver2]) milestones[ver2] = {}
+      milestones[ver2][phase2 + '_target'] = dateStr
+      continue
+    }
+
+    // GA Code Freeze
+    m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?Code\s+Freeze$/i)
+    if (m) {
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]].ga_freeze = dateStr
+      continue
+    }
+
+    // GA Release
+    m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?GA$/i)
+    if (m) {
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]].ga_target = dateStr
+      continue
+    }
+  }
+
+  var REQUIRED_MILESTONES = ['ea1_freeze', 'ea1_target', 'ea2_freeze', 'ea2_target', 'ga_freeze', 'ga_target']
+
+  var releases = Object.keys(milestones)
+    .filter(function(version) {
+      var ms = milestones[version]
+      return REQUIRED_MILESTONES.every(function(key) { return !!ms[key] })
+    })
+    .sort(function(a, b) {
+      var ap = a.split('.').map(Number)
+      var bp = b.split('.').map(Number)
+      return ap[0] - bp[0] || ap[1] - bp[1]
+    })
+    .map(function(version) {
+      var ms = milestones[version]
+      return {
+        version: version,
+        ea1Freeze: ms.ea1_freeze || null,
+        ea1Target: ms.ea1_target || null,
+        ea2Freeze: ms.ea2_freeze || null,
+        ea2Target: ms.ea2_target || null,
+        gaFreeze: ms.ga_freeze || null,
+        gaTarget: ms.ga_target || null
+      }
+    })
+
+  return releases
+}
+
+module.exports = {
+  discoverReleases: discoverReleases,
+  discoverReleasesWithFreezes: discoverReleasesWithFreezes,
+  isConfigured: isConfigured,
+  SMARTSHEET_SHEET_ID: SMARTSHEET_SHEET_ID
+}


### PR DESCRIPTION
## Summary

- Adds a comprehensive **Release Plan Health** dashboard as a new tab in the release-planning module, replacing the previous "Release Health" view with a pre-planning readiness tool
- Implements risk engine with 8 categories (MILESTONE_MISS, VELOCITY_LAG, DOR_INCOMPLETE, BLOCKED, UNESTIMATED, MISSING_OWNER, NO_BIG_ROCK, LATE_COMMITMENT), including planning-specific suppression of execution-phase risks before the planning deadline
- Sources features from the **Big Rocks candidates pipeline** (Tier 1/2/3) instead of feature-traffic index, with phase selector (EA1/EA2/GA) and planning deadline awareness (code freeze minus 7 days)
- Includes DoR (Definition of Readiness) checklist, RICE scoring display, milestone timeline, feature health table with risk badges/sorting/pagination/export, and Jira enrichment for epic/issue/blocker counts
- 546 tests across 22 test files, all passing

### Key files
- `server/health/` — risk-engine, health-pipeline, health-routes, dor-checker, jira-enrichment, rice-scorer
- `client/components/` — PhaseSelector, HealthSummaryCards, HealthFilterBar, FeatureHealthTable, MilestoneTimeline, RiskBadge, DorChecklist, RiceScoreDisplay
- `client/views/HealthDashboardView.vue` — main dashboard view
- `client/composables/useReleaseHealth.js` — data fetching with phase support

## Test plan

- [x] All 546 tests pass (`npm test`)
- [ ] `npm run dev:full` — health dashboard loads with phase selector
- [ ] Select a phase → only matching features shown, planning deadline displayed
- [ ] Risk flags: MISSING_OWNER/NO_BIG_ROCK/LATE_COMMITMENT appear correctly
- [ ] MILESTONE_MISS/VELOCITY_LAG suppressed when before planning deadline
- [ ] `DEMO_MODE=true npm run dev:full` — demo fixture renders with new fields
- [ ] Existing DoR and override functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)