### PR TITLE
fix(ai-impact): improve RFE review trend charts readability

### DIFF
--- a/modules/ai-impact/client/components/PhaseContent.vue
+++ b/modules/ai-impact/client/components/PhaseContent.vue
@@ -50,8 +50,10 @@ const isEmpty = computed(() => !props.rfeData?.fetchedAt)
         <h2 class="text-lg font-semibold dark:text-gray-100">{{ phase.name }}</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400">AI adoption metrics and RFE tracking</p>
       </div>
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-2">
+        <label for="time-window" class="text-sm text-gray-500 dark:text-gray-400">Showing:</label>
         <select
+          id="time-window"
           :value="timeWindow"
           @change="emit('update:timeWindow', $event.target.value)"
           class="border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300"

--- a/modules/ai-impact/client/components/PhaseContent.vue
+++ b/modules/ai-impact/client/components/PhaseContent.vue
@@ -110,6 +110,7 @@ const isEmpty = computed(() => !props.rfeData?.fetchedAt)
           :breakdown="breakdown"
           :expanded="chartExpanded"
           :filteredAssessments="filteredAssessments"
+          :timeWindow="timeWindow"
           @toggle="emit('update:chartExpanded', !chartExpanded)"
         />
 
@@ -123,6 +124,7 @@ const isEmpty = computed(() => !props.rfeData?.fetchedAt)
           :passFailFilter="passFailFilter"
           :priorityFilter="priorityFilter"
           :statusFilter="statusFilter"
+          :timeWindow="timeWindow"
           @update:filter="emit('update:filter', $event)"
           @update:searchQuery="emit('update:searchQuery', $event)"
           @update:sortBy="emit('update:sortBy', $event)"

