### PR TITLE
feat(release-planning): backend foundation for health dashboard redesign

### DIFF
--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -422,12 +422,12 @@ describe('loadMilestones', function() {
 
 const smartsheetClient = require('../../../../shared/server/smartsheet')
 vi.spyOn(smartsheetClient, 'isConfigured')
-vi.spyOn(smartsheetClient, 'discoverReleasesWithFreezes')
+vi.spyOn(smartsheetClient, 'discoverReleasesPartial')
 
 describe('backfillFreezeDatesFromSmartsheet', function() {
   beforeEach(function() {
     smartsheetClient.isConfigured.mockReturnValue(false)
-    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([])
+    smartsheetClient.discoverReleasesPartial.mockResolvedValue([])
   })
 
   it('returns milestones unchanged when Smartsheet is not configured and milestones have freeze dates', async function() {
@@ -475,12 +475,12 @@ describe('backfillFreezeDatesFromSmartsheet', function() {
     var result = await backfillFreezeDatesFromSmartsheet(milestones, '3.5')
     expect(result.milestones).toEqual(milestones)
     expect(result.warnings).toHaveLength(0)
-    expect(smartsheetClient.discoverReleasesWithFreezes).not.toHaveBeenCalled()
+    expect(smartsheetClient.discoverReleasesPartial).not.toHaveBeenCalled()
   })
 
   it('loads everything from Smartsheet when milestones is null', async function() {
     smartsheetClient.isConfigured.mockReturnValue(true)
-    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([
+    smartsheetClient.discoverReleasesPartial.mockResolvedValue([
       { version: '3.5', ea1Freeze: '2026-05-15', ea1Target: '2026-06-18', ea2Freeze: '2026-06-19', ea2Target: '2026-07-16', gaFreeze: '2026-07-24', gaTarget: '2026-08-20' }
     ])
     var result = await backfillFreezeDatesFromSmartsheet(null, '3.5')
@@ -494,7 +494,7 @@ describe('backfillFreezeDatesFromSmartsheet', function() {
 
   it('merges Smartsheet freeze dates into Product Pages milestones', async function() {
     smartsheetClient.isConfigured.mockReturnValue(true)
-    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([
+    smartsheetClient.discoverReleasesPartial.mockResolvedValue([
       { version: '3.5', ea1Freeze: '2026-05-15', ea1Target: '2026-06-18', ea2Freeze: '2026-06-19', ea2Target: '2026-07-16', gaFreeze: '2026-07-24', gaTarget: '2026-08-20' }
     ])
     var milestones = {
@@ -515,7 +515,7 @@ describe('backfillFreezeDatesFromSmartsheet', function() {
 
   it('returns null when Smartsheet has no matching version', async function() {
     smartsheetClient.isConfigured.mockReturnValue(true)
-    smartsheetClient.discoverReleasesWithFreezes.mockResolvedValue([
+    smartsheetClient.discoverReleasesPartial.mockResolvedValue([
       { version: '3.4', ea1Freeze: '2026-01-01', ea1Target: '2026-02-01', ea2Freeze: '2026-03-01', ea2Target: '2026-04-01', gaFreeze: '2026-05-01', gaTarget: '2026-06-01' }
     ])
     var result = await backfillFreezeDatesFromSmartsheet(null, '3.5')
@@ -527,7 +527,7 @@ describe('backfillFreezeDatesFromSmartsheet', function() {
 
   it('handles Smartsheet API errors gracefully', async function() {
     smartsheetClient.isConfigured.mockReturnValue(true)
-    smartsheetClient.discoverReleasesWithFreezes.mockRejectedValue(new Error('API timeout'))
+    smartsheetClient.discoverReleasesPartial.mockRejectedValue(new Error('API timeout'))
     var milestones = {
       ea1Freeze: null, ea1Target: '2026-06-18',
       ea2Freeze: null, ea2Target: '2026-07-16',
@@ -710,5 +710,65 @@ describe('runHealthPipeline', function() {
     expect(result.features[0]).toHaveProperty('key')
     expect(result.features[0]).toHaveProperty('risk')
     expect(result.features[0]).toHaveProperty('dor')
+  })
+
+  it('includes planningFreezes in cache output when milestones are present', async function() {
+    var data = makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ])
+    data['release-analysis/product-pages-releases-cache.json'] = {
+      source: 'api',
+      fetchedAt: '2026-04-26T00:00:00Z',
+      releases: [
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: '2026-05-01' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA2', dueDate: '2026-07-01', codeFreezeDate: '2026-06-15' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
+      ]
+    }
+    var storage = makeStorage(data)
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.planningFreezes).not.toBeNull()
+    // Planning freeze = code freeze - 7 days
+    expect(result.planningFreezes.ea1).toBe('2026-04-24')
+    expect(result.planningFreezes.ea2).toBe('2026-06-08')
+    expect(result.planningFreezes.ga).toBe('2026-07-25')
+  })
+
+  it('returns null planningFreezes when milestones are null', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.planningFreezes).toBeNull()
+  })
+
+  it('attaches priorityScore and priorityBreakdown to health features', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', priority: 'Major', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 },
+      { issueKey: 'T-2', summary: 'F2', status: 'New', priority: 'Minor', components: '', fixVersion: '', deliveryOwner: 'Bob', tier: 3 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.features).toHaveLength(2)
+    for (var i = 0; i < result.features.length; i++) {
+      expect(result.features[i]).toHaveProperty('priorityScore')
+      expect(result.features[i]).toHaveProperty('priorityBreakdown')
+      expect(typeof result.features[i].priorityScore).toBe('number')
+      expect(result.features[i].priorityBreakdown).toBeDefined()
+      expect(result.features[i].priorityBreakdown).toHaveProperty('rice')
+      expect(result.features[i].priorityBreakdown).toHaveProperty('bigRock')
+      expect(result.features[i].priorityBreakdown).toHaveProperty('priority')
+      expect(result.features[i].priorityBreakdown).toHaveProperty('complexity')
+    }
+    // Tier 1 Major should score higher than Tier 3 Minor
+    expect(result.features[0].priorityScore).toBeGreaterThan(result.features[1].priorityScore)
+  })
+
+  it('includes storyPoints on health features (null without enrichment)', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.features[0]).toHaveProperty('storyPoints')
+    expect(result.features[0].storyPoints).toBeNull()
   })
 })

--- a/modules/release-planning/__tests__/server/priority-scorer.test.js
+++ b/modules/release-planning/__tests__/server/priority-scorer.test.js
@@ -1,0 +1,321 @@
+import { describe, it, expect } from 'vitest'
+
+const {
+  computePriorityScores,
+  WEIGHTS,
+  TIER_SCORES,
+  PRIORITY_SCORES,
+  TSHIRT_SCORES
+} = require('../../server/health/priority-scorer')
+
+describe('exported constants', function() {
+  it('weights sum to 1.0', function() {
+    var sum = WEIGHTS.rice + WEIGHTS.bigRock + WEIGHTS.priority + WEIGHTS.complexity
+    expect(sum).toBeCloseTo(1.0)
+  })
+
+  it('exposes correct weight values', function() {
+    expect(WEIGHTS.rice).toBe(0.30)
+    expect(WEIGHTS.bigRock).toBe(0.30)
+    expect(WEIGHTS.priority).toBe(0.25)
+    expect(WEIGHTS.complexity).toBe(0.15)
+  })
+
+  it('exposes tier scores', function() {
+    expect(TIER_SCORES[1]).toBe(1.0)
+    expect(TIER_SCORES[2]).toBe(0.6)
+    expect(TIER_SCORES[3]).toBe(0.2)
+  })
+
+  it('exposes priority scores', function() {
+    expect(PRIORITY_SCORES['Blocker']).toBe(1.0)
+    expect(PRIORITY_SCORES['Critical']).toBe(0.8)
+    expect(PRIORITY_SCORES['Major']).toBe(0.6)
+    expect(PRIORITY_SCORES['Normal']).toBe(0.4)
+    expect(PRIORITY_SCORES['Minor']).toBe(0.2)
+  })
+
+  it('exposes t-shirt scores', function() {
+    expect(TSHIRT_SCORES['XS']).toBe(1.0)
+    expect(TSHIRT_SCORES['S']).toBe(0.8)
+    expect(TSHIRT_SCORES['M']).toBe(0.6)
+    expect(TSHIRT_SCORES['L']).toBe(0.4)
+    expect(TSHIRT_SCORES['XL']).toBe(0.2)
+  })
+})
+
+describe('computePriorityScores', function() {
+  it('returns a Map with entries for each feature', function() {
+    var features = [
+      { key: 'T-1', rice: { score: 100 }, tier: 1, priority: 'Major', tshirtSize: 'M' },
+      { key: 'T-2', rice: { score: 50 }, tier: 2, priority: 'Minor', tshirtSize: 'XL' }
+    ]
+    var results = computePriorityScores(features)
+    expect(results).toBeInstanceOf(Map)
+    expect(results.size).toBe(2)
+    expect(results.has('T-1')).toBe(true)
+    expect(results.has('T-2')).toBe(true)
+  })
+
+  it('returns score and breakdown for each feature', function() {
+    var features = [
+      { key: 'T-1', rice: { score: 100 }, tier: 1, priority: 'Blocker', tshirtSize: 'XS' }
+    ]
+    var results = computePriorityScores(features)
+    var r = results.get('T-1')
+    expect(r).toBeDefined()
+    expect(typeof r.score).toBe('number')
+    expect(r.breakdown).toBeDefined()
+    expect(typeof r.breakdown.rice).toBe('number')
+    expect(typeof r.breakdown.bigRock).toBe('number')
+    expect(typeof r.breakdown.priority).toBe('number')
+    expect(typeof r.breakdown.complexity).toBe('number')
+  })
+
+  it('scores range from 0-100', function() {
+    var features = [
+      { key: 'T-1', rice: { score: 100 }, tier: 1, priority: 'Blocker', tshirtSize: 'XS' },
+      { key: 'T-2', rice: { score: 10 }, tier: 3, priority: 'Minor', tshirtSize: 'XL' }
+    ]
+    var results = computePriorityScores(features)
+    expect(results.get('T-1').score).toBeGreaterThanOrEqual(0)
+    expect(results.get('T-1').score).toBeLessThanOrEqual(100)
+    expect(results.get('T-2').score).toBeGreaterThanOrEqual(0)
+    expect(results.get('T-2').score).toBeLessThanOrEqual(100)
+  })
+
+  describe('RICE normalization', function() {
+    it('min-max normalizes RICE scores across features', function() {
+      var features = [
+        { key: 'HIGH', rice: { score: 200 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'LOW', rice: { score: 50 }, tier: 1, priority: 'Normal', tshirtSize: null }
+      ]
+      var results = computePriorityScores(features)
+      // HIGH should have riceNorm=1.0, LOW should have riceNorm=0.0
+      expect(results.get('HIGH').breakdown.rice).toBe(100)
+      expect(results.get('LOW').breakdown.rice).toBe(0)
+    })
+
+    it('normalizes to 0.5 when all RICE scores are the same', function() {
+      var features = [
+        { key: 'T-1', rice: { score: 100 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'T-2', rice: { score: 100 }, tier: 1, priority: 'Normal', tshirtSize: null }
+      ]
+      var results = computePriorityScores(features)
+      // riceRange is 0, so fallback to 0.5
+      expect(results.get('T-1').breakdown.rice).toBe(50)
+      expect(results.get('T-2').breakdown.rice).toBe(50)
+    })
+  })
+
+  describe('median fallback for missing RICE', function() {
+    it('uses median when feature has no RICE score', function() {
+      var features = [
+        { key: 'WITH-RICE-1', rice: { score: 100 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'WITH-RICE-2', rice: { score: 200 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'NO-RICE', rice: null, tier: 1, priority: 'Normal', tshirtSize: null }
+      ]
+      var results = computePriorityScores(features)
+      // Median of [100, 200] = 150; normalized = (150-100)/(200-100) = 0.5
+      expect(results.get('NO-RICE').breakdown.rice).toBe(50)
+    })
+
+    it('uses 0.5 fallback when no features have RICE', function() {
+      var features = [
+        { key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'T-2', rice: null, tier: 2, priority: 'Major', tshirtSize: 'M' }
+      ]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.rice).toBe(50)
+      expect(results.get('T-2').breakdown.rice).toBe(50)
+    })
+
+    it('handles rice object with null score', function() {
+      var features = [
+        { key: 'T-1', rice: { score: null }, tier: 1, priority: 'Normal', tshirtSize: null }
+      ]
+      var results = computePriorityScores(features)
+      // No valid RICE values, median is 0.5
+      expect(results.get('T-1').breakdown.rice).toBe(50)
+    })
+
+    it('computes correct median for odd number of RICE values', function() {
+      var features = [
+        { key: 'T-1', rice: { score: 10 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'T-2', rice: { score: 50 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'T-3', rice: { score: 90 }, tier: 1, priority: 'Normal', tshirtSize: null },
+        { key: 'T-NONE', rice: null, tier: 1, priority: 'Normal', tshirtSize: null }
+      ]
+      var results = computePriorityScores(features)
+      // Median of [10, 50, 90] = 50; normalized = (50-10)/(90-10) = 0.5
+      expect(results.get('T-NONE').breakdown.rice).toBe(50)
+    })
+  })
+
+  describe('tier mapping', function() {
+    it('maps tier 1 to 1.0', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.bigRock).toBe(100)
+    })
+
+    it('maps tier 2 to 0.6', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 2, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.bigRock).toBe(60)
+    })
+
+    it('maps tier 3 to 0.2', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 3, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.bigRock).toBe(20)
+    })
+
+    it('defaults to tier 3 for unknown tier', function() {
+      var features = [{ key: 'T-1', rice: null, tier: null, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.bigRock).toBe(20)
+    })
+
+    it('defaults to tier 3 for missing tier', function() {
+      var features = [{ key: 'T-1', rice: null, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.bigRock).toBe(20)
+    })
+  })
+
+  describe('priority mapping', function() {
+    it('maps Blocker to 1.0', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Blocker', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(100)
+    })
+
+    it('maps Critical to 0.8', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Critical', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(80)
+    })
+
+    it('maps Major to 0.6', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Major', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(60)
+    })
+
+    it('maps Normal to 0.4', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(40)
+    })
+
+    it('maps Minor to 0.2', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Minor', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(20)
+    })
+
+    it('defaults to Normal for unknown priority', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Undefined', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(40)
+    })
+
+    it('defaults to Normal for missing priority', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.priority).toBe(40)
+    })
+  })
+
+  describe('t-shirt size mapping', function() {
+    it('maps XS to 1.0', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: 'XS' }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(100)
+    })
+
+    it('maps S to 0.8', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: 'S' }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(80)
+    })
+
+    it('maps M to 0.6', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: 'M' }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(60)
+    })
+
+    it('maps L to 0.4', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: 'L' }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(40)
+    })
+
+    it('maps XL to 0.2', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: 'XL' }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(20)
+    })
+
+    it('defaults to 0.5 for null tshirtSize', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal', tshirtSize: null }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(50)
+    })
+
+    it('defaults to 0.5 for undefined tshirtSize', function() {
+      var features = [{ key: 'T-1', rice: null, tier: 1, priority: 'Normal' }]
+      var results = computePriorityScores(features)
+      expect(results.get('T-1').breakdown.complexity).toBe(50)
+    })
+  })
+
+  describe('edge cases', function() {
+    it('handles empty features array', function() {
+      var results = computePriorityScores([])
+      expect(results).toBeInstanceOf(Map)
+      expect(results.size).toBe(0)
+    })
+
+    it('handles single feature with all null signals', function() {
+      var features = [{ key: 'T-1', rice: null, tier: null, priority: null, tshirtSize: null }]
+      var results = computePriorityScores(features)
+      var r = results.get('T-1')
+      expect(r).toBeDefined()
+      expect(typeof r.score).toBe('number')
+      // rice=0.5, bigRock=tier3=0.2, priority=Normal=0.4, complexity=0.5
+      // 0.5*0.30 + 0.2*0.30 + 0.4*0.25 + 0.5*0.15 = 0.15 + 0.06 + 0.10 + 0.075 = 0.385
+      expect(r.score).toBe(39) // Math.round(0.385 * 100)
+    })
+
+    it('computes correct score for a max-priority feature', function() {
+      // Only one feature, so RICE normalizes to 0.5
+      var features = [{ key: 'T-1', rice: { score: 100 }, tier: 1, priority: 'Blocker', tshirtSize: 'XS' }]
+      var results = computePriorityScores(features)
+      var r = results.get('T-1')
+      // rice=0.5 (single feature), bigRock=1.0, priority=1.0, complexity=1.0
+      // 0.5*0.30 + 1.0*0.30 + 1.0*0.25 + 1.0*0.15 = 0.15 + 0.30 + 0.25 + 0.15 = 0.85
+      expect(r.score).toBe(85)
+    })
+
+    it('computes correct score for a min-priority feature', function() {
+      var features = [{ key: 'T-1', rice: { score: 10 }, tier: 3, priority: 'Minor', tshirtSize: 'XL' }]
+      var results = computePriorityScores(features)
+      var r = results.get('T-1')
+      // rice=0.5 (single feature), bigRock=0.2, priority=0.2, complexity=0.2
+      // 0.5*0.30 + 0.2*0.30 + 0.2*0.25 + 0.2*0.15 = 0.15 + 0.06 + 0.05 + 0.03 = 0.29
+      expect(r.score).toBe(29)
+    })
+
+    it('higher-priority features score higher than lower-priority features', function() {
+      var features = [
+        { key: 'HIGH', rice: { score: 200 }, tier: 1, priority: 'Blocker', tshirtSize: 'XS' },
+        { key: 'LOW', rice: { score: 10 }, tier: 3, priority: 'Minor', tshirtSize: 'XL' }
+      ]
+      var results = computePriorityScores(features)
+      expect(results.get('HIGH').score).toBeGreaterThan(results.get('LOW').score)
+    })
+  })
+})

