### PR TITLE
feat(release-planning): committed list tabs with strict/inclusive phase filtering

### DIFF
--- a/modules/release-planning/__tests__/client/phase-filter.test.js
+++ b/modules/release-planning/__tests__/client/phase-filter.test.js
@@ -62,4 +62,49 @@ describe('passesPhaseFilter', function() {
     expect(passesPhaseFilter(feature, '3.5', 'EA1')).toBe(true)
     expect(passesPhaseFilter(feature, '3.5', 'EA2')).toBe(true)
   })
+
+  // strict=true is the default, tested above. Tests below cover strict=false (inclusive mode).
+
+  it('inclusive: passes features with no phase-specific fix version', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'EA2', false)).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'GA', false)).toBe(true)
+  })
+
+  it('inclusive: passes features with matching phase fix version', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.EA2' }, '3.5', 'EA2', false)).toBe(true)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.GA' }, '3.5', 'GA', false)).toBe(true)
+  })
+
+  it('inclusive: excludes features tagged for a different phase', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.EA1' }, '3.5', 'EA2', false)).toBe(false)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.EA1' }, '3.5', 'GA', false)).toBe(false)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5.GA' }, '3.5', 'EA2', false)).toBe(false)
+  })
+
+  it('inclusive: passes when one fix version has no phase and another has a different phase', function() {
+    var feature = { fixVersions: 'rhoai-3.5, rhoai-3.5.EA1' }
+    expect(passesPhaseFilter(feature, '3.5', 'EA2', false)).toBe(true)
+    expect(passesPhaseFilter(feature, '3.5', 'GA', false)).toBe(true)
+    expect(passesPhaseFilter(feature, '3.5', 'EA1', false)).toBe(true)
+  })
+
+  it('inclusive: excludes when all fix versions are for a different phase', function() {
+    var feature = { fixVersions: 'rhoai-3.5.EA1, rhaiis-3.5.EA1' }
+    expect(passesPhaseFilter(feature, '3.5', 'EA2', false)).toBe(false)
+    expect(passesPhaseFilter(feature, '3.5', 'GA', false)).toBe(false)
+  })
+
+  it('inclusive: strict=true still rejects unphased fix versions', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'EA2', true)).toBe(false)
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'GA', true)).toBe(false)
+  })
+
+  it('inclusive: returns false when fixVersions is empty', function() {
+    expect(passesPhaseFilter({ fixVersions: '' }, '3.5', 'EA2', false)).toBe(false)
+    expect(passesPhaseFilter({}, '3.5', 'EA2', false)).toBe(false)
+  })
+
+  it('inclusive: wrong version does not match', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.4' }, '3.5', 'EA2', false)).toBe(false)
+  })
 })

