### PR TITLE
feat(release-planning): t-shirt size parsing from Jira descriptions

### DIFF
--- a/modules/release-planning/__tests__/server/jira-enrichment.test.js
+++ b/modules/release-planning/__tests__/server/jira-enrichment.test.js
@@ -219,6 +219,32 @@ describe('runPass1', function() {
     expect(result.get('TEST-1').storyPoints).toBe(5)
   })
 
+  it('populates tshirtSize from description in Pass 1', async function() {
+    var mockFetch = vi.fn().mockResolvedValue([{
+      key: 'TEST-2',
+      fields: {
+        description: 'Feature overview.\nT-Shirt Size: L\nMore details.',
+        customfield_10028: 3,
+        issuelinks: []
+      }
+    }])
+    var result = await runPass1(vi.fn(), mockFetch, ['TEST-2'], { batchSize: 40, throttleMs: 0 })
+    expect(result.get('TEST-2').tshirtSize).toBe('L')
+  })
+
+  it('sets tshirtSize to null when description has no size', async function() {
+    var mockFetch = vi.fn().mockResolvedValue([{
+      key: 'TEST-3',
+      fields: {
+        description: 'A description with no size info',
+        customfield_10028: 5,
+        issuelinks: []
+      }
+    }])
+    var result = await runPass1(vi.fn(), mockFetch, ['TEST-3'], { batchSize: 40, throttleMs: 0 })
+    expect(result.get('TEST-3').tshirtSize).toBeNull()
+  })
+
   it('batches keys correctly', async function() {
     var keys = []
     for (var i = 1; i <= 5; i++) keys.push('T-' + i)

--- a/modules/release-planning/__tests__/server/tshirt-parser.test.js
+++ b/modules/release-planning/__tests__/server/tshirt-parser.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest'
+
+const { parseTshirtSize, adfToText, VALID_SIZES } = require('../../server/health/tshirt-parser')
+
+describe('VALID_SIZES', function() {
+  it('contains all expected sizes', function() {
+    expect(VALID_SIZES).toEqual(['XS', 'S', 'M', 'L', 'XL'])
+  })
+})
+
+describe('adfToText', function() {
+  it('returns empty string for null', function() {
+    expect(adfToText(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', function() {
+    expect(adfToText(undefined)).toBe('')
+  })
+
+  it('returns the string itself for string input', function() {
+    expect(adfToText('hello')).toBe('hello')
+  })
+
+  it('extracts text from a text node', function() {
+    expect(adfToText({ type: 'text', text: 'some text' })).toBe('some text')
+  })
+
+  it('returns empty string for text node without text', function() {
+    expect(adfToText({ type: 'text' })).toBe('')
+  })
+
+  it('extracts text from nested content', function() {
+    var node = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Hello ' },
+            { type: 'text', text: 'World' }
+          ]
+        }
+      ]
+    }
+    expect(adfToText(node)).toBe('Hello World')
+  })
+
+  it('returns empty string for node without content array', function() {
+    expect(adfToText({ type: 'doc' })).toBe('')
+  })
+})
+
+describe('parseTshirtSize', function() {
+  // Null/empty/invalid inputs
+  it('returns null for null description', function() {
+    expect(parseTshirtSize(null)).toBeNull()
+  })
+
+  it('returns null for undefined description', function() {
+    expect(parseTshirtSize(undefined)).toBeNull()
+  })
+
+  it('returns null for empty string', function() {
+    expect(parseTshirtSize('')).toBeNull()
+  })
+
+  it('returns null for description with no size', function() {
+    expect(parseTshirtSize('This is a feature description without any size info.')).toBeNull()
+  })
+
+  it('returns null for non-ADF non-string object', function() {
+    expect(parseTshirtSize({ type: 'something-else' })).toBeNull()
+  })
+
+  // Pattern 1: Size label
+  it('parses "T-Shirt Size: M"', function() {
+    expect(parseTshirtSize('T-Shirt Size: M')).toBe('M')
+  })
+
+  it('parses "T-shirt Size: XL"', function() {
+    expect(parseTshirtSize('T-shirt Size: XL')).toBe('XL')
+  })
+
+  it('parses "Tshirt Size: S"', function() {
+    expect(parseTshirtSize('Tshirt Size: S')).toBe('S')
+  })
+
+  it('parses "Size: L"', function() {
+    expect(parseTshirtSize('Size: L')).toBe('L')
+  })
+
+  it('parses "Size: XS"', function() {
+    expect(parseTshirtSize('Size: XS')).toBe('XS')
+  })
+
+  it('parses "Size= M"', function() {
+    expect(parseTshirtSize('Size= M')).toBe('M')
+  })
+
+  it('parses "Size:M" without space after colon', function() {
+    expect(parseTshirtSize('Size:M')).toBe('M')
+  })
+
+  // Case insensitivity
+  it('handles lowercase "size: m"', function() {
+    expect(parseTshirtSize('size: m')).toBe('M')
+  })
+
+  it('handles uppercase "SIZE: XL"', function() {
+    expect(parseTshirtSize('SIZE: XL')).toBe('XL')
+  })
+
+  it('handles mixed case "Size: xs"', function() {
+    expect(parseTshirtSize('Size: xs')).toBe('XS')
+  })
+
+  // Pattern 2: Complexity/Effort
+  it('parses "Complexity: S"', function() {
+    expect(parseTshirtSize('Complexity: S')).toBe('S')
+  })
+
+  it('parses "Effort: L"', function() {
+    expect(parseTshirtSize('Effort: L')).toBe('L')
+  })
+
+  it('parses "Complexity= XL"', function() {
+    expect(parseTshirtSize('Complexity= XL')).toBe('XL')
+  })
+
+  // Size in context (followed by delimiters)
+  it('parses size followed by comma', function() {
+    expect(parseTshirtSize('Size: M, other info')).toBe('M')
+  })
+
+  it('parses size followed by semicolon', function() {
+    expect(parseTshirtSize('Size: L; notes')).toBe('L')
+  })
+
+  it('parses size followed by period', function() {
+    expect(parseTshirtSize('Size: S. More text.')).toBe('S')
+  })
+
+  it('parses size followed by dash', function() {
+    expect(parseTshirtSize('Size: M - estimated')).toBe('M')
+  })
+
+  it('parses size followed by closing paren', function() {
+    expect(parseTshirtSize('(Size: M)')).toBe('M')
+  })
+
+  it('parses size followed by closing bracket', function() {
+    expect(parseTshirtSize('[Size: XL]')).toBe('XL')
+  })
+
+  it('parses size followed by pipe', function() {
+    expect(parseTshirtSize('Size: S| other')).toBe('S')
+  })
+
+  // FALSE POSITIVE tests -- critical for C4 resolution
+  it('does NOT match "Size: Small"', function() {
+    expect(parseTshirtSize('Size: Small')).toBeNull()
+  })
+
+  it('does NOT match "Size: Special"', function() {
+    expect(parseTshirtSize('Size: Special')).toBeNull()
+  })
+
+  it('does NOT match "Size: Medium"', function() {
+    expect(parseTshirtSize('Size: Medium')).toBeNull()
+  })
+
+  it('does NOT match "Size: Large"', function() {
+    expect(parseTshirtSize('Size: Large')).toBeNull()
+  })
+
+  it('does NOT match "Size: XLarge"', function() {
+    expect(parseTshirtSize('Size: XLarge')).toBeNull()
+  })
+
+  // ADF input
+  it('parses size from ADF document', function() {
+    var adf = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Feature description.\nT-Shirt Size: M\nOther info.' }
+          ]
+        }
+      ]
+    }
+    expect(parseTshirtSize(adf)).toBe('M')
+  })
+
+  it('parses size from nested ADF structure', function() {
+    var adf = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Some text' }
+          ]
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Complexity: XL' }
+          ]
+        }
+      ]
+    }
+    expect(parseTshirtSize(adf)).toBe('XL')
+  })
+
+  it('returns null for ADF document with no size', function() {
+    var adf = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Just a regular description.' }
+          ]
+        }
+      ]
+    }
+    expect(parseTshirtSize(adf)).toBeNull()
+  })
+
+  // Embedded in larger text
+  it('finds size embedded in multi-line text', function() {
+    var text = 'Feature: Implement widget\nPriority: High\nT-Shirt Size: L\nOwner: Alice'
+    expect(parseTshirtSize(text)).toBe('L')
+  })
+
+  // XS and XL should match before S and L
+  it('correctly matches XS (not just S)', function() {
+    expect(parseTshirtSize('Size: XS')).toBe('XS')
+  })
+
+  it('correctly matches XL (not just L)', function() {
+    expect(parseTshirtSize('Size: XL')).toBe('XL')
+  })
+})

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -317,6 +317,10 @@ var flagSeverityClass = {
                   <span class="text-gray-500 dark:text-gray-400">Tier:</span>
                   <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.tier }}</span>
                 </div>
