### PR TITLE
fix(release-planning): switch health milestones from Smartsheet to Product Pages

### DIFF
--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -4,6 +4,7 @@ const {
   runHealthPipeline,
   loadFeaturesForRelease,
   loadFeaturesFromCandidates,
+  loadMilestones,
   computeMilestoneInfo,
   computePlanningDeadline,
   getFeaturePhase,
@@ -350,6 +351,73 @@ describe('loadFeaturesForRelease', function() {
   })
 })
 
+describe('loadMilestones', function() {
+  function ppCache(releases) {
+    return {
+      'release-analysis/product-pages-releases-cache.json': {
+        source: 'api',
+        fetchedAt: '2026-04-26T00:00:00Z',
+        releases: releases
+      }
+    }
+  }
+
+  it('returns milestones from Product Pages cache', function() {
+    var storage = makeStorage(ppCache([
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: '2026-05-01' },
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA2', dueDate: '2026-07-01', codeFreezeDate: '2026-06-15' },
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
+    ]))
+    var result = loadMilestones(storage.readFromStorage, '3.5')
+    expect(result).not.toBeNull()
+    expect(result.ea1Freeze).toBe('2026-05-01')
+    expect(result.ea1Target).toBe('2026-05-15')
+    expect(result.ea2Freeze).toBe('2026-06-15')
+    expect(result.ea2Target).toBe('2026-07-01')
+    expect(result.gaFreeze).toBe('2026-08-01')
+    expect(result.gaTarget).toBe('2026-08-15')
+  })
+
+  it('returns null when cache is missing', function() {
+    var storage = makeStorage({})
+    expect(loadMilestones(storage.readFromStorage, '3.5')).toBeNull()
+  })
+
+  it('returns null when no matching version', function() {
+    var storage = makeStorage(ppCache([
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.4', dueDate: '2026-03-01', codeFreezeDate: '2026-02-15' }
+    ]))
+    expect(loadMilestones(storage.readFromStorage, '3.5')).toBeNull()
+  })
+
+  it('handles missing codeFreezeDate', function() {
+    var storage = makeStorage(ppCache([
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: null },
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: null }
+    ]))
+    var result = loadMilestones(storage.readFromStorage, '3.5')
+    expect(result).not.toBeNull()
+    expect(result.ea1Freeze).toBeNull()
+    expect(result.ea1Target).toBe('2026-05-15')
+    expect(result.gaFreeze).toBeNull()
+    expect(result.gaTarget).toBe('2026-08-15')
+  })
+
+  it('returns partial milestones when only some phases exist', function() {
+    var storage = makeStorage(ppCache([
+      { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
+    ]))
+    var result = loadMilestones(storage.readFromStorage, '3.5')
+    expect(result).not.toBeNull()
+    expect(result.ea1Freeze).toBeNull()
+    expect(result.ea1Target).toBeNull()
+    expect(result.ea2Freeze).toBeNull()
+    expect(result.ea2Target).toBeNull()
+    expect(result.gaFreeze).toBe('2026-08-01')
+    expect(result.gaTarget).toBe('2026-08-15')
+  })
+})
+
 describe('runHealthPipeline', function() {
   function makeCandidatesCache(features) {
     return {
@@ -409,15 +477,35 @@ describe('runHealthPipeline', function() {
     expect(Array.isArray(result.enrichmentStatus.warnings)).toBe(true)
   })
 
-  it('returns null milestones when Smartsheet is unavailable', async function() {
+  it('returns null milestones when Product Pages cache is unavailable', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     expect(result.milestones).toBeNull()
     expect(result.enrichmentStatus.warnings).toEqual(
-      expect.arrayContaining([expect.stringContaining('Smartsheet')])
+      expect.arrayContaining([expect.stringContaining('Product Pages')])
     )
+  })
+
+  it('loads milestones from Product Pages cache when available', async function() {
+    var data = makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ])
+    data['release-analysis/product-pages-releases-cache.json'] = {
+      source: 'api',
+      fetchedAt: '2026-04-26T00:00:00Z',
+      releases: [
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: '2026-05-01' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA2', dueDate: '2026-07-01', codeFreezeDate: '2026-06-15' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
+      ]
+    }
+    var storage = makeStorage(data)
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.milestones).not.toBeNull()
+    expect(result.milestones.ea1Freeze).toBe('2026-05-01')
+    expect(result.milestones.gaTarget).toBe('2026-08-15')
   })
 
   it('produces correct cache structure', async function() {

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -2,8 +2,8 @@
  * Health pipeline orchestrator.
  *
  * Coordinates the full health assessment flow:
- *   1. Load feature-traffic index and detail files
- *   2. Load Smartsheet milestone dates (with freeze dates)
+ *   1. Load features from Big Rocks candidates cache
+ *   2. Load Product Pages milestone dates (with freeze dates)
  *   3. Run Jira enrichment (two-pass)
  *   4. Evaluate DoR for each feature
  *   5. Compute risk for each feature
@@ -21,7 +21,6 @@ const { enrichFeatures } = require('./jira-enrichment')
 const { evaluateDor } = require('./dor-checker')
 const { computeFeatureRisk } = require('./risk-engine')
 const { buildRiceResult } = require('./rice-scorer')
-const smartsheetClient = require('../../../../shared/server/smartsheet')
 
 var DATA_PREFIX = 'release-planning'
 
@@ -215,28 +214,46 @@ function getFeaturePhase(feature) {
 }
 
 /**
- * Load milestone data from Smartsheet.
- * Returns milestones for the requested version, or null if unavailable.
+ * Load milestone data from the Product Pages cache (written by release-analysis module).
+ * Maps Product Pages release entries to the milestones shape the health pipeline expects.
  *
+ * @param {Function} readFromStorage
  * @param {string} version - Release version (e.g., '3.5')
- * @returns {Promise<object|null>} Milestone dates or null
+ * @returns {object|null} Milestone dates or null
  */
-async function loadMilestones(version) {
-  if (!smartsheetClient.isConfigured()) {
+function loadMilestones(readFromStorage, version) {
+  var cached = readFromStorage('release-analysis/product-pages-releases-cache.json')
+  if (!cached || !cached.releases || !Array.isArray(cached.releases)) {
     return null
   }
 
-  try {
-    var releases = await smartsheetClient.discoverReleasesWithFreezes()
-    for (var i = 0; i < releases.length; i++) {
-      if (releases[i].version === version) {
-        return releases[i]
-      }
+  var ea1Entry = null
+  var ea2Entry = null
+  var gaEntry = null
+
+  for (var i = 0; i < cached.releases.length; i++) {
+    var r = cached.releases[i]
+    var rn = r.releaseNumber || ''
+    if (rn.indexOf(version + '.EA1') !== -1) {
+      ea1Entry = r
+    } else if (rn.indexOf(version + '.EA2') !== -1) {
+      ea2Entry = r
+    } else if (rn.indexOf(version) !== -1 && rn.indexOf('.EA') === -1) {
+      gaEntry = r
     }
+  }
+
+  if (!ea1Entry && !ea2Entry && !gaEntry) {
     return null
-  } catch (err) {
-    console.warn('[health] Failed to load Smartsheet milestones:', err.message)
-    return null
+  }
+
+  return {
+    ea1Freeze: ea1Entry ? ea1Entry.codeFreezeDate || null : null,
+    ea1Target: ea1Entry ? ea1Entry.dueDate || null : null,
+    ea2Freeze: ea2Entry ? ea2Entry.codeFreezeDate || null : null,
+    ea2Target: ea2Entry ? ea2Entry.dueDate || null : null,
+    gaFreeze: gaEntry ? gaEntry.codeFreezeDate || null : null,
+    gaTarget: gaEntry ? gaEntry.dueDate || null : null
   }
 }
 
@@ -394,10 +411,10 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
 
   console.log('[health] Found ' + features.length + ' features for version ' + version + ' phase ' + phaseKey)
 
-  // Step 2: Load milestone dates from Smartsheet
-  var milestones = await loadMilestones(version)
+  // Step 2: Load milestone dates from Product Pages cache
+  var milestones = loadMilestones(readFromStorage, version)
   if (!milestones) {
-    warnings.push('Smartsheet milestone dates not available -- milestone risk checks will be skipped')
+    warnings.push('Product Pages milestone dates not available -- milestone risk checks will be skipped')
   }
 
   // Step 3: Run Jira enrichment

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -151,7 +151,7 @@ function loadFeaturesFromCandidates(readFromStorage, version, phase) {
  * Compute the planning deadline for a given phase.
  * The planning deadline is the code freeze date minus PLANNING_DEADLINE_OFFSET_DAYS.
  *
- * @param {object|null} milestones - Milestone dates from Smartsheet
+ * @param {object|null} milestones - Milestone dates from Product Pages
  * @param {string|null} phase - Selected phase (EA1/EA2/GA)
  * @returns {{ date: string, daysRemaining: number }|null}
  */

--- a/modules/release-planning/server/health/risk-engine.js
+++ b/modules/release-planning/server/health/risk-engine.js
@@ -116,7 +116,7 @@ function expectedCompletionForPhase(currentMilestone, featurePhase, customExpect
  * Compute risk assessment for a single feature.
  *
  * @param {object} feature - Feature data with status, completionPct, etc.
- * @param {object|null} milestones - Smartsheet milestone dates
+ * @param {object|null} milestones - Product Pages milestone dates
  * @param {object} dorStatus - DoR evaluation result from evaluateDor()
  * @param {object|null} enrichment - Jira enrichment data
  * @param {object} opts - Options: { riskThresholds, phaseCompletionExpectations, today, planningDeadline, phase, version }


### PR DESCRIPTION
## Summary

- Switches `loadMilestones()` in the health pipeline from Smartsheet API to the Product Pages cache already maintained by the release-analysis module
- Smartsheet API token was unavailable in production, so milestones were always null — this fix enables the planning deadline, milestone timeline, and milestone-based risk flags
- Reads from `release-analysis/product-pages-releases-cache.json` and maps EA1/EA2/GA entries to the expected milestones shape

## Test plan

- [x] All 552 tests pass
- [x] 6 new tests for `loadMilestones` (full mapping, missing cache, no match, null freeze dates, partial phases, end-to-end integration)
- [ ] Verify milestone timeline renders with Product Pages data in live environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)