--- a/modules/release-planning/client/utils/phase-filter.js
+++ b/modules/release-planning/client/utils/phase-filter.js
@@ -1,15 +1,4 @@
-/**
- * Client-side phase filter utility.
- *
- * Determines whether a feature should appear in a given phase tab
- * based on its fix version strings. A feature passes the filter when
- * at least one of its fix versions contains both the release version
- * (e.g., "3.5") AND the phase label (e.g., "EA1"), case-insensitively
- * and regardless of separator (dot, dash, space, or none).
- *
- * Features without a matching phase-specific fix version do NOT appear
- * in individual phase tabs — only in the "All Features" view.
- */
+var PHASE_LABELS = ['EA1', 'EA2', 'GA']
 
 function splitCommaString(str) {
   if (!str || typeof str !== 'string') return []
@@ -20,9 +9,14 @@ function splitCommaString(str) {
  * @param {object} feature - Feature object with fixVersions or fixVersion
  * @param {string} version - Release version (e.g., '3.5')
  * @param {string|null} phase - Selected phase (EA1/EA2/GA) or null
+ * @param {boolean} [strict=true] - When true, only match phase-specific fix versions.
+ *   When false (inclusive), also include features whose fix versions match the
+ *   release version but have no phase-specific suffix. Excludes features tagged
+ *   for a different phase.
  * @returns {boolean}
  */
-export function passesPhaseFilter(feature, version, phase) {
+export function passesPhaseFilter(feature, version, phase, strict) {
+  if (strict === undefined) strict = true
   if (!phase) return true
 
   var fixVersionStr = feature.fixVersions || feature.fixVersion || ''
@@ -35,8 +29,19 @@ export function passesPhaseFilter(feature, version, phase) {
 
   for (var i = 0; i < fixVersions.length; i++) {
     var fv = fixVersions[i].toUpperCase()
-    if (fv.indexOf(versionUpper) !== -1 && fv.indexOf(phaseUpper) !== -1) {
-      return true
+    if (fv.indexOf(versionUpper) === -1) continue
+
+    if (fv.indexOf(phaseUpper) !== -1) return true
+
+    if (!strict) {
+      var hasAnyPhase = false
+      for (var j = 0; j < PHASE_LABELS.length; j++) {
+        if (fv.indexOf(PHASE_LABELS[j]) !== -1) {
+          hasAnyPhase = true
+          break
+        }
+      }
+      if (!hasAnyPhase) return true
     }
   }
 

--- a/modules/release-planning/client/views/AuditLogView.vue
+++ b/modules/release-planning/client/views/AuditLogView.vue
@@ -24,7 +24,8 @@ const ACTION_OPTIONS = [
   { value: 'import_doc', label: 'Doc import' },
   { value: 'add_pm', label: 'Added PM' },
   { value: 'remove_pm', label: 'Removed PM' },
-  { value: 'seed', label: 'Seeded data' }
+  { value: 'seed', label: 'Seeded data' },
+  { value: 'committed_list_change', label: 'Committed list change' }
 ]
 
 const ACTION_COLORS = {
@@ -38,7 +39,8 @@ const ACTION_COLORS = {
   import_doc: 'bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400',
   add_pm: 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400',
   remove_pm: 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400',
-  seed: 'bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400'
+  seed: 'bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400',
+  committed_list_change: 'bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400'
 }
 
 function actionColor(action) {

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -7,7 +7,6 @@ import { useAuth } from '@shared/client'
 import { passesPhaseFilter } from '../utils/phase-filter'
 import ReleaseSelector from '../components/ReleaseSelector.vue'
 import MilestoneTimeline from '../components/MilestoneTimeline.vue'
-import HealthSummaryCards from '../components/HealthSummaryCards.vue'
 import HealthFilterBar from '../components/HealthFilterBar.vue'
 import FeatureHealthTable from '../components/FeatureHealthTable.vue'
 
@@ -24,7 +23,7 @@ var { isAdmin } = useAuth()
 var selectedVersion = ref('')
 
 // Phase tabs
-var activePhase = ref('all')
+var activePhase = ref('EA1')
 
 // Filter state
 var bigRockFilter = ref('')
@@ -73,92 +72,46 @@ var enrichmentStatus = computed(function() {
 
 // ─── Phase tabs ───
 
+function isPhaseCommitted(phaseId) {
+  var pf = planningFreezes.value
+  if (!pf) return false
+  var freezeDate = pf[phaseId.toLowerCase()]
+  if (!freezeDate) return false
+  var today = new Date().toISOString().split('T')[0]
+  return today >= freezeDate
+}
+
 var phaseTabs = computed(function() {
-  var tabs = [{ id: 'all', label: 'All Features' }]
+  var tabs = []
   var ms = milestones.value
   if (!ms) return tabs
-  if (ms.ea1Freeze || ms.ea1Target) tabs.push({ id: 'EA1', label: 'EA1' })
-  if (ms.ea2Freeze || ms.ea2Target) tabs.push({ id: 'EA2', label: 'EA2' })
-  if (ms.gaFreeze || ms.gaTarget) tabs.push({ id: 'GA', label: 'GA' })
+  if (ms.ea1Freeze || ms.ea1Target) {
+    tabs.push({ id: 'EA1', label: isPhaseCommitted('EA1') ? 'EA1 Committed' : 'EA1' })
+  }
+  if (ms.ea2Freeze || ms.ea2Target) {
+    tabs.push({ id: 'EA2', label: isPhaseCommitted('EA2') ? 'EA2 Committed' : 'EA2' })
+  }
+  if (ms.gaFreeze || ms.gaTarget) {
+    tabs.push({ id: 'GA', label: isPhaseCommitted('GA') ? 'GA Committed' : 'GA' })
+  }
   return tabs
 })
 
 // ─── Phase-filtered features ───
 
 var phasedFeatures = computed(function() {
-  if (activePhase.value === 'all') return features.value
+  var strict = isPhaseCommitted(activePhase.value)
   return features.value.filter(function(f) {
-    return passesPhaseFilter(f, selectedVersion.value, activePhase.value)
+    return passesPhaseFilter(f, selectedVersion.value, activePhase.value, strict)
   })
-})
-
-// ─── Card counts (computed client-side from phasedFeatures) ───
-
-var cardCounts = computed(function() {
-  var feats = phasedFeatures.value
-  var total = feats.length
-  var ownerAssigned = 0
-  var scopeEstimated = 0
-  var riceComplete = 0
-  var dorComplete = 0
-
-  for (var i = 0; i < feats.length; i++) {
-    var f = feats[i]
-    if (f.deliveryOwner) ownerAssigned++
-    if (f.storyPoints) scopeEstimated++
-    if (f.rice && f.rice.score != null) riceComplete++
-    if (f.dor && f.dor.completionPct >= 80) dorComplete++
-  }
-
-  return {
-    total: total,
-    ownerAssigned: ownerAssigned,
-    scopeEstimated: scopeEstimated,
-    riceComplete: riceComplete,
-    dorComplete: dorComplete
-  }
-})
-
-// ─── Planning deadline (client-side for "all" tab) ───
-
-function daysUntil(dateStr, todayStr) {
-  var d = new Date(dateStr + 'T00:00:00Z')
-  var t = new Date(todayStr + 'T00:00:00Z')
-  return Math.ceil((d - t) / (1000 * 60 * 60 * 24))
-}
-
-var activePlanningDeadline = computed(function() {
-  var pf = planningFreezes.value
-  if (!pf) return null
-
-  var todayStr = new Date().toISOString().split('T')[0]
-
-  if (activePhase.value !== 'all') {
-    var phaseKey = activePhase.value.toLowerCase()
-    var dateStr = pf[phaseKey]
-    if (!dateStr) return null
-    return { date: dateStr, daysRemaining: daysUntil(dateStr, todayStr) }
-  }
-
-  var nearest = null
-  var phases = ['ea1', 'ea2', 'ga']
-  for (var i = 0; i < phases.length; i++) {
-    var ds = pf[phases[i]]
-    if (!ds || ds < todayStr) continue
-    if (!nearest || ds < nearest.date) {
-      nearest = { date: ds, daysRemaining: daysUntil(ds, todayStr) }
-    }
-  }
-
-  return nearest
 })
 
 // ─── Tab feature counts ───
 
 function phaseFeatureCount(tabId) {
-  if (tabId === 'all') return features.value.length
+  var strict = isPhaseCommitted(tabId)
   return features.value.filter(function(f) {
-    return passesPhaseFilter(f, selectedVersion.value, tabId)
+    return passesPhaseFilter(f, selectedVersion.value, tabId, strict)
   }).length
 }
 
@@ -321,7 +274,7 @@ function formatDate(iso) {
 
 watch(selectedVersion, function(newVersion) {
   healthError.value = null
-  activePhase.value = 'all'
+  activePhase.value = 'EA1'
   clearFilters()
   if (newVersion) {
     loadHealth(newVersion)
@@ -436,9 +389,6 @@ onUnmounted(function() {
           </div>
         </div>
       </div>
-
-      <!-- Summary Cards -->
-      <HealthSummaryCards :cardCounts="cardCounts" :planningDeadline="activePlanningDeadline" />
 
       <!-- Filters -->
       <HealthFilterBar

--- a/modules/release-planning/server/health/health-routes.js
+++ b/modules/release-planning/server/health/health-routes.js
@@ -24,6 +24,39 @@ var MAX_NOTES_LENGTH = 2000
 var MAX_REASON_LENGTH = 500
 
 var DEMO_MODE = process.env.DEMO_MODE === 'true'
+var PHASE_LABELS = ['EA1', 'EA2', 'GA']
+
+function getStrictPhaseKeys(features, version, phase) {
+  if (!features || !version || !phase) return []
+  var vUpper = version.toUpperCase()
+  var pUpper = phase.toUpperCase()
+  var keys = []
+  for (var i = 0; i < features.length; i++) {
+    var fvStr = features[i].fixVersions || ''
+    var parts = fvStr.split(',')
+    for (var j = 0; j < parts.length; j++) {
+      var fv = parts[j].trim().toUpperCase()
+      if (fv.indexOf(vUpper) !== -1 && fv.indexOf(pUpper) !== -1) {
+        keys.push(features[i].key)
+        break
+      }
+    }
+  }
+  return keys
+}
+
+function getCommittedPhases(planningFreezes) {
+  if (!planningFreezes) return []
+  var today = new Date().toISOString().split('T')[0]
+  var committed = []
+  for (var i = 0; i < PHASE_LABELS.length; i++) {
+    var freezeDate = planningFreezes[PHASE_LABELS[i].toLowerCase()]
+    if (freezeDate && today >= freezeDate) {
+      committed.push(PHASE_LABELS[i])
+    }
+  }
+  return committed
+}
 
 /**
  * Register health routes on the module router.
@@ -534,6 +567,10 @@ function healthRoutes(router, context) {
     var healthConfig = config.healthConfig || {}
     var timeoutMs = healthConfig.healthRefreshTimeoutMs || 480000
 
+    // Snapshot old cache for committed-list audit
+    var cacheFile = DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json'
+    var oldCache = readFromStorage(cacheFile)
+
     refreshStates.set(stateKey, {
       running: true,
       version: version,
@@ -561,6 +598,40 @@ function healthRoutes(router, context) {
             completedAt: new Date().toISOString()
           }
         })
+
+        // Audit committed list changes
+        try {
+          var newFreezes = result && result.planningFreezes
+          var committed = getCommittedPhases(newFreezes)
+          var oldFeatures = oldCache && oldCache.features ? oldCache.features : []
+          var newFeatures = result && result.features ? result.features : []
+
+          for (var i = 0; i < committed.length; i++) {
+            var cp = committed[i]
+            var oldKeys = getStrictPhaseKeys(oldFeatures, version, cp)
+            var newKeys = getStrictPhaseKeys(newFeatures, version, cp)
+
+            var oldSet = {}
+            for (var a = 0; a < oldKeys.length; a++) oldSet[oldKeys[a]] = true
+            var newSet = {}
+            for (var b = 0; b < newKeys.length; b++) newSet[newKeys[b]] = true
+
+            var added = newKeys.filter(function(k) { return !oldSet[k] })
+            var removed = oldKeys.filter(function(k) { return !newSet[k] })
+
+            if (added.length > 0 || removed.length > 0) {
+              logAudit(readFromStorage, writeToStorage, {
+                version: version,
+                action: 'committed_list_change',
+                user: 'system',
+                summary: 'Committed list changed for ' + cp + ': +' + added.length + ' added, -' + removed.length + ' removed',
+                details: { phase: cp, added: added, removed: removed }
+              })
+            }
+          }
+        } catch (auditErr) {
+          console.error('[health] Failed to audit committed list changes:', auditErr)
+        }
       })
       .catch(function(err) {
         console.error('[health] Background health refresh failed for ' + version + ' phase ' + pk + ':', err)


### PR DESCRIPTION
## Summary
- Remove the "All Features" tab — only EA1, EA2, and GA phase tabs remain
- Phases past their planning freeze date show as "Committed" with strict filtering (only phase-specific fix versions); uncommitted phases use inclusive filtering (features without a phase suffix also appear, excluding those tagged for a different phase)
- Health refreshes audit committed list changes — additions and removals are logged to the audit log with action `committed_list_change`
- Summary cards removed from the dashboard
- 8 new tests for inclusive phase filtering mode

## Test plan
- [x] All 1904 tests pass (19 phase filter tests including 8 new inclusive mode tests)
- [ ] Load Release Health dashboard — confirm only EA1/EA2/GA tabs show (no "All Features")
- [ ] EA1 tab shows "EA1 Committed" label and only features with EA1-specific fix versions
- [ ] EA2/GA tabs show all features for the release version inclusively
- [ ] Summary cards are not displayed
- [ ] Refresh data and check Audit Log for committed list change entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)