+                <div v-if="feature.tshirtSize">
+                  <span class="text-gray-500 dark:text-gray-400">Size:</span>
+                  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.tshirtSize }}</span>
+                </div>
               </div>
             </div>
           </div>

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -661,6 +661,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       dor: dorStatus,
       rice: riceResult,
       storyPoints: enrichment ? enrichment.storyPoints || null : null,
+      tshirtSize: enrichment ? enrichment.tshirtSize || null : null,
       jiraUrl: JIRA_BROWSE_URL + '/' + key
     })
   }

--- a/modules/release-planning/server/health/jira-enrichment.js
+++ b/modules/release-planning/server/health/jira-enrichment.js
@@ -219,6 +219,7 @@ async function runPass1(jiraRequest, fetchAllJqlResults, featureKeys, opts) {
             dependencyLinks: [],
             refinementHistory: null,
             rice: null,
+            tshirtSize: null,
             _error: true
           })
         }

--- a/modules/release-planning/server/health/jira-enrichment.js
+++ b/modules/release-planning/server/health/jira-enrichment.js
@@ -12,6 +12,7 @@
  */
 
 const { ENRICHMENT_FIELDS, CHANGELOG_FIELDS, EARLY_STATUSES } = require('../constants')
+const { parseTshirtSize } = require('./tshirt-parser')
 
 /**
  * Check whether Jira credentials are configured.
@@ -203,7 +204,8 @@ async function runPass1(jiraRequest, fetchAllJqlResults, featureKeys, opts) {
           storyPoints: fields.customfield_10028 || null,
           dependencyLinks: parseIssueLinks(fields.issuelinks),
           refinementHistory: null,
-          rice: null
+          rice: null,
+          tshirtSize: parseTshirtSize(fields.description)
         })
       }
     } catch (err) {

--- a/modules/release-planning/server/health/tshirt-parser.js
+++ b/modules/release-planning/server/health/tshirt-parser.js
@@ -6,8 +6,7 @@
  *
  * Tries multiple patterns in priority order:
  *   1. Explicit label: "T-Shirt Size: XL" or "Size: M"
- *   2. Bracketed: "[M]" or "(L)" as standalone text
- *   3. Table cell with "size" header
+ *   2. Complexity/effort label: "Complexity: M" or "Effort: L"
  */
 
 var VALID_SIZES = ['XS', 'S', 'M', 'L', 'XL']

