### PR TITLE
refactor(release-planning): clean up health table columns and filters

### DIFF
--- a/modules/release-planning/__tests__/client/health-components.test.js
+++ b/modules/release-planning/__tests__/client/health-components.test.js
@@ -229,12 +229,6 @@ describe('HealthFilterBar', function() {
     expect(wrapper.find('input[type="text"]').exists()).toBe(true)
   })
 
-  it('renders risk filter select', function() {
-    var wrapper = mount(HealthFilterBar)
-    var selects = wrapper.findAll('select')
-    expect(selects.length).toBeGreaterThanOrEqual(2)
-  })
-
   it('renders big rocks select when bigRocks provided', function() {
     var wrapper = mount(HealthFilterBar, { props: { bigRocks: ['Rock A', 'Rock B'] } })
     expect(wrapper.text()).toContain('Rock A')
@@ -286,26 +280,6 @@ describe('HealthFilterBar', function() {
       await removeBtn[0].trigger('click')
       expect(wrapper.emitted('update:selectedComponents')).toBeDefined()
       expect(wrapper.emitted('update:selectedComponents')[0][0]).toEqual([])
-    }
-  })
-
-  it('renders tier filter select', function() {
-    var wrapper = mount(HealthFilterBar)
-    expect(wrapper.text()).toContain('All Tiers')
-    expect(wrapper.text()).toContain('Tier 1')
-    expect(wrapper.text()).toContain('Tier 2')
-    expect(wrapper.text()).toContain('Tier 3')
-  })
-
-  it('emits update:tierFilter on tier select change', async function() {
-    var wrapper = mount(HealthFilterBar)
-    var tierSelect = wrapper.findAll('select').filter(function(s) {
-      return s.text().includes('All Tiers')
-    })
-    if (tierSelect.length > 0) {
-      await tierSelect[0].setValue('2')
-      expect(wrapper.emitted('update:tierFilter')).toBeDefined()
-      expect(wrapper.emitted('update:tierFilter')[0][0]).toBe('2')
     }
   })
 

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -194,21 +194,10 @@ var flagSeverityClass = {
     <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.components || '-' }}</td>
     <!-- Owner -->
     <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.deliveryOwner || '-' }}</td>
-    <!-- Phase -->
-    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
-      <span
-        v-if="feature.phase"
-        class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
-        :class="{
-          'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400': feature.phase === 'TP' || feature.phase === 'EA1',
-          'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400': feature.phase === 'DP' || feature.phase === 'EA2',
-          'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400': feature.phase === 'GA'
-        }"
-      >{{ feature.phase }}</span>
-      <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
-    </td>
-    <!-- Tier -->
-    <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.tier || '-' }}</td>
+    <!-- Fix Version -->
+    <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.fixVersions || '-' }}</td>
+    <!-- Target Release -->
+    <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">{{ feature.targetRelease || '-' }}</td>
   </tr>
 
   <!-- Expanded detail row -->

--- a/modules/release-planning/client/components/FeatureHealthTable.vue
+++ b/modules/release-planning/client/components/FeatureHealthTable.vue
@@ -26,8 +26,8 @@ var columns = [
   { key: 'rice', label: 'RICE', sortable: true },
   { key: 'components', label: 'Component', sortable: true },
   { key: 'owner', label: 'Owner', sortable: true },
-  { key: 'phase', label: 'Phase', sortable: true },
-  { key: 'tier', label: 'Tier', sortable: true }
+  { key: 'fixVersions', label: 'Fix Version', sortable: true },
+  { key: 'targetRelease', label: 'Target Release', sortable: true }
 ]
 
 var RISK_ORDER = { red: 0, yellow: 1, green: 2 }