--- a/modules/release-planning/__tests__/server/smartsheet.test.js
+++ b/modules/release-planning/__tests__/server/smartsheet.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-const { isConfigured } = require('../../../../shared/server/smartsheet')
+const smartsheet = require('../../../../shared/server/smartsheet')
 
 // Note: We can't easily unit test discoverReleases without mocking https.get,
 // which requires a heavier test setup. The isConfigured and regex logic are
@@ -10,8 +10,30 @@ describe('isConfigured', () => {
     // Default in the module is '' when env var is not set
     // Since we can't easily reset module-level vars, we verify the function exists
     // and returns a boolean. In CI, the token is not set, so this should be false.
-    const result = isConfigured()
+    const result = smartsheet.isConfigured()
     expect(typeof result).toBe('boolean')
+  })
+})
+
+describe('module exports', () => {
+  it('exports discoverReleases', () => {
+    expect(typeof smartsheet.discoverReleases).toBe('function')
+  })
+
+  it('exports discoverReleasesWithFreezes', () => {
+    expect(typeof smartsheet.discoverReleasesWithFreezes).toBe('function')
+  })
+
+  it('exports discoverReleasesPartial', () => {
+    expect(typeof smartsheet.discoverReleasesPartial).toBe('function')
+  })
+
+  it('exports isConfigured', () => {
+    expect(typeof smartsheet.isConfigured).toBe('function')
+  })
+
+  it('exports SMARTSHEET_SHEET_ID', () => {
+    expect(typeof smartsheet.SMARTSHEET_SHEET_ID).toBe('string')
   })
 })
 

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -21,6 +21,7 @@ const { enrichFeatures } = require('./jira-enrichment')
 const { evaluateDor } = require('./dor-checker')
 const { computeFeatureRisk } = require('./risk-engine')
 const { buildRiceResult } = require('./rice-scorer')
