### PR TITLE
feat(release-planning): derive freeze dates when external sources unavailable

### DIFF
--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -6,6 +6,7 @@ const {
   loadFeaturesFromCandidates,
   loadMilestones,
   backfillFreezeDatesFromSmartsheet,
+  deriveFreezeDates,
   computeMilestoneInfo,
   computePlanningDeadline,
   getFeaturePhase,
@@ -537,6 +538,67 @@ describe('backfillFreezeDatesFromSmartsheet', function() {
     expect(result.warnings).toEqual(
       expect.arrayContaining([expect.stringContaining('Smartsheet fallback failed')])
     )
+  })
+})
+
+describe('deriveFreezeDates', function() {
+  it('returns null milestones unchanged', function() {
+    var result = deriveFreezeDates(null)
+    expect(result.milestones).toBeNull()
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  it('derives all freeze dates from target dates', function() {
+    var milestones = {
+      ea1Freeze: null, ea1Target: '2026-06-18',
+      ea2Freeze: null, ea2Target: '2026-07-16',
+      gaFreeze: null, gaTarget: '2026-08-20'
+    }
+    var result = deriveFreezeDates(milestones)
+    expect(result.milestones.ea1Freeze).toBe('2026-05-19')
+    expect(result.milestones.ea2Freeze).toBe('2026-06-16')
+    expect(result.milestones.gaFreeze).toBe('2026-07-21')
+    expect(result.warnings[0]).toContain('Derived freeze dates')
+    expect(result.warnings[0]).toContain('ea1Freeze')
+    expect(result.warnings[0]).toContain('ea2Freeze')
+    expect(result.warnings[0]).toContain('gaFreeze')
+  })
+
+  it('does not overwrite existing freeze dates', function() {
+    var milestones = {
+      ea1Freeze: '2026-05-01', ea1Target: '2026-06-18',
+      ea2Freeze: null, ea2Target: '2026-07-16',
+      gaFreeze: '2026-08-01', gaTarget: '2026-08-20'
+    }
+    var result = deriveFreezeDates(milestones)
+    expect(result.milestones.ea1Freeze).toBe('2026-05-01')
+    expect(result.milestones.ea2Freeze).toBe('2026-06-16')
+    expect(result.milestones.gaFreeze).toBe('2026-08-01')
+    expect(result.warnings[0]).toContain('ea2Freeze')
+    expect(result.warnings[0]).not.toContain('ea1Freeze')
+    expect(result.warnings[0]).not.toContain('gaFreeze')
+  })
+
+  it('produces no warnings when all freeze dates already exist', function() {
+    var milestones = {
+      ea1Freeze: '2026-05-01', ea1Target: '2026-06-18',
+      ea2Freeze: '2026-06-15', ea2Target: '2026-07-16',
+      gaFreeze: '2026-08-01', gaTarget: '2026-08-20'
+    }
+    var result = deriveFreezeDates(milestones)
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  it('handles month boundary rollover correctly', function() {
+    var milestones = {
+      ea1Freeze: null, ea1Target: '2026-01-15',
+      ea2Freeze: null, ea2Target: null,
+      gaFreeze: null, gaTarget: null
+    }
+    var result = deriveFreezeDates(milestones)
+    expect(result.milestones.ea1Freeze).toBe('2025-12-16')
+    expect(result.milestones.ea2Freeze).toBeNull()
+    expect(result.milestones.gaFreeze).toBeNull()
   })
 })
 

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -344,6 +344,46 @@ async function backfillFreezeDatesFromSmartsheet(milestones, version) {
   }
 }
 
+var FREEZE_OFFSET_DAYS = 30
+
+/**
+ * Derive missing freeze dates by subtracting FREEZE_OFFSET_DAYS from target dates.
+ *
+ * @param {object|null} milestones
+ * @returns {{ milestones: object|null, warnings: string[] }}
+ */
+function deriveFreezeDates(milestones) {
+  var warnings = []
+  if (!milestones) return { milestones: null, warnings: warnings }
+
+  var derived = []
+
+  function offset(dateStr) {
+    var d = new Date(dateStr + 'T00:00:00Z')
+    d.setUTCDate(d.getUTCDate() - FREEZE_OFFSET_DAYS)
+    return d.toISOString().split('T')[0]
+  }
+
+  if (!milestones.ea1Freeze && milestones.ea1Target) {
+    milestones.ea1Freeze = offset(milestones.ea1Target)
+    derived.push('ea1Freeze')
+  }
+  if (!milestones.ea2Freeze && milestones.ea2Target) {
+    milestones.ea2Freeze = offset(milestones.ea2Target)
+    derived.push('ea2Freeze')
+  }
+  if (!milestones.gaFreeze && milestones.gaTarget) {
+    milestones.gaFreeze = offset(milestones.gaTarget)
+    derived.push('gaFreeze')
+  }
+
+  if (derived.length > 0) {
+    warnings.push('Derived freeze dates (target minus ' + FREEZE_OFFSET_DAYS + ' days): ' + derived.join(', '))
+  }
+
+  return { milestones: milestones, warnings: warnings }
+}
+
 /**
  * Load features for a release version from the feature-traffic cache.
  * Filters features by target version match and excludes closed statuses.
@@ -498,11 +538,14 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
 
   console.log('[health] Found ' + features.length + ' features for version ' + version + ' phase ' + phaseKey)
 
-  // Step 2: Load milestone dates (Product Pages → Smartsheet fallback for freeze dates)
+  // Step 2: Load milestone dates (Product Pages → Smartsheet fallback → derived from targets)
   var milestones = loadMilestones(readFromStorage, version)
   var fallbackResult = await backfillFreezeDatesFromSmartsheet(milestones, version)
   milestones = fallbackResult.milestones
   warnings = warnings.concat(fallbackResult.warnings)
+  var deriveResult = deriveFreezeDates(milestones)
+  milestones = deriveResult.milestones
+  warnings = warnings.concat(deriveResult.warnings)
 
   // Step 3: Run Jira enrichment
   var enrichResult = { enrichments: new Map(), riceData: new Map(), warnings: [], stats: { pass1: 0, pass2: 0, rice: 0 } }
@@ -699,6 +742,7 @@ module.exports = {
   loadFeaturesFromCandidates: loadFeaturesFromCandidates,
   loadMilestones: loadMilestones,
   backfillFreezeDatesFromSmartsheet: backfillFreezeDatesFromSmartsheet,
+  deriveFreezeDates: deriveFreezeDates,
   computeMilestoneInfo: computeMilestoneInfo,
   computePlanningDeadline: computePlanningDeadline,
   getFeaturePhase: getFeaturePhase,


### PR DESCRIPTION
## Summary
- Add calculated freeze dates as a final fallback: freeze = target date minus 30 days
- Fallback chain is now: Product Pages → Smartsheet API → derived from targets
- This ensures the planning deadline and milestone risk checks work even when neither Product Pages nor Smartsheet credentials are configured in the cluster
- Includes both the Smartsheet fallback (PR #388) and the derived dates in one branch

## Test plan
- [x] All 1795 tests pass (65 health-pipeline tests, including 5 new for `deriveFreezeDates`)
- [x] No lint errors
- [x] Derived dates verified: handles month boundaries, doesn't overwrite existing freeze dates
- [ ] Verify in live environment: freeze dates should now appear even without Smartsheet token

🤖 Generated with [Claude Code](https://claude.com/claude-code)