### PR TITLE
fix(release-planning): planning freeze uses previous phase's code freeze

### DIFF
--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -173,28 +173,29 @@ describe('computePlanningDeadline', function() {
     ea2Freeze: '2026-06-18',
     gaFreeze: '2026-08-01'
   }
-
-  it('returns null when milestones is null', function() {
-    expect(computePlanningDeadline(null, 'EA1')).toBeNull()
-  })
+  var prevGaFreeze = '2026-04-17'
 
   it('returns null when phase is null', function() {
     expect(computePlanningDeadline(milestones, null)).toBeNull()
   })
 
-  it('computes deadline as freeze minus 7 days for EA1', function() {
-    var result = computePlanningDeadline(milestones, 'EA1')
+  it('computes EA1 deadline from previous version GA freeze minus 7 days', function() {
+    var result = computePlanningDeadline(milestones, 'EA1', prevGaFreeze)
+    expect(result.date).toBe('2026-04-10')
+  })
+
+  it('returns null for EA1 when no previous GA freeze', function() {
+    expect(computePlanningDeadline(milestones, 'EA1', null)).toBeNull()
+  })
+
+  it('computes EA2 deadline from EA1 freeze minus 7 days', function() {
+    var result = computePlanningDeadline(milestones, 'EA2')
     expect(result.date).toBe('2026-04-24')
   })
 
-  it('computes deadline as freeze minus 7 days for EA2', function() {
-    var result = computePlanningDeadline(milestones, 'EA2')
-    expect(result.date).toBe('2026-06-11')
-  })
-
-  it('computes deadline as freeze minus 7 days for GA', function() {
+  it('computes GA deadline from EA2 freeze minus 7 days', function() {
     var result = computePlanningDeadline(milestones, 'GA')
-    expect(result.date).toBe('2026-07-25')
+    expect(result.date).toBe('2026-06-11')
   })
 
   it('returns null for unknown phase', function() {
@@ -712,7 +713,32 @@ describe('runHealthPipeline', function() {
     expect(result.features[0]).toHaveProperty('dor')
   })
 
-  it('includes planningFreezes in cache output when milestones are present', async function() {
+  it('computes planningFreezes from previous phase code freeze minus 7 days', async function() {
+    var data = makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ])
+    data['release-analysis/product-pages-releases-cache.json'] = {
+      source: 'api',
+      fetchedAt: '2026-04-26T00:00:00Z',
+      releases: [
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.4', dueDate: '2026-04-30', codeFreezeDate: '2026-04-17' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: '2026-05-01' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA2', dueDate: '2026-07-01', codeFreezeDate: '2026-06-15' },
+        { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
+      ]
+    }
+    var storage = makeStorage(data)
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    expect(result.planningFreezes).not.toBeNull()
+    // EA1 planning freeze = previous version (3.4) GA code freeze - 7 = 2026-04-17 - 7 = 2026-04-10
+    expect(result.planningFreezes.ea1).toBe('2026-04-10')
+    // EA2 planning freeze = EA1 code freeze - 7 = 2026-05-01 - 7 = 2026-04-24
+    expect(result.planningFreezes.ea2).toBe('2026-04-24')
+    // GA planning freeze = EA2 code freeze - 7 = 2026-06-15 - 7 = 2026-06-08
+    expect(result.planningFreezes.ga).toBe('2026-06-08')
+  })
+
+  it('returns null ea1 planning freeze when no previous version data', async function() {
     var data = makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ])
@@ -727,19 +753,19 @@ describe('runHealthPipeline', function() {
     }
     var storage = makeStorage(data)
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
-    expect(result.planningFreezes).not.toBeNull()
-    // Planning freeze = code freeze - 7 days
-    expect(result.planningFreezes.ea1).toBe('2026-04-24')
-    expect(result.planningFreezes.ea2).toBe('2026-06-08')
-    expect(result.planningFreezes.ga).toBe('2026-07-25')
+    expect(result.planningFreezes.ea1).toBeNull()
+    expect(result.planningFreezes.ea2).toBe('2026-04-24')
+    expect(result.planningFreezes.ga).toBe('2026-06-08')
   })
 
-  it('returns null planningFreezes when milestones are null', async function() {
+  it('returns all null planningFreezes when no milestones and no previous version', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
-    expect(result.planningFreezes).toBeNull()
+    expect(result.planningFreezes.ea1).toBeNull()
+    expect(result.planningFreezes.ea2).toBeNull()
+    expect(result.planningFreezes.ga).toBeNull()
   })
 
   it('attaches priorityScore and priorityBreakdown to health features', async function() {

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -151,22 +151,29 @@ function loadFeaturesFromCandidates(readFromStorage, version, phase) {
 
 /**
  * Compute the planning deadline for a given phase.
- * The planning deadline is the code freeze date minus PLANNING_DEADLINE_OFFSET_DAYS.
+ * The planning freeze is 1 week before the PREVIOUS phase's code freeze:
+ *   EA1 planning freeze = previous version GA code freeze - 7 days
+ *   EA2 planning freeze = EA1 code freeze - 7 days
+ *   GA  planning freeze = EA2 code freeze - 7 days
  *
- * @param {object|null} milestones - Milestone dates from Product Pages
+ * @param {object|null} milestones - Milestone dates for the current version
  * @param {string|null} phase - Selected phase (EA1/EA2/GA)
+ * @param {string|null} prevGaFreeze - Previous version's GA code freeze date
  * @returns {{ date: string, daysRemaining: number }|null}
  */
-function computePlanningDeadline(milestones, phase) {
-  if (!milestones || !phase) return null
+function computePlanningDeadline(milestones, phase, prevGaFreeze) {
+  if (!phase) return null
 
-  var freezeMap = {
-    'EA1': milestones.ea1Freeze,
-    'EA2': milestones.ea2Freeze,
-    'GA': milestones.gaFreeze
+  var freezeDate = null
+  var p = phase.toUpperCase()
+  if (p === 'EA1') {
+    freezeDate = prevGaFreeze || null
+  } else if (p === 'EA2' && milestones) {
+    freezeDate = milestones.ea1Freeze
+  } else if (p === 'GA' && milestones) {
+    freezeDate = milestones.ea2Freeze
   }
 
-  var freezeDate = freezeMap[phase.toUpperCase()]
   if (!freezeDate) return null
 
   var freeze = new Date(freezeDate + 'T00:00:00Z')
@@ -257,6 +264,37 @@ function loadMilestones(readFromStorage, version) {
     gaFreeze: gaEntry ? gaEntry.codeFreezeDate || null : null,
     gaTarget: gaEntry ? gaEntry.dueDate || null : null
   }
+}
+
+/**
+ * Look up the previous version's GA code freeze date from Product Pages cache.
+ * Used to compute EA1's planning freeze (1 week before previous GA code freeze).
+ *
+ * @param {Function} readFromStorage
+ * @param {string} version - Current version (e.g., '3.5')
+ * @returns {string|null} Previous version's GA code freeze date, or null
+ */
+function loadPreviousGaFreeze(readFromStorage, version) {
+  var parts = version.split('.')
+  if (parts.length < 2) return null
+  var prevMinor = parseInt(parts[1], 10) - 1
+  if (prevMinor < 0) return null
+  var prevVersion = parts[0] + '.' + prevMinor
+
+  var cached = readFromStorage('release-analysis/product-pages-releases-cache.json')
+  if (!cached || !cached.releases || !Array.isArray(cached.releases)) {
+    return null
+  }
+
+  for (var i = 0; i < cached.releases.length; i++) {
+    var r = cached.releases[i]
+    var rn = r.releaseNumber || ''
+    if (rn.indexOf(prevVersion) !== -1 && rn.indexOf('.EA') === -1) {
+      return r.codeFreezeDate || null
+    }
+  }
+
+  return null
 }
 
 /**
@@ -553,6 +591,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   var deriveResult = deriveFreezeDates(milestones)
   milestones = deriveResult.milestones
   warnings = warnings.concat(deriveResult.warnings)
+  var prevGaFreeze = loadPreviousGaFreeze(readFromStorage, version)
 
   // Step 3: Run Jira enrichment
   var enrichResult = { enrichments: new Map(), riceData: new Map(), warnings: [], stats: { pass1: 0, pass2: 0, rice: 0 } }
@@ -569,7 +608,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || { overrides: {} }
 
   // Step 5: Build per-feature health assessments
-  var planningDeadline = computePlanningDeadline(milestones, phase)
+  var planningDeadline = computePlanningDeadline(milestones, phase, prevGaFreeze)
   var milestoneInfo = computeMilestoneInfo(milestones, today)
   var healthFeatures = []
   var riskCounts = { green: 0, yellow: 0, red: 0 }
@@ -690,11 +729,11 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       gaFreeze: milestones.gaFreeze,
       gaTarget: milestones.gaTarget
     } : null,
-    planningFreezes: milestones ? {
-      ea1: milestones.ea1Freeze ? offsetDate(milestones.ea1Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
-      ea2: milestones.ea2Freeze ? offsetDate(milestones.ea2Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
-      ga: milestones.gaFreeze ? offsetDate(milestones.gaFreeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null
-    } : null,
+    planningFreezes: {
+      ea1: prevGaFreeze ? offsetDate(prevGaFreeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
+      ea2: milestones && milestones.ea1Freeze ? offsetDate(milestones.ea1Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
+      ga: milestones && milestones.ea2Freeze ? offsetDate(milestones.ea2Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null
+    },
     phase: phaseKey,
     summary: {
       totalFeatures: features.length,


### PR DESCRIPTION
## Summary

- **Bug fix**: Planning freeze was incorrectly computed as the same phase's code freeze minus 7 days. The correct calculation is 1 week before the **previous** phase's code freeze:
  - EA1 planning freeze = previous version's GA code freeze - 7 days
  - EA2 planning freeze = EA1 code freeze - 7 days
  - GA planning freeze = EA2 code freeze - 7 days
- **New helper**: `loadPreviousGaFreeze()` looks up the previous version's GA code freeze from the Product Pages cache (e.g., version 3.5 looks up 3.4's GA freeze)
- **Updated**: Both `computePlanningDeadline()` and the `planningFreezes` cache output use the corrected logic

## Test plan

- [ ] All 1898 tests pass (123 test files)
- [ ] Updated `computePlanningDeadline` tests — EA1 from prev GA freeze, EA2 from EA1 freeze, GA from EA2 freeze
- [ ] 3 new integration tests — planning freezes with previous version data, without previous version, and without any milestones

🤖 Generated with [Claude Code](https://claude.com/claude-code)