### PR TITLE
fix(release-planning): Smartsheet fallback for previous version GA freeze

### DIFF
--- a/modules/release-planning/__tests__/server/health-pipeline.test.js
+++ b/modules/release-planning/__tests__/server/health-pipeline.test.js
@@ -768,6 +768,20 @@ describe('runHealthPipeline', function() {
     expect(result.planningFreezes.ga).toBeNull()
   })
 
+  it('falls back to Smartsheet for previous GA freeze when Product Pages cache is missing', async function() {
+    smartsheetClient.isConfigured.mockReturnValue(true)
+    smartsheetClient.discoverReleasesPartial.mockResolvedValue([
+      { version: '3.4', ea1Freeze: '2025-12-01', ea1Target: '2025-12-15', ea2Freeze: '2026-02-01', ea2Target: '2026-02-15', gaFreeze: '2026-04-17', gaTarget: '2026-04-30' },
+      { version: '3.5', ea1Freeze: '2026-05-01', ea1Target: '2026-05-15', ea2Freeze: '2026-06-15', ea2Target: '2026-07-01', gaFreeze: '2026-08-01', gaTarget: '2026-08-15' }
+    ])
+    var storage = makeStorage(makeCandidatesCache([
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    // EA1 planning freeze = previous version (3.4) GA freeze from Smartsheet - 7 = 2026-04-17 - 7 = 2026-04-10
+    expect(result.planningFreezes.ea1).toBe('2026-04-10')
+  })
+
   it('attaches priorityScore and priorityBreakdown to health features', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', priority: 'Major', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 },

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -272,7 +272,7 @@ function loadMilestones(readFromStorage, version) {
  *
  * @param {Function} readFromStorage
  * @param {string} version - Current version (e.g., '3.5')
- * @returns {string|null} Previous version's GA code freeze date, or null
+ * @returns {Promise<string|null>} Previous version's GA code freeze date, or null
  */
 async function loadPreviousGaFreeze(readFromStorage, version) {
   var parts = version.split('.')

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -274,23 +274,36 @@ function loadMilestones(readFromStorage, version) {
  * @param {string} version - Current version (e.g., '3.5')
  * @returns {string|null} Previous version's GA code freeze date, or null
  */
-function loadPreviousGaFreeze(readFromStorage, version) {
+async function loadPreviousGaFreeze(readFromStorage, version) {
   var parts = version.split('.')
   if (parts.length < 2) return null
   var prevMinor = parseInt(parts[1], 10) - 1
   if (prevMinor < 0) return null
   var prevVersion = parts[0] + '.' + prevMinor
 
+  // Try Product Pages cache first
   var cached = readFromStorage('release-analysis/product-pages-releases-cache.json')
-  if (!cached || !cached.releases || !Array.isArray(cached.releases)) {
-    return null
+  if (cached && cached.releases && Array.isArray(cached.releases)) {
+    for (var i = 0; i < cached.releases.length; i++) {
+      var r = cached.releases[i]
+      var rn = r.releaseNumber || ''
+      if (rn.indexOf(prevVersion) !== -1 && rn.indexOf('.EA') === -1) {
+        if (r.codeFreezeDate) return r.codeFreezeDate
+      }
+    }
   }
 
-  for (var i = 0; i < cached.releases.length; i++) {
-    var r = cached.releases[i]
-    var rn = r.releaseNumber || ''
-    if (rn.indexOf(prevVersion) !== -1 && rn.indexOf('.EA') === -1) {
-      return r.codeFreezeDate || null
+  // Fallback to Smartsheet
+  if (smartsheetClient.isConfigured()) {
+    try {
+      var releases = await smartsheetClient.discoverReleasesPartial()
+      for (var j = 0; j < releases.length; j++) {
+        if (releases[j].version === prevVersion && releases[j].gaFreeze) {
+          return releases[j].gaFreeze
+        }
+      }
+    } catch {
+      // fall through
     }
   }
 
@@ -591,7 +604,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   var deriveResult = deriveFreezeDates(milestones)
   milestones = deriveResult.milestones
   warnings = warnings.concat(deriveResult.warnings)
-  var prevGaFreeze = loadPreviousGaFreeze(readFromStorage, version)
+  var prevGaFreeze = await loadPreviousGaFreeze(readFromStorage, version)
 
   // Step 3: Run Jira enrichment
   var enrichResult = { enrichments: new Map(), riceData: new Map(), warnings: [], stats: { pass1: 0, pass2: 0, rice: 0 } }


### PR DESCRIPTION
## Summary
- `loadPreviousGaFreeze()` only checked the Product Pages cache file, which doesn't exist in environments where milestones come from Smartsheet
- Added Smartsheet fallback via `discoverReleasesPartial()`, matching the same pattern used by `backfillFreezeDatesFromSmartsheet()`
- Fixes planning freeze dates showing as null when Product Pages cache is unavailable

## Test plan
- [x] All 71 health pipeline tests pass (including new Smartsheet fallback test)
- [x] Verified locally: planning freezes now compute correctly (EA1=Apr 8, EA2=May 8, GA=Jun 12)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)