+const { computePriorityScores } = require('./priority-scorer')
 const smartsheetClient = require('../../../../shared/server/smartsheet')
 
 var DATA_PREFIX = 'release-planning'
@@ -290,7 +291,7 @@ async function backfillFreezeDatesFromSmartsheet(milestones, version) {
   }
 
   try {
-    var releases = await smartsheetClient.discoverReleasesWithFreezes()
+    var releases = await smartsheetClient.discoverReleasesPartial()
     var match = null
     for (var i = 0; i < releases.length; i++) {
       if (releases[i].version === version) {
@@ -347,6 +348,18 @@ async function backfillFreezeDatesFromSmartsheet(milestones, version) {
 var FREEZE_OFFSET_DAYS = 30
 
 /**
+ * Offset a date string by a given number of days.
+ * @param {string} dateStr - ISO date string (YYYY-MM-DD)
+ * @param {number} days - Number of days to offset (positive = forward, negative = backward)
+ * @returns {string} Offset date as YYYY-MM-DD
+ */
+function offsetDate(dateStr, days) {
+  var d = new Date(dateStr + 'T00:00:00Z')
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().split('T')[0]
+}
+
+/**
  * Derive missing freeze dates by subtracting FREEZE_OFFSET_DAYS from target dates.
  *
  * @param {object|null} milestones
@@ -358,22 +371,16 @@ function deriveFreezeDates(milestones) {
 
   var derived = []
 
-  function offset(dateStr) {
-    var d = new Date(dateStr + 'T00:00:00Z')
-    d.setUTCDate(d.getUTCDate() - FREEZE_OFFSET_DAYS)
-    return d.toISOString().split('T')[0]
-  }
-
   if (!milestones.ea1Freeze && milestones.ea1Target) {
-    milestones.ea1Freeze = offset(milestones.ea1Target)
+    milestones.ea1Freeze = offsetDate(milestones.ea1Target, -FREEZE_OFFSET_DAYS)
     derived.push('ea1Freeze')
   }
   if (!milestones.ea2Freeze && milestones.ea2Target) {
-    milestones.ea2Freeze = offset(milestones.ea2Target)
+    milestones.ea2Freeze = offsetDate(milestones.ea2Target, -FREEZE_OFFSET_DAYS)
     derived.push('ea2Freeze')
   }
   if (!milestones.gaFreeze && milestones.gaTarget) {
-    milestones.gaFreeze = offset(milestones.gaTarget)
+    milestones.gaFreeze = offsetDate(milestones.gaTarget, -FREEZE_OFFSET_DAYS)
     derived.push('gaFreeze')
   }
 
@@ -653,8 +660,18 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       },
       dor: dorStatus,
       rice: riceResult,
+      storyPoints: enrichment ? enrichment.storyPoints || null : null,
       jiraUrl: JIRA_BROWSE_URL + '/' + key
     })
+  }
+
+  // Step 6b: Compute composite priority scores
+  var priorityScores = computePriorityScores(healthFeatures)
+  for (var pi = 0; pi < healthFeatures.length; pi++) {
+    var pKey = healthFeatures[pi].key
+    var pResult = priorityScores.get(pKey)
+    healthFeatures[pi].priorityScore = pResult ? pResult.score : null
+    healthFeatures[pi].priorityBreakdown = pResult ? pResult.breakdown : null
   }
 
   // Step 6: Build summary
@@ -671,6 +688,11 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       ea2Target: milestones.ea2Target,
       gaFreeze: milestones.gaFreeze,
       gaTarget: milestones.gaTarget
+    } : null,
+    planningFreezes: milestones ? {
+      ea1: milestones.ea1Freeze ? offsetDate(milestones.ea1Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
+      ea2: milestones.ea2Freeze ? offsetDate(milestones.ea2Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
+      ga: milestones.gaFreeze ? offsetDate(milestones.gaFreeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null
     } : null,
     phase: phaseKey,
     summary: {

--- a/modules/release-planning/server/health/priority-scorer.js
+++ b/modules/release-planning/server/health/priority-scorer.js
@@ -1,0 +1,114 @@
+/**
+ * Composite priority scoring.
+ *
+ * Combines four signals into a single 0-100 priority score:
+ *   - RICE Score (30%): min-max normalized across all features
+ *   - Big Rock Membership (30%): Tier 1=1.0, Tier 2=0.6, Tier 3=0.2
+ *   - Feature Priority (25%): Blocker=1.0 ... Minor=0.2
+ *   - Inverse Complexity (15%): XS=1.0 ... XL=0.2, Unknown=0.5
+ */
+
+var TIER_SCORES = { 1: 1.0, 2: 0.6, 3: 0.2 }
+
+var PRIORITY_SCORES = {
+  'Blocker': 1.0,
+  'Critical': 0.8,
+  'Major': 0.6,
+  'Normal': 0.4,
+  'Minor': 0.2
+}
+
+var TSHIRT_SCORES = {
+  'XS': 1.0,
+  'S': 0.8,
+  'M': 0.6,
+  'L': 0.4,
+  'XL': 0.2
+}
+
+// Weights are hardcoded per user request. A future iteration could make
+// these configurable via admin settings (stored in data/release-planning/
+// health-config.json), but for now they are fixed constants.
+var WEIGHTS = {
+  rice: 0.30,
+  bigRock: 0.30,
+  priority: 0.25,
+  complexity: 0.15
+}
+
+/**
+ * Compute composite priority scores for a set of features.
+ *
+ * @param {Array<object>} features - Health pipeline features
+ * @returns {Map<string, { score: number, breakdown: object }>}
+ */
+function computePriorityScores(features) {
+  // Collect RICE scores for min-max normalization
+  var riceValues = []
+  for (var i = 0; i < features.length; i++) {
+    if (features[i].rice && features[i].rice.score != null) {
+      riceValues.push(features[i].rice.score)
+    }
+  }
+
+  var riceMin = riceValues.length > 0 ? Math.min.apply(null, riceValues) : 0
+  var riceMax = riceValues.length > 0 ? Math.max.apply(null, riceValues) : 0
+  var riceRange = riceMax - riceMin
+
+  // Compute median for fallback
+  var riceMedian = 0.5
+  if (riceValues.length > 0) {
+    var sorted = riceValues.slice().sort(function(a, b) { return a - b })
+    var mid = Math.floor(sorted.length / 2)
+    var medianRaw = sorted.length % 2 === 0
+      ? (sorted[mid - 1] + sorted[mid]) / 2
+      : sorted[mid]
+    riceMedian = riceRange > 0 ? (medianRaw - riceMin) / riceRange : 0.5
+  }
+
+  var results = new Map()
+
+  for (var j = 0; j < features.length; j++) {
+    var f = features[j]
+
+    // RICE normalization
+    var riceNorm = riceMedian // fallback
+    if (f.rice && f.rice.score != null) {
+      riceNorm = riceRange > 0 ? (f.rice.score - riceMin) / riceRange : 0.5
+    }
+
+    // Big Rock tier
+    var tierNorm = TIER_SCORES[f.tier] || TIER_SCORES[3]
+
+    // Feature priority
+    var priorityNorm = PRIORITY_SCORES[f.priority] || PRIORITY_SCORES['Normal']
+
+    // Inverse complexity (t-shirt size)
+    var complexityNorm = TSHIRT_SCORES[f.tshirtSize] || 0.5
+
+    var score = (riceNorm * WEIGHTS.rice) +
+                (tierNorm * WEIGHTS.bigRock) +
+                (priorityNorm * WEIGHTS.priority) +
+                (complexityNorm * WEIGHTS.complexity)
+
+    results.set(f.key, {
+      score: Math.round(score * 100),
+      breakdown: {
+        rice: Math.round(riceNorm * 100),
+        bigRock: Math.round(tierNorm * 100),
+        priority: Math.round(priorityNorm * 100),
+        complexity: Math.round(complexityNorm * 100)
+      }
+    })
+  }
+
+  return results
+}
+
+module.exports = {
+  computePriorityScores: computePriorityScores,
+  WEIGHTS: WEIGHTS,
+  TIER_SCORES: TIER_SCORES,
+  PRIORITY_SCORES: PRIORITY_SCORES,
+  TSHIRT_SCORES: TSHIRT_SCORES
+}

--- a/shared/server/smartsheet.js
+++ b/shared/server/smartsheet.js
@@ -52,18 +52,18 @@ async function fetchSheet() {
   return data
 }
 
+var REQUIRED_MILESTONES = ['ea1_freeze', 'ea1_target', 'ea2_freeze', 'ea2_target', 'ga_freeze', 'ga_target']
+
 /**
- * Extract release versions and their key milestone dates from the SmartSheet.
+ * Private helper -- shared sheet-fetch-and-parse logic used by all
+ * discoverReleases* functions.  Parses the Smartsheet rows for milestone
+ * dates, filters versions via the supplied predicate, and returns the
+ * full milestone object per version.
  *
- * Ports the regex logic from release-pulse's smartsheet_client.py.
- * Matches the same four row patterns: EA1/EA2 Code Freeze, EA1/EA2
- * RELEASE, GA Code Freeze, GA. Only surfaces versions that have all 6
- * required milestones (ea1_freeze, ea1_target, ea2_freeze, ea2_target,
- * ga_freeze, ga_target), matching the Python client's completeness check.
- *
- * @returns {Array<{ version: string, ea1Target: string|null, ea2Target: string|null, gaTarget: string|null }>}
+ * @param {Function} filterFn - Predicate receiving a milestones object; return true to include
+ * @returns {Promise<Array<{ version: string, ea1Freeze: string|null, ea1Target: string|null, ea2Freeze: string|null, ea2Target: string|null, gaFreeze: string|null, gaTarget: string|null }>>}
  */
-async function discoverReleases() {
+async function parseSmartsheetReleases(filterFn) {
   var sheet = await fetchSheet()
 
   var colMap = {}
@@ -73,7 +73,7 @@ async function discoverReleases() {
   var taskCol = colMap['Task Name']
   var startCol = colMap['Start']
 
-  var milestones = {} // version -> { ea1_freeze, ea1_target, ea2_freeze, ea2_target, ga_freeze, ga_target }
+  var milestones = {}
 
   for (var r = 0; r < sheet.rows.length; r++) {
     var row = sheet.rows[r]
@@ -88,35 +88,24 @@ async function discoverReleases() {
     var dateStr = String(startVal).split('T')[0]
     var m
 
-    // EA1/EA2 Code Freeze -- e.g. "3.4.EA1 RHOAI Code Freeze"
     m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?Code\s+Freeze/i)
     if (m) {
-      var ver = m[1]
-      var phase = m[2].toLowerCase()
-      if (!milestones[ver]) milestones[ver] = {}
-      milestones[ver][phase + '_freeze'] = dateStr
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]][m[2].toLowerCase() + '_freeze'] = dateStr
       continue
     }
-
-    // EA1/EA2 Release -- e.g. "3.5.EA1 RHOAI RELEASE"
     m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?RELEASE/i)
     if (m) {
-      var ver2 = m[1]
-      var phase2 = m[2].toLowerCase()
-      if (!milestones[ver2]) milestones[ver2] = {}
-      milestones[ver2][phase2 + '_target'] = dateStr
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]][m[2].toLowerCase() + '_target'] = dateStr
       continue
     }
-
-    // GA Code Freeze -- e.g. "3.4 RHOAI Code Freeze" (not EA, not Feature Freeze)
     m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?Code\s+Freeze$/i)
     if (m) {
       if (!milestones[m[1]]) milestones[m[1]] = {}
       milestones[m[1]].ga_freeze = dateStr
       continue
     }
-
-    // GA Release -- e.g. "3.5 RHOAI GA"
     m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?GA$/i)
     if (m) {
       if (!milestones[m[1]]) milestones[m[1]] = {}
@@ -125,15 +114,8 @@ async function discoverReleases() {
     }
   }
 
-  // Only include versions that have all 6 required milestones
-  // (matches the Python client's completeness check)
-  var REQUIRED_MILESTONES = ['ea1_freeze', 'ea1_target', 'ea2_freeze', 'ea2_target', 'ga_freeze', 'ga_target']
-
-  var releases = Object.keys(milestones)
-    .filter(function(version) {
-      var ms = milestones[version]
-      return REQUIRED_MILESTONES.every(function(key) { return !!ms[key] })
-    })
+  return Object.keys(milestones)
+    .filter(function(version) { return filterFn(milestones[version]) })
     .sort(function(a, b) {
       var ap = a.split('.').map(Number)
       var bp = b.split('.').map(Number)
@@ -143,13 +125,41 @@ async function discoverReleases() {
       var ms = milestones[version]
       return {
         version: version,
+        ea1Freeze: ms.ea1_freeze || null,
         ea1Target: ms.ea1_target || null,
+        ea2Freeze: ms.ea2_freeze || null,
         ea2Target: ms.ea2_target || null,
+        gaFreeze: ms.ga_freeze || null,
         gaTarget: ms.ga_target || null
       }
     })
+}
 
-  return releases
+/**
+ * Extract release versions and their key milestone dates from the SmartSheet.
+ *
+ * Ports the regex logic from release-pulse's smartsheet_client.py.
+ * Matches the same four row patterns: EA1/EA2 Code Freeze, EA1/EA2
+ * RELEASE, GA Code Freeze, GA. Only surfaces versions that have all 6
+ * required milestones (ea1_freeze, ea1_target, ea2_freeze, ea2_target,
+ * ga_freeze, ga_target), matching the Python client's completeness check.
+ *
+ * @returns {Array<{ version: string, ea1Target: string|null, ea2Target: string|null, gaTarget: string|null }>}
+ */
+async function discoverReleases() {
+  var releases = await parseSmartsheetReleases(function(ms) {
+    return REQUIRED_MILESTONES.every(function(key) { return !!ms[key] })
+  })
+
+  // Map to the original shape -- target dates only, no freeze dates
+  return releases.map(function(r) {
+    return {
+      version: r.version,
+      ea1Target: r.ea1Target,
+      ea2Target: r.ea2Target,
+      gaTarget: r.gaTarget
+    }
+  })
 }
 
 function httpGet(url, headers) {
@@ -186,98 +196,29 @@ function httpGet(url, headers) {
  * @returns {Array<{ version: string, ea1Freeze: string|null, ea1Target: string|null, ea2Freeze: string|null, ea2Target: string|null, gaFreeze: string|null, gaTarget: string|null }>}
  */
 async function discoverReleasesWithFreezes() {
-  var sheet = await fetchSheet()
+  return parseSmartsheetReleases(function(ms) {
+    return REQUIRED_MILESTONES.every(function(key) { return !!ms[key] })
+  })
+}
 
-  var colMap = {}
-  for (var c = 0; c < sheet.columns.length; c++) {
-    colMap[sheet.columns[c].title] = sheet.columns[c].id
-  }
-  var taskCol = colMap['Task Name']
-  var startCol = colMap['Start']
-
-  var milestones = {}
-
-  for (var r = 0; r < sheet.rows.length; r++) {
-    var row = sheet.rows[r]
-    var cells = {}
-    for (var ci = 0; ci < row.cells.length; ci++) {
-      cells[row.cells[ci].columnId] = row.cells[ci].value
-    }
-    var task = cells[taskCol]
-    var startVal = cells[startCol]
-    if (!task || !startVal) continue
-
-    var dateStr = String(startVal).split('T')[0]
-    var m
-
-    // EA1/EA2 Code Freeze
-    m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?Code\s+Freeze/i)
-    if (m) {
-      var ver = m[1]
-      var phase = m[2].toLowerCase()
-      if (!milestones[ver]) milestones[ver] = {}
-      milestones[ver][phase + '_freeze'] = dateStr
-      continue
-    }
-
-    // EA1/EA2 Release
-    m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?RELEASE/i)
-    if (m) {
-      var ver2 = m[1]
-      var phase2 = m[2].toLowerCase()
-      if (!milestones[ver2]) milestones[ver2] = {}
-      milestones[ver2][phase2 + '_target'] = dateStr
-      continue
-    }
-
-    // GA Code Freeze
-    m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?Code\s+Freeze$/i)
-    if (m) {
-      if (!milestones[m[1]]) milestones[m[1]] = {}
-      milestones[m[1]].ga_freeze = dateStr
-      continue
-    }
-
-    // GA Release
-    m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?GA$/i)
-    if (m) {
-      if (!milestones[m[1]]) milestones[m[1]] = {}
-      milestones[m[1]].ga_target = dateStr
-      continue
-    }
-  }
-
-  var REQUIRED_MILESTONES = ['ea1_freeze', 'ea1_target', 'ea2_freeze', 'ea2_target', 'ga_freeze', 'ga_target']
-
-  var releases = Object.keys(milestones)
-    .filter(function(version) {
-      var ms = milestones[version]
-      return REQUIRED_MILESTONES.every(function(key) { return !!ms[key] })
-    })
-    .sort(function(a, b) {
-      var ap = a.split('.').map(Number)
-      var bp = b.split('.').map(Number)
-      return ap[0] - bp[0] || ap[1] - bp[1]
-    })
-    .map(function(version) {
-      var ms = milestones[version]
-      return {
-        version: version,
-        ea1Freeze: ms.ea1_freeze || null,
-        ea1Target: ms.ea1_target || null,
-        ea2Freeze: ms.ea2_freeze || null,
-        ea2Target: ms.ea2_target || null,
-        gaFreeze: ms.ga_freeze || null,
-        gaTarget: ms.ga_target || null
-      }
-    })
-
-  return releases
+/**
+ * Relaxed version of discoverReleasesWithFreezes that includes versions
+ * with at least one milestone date.  Used by the health pipeline's
+ * backfill flow, where upcoming releases may not yet have all 6 dates
+ * in Smartsheet (e.g., GA dates not set while EA1 is being planned).
+ *
+ * @returns {Array<{ version: string, ea1Freeze: string|null, ea1Target: string|null, ea2Freeze: string|null, ea2Target: string|null, gaFreeze: string|null, gaTarget: string|null }>}
+ */
+async function discoverReleasesPartial() {
+  return parseSmartsheetReleases(function(ms) {
+    return Object.keys(ms).length > 0
+  })
 }
 
 module.exports = {
   discoverReleases: discoverReleases,
   discoverReleasesWithFreezes: discoverReleasesWithFreezes,
+  discoverReleasesPartial: discoverReleasesPartial,
   isConfigured: isConfigured,
   SMARTSHEET_SHEET_ID: SMARTSHEET_SHEET_ID
 }