--- a/modules/release-planning/server/health/tshirt-parser.js
+++ b/modules/release-planning/server/health/tshirt-parser.js
@@ -1,0 +1,70 @@
+/**
+ * T-shirt size parser.
+ *
+ * Extracts t-shirt sizing from Jira feature descriptions.
+ * The description may be a string (v2 API) or ADF object (v3 API).
+ *
+ * Tries multiple patterns in priority order:
+ *   1. Explicit label: "T-Shirt Size: XL" or "Size: M"
+ *   2. Bracketed: "[M]" or "(L)" as standalone text
+ *   3. Table cell with "size" header
+ */
+
+var VALID_SIZES = ['XS', 'S', 'M', 'L', 'XL']
+
+/**
+ * Extract plain text from an ADF (Atlassian Document Format) node.
+ * @param {object} node - ADF node
+ * @returns {string}
+ */
+function adfToText(node) {
+  if (!node) return ''
+  if (typeof node === 'string') return node
+  if (node.type === 'text') return node.text || ''
+  if (Array.isArray(node.content)) {
+    return node.content.map(adfToText).join('')
+  }
+  return ''
+}
+
+/**
+ * Parse t-shirt size from a Jira description.
+ * @param {*} description - String or ADF object
+ * @returns {string|null} One of 'XS', 'S', 'M', 'L', 'XL', or null
+ */
+function parseTshirtSize(description) {
+  if (!description) return null
+
+  var text
+  if (typeof description === 'string') {
+    text = description
+  } else if (description.type === 'doc') {
+    text = adfToText(description)
+  } else {
+    return null
+  }
+
+  // Pattern 1: "T-Shirt Size: XL" or "Size: M" (case-insensitive)
+  // NOTE: Alternation order matters -- put longer alternatives first (XS, XL)
+  // so "XS" and "XL" match before the single-letter "S" or "L" can greedily
+  // consume the first character. Use a lookahead instead of \b after the match
+  // to avoid false positives like "Size: Small" capturing "S" from "Small".
+  var sizeMatch = text.match(/(?:t-?shirt\s+)?size\s*[:=]\s*(XS|XL|S|M|L)(?=[\s,;.\-)\]|]|$)/i)
+  if (sizeMatch) {
+    return sizeMatch[1].toUpperCase()
+  }
+
+  // Pattern 2: "Complexity: M" or "Effort: L"
+  var complexityMatch = text.match(/(?:complexity|effort)\s*[:=]\s*(XS|XL|S|M|L)(?=[\s,;.\-)\]|]|$)/i)
+  if (complexityMatch) {
+    return complexityMatch[1].toUpperCase()
+  }
+
+  return null
+}
+
+module.exports = {
+  parseTshirtSize: parseTshirtSize,
+  adfToText: adfToText,
+  VALID_SIZES: VALID_SIZES
+}