@@ -70,12 +70,12 @@ var sortedFeatures = computed(function() {
     } else if (key === 'owner') {
       va = (a.deliveryOwner || '').toLowerCase()
       vb = (b.deliveryOwner || '').toLowerCase()
-    } else if (key === 'phase') {
-      va = a.phase || ''
-      vb = b.phase || ''
-    } else if (key === 'tier') {
-      va = a.tier || ''
-      vb = b.tier || ''
+    } else if (key === 'fixVersions') {
+      va = (a.fixVersions || '').toLowerCase()
+      vb = (b.fixVersions || '').toLowerCase()
+    } else if (key === 'targetRelease') {
+      va = (a.targetRelease || '').toLowerCase()
+      vb = (b.targetRelease || '').toLowerCase()
     } else {
       return 0
     }

--- a/modules/release-planning/client/components/HealthFilterBar.vue
+++ b/modules/release-planning/client/components/HealthFilterBar.vue
@@ -2,11 +2,8 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 
 var props = defineProps({
-  riskFilter: { type: String, default: '' },
-  dorFilter: { type: String, default: '' },
   bigRockFilter: { type: String, default: '' },
   selectedComponents: { type: Array, default: () => [] },
-  tierFilter: { type: String, default: '' },
   searchQuery: { type: String, default: '' },
   bigRocks: { type: Array, default: () => [] },
   components: { type: Array, default: () => [] },
@@ -14,11 +11,8 @@ var props = defineProps({
 })
 
 var emit = defineEmits([
-  'update:riskFilter',
-  'update:dorFilter',
   'update:bigRockFilter',
   'update:selectedComponents',
-  'update:tierFilter',
   'update:searchQuery',
   'clearFilters'
 ])
@@ -75,30 +69,6 @@ onUnmounted(function() {
       aria-label="Search features"
       class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
     />
-
-    <select
-      :value="riskFilter"
-      @change="$emit('update:riskFilter', $event.target.value)"
-      :class="selectClass"
-      aria-label="Filter by risk level"
-    >
-      <option value="">All Risk Levels</option>
-      <option value="green">Green - On Track</option>
-      <option value="yellow">Yellow - At Risk</option>
-      <option value="red">Red - Critical</option>
-    </select>
-
-    <select
-      :value="dorFilter"
-      @change="$emit('update:dorFilter', $event.target.value)"
-      :class="selectClass"
-      aria-label="Filter by DoR status"
-    >
-      <option value="">All DoR Status</option>
-      <option value="complete">DoR Complete (80%+)</option>
-      <option value="partial">DoR Partial (50-79%)</option>
-      <option value="incomplete">DoR Incomplete (&lt;50%)</option>
-    </select>
 
     <select
       v-if="bigRocks.length > 0"
@@ -165,18 +135,6 @@ onUnmounted(function() {
         >&times;</button>
       </span>
     </div>
-
-    <select
-      :value="tierFilter"
-      @change="$emit('update:tierFilter', $event.target.value)"
-      :class="selectClass"
-      aria-label="Filter by tier"
-    >
-      <option value="">All Tiers</option>
-      <option value="1">Tier 1</option>
-      <option value="2">Tier 2</option>
-      <option value="3">Tier 3</option>
-    </select>
 
     <button
       v-if="hasActiveFilters"

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -27,11 +27,8 @@ var selectedVersion = ref('')
 var activePhase = ref('all')
 
 // Filter state
-var riskFilter = ref('')
-var dorFilter = ref('')
 var bigRockFilter = ref('')
 var selectedComponents = ref([])
-var tierFilter = ref('')
 var searchQuery = ref('')
 
 // Refresh polling
@@ -197,21 +194,6 @@ var filteredFeatures = computed(function() {
   if (!list || list.length === 0) return []
 
   return list.filter(function(f) {
-    // Risk filter
-    if (riskFilter.value) {
-      var featureRisk = f.risk ? f.risk.level : 'green'
-      if (f.risk && f.risk.override) featureRisk = f.risk.override.riskOverride || featureRisk
-      if (featureRisk !== riskFilter.value) return false
-    }
-
-    // DoR filter
-    if (dorFilter.value) {
-      var dorPct = f.dor ? f.dor.completionPct : 0
-      if (dorFilter.value === 'complete' && dorPct < 80) return false
-      if (dorFilter.value === 'partial' && (dorPct < 50 || dorPct >= 80)) return false
-      if (dorFilter.value === 'incomplete' && dorPct >= 50) return false
-    }
-
     // Big Rock filter
     if (bigRockFilter.value && f.bigRock !== bigRockFilter.value) return false
 
@@ -226,9 +208,6 @@ var filteredFeatures = computed(function() {
       if (!hasMatch) return false
     }
 
-    // Tier filter
-    if (tierFilter.value && String(f.tier) !== tierFilter.value) return false
-
     // Search
     if (searchQuery.value) {
       var q = searchQuery.value.toLowerCase()
@@ -241,15 +220,12 @@ var filteredFeatures = computed(function() {
 })
 
 var hasActiveFilters = computed(function() {
-  return !!(riskFilter.value || dorFilter.value || bigRockFilter.value || selectedComponents.value.length > 0 || tierFilter.value || searchQuery.value)
+  return !!(bigRockFilter.value || selectedComponents.value.length > 0 || searchQuery.value)
 })
 
 function clearFilters() {
-  riskFilter.value = ''
-  dorFilter.value = ''
   bigRockFilter.value = ''
   selectedComponents.value = []
-  tierFilter.value = ''
   searchQuery.value = ''
 }
 
@@ -466,11 +442,8 @@ onUnmounted(function() {
 
       <!-- Filters -->
       <HealthFilterBar
-        v-model:riskFilter="riskFilter"
-        v-model:dorFilter="dorFilter"
         v-model:bigRockFilter="bigRockFilter"
         v-model:selectedComponents="selectedComponents"
-        v-model:tierFilter="tierFilter"
         v-model:searchQuery="searchQuery"
         :bigRocks="bigRockOptions"
         :components="componentOptions"

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -699,6 +699,8 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       pm: getDisplayName(feature.pm),
       deliveryOwner: getDisplayName(feature.assignee),
       components: components,
+      fixVersions: Array.isArray(feature.fixVersions) ? feature.fixVersions.join(', ') : '',
+      targetRelease: Array.isArray(feature.targetVersions) ? feature.targetVersions.join(', ') : '',
       completionPct: typeof feature.completionPct === 'number' ? feature.completionPct : 0,
       epicCount: feature.epicCount || 0,
       issueCount: feature.issueCount || 0,


### PR DESCRIPTION
## Summary
- Remove Tier column from the feature health table
- Rename "Phase" column to "Fix Version" and display actual Jira fix version strings
- Add "Target Release" column with data surfaced from the health pipeline
- Remove Risk Levels, DoR Status, and Tiers filter dropdowns (keep Search, Big Rocks, Components)
- Remove corresponding filter state, logic, and tests

## Test plan
- [ ] Verify table displays Fix Version and Target Release columns correctly
- [ ] Verify Tier column is no longer visible
- [ ] Verify only Search, Big Rocks, and Components filters remain
- [ ] Confirm sorting works on the new columns
- [ ] Run `npm test` — 669 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)