### PR TITLE
fix(release-planning): strict phase tab filtering by fix version

### DIFF
--- a/modules/release-planning/__tests__/client/phase-filter.test.js
+++ b/modules/release-planning/__tests__/client/phase-filter.test.js
@@ -3,68 +3,62 @@ import { passesPhaseFilter } from '../../client/utils/phase-filter'
 
 describe('passesPhaseFilter', function() {
   it('returns true for all features when no phase is specified', function() {
-    var feature = { fixVersion: 'rhoai-3.5-EA1, rhoai-3.5' }
+    var feature = { fixVersions: 'rhoai-3.5.EA1, rhoai-3.5' }
     expect(passesPhaseFilter(feature, '3.5', null)).toBe(true)
     expect(passesPhaseFilter(feature, '3.5', '')).toBe(true)
     expect(passesPhaseFilter(feature, '3.5', undefined)).toBe(true)
   })
 
-  it('returns true when feature has matching phase fixVersion', function() {
-    var feature = { fixVersion: 'rhoai-3.5-EA1' }
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
+  it('returns true when fixVersions contains matching version and phase', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.EA1' }, '3.5', 'EA1')).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'rhaiis-3.5.EA1' }, '3.5', 'EA1')).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5-EA2' }, '3.5', 'EA2')).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'RHOAI-3.5 GA' }, '3.5', 'GA')).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'RHAIIS-3.5EA1' }, '3.5', 'EA1')).toBe(true)
   })
 
-  it('returns false when feature has phase fixVersion but different phase', function() {
-    var feature = { fixVersion: 'rhoai-3.5-EA1' }
-    expect(passesPhaseFilter(feature, '3.5', 'EA2')).toBe(false)
-    expect(passesPhaseFilter(feature, '3.5', 'GA')).toBe(false)
+  it('returns false when fixVersions has phase but wrong phase', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.EA1' }, '3.5', 'EA2')).toBe(false)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.EA1' }, '3.5', 'GA')).toBe(false)
   })
 
-  it('returns true when feature has no phase-specific fixVersions', function() {
-    var feature = { fixVersion: 'rhoai-3.5' }
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
-    expect(passesPhaseFilter(feature, '3.5', 'EA2')).toBe(true)
-    expect(passesPhaseFilter(feature, '3.5', 'GA')).toBe(true)
+  it('returns false when fixVersions has no phase-specific version', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'EA1')).toBe(false)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'EA2')).toBe(false)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'GA')).toBe(false)
   })
 
