### PR TITLE
fix(release-planning): fix EA2/GA inclusive filter and rename Owner column

### DIFF
--- a/modules/release-planning/__tests__/client/phase-filter.test.js
+++ b/modules/release-planning/__tests__/client/phase-filter.test.js
@@ -99,12 +99,12 @@ describe('passesPhaseFilter', function() {
     expect(passesPhaseFilter({ fixVersions: 'rhoai-3.5' }, '3.5', 'GA', true)).toBe(false)
   })
 
-  it('inclusive: returns false when fixVersions is empty', function() {
-    expect(passesPhaseFilter({ fixVersions: '' }, '3.5', 'EA2', false)).toBe(false)
-    expect(passesPhaseFilter({}, '3.5', 'EA2', false)).toBe(false)
+  it('inclusive: passes features with empty or missing fixVersions', function() {
+    expect(passesPhaseFilter({ fixVersions: '' }, '3.5', 'EA2', false)).toBe(true)
+    expect(passesPhaseFilter({}, '3.5', 'EA2', false)).toBe(true)
   })
 
-  it('inclusive: wrong version does not match', function() {
-    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.4' }, '3.5', 'EA2', false)).toBe(false)
+  it('inclusive: passes features with non-matching version (not phase-excluded)', function() {
+    expect(passesPhaseFilter({ fixVersions: 'rhoai-3.4' }, '3.5', 'EA2', false)).toBe(true)
   })
 })

--- a/modules/release-planning/client/components/FeatureHealthTable.vue
+++ b/modules/release-planning/client/components/FeatureHealthTable.vue
@@ -25,7 +25,7 @@ var columns = [
   { key: 'priority', label: 'Priority', sortable: true },
   { key: 'rice', label: 'RICE', sortable: true },
   { key: 'components', label: 'Component', sortable: true },
-  { key: 'owner', label: 'Owner', sortable: true },
+  { key: 'owner', label: 'Delivery Owner', sortable: true },
   { key: 'fixVersions', label: 'Fix Version', sortable: true },
   { key: 'targetRelease', label: 'Target Release', sortable: true }
 ]

--- a/modules/release-planning/client/utils/phase-filter.js
+++ b/modules/release-planning/client/utils/phase-filter.js
@@ -9,10 +9,10 @@ function splitCommaString(str) {
  * @param {object} feature - Feature object with fixVersions or fixVersion
  * @param {string} version - Release version (e.g., '3.5')
  * @param {string|null} phase - Selected phase (EA1/EA2/GA) or null
- * @param {boolean} [strict=true] - When true, only match phase-specific fix versions.
- *   When false (inclusive), also include features whose fix versions match the
- *   release version but have no phase-specific suffix. Excludes features tagged
- *   for a different phase.
+ * @param {boolean} [strict=true] - When true (committed phase), only features
+ *   with a fix version containing both the version AND the phase label pass.
+ *   When false (uncommitted phase), all features pass EXCEPT those exclusively
+ *   tagged for a different phase (e.g., EA1-only features are excluded from EA2).
  * @returns {boolean}
  */
 export function passesPhaseFilter(feature, version, phase, strict) {
@@ -21,29 +21,52 @@ export function passesPhaseFilter(feature, version, phase, strict) {
 
   var fixVersionStr = feature.fixVersions || feature.fixVersion || ''
   var fixVersions = splitCommaString(fixVersionStr)
-
-  if (fixVersions.length === 0) return false
-
   var phaseUpper = phase.toUpperCase()
   var versionUpper = (version || '').toUpperCase()
 
-  for (var i = 0; i < fixVersions.length; i++) {
-    var fv = fixVersions[i].toUpperCase()
-    if (fv.indexOf(versionUpper) === -1) continue
-
-    if (fv.indexOf(phaseUpper) !== -1) return true
-
-    if (!strict) {
-      var hasAnyPhase = false
-      for (var j = 0; j < PHASE_LABELS.length; j++) {
-        if (fv.indexOf(PHASE_LABELS[j]) !== -1) {
-          hasAnyPhase = true
-          break
-        }
+  if (strict) {
+    for (var i = 0; i < fixVersions.length; i++) {
+      var fv = fixVersions[i].toUpperCase()
+      if (fv.indexOf(versionUpper) !== -1 && fv.indexOf(phaseUpper) !== -1) {
+        return true
       }
-      if (!hasAnyPhase) return true
+    }
+    return false
+  }
+
+  // Inclusive mode: exclude features exclusively tagged for a different phase
+  if (fixVersions.length === 0) return true
+
+  var hasMatchingPhase = false
+  var hasDifferentPhase = false
+  var hasUnphased = false
+
+  for (var k = 0; k < fixVersions.length; k++) {
+    var fvk = fixVersions[k].toUpperCase()
+    if (fvk.indexOf(versionUpper) === -1) continue
+
+    if (fvk.indexOf(phaseUpper) !== -1) {
+      hasMatchingPhase = true
+      continue
+    }
+
+    var taggedPhase = false
+    for (var j = 0; j < PHASE_LABELS.length; j++) {
+      if (fvk.indexOf(PHASE_LABELS[j]) !== -1) {
+        taggedPhase = true
+        break
+      }
+    }
+
+    if (taggedPhase) {
+      hasDifferentPhase = true
+    } else {
+      hasUnphased = true
     }
   }
 
-  return false
+  if (hasMatchingPhase) return true
+  if (hasUnphased) return true
+  if (hasDifferentPhase) return false
+  return true
 }


### PR DESCRIPTION
## Summary
- Fix EA2/GA inclusive filter: show all Big Rocks features minus those exclusively tagged for a different committed phase (e.g., EA1). Features with no fix version or no phase-specific suffix now correctly appear.
- Rename "Owner" column to "Delivery Owner" in the health table

## Test plan
- [x] All 1904 tests pass (19 phase filter tests updated for new inclusive behavior)
- [ ] EA2 tab shows all Big Rocks features minus those committed to EA1
- [ ] GA tab shows all Big Rocks features minus those committed to earlier phases
- [ ] Features with no fix version appear in EA2/GA tabs
- [ ] "Delivery Owner" column header displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)