### PR TITLE
feat(release-planning): committed snapshots, visual diff, RICE config, timeline redesign

### DIFF
--- a/modules/release-planning/__tests__/client/health-components.test.js
+++ b/modules/release-planning/__tests__/client/health-components.test.js
@@ -398,11 +398,11 @@ describe('FeatureHealthTable', function() {
     expect(wrapper.text()).not.toContain('Next')
   })
 
-  it('sorts features by health by default (red first)', function() {
+  it('sorts features by priority descending by default (highest first)', function() {
     var wrapper = mount(FeatureHealthTable, { props: { features: features } })
     var rows = wrapper.findAll('tr')
     var firstDataRow = rows.length > 1 ? rows[1].text() : ''
-    expect(firstDataRow).toContain('T-2')
+    expect(firstDataRow).toContain('T-1')
   })
 
   it('has 11 column headers', function() {

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -8,7 +8,9 @@ const props = defineProps({
   feature: { type: Object, required: true },
   expanded: { type: Boolean, default: false },
   canEdit: { type: Boolean, default: false },
-  jiraBaseUrl: { type: String, default: '' }
+  jiraBaseUrl: { type: String, default: '' },
+  isAdded: { type: Boolean, default: false },
+  showChanges: { type: Boolean, default: true }
 })
 
 const emit = defineEmits(['toggle', 'toggleDorItem', 'updateNotes', 'setOverride', 'removeOverride'])
@@ -78,15 +80,6 @@ var priorityScoreClass = computed(function() {
   return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
 })
 
-var priorityTooltip = computed(function() {
-  if (!props.feature.priorityBreakdown) return ''
-  var b = props.feature.priorityBreakdown
-  return 'RICE: ' + b.rice + '% (30w)\n' +
-         'Big Rock: ' + b.bigRock + '% (30w)\n' +
-         'Priority: ' + b.priority + '% (25w)\n' +
-         'Complexity: ' + b.complexity + '% (15w)'
-})
-
 var featureUrl = computed(function() {
   if (props.feature.jiraUrl) return props.feature.jiraUrl
   if (props.jiraBaseUrl && props.feature.key) return props.jiraBaseUrl + '/' + props.feature.key
@@ -115,6 +108,7 @@ var flagSeverityClass = {
   <!-- Main row -->
   <tr
     class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
+    :class="isAdded && showChanges ? 'border-l-4 border-l-green-500 bg-green-50/50 dark:bg-green-500/5' : ''"
     @click="handleToggle"
   >
     <!-- Expand toggle -->
@@ -153,7 +147,9 @@ var flagSeverityClass = {
       </div>
     </td>
     <!-- Summary -->
-    <td class="px-3 py-2 text-gray-900 dark:text-gray-100 max-w-[200px] truncate border border-gray-300 dark:border-gray-600 text-xs">{{ feature.summary }}</td>
+    <td class="px-3 py-2 text-gray-900 dark:text-gray-100 max-w-[300px] border border-gray-300 dark:border-gray-600 text-xs">
+      <span class="line-clamp-2" :title="feature.summary">{{ feature.summary }}</span>
+    </td>
     <!-- Status -->
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
       <StatusBadge :status="feature.status" />
@@ -178,13 +174,23 @@ var flagSeverityClass = {
       </div>
     </td>
     <!-- Priority -->
-    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center" :title="priorityTooltip">
+    <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center relative group/priority">
       <span
         v-if="feature.priorityScore != null"
         class="inline-block px-1.5 py-0.5 rounded text-[10px] font-bold"
         :class="priorityScoreClass"
       >{{ feature.priorityScore }}</span>
       <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
+      <div v-if="feature.priorityBreakdown"
+           class="hidden group-hover/priority:block absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-1 w-44 bg-gray-900 text-white text-[10px] rounded-lg p-2 shadow-lg pointer-events-none">
+        <div class="font-semibold mb-1">Priority Breakdown</div>
+        <div class="space-y-0.5">
+          <div class="flex justify-between"><span>RICE (30w)</span><span>{{ feature.priorityBreakdown.rice }}%</span></div>
+          <div class="flex justify-between"><span>Big Rock (30w)</span><span>{{ feature.priorityBreakdown.bigRock }}%</span></div>
+          <div class="flex justify-between"><span>Priority (25w)</span><span>{{ feature.priorityBreakdown.priority }}%</span></div>
+          <div class="flex justify-between"><span>Complexity (15w)</span><span>{{ feature.priorityBreakdown.complexity }}%</span></div>
+        </div>
+      </div>
     </td>
     <!-- RICE -->
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center" @click.stop>
@@ -219,6 +225,13 @@ var flagSeverityClass = {
 
           <!-- Risk Flags & Details -->
           <div class="space-y-3">
+            <!-- Commitment Status -->
+            <div v-if="isAdded && showChanges" class="bg-green-50 dark:bg-green-500/10 rounded-lg border border-green-200 dark:border-green-500/30 p-3">
+              <div class="text-xs font-semibold text-green-700 dark:text-green-400 mb-1">Added After Commitment</div>
+              <div class="text-xs text-green-600 dark:text-green-400/80">
+                This feature was not in the committed list when the snapshot was taken.
+              </div>
+            </div>
             <!-- Risk flags -->
             <div v-if="riskFlags.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
               <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Risk Flags</div>
@@ -309,6 +322,20 @@ var flagSeverityClass = {
                 <div v-if="feature.tshirtSize">
                   <span class="text-gray-500 dark:text-gray-400">Size:</span>
                   <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.tshirtSize }}</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Version History -->
+            <div v-if="feature.versionHistory && feature.versionHistory.length > 0"
+                 class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+              <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Version History</div>
+              <div class="space-y-1">
+                <div v-for="(change, idx) in feature.versionHistory" :key="idx" class="text-xs text-gray-600 dark:text-gray-400">
+                  <span class="text-gray-400">{{ change.date ? new Date(change.date).toLocaleDateString() : '' }}:</span>
+                  <span v-if="change.from" class="line-through text-red-500 ml-1">{{ change.from }}</span>
+                  <span class="mx-1">&rarr;</span>
+                  <span class="text-green-600">{{ change.to }}</span>
                 </div>
               </div>
             </div>

--- a/modules/release-planning/client/components/FeatureHealthTable.vue
+++ b/modules/release-planning/client/components/FeatureHealthTable.vue
@@ -5,15 +5,18 @@ import FeatureHealthRow from './FeatureHealthRow.vue'
 const props = defineProps({
   features: { type: Array, default: () => [] },
   canEdit: { type: Boolean, default: false },
-  jiraBaseUrl: { type: String, default: '' }
+  jiraBaseUrl: { type: String, default: '' },
+  addedKeys: { type: Set, default: () => new Set() },
+  removedFeatures: { type: Array, default: () => [] },
+  showChanges: { type: Boolean, default: true }
 })
 
 const emit = defineEmits(['toggleDorItem', 'updateNotes', 'setOverride', 'removeOverride'])
 
 var PAGE_SIZE = 50
 var expandedRows = ref({})
-var sortKey = ref('health')
-var sortAsc = ref(true)
+var sortKey = ref('priority')
+var sortAsc = ref(false)
 var currentPage = ref(1)
 
 var columns = [
@@ -174,13 +177,33 @@ function sortIndicator(key) {
               :expanded="!!expandedRows[feature.key]"
               :canEdit="canEdit"
               :jiraBaseUrl="jiraBaseUrl"
+              :isAdded="addedKeys.has(feature.key)"
+              :showChanges="showChanges"
               @toggle="toggleRow"
               @toggleDorItem="handleDorToggle"
               @updateNotes="handleNotesUpdate"
               @removeOverride="handleRemoveOverride"
             />
           </template>
-          <tr v-if="!features || features.length === 0">
+          <template v-if="showChanges && removedFeatures.length > 0">
+            <tr v-for="removed in removedFeatures" :key="removed.key + '-removed'"
+                class="opacity-60 border-l-4 border-l-red-400 bg-red-50/30 dark:bg-red-500/5">
+              <td class="px-2 py-2 border border-gray-300 dark:border-gray-600 w-8"></td>
+              <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+                <span class="font-mono text-xs text-gray-500 line-through">{{ removed.key }}</span>
+              </td>
+              <td class="px-3 py-2 text-gray-500 dark:text-gray-400 max-w-[300px] border border-gray-300 dark:border-gray-600 text-xs line-through">{{ removed.summary }}</td>
+              <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-gray-400">{{ removed.status || '-' }}</td>
+              <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-gray-400">-</td>
+              <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-gray-400">-</td>
+              <td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-gray-400">-</td>
+              <td class="px-3 py-2 text-xs text-gray-400 border border-gray-300 dark:border-gray-600">{{ removed.components || '-' }}</td>
+              <td class="px-3 py-2 text-xs text-gray-400 border border-gray-300 dark:border-gray-600">{{ removed.deliveryOwner || '-' }}</td>
+              <td class="px-3 py-2 text-xs text-gray-400 border border-gray-300 dark:border-gray-600">-</td>
+              <td class="px-3 py-2 text-xs text-gray-400 border border-gray-300 dark:border-gray-600">-</td>
+            </tr>
+          </template>
+          <tr v-if="(!features || features.length === 0) && removedFeatures.length === 0">
             <td colspan="11" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
               No features found matching the current filters.
             </td>

--- a/modules/release-planning/client/components/MilestoneTimeline.vue
+++ b/modules/release-planning/client/components/MilestoneTimeline.vue
@@ -112,13 +112,8 @@ const nextMilestone = computed(function() {
   return null
 })
 
-const NEAR_STEM = 20
-const FAR_STEM = 36
 const CHAR_WIDTH_PCT = 0.6
 const LABEL_GAP_PCT = 1.5
-
-// tier 0 = above-near, 1 = below-near, 2 = above-far, 3 = below-far
-const TIER_PREFERENCE = [0, 1, 2, 3]
 
 function estimateLabelWidthPct(label, dateStr) {
   var chars = Math.max(label.length, dateStr.length)
@@ -129,8 +124,8 @@ const staggeredPoints = computed(function() {
   var points = milestonePoints.value
   if (points.length === 0) return []
 
-  // Track rightmost edge per tier (in % units)
-  var tierEdges = [-Infinity, -Infinity, -Infinity, -Infinity]
+  var aboveEdge = -Infinity
+  var belowEdge = -Infinity
   var result = []
 
   for (var i = 0; i < points.length; i++) {
@@ -138,37 +133,21 @@ const staggeredPoints = computed(function() {
     var halfWidth = estimateLabelWidthPct(points[i].label, points[i].dateStr) / 2
     var leftEdge = pct - halfWidth
 
-    var bestTier = 0
-    for (var t = 0; t < TIER_PREFERENCE.length; t++) {
-      var tier = TIER_PREFERENCE[t]
-      if (leftEdge >= tierEdges[tier] + LABEL_GAP_PCT) {
-        bestTier = tier
-        break
-      }
-    }
+    var preferAbove = (i % 2 === 0)
+    var canAbove = leftEdge >= aboveEdge + LABEL_GAP_PCT
+    var canBelow = leftEdge >= belowEdge + LABEL_GAP_PCT
 
-    tierEdges[bestTier] = pct + halfWidth
+    var band
+    if (preferAbove && canAbove) { band = 'above'; aboveEdge = pct + halfWidth }
+    else if (!preferAbove && canBelow) { band = 'below'; belowEdge = pct + halfWidth }
+    else if (canAbove) { band = 'above'; aboveEdge = pct + halfWidth }
+    else if (canBelow) { band = 'below'; belowEdge = pct + halfWidth }
+    else { band = 'above'; aboveEdge = pct + halfWidth }
 
-    result.push(Object.assign({}, points[i], {
-      pct: pct,
-      tier: bestTier
-    }))
+    result.push(Object.assign({}, points[i], { pct: pct, band: band }))
   }
   return result
 })
-
-function tierIsAbove(tier) {
-  return tier === 0 || tier === 2
-}
-
-function stemHeight(tier) {
-  return (tier === 0 || tier === 1) ? NEAR_STEM : FAR_STEM
-}
-
-function labelOffset(tier) {
-  if (tier === 0 || tier === 1) return 0
-  return NEAR_STEM + 16
-}
 </script>
 
 <template>
@@ -181,23 +160,36 @@ function labelOffset(tier) {
     </div>
 
     <!-- Desktop horizontal timeline -->
-    <div class="hidden sm:block relative mx-4" style="height: 140px">
-      <!-- Track line — centered vertically -->
+    <div class="hidden sm:block relative mx-4" style="height: 80px">
+      <!-- SVG layer for leader lines -->
+      <svg class="absolute inset-0 w-full h-full pointer-events-none">
+        <template v-for="point in staggeredPoints" :key="point.key + '-line'">
+          <line
+            :x1="point.pct + '%'" y1="50%"
+            :x2="point.pct + '%'"
+            :y2="point.band === 'above' ? '20%' : '80%'"
+            class="stroke-gray-300 dark:stroke-gray-500"
+            stroke-width="1"
+            stroke-dasharray="2,2"
+          />
+        </template>
+      </svg>
+
+      <!-- Track line -->
       <div class="absolute left-0 right-0 h-0.5 bg-gray-300 dark:bg-gray-600" style="top: 50%"></div>
 
       <!-- Today marker -->
       <div
         v-if="todayPosition != null"
         class="absolute -translate-x-1/2 z-10"
-        :style="{ left: todayPosition + '%', top: '10%', height: '80%' }"
+        :style="{ left: todayPosition + '%', top: '15%', height: '70%' }"
       >
         <div class="w-px h-full bg-red-400/40 dark:bg-red-400/30 mx-auto"></div>
-        <div class="text-[10px] font-medium text-red-600 dark:text-red-400 mt-0.5 whitespace-nowrap text-center -translate-x-1/4">Today</div>
+        <div class="text-[10px] font-medium text-red-600 dark:text-red-400 whitespace-nowrap text-center">Today</div>
       </div>
 
-      <!-- Milestone points -->
-      <template v-for="point in staggeredPoints" :key="point.key">
-        <!-- Dot — always on the track -->
+      <!-- Dots on track -->
+      <template v-for="point in staggeredPoints" :key="point.key + '-dot'">
         <div
           class="absolute -translate-x-1/2 -translate-y-1/2 z-[5]"
           :style="{ left: point.pct + '%', top: '50%' }"
@@ -208,31 +200,21 @@ function labelOffset(tier) {
             :title="point.longLabel + ' — ' + point.dateStr"
           ></div>
         </div>
+      </template>
 
-        <!-- Label above -->
-        <div
-          v-if="tierIsAbove(point.tier)"
-          class="absolute -translate-x-1/2 text-center flex flex-col items-center"
-          :style="{ left: point.pct + '%', bottom: '50%' }"
-        >
-          <div :style="{ marginBottom: labelOffset(point.tier) + 'px' }">
-            <div class="text-[10px] text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ point.label }}</div>
-            <div class="text-[10px] font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ point.dateStr }}</div>
-          </div>
-          <div class="w-px bg-gray-300 dark:bg-gray-500 mt-0.5" :style="{ height: stemHeight(point.tier) + 'px' }"></div>
+      <!-- Labels -->
+      <template v-for="point in staggeredPoints" :key="point.key + '-label'">
+        <div v-if="point.band === 'above'"
+             class="absolute -translate-x-1/2 text-center"
+             :style="{ left: point.pct + '%', top: '0' }">
+          <div class="text-[10px] text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ point.label }}</div>
+          <div class="text-[10px] font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ point.dateStr }}</div>
         </div>
-
-        <!-- Label below -->
-        <div
-          v-else
-          class="absolute -translate-x-1/2 text-center flex flex-col items-center"
-          :style="{ left: point.pct + '%', top: '50%' }"
-        >
-          <div class="w-px bg-gray-300 dark:bg-gray-500 mb-0.5" :style="{ height: stemHeight(point.tier) + 'px' }"></div>
-          <div :style="{ marginTop: labelOffset(point.tier) + 'px' }">
-            <div class="text-[10px] text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ point.label }}</div>
-            <div class="text-[10px] font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ point.dateStr }}</div>
-          </div>
+        <div v-else
+             class="absolute -translate-x-1/2 text-center"
+             :style="{ left: point.pct + '%', bottom: '0' }">
+          <div class="text-[10px] font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ point.dateStr }}</div>
+          <div class="text-[10px] text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ point.label }}</div>
         </div>
       </template>
     </div>

--- a/modules/release-planning/client/components/RiceFieldConfig.vue
+++ b/modules/release-planning/client/components/RiceFieldConfig.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useReleaseHealth } from '../composables/useReleaseHealth'
 
 var { searchJiraFields, loadRiceConfig, saveRiceConfig } = useReleaseHealth()
@@ -41,6 +41,10 @@ onMounted(async function() {
   } catch {
     // Config not available
   }
+})
+
+onUnmounted(function() {
+  if (searchDebounce) clearTimeout(searchDebounce)
 })
 
 function startSearch(fieldKey) {

--- a/modules/release-planning/client/components/RiceFieldConfig.vue
+++ b/modules/release-planning/client/components/RiceFieldConfig.vue
@@ -1,0 +1,169 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useReleaseHealth } from '../composables/useReleaseHealth'
+
+var { searchJiraFields, loadRiceConfig, saveRiceConfig } = useReleaseHealth()
+
+var enableRice = ref(false)
+var fields = ref({
+  riceReach: { id: '', name: '' },
+  riceImpact: { id: '', name: '' },
+  riceConfidence: { id: '', name: '' },
+  riceEffort: { id: '', name: '' }
+})
+
+var activeSearch = ref(null)
+var searchQuery = ref('')
+var searchResults = ref([])
+var searching = ref(false)
+var saving = ref(false)
+var saveMessage = ref('')
+var searchDebounce = null
+
+var RICE_FIELDS = [
+  { key: 'riceReach', label: 'Reach' },
+  { key: 'riceImpact', label: 'Impact' },
+  { key: 'riceConfidence', label: 'Confidence' },
+  { key: 'riceEffort', label: 'Effort' }
+]
+
+onMounted(async function() {
+  try {
+    var config = await loadRiceConfig()
+    enableRice.value = !!config.enableRice
+    var ids = config.customFieldIds || {}
+    for (var i = 0; i < RICE_FIELDS.length; i++) {
+      var k = RICE_FIELDS[i].key
+      if (ids[k]) {
+        fields.value[k] = { id: ids[k], name: ids[k] }
+      }
+    }
+  } catch {
+    // Config not available
+  }
+})
+
+function startSearch(fieldKey) {
+  activeSearch.value = fieldKey
+  searchQuery.value = ''
+  searchResults.value = []
+}
+
+function cancelSearch() {
+  activeSearch.value = null
+  searchQuery.value = ''
+  searchResults.value = []
+}
+
+function handleSearchInput() {
+  if (searchDebounce) clearTimeout(searchDebounce)
+  if (searchQuery.value.length < 2) {
+    searchResults.value = []
+    return
+  }
+  searchDebounce = setTimeout(async function() {
+    searching.value = true
+    try {
+      var result = await searchJiraFields(searchQuery.value)
+      searchResults.value = result.fields || []
+    } catch {
+      searchResults.value = []
+    } finally {
+      searching.value = false
+    }
+  }, 300)
+}
+
+function selectField(field) {
+  if (activeSearch.value) {
+    fields.value[activeSearch.value] = { id: field.id, name: field.name }
+  }
+  cancelSearch()
+}
+
+async function handleSave() {
+  saving.value = true
+  saveMessage.value = ''
+  try {
+    var fieldIds = {}
+    for (var i = 0; i < RICE_FIELDS.length; i++) {
+      var k = RICE_FIELDS[i].key
+      fieldIds[k] = fields.value[k].id || ''
+    }
+    await saveRiceConfig(fieldIds, enableRice.value)
+    saveMessage.value = 'Saved'
+    setTimeout(function() { saveMessage.value = '' }, 3000)
+  } catch (err) {
+    saveMessage.value = 'Error: ' + (err.message || 'Save failed')
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="flex items-center gap-3">
+      <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+        <input type="checkbox" v-model="enableRice" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+        Enable RICE Scoring
+      </label>
+      <span v-if="enableRice" class="text-xs text-green-600 dark:text-green-400">Active</span>
+      <span v-else class="text-xs text-gray-400">Disabled</span>
+    </div>
+
+    <div v-if="enableRice" class="space-y-3">
+      <div v-for="rf in RICE_FIELDS" :key="rf.key" class="flex items-center gap-3">
+        <span class="text-xs font-medium text-gray-600 dark:text-gray-400 w-24">{{ rf.label }}</span>
+        <div class="flex-1 relative">
+          <div v-if="activeSearch !== rf.key" class="flex items-center gap-2">
+            <span v-if="fields[rf.key].id" class="text-xs bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-gray-700 dark:text-gray-300">
+              {{ fields[rf.key].name || fields[rf.key].id }}
+            </span>
+            <span v-else class="text-xs text-gray-400">Not configured</span>
+            <button @click="startSearch(rf.key)" class="text-xs text-primary-600 dark:text-primary-400 hover:underline">
+              {{ fields[rf.key].id ? 'Change' : 'Search' }}
+            </button>
+          </div>
+          <div v-else class="space-y-1">
+            <div class="flex items-center gap-2">
+              <input
+                v-model="searchQuery"
+                @input="handleSearchInput"
+                placeholder="Search Jira fields..."
+                class="flex-1 text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                autofocus
+              />
+              <button @click="cancelSearch" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">Cancel</button>
+            </div>
+            <div v-if="searching" class="text-xs text-gray-400 px-1">Searching...</div>
+            <div v-if="searchResults.length > 0" class="max-h-32 overflow-y-auto border border-gray-200 dark:border-gray-600 rounded bg-white dark:bg-gray-800">
+              <button
+                v-for="f in searchResults" :key="f.id"
+                @click="selectField(f)"
+                class="w-full text-left px-2 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-700 border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+              >
+                <div class="font-medium text-gray-900 dark:text-gray-100">{{ f.name }}</div>
+                <div class="text-gray-400">{{ f.id }} ({{ f.type }})</div>
+              </button>
+            </div>
+            <div v-if="searchQuery.length >= 2 && !searching && searchResults.length === 0" class="text-xs text-gray-400 px-1">
+              No matching fields found
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button
+        @click="handleSave"
+        :disabled="saving"
+        class="px-3 py-1.5 text-xs font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50"
+      >{{ saving ? 'Saving...' : 'Save RICE Config' }}</button>
+      <span v-if="saveMessage" class="text-xs" :class="saveMessage.startsWith('Error') ? 'text-red-600' : 'text-green-600'">
+        {{ saveMessage }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/modules/release-planning/client/composables/useReleaseHealth.js
+++ b/modules/release-planning/client/composables/useReleaseHealth.js
@@ -116,6 +116,29 @@ export function useReleaseHealth() {
     }
   }
 
+  async function searchJiraFields(query) {
+    return apiRequest(API_BASE + '/releases/health-admin/jira-fields?query=' + encodeURIComponent(query))
+  }
+
+  async function loadRiceConfig() {
+    return apiRequest(API_BASE + '/releases/health-admin/config')
+  }
+
+  async function saveRiceConfig(fieldIds, enableRice) {
+    return apiRequest(API_BASE + '/releases/health-admin/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ riceFieldIds: fieldIds, enableRice: enableRice })
+    })
+  }
+
+  async function createSnapshot(version, phase) {
+    return apiRequest(
+      API_BASE + '/releases/' + encodeURIComponent(version) + '/health/snapshot/' + encodeURIComponent(phase),
+      { method: 'POST' }
+    )
+  }
+
   return {
     healthData: healthData,
     healthLoading: healthLoading,
@@ -127,6 +150,10 @@ export function useReleaseHealth() {
     setRiskOverride: setRiskOverride,
     removeRiskOverride: removeRiskOverride,
     triggerHealthRefresh: triggerHealthRefresh,
-    checkHealthRefreshStatus: checkHealthRefreshStatus
+    checkHealthRefreshStatus: checkHealthRefreshStatus,
+    createSnapshot: createSnapshot,
+    searchJiraFields: searchJiraFields,
+    loadRiceConfig: loadRiceConfig,
+    saveRiceConfig: saveRiceConfig
   }
 }

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -9,11 +9,13 @@ import ReleaseSelector from '../components/ReleaseSelector.vue'
 import MilestoneTimeline from '../components/MilestoneTimeline.vue'
 import HealthFilterBar from '../components/HealthFilterBar.vue'
 import FeatureHealthTable from '../components/FeatureHealthTable.vue'
+import RiceFieldConfig from '../components/RiceFieldConfig.vue'
 
 var {
   healthData, healthLoading, healthError, healthRefreshing, healthCacheStale,
   loadHealth, triggerHealthRefresh, checkHealthRefreshStatus,
-  removeRiskOverride: removeRiskOverrideApi
+  removeRiskOverride: removeRiskOverrideApi,
+  createSnapshot
 } = useReleaseHealth()
 
 var { toggleItem, updateNotes, cancelAll: cancelDorPending } = useDorChecklist()
@@ -24,6 +26,9 @@ var selectedVersion = ref('')
 
 // Phase tabs
 var activePhase = ref('EA1')
+
+// Admin settings
+var showRiceConfig = ref(false)
 
 // Filter state
 var bigRockFilter = ref('')
@@ -105,6 +110,45 @@ var phasedFeatures = computed(function() {
     return passesPhaseFilter(f, selectedVersion.value, activePhase.value, strict)
   })
 })
+
+// ─── Committed snapshot + visual diff ───
+
+var showChanges = ref(true)
+
+var committedSnapshot = computed(function() {
+  if (!healthData.value || !healthData.value.committedSnapshots) return null
+  return healthData.value.committedSnapshots[activePhase.value] || null
+})
+
+var addedFeatureKeys = computed(function() {
+  var snap = committedSnapshot.value
+  if (!snap || !isPhaseCommitted(activePhase.value)) return new Set()
+  var snapKeys = new Set(snap.featureKeys)
+  var added = new Set()
+  for (var i = 0; i < phasedFeatures.value.length; i++) {
+    if (!snapKeys.has(phasedFeatures.value[i].key)) {
+      added.add(phasedFeatures.value[i].key)
+    }
+  }
+  return added
+})
+
+var removedFeatures = computed(function() {
+  var snap = committedSnapshot.value
+  if (!snap || !isPhaseCommitted(activePhase.value)) return []
+  if (!snap.features) return []
+  var currentKeys = new Set(phasedFeatures.value.map(function(f) { return f.key }))
+  return snap.features.filter(function(f) { return !currentKeys.has(f.key) })
+})
+
+function handleResnapshot() {
+  if (!selectedVersion.value || !activePhase.value) return
+  createSnapshot(selectedVersion.value, activePhase.value).then(function() {
+    loadHealth(selectedVersion.value)
+  }).catch(function(err) {
+    healthError.value = err.message || 'Failed to create snapshot'
+  })
+}
 
 // ─── Tab feature counts ───
 
@@ -318,7 +362,24 @@ onUnmounted(function() {
         >
           {{ healthRefreshing ? 'Refreshing...' : 'Refresh' }}
         </button>
+        <button
+          v-if="canEdit"
+          @click="showRiceConfig = !showRiceConfig"
+          :title="showRiceConfig ? 'Hide RICE settings' : 'RICE settings'"
+          class="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 rounded"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
       </div>
+    </div>
+
+    <!-- RICE Configuration (admin only) -->
+    <div v-if="showRiceConfig && canEdit" class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+      <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">RICE Configuration</h3>
+      <RiceFieldConfig />
     </div>
 
     <!-- Demo mode banner -->
@@ -390,6 +451,41 @@ onUnmounted(function() {
         </div>
       </div>
 
+      <!-- Committed snapshot info -->
+      <div v-if="committedSnapshot && isPhaseCommitted(activePhase)" class="flex items-center gap-3 flex-wrap">
+        <span class="text-xs text-gray-500 dark:text-gray-400">
+          Committed {{ committedSnapshot.featureCount }} features on {{ formatDate(committedSnapshot.snapshotAt) }}
+        </span>
+        <label class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-pointer">
+          <input type="checkbox" v-model="showChanges" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+          Show changes since commit
+        </label>
+        <button v-if="canEdit" @click="handleResnapshot" class="text-xs text-primary-600 dark:text-primary-400 hover:underline">
+          Re-snapshot
+        </button>
+      </div>
+
+      <!-- Changes since commitment summary -->
+      <div v-if="committedSnapshot && isPhaseCommitted(activePhase) && showChanges && (addedFeatureKeys.size > 0 || removedFeatures.length > 0)"
+           class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+          Changes Since Commitment
+        </h3>
+        <div class="flex gap-6 text-sm">
+          <div v-if="addedFeatureKeys.size > 0" class="flex items-center gap-1.5">
+            <span class="w-2 h-2 rounded-full bg-green-500"></span>
+            <span class="text-gray-600 dark:text-gray-400">{{ addedFeatureKeys.size }} added</span>
+          </div>
+          <div v-if="removedFeatures.length > 0" class="flex items-center gap-1.5">
+            <span class="w-2 h-2 rounded-full bg-red-500"></span>
+            <span class="text-gray-600 dark:text-gray-400">{{ removedFeatures.length }} removed</span>
+          </div>
+          <div class="text-gray-500 dark:text-gray-400">
+            {{ phasedFeatures.length }} current (was {{ committedSnapshot.featureCount }})
+          </div>
+        </div>
+      </div>
+
       <!-- Filters -->
       <HealthFilterBar
         v-model:bigRockFilter="bigRockFilter"
@@ -406,6 +502,9 @@ onUnmounted(function() {
         :features="filteredFeatures"
         :canEdit="canEdit"
         :jiraBaseUrl="jiraBaseUrl"
+        :addedKeys="addedFeatureKeys"
+        :removedFeatures="removedFeatures"
+        :showChanges="showChanges"
         @toggleDorItem="handleDorToggle"
         @updateNotes="handleNotesUpdate"
         @removeOverride="handleRemoveOverride"

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -716,6 +716,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       rice: riceResult,
       storyPoints: enrichment ? enrichment.storyPoints || null : null,
       tshirtSize: enrichment ? enrichment.tshirtSize || null : null,
+      versionHistory: enrichment && enrichment.refinementHistory ? enrichment.refinementHistory : [],
       jiraUrl: JIRA_BROWSE_URL + '/' + key
     })
   }

--- a/modules/release-planning/server/health/health-routes.js
+++ b/modules/release-planning/server/health/health-routes.js
@@ -585,7 +585,7 @@ function healthRoutes(router, context) {
 
     writeToStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json', snapshotData)
 
-    var user = req.headers['x-forwarded-email'] || 'unknown'
+    var user = req.userEmail || 'unknown'
     logAudit(readFromStorage, writeToStorage, {
       version: version,
       action: 'committed_snapshot',

--- a/modules/release-planning/server/health/health-routes.js
+++ b/modules/release-planning/server/health/health-routes.js
@@ -11,7 +11,8 @@
 
 const { getConfig } = require('../config')
 const { CACHE_MAX_AGE_MS, MANUAL_DOR_IDS, DOR_ITEM_IDS, VALID_PHASES } = require('../constants')
-const { runHealthPipeline } = require('./health-pipeline')
+const { runHealthPipeline, loadMilestones, backfillFreezeDatesFromSmartsheet, deriveFreezeDates } = require('./health-pipeline')
+const smartsheetClient = require('../../../../shared/server/smartsheet')
 const { DOR_ITEMS } = require('./dor-checker')
 const { logAudit } = require('../audit-log')
 const { jiraRequest, fetchAllJqlResults } = require('../../../../shared/server/jira')
@@ -137,9 +138,24 @@ function healthRoutes(router, context) {
         triggerHealthRefresh(version, phase)
       }
 
+      var snapshots = {}
+      for (var si = 0; si < PHASE_LABELS.length; si++) {
+        var snap = readFromStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + PHASE_LABELS[si] + '.json')
+        if (snap) {
+          snapshots[PHASE_LABELS[si]] = {
+            snapshotAt: snap.snapshotAt,
+            featureKeys: snap.featureKeys,
+            featureCount: snap.featureKeys.length,
+            trigger: snap.snapshotTrigger,
+            features: snap.features || []
+          }
+        }
+      }
+
       return sendJsonWithETag(req, res, Object.assign({}, cached, {
         _cacheStale: isStale,
-        _refreshing: getHealthRefreshState(version, phase).running
+        _refreshing: getHealthRefreshState(version, phase).running,
+        committedSnapshots: snapshots
       }))
     }
 
@@ -506,6 +522,81 @@ function healthRoutes(router, context) {
     res.json({ featureKey: featureKey, removed: true })
   })
 
+  // ─── GET /releases/:version/health/snapshot/:phase ───
+
+  router.get('/releases/:version/health/snapshot/:phase', requireAuth, function(req, res) {
+    var version = req.params.version
+    var phase = (req.params.phase || '').toUpperCase()
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (PHASE_LABELS.indexOf(phase) === -1) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + PHASE_LABELS.join(', ') })
+    }
+
+    var snap = readFromStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json')
+    if (!snap) {
+      return res.status(404).json({ error: 'No committed snapshot found for ' + version + ' ' + phase })
+    }
+
+    res.json(snap)
+  })
+
+  // ─── POST /releases/:version/health/snapshot/:phase ───
+
+  router.post('/releases/:version/health/snapshot/:phase', requirePM, function(req, res) {
+    var version = req.params.version
+    var phase = (req.params.phase || '').toUpperCase()
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+    if (PHASE_LABELS.indexOf(phase) === -1) {
+      return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + PHASE_LABELS.join(', ') })
+    }
+
+    var pk = phaseKey(null)
+    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    if (!cached || !cached.features) {
+      return res.status(404).json({ error: 'No health cache available. Run a health refresh first.' })
+    }
+
+    var snapshotKeys = getStrictPhaseKeys(cached.features, version, phase)
+    var snapshotFeatures = []
+    for (var i = 0; i < cached.features.length; i++) {
+      if (snapshotKeys.indexOf(cached.features[i].key) !== -1) {
+        snapshotFeatures.push({
+          key: cached.features[i].key,
+          summary: cached.features[i].summary,
+          status: cached.features[i].status,
+          components: cached.features[i].components,
+          deliveryOwner: cached.features[i].deliveryOwner
+        })
+      }
+    }
+
+    var snapshotData = {
+      version: version,
+      phase: phase,
+      snapshotAt: new Date().toISOString(),
+      snapshotTrigger: 'manual',
+      featureKeys: snapshotKeys,
+      features: snapshotFeatures
+    }
+
+    writeToStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json', snapshotData)
+
+    var user = req.headers['x-forwarded-email'] || 'unknown'
+    logAudit(readFromStorage, writeToStorage, {
+      version: version,
+      action: 'committed_snapshot',
+      user: user,
+      summary: 'Manual committed snapshot for ' + phase + ' with ' + snapshotKeys.length + ' features',
+      details: { phase: phase, featureCount: snapshotKeys.length, trigger: 'manual' }
+    })
+
+    res.json({ phase: phase, featureCount: snapshotKeys.length, snapshotAt: snapshotData.snapshotAt })
+  })
+
   // ─── POST /releases/:version/health/refresh ───
 
   router.post('/releases/:version/health/refresh', requirePM, function(req, res) {
@@ -632,6 +723,57 @@ function healthRoutes(router, context) {
         } catch (auditErr) {
           console.error('[health] Failed to audit committed list changes:', auditErr)
         }
+
+        // Auto-snapshot: on first health refresh at/after planning freeze
+        try {
+          var snapFreezes = result && result.planningFreezes
+          if (snapFreezes) {
+            for (var si = 0; si < PHASE_LABELS.length; si++) {
+              var sp = PHASE_LABELS[si]
+              var freezeDate = snapFreezes[sp.toLowerCase()]
+              if (!freezeDate) continue
+              var todayStr = new Date().toISOString().split('T')[0]
+              if (todayStr < freezeDate) continue
+
+              var snapshotKey = DATA_PREFIX + '/committed-snapshot-' + version + '-' + sp + '.json'
+              var existingSnapshot = readFromStorage(snapshotKey)
+              if (existingSnapshot) continue
+
+              var snapshotKeys = getStrictPhaseKeys(newFeatures, version, sp)
+              var snapshotFeatures = []
+              for (var sf = 0; sf < newFeatures.length; sf++) {
+                if (snapshotKeys.indexOf(newFeatures[sf].key) !== -1) {
+                  snapshotFeatures.push({
+                    key: newFeatures[sf].key,
+                    summary: newFeatures[sf].summary,
+                    status: newFeatures[sf].status,
+                    components: newFeatures[sf].components,
+                    deliveryOwner: newFeatures[sf].deliveryOwner
+                  })
+                }
+              }
+
+              writeToStorage(snapshotKey, {
+                version: version,
+                phase: sp,
+                snapshotAt: new Date().toISOString(),
+                snapshotTrigger: 'auto',
+                featureKeys: snapshotKeys,
+                features: snapshotFeatures
+              })
+
+              logAudit(readFromStorage, writeToStorage, {
+                version: version,
+                action: 'committed_snapshot',
+                user: 'system',
+                summary: 'Auto-created committed snapshot for ' + sp + ' with ' + snapshotKeys.length + ' features',
+                details: { phase: sp, featureCount: snapshotKeys.length }
+              })
+            }
+          }
+        } catch (snapErr) {
+          console.error('[health] Failed to create committed snapshot:', snapErr)
+        }
       })
       .catch(function(err) {
         console.error('[health] Background health refresh failed for ' + version + ' phase ' + pk + ':', err)
@@ -647,6 +789,132 @@ function healthRoutes(router, context) {
         })
       })
   }
+
+  // ─── RICE admin: Jira field search ───
+
+  var FIELD_CACHE_KEY = DATA_PREFIX + '/jira-field-list-cache.json'
+  var FIELD_CACHE_TTL_MS = 60 * 60 * 1000
+
+  async function getCachedFieldList() {
+    var cached = readFromStorage(FIELD_CACHE_KEY)
+    if (cached && cached.fetchedAt) {
+      var age = Date.now() - new Date(cached.fetchedAt).getTime()
+      if (age < FIELD_CACHE_TTL_MS) return cached.fields
+    }
+    var fields = await jiraRequest('/rest/api/3/field')
+    writeToStorage(FIELD_CACHE_KEY, { fetchedAt: new Date().toISOString(), fields: fields })
+    return fields
+  }
+
+  router.get('/releases/health-admin/jira-fields', requirePM, async function(req, res) {
+    var query = (req.query.query || '').toLowerCase()
+    if (!query || query.length < 2) {
+      return res.status(400).json({ error: 'Query must be at least 2 characters' })
+    }
+
+    try {
+      var allFields = await getCachedFieldList()
+
+      var matches = allFields.filter(function(f) {
+        if (!f.custom) return false
+        var name = (f.name || '').toLowerCase()
+        var id = (f.id || '').toLowerCase()
+        return name.indexOf(query) !== -1 || id.indexOf(query) !== -1
+      }).slice(0, 50).map(function(f) {
+        return {
+          id: f.id,
+          name: f.name,
+          description: f.description || '',
+          type: f.schema ? f.schema.type : 'unknown'
+        }
+      })
+
+      res.json({ fields: matches, total: matches.length })
+    } catch (err) {
+      console.error('[health] Jira field search failed:', err.message)
+      res.status(500).json({ error: 'Failed to search Jira fields: ' + err.message })
+    }
+  })
+
+  // ─── RICE admin: save config ───
+
+  router.put('/releases/health-admin/config', requirePM, function(req, res) {
+    var config = getConfig(readFromStorage)
+
+    if (req.body.riceFieldIds) {
+      var ids = req.body.riceFieldIds
+      config.customFieldIds = Object.assign({}, config.customFieldIds, {
+        riceReach: ids.riceReach || config.customFieldIds.riceReach || '',
+        riceImpact: ids.riceImpact || config.customFieldIds.riceImpact || '',
+        riceConfidence: ids.riceConfidence || config.customFieldIds.riceConfidence || '',
+        riceEffort: ids.riceEffort || config.customFieldIds.riceEffort || ''
+      })
+    }
+
+    if (req.body.enableRice !== undefined) {
+      config.healthConfig = Object.assign({}, config.healthConfig, {
+        enableRice: !!req.body.enableRice
+      })
+    }
+
+    writeToStorage('release-planning/config.json', config)
+    res.json({ saved: true, customFieldIds: config.customFieldIds, enableRice: config.healthConfig ? config.healthConfig.enableRice : false })
+  })
+
+  // ─── RICE admin: get config ───
+
+  router.get('/releases/health-admin/config', requirePM, function(req, res) {
+    var config = getConfig(readFromStorage)
+    res.json({
+      customFieldIds: config.customFieldIds || {},
+      enableRice: config.healthConfig ? !!config.healthConfig.enableRice : false
+    })
+  })
+
+  // ─── GET /releases/:version/health/milestones/debug ───
+
+  router.get('/releases/:version/health/milestones/debug', requirePM, async function(req, res) {
+    var version = req.params.version
+    if (!isValidVersion(version)) {
+      return res.status(400).json({ error: 'Invalid version format' })
+    }
+
+    try {
+      var ppCache = readFromStorage('release-analysis/product-pages-releases-cache.json')
+      var ppEntries = []
+      if (ppCache && ppCache.releases) {
+        ppEntries = ppCache.releases.filter(function(r) {
+          return (r.releaseNumber || '').indexOf(version) !== -1
+        })
+      }
+
+      var ssData = null
+      if (smartsheetClient.isConfigured()) {
+        try {
+          var releases = await smartsheetClient.discoverReleasesPartial()
+          ssData = releases.filter(function(r) { return r.version === version })
+        } catch (err) {
+          ssData = { error: err.message }
+        }
+      }
+
+      var derived = loadMilestones(readFromStorage, version)
+      var backfilled = await backfillFreezeDatesFromSmartsheet(derived, version)
+      var final = deriveFreezeDates(backfilled.milestones)
+
+      res.json({
+        version: version,
+        productPages: ppEntries,
+        smartsheet: ssData,
+        afterLoadMilestones: derived,
+        afterBackfill: { milestones: backfilled.milestones, warnings: backfilled.warnings },
+        afterDerive: { milestones: final.milestones, warnings: final.warnings }
+      })
+    } catch (err) {
+      console.error('[health] Milestones debug failed:', err)
+      res.status(500).json({ error: 'Debug endpoint failed: ' + err.message })
+    }
+  })
 }
 
 module.exports = healthRoutes


### PR DESCRIPTION
## Summary

- **Committed snapshots**: Auto-snapshot on first health refresh after planning freeze + manual admin re-snapshot endpoint. Snapshot data included in health response for visual diff
- **Visual diff**: Added features show green left border/tint; removed features rendered as strikethrough rows at bottom of table. "Changes Since Commitment" summary card with added/removed counts. Toggle (ON by default) to show/hide changes
- **Priority UX**: Default sort changed to priority descending. Styled popover on hover shows weight breakdown (RICE 30w, Big Rock 30w, Priority 25w, Complexity 15w). Summary column wraps to 2 lines instead of truncating
- **RICE field discovery**: Admin UI to search Jira custom fields, map RICE fields (Reach/Impact/Confidence/Effort), and save config. Storage-backed field list cache. Routes under `/releases/health-admin/` to avoid `/:version` conflicts
- **Timeline redesign**: 2-band above/below layout with dashed SVG leader lines, reduced from 140px to 80px height
- **Date investigation**: Debug endpoint at `/releases/:version/health/milestones/debug` dumps raw milestone data chain (Product Pages → Smartsheet → derived)
- **Version history**: `versionHistory` field added to health cache features from Jira changelog (Pass 2 features), displayed in expanded row

## Test plan

- [x] All 1904 tests pass (677 release-planning, 123 test files total)
- [x] ESLint clean on all changed files
- [ ] Verify EA1 Committed tab shows added (green) and removed (strikethrough) features with test snapshot
- [ ] Verify "Changes Since Commitment" summary card appears
- [ ] Verify "Show changes since commit" toggle hides/shows diff styling
- [ ] Verify priority popover appears on hover
- [ ] Verify summary column wraps to 2 lines
- [ ] Verify timeline height reduced with 2-band layout
- [ ] Verify RICE config panel opens via gear icon (admin only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)