-  it('returns true when feature has empty fixVersion', function() {
-    var feature = { fixVersion: '' }
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
+  it('returns false when fixVersions is empty', function() {
+    expect(passesPhaseFilter({ fixVersions: '' }, '3.5', 'EA1')).toBe(false)
   })
 
-  it('returns true when feature has no fixVersion property', function() {
-    var feature = {}
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
+  it('returns false when fixVersions property is missing', function() {
+    expect(passesPhaseFilter({}, '3.5', 'EA1')).toBe(false)
   })
 
   it('handles multiple comma-separated fixVersions', function() {
-    var feature = { fixVersion: 'rhoai-3.5-EA1, rhoai-3.5-EA2' }
+    var feature = { fixVersions: 'rhoai-3.5.EA1, rhoai-3.5.EA2' }
     expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
     expect(passesPhaseFilter(feature, '3.5', 'EA2')).toBe(true)
     expect(passesPhaseFilter(feature, '3.5', 'GA')).toBe(false)
   })
 
-  it('is case insensitive for phase matching', function() {
-    var feature = { fixVersion: 'rhoai-3.5-ea1' }
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
-    expect(passesPhaseFilter(feature, '3.5', 'ea1')).toBe(true)
+  it('is case insensitive', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.ea1' }, '3.5', 'EA1')).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'RHOAI-3.5.EA1' }, '3.5', 'ea1')).toBe(true)
   })
 
-  it('handles fixVersion with GA phase', function() {
-    var feature = { fixVersion: 'rhoai-3.5-GA' }
-    expect(passesPhaseFilter(feature, '3.5', 'GA')).toBe(true)
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(false)
+  it('does not match wrong version', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.4.EA1' }, '3.5', 'EA1')).toBe(false)
   })
 
-  it('handles mixed phase-specific and non-phase fixVersions', function() {
-    var feature = { fixVersion: 'rhoai-3.5, rhoai-3.5-EA2' }
-    // Has phase-specific, so it should only match EA2
-    expect(passesPhaseFilter(feature, '3.5', 'EA2')).toBe(true)
-    expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(false)
+  it('falls back to fixVersion field when fixVersions is absent', function() {
+    expect(passesPhaseFilter({ fixVersion: 'rhoai-3.5.EA1' }, '3.5', 'EA1')).toBe(true)
+    expect(passesPhaseFilter({ fixVersion: 'rhoai-3.5' }, '3.5', 'EA1')).toBe(false)
   })
 
   it('handles fixVersions without spaces after commas', function() {
-    var feature = { fixVersion: 'rhoai-3.5-EA1,rhoai-3.5-EA2' }
+    var feature = { fixVersions: 'rhoai-3.5.EA1,rhoai-3.5.EA2' }
     expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
     expect(passesPhaseFilter(feature, '3.5', 'EA2')).toBe(true)
   })

--- a/modules/release-planning/client/utils/phase-filter.js
+++ b/modules/release-planning/client/utils/phase-filter.js
@@ -1,31 +1,23 @@
 /**
  * Client-side phase filter utility.
  *
- * Ported from server/health/health-pipeline.js passesPhaseFilter().
  * Determines whether a feature should appear in a given phase tab
- * based on its fixVersion string.
+ * based on its fix version strings. A feature passes the filter when
+ * at least one of its fix versions contains both the release version
+ * (e.g., "3.5") AND the phase label (e.g., "EA1"), case-insensitively
+ * and regardless of separator (dot, dash, space, or none).
+ *
+ * Features without a matching phase-specific fix version do NOT appear
+ * in individual phase tabs — only in the "All Features" view.
  */
 
-var VALID_PHASES = ['EA1', 'EA2', 'GA']
-
-/**
- * Split a comma-separated string into a trimmed array.
- * @param {string} str
- * @returns {Array<string>}
- */
 function splitCommaString(str) {
   if (!str || typeof str !== 'string') return []
   return str.split(',').map(function(s) { return s.trim() }).filter(Boolean)
 }
 
 /**
- * Check whether a feature passes the phase filter.
- * If no phase is specified, all features pass.
- * If a feature has a phase-specific fixVersion (e.g., rhoai-3.5-EA2),
- * it only appears in the matching phase view.
- * Features without phase-specific fixVersions appear in all views.
- *
- * @param {object} feature - Feature object with fixVersion string
+ * @param {object} feature - Feature object with fixVersions or fixVersion
  * @param {string} version - Release version (e.g., '3.5')
  * @param {string|null} phase - Selected phase (EA1/EA2/GA) or null
  * @returns {boolean}
@@ -33,24 +25,20 @@ function splitCommaString(str) {
 export function passesPhaseFilter(feature, version, phase) {
   if (!phase) return true
 
-  var fixVersionStr = feature.fixVersion || ''
+  var fixVersionStr = feature.fixVersions || feature.fixVersion || ''
   var fixVersions = splitCommaString(fixVersionStr)
 
-  var hasPhaseSpecific = false
-  var matchesRequestedPhase = false
+  if (fixVersions.length === 0) return false
+
+  var phaseUpper = phase.toUpperCase()
+  var versionUpper = (version || '').toUpperCase()
 
   for (var i = 0; i < fixVersions.length; i++) {
     var fv = fixVersions[i].toUpperCase()
-    for (var j = 0; j < VALID_PHASES.length; j++) {
-      if (fv.indexOf('-' + VALID_PHASES[j]) !== -1) {
-        hasPhaseSpecific = true
-        if (VALID_PHASES[j] === phase.toUpperCase()) {
-          matchesRequestedPhase = true
-        }
-      }
+    if (fv.indexOf(versionUpper) !== -1 && fv.indexOf(phaseUpper) !== -1) {
+      return true
     }
   }
 
-  if (!hasPhaseSpecific) return true
-  return matchesRequestedPhase
+  return false
 }


### PR DESCRIPTION
## Summary
- Phase tabs (EA1/EA2/GA) now strictly filter by fix version — only features with a fix version containing both the release version and the phase are shown (e.g., `rhoai-3.5.EA1` or `rhaiis-3.5.EA1` for the EA1 tab)
- Features without a phase-specific fix version appear only in the "All Features" view
- Handles all separator formats found in Jira data (dot, dash, space, none)
- Reads from `fixVersions` field (added in #412) with fallback to `fixVersion`

## Test plan
- [ ] EA1 tab shows only features with EA1 fix versions
- [ ] Features with just `rhoai-3.5` (no phase) appear only in All Features
- [ ] EA2 and GA tabs filter similarly
- [ ] Run `npm test` — 669 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)