### PR TITLE
feat(release-planning): add Smartsheet fallback for milestone freeze dates

### DIFF
--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -5,6 +5,7 @@ const {
   loadFeaturesForRelease,
   loadFeaturesFromCandidates,
   loadMilestones,
+  backfillFreezeDatesFromSmartsheet,
   computeMilestoneInfo,
   computePlanningDeadline,
   getFeaturePhase,
@@ -418,7 +419,132 @@ describe('loadMilestones', function() {
   })
 })
 
+const smartsheetClient = require('../../../../shared/server/smartsheet')
+vi.spyOn(smartsheetClient, 'isConfigured')
+vi.spyOn(smartsheetClient, 'discoverReleasesWithFreezes')
+
+describe('backfillFreezeDatesFromSmartsheet', function() {
+  beforeEach(function() {
+    smartsheetClient.isConfigured.mockReturnValue(false)
+    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([])
+  })
+
+  it('returns milestones unchanged when Smartsheet is not configured and milestones have freeze dates', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(false)
+    var milestones = {
+      ea1Freeze: '2026-05-01', ea1Target: '2026-05-15',
+      ea2Freeze: '2026-06-15', ea2Target: '2026-07-01',
+      gaFreeze: '2026-08-01', gaTarget: '2026-08-15'
+    }
+    var result = await backfillFreezeDatesFromSmartsheet(milestones, '3.5')
+    expect(result.milestones).toEqual(milestones)
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  it('warns when neither source is configured and milestones is null', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(false)
+    var result = await backfillFreezeDatesFromSmartsheet(null, '3.5')
+    expect(result.milestones).toBeNull()
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Neither Product Pages nor Smartsheet')])
+    )
+  })
+
+  it('warns when freeze dates missing and Smartsheet not configured', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(false)
+    var milestones = {
+      ea1Freeze: null, ea1Target: '2026-05-15',
+      ea2Freeze: null, ea2Target: '2026-07-01',
+      gaFreeze: null, gaTarget: '2026-08-15'
+    }
+    var result = await backfillFreezeDatesFromSmartsheet(milestones, '3.5')
+    expect(result.milestones).toEqual(milestones)
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Smartsheet is not configured')])
+    )
+  })
+
+  it('skips fallback when milestones already have freeze dates', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(true)
+    var milestones = {
+      ea1Freeze: '2026-05-01', ea1Target: '2026-05-15',
+      ea2Freeze: '2026-06-15', ea2Target: '2026-07-01',
+      gaFreeze: '2026-08-01', gaTarget: '2026-08-15'
+    }
+    var result = await backfillFreezeDatesFromSmartsheet(milestones, '3.5')
+    expect(result.milestones).toEqual(milestones)
+    expect(result.warnings).toHaveLength(0)
+    expect(smartsheetClient.discoverReleasesWithFreezes).not.toHaveBeenCalled()
+  })
+
+  it('loads everything from Smartsheet when milestones is null', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(true)
+    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([
+      { version: '3.5', ea1Freeze: '2026-05-15', ea1Target: '2026-06-18', ea2Freeze: '2026-06-19', ea2Target: '2026-07-16', gaFreeze: '2026-07-24', gaTarget: '2026-08-20' }
+    ])
+    var result = await backfillFreezeDatesFromSmartsheet(null, '3.5')
+    expect(result.milestones).not.toBeNull()
+    expect(result.milestones.ea1Freeze).toBe('2026-05-15')
+    expect(result.milestones.gaTarget).toBe('2026-08-20')
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Using Smartsheet')])
+    )
+  })
+
+  it('merges Smartsheet freeze dates into Product Pages milestones', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(true)
+    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([
+      { version: '3.5', ea1Freeze: '2026-05-15', ea1Target: '2026-06-18', ea2Freeze: '2026-06-19', ea2Target: '2026-07-16', gaFreeze: '2026-07-24', gaTarget: '2026-08-20' }
+    ])
+    var milestones = {
+      ea1Freeze: null, ea1Target: '2026-06-18',
+      ea2Freeze: null, ea2Target: '2026-07-16',
+      gaFreeze: null, gaTarget: '2026-08-20'
+    }
+    var result = await backfillFreezeDatesFromSmartsheet(milestones, '3.5')
+    expect(result.milestones.ea1Freeze).toBe('2026-05-15')
+    expect(result.milestones.ea2Freeze).toBe('2026-06-19')
+    expect(result.milestones.gaFreeze).toBe('2026-07-24')
+    // Product Pages target dates preserved
+    expect(result.milestones.ea1Target).toBe('2026-06-18')
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Backfilled freeze dates')])
+    )
+  })
+
+  it('returns null when Smartsheet has no matching version', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(true)
+    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([
+      { version: '3.4', ea1Freeze: '2026-01-01', ea1Target: '2026-02-01', ea2Freeze: '2026-03-01', ea2Target: '2026-04-01', gaFreeze: '2026-05-01', gaTarget: '2026-06-01' }
+    ])
+    var result = await backfillFreezeDatesFromSmartsheet(null, '3.5')
+    expect(result.milestones).toBeNull()
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('No milestone data found')])
+    )
+  })
+
+  it('handles Smartsheet API errors gracefully', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(true)
+    smartsheetClient.discoverReleasesWithFreezes.mockRejectedValue(new Error('API timeout'))
+    var milestones = {
+      ea1Freeze: null, ea1Target: '2026-06-18',
+      ea2Freeze: null, ea2Target: '2026-07-16',
+      gaFreeze: null, gaTarget: '2026-08-20'
+    }
+    var result = await backfillFreezeDatesFromSmartsheet(milestones, '3.5')
+    expect(result.milestones).toEqual(milestones)
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Smartsheet fallback failed')])
+    )
+  })
+})
+
 describe('runHealthPipeline', function() {
+  beforeEach(function() {
+    smartsheetClient.isConfigured.mockReturnValue(false)
+  })
+
   function makeCandidatesCache(features) {
     return {
       'release-planning/candidates-cache-3.5.json': {
@@ -477,14 +603,14 @@ describe('runHealthPipeline', function() {
     expect(Array.isArray(result.enrichmentStatus.warnings)).toBe(true)
   })
 
-  it('returns null milestones when Product Pages cache is unavailable', async function() {
+  it('returns null milestones when neither source is available', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     expect(result.milestones).toBeNull()
     expect(result.enrichmentStatus.warnings).toEqual(
-      expect.arrayContaining([expect.stringContaining('Product Pages')])
+      expect.arrayContaining([expect.stringContaining('Neither Product Pages nor Smartsheet')])
     )
   })
 

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -3,7 +3,7 @@
  *
  * Coordinates the full health assessment flow:
  *   1. Load features from Big Rocks candidates cache
- *   2. Load Product Pages milestone dates (with freeze dates)
+ *   2. Load milestone dates (Product Pages → Smartsheet fallback for freeze dates)
  *   3. Run Jira enrichment (two-pass)
  *   4. Evaluate DoR for each feature
  *   5. Compute risk for each feature
@@ -21,6 +21,7 @@ const { enrichFeatures } = require('./jira-enrichment')
 const { evaluateDor } = require('./dor-checker')
 const { computeFeatureRisk } = require('./risk-engine')
 const { buildRiceResult } = require('./rice-scorer')
+const smartsheetClient = require('../../../../shared/server/smartsheet')
 
 var DATA_PREFIX = 'release-planning'
 
@@ -258,6 +259,92 @@ function loadMilestones(readFromStorage, version) {
 }
 
 /**
+ * Fill missing freeze dates from Smartsheet.
+ *
+ * If milestones is null (no Product Pages data), attempts to load everything
+ * from Smartsheet. If milestones exist but freeze dates are null, merges
+ * Smartsheet freeze dates into the existing object.
+ *
+ * @param {object|null} milestones - Milestones from Product Pages (may have null freeze fields)
+ * @param {string} version - Release version (e.g., '3.5')
+ * @returns {Promise<{ milestones: object|null, warnings: string[] }>}
+ */
+async function backfillFreezeDatesFromSmartsheet(milestones, version) {
+  var warnings = []
+
+  if (!smartsheetClient.isConfigured()) {
+    if (!milestones) {
+      warnings.push('Neither Product Pages nor Smartsheet is configured -- milestone risk checks will be skipped')
+    } else if (!milestones.ea1Freeze && !milestones.ea2Freeze && !milestones.gaFreeze) {
+      warnings.push('Product Pages freeze dates are missing and Smartsheet is not configured')
+    }
+    return { milestones: milestones, warnings: warnings }
+  }
+
+  var needsFullLoad = !milestones
+  var needsFreezeFill = milestones &&
+    !milestones.ea1Freeze && !milestones.ea2Freeze && !milestones.gaFreeze
+
+  if (!needsFullLoad && !needsFreezeFill) {
+    return { milestones: milestones, warnings: warnings }
+  }
+
+  try {
+    var releases = await smartsheetClient.discoverReleasesWithFreezes()
+    var match = null
+    for (var i = 0; i < releases.length; i++) {
+      if (releases[i].version === version) {
+        match = releases[i]
+        break
+      }
+    }
+
+    if (!match) {
+      if (needsFullLoad) {
+        warnings.push('No milestone data found in Smartsheet for version ' + version)
+      }
+      return { milestones: milestones, warnings: warnings }
+    }
+
+    if (needsFullLoad) {
+      warnings.push('Using Smartsheet as milestone source (Product Pages unavailable)')
+      return {
+        milestones: {
+          ea1Freeze: match.ea1Freeze,
+          ea1Target: match.ea1Target,
+          ea2Freeze: match.ea2Freeze,
+          ea2Target: match.ea2Target,
+          gaFreeze: match.gaFreeze,
+          gaTarget: match.gaTarget
+        },
+        warnings: warnings
+      }
+    }
+
+    // Merge freeze dates from Smartsheet into existing Product Pages milestones
+    var merged = {
+      ea1Freeze: milestones.ea1Freeze || match.ea1Freeze || null,
+      ea1Target: milestones.ea1Target,
+      ea2Freeze: milestones.ea2Freeze || match.ea2Freeze || null,
+      ea2Target: milestones.ea2Target,
+      gaFreeze: milestones.gaFreeze || match.gaFreeze || null,
+      gaTarget: milestones.gaTarget
+    }
+    var filled = []
+    if (!milestones.ea1Freeze && merged.ea1Freeze) filled.push('ea1Freeze')
+    if (!milestones.ea2Freeze && merged.ea2Freeze) filled.push('ea2Freeze')
+    if (!milestones.gaFreeze && merged.gaFreeze) filled.push('gaFreeze')
+    if (filled.length > 0) {
+      warnings.push('Backfilled freeze dates from Smartsheet: ' + filled.join(', '))
+    }
+    return { milestones: merged, warnings: warnings }
+  } catch (err) {
+    warnings.push('Smartsheet fallback failed: ' + err.message)
+    return { milestones: milestones, warnings: warnings }
+  }
+}
+
+/**
  * Load features for a release version from the feature-traffic cache.
  * Filters features by target version match and excludes closed statuses.
  * Loads detail files for each feature to get pm, components, releaseType, etc.
@@ -411,11 +498,11 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
 
   console.log('[health] Found ' + features.length + ' features for version ' + version + ' phase ' + phaseKey)
 
-  // Step 2: Load milestone dates from Product Pages cache
+  // Step 2: Load milestone dates (Product Pages → Smartsheet fallback for freeze dates)
   var milestones = loadMilestones(readFromStorage, version)
-  if (!milestones) {
-    warnings.push('Product Pages milestone dates not available -- milestone risk checks will be skipped')
-  }
+  var fallbackResult = await backfillFreezeDatesFromSmartsheet(milestones, version)
+  milestones = fallbackResult.milestones
+  warnings = warnings.concat(fallbackResult.warnings)
 
   // Step 3: Run Jira enrichment
   var enrichResult = { enrichments: new Map(), riceData: new Map(), warnings: [], stats: { pass1: 0, pass2: 0, rice: 0 } }
@@ -611,6 +698,7 @@ module.exports = {
   loadFeaturesForRelease: loadFeaturesForRelease,
   loadFeaturesFromCandidates: loadFeaturesFromCandidates,
   loadMilestones: loadMilestones,
+  backfillFreezeDatesFromSmartsheet: backfillFreezeDatesFromSmartsheet,
   computeMilestoneInfo: computeMilestoneInfo,
   computePlanningDeadline: computePlanningDeadline,
   getFeaturePhase: getFeaturePhase,


### PR DESCRIPTION
## Summary
- Add fallback chain for health pipeline milestone dates: Product Pages cache first, then Smartsheet API for missing code freeze dates
- If Product Pages has target dates but no freeze dates, backfills freeze dates from Smartsheet
- If neither source is configured, degrades gracefully with clear warning messages
- 8 new tests for the `backfillFreezeDatesFromSmartsheet` function covering all branches

## Test plan
- [x] All 1790 tests pass (60 health-pipeline tests, including 8 new)
- [x] No lint errors
- [ ] Verify in live environment: with Smartsheet configured, freeze dates should appear even if Product Pages lacks them
- [ ] Verify warning messages in health pipeline output when sources are unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)