### PR TITLE
feat: add Other Enablement section with Agent Eval Harness entry

### DIFF
--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -174,6 +174,27 @@
           </a>
         </div>
       </div>
+
+      <!-- Other Enablement -->
+      <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mt-8 mb-3">Other Enablement</h2>
+
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Agent Eval Harness</h3>
+        <div class="flex flex-wrap gap-4">
+          <a
+            v-for="link in agentEvalHarnessLinks"
+            :key="link.label"
+            :href="link.url"
+            target="_blank"
+            rel="noopener"
+            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
+          >
+            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
+            <span>{{ link.label }}</span>
+            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
+          </a>
+        </div>
+      </div>
     </template>
 
     <!-- Help & Debug tab -->
@@ -419,6 +440,12 @@ const jiraAutofixLinks = [
   { label: 'Enablement Recording', icon: Video, url: 'https://drive.google.com/file/d/1b-PZD3OiPAA8LOZ8lWmfcNZBByUa0Nel/view?ts=69e8ff07' },
   { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/1_UaHAI65K1P5Y2pAhZ4ie2KY-tHiSrqbnWN0UUqvsYs/edit?slide=id.g3d84ce2c2ca_1_0#slide=id.g3d84ce2c2ca_1_0' },
   { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1O3i5Ijoo3fi-gPHG0e9ON70Nfij2EUdfU18KOrVQADY/edit?tab=t.4ih80ylpl5y1' }
+]
+
+const agentEvalHarnessLinks = [
+  { label: 'Enablement Recording', icon: Video, url: 'https://drive.google.com/file/d/1SVPwRZzo2U1ohnlTtgjlyOvXHrJB1Jxu/view' },
+  { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/15vhrPqtu-uzxQC4v3whN8YQL1NK46kqNULhZff3uC8E/edit?slide=id.g3d8e714406d_0_0#slide=id.g3d8e714406d_0_0' },
+  { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1HJJBt2Psnqy7JWx26UUP0fENJqDPAZBDhFcHpHt6sjM/edit?tab=t.tcc7ue9usok7' }
 ]
 
 // --- Help & Debug state ---


### PR DESCRIPTION
Adds a new "Other Enablement" section to the Docs tab in the About page, below the existing AI Workflows Enablement section. The first entry is Agent Eval Harness with links to enablement recording, slides, and notes.

Closes #394

Generated with [Claude Code](https://claude.ai/code)