### PR DESCRIPTION
## Summary

- **Smartsheet refactor**: Extract shared `parseSmartsheetReleases(filterFn)` helper to eliminate ~60 lines of duplication between `discoverReleases()`, `discoverReleasesWithFreezes()`, and the new `discoverReleasesPartial()` (relaxed filter — at least 1 milestone date)
- **Planning freeze dates**: Add `planningFreezes` (ea1/ea2/ga) to health cache output, computed as code freeze minus 7 days. Extracted `offsetDate()` helper to avoid duplication with `deriveFreezeDates()`
- **Priority scorer**: New `priority-scorer.js` with composite scoring — RICE (30%), Big Rock tier (30%), Feature Priority (25%), Inverse Complexity (15%). Median fallback for missing RICE scores
- **Health feature output**: Added `priorityScore`, `priorityBreakdown`, and `storyPoints` fields to health features. Summary card counts are intentionally NOT added server-side — they'll be computed client-side per phase tab (PR 2)
- **Backfill update**: Health pipeline now calls `discoverReleasesPartial()` instead of `discoverReleasesWithFreezes()` so upcoming releases with incomplete milestones are included

PR 1 of 4 for the Release Health dashboard redesign ([plan](design/release-health-redesign-plan.md)).

## Test plan

- [ ] All 1839 tests pass (121 test files)
- [ ] 38 new tests for `priority-scorer.js` — weights, normalization, median fallback, tier/priority/tshirt mapping, edge cases
- [ ] 4 new tests for `health-pipeline.js` — planningFreezes, priorityScore/priorityBreakdown, storyPoints
- [ ] Updated Smartsheet tests — `discoverReleasesPartial` export verification
- [ ] Existing health pipeline tests unbroken (backfill tests updated to use `discoverReleasesPartial`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)