--- a/modules/ai-impact/client/components/RFEList.vue
+++ b/modules/ai-impact/client/components/RFEList.vue
@@ -12,7 +12,14 @@ const props = defineProps({
   sortBy: { type: String, default: 'default' },
   passFailFilter: { type: String, default: 'all' },
   priorityFilter: { type: String, default: 'all' },
-  statusFilter: { type: String, default: 'all' }
+  statusFilter: { type: String, default: 'all' },
+  timeWindow: { type: String, default: 'month' }
+})
+
+const windowDescription = computed(() => {
+  const days = props.timeWindow === 'week' ? 7 : props.timeWindow === '3months' ? 90 : 30
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  return `since ${cutoff.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
 })
 
 const emit = defineEmits(['update:filter', 'update:searchQuery', 'update:sortBy', 'update:passFailFilter', 'update:priorityFilter', 'update:statusFilter', 'selectRFE'])
@@ -109,7 +116,7 @@ function handleSelectRFE(rfe) {
             d="M4 6h16M4 10h16M4 14h16M4 18h16" />
         </svg>
         RFE List
-        <span class="text-sm font-normal text-gray-500 dark:text-gray-400">({{ sortedAndFilteredRFEs.length }})</span>
+        <span class="text-sm font-normal text-gray-500 dark:text-gray-400">({{ sortedAndFilteredRFEs.length }}) · {{ windowDescription }}</span>
       </h3>
       <div class="flex gap-2">
         <div class="relative">

--- a/modules/ai-impact/client/components/TrendCharts.vue
+++ b/modules/ai-impact/client/components/TrendCharts.vue
@@ -33,37 +33,46 @@ const hasAssessments = computed(() => Object.keys(props.filteredAssessments).len
 
 const emit = defineEmits(['toggle'])
 
-const adoptionChartData = computed(() => ({
+const createdPctChartData = computed(() => ({
   labels: props.trendData.map(p => p.date),
-  datasets: [
-    {
-      label: 'Created with AI (%)',
-      data: props.trendData.map(p => p.createdPct),
-      borderColor: '#10b981',
-      backgroundColor: 'rgba(16, 185, 129, 0.1)',
-      fill: true,
-      tension: 0.3,
-      type: 'line',
-      yAxisID: 'y'
-    },
-    {
-      label: 'Revised with AI',
-      data: props.trendData.map(p => p.revisedCount),
-      backgroundColor: 'rgba(245, 158, 11, 0.5)',
-      type: 'bar',
-      yAxisID: 'y1'
-    }
-  ]
+  datasets: [{
+    label: 'Created with AI (%)',
+    data: props.trendData.map(p => p.createdPct),
+    borderColor: '#10b981',
+    backgroundColor: 'rgba(16, 185, 129, 0.1)',
+    fill: true,
+    tension: 0.3
+  }]
 }))
 
-const adoptionChartOptions = {
+const createdPctChartOptions = {
   responsive: true,
   maintainAspectRatio: false,
-  plugins: { legend: { display: true, position: 'top', labels: { font: { size: 11 } } } },
+  plugins: { legend: { display: false } },
   scales: {
     x: { ticks: { font: { size: 10 } } },
-    y: { position: 'left', ticks: { font: { size: 10 } }, title: { display: true, text: '% Created with AI' } },
-    y1: { position: 'right', ticks: { font: { size: 10 }, precision: 0 }, title: { display: true, text: 'Revised (count)' }, grid: { drawOnChartArea: false } }
+    y: { min: 0, max: 100, ticks: { font: { size: 10 }, callback: v => v + '%' }, title: { display: true, text: '% Created with AI' } }
+  }
+}
+
+const revisedCountChartData = computed(() => ({
+  labels: props.trendData.map(p => p.date),
+  datasets: [{
+    label: 'Revised with AI',
+    data: props.trendData.map(p => p.revisedCount),
+    backgroundColor: 'rgba(245, 158, 11, 0.6)',
+    borderColor: 'rgba(245, 158, 11, 0.8)',
+    borderWidth: 1
+  }]
+}))
+
+const revisedCountChartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 } } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, precision: 0 }, title: { display: true, text: 'Revised (count)' } }
   }
 }
 
@@ -110,26 +119,44 @@ const breakdownChartOptions = {
     </button>
 
     <div v-if="expanded" class="px-6 pb-6 space-y-6">
-      <div class="grid md:grid-cols-2 gap-6">
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <div class="flex flex-wrap gap-6">
+      <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
         <div class="flex items-center justify-between mb-3">
-          <h3 class="text-sm font-medium dark:text-gray-300">Adoption Over Time</h3>
+          <h3 class="text-sm font-medium dark:text-gray-300">Created with AI (%)</h3>
           <div class="relative group">
             <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
-              Shows the percentage of RFEs created with AI per week (line) and the count of RFEs revised with AI per week (bars) over the selected time window.
+              Percentage of RFEs created with AI per week over the selected time window.
             </div>
           </div>
         </div>
         <div class="h-[180px]">
-          <Line :data="adoptionChartData" :options="adoptionChartOptions" />
+          <Line :data="createdPctChartData" :options="createdPctChartOptions" />
         </div>
       </div>
 
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+      <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-sm font-medium dark:text-gray-300">Revised with AI</h3>
+          <div class="relative group">
+            <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+              Count of RFEs revised with AI per week over the selected time window.
+            </div>
+          </div>
+        </div>
+        <div class="h-[180px]">
+          <Bar :data="revisedCountChartData" :options="revisedCountChartOptions" />
+        </div>
+      </div>
+
+      <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
         <div class="flex items-center justify-between mb-3">
           <h3 class="text-sm font-medium dark:text-gray-300">AI Involvement Breakdown</h3>
           <div class="relative group">
@@ -149,9 +176,9 @@ const breakdownChartOptions = {
       </div>
 
       <!-- Assessment Quality Charts -->
-      <div v-if="hasAssessments" class="grid md:grid-cols-2 gap-6">
-        <ScoreDistributionChart :assessments="filteredAssessments" />
-        <CriteriaBreakdownChart :assessments="filteredAssessments" />
+      <div v-if="hasAssessments" class="flex flex-wrap gap-6">
+        <ScoreDistributionChart class="min-w-[280px] flex-1" :assessments="filteredAssessments" />
+        <CriteriaBreakdownChart class="min-w-[280px] flex-1" :assessments="filteredAssessments" />
       </div>
     </div>
   </div>

--- a/modules/ai-impact/client/components/TrendCharts.vue
+++ b/modules/ai-impact/client/components/TrendCharts.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { Line, Bar } from 'vue-chartjs'
 import {
   Chart as ChartJS,
@@ -33,6 +33,19 @@ const hasAssessments = computed(() => Object.keys(props.filteredAssessments).len
 
 const emit = defineEmits(['toggle'])
 
+const isDark = ref(false)
+onMounted(() => {
+  isDark.value = document.documentElement.classList.contains('dark')
+  const observer = new MutationObserver(() => {
+    isDark.value = document.documentElement.classList.contains('dark')
+  })
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+  onBeforeUnmount(() => observer.disconnect())
+})
+
+const textColor = computed(() => isDark.value ? 'rgba(209, 213, 219, 1)' : 'rgba(107, 114, 128, 1)')
+const gridColor = computed(() => isDark.value ? 'rgba(75, 85, 99, 0.5)' : 'rgba(229, 231, 235, 1)')
+
 const createdPctChartData = computed(() => ({
   labels: props.trendData.map(p => p.date),
   datasets: [{
@@ -45,15 +58,15 @@ const createdPctChartData = computed(() => ({
   }]
 }))
 
-const createdPctChartOptions = {
+const createdPctChartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
   plugins: { legend: { display: false } },
   scales: {
-    x: { ticks: { font: { size: 10 } } },
-    y: { min: 0, max: 100, ticks: { font: { size: 10 }, callback: v => v + '%' }, title: { display: true, text: '% Created with AI' } }
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { min: 0, max: 100, ticks: { font: { size: 10 }, color: textColor.value, callback: v => v + '%' }, title: { display: true, text: '% Created with AI', color: textColor.value }, grid: { color: gridColor.value } }
   }
-}
+}))
 
 const revisedCountChartData = computed(() => ({
   labels: props.trendData.map(p => p.date),
@@ -66,15 +79,15 @@ const revisedCountChartData = computed(() => ({
   }]
 }))
 
-const revisedCountChartOptions = {
+const revisedCountChartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
   plugins: { legend: { display: false } },
   scales: {
-    x: { ticks: { font: { size: 10 } } },
-    y: { beginAtZero: true, ticks: { font: { size: 10 }, precision: 0 }, title: { display: true, text: 'Revised (count)' } }
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, color: textColor.value, precision: 0 }, title: { display: true, text: 'Revised (count)', color: textColor.value }, grid: { color: gridColor.value } }
   }
-}
+}))
 
 const breakdownChartData = computed(() => ({
   labels: props.breakdown.map(b => b.name),
@@ -84,16 +97,16 @@ const breakdownChartData = computed(() => ({
   }]
 }))
 
-const breakdownChartOptions = {
+const breakdownChartOptions = computed(() => ({
   indexAxis: 'y',
   responsive: true,
   maintainAspectRatio: false,
   plugins: { legend: { display: false } },
   scales: {
-    x: { ticks: { font: { size: 10 } } },
-    y: { ticks: { font: { size: 10 } } }
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } }
   }
-}
+}))
 </script>
 
 <template>

--- a/modules/ai-impact/client/components/TrendCharts.vue
+++ b/modules/ai-impact/client/components/TrendCharts.vue
@@ -26,7 +26,8 @@ const props = defineProps({
   trendData: { type: Array, default: () => [] },
   breakdown: { type: Array, default: () => [] },
   expanded: { type: Boolean, default: true },
-  filteredAssessments: { type: Object, default: () => ({}) }
+  filteredAssessments: { type: Object, default: () => ({}) },
+  timeWindow: { type: String, default: 'month' }
 })
 
 const hasAssessments = computed(() => Object.keys(props.filteredAssessments).length > 0)
@@ -45,6 +46,14 @@ onMounted(() => {
 
 const textColor = computed(() => isDark.value ? 'rgba(209, 213, 219, 1)' : 'rgba(107, 114, 128, 1)')
 const gridColor = computed(() => isDark.value ? 'rgba(75, 85, 99, 0.5)' : 'rgba(229, 231, 235, 1)')
+
+const trailingWeeks = computed(() => {
+  if (props.timeWindow === 'week') return 4
+  if (props.timeWindow === '3months') return 13
+  return 8
+})
+
+const trailingLabel = computed(() => `Weekly trend · trailing ${trailingWeeks.value} weeks`)
 
 const createdPctChartData = computed(() => ({
   labels: props.trendData.map(p => p.date),
@@ -121,6 +130,7 @@ const breakdownChartOptions = computed(() => ({
             d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
         </svg>
         Trend Visualization
+        <span class="text-xs font-normal text-gray-400 dark:text-gray-500">{{ trailingLabel }}</span>
       </span>
       <svg
         class="h-4 w-4 transition-transform dark:text-gray-300"

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -11,7 +11,7 @@ import AIImpactGuide from '../components/AIImpactGuide.vue'
 const moduleNav = inject('moduleNav')
 
 const selectedRFE = ref(null)
-const timeWindow = ref('week')
+const timeWindow = ref('month')
 const filter = ref('all')
 const searchQuery = ref('')
 const chartExpanded = ref(true)


### PR DESCRIPTION
## Summary
- Split the confusing dual-axis "Adoption Over Time" chart into three separate charts (Created with AI %, Revised with AI, AI Involvement Breakdown) in a flex-wrap row
- Fix chart axis labels/grid being invisible in dark mode
- Add "Showing:" label to time range picker and contextual labels so users understand what each section displays ("Weekly trend · trailing 8 weeks" on charts, "since Mar 28" on the RFE list)
- Default time window to "This Month" instead of "This Week"

## Test plan
- [ ] Verify the three trend charts render side-by-side on wide screens and wrap on narrow screens
- [ ] Toggle dark mode and confirm chart axis labels, tick marks, and grid lines are visible
- [ ] Change time range picker and confirm the trailing weeks count updates in the chart subtitle and the date updates in the RFE list header
- [ ] Confirm the page defaults to "This Month" on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)