### PR DESCRIPTION
## Summary

- **T-shirt size parser**: New `tshirt-parser.js` extracts sizes (XS/S/M/L/XL) from Jira feature descriptions — supports both plain text and ADF (Atlassian Document Format). Regex uses longest-first alternation (`XS|XL|S|M|L`) and lookahead (`(?=[\s,;.\-)\]|]|$)`) to prevent false positives like "Size: Small"
- **Enrichment integration**: `parseTshirtSize()` added to Pass 1 enrichment output alongside existing fields
- **Pipeline integration**: `tshirtSize` carried through to health features — feeds into the inverse complexity component (15% weight) of the composite priority scorer from PR 1
- **Feature detail display**: T-shirt size shown in the expanded feature row metadata grid

PR 4 of 4 (final) for the Release Health dashboard redesign ([plan](design/release-health-redesign-plan.md)). Depends on PRs 1-3 (#395, #397, #399 — all merged).

## Test plan

- [ ] All 1897 tests pass (123 test files)
- [ ] 44 new tests for `tshirt-parser.js` — pattern matching, ADF support, case insensitivity, false positive prevention
- [ ] 2 new tests for `jira-enrichment.js` — tshirtSize populated/null in Pass 1 output
- [ ] Priority scorer correctly uses tshirtSize for inverse complexity (covered by PR 1 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)