### PR TITLE
feat(release-planning): combined health column, priority score, component chips

### DIFF
--- a/modules/release-planning/__tests__/client/health-components.test.js
+++ b/modules/release-planning/__tests__/client/health-components.test.js
@@ -226,7 +226,7 @@ describe('RiceScoreDisplay', function() {
 describe('HealthFilterBar', function() {
   it('renders search input', function() {
     var wrapper = mount(HealthFilterBar)
-    expect(wrapper.find('input').exists()).toBe(true)
+    expect(wrapper.find('input[type="text"]').exists()).toBe(true)
   })
 
   it('renders risk filter select', function() {
@@ -241,10 +241,52 @@ describe('HealthFilterBar', function() {
     expect(wrapper.text()).toContain('Rock B')
   })
 
-  it('renders components select when components provided', function() {
+  it('renders component multi-select button when components provided', function() {
     var wrapper = mount(HealthFilterBar, { props: { components: ['Model Serving', 'Pipelines'] } })
+    expect(wrapper.text()).toContain('All Components')
+  })
+
+  it('shows component options in dropdown when button clicked', async function() {
+    var wrapper = mount(HealthFilterBar, {
+      props: { components: ['Model Serving', 'Pipelines'] },
+      attachTo: document.body
+    })
+    var compBtn = wrapper.findAll('button').filter(function(b) {
+      return b.text().includes('All Components')
+    })
+    if (compBtn.length > 0) {
+      await compBtn[0].trigger('click')
+      expect(wrapper.text()).toContain('Model Serving')
+      expect(wrapper.text()).toContain('Pipelines')
+    }
+    wrapper.unmount()
+  })
+
+  it('shows selected component chips', function() {
+    var wrapper = mount(HealthFilterBar, {
+      props: {
+        components: ['Model Serving', 'Pipelines'],
+        selectedComponents: ['Model Serving']
+      }
+    })
     expect(wrapper.text()).toContain('Model Serving')
-    expect(wrapper.text()).toContain('Pipelines')
+  })
+
+  it('emits update:selectedComponents when chip remove is clicked', async function() {
+    var wrapper = mount(HealthFilterBar, {
+      props: {
+        components: ['Model Serving', 'Pipelines'],
+        selectedComponents: ['Model Serving']
+      }
+    })
+    var removeBtn = wrapper.findAll('button').filter(function(b) {
+      return b.attributes('aria-label') === 'Remove component filter'
+    })
+    if (removeBtn.length > 0) {
+      await removeBtn[0].trigger('click')
+      expect(wrapper.emitted('update:selectedComponents')).toBeDefined()
+      expect(wrapper.emitted('update:selectedComponents')[0][0]).toEqual([])
+    }
   })
 
   it('renders tier filter select', function() {
@@ -290,7 +332,7 @@ describe('HealthFilterBar', function() {
 
   it('emits update:searchQuery on input', async function() {
     var wrapper = mount(HealthFilterBar)
-    await wrapper.find('input').setValue('test query')
+    await wrapper.find('input[type="text"]').setValue('test query')
     expect(wrapper.emitted('update:searchQuery')).toBeDefined()
     expect(wrapper.emitted('update:searchQuery')[0][0]).toBe('test query')
   })
@@ -341,21 +383,27 @@ describe('FeatureHealthTable', function() {
       key: 'T-1', summary: 'Feature 1', status: 'In Progress',
       risk: { level: 'green', flags: [], riskScore: 0 },
       dor: { checkedCount: 10, totalCount: 13, completionPct: 77, items: [] },
-      rice: null, components: ['Model Serving'], phase: 'GA', bigRock: 'MaaS'
+      rice: null, components: 'Model Serving', phase: 'GA', bigRock: 'MaaS',
+      deliveryOwner: 'Alice', priorityScore: 65, priorityBreakdown: { rice: 50, bigRock: 100, priority: 60, complexity: 50 }
     },
     {
       key: 'T-2', summary: 'Feature 2', status: 'New',
-      risk: { level: 'red', flags: [{ category: 'MILESTONE_MISS', severity: 'high' }], riskScore: 1 },
+      risk: { level: 'red', flags: [{ category: 'MILESTONE_MISS', severity: 'high', message: 'Past deadline' }], riskScore: 1 },
       dor: { checkedCount: 3, totalCount: 13, completionPct: 23, items: [] },
-      rice: { score: 250, complete: true }, components: ['Pipelines'], phase: 'TP', bigRock: null
+      rice: { score: 250, complete: true }, components: 'Pipelines', phase: 'TP', bigRock: null,
+      deliveryOwner: 'Bob', priorityScore: 42, priorityBreakdown: { rice: 40, bigRock: 60, priority: 40, complexity: 30 }
     }
   ]
 
-  it('renders table headers', function() {
+  it('renders table headers including Health, Priority, and Owner', function() {
     var wrapper = mount(FeatureHealthTable, { props: { features: features } })
     expect(wrapper.text()).toContain('Feature')
     expect(wrapper.text()).toContain('Summary')
-    expect(wrapper.text()).toContain('Risk')
+    expect(wrapper.text()).toContain('Health')
+    expect(wrapper.text()).toContain('Priority')
+    expect(wrapper.text()).toContain('Owner')
+    expect(wrapper.text()).not.toContain('Risk')
+    expect(wrapper.text()).not.toContain('DoR')
   })
 
   it('shows empty state when features array is empty', function() {
@@ -376,10 +424,16 @@ describe('FeatureHealthTable', function() {
     expect(wrapper.text()).not.toContain('Next')
   })
 
-  it('sorts features by risk by default (red first)', function() {
+  it('sorts features by health by default (red first)', function() {
     var wrapper = mount(FeatureHealthTable, { props: { features: features } })
     var rows = wrapper.findAll('tr')
     var firstDataRow = rows.length > 1 ? rows[1].text() : ''
     expect(firstDataRow).toContain('T-2')
+  })
+
+  it('has 11 column headers', function() {
+    var wrapper = mount(FeatureHealthTable, { props: { features: features } })
+    var headers = wrapper.findAll('th')
+    expect(headers.length).toBe(11)
   })
 })

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { computed } from 'vue'
-import RiskBadge from './RiskBadge.vue'
 import RiceScoreDisplay from './RiceScoreDisplay.vue'
 import DorChecklist from './DorChecklist.vue'
 import StatusBadge from './StatusBadge.vue'
@@ -39,9 +38,53 @@ var riskOverride = computed(function() {
   return props.feature.risk.override || null
 })
 
+var effectiveRisk = computed(function() {
+  if (riskOverride.value) return riskOverride.value.riskOverride || riskLevel.value
+  return riskLevel.value
+})
+
 var dorPct = computed(function() {
   if (!props.feature.dor) return 0
   return props.feature.dor.completionPct || 0
+})
+
+var dorPctClass = computed(function() {
+  if (dorPct.value >= 80) return 'text-green-600 dark:text-green-400'
+  if (dorPct.value >= 50) return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-red-600 dark:text-red-400'
+})
+
+var healthTooltip = computed(function() {
+  var lines = []
+  lines.push('Risk: ' + effectiveRisk.value.charAt(0).toUpperCase() + effectiveRisk.value.slice(1))
+  var dor = props.feature.dor
+  lines.push('DoR: ' + dorPct.value + '% (' + (dor ? dor.checkedCount : 0) + '/' + (dor ? dor.totalCount : 0) + ')')
+  if (riskFlags.value.length > 0) {
+    lines.push(riskFlags.value.length + ' risk flag(s):')
+    for (var i = 0; i < riskFlags.value.length; i++) {
+      lines.push('  - ' + riskFlags.value[i].category + ': ' + riskFlags.value[i].message)
+    }
+  }
+  if (riskOverride.value) {
+    lines.push('Override: ' + riskOverride.value.riskOverride + ' (' + riskOverride.value.reason + ')')
+  }
+  return lines.join('\n')
+})
+
+var priorityScoreClass = computed(function() {
+  var score = props.feature.priorityScore
+  if (score >= 70) return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  if (score >= 40) return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
+  return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+})
+
+var priorityTooltip = computed(function() {
+  if (!props.feature.priorityBreakdown) return ''
+  var b = props.feature.priorityBreakdown
+  return 'RICE: ' + b.rice + '% (30w)\n' +
+         'Big Rock: ' + b.bigRock + '% (30w)\n' +
+         'Priority: ' + b.priority + '% (25w)\n' +
+         'Complexity: ' + b.complexity + '% (15w)'
 })
 
 var featureUrl = computed(function() {
@@ -115,21 +158,33 @@ var flagSeverityClass = {
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
       <StatusBadge :status="feature.status" />
     </td>
-    <!-- Risk -->
+    <!-- Health (combined Risk + DoR) -->
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
-      <RiskBadge
-        :level="riskLevel"
-        :flagCount="feature.risk ? feature.risk.score : 0"
-        :flags="riskFlags"
-        :override="riskOverride"
-      />
+      <div class="flex items-center gap-1.5" :title="healthTooltip">
+        <span
+          class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+          role="img"
+          :aria-label="'Risk level: ' + effectiveRisk"
+          :class="{
+            'bg-green-500': effectiveRisk === 'green',
+            'bg-yellow-500': effectiveRisk === 'yellow',
+            'bg-red-500': effectiveRisk === 'red'
+          }"
+        ></span>
+        <span
+          class="text-xs font-medium"
+          :class="dorPctClass"
+        >{{ dorPct }}%</span>
+      </div>
     </td>
-    <!-- DoR -->
-    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-center">
+    <!-- Priority -->
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center" :title="priorityTooltip">
       <span
-        class="font-medium"
-        :class="dorPct >= 80 ? 'text-green-600 dark:text-green-400' : dorPct >= 50 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'"
-      >{{ dorPct }}%</span>
+        v-if="feature.priorityScore != null"
+        class="inline-block px-1.5 py-0.5 rounded text-[10px] font-bold"
+        :class="priorityScoreClass"
+      >{{ feature.priorityScore }}</span>
+      <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
     </td>
     <!-- RICE -->
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center" @click.stop>
@@ -137,6 +192,8 @@ var flagSeverityClass = {
     </td>
     <!-- Component -->
     <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.components || '-' }}</td>
+    <!-- Owner -->
+    <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.deliveryOwner || '-' }}</td>
     <!-- Phase -->
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
       <span
@@ -156,7 +213,7 @@ var flagSeverityClass = {
 
   <!-- Expanded detail row -->
   <tr v-if="expanded">
-    <td colspan="10" class="border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/50 p-0">
+    <td colspan="11" class="border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/50 p-0">
       <div class="p-4 space-y-4">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <!-- DoR Checklist -->

--- a/modules/release-planning/client/components/FeatureHealthTable.vue
+++ b/modules/release-planning/client/components/FeatureHealthTable.vue
@@ -12,7 +12,7 @@ const emit = defineEmits(['toggleDorItem', 'updateNotes', 'setOverride', 'remove
 
 var PAGE_SIZE = 50
 var expandedRows = ref({})
-var sortKey = ref('risk')
+var sortKey = ref('health')
 var sortAsc = ref(true)
 var currentPage = ref(1)
 
@@ -21,10 +21,11 @@ var columns = [
   { key: 'key', label: 'Feature', sortable: true },
   { key: 'summary', label: 'Summary', sortable: true },
   { key: 'status', label: 'Status', sortable: true },
-  { key: 'risk', label: 'Risk', sortable: true },
-  { key: 'dor', label: 'DoR', sortable: true },
+  { key: 'health', label: 'Health', sortable: true },
+  { key: 'priority', label: 'Priority', sortable: true },
   { key: 'rice', label: 'RICE', sortable: true },
   { key: 'components', label: 'Component', sortable: true },
+  { key: 'owner', label: 'Owner', sortable: true },
   { key: 'phase', label: 'Phase', sortable: true },
   { key: 'tier', label: 'Tier', sortable: true }
 ]
@@ -54,20 +55,21 @@ var sortedFeatures = computed(function() {
     } else if (key === 'status') {
       va = a.status || ''
       vb = b.status || ''
-    } else if (key === 'risk') {
-      va = RISK_ORDER[getRiskLevel(a)]
-      vb = RISK_ORDER[getRiskLevel(b)]
-      if (va == null) va = 3
-      if (vb == null) vb = 3
-    } else if (key === 'dor') {
-      va = a.dor ? a.dor.completionPct : 0
-      vb = b.dor ? b.dor.completionPct : 0
+    } else if (key === 'health') {
+      va = RISK_ORDER[getRiskLevel(a)] * 1000 + (1000 - (a.dor ? a.dor.completionPct : 0))
+      vb = RISK_ORDER[getRiskLevel(b)] * 1000 + (1000 - (b.dor ? b.dor.completionPct : 0))
+    } else if (key === 'priority') {
+      va = a.priorityScore != null ? a.priorityScore : -1
+      vb = b.priorityScore != null ? b.priorityScore : -1
     } else if (key === 'rice') {
       va = a.rice && a.rice.score != null ? a.rice.score : -1
       vb = b.rice && b.rice.score != null ? b.rice.score : -1
     } else if (key === 'components') {
       va = (a.components || '').toLowerCase()
       vb = (b.components || '').toLowerCase()
+    } else if (key === 'owner') {
+      va = (a.deliveryOwner || '').toLowerCase()
+      vb = (b.deliveryOwner || '').toLowerCase()
     } else if (key === 'phase') {
       va = a.phase || ''
       vb = b.phase || ''
@@ -179,7 +181,7 @@ function sortIndicator(key) {
             />
           </template>
           <tr v-if="!features || features.length === 0">
-            <td colspan="10" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
+            <td colspan="11" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
               No features found matching the current filters.
             </td>
           </tr>

--- a/modules/release-planning/client/components/HealthFilterBar.vue
+++ b/modules/release-planning/client/components/HealthFilterBar.vue
@@ -129,7 +129,7 @@ onUnmounted(function() {
       </button>
       <div
         v-if="compOpen"
-        role="listbox"
+        role="group"
         aria-label="Components"
         class="absolute z-50 mt-1 w-64 max-h-60 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg"
         @keydown.escape="compOpen = false"

--- a/modules/release-planning/client/components/HealthFilterBar.vue
+++ b/modules/release-planning/client/components/HealthFilterBar.vue
@@ -1,9 +1,11 @@
 <script setup>
-defineProps({
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+var props = defineProps({
   riskFilter: { type: String, default: '' },
   dorFilter: { type: String, default: '' },
   bigRockFilter: { type: String, default: '' },
-  componentFilter: { type: String, default: '' },
+  selectedComponents: { type: Array, default: () => [] },
   tierFilter: { type: String, default: '' },
   searchQuery: { type: String, default: '' },
   bigRocks: { type: Array, default: () => [] },
@@ -11,17 +13,56 @@ defineProps({
   hasActiveFilters: { type: Boolean, default: false }
 })
 
-defineEmits([
+var emit = defineEmits([
   'update:riskFilter',
   'update:dorFilter',
   'update:bigRockFilter',
-  'update:componentFilter',
+  'update:selectedComponents',
   'update:tierFilter',
   'update:searchQuery',
   'clearFilters'
 ])
 
 var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500'
+
+var compOpen = ref(false)
+var compDropdownRef = ref(null)
+
+var compLabel = computed(function() {
+  if (props.selectedComponents.length === 0) return 'All Components'
+  if (props.selectedComponents.length === 1) return props.selectedComponents[0]
+  return props.selectedComponents.length + ' components'
+})
+
+function toggleComponent(comp) {
+  var current = props.selectedComponents.slice()
+  var idx = current.indexOf(comp)
+  if (idx === -1) {
+    current.push(comp)
+  } else {
+    current.splice(idx, 1)
+  }
+  emit('update:selectedComponents', current)
+}
+
+function removeComponent(comp) {
+  var current = props.selectedComponents.filter(function(c) { return c !== comp })
+  emit('update:selectedComponents', current)
+}
+
+function handleClickOutside(event) {
+  if (compDropdownRef.value && !compDropdownRef.value.contains(event.target)) {
+    compOpen.value = false
+  }
+}
+
+onMounted(function() {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(function() {
+  document.removeEventListener('click', handleClickOutside)
+})
 </script>
 
 <template>
@@ -70,16 +111,60 @@ var selectClass = 'bg-white dark:bg-gray-800 border border-gray-300 dark:border-
       <option v-for="rock in bigRocks" :key="rock" :value="rock">{{ rock }}</option>
     </select>
 
-    <select
-      v-if="components.length > 0"
-      :value="componentFilter"
-      @change="$emit('update:componentFilter', $event.target.value)"
-      :class="selectClass"
-      aria-label="Filter by component"
-    >
-      <option value="">All Components</option>
-      <option v-for="comp in components" :key="comp" :value="comp">{{ comp }}</option>
-    </select>
+    <!-- Component multi-select with chips -->
+    <div v-if="components.length > 0" ref="compDropdownRef" class="relative">
+      <button
+        type="button"
+        @click="compOpen = !compOpen"
+        @keydown.escape="compOpen = false"
+        :aria-expanded="compOpen"
+        aria-haspopup="listbox"
+        aria-label="Filter by component"
+        :class="[selectClass, 'flex items-center gap-1.5 cursor-pointer']"
+      >
+        <span class="truncate max-w-[180px]">{{ compLabel }}</span>
+        <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div
+        v-if="compOpen"
+        role="listbox"
+        aria-label="Components"
+        class="absolute z-50 mt-1 w-64 max-h-60 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg"
+        @keydown.escape="compOpen = false"
+      >
+        <label
+          v-for="comp in components"
+          :key="comp"
+          class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
+        >
+          <input
+            type="checkbox"
+            :checked="selectedComponents.includes(comp)"
+            @change="toggleComponent(comp)"
+            class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+          />
+          <span class="truncate">{{ comp }}</span>
+        </label>
+      </div>
+    </div>
+
+    <!-- Selected component chips -->
+    <div v-if="selectedComponents.length > 0" class="flex flex-wrap gap-1.5">
+      <span
+        v-for="comp in selectedComponents"
+        :key="comp"
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-400"
+      >
+        {{ comp }}
+        <button
+          @click="removeComponent(comp)"
+          class="hover:text-primary-900 dark:hover:text-primary-200"
+          aria-label="Remove component filter"
+        >&times;</button>
+      </span>
+    </div>
 
     <select
       :value="tierFilter"

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -30,12 +30,9 @@ var activePhase = ref('all')
 var riskFilter = ref('')
 var dorFilter = ref('')
 var bigRockFilter = ref('')
-var componentFilter = ref('')
+var selectedComponents = ref([])
 var tierFilter = ref('')
 var searchQuery = ref('')
-
-// Export menu
-var exportMenuOpen = ref(false)
 
 // Refresh polling
 var refreshPollTimer = null
@@ -180,12 +177,17 @@ var bigRockOptions = computed(function() {
 })
 
 var componentOptions = computed(function() {
-  var comps = {}
-  for (var i = 0; i < features.value.length; i++) {
-    var comp = features.value[i].components
-    if (comp) comps[comp] = true
+  var set = new Set()
+  var feats = features.value || []
+  for (var i = 0; i < feats.length; i++) {
+    if (feats[i].components) {
+      var parts = feats[i].components.split(/\s*,\s*/).filter(Boolean)
+      for (var j = 0; j < parts.length; j++) {
+        set.add(parts[j])
+      }
+    }
   }
-  return Object.keys(comps).sort()
+  return Array.from(set).sort()
 })
 
 // ─── Filtered features (applied on top of phasedFeatures) ───
@@ -213,8 +215,16 @@ var filteredFeatures = computed(function() {
     // Big Rock filter
     if (bigRockFilter.value && f.bigRock !== bigRockFilter.value) return false
 
-    // Component filter
-    if (componentFilter.value && f.components !== componentFilter.value) return false
+    // Component filter (multi-select with comma split)
+    if (selectedComponents.value.length > 0) {
+      var featureComps = f.components
+        ? f.components.split(/\s*,\s*/).filter(Boolean)
+        : []
+      var hasMatch = selectedComponents.value.some(function(comp) {
+        return featureComps.includes(comp)
+      })
+      if (!hasMatch) return false
+    }
 
     // Tier filter
     if (tierFilter.value && String(f.tier) !== tierFilter.value) return false
@@ -231,14 +241,14 @@ var filteredFeatures = computed(function() {
 })
 
 var hasActiveFilters = computed(function() {
-  return !!(riskFilter.value || dorFilter.value || bigRockFilter.value || componentFilter.value || tierFilter.value || searchQuery.value)
+  return !!(riskFilter.value || dorFilter.value || bigRockFilter.value || selectedComponents.value.length > 0 || tierFilter.value || searchQuery.value)
 })
 
 function clearFilters() {
   riskFilter.value = ''
   dorFilter.value = ''
   bigRockFilter.value = ''
-  componentFilter.value = ''
+  selectedComponents.value = []
   tierFilter.value = ''
   searchQuery.value = ''
 }
@@ -324,99 +334,6 @@ function handleRemoveOverride(featureKey) {
   })
 }
 
-// ─── Export ───
-
-function escapeCsv(val) {
-  var s = String(val)
-  if (s.indexOf(',') !== -1 || s.indexOf('"') !== -1 || s.indexOf('\n') !== -1 || s.indexOf('\r') !== -1) {
-    return '"' + s.replace(/"/g, '""') + '"'
-  }
-  return s
-}
-
-function exportCsv() {
-  exportMenuOpen.value = false
-  var rows = []
-  rows.push(['Feature', 'Summary', 'Status', 'Risk', 'DoR %', 'RICE', 'Component', 'Phase', 'Tier', 'PM', 'Owner', 'Epics', 'Issues', 'Completion %', 'Blockers'])
-
-  for (var i = 0; i < filteredFeatures.value.length; i++) {
-    var f = filteredFeatures.value[i]
-    rows.push([
-      f.key || '',
-      f.summary || '',
-      f.status || '',
-      f.risk ? f.risk.level : '',
-      f.dor ? f.dor.completionPct : '',
-      f.rice && f.rice.score != null ? f.rice.score : '',
-      f.components || '',
-      f.phase || '',
-      f.tier || '',
-      f.pm || '',
-      f.deliveryOwner || '',
-      f.epicCount != null ? f.epicCount : '',
-      f.issueCount != null ? f.issueCount : '',
-      f.completionPct != null ? f.completionPct : '',
-      f.blockerCount != null ? f.blockerCount : ''
-    ])
-  }
-
-  var csv = rows.map(function(row) { return row.map(escapeCsv).join(',') }).join('\n')
-  var blob = new Blob([csv + '\n'], { type: 'text/csv' })
-  var url = URL.createObjectURL(blob)
-  var a = document.createElement('a')
-  a.href = url
-  a.download = 'plan-health-' + selectedVersion.value + '-' + (activePhase.value || 'all') + '.csv'
-  a.click()
-  URL.revokeObjectURL(url)
-}
-
-function escapeCell(val) {
-  return String(val).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
-}
-
-function exportMarkdown() {
-  exportMenuOpen.value = false
-  var lines = []
-  lines.push('# Release Plan Health - ' + selectedVersion.value + (activePhase.value !== 'all' ? ' ' + activePhase.value : ''))
-  lines.push('')
-  lines.push('| **Feature** | **Summary** | **Status** | **Risk** | **DoR %** | **RICE** | **Component** | **Phase** |')
-  lines.push('|---------|---------|--------|------|-------|------|-----------|-------|')
-
-  for (var i = 0; i < filteredFeatures.value.length; i++) {
-    var f = filteredFeatures.value[i]
-    lines.push('| ' + [
-      f.key || '-',
-      escapeCell(f.summary || '-'),
-      escapeCell(f.status || '-'),
-      f.risk ? f.risk.level : '-',
-      f.dor ? f.dor.completionPct + '%' : '-',
-      f.rice && f.rice.score != null ? f.rice.score : '-',
-      escapeCell(f.components || '-'),
-      f.phase || '-'
-    ].join(' | ') + ' |')
-  }
-
-  var blob = new Blob([lines.join('\n') + '\n'], { type: 'text/markdown' })
-  var url = URL.createObjectURL(blob)
-  var a = document.createElement('a')
-  a.href = url
-  a.download = 'plan-health-' + selectedVersion.value + '-' + (activePhase.value !== 'all' ? activePhase.value : 'all') + '.md'
-  a.click()
-  URL.revokeObjectURL(url)
-}
-
-function toggleExportMenu() {
-  exportMenuOpen.value = !exportMenuOpen.value
-}
-
-function closeExportMenu() {
-  exportMenuOpen.value = false
-}
-
-function handleClickOutside() {
-  exportMenuOpen.value = false
-}
-
 // ─── Format helpers ───
 
 function formatDate(iso) {
@@ -436,7 +353,6 @@ watch(selectedVersion, function(newVersion) {
 })
 
 onMounted(async function() {
-  document.addEventListener('click', handleClickOutside)
   await loadReleases()
   if (releases.value.length > 0) {
     selectedVersion.value = releases.value[0].version
@@ -444,7 +360,6 @@ onMounted(async function() {
 })
 
 onUnmounted(function() {
-  document.removeEventListener('click', handleClickOutside)
   stopRefreshPolling()
   cancelDorPending()
 })
@@ -474,37 +389,6 @@ onUnmounted(function() {
         >
           {{ healthRefreshing ? 'Refreshing...' : 'Refresh' }}
         </button>
-        <div class="relative" @click.stop @keydown.escape="closeExportMenu">
-          <button
-            v-if="features.length > 0"
-            @click="toggleExportMenu"
-            :aria-expanded="exportMenuOpen"
-            aria-haspopup="menu"
-            aria-label="Export data"
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
-          >
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-            </svg>
-            Export
-          </button>
-          <div
-            v-if="exportMenuOpen"
-            role="menu"
-            class="absolute right-0 mt-1 w-40 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-600 py-1 z-10"
-          >
-            <button
-              role="menuitem"
-              @click="exportMarkdown"
-              class="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
-            >Markdown (.md)</button>
-            <button
-              role="menuitem"
-              @click="exportCsv"
-              class="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
-            >CSV (.csv)</button>
-          </div>
-        </div>
       </div>
     </div>
 
@@ -585,7 +469,7 @@ onUnmounted(function() {
         v-model:riskFilter="riskFilter"
         v-model:dorFilter="dorFilter"
         v-model:bigRockFilter="bigRockFilter"
-        v-model:componentFilter="componentFilter"
+        v-model:selectedComponents="selectedComponents"
         v-model:tierFilter="tierFilter"
         v-model:searchQuery="searchQuery"
         :bigRocks="bigRockOptions"


### PR DESCRIPTION
## Summary

- **Combined Health column**: Merge Risk and DoR into a single column — accessible risk dot (10px, `role="img"`, `aria-label`) + DoR percentage. Tooltip shows risk flags and override info. Sorts by risk level then DoR%
- **Priority score column**: Displays composite 0-100 score with color-coded badge (green/yellow/red). Tooltip breaks down RICE (30w), Big Rock (30w), Priority (25w), Complexity (15w)
- **Owner column**: Shows delivery owner between Component and Phase columns
- **Component multi-select chips**: Replace single-select dropdown with checkbox dropdown + removable chip tags. Robust `/\s*,\s*/` regex splitting handles inconsistent Jira comma formatting. Component list built from all features' split/deduplicated components
- **Export button removed**: Deleted exportCsv, exportMarkdown, and all associated refs/handlers
- **Column count**: 11 total (expand, Feature, Summary, Status, Health, Priority, RICE, Component, Owner, Phase, Tier)

PR 3 of 4 for the Release Health dashboard redesign ([plan](design/release-health-redesign-plan.md)). Depends on PR 2 (#397, merged).

## Test plan

- [ ] All 1851 tests pass (122 test files)
- [ ] Updated `health-components.test.js` — column header assertions, multi-select filter tests
- [ ] Start dev server and verify: combined health column sorts correctly, priority badges render, component chips work, export button gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)