### PR TITLE
docs: add architecture design documents

### DIFF
--- a/design/2026-04-22-release-planning-proposal.md
+++ b/design/2026-04-22-release-planning-proposal.md
@@ -1,0 +1,876 @@
+# AI Engineering Release Planning: Operational Proposal
+
+**Author:** Planning Domain Owners
+**Date:** 2026-04-22
+**Status:** Draft for VP review
+**Audience:** VP (approval), AI Engineering leadership, PgMs, Agilists
+
+---
+
+## Part 1: Executive Summary
+
+### The Problem
+
+AI Engineering ships quarterly releases of RHOAI, with three releases in flight at any time: one being planned, one being executed, and one being released. This cadence demands disciplined coordination across dozens of teams, hundreds of features, and multiple stakeholder groups. Today, that coordination relies heavily on tribal knowledge, informal handoffs, and manual tracking.
+
+Three systemic issues undermine our ability to deliver predictably:
+
+**Teams over-commit and descope late.** Big Rocks and features are committed into releases without validating them against team capacity. When reality catches up mid-cycle, features get descoped, which cascades into customer disappointment and cross-team rework. There is no mechanism to compare what we are committing against what teams can realistically deliver. The "commit" moment itself is undefined -- there is no formal gate between planning and execution, so scope creeps in after the plan is nominally locked.
+
+**Lack of visibility creates drift.** Once a release enters execution, there is no consistent way to track whether the committed scope is on track. Cross-team and cross-domain dependencies are not systematically identified or tracked. When one team slips, downstream teams learn late. The operating model document identifies Execution as a separate domain, but without a clear handoff from Planning, Execution inherits an ambiguous scope baseline.
+
+**Quality and readiness gaps persist.** Work is committed before it meets a Definition of Ready -- requirements are incomplete, dependencies are unresolved, and acceptance criteria are missing. This pushes refinement into the execution phase, consuming sprint capacity that was budgeted for delivery. The Definition of Ready exists as a concept but is not enforced through any workflow gate, Jira automation, or review ceremony.
+
+### The Proposed Solution
+
+This proposal defines the operational mechanics of the **Planning domain** -- the first of the three control domains in the operating model. It establishes:
+
+1. A **planning lifecycle** with named phases, ceremonies, and deadlines tied to the quarterly release calendar
+2. A **Definition of Ready enforcement model** with Jira workflow gates and review ceremonies
+3. A **capacity alignment process** that validates Big Rock commitments against historical team throughput data
+4. A **dependency management system** using Jira links and a dedicated tracking view
+5. A **formal commit gate** -- the ceremony that transitions a release from Planning to Execution
+
+The proposal maps each need against existing tooling in the People & Teams platform (release-planning, feature-traffic, release-analysis, team-tracker, allocation-tracker modules) and identifies specific gaps to close. It is honest about data limitations -- notably that capacity signals are directional estimates (not precise sprint velocity), that several pipeline extensions are needed before automated checks work, and that cross-module data access requires architectural care.
+
+### Key Decisions Needed
+
+1. **Adopt the commit gate ceremony?** Should we formalize a "Planning Complete" review as the handoff point to Execution, with authority to reject uncommitted work?
+2. **Enforce DoR via Jira workflow?** Should we add a Jira workflow transition validator that blocks features from moving to "Committed" without meeting DoR criteria, or use a lighter-touch review-based approach?
+3. **Capacity validation authority?** When capacity analysis shows a team is over-committed, who has final authority to cut scope -- the Planning Owner, the team's Director, or both jointly?
+4. **Tooling investment level?** Should we build capacity planning into the release-planning module (estimated 5-6 sprint effort including prerequisites -- see Section 2.3 and Part 5 for details), or start with a manual spreadsheet-based approach?
+
+### Expected Outcomes
+
+- **Fewer mid-cycle descopes:** Capacity-validated commitments reduce the surprise factor
+- **Clearer accountability:** The commit gate creates an unambiguous baseline for Execution
+- **Earlier risk detection:** Dependency tracking and DoR enforcement surface problems in Planning, not Execution
+- **Measurable process health:** Defined metrics let us track improvement quarter over quarter
+- **Consistent quality bar:** Enforced DoR means Execution receives work that is actually ready to build
+
+---
+
+## Part 2: Planning Domain -- Deep Dive
+
+### 2.1 Planning Lifecycle
+
+The planning cycle runs continuously, offset by one release from Execution and two from Release. With quarterly cadence, planning for release N+1 begins as release N enters execution and release N-1 enters release.
+
+#### Phases
+
+The planning cycle has four phases, each with defined activities and exit criteria:
+
+```mermaid
+graph LR
+    A["Phase 1: Discovery<br/>(Weeks 1-4)"] --> B["Phase 2: Refinement<br/>(Weeks 5-8)"]
+    B --> C["Phase 3: Capacity Validation<br/>(Weeks 9-10)"]
+    C --> D["Phase 4: Commit Gate<br/>(Week 11)"]
+    D --> E["Handoff to Execution"]
+
+    style A fill:#e8f4fd,stroke:#1a73e8
+    style B fill:#f3e8fd,stroke:#7c3aed
+    style C fill:#fde8e8,stroke:#dc2626
+    style D fill:#e8fde8,stroke:#16a34a
+    style E fill:#fdf8e8,stroke:#ca8a04
+```
+
+**Phase 1: Discovery (Weeks 1-4 of planning cycle)**
+
+Activities:
+- Product Management defines or refines Big Rocks for the upcoming release
+- Big Rocks are entered into the release-planning module with pillar, owner, and outcome keys
+- Google Doc import workflow used for bulk Big Rock ingestion from PM planning documents
+- SmartSheet milestone dates (EA1/EA2/GA) are pulled for the target release version
+- Initial feature discovery: Tier 1 pipeline runs to identify features linked to Big Rock outcomes
+
+Inputs:
+- Strategy priorities from leadership
+- Customer RFEs (RHAIRFE project)
+- Carryover items from previous release
+- SmartSheet milestone dates
+
+Outputs:
+- Prioritized Big Rock list in the release-planning module
+- Initial feature/RFE candidate list (Tier 1 + Tier 2)
+- Milestone dates confirmed
+
+Exit criteria:
+- All Big Rocks have named owners
+- All Big Rocks have at least one outcome key linked in Jira (or documented reason for none)
+- SmartSheet milestone dates are confirmed and loaded
+
+**Phase 2: Refinement (Weeks 5-8)**
+
+Activities:
+- Feature-level refinement: each Tier 1 and Tier 2 feature is assessed against the Definition of Ready
+- Cross-team dependency identification (see Section 2.4)
+- PM assigns features to pillars and validates target release versions in Jira
+- Tier 3 discovery (in-progress orphans) reviewed for inclusion or explicit exclusion
+- RFE triage: customer-driven RFEs assessed for alignment with Big Rocks
+
+Inputs:
+- Big Rock list with outcome keys
+- Feature candidate list from Phase 1
+- Team input on feasibility
+
+Outputs:
+- Features marked as "Ready" or "Not Ready" against DoR checklist
+- Dependency map (initial)
+- Updated Big Rock notes with refinement status
+
+Exit criteria:
+- At least 80% of Tier 1 features meet Definition of Ready
+- All cross-team dependencies identified and logged
+- Each Big Rock owner has reviewed and confirmed their feature list
+
+**Phase 3: Capacity Validation (Weeks 9-10)**
+
+Activities:
+- Historical throughput data pulled from team-tracker (resolved issues per person per month, aggregated to team level)
+- Committed scope compared against team throughput using the capacity equation (see Section 2.3)
+- Over-committed teams identified; scope negotiation with Big Rock owners and team Directors
+- Allocation-tracker sprint data reviewed for teams using the 40-40-20 model (where available -- this module is opt-in)
+- Final dependency review: all dependencies have named owners and resolution dates
+
+Inputs:
+- Refined feature list with DoR status
+- Team throughput data (from team-tracker module -- person-level issue resolution counts)
+- Sprint allocation data (from allocation-tracker module, where enabled)
+- Dependency map
+
+Outputs:
+- Capacity analysis per team (committed feature count vs. historical throughput)
+- Scope adjustment recommendations
+- Final dependency register with owners
+
+Exit criteria:
+- No team is committed beyond 110% of historical throughput as measured by the capacity equation (with documented exceptions). See Section 2.3 for caveats on this threshold.
+- All dependencies have resolution owners
+- Scope adjustments agreed between Planning Owner and team Directors
+
+**Phase 4: Commit Gate (Week 11)**
+
+Activities:
+- Formal "Planning Complete" review (see Section 2.1.1 below)
+- Final Big Rock priority confirmation
+- Commit gate approval or conditional approval with action items
+- Handoff package prepared for Execution Owner
+
+Inputs:
+- Capacity-validated feature list
+- DoR compliance report
+- Dependency register
+- Risk summary
+
+Outputs:
+- Signed-off release scope baseline
+- Handoff package to Execution domain
+- Published release plan (Big Rocks, features, milestones, dependencies)
+
+Exit criteria:
+- Commit gate ceremony completed
+- Planning Owner and Execution Owner have jointly reviewed the scope
+- Baseline recorded in release-planning module
+
+#### 2.1.1 The Commit Gate Ceremony
+
+The commit gate is the single most important ceremony in this model. It is the formal moment when Planning transfers ownership of a release scope to Execution.
+
+**Format:** 90-minute meeting, held in Week 11 of the planning cycle
+
+**Attendees:**
+- Planning Owner -- presenting
+- Execution Owner -- receiving
+- Release Owner -- observer / quality input
+- PgMs (all pillars represented)
+- Agilists
+- Directors (each org represented)
+
+**Agenda:**
+
+| Time | Topic | Owner |
+|------|-------|-------|
+| 0-15 min | Big Rock overview: priorities, owners, expected outcomes | Planning Owner |
+| 15-35 min | Feature scope walkthrough by pillar/team (Tier 1 + Tier 2) | PgMs |
+| 35-50 min | Capacity analysis: team-by-team fit assessment | Agilist |
+| 50-65 min | Dependency register review | PgM |
+| 65-80 min | DoR compliance report and remaining gaps | Planning Owner |
+| 80-90 min | Decision: Approve / Conditional Approve / Defer | All Directors |
+
+**Decision outcomes:**
+
+- **Approved:** Scope is baselined. Execution Owner takes ownership. No further scope additions without formal change request.
+- **Conditional Approval:** Scope is baselined with documented action items (e.g., "Feature X must complete DoR by Week 2 of Execution or is auto-descoped"). Execution Owner takes ownership with conditions.
+- **Deferred:** Planning cycle extends by 1-2 weeks. Specific gaps are identified with owners and deadlines.
+
+**Post-ceremony:**
+- Release-planning module snapshot is taken as the committed baseline
+- Execution Owner receives the handoff package
+- Planning Owner's active involvement in the release ends (shifts to next release's Phase 1)
+
+#### Lifecycle Diagram (Three Releases in Flight)
+
+```mermaid
+gantt
+    title Three Releases in Flight (Quarterly Cadence) — Illustrative Dates
+    dateFormat YYYY-MM-DD
+
+    section Release N-1
+    Release Domain (N-1)        :active, rn1, 2026-07-01, 2026-09-30
+
+    section Release N
+    Execution Domain (N)        :active, en, 2026-07-01, 2026-09-30
+
+    section Release N+1
+    Planning: Discovery         :p1, 2026-07-01, 2026-07-28
+    Planning: Refinement        :p2, 2026-07-29, 2026-08-25
+    Planning: Capacity Valid.   :p3, 2026-08-26, 2026-09-08
+    Planning: Commit Gate       :milestone, p4, 2026-09-12, 1d
+    Execution Domain (N+1)      :en1, 2026-09-15, 2026-12-31
+```
+
+> **Note:** Dates above are illustrative, showing a generic quarterly cadence. Actual dates will be derived from SmartSheet milestone dates for each specific release version.
+
+### 2.2 Definition of Ready (Enforcement Model)
+
+#### What the DoR Contains
+
+The DoR operates at two levels: Big Rock and Feature.
+
+**Big Rock Definition of Ready:**
+
+| # | Criterion | Verification Method |
+|---|-----------|-------------------|
+| BR-1 | Named owner (Director-level or delegate) | release-planning module: `owner` field populated |
+| BR-2 | At least one outcome key linked in Jira | release-planning module: `outcomeKeys` array non-empty |
+| BR-3 | Pillar assignment | release-planning module: `pillar` field populated |
+| BR-4 | Success criteria documented (what does "done" look like for this Big Rock?) | release-planning module: `description` field or linked Jira outcome summary |
+| BR-5 | Feature list identified (Tier 1 pipeline has run) | release-planning module: pipeline results show >0 features for this rock |
+| BR-6 | Dependencies on other Big Rocks identified | Dependency register (see Section 2.4) |
+
+**Feature Definition of Ready:**
+
+| # | Criterion | Verification Method |
+|---|-----------|-------------------|
+| F-1 | Clear title and description in Jira | Jira `summary` and `description` fields non-empty |
+| F-2 | Target release version set | Jira `customfield_10855` (Target Version) matches the release |
+| F-3 | Acceptance criteria defined | Jira description or linked doc contains testable acceptance criteria |
+| F-4 | PM assigned | Jira `customfield_10469` (Product Manager) populated |
+| F-5 | Delivery owner assigned | Jira `assignee` field populated |
+| F-6 | Component/team assignment | Jira `components` field populated |
+| F-7 | Estimated scope (story points or T-shirt size) | Jira `customfield_10028` (story points) > 0, or size label present. **Note:** Story points are not currently fetched by the release-planning pipeline -- this field must be added to the pipeline before automated DoR checks can verify F-7 (see Section 2.3 prerequisites). |
+| F-8 | Dependencies identified and linked | Jira issue links present for blocking/blocked-by relationships |
+| F-9 | RFE linkage (if customer-driven) | Jira link to RHAIRFE issue, or explicit "no RFE" label |
+| F-10 | Release type/phase specified | Jira `customfield_10851` (Release Type) set (EA1/EA2/GA) |
+
+#### How Enforcement Works
+
+We recommend a **two-tier enforcement model** that combines automated checks with human review:
+
+**Tier 1: Automated Jira checks (always-on)**
+
+A Jira automation rule or scheduled script checks DoR criteria for any feature with `status = "Committed"` and a target release version. Features that fail are flagged with a `dor-incomplete` label and their PM is notified via Jira comment.
+
+Implementation: A new endpoint in the release-planning module server (`POST /releases/:version/dor-check`). This endpoint checks criteria in two tiers based on data availability:
+
+**Checkable from cached pipeline data (no additional Jira calls):**
+- F-1 (partial): `summary` is present in the pipeline cache. However, `description` content is not stored by `mapToCandidate()` -- only the summary is retained. Checking description non-emptiness requires a Jira call.
+- F-2: `targetRelease` field is in the pipeline cache.
+- F-4: `pm` field is in the pipeline cache.
+- F-5: `deliveryOwner` (assignee) is in the pipeline cache.
+- F-6: `components` field is in the pipeline cache.
+- F-10: `phase` (release type) field is in the pipeline cache.
+
+**Requires fresh Jira API calls (not in pipeline cache):**
+- F-1 (description): The pipeline requests the `description` field from Jira but `mapToCandidate()` does not include it in the candidate object. Either extend the candidate model to store a `hasDescription` boolean, or make a targeted Jira call. Note: Jira Cloud stores descriptions in ADF (Atlassian Document Format) -- use the existing `adfToPlainText()` function from `jira-client.js` to extract text for non-emptiness checks.
+- F-7: Story points (`customfield_10028`) are not in the pipeline -- requires a Jira call or pipeline extension (see Section 2.3 prerequisites).
+- F-8: Full issue links are not stored (see Section 2.4). The pipeline fetches `issuelinks` but `mapToCandidate()` discards them. Requires either pipeline extension or a Jira call.
+
+**Impact on effort estimate:** The DoR check endpoint needs to make supplementary Jira API calls for criteria not in the cache (F-1 description, F-7, F-8). This can be done efficiently via batch JQL queries using the existing `batchFetchLinkedIssues()` utility. Estimated effort remains 1 sprint but is at the higher end of that estimate.
+
+**Tier 2: Human review (ceremony-based)**
+
+Criteria F-3, F-8, and F-9 require human judgment (quality of acceptance criteria, completeness of dependency identification). These are verified in the weekly **Refinement Review** during Phase 2:
+
+- **Who:** PM for each pillar + Planning Owner + Agilist
+- **When:** Weekly during Refinement phase (Weeks 5-8), 30 minutes per pillar
+- **Format:** Walk through each feature, review DoR checklist, mark as Ready or Not Ready
+- **Outcome:** Features marked Ready in Jira (label `dor-complete`); Not Ready features get action items with owners and deadlines
+
+**Escalation path:**
+
+Features that do not meet DoR by end of Phase 2 (Week 8) are flagged to the Big Rock owner. If still not ready by end of Phase 3 (Week 10), they are:
+1. Removed from Tier 1 scope and downgraded to Tier 2 ("nice to have")
+2. Or explicitly accepted with a documented risk exception signed by the Big Rock owner and Planning Owner
+
+#### Who Enforces and When
+
+| Phase | Enforcer | Action |
+|-------|----------|--------|
+| Discovery (Weeks 1-4) | PMs | Populate Big Rock DoR fields in release-planning module |
+| Refinement (Weeks 5-8) | PMs + Agilist | Weekly DoR review; flag incomplete features |
+| Capacity Validation (Weeks 9-10) | Planning Owner | Final DoR compliance check; escalate blockers |
+| Commit Gate (Week 11) | Planning Owner | DoR compliance is a gate condition for commit approval |
+
+### 2.3 Capacity Alignment
+
+#### How Commitments Are Validated Against Team Capacity
+
+Capacity alignment is the process of comparing what we plan to commit against what teams have historically demonstrated they can deliver. This is not about precision -- it is about catching gross mismatches before they become mid-cycle crises.
+
+**The Capacity Equation:**
+
+```
+Committed Load (feature count or story points) <= Historical Throughput x Availability Factor
+```
+
+Where:
+- **Committed Load** = count of committed features assigned to a team in the release, weighted by story points when available. See note below on story points.
+- **Historical Throughput** = average monthly resolved-issue count per team from team-tracker data (trailing 6 months). This is person-level issue resolution aggregated to the team level -- it is *not* sprint-based velocity in the Scrum sense. See "Data limitations" below.
+- **Availability Factor** = adjustment for holidays, team changes, and allocation model (e.g., 40% for teams using 40-40-20)
+
+**Data limitations (important caveats):**
+
+1. **Story points are not in the release-planning pipeline today.** The pipeline's `mapToCandidate()` function does not fetch or store `customfield_10028` (story points). Team-tracker's person-metrics module does fetch story points for individual issues, but that data is not available per-feature in the release-planning context. **Prerequisite:** The release-planning pipeline must be extended to include story points in the candidate data model before the capacity dashboard can use point-based load calculations. Until then, capacity analysis will use feature counts as a proxy.
+
+2. **"Velocity" here means monthly throughput, not sprint velocity.** Team-tracker's `/team/:teamKey/metrics` endpoint returns individual issue resolution counts summed across a team over a trailing 365-day window. This is useful for relative comparison (Team A resolves ~30 issues/month, Team B resolves ~50) but it does not translate directly to "features committable per quarter." Feature-level issues in RHAISTRAT are coarser than the stories and bugs measured by team-tracker. The capacity dashboard should present this as a *directional signal* rather than a precise capacity number.
+
+3. **Sprint-based velocity is available but opt-in.** The allocation-tracker module has true sprint-level data (committed vs. delivered per sprint via the Sprint Report API), but it has `defaultEnabled: false` and may not be operational in all deployments. Where available, sprint data is a better capacity signal. The capacity dashboard should use it as *optional enrichment* -- improving the estimate when present, but not requiring it.
+
+**Process:**
+
+```mermaid
+flowchart TD
+    A[Pull team throughput<br/>from team-tracker] --> B[Pull committed features<br/>from release-planning pipeline]
+    B --> C[Match features to teams<br/>via team mapping]
+    C --> D{Committed Load<br/>vs. Throughput}
+    D -->|Under 80%| E["Green: Proceed"]
+    D -->|80-110%| F["Yellow: Review with<br/>Big Rock owner"]
+    D -->|Over 110%| G["Red: Mandatory scope<br/>reduction"]
+    F --> H[Negotiate scope<br/>with Director]
+    G --> H
+    H --> I[Updated commitment<br/>recorded]
+```
+
+> **Note on the 110% threshold:** Given that the throughput metric is based on person-level issue resolution counts (not sprint-scoped feature velocity), the 80%/110% thresholds are heuristic guardrails, not precise capacity limits. They are intended to flag teams that appear significantly over-committed relative to their historical output rate. The thresholds should be calibrated after the first cycle of use and adjusted based on retrospective data.
+
+#### Team Identity Mapping (Prerequisite)
+
+A key prerequisite for the capacity dashboard is resolving the **team identity mismatch** between modules:
+
+- **Team-tracker** identifies teams via roster composite keys (`orgKey::teamName`, e.g., `shgriffi::Model Serving`), derived from the LDAP/Google Sheets roster sync.
+- **Release-planning** identifies teams via Jira `components` (e.g., `"Model Serving, KServe"` -- a comma-joined string, not a structured array) and a custom team field.
+
+There is no automatic mapping between these two identity systems. The capacity dashboard cannot match features to team-tracker throughput data without solving this.
+
+**Proposed solution:** A manually-maintained **team mapping table** stored in the release-planning module configuration (`data/release-planning-config.json`), managed via the Settings UI. Each entry maps a Jira component string (or substring) to a team-tracker composite key:
+
+```json
+{
+  "teamMapping": [
+    { "component": "Model Serving", "teamKey": "shgriffi::Model Serving" },
+    { "component": "KServe", "teamKey": "shgriffi::Model Serving" },
+    { "component": "Pipelines", "teamKey": "shgriffi::Pipelines" }
+  ]
+}
+```
+
+The capacity endpoint should parse the comma-separated `components` string into individual component names and match each against this table. Unmatched components should be flagged in the UI for the admin to map. This adds ~0.5 sprints to the capacity dashboard effort estimate.
+
+#### Module Isolation: How the Capacity Endpoint Accesses Team-Tracker Data
+
+The `shared/API.md` stability contract states that **modules cannot import from other modules**. The capacity endpoint in release-planning needs team-tracker throughput data, which creates a cross-module data dependency.
+
+**Recommended approach: internal HTTP calls.** The release-planning server will make internal HTTP requests to team-tracker's API endpoints (e.g., `GET /api/modules/team-tracker/...` or the legacy-forwarded `GET /api/team/:teamKey/metrics`). This is the safest pattern because:
+- It respects the module isolation contract
+- It uses the same API surface that the frontend already consumes
+- It does not create hidden coupling between module internals
+
+The capacity endpoint will cache team-tracker responses for the duration of a single request to avoid repeated round-trips. This adds minimal latency since both modules run in the same Express process (requests are in-process, not over the network).
+
+#### Where Capacity Data Comes From
+
+| Data Source | Module | What It Provides | Availability |
+|------------|--------|-----------------|--------------|
+| Monthly resolved-issue counts per person | team-tracker | Historical throughput aggregated to team level (trailing 12 months) | Always available |
+| GitHub/GitLab contributions | team-tracker | Code throughput signal (supplementary) | Always available |
+| Story points on committed features | release-planning pipeline | Effort estimate per feature | **Not yet available** -- pipeline must be extended (see prerequisite above) |
+| Component-level velocity | release-analysis | Issues resolved per Jira component per 2-week window (6-month baseline) | Always available |
+| Sprint velocity (committed vs. delivered) | allocation-tracker | Per-sprint allocation against 40-40-20 model | **Optional** -- module is disabled by default |
+| Team headcount | team-tracker roster | Current team size (from roster sync) | Always available |
+
+#### What the Release-Planning Module Needs to Add vs. What Is Manual
+
+**Already available (no changes needed):**
+- Big Rock list with features mapped to teams (via Jira `components` field -- note: comma-joined string, needs parsing)
+- Feature counts and priority breakdown per Big Rock (pipeline output: `perRockStats`)
+- SmartSheet milestone dates (EA1/EA2/GA targets, plus freeze dates -- see Section 2.5)
+- Team throughput data accessible via team-tracker API (via internal HTTP)
+- Component-level velocity in release-analysis
+
+**Prerequisites to build first:**
+- **Story points in pipeline** (`customfield_10028`): Add story points to `getRequestedFields()` and `mapToCandidate()` in `jira-client.js`. Small change (~0.5 sprints), but required before the capacity dashboard can use point-based load calculations.
+- **Team mapping configuration**: Admin-managed table mapping Jira components to team-tracker composite keys (~0.5 sprints, can be done in parallel with story points).
+
+**Needs to be built (after prerequisites):**
+- **Capacity dashboard view** in release-planning: a new client view that pulls team throughput from team-tracker API (via internal HTTP) and compares it against the committed feature load from the pipeline. Displays green/yellow/red per team. Uses allocation-tracker sprint data as optional enrichment when available. Estimated effort: 3-4 sprints (increased from original 2-3 to account for team mapping, story points integration, and internal HTTP plumbing).
+- **Capacity snapshot endpoint** (`GET /releases/:version/capacity`): server-side aggregation that joins pipeline results with team-tracker throughput data via internal HTTP calls. Returns per-team capacity utilization. Estimated effort: 1-2 sprints.
+
+**Manual for now (consider automating later):**
+- Availability factor adjustments (holidays, team changes) -- entered by PgMs
+- Scope negotiation decisions -- recorded as Big Rock notes in the release-planning module
+- Override approvals for over-committed teams -- tracked via Jira comments or meeting notes
+
+### 2.4 Dependency Management
+
+#### How Dependencies Are Identified During Planning
+
+Dependencies are identified at two levels:
+
+**Feature-level dependencies** (cross-team):
+- Identified during Phase 2 Refinement as PMs review each feature's DoR
+- Captured as Jira issue links (`blocks` / `is blocked by`)
+- The release-planning pipeline requests `issuelinks` from Jira (see `jira-client.js` `getRequestedFields`), but **the `mapToCandidate()` function discards the full issuelinks array** -- it only extracts the RFE link (via `getRfeLink()`) and parent RFE key (via `getParentRfeKey()`). The raw link data (link type, linked issue key, status, summary) is not stored in the pipeline output.
+
+**Big Rock-level dependencies** (cross-domain):
+- Identified during Phase 1 Discovery as Big Rock owners review their scope
+- Captured in the Big Rock `notes` field in release-planning, and as a separate dependency register
+
+#### Tracking Mechanism
+
+**Short-term (immediate, no tooling changes):**
+- Jira issue links for feature-level dependencies (already supported by Jira natively)
+- A shared Google Sheet or Confluence page for the cross-Big-Rock dependency register
+- PgMs maintain the register and review it weekly during Refinement
+
+**Medium-term (release-planning module enhancement):**
+- New **dependency view** in the release-planning client that visualizes cross-team dependencies from Jira issue links
+- **Server-side pipeline changes required:** The `mapToCandidate()` function must be extended to preserve the full `issuelinks` array in the candidate data model. Currently it only extracts RFE-specific links and discards the rest. Each link should include: link type (e.g., `blocks`, `is blocked by`), linked issue key, linked issue status, and linked issue summary. This is a moderate change to `jira-client.js` and will increase the size of the cached pipeline output.
+- Client-side: render the preserved link data as a directed graph, filterable by Big Rock, team, or status, with highlights on blocked items and critical path
+- Estimated effort: 3 sprints (increased from 2 to account for the pipeline changes, data model extension, and increased cache size)
+
+**Dependency data model (what the pipeline provides today vs. what is needed):**
+
+The `jira-client.js` module *requests* `issuelinks` from Jira for every feature and RFE. However, `mapToCandidate()` only extracts:
+- The RFE link (via `getRfeLink()`) -- stored as `rfe` and `rfeStatus` fields
+- The parent RFE key (via `getParentRfeKey()`) -- stored as `rfe` field
+
+The full issuelinks array (which includes `blocks`, `is blocked by`, `is required by`, and other relationship types with their linked issue keys, statuses, and summaries) is **discarded**. The pipeline change must add a `dependencies` array to each candidate:
+
+```json
+{
+  "dependencies": [
+    { "type": "blocks", "key": "RHAISTRAT-1234", "status": "In Progress", "summary": "..." },
+    { "type": "is blocked by", "key": "RHAISTRAT-5678", "status": "New", "summary": "..." }
+  ]
+}
+```
+
+#### Escalation Path for Unresolved Dependencies
+
+```mermaid
+flowchart TD
+    A[Dependency identified<br/>in Refinement] --> B[Owner assigned<br/>resolution date set]
+    B --> C{Resolved by<br/>end of Phase 2?}
+    C -->|Yes| D[Marked resolved<br/>in register]
+    C -->|No| E[Escalated to<br/>Big Rock owner]
+    E --> F{Resolved by<br/>end of Phase 3?}
+    F -->|Yes| D
+    F -->|No| G[Raised at<br/>Commit Gate]
+    G --> H{Planning Owner<br/>decision}
+    H -->|Accept risk| I[Documented exception<br/>Conditional approval]
+    H -->|Remove scope| J[Feature descoped<br/>or moved to Tier 2]
+```
+
+### 2.5 Tooling Gap Analysis
+
+| Need | Current Tool/Process | Gap | Recommended Action |
+|------|---------------------|-----|-------------------|
+| Big Rock management | **release-planning module** -- full CRUD, validation, reordering, backups, Google Doc import, PM role-based access | None -- fully operational | Continue using as-is |
+| Feature discovery | **release-planning pipeline** -- 3-tier Jira discovery (Tier 1: Big Rock outcomes, Tier 2: version-matched unaffiliated, Tier 3: in-progress orphans) | None -- fully operational | Continue using as-is |
+| Milestone dates | **SmartSheet integration** (`shared/server/smartsheet.js`) -- auto-discovers EA1/EA2/GA dates from SmartSheet | SmartSheet stores all 6 milestones (EA1/EA2/GA freeze *and* target dates), but `discoverReleases()` only returns target dates (`ea1Target`, `ea2Target`, `gaTarget`). **Freeze dates are parsed internally but not surfaced in the API response.** | Extend `discoverReleases()` to include freeze dates in the response. Minor change (~0.5 sprints). Freeze dates are needed for commit gate timing (the commit gate should land before the earliest code freeze). |
+| Capacity planning | **team-tracker** has throughput data (person-level issue resolution); **allocation-tracker** has sprint-level allocation targets (opt-in); **release-analysis** has component velocity | **No unified view** comparing committed scope against team capacity. Team identity mismatch between modules (see Section 2.3). Story points not in pipeline. | Build capacity dashboard in release-planning module (Phase 2 of roadmap). Requires prerequisites: story points in pipeline, team mapping config (see Section 2.3). |
+| Dependency tracking | **Jira issue links** requested by pipeline but **discarded by `mapToCandidate()`** -- only RFE links are preserved | **No dependency data in pipeline output** and **no dependency visualization**. Both server and client changes needed. | Extend pipeline to preserve full issuelinks; build dependency view in client (Phase 2 of roadmap). |
+| DoR enforcement | Definition exists conceptually; not enforced in any workflow | **No automated DoR checks**; no Jira workflow gates | Build DoR check endpoint + Jira labels (Phase 1 of roadmap); establish review ceremony immediately |
+| Commit gate | **Does not exist** -- no formal ceremony or artifact | **Completely undefined** -- the handoff from Planning to Execution is informal | Define and institute the ceremony (Phase 1 of roadmap -- process only, no tooling needed) |
+| Feature delivery tracking | **feature-traffic module** -- tracks delivery across repos/components with health scores | Operates independently from release-planning; no cross-link | Consider linking feature-traffic data into execution-phase tracking (Execution Owner's scope) |
+| Release risk analysis | **release-analysis module** -- risk scoring based on incomplete issues vs. time remaining, component velocity, sprint detection | Operates on Jira Fix Versions / Product Pages releases; not directly linked to Big Rocks | Useful during Execution phase; recommend Execution Owner adopts as primary dashboard |
+| Release milestones | **release-analysis** has Product Pages integration (OAuth-authenticated, production milestone dates); **release-planning** has SmartSheet dates (planning milestone dates, including freeze dates) | **Two separate milestone sources with no reconciliation.** If SmartSheet and Product Pages dates diverge, the Planning and Release domains will operate from different schedules. This is a real risk -- SmartSheet dates are maintained by PgMs, while Product Pages dates are maintained by Release Engineering. | **Authoritative source by domain:** SmartSheet is authoritative for *planning* milestones (the dates that govern the planning lifecycle and commit gate timing). Product Pages is authoritative for *release* milestones (the dates that govern EA/GA availability). **Reconciliation process:** At the start of each planning cycle (Phase 1), the Planning Owner should verify that SmartSheet and Product Pages dates agree. If they diverge, escalate to the Release Owner for resolution before proceeding past Phase 1. Consider a future automated check that flags date mismatches. |
+| Reporting/dashboards | Each module has its own dashboard | **No cross-module release health view** | Longer-term: unified release dashboard pulling from all modules (Phase 3 of roadmap) |
+| PM workflow | **release-planning** has PM role-based access control | Works well; PMs can edit Big Rocks and import data | Continue using as-is |
+| Prioritization | **release-planning** has priority ordering with reorder API | Works well for Big Rock-level prioritization | Extend to feature-level priority within Big Rocks (minor enhancement) |
+
+### 2.6 Prioritization Framework
+
+#### How Big Rocks and Features Are Prioritized
+
+**Big Rock prioritization:**
+
+Big Rocks are prioritized by the Planning Owner in consultation with Product Management and strategy leadership. The release-planning module supports explicit priority ordering (integer priority, drag-to-reorder in the UI, `PUT /releases/:version/big-rocks/reorder` API).
+
+Priority factors (in order of weight):
+1. **Strategic alignment:** Does this Big Rock directly support announced strategy themes?
+2. **Customer demand:** Are there linked RFEs with significant customer weight?
+3. **Continuation vs. new:** Continuing work (state: "continue from N-1") generally takes priority over new starts, because stopping mid-stream is wasteful
+4. **Cross-release dependencies:** Does another Big Rock or release depend on this completing?
+5. **Technical risk:** Higher-risk items may be prioritized earlier to allow time for course correction
+
+**Feature prioritization within a Big Rock:**
+
+Features within a Big Rock are currently sorted by Jira priority (Blocker > Critical > Major > Normal > Minor) as implemented in the pipeline's `sortByPriority` function. This is a reasonable default but should be supplemented with PM judgment.
+
+Recommendation: Add a `featurePriority` override field to the pipeline output that PMs can set, which overrides the Jira priority sort within a Big Rock. This is a minor enhancement to the release-planning module.
+
+#### The Tier System: Assessment
+
+The current 3-tier system is well-designed and maps cleanly to commitment levels:
+
+| Tier | Description | Commitment Level |
+|------|-------------|-----------------|
+| **Tier 1** | Big Rock-associated features -- PM has identified as essential | **Committed** -- these are the baseline scope for the release |
+| **Tier 2** | Features not tied to Big Rocks but important for customers or usability | **Best effort** -- delivered if capacity allows after Tier 1 is satisfied |
+| **Tier 3** | In-progress features with no target version and no fix version (orphans not claimed by any release) | **Opportunistic** -- teams may work on these in slack time; not committed |
+
+This tier system is sufficient. The key improvement is making the tier designation binding at the commit gate: Tier 1 is what we commit to; Tier 2 and 3 are explicitly not committed.
+
+#### Who Has Authority to Change Priority and When
+
+| When | Who Can Change | Scope of Change | Approval Required |
+|------|---------------|-----------------|-------------------|
+| Discovery (Weeks 1-4) | PMs | Any -- Big Rock and feature priority is fluid | Big Rock owner |
+| Refinement (Weeks 5-8) | PMs with Big Rock owner agreement | Feature priority within a Big Rock; add/remove Tier 2 features | Big Rock owner |
+| Capacity Validation (Weeks 9-10) | Planning Owner | Remove features from Tier 1; adjust Big Rock priority | Director of affected team |
+| After Commit Gate | Execution Owner | Scope changes require a **Change Request** reviewed by Planning Owner | Planning Owner + Director + Execution Owner |
+
+---
+
+## Part 3: Lightweight Recommendations for Execution & Release
+
+### 3.1 Execution Domain
+
+The Execution domain spans from the commit gate to feature completion. Its job is to ensure what was committed actually gets delivered.
+
+#### Key Ceremonies
+
+| Ceremony | Frequency | Attendees | Purpose |
+|----------|-----------|-----------|---------|
+| **Execution Stand-up** | Weekly, 30 min | Execution Owner, PgM, Agilist, Big Rock owners | Progress against committed scope; surface blockers |
+| **Risk Review** | Bi-weekly, 45 min | Execution Owner, Directors, PgMs | Review at-risk features using release-analysis risk scores; decide on interventions |
+| **Dependency Sync** | Weekly, 15 min | PgM + dependency owners | Status check on cross-team dependencies from the dependency register |
+| **Mid-Cycle Checkpoint** | Once, at mid-cycle | All Directors, PgMs, Execution Owner | Formal "are we on track?" assessment with go/no-go for at-risk scope |
+
+#### Key Metrics
+
+- **Scope stability:** % of Tier 1 features that remain committed from gate to completion (target: >90%)
+- **Delivery velocity:** Actual vs. planned feature completion rate per sprint
+- **Blocker aging:** Average time from blocker identification to resolution
+- **Dependency resolution rate:** % of dependencies resolved on schedule
+
+#### Tooling Considerations
+
+The Execution domain should adopt:
+- **release-analysis module** as the primary execution dashboard (already provides risk scoring, component velocity, sprint detection)
+- **feature-traffic module** for tracking delivery progress across repos and components
+- **team-tracker** for sprint-level visibility into team throughput
+
+#### Handoff from Planning
+
+The commit gate ceremony produces the handoff package:
+1. Release scope baseline (Big Rocks, Tier 1 features, milestone dates)
+2. Dependency register with owners and resolution dates
+3. DoR compliance report (any conditional items)
+4. Capacity analysis (team-by-team utilization)
+5. Known risks and mitigation plans
+
+The Execution Owner should review this package and confirm acceptance within 48 hours of the commit gate.
+
+### 3.2 Release Domain
+
+The Release domain spans from feature completion to GA. Its job is to ensure what was built is shippable.
+
+#### Key Ceremonies
+
+| Ceremony | Frequency | Attendees | Purpose |
+|----------|-----------|-----------|---------|
+| **Release Readiness Review** | Weekly during release phase | Release Owner, PgM, QE leads | Track readiness against release checklist |
+| **Go/No-Go Decision** | At each milestone (EA1, EA2, GA) | Release Owner, Directors, Execution Owner | Formal decision to proceed or hold |
+| **Release Retrospective** | After GA | All domain owners, PgMs, Agilists | What worked, what did not, process improvements |
+
+#### Key Gates
+
+| Gate | Criteria | Authority |
+|------|----------|-----------|
+| **EA1 Gate** | Feature-complete for EA1 scope; test plan exists; known blockers documented | Release Owner |
+| **EA2 Gate** | EA1 feedback addressed; full feature scope complete; release notes drafted | Release Owner |
+| **GA Gate** | All blockers resolved or accepted; docs complete; upgrade testing passed; security review passed | Release Owner (with veto power) |
+
+#### Handoff from Execution
+
+The Execution Owner produces a handoff package at the end of execution:
+1. Feature completion status (what shipped, what was descoped, what is partial)
+2. Outstanding bugs and blockers with severity
+3. Scope changes from the committed baseline (with reasons)
+4. Testing status and coverage
+
+#### Tooling Considerations
+
+- **release-analysis module** continues to be relevant for tracking remaining work against milestone dates
+- Consider building a **release checklist** feature in the release-planning module that tracks gate criteria completion
+
+---
+
+## Part 4: Overlooked Areas
+
+### 4.1 Risk Management and Escalation Paths
+
+The operating model defines domain owners but does not define how risks escalate beyond them. Recommended escalation ladder:
+
+| Level | Who | When |
+|-------|-----|------|
+| L1 | Big Rock owner + PgM | Feature-level risk identified |
+| L2 | Domain owner (Planning/Execution/Release) | Cross-team or cross-Big Rock risk |
+| L3 | Directors meeting | Risk affects multiple orgs or threatens milestone |
+| L4 | VP | Risk threatens release viability or requires strategic re-prioritization |
+
+Each level has a 48-hour resolution SLA. If not resolved within that window, the domain owner (or PgM at L1) is responsible for manually escalating to the next level. There is no automated escalation mechanism today -- this is a process discipline enforced through the weekly ceremonies and tracked in the dependency register.
+
+### 4.2 Communication and Reporting Cadence
+
+| Report | Frequency | Audience | Owner |
+|--------|-----------|----------|-------|
+| **Release Planning Status** | Weekly during planning | Directors, PgMs | Planning Owner |
+| **Execution Progress** | Weekly during execution | Directors, PgMs | Execution Owner |
+| **Release Health** | Weekly during release | Directors, PgMs, QE | Release Owner |
+| **Executive Summary** | Bi-weekly | VP | Rotating domain owner |
+| **All-Hands Release Update** | Monthly | AI Engineering all-hands | PgM lead |
+
+### 4.3 Stakeholder Alignment (PM, Engineering, QA, Docs)
+
+The current operating model focuses on PM and Engineering. It should explicitly include:
+
+- **QA/QE:** Must be involved in Phase 2 (Refinement) to validate that features have testable acceptance criteria. QE capacity should be factored into the capacity validation.
+- **Documentation:** Docs team needs a signal at the commit gate to begin planning doc work. Add "documentation requirements identified" as a DoR criterion (future enhancement).
+- **UX:** For user-facing features, UX review should be a DoR criterion. Add "UX mockups approved" for UI-impacting features.
+
+### 4.4 Hotfix and Patch Release Planning
+
+The quarterly model addresses major releases but not:
+- **Hotfixes:** Critical customer issues that require an out-of-band release. These bypass the Planning domain entirely and go directly to Execution/Release with VP approval.
+- **Patch releases (z-stream):** Minor updates between major releases. These should have a lightweight version of the Planning lifecycle (1-week compressed cycle with the same DoR criteria).
+
+Recommendation: Define a separate, abbreviated process for z-stream releases. The release-planning module already supports creating releases for any version string, so the tooling works.
+
+### 4.5 How Customer-Driven RFEs Flow into Planning
+
+Current state: RFEs exist in the RHAIRFE Jira project. The release-planning pipeline discovers them in two ways:
+- Tier 1: RFEs linked as children of Big Rock outcomes (via `fetchOutcomeRfes`)
+- Tier 2: RFEs with a `{version}-candidate` label (via `fetchTier2Rfes`)
+
+Gap: There is no systematic process for triaging new RFEs into the planning cycle. RFEs accumulate in the backlog without being reviewed against upcoming release priorities.
+
+Recommendation: Institute a **monthly RFE triage** ceremony during the Planning cycle:
+- PMs review new RHAIRFE issues
+- Each RFE is either: linked to an existing Big Rock, flagged as a candidate for the next release (labeled `{version}-candidate`), or explicitly deferred
+- The release-planning pipeline will then pick them up automatically
+
+### 4.6 Metrics for Measuring Process Health
+
+Define and track these metrics quarterly:
+
+| Metric | Target | Source |
+|--------|--------|--------|
+| DoR compliance at commit gate | >90% of Tier 1 features meet DoR | DoR check endpoint |
+| Scope stability (commit to GA) | >85% of Tier 1 scope delivered | release-planning baseline vs. actual |
+| Capacity accuracy | Actual delivery within 20% of capacity estimate | team-tracker throughput vs. committed load |
+| Dependency resolution on time | >80% resolved by agreed date | Dependency register |
+| Commit gate cycle time | Planning cycle completes within 11 weeks | Calendar tracking |
+| Post-gate scope changes | <15% of committed features changed after gate | Change request log |
+| Time to fill DoR gaps | Average <5 business days from flagged to resolved | DoR tracking |
+
+### 4.7 Continuous Improvement / Retrospective Mechanism
+
+Each release cycle should include:
+
+1. **Planning Retrospective** (after commit gate): What worked in the planning process? What did not? Changes for next cycle.
+2. **Release Retrospective** (after GA): End-to-end review across all three domains. Identify systemic improvements.
+3. **Quarterly Process Review** (with VP): Review the health metrics above. Decide on process changes for the next quarter.
+
+Retrospective findings should be tracked as action items with owners and deadlines. The Agilists own facilitation.
+
+---
+
+## Part 5: Implementation Roadmap
+
+### Phase 0: Immediate (No Tooling Changes) -- Weeks 1-2
+
+These actions require only process changes and can start immediately. While no *code* changes are needed, the operational effort of establishing these processes should not be underestimated -- each item requires coordination across multiple teams and stakeholders.
+
+1. **Institute the commit gate ceremony** for the next upcoming release
+   - Define the meeting, invite list, and agenda (template provided in Section 2.1.1)
+   - Identify which release will be the first to use the full ceremony
+   - Assign PgM to own logistics
+
+2. **Publish the Definition of Ready** as a documented standard
+   - Circulate the Big Rock DoR and Feature DoR tables from Section 2.2
+   - Get sign-off from Planning Owner and Directors
+   - Add to the team's Confluence or internal docs
+
+3. **Establish the weekly Refinement Review** ceremony
+   - Schedule recurring 30-minute sessions per pillar during Phase 2
+   - PgMs lead; Agilist observes and tracks DoR compliance
+
+4. **Create the dependency register** (Google Sheet or Confluence)
+   - Template: Feature Key | Depends On (Feature Key) | Owning Team | Resolution Owner | Target Date | Status
+   - PgM maintains; reviewed weekly
+   - **Note:** Setting up and populating the dependency register for the first time is a significant effort. Expect 2-3 hours of PgM time per pillar to do the initial identification pass, plus ongoing maintenance. This is the highest-effort item in Phase 0.
+
+5. **Verify milestone date alignment** between SmartSheet and Product Pages
+   - Planning Owner confirms that SmartSheet milestone dates (EA1/EA2/GA) match Product Pages dates for the target release
+   - If they diverge, escalate to Release Owner for resolution before proceeding
+
+### Phase 1: Quick Tooling Wins -- Sprints 1-4
+
+Changes to the release-planning module that are low effort and high impact:
+
+1. **Pipeline data model extensions** (prerequisite for Phase 1 and Phase 2 items)
+   - Add `customfield_10028` (story points) to `getRequestedFields()` and store in `mapToCandidate()` output as `storyPoints`
+   - Add `hasDescription` boolean to `mapToCandidate()` (checks if `description` field is non-empty, using `adfToPlainText()` for ADF format)
+   - Estimated effort: 0.5 sprints
+
+2. **DoR check endpoint** (`POST /releases/:version/dor-check`)
+   - Server-side: iterate pipeline features, check cached fields (F-2, F-4, F-5, F-6, F-10, and F-1/F-7 after pipeline extension above)
+   - For F-8 (dependency links): make supplementary batch Jira API calls using `batchFetchLinkedIssues()` to check for blocking/blocked-by relationships
+   - Return per-feature DoR compliance: `{ featureKey, dorComplete: boolean, missingCriteria: string[], checkableFromCache: string[], requiredJiraCall: boolean }`
+   - Client-side: add a "DoR Status" column to the feature table with green/yellow/red indicators
+   - Estimated effort: 1 sprint (depends on item 1)
+
+3. **Commit baseline snapshot**
+   - Server-side: `POST /releases/:version/baseline` -- saves the current pipeline output as the committed baseline
+   - Enables later comparison (committed vs. actual) for scope stability metrics
+   - Estimated effort: 0.5 sprints
+
+4. **Feature priority override**
+   - Allow PMs to set a manual priority order on features within a Big Rock, overriding the Jira-derived sort
+   - Stored in release-planning config alongside Big Rock data
+   - Estimated effort: 0.5 sprints
+
+### Phase 2: Capacity and Dependency Visualization -- Sprints 5-11
+
+Larger enhancements that close the two biggest tooling gaps:
+
+1. **Team mapping configuration** (prerequisite for capacity dashboard)
+   - Admin UI for mapping Jira components to team-tracker composite keys
+   - Stored in release-planning config, managed via Settings
+   - Handles comma-separated component strings (e.g., `"Model Serving, KServe"` maps both components)
+   - Estimated effort: 1 sprint
+
+2. **SmartSheet freeze date exposure**
+   - Extend `discoverReleases()` to include `ea1Freeze`, `ea2Freeze`, `gaFreeze` in API response (already parsed internally, just not returned)
+   - Use freeze dates in commit gate timing recommendations
+   - Estimated effort: 0.5 sprints
+
+3. **Capacity dashboard**
+   - New view in release-planning client
+   - Server-side: capacity endpoint makes **internal HTTP calls** to team-tracker API (`GET /api/team/:teamKey/metrics`) to respect the module isolation contract (see Section 2.3)
+   - Pulls committed feature load from pipeline results, matched to teams via the team mapping table (item 1 above)
+   - Displays per-team capacity utilization: green (<80%), yellow (80-110%), red (>110%) -- with clear labeling that thresholds are heuristic, based on monthly issue resolution rates (not sprint velocity)
+   - Uses allocation-tracker sprint data as **optional enrichment** when available (module is disabled by default)
+   - Estimated effort: 3-4 sprints (includes internal HTTP plumbing, team mapping integration, and allocation-tracker optional path)
+
+4. **Dependency graph view**
+   - **Pipeline change required:** extend `mapToCandidate()` to preserve the full `issuelinks` array as a `dependencies` field (link type, linked issue key, status, summary)
+   - New view in release-planning client that renders dependency data as a directed graph
+   - Filter by Big Rock, team, or status; highlights blocked items and critical path
+   - Estimated effort: 3 sprints (1 sprint pipeline + data model, 2 sprints client visualization)
+
+### Phase 3: Cross-Module Integration -- Sprints 12-18
+
+Longer-term enhancements for unified release visibility:
+
+1. **Unified release health dashboard**
+   - A new module or view that pulls data from release-planning (committed scope), release-analysis (risk scores), feature-traffic (delivery progress), and team-tracker (throughput)
+   - Provides a single pane of glass for the Executive Summary report
+   - Estimated effort: 4-5 sprints
+
+2. **Automated scope change tracking**
+   - Compare committed baseline snapshot with current pipeline output
+   - Generate a diff report: added features, removed features, changed priorities
+   - Alert Execution Owner when drift exceeds threshold
+   - Estimated effort: 2 sprints
+
+3. **DoR Jira workflow integration**
+   - Jira automation rule that prevents features from transitioning to "Committed" status without meeting DoR criteria F-1 through F-7
+   - Requires Jira admin access and workflow modification
+   - Estimated effort: 1 sprint (Jira configuration, not code)
+
+4. **Per-version pipeline concurrency**
+   - The release-planning module currently uses a single global `refreshState`, which means only one pipeline run can execute at a time across all release versions. When planning for multiple releases overlaps (which is common with three releases in flight), this becomes a bottleneck.
+   - Refactor to per-version refresh state to allow concurrent pipeline runs for different release versions.
+   - Estimated effort: 0.5 sprints
+
+### Rollout Plan
+
+| Quarter | What | Who |
+|---------|------|-----|
+| **Current (Q2 2026)** | Phase 0: Process changes (commit gate ceremony, DoR publication, refinement reviews, dependency register, milestone date verification). Run first commit gate for the next release. | Planning Owner + PgMs |
+| **Q3 2026** | Phase 1: Pipeline extensions (story points, description check), DoR check endpoint, baseline snapshots, feature priority override. First full planning cycle with the new process. | Agilists + 1 developer |
+| **Q4 2026 - Q1 2027** | Phase 2: Team mapping config, SmartSheet freeze dates, capacity dashboard, dependency graph view. Retrospective on first full cycle. Timeline extended vs. original estimate due to pipeline changes, team identity mapping, and module isolation plumbing. | 1-2 developers |
+| **Q2 2027** | Phase 3: Cross-module integration. Process refinements based on 2-3 cycles of data. | Team decision based on ROI |
+
+### Success Criteria for the First Cycle
+
+The first release to use this process should be evaluated against:
+- Commit gate ceremony was held and produced a baseline
+- >70% of Tier 1 features met DoR at the commit gate (stretch target: >90% by Q4)
+- Capacity analysis was performed (even if manually) and no team was >130% of historical throughput
+- Dependency register existed and was reviewed weekly
+- Post-release retrospective identified at least 3 specific process improvements
+
+---
+
+## Appendix A: Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Big Rock** | A strategic theme or initiative for a release, consisting of multiple features |
+| **Commit gate** | The formal ceremony where Planning transitions scope ownership to Execution |
+| **DoR** | Definition of Ready -- criteria that must be met before work is considered ready for commitment |
+| **EA1 / EA2** | Early Access release milestones (subset of features available for early customer validation) |
+| **GA** | General Availability -- the full public release |
+| **Tier 1** | Features directly linked to Big Rock outcomes (committed scope) |
+| **Tier 2** | Features not tied to Big Rocks but important for customers (best-effort scope) |
+| **Tier 3** | In-progress features with no target version and no fix version -- not claimed by any release (opportunistic scope) |
+| **Outcome key** | A Jira issue key (e.g., RHAISTRAT-1513) representing a strategic outcome that a Big Rock delivers |
+| **Pipeline** | The release-planning module's automated Jira discovery process that finds features and RFEs associated with Big Rocks |
+
+## Appendix B: Module Reference
+
+| Module | Slug | Relevance to Planning |
+|--------|------|----------------------|
+| Release Planning | `release-planning` | **Primary** -- Big Rock CRUD, feature/RFE discovery, milestone dates |
+| Team Tracker | `team-tracker` | Throughput data (person-level issue resolution), team roster, sprint metrics |
+| Release Analysis | `release-analysis` | Risk scoring, component velocity, release milestone tracking |
+| Feature Traffic | `feature-traffic` | Feature delivery tracking across repos (Execution phase) |
+| Allocation Tracker | `allocation-tracker` | Sprint allocation against 40-40-20 model |
+| AI Impact | `ai-impact` | AI adoption tracking (not directly relevant to planning process) |
+| Upstream Pulse | `upstream-pulse` | Upstream open-source contribution insights (not directly relevant to planning process; `defaultEnabled: false`) |
+
+## Appendix C: Current Big Rock Data Model
+
+For reference, the release-planning module stores Big Rocks with this structure:
+
+```json
+{
+  "priority": 1,
+  "name": "MaaS",
+  "fullName": "MaaS (continue from 3.4)",
+  "pillar": "Inference",
+  "state": "continue from 3.4",
+  "owner": "",
+  "outcomeKeys": ["RHAISTRAT-1513"],
+  "notes": "",
+  "description": ""
+}
+```
+
+The `owner`, `description`, and `notes` fields are underutilized today. The DoR enforcement model depends on these being populated. No schema changes are needed -- only process discipline.

--- a/design/2026-04-23-release-planning-review.md
+++ b/design/2026-04-23-release-planning-review.md
@@ -1,0 +1,623 @@
+# Release Planning Module -- Comprehensive Review & Improvement Plan
+
+**Date:** 2026-04-23
+**Reviewer:** Architect Agent
+**Module:** `modules/release-planning/`
+**Scope:** Security, code simplification, architecture, reliability, UX, testability
+
+---
+
+## Table of Contents
+
+1. [Current State Assessment](#1-current-state-assessment)
+2. [Security Review](#2-security-review)
+3. [Code Simplification](#3-code-simplification)
+4. [Architecture Review](#4-architecture-review)
+5. [Reliability & Performance](#5-reliability--performance)
+6. [UX / Frontend Quality](#6-ux--frontend-quality)
+7. [Testability & Deployability](#7-testability--deployability)
+8. [Backward Compatibility](#8-backward-compatibility)
+9. [Recommended Improvements](#9-recommended-improvements)
+10. [Files Modified](#10-files-modified)
+
+---
+
+## 1. Current State Assessment
+
+### What Exists Today
+
+The Release Planning module is a full-stack feature that enables Product Managers (PMs) and Engineering Managers (EMs) to orchestrate RHOAI releases around "Big Rocks" -- high-priority strategic initiatives that are tied to Jira outcome keys. The module provides:
+
+**Core capabilities:**
+- **Release lifecycle management** -- create, clone, delete releases identified by version strings (e.g., "3.5")
+- **Big Rock CRUD** -- create, read, update, delete, and reorder strategic Big Rocks within a release
+- **3-tier Jira pipeline** -- background pipeline that discovers Features and RFEs across three tiers:
+  - Tier 1: Children of Big Rock outcome keys matching the release's target version
+  - Tier 2: Features/RFEs in RHAISTRAT/RHAIRFE with matching release label, but not linked to any Big Rock
+  - Tier 3: In-progress features with no target version or fix version
+- **Google Doc import** -- parse Big Rocks from a structured Google Doc with preview/replace/append modes
+- **SmartSheet integration** -- discover available release versions and milestone dates from the RHOAI GA schedule
+- **PM role system** -- separate from platform admin; PMs can edit Big Rocks, admins manage PM list
+- **Admin seed/bootstrap** -- bulk-load fixture data for initial setup or demo
+- **Export** -- Markdown table export for Big Rocks, Features, and RFEs
+- **Demo mode** -- fixture-backed read-only mode for demonstrations
+
+**Data flow:**
+- Config stored as `data/release-planning/config.json` (single JSON file, all releases)
+- Candidates cached per-release as `data/release-planning/candidates-cache-{version}.json`
+- PM users stored as `data/release-planning/pm-users.json`
+- Backups stored as `data/release-planning/config-backup-{timestamp}.json` (max 10 retained)
+
+### Key Strengths
+
+1. **Solid test coverage** -- 205 tests across 13 test files, covering server logic comprehensively (config CRUD, validation, pipeline, Jira client, doc import, backups, locking, PM auth, SmartSheet)
+2. **Config lock** -- in-process mutex prevents concurrent read-modify-write races on the shared config file
+3. **Input validation** -- `validation.js` enforces field limits, outcome key format, reserved names, and uniqueness
+4. **Backup-before-delete** -- destructive operations (delete rock, delete release, replace import) create timestamped backups with automatic pruning
+5. **Version parameter sanitization** -- `isValidVersion()` regex and reserved-name checks on all route parameters
+6. **Background pipeline** -- Jira fetching runs asynchronously; stale-while-revalidate pattern serves cached data immediately
+7. **Demo mode** -- complete fixture-backed mode with proper guard on all write operations
+8. **Clean separation** -- pipeline logic, Jira client, config management, validation, and auth are each in separate files
+
+---
+
+## 2. Security Review
+
+### 2.1 Authentication & Authorization
+
+| Finding | Severity | Location |
+|---------|----------|----------|
+| PM auth reads from storage on every request (no caching) | Low | `pm-auth.js:9` |
+| PM email comparison in `isPM()` does not independently lowercase (defense-in-depth) | Low | `pm-auth.js:10` vs `pm-auth.js:28` |
+| `requirePM` checks `req.isAdmin` but doesn't verify `req.userEmail` exists | Low | `pm-auth.js:14` |
+| No rate limiting on any endpoints | Medium | `server/index.js` |
+| Admin seed endpoint accepts arbitrary config shapes beyond `releases` | Low | `server/index.js:636` |
+
+**PM email normalization (defense-in-depth, P2):** `addPMUser` normalizes to lowercase, and `isPM()` compares `req.userEmail` against the stored list without independently lowercasing. However, `shared/server/auth.js` already lowercases `req.userEmail` in all three auth paths: proxy auth (line 74), local dev fallback (line 76), and token auth (line 60, which stores `ownerEmail` from an already-lowercased `req.userEmail`). Since both sides are always lowercase by the time module middleware runs, this is not a real bug. Adding `.toLowerCase()` in `isPM()` is a defense-in-depth measure in case a future auth path omits normalization.
+
+**Duplicate PM check in `/permissions` route (P1):** The `GET /permissions` endpoint (lines 236-242 of `server/index.js`) uses `getPMUsers(readFromStorage)` and `pmList.includes(req.userEmail)` directly instead of calling `isPM()` via `createRequirePM`. This is a separate code path that would get out of sync if PM-checking logic ever changes (e.g., adding role-based checks or group membership). This should use the same `isPM()` function from `pm-auth.js`.
+
+```javascript
+// Current (server/index.js:236-242) -- inline PM check, bypasses isPM()
+router.get('/permissions', requireAuth, function(req, res) {
+  var pmList = getPMUsers(readFromStorage)
+  var isPM = pmList.includes(req.userEmail)
+  res.json({ canEdit: !!req.isAdmin || isPM })
+})
+
+// Should call the canonical isPM from pm-auth.js
+```
+
+### 2.2 Input Validation & Injection
+
+| Finding | Severity | Location |
+|---------|----------|----------|
+| Outcome keys injected directly into JQL `key in (...)` (defense-in-depth) | Medium | `jira-client.js:248` |
+| Release version injected into JQL label filter with limited sanitization | Medium | `jira-client.js:228-229` |
+| `decodeURIComponent` on URL params without try/catch (malformed URI throws) | Low | `server/index.js:276, 356, 515` |
+| Admin seed endpoint does not validate individual Big Rock objects | **High** | `server/index.js:649-660` |
+
+**JQL injection via outcome keys (P1, defense-in-depth):** The `fetchOutcomeSummaries` function joins outcome keys directly into JQL without escaping:
+
+```javascript
+// jira-client.js:248
+const keysStr = outcomeKeys.join(', ')
+const jql = `key in (${keysStr}) ORDER BY key ASC`
+```
+
+Outcome keys are validated at input time by `OUTCOME_KEY_PATTERN = /^[A-Z]+-\d+$/` for all CRUD operations. The primary attack vector is the admin seed endpoint, which does NOT validate individual Big Rock fields within the `releases` object. However, exploiting this requires admin access -- and an admin can already delete releases, overwrite config, etc. The real vulnerability is the unvalidated admin seed endpoint (see item 0.2), not the JQL interpolation itself. Adding a JQL-safe assertion in the pipeline is a defense-in-depth measure, not a critical fix.
+
+Similarly, `parent = "${outcomeKey}"` in `fetchOutcomeFeatures` (line 203) interpolates directly -- though the same OUTCOME_KEY_PATTERN constraint applies via config validation.
+
+**Recommended fix:** Promote admin seed validation to Phase 0 (item 0.2) as the primary fix. Add JQL-safe assertion in the pipeline as a P1 defense-in-depth measure.
+
+**Downstream consequence of seed validation gap:** `BigRocksTable` uses `name` as `item-key` for vuedraggable. If the admin seed creates Big Rocks with duplicate names (which `validateBigRock` would catch but the unvalidated seed does not), the drag-and-drop interface will break with duplicate key errors. This is another reason seed validation is P0.
+
+### 2.3 Data Exposure
+
+| Finding | Severity | Location |
+|---------|----------|----------|
+| `GET /config` returns full config including custom field IDs to admins only | Low | `server/index.js:218` |
+| Error messages may leak internal paths or Jira details | Low | Various catch blocks |
+| `GET /admin/seed/fixture` exposes fixture data | Low | `server/index.js:677` |
+
+### 2.4 Denial of Service
+
+| Finding | Severity | Location |
+|---------|----------|----------|
+| No pagination on `GET /releases/:version/candidates` response | Medium | `server/index.js:124` |
+| `POST /jira/validate-keys` capped at 50 but still allows expensive Jira queries | Low | `server/index.js:450` |
+| Background refresh has no timeout -- a stalled Jira response blocks future refreshes | **Medium** | `server/index.js:77` |
+| Config backup pruning lists all files in `release-planning/` directory | Low | `config-backup.js:25` |
+
+---
+
+## 3. Code Simplification
+
+### 3.1 Duplicated Logic
+
+| Issue | Files Affected | Effort |
+|-------|---------------|--------|
+| `PRIORITY_STYLES` duplicated identically in `FeaturesTable.vue`, `RfesTable.vue`, and `constants.js` | 3 files | S |
+| `docId` computed (Google Doc URL parsing) in `NewReleaseDialog.vue` (note: `ImportDocDialog.vue` is dead code -- see 3.2) | 1 file | S |
+| Tier grouping logic (`tierCounts` + `groupedFeatures`/`groupedRfes`) is nearly identical in `FeaturesTable.vue` and `RfesTable.vue` | 2 files | S |
+| Preview table markup (with status badge) in `NewReleaseDialog.vue` (note: `ImportDocDialog.vue` is dead code -- see 3.2) | 1 file | N/A |
+| Status color mappings duplicated between `StatusBadge.vue` and `constants.js` | 2 files | S |
+| `closedList` construction (`CLOSED_STATUSES.map(...)`) repeated in 4 Jira client functions (lines 193, 227, 263, 309) | 1 file | S |
+| `targetVersionJql` construction with `cfMatch` regex repeated in 3 functions | 1 file | S |
+
+**Recommendations:**
+1. Extract `PRIORITY_STYLES` into a shared constants file or import from `constants.js` on the client side
+2. Extract `parseDocId()` (already exists in `doc-import.js`) and share it with the client via a utils module or expose it from the composable
+3. Consider extracting a `useTierGrouping(items)` composable, though the logic is only ~20 lines in each file and structurally differs slightly -- this may add indirection without meaningful DRY benefit (see Phase 1 notes)
+4. Extract `buildClosedStatusList()` and `buildTargetVersionJql()` helper functions in `jira-client.js`
+
+### 3.2 Dead Code & Unused Exports
+
+| Issue | Location | Effort |
+|-------|----------|--------|
+| `batchFetchLinkedIssues` is exported but never called | `jira-client.js:368` | S |
+| `discoverCustomFields` is exported but never called | `jira-client.js:395` | S |
+| `loadFieldMapping` is exported but only used transitively via `getConfig` | `config.js:40` | S |
+| `useRockColors` composable is defined but never imported by any component | `composables/useRockColors.js` | S |
+| `checkRefreshStatus` is exported from composable but never called by any view | `useReleasePlanning.js:49` | S |
+| `ImportDocDialog.vue` is never imported by any component or view | `components/ImportDocDialog.vue` | S |
+
+**Recommendation:** Remove `batchFetchLinkedIssues`, `discoverCustomFields`, and `ImportDocDialog.vue` (dead code, never imported). If the Jira functions are exploration/debugging utilities, move them to a separate `jira-debug.js` file. Keep `checkRefreshStatus` -- it will likely be needed for polling (see reliability section).
+
+### 3.3 Style Inconsistencies
+
+| Issue | Location |
+|-------|----------|
+| Mix of `var` and `const`/`let` within the same file | `server/index.js`, `config.js` |
+| Some functions use `function()` callbacks, others use arrow functions | Throughout server files |
+| Inconsistent `function(req, res)` vs `async function(req, res)` -- some routes are unnecessarily `async` | `server/index.js` |
+
+These are cosmetic but create cognitive friction during review. The codebase convention (from AGENTS.md) is CommonJS for server code. The `var` vs `const` inconsistency suggests multiple authoring passes. A single formatting pass would improve readability.
+
+---
+
+## 4. Architecture Review
+
+### 4.1 Data Model
+
+**Current:** All release data lives in a single `config.json` file. Each release's Big Rocks array, field mappings, and custom field IDs are stored together.
+
+**Concern:** As the number of releases grows, every read/write operation loads and serializes the entire config. With 5+ releases, each with 15+ Big Rocks, this file grows to 50KB+. More importantly, the config lock serializes ALL writes across ALL releases -- editing a Big Rock in release 3.6 blocks edits in release 3.5.
+
+**Recommendation (P1, M):** Consider splitting config into per-release files: `config-meta.json` (field mappings, custom field IDs) and `config-release-{version}.json` (Big Rocks for that release). This allows per-release locking and reduces I/O. The migration path is straightforward: read old format, write new format, prefer new format on load.
+
+### 4.2 Caching Strategy
+
+**Current:** Candidates are cached per-release with a 15-minute TTL. When stale, a background refresh is triggered and stale data is served. The `refreshState` is module-level (singleton), so only one refresh can run at a time across all releases.
+
+**Issues:**
+1. **Single-refresh bottleneck** -- If release 3.5 is refreshing, a request for stale 3.6 data will not trigger a refresh. It will serve stale data until 3.5 finishes.
+2. **No refresh timeout** -- A stalled Jira connection will block all future refreshes indefinitely.
+3. **No ETag or conditional caching** -- The client has no way to know if cached data has changed without re-fetching the full payload.
+4. **Cache invalidation on Big Rock changes** -- `invalidateCache()` deletes the cache file AND immediately triggers a refresh, but the client is not notified that a refresh is happening.
+
+**Recommendations:**
+1. **(P1, M)** Track refresh state per-version instead of globally. Use a `Map<version, refreshState>` pattern.
+2. **(P1, S)** Add a refresh timeout (e.g., 5 minutes). Use `AbortController` or a wrapper that rejects after timeout.
+3. **(P2, M)** Add `ETag` or `Last-Modified` headers to the candidates endpoint so the client can use conditional requests.
+4. **(P1, S)** After `invalidateCache()`, return the in-flight refresh state to the client so the UI can show a loading indicator.
+
+### 4.3 API Design
+
+**Current API surface is clean and RESTful.** A few observations:
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| `POST /releases/:version/refresh` requires admin but `GET /releases/:version/candidates?refresh=true` triggers refresh with just auth | Medium | Authorization inconsistency -- any authenticated user can force-refresh via query param, bypassing the admin guard on the POST endpoint |
+| No PATCH support for Big Rocks -- PUT requires the full object | Low | Forces client to send all fields even for single-field updates |
+| `GET /releases` does not include milestone dates from SmartSheet | Low | Requires separate API call for dates |
+| `GET /refresh/status` is global, not per-version | Medium | Client cannot check status for a specific release |
+
+**Force-refresh authorization inconsistency (P1):** The `GET /releases/:version/candidates?refresh=true` endpoint triggers `triggerBackgroundRefresh()` for any authenticated user, bypassing the `requireAdmin` guard on `POST /releases/:version/refresh`. However, the same refresh fires automatically when cache expires (the `isStale` check at line 157-159), so any authenticated user viewing stale data already triggers a refresh. The `refresh=true` query param is a convenience bypass of the staleness timer, not a security vulnerability. It should still be gated behind `requirePM` for consistency, but this is a P1 authorization inconsistency, not a P0 privilege escalation. This should either:
+- Remove the `refresh=true` query param from the GET endpoint, or
+- Gate it behind `requirePM` or `requireAdmin`
+
+### 4.4 Error Handling Patterns
+
+Error handling is generally good (try/catch with statusCode propagation), but has inconsistencies:
+
+| Issue | Location | Impact |
+|-------|----------|--------|
+| `decodeURIComponent` can throw `URIError` on malformed input | `server/index.js:276, 356, 515` | Unhandled exception crashes the route |
+| Jira client functions silently return empty arrays on error | `jira-client.js` all fetch functions | Pipeline proceeds with partial data -- no indication to user |
+| `triggerBackgroundRefresh` catches errors but only logs them | `server/index.js:90-95` | User sees stale data with no explanation |
+| `loadFixture` swallows all errors silently | `server/index.js:48-50` | Demo mode silently fails |
+
+**Recommendation (P1, S):** Wrap all three `decodeURIComponent` calls (lines 276, 356, and 515) in try/catch and return 400 on `URIError`. For the pipeline, consider accumulating warnings alongside results so the frontend can display partial-data notices.
+
+### 4.5 Separation of Concerns
+
+The module has good file-level separation. However, `server/index.js` at 707 lines is doing too much:
+- Route registration
+- Demo mode fixture loading
+- Background refresh orchestration
+- Cache invalidation logic
+- Version validation
+
+**Recommendation (P2, M):** Extract background refresh management into a `refresh-manager.js` module. Extract route handlers into grouped files (e.g., `routes-releases.js`, `routes-big-rocks.js`, `routes-import.js`) if the file grows further.
+
+---
+
+## 5. Reliability & Performance
+
+### 5.1 Race Conditions
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| `refreshState` is a mutable singleton -- concurrent requests can read inconsistent state | Low | Acceptable for single-replica |
+| Config lock is in-process only -- multi-replica deployment would cause data corruption | **Medium** | Documented as single-replica constraint, but should be called out in operational docs |
+| `invalidateCache` deletes cache then starts refresh -- a concurrent read between delete and write returns 202 (no cache) | Low | User sees "pipeline running" briefly |
+| `executeDocImport` in replace mode deletes all rocks then re-adds -- if the process crashes mid-import, data is lost | Medium | Mitigated by backup-before-delete |
+
+**Multi-replica concern (P1, documented):** The config lock comment says "sufficient for current single-replica deployment." If the deployment ever scales to multiple replicas, the filesystem-based locking will silently break. Consider adding a startup log warning or a health-check assertion for single-replica mode.
+
+### 5.2 Error Recovery
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| Background refresh failure sets `lastResult.status = 'error'` but provides no retry mechanism | Medium | User must manually trigger refresh |
+| No exponential backoff on Jira API errors (only rate-limit 429 retries exist in shared client) | Low | Transient Jira errors require manual retry |
+| `writeToStorage` is synchronous (`writeFileSync`) -- a crash during write can corrupt the file | Medium | Mitigated by backup system |
+| No health check for Jira connectivity | Low | Pipeline fails silently on auth errors |
+
+**Recommendation (P1, S):** Add automatic retry for background refresh failures (1-2 retries with exponential backoff). Note: do NOT wire Jira connectivity checks into k8s liveness/readiness probes -- a Jira outage should not cause pod restarts. Use the existing `registerDiagnostics` callback instead, which is already implemented and reports module health without affecting pod lifecycle.
+
+### 5.3 Performance Concerns
+
+| Issue | Impact | Detail |
+|-------|--------|--------|
+| Pipeline makes N+1 Jira queries (one per outcome key per rock, plus tier 2/3 queries) | High for large configs | 15 rocks x 2 outcomes = 30+ sequential throttled queries at 1s each = 30s minimum |
+| `getConfig(readFromStorage)` is called redundantly within locked sections | Low | Multiple reads of the same file within a single lock acquisition |
+| `BigRocksTable.vue` re-renders all rows on any reorder | Low | Could use `key` optimization with stable IDs |
+| Markdown export processes all data synchronously on the main thread | Low | Acceptable for current scale |
+
+**Pipeline query count (P1, M):** For a release with 15 Big Rocks averaging 2 outcome keys each, the Tier 1 phase makes 30 feature queries and 30 RFE queries (60 total), throttled at 1s each = 1 minute minimum. Tier 2 adds 2 more queries. Consider batching outcome keys into a single JQL query where possible:
+
+```
+parent IN (KEY-1, KEY-2, KEY-3, ...) AND type = Feature AND ...
+```
+
+This would reduce 30 queries to a handful of batched queries. The tradeoff is losing the per-outcome-key rock mapping, which would need to be resolved in post-processing by checking each issue's parent field.
+
+### 5.4 Stale Data Handling
+
+The stale-while-revalidate pattern is well-implemented. One gap: when a PM edits a Big Rock and then immediately views the Features tab, the cached candidates still reference the old Big Rock names. The `invalidateCache()` function triggers a background refresh, but the user sees stale feature-to-rock mappings until it completes. The UI should indicate this more prominently.
+
+---
+
+## 6. UX / Frontend Quality
+
+### 6.1 Component Design
+
+| Observation | Severity | Detail |
+|-------------|----------|--------|
+| `BigRocksTable.vue` has two full table body implementations (draggable vs read-only) with duplicated column markup | Medium | 80 lines of duplicated table cells |
+| Edit panel uses module-level singleton refs -- two browser tabs editing simultaneously will conflict | Medium | `useBigRockEditor.js` uses `const isOpen = ref(false)` at module scope |
+| No keyboard shortcut support (Escape to close panels, Enter to save) | Low | Accessibility improvement |
+| ~~`ImportDocDialog.vue` duplicates API calls~~ | ~~Medium~~ | Removed -- `ImportDocDialog.vue` is dead code (never imported); see section 3.2 |
+| No loading skeleton / placeholder during initial load | Low | Shows "Loading release planning data..." text only |
+
+**BigRocksTable duplication (P1, M):** The draggable and read-only table bodies share identical column templates. Extract the column cells into a `BigRockRow.vue` component that both paths use. The draggable wrapper can use it via slot, and the static tbody can iterate over it.
+
+**Singleton editor state (P1, S):** Because `useBigRockEditor` uses module-level refs, all component instances share the same state. In a single-tab SPA this works fine, but if the module is ever used in multiple module views or tabs, it will break. Consider using `provide`/`inject` with a factory pattern, or at minimum document this as a known constraint.
+
+**`isDirty` edit tracking scope (intentional, documented):** `useBigRockEditor.js` lines 44-48 only compare `owner`, `architect`, `outcomeKeys`, and `notes` in the edit-mode dirty check. The fields `name`, `fullName`, and `pillar` are excluded. This is intentional -- these fields are read-only in the edit panel (they can only be set during creation, where the "new rock" dirty check at lines 35-41 does check all fields). This is not a bug but should be documented with a code comment to prevent confusion.
+
+### 6.2 State Management
+
+The composable pattern (`useReleasePlanning.js`) uses module-level refs for singleton state. This is a deliberate choice per the codebase conventions (shared/client composables use the same pattern). Observations:
+
+1. **No optimistic updates for reorder** -- dragging a Big Rock triggers an API call, and the list reverts to the server response. If the API is slow, the user sees a jarring revert-then-update. The current `onDragEnd` emits the new order, but `handleReorder` in `DashboardView.vue` does not optimistically update the local state before the API call.
+
+2. **Error state is global** -- `error.value` is shared across all operations. A failed delete sets the error, which persists even when the user switches releases or tabs.
+
+3. **No polling for refresh completion** -- `checkRefreshStatus` exists but is never called. After triggering a refresh, the user has no feedback when it completes. They must manually reload.
+
+**Recommendations:**
+- **(P1, S)** Clear `error.value` on release change or tab switch
+- **(P1, M)** Implement refresh polling: after triggering refresh, poll `GET /refresh/status` every 5-10 seconds until `running === false`, then reload candidates
+- **(P2, S)** Add optimistic reorder: update `localRocks` immediately, revert on error
+
+### 6.3 Accessibility
+
+| Issue | WCAG Level | Detail |
+|-------|------------|--------|
+| Drag handle uses Unicode character (braille dots) with no `aria-label` | A | Screen readers cannot identify the drag handle |
+| Modal dialogs do not trap focus | A | Tab key can escape the modal to background elements |
+| No `aria-live` region for background refresh notifications | AA | Status changes are not announced to screen readers |
+| Select dropdowns have no accessible labels (only visual labels) | A | Filter selects in `FilterBar.vue` lack `id`/`for` association |
+| Tables lack `<caption>` elements | AA | Screen readers cannot identify table purpose |
+
+### 6.4 Responsive Design
+
+The dashboard uses Tailwind responsive classes well for summary cards (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`). However:
+- Tables overflow horizontally on mobile (handled by `overflow-x-auto`) but with no mobile-friendly alternative view
+- The edit panel is `max-w-lg` with `w-full` which works on mobile but is dense
+- Filter bar wraps naturally via `flex-wrap` -- acceptable
+
+---
+
+## 7. Testability & Deployability
+
+### 7.1 Current Test Coverage
+
+**Strengths:**
+- 205 tests, all passing, across 13 files
+- Server-side logic is comprehensively tested: config CRUD, validation, pipeline, Jira client field extraction, doc import/parse, backup management, locking, PM auth
+- Tests use proper mocking (vi.fn()) for storage and Jira functions
+- Pipeline tests cover all three tiers, deduplication, filtering, and edge cases
+
+**Gaps:**
+
+| Gap | Severity | Detail |
+|-----|----------|--------|
+| No client-side (Vue component) tests | **Medium** | Zero component tests -- all 13 test files are server-side |
+| No integration tests for route handlers | Medium | `server/index.js` is untested; validation/auth flow is only tested at unit level |
+| No test for `loadFixture()` behavior | Low | Demo mode fixture loading is untested |
+| No test for `invalidateCache()` | Low | Cache invalidation logic is untested |
+| No test for the admin seed endpoint validation | Medium | Seed endpoint accepts arbitrary config shapes |
+| SmartSheet test mocks the HTTP layer but doesn't test error paths | Low | `smartsheet.test.js` -- limited error path coverage |
+
+**Recommendations:**
+1. **(P1, L)** Add route-handler integration tests using `supertest` -- test the full request/response cycle including auth guards, validation, and error responses across all 21 routes
+2. **(P1, M)** Add Vue component tests for `DashboardView`, `BigRocksTable`, and `BigRockEditPanel` -- focus on user interactions (edit, delete, reorder)
+3. **(P2, S)** Add a test for the admin seed endpoint that verifies it rejects malformed Big Rock data
+
+### 7.2 Deployability
+
+- Module follows the standard module system (auto-discovered via `module.json`)
+- No external dependencies beyond the shared Jira, Google Docs, and SmartSheet clients
+- Data stored in the standard PVC-mounted `data/` directory
+- No database or external state -- fully filesystem-backed
+- Demo mode is fully functional for demonstrations without credentials
+
+**CI/CD considerations:**
+- Fixture files are included in the repo and tested against
+- No migration scripts needed (config format is forward-compatible via spread defaults)
+- The `fixtures/release-planning/` directory must be included in the backend Docker image (it is, per `deploy/backend.Dockerfile`)
+- **Pre-existing gap (D1):** The ARM Mac build workaround in `deploy/OPENSHIFT.md` does not include `COPY fixtures/` -- fixture files are not available in ARM-built images. This is a pre-existing issue, not introduced by this module.
+- **Pre-existing gap (D4):** The `fixtures/` path is not included in `build-images.yml` trigger paths, so fixture-only changes will not trigger image rebuilds. Low risk since fixture changes typically accompany code changes.
+
+**Health check considerations:**
+- **Do NOT wire module health into k8s probes (D2).** A Jira outage should not cause pod restarts. Instead, use the existing `registerDiagnostics` callback (already implemented at line 686) which exposes module health via the platform's `/api/healthz` diagnostics endpoint without affecting pod lifecycle.
+
+---
+
+## 8. Backward Compatibility
+
+### Existing APIs & Data Contracts
+
+| Contract | Status | Risk |
+|----------|--------|------|
+| `GET /releases` response format | Stable | None -- additive changes only |
+| `GET /releases/:version/candidates` response format | Stable | Adding `_cacheStale` and `_refreshing` was additive |
+| `config.json` data format | Stable | `getConfig()` merges with defaults; old configs work |
+| `pm-users.json` format | Stable | Simple `{ emails: [] }` structure |
+| `candidates-cache-{version}.json` format | Internal | Cache files can be regenerated; format changes are safe |
+| Fixture file format | Stable | Demo mode depends on fixture structure |
+
+**Breaking change risk from proposed improvements:**
+- Splitting `config.json` into per-release files would require a one-time migration. This MUST be backward-compatible: the system should read the old single-file format if per-release files don't exist, then lazily migrate on the next write.
+- Changing the refresh state from global to per-version changes the `GET /refresh/status` response shape. Since this endpoint is internal (only used by the frontend), this is a coordinated change, not a breaking API change.
+- PM email `.toLowerCase()` in `isPM()` is a defense-in-depth addition; no behavior change since `req.userEmail` is already lowercased by the auth middleware.
+- Gating `refresh=true` behind `requirePM` is a minor authorization tightening -- non-PM authenticated users will no longer be able to force-refresh via query param (but stale cache auto-refreshes unaffected).
+
+---
+
+## 9. Recommended Improvements
+
+### Phase 0: Critical Fixes (Ship This Week)
+
+| # | Improvement | Effort | Priority | Files |
+|---|-------------|--------|----------|-------|
+| 0.1 | **Fix RFE markdown export `.join()` on string** -- `DashboardView.vue` line 147 calls `(r.labels \|\| []).join(', ')` but `r.labels` is already a comma-separated string from `mapToCandidate`, not an array. Calling `.join()` on a string iterates characters, producing garbled output like `"l, a, b, e, l, 1"`. Fix: use `r.labels \|\| '-'` directly (it is already a string) | S | P0 | `DashboardView.vue` |
+| 0.2 | **Admin seed validation** -- validate Big Rock objects within seeded releases through `validateBigRock`. The seed endpoint accepts arbitrary config shapes and is the primary vector for injecting malformed data (including invalid outcome keys that bypass JQL input validation) | S | P0 | `server/index.js` |
+| 0.3 | **Wrap `decodeURIComponent` in try/catch** -- return 400 on URIError for all three call sites: `:name` params (lines 276, 356) and `:email` param (line 515) | S | P0 | `server/index.js` |
+| 0.4 | **Fix `/permissions` route duplicate PM check** -- the `GET /permissions` endpoint (lines 236-242) uses `getPMUsers(readFromStorage)` and `pmList.includes(req.userEmail)` directly instead of calling `isPM()` via `createRequirePM`. Refactor to use the canonical `isPM()` function to prevent logic drift | S | P0 | `server/index.js`, `pm-auth.js` |
+
+### Phase 1: Reliability & Core Quality (Next 2 Sprints)
+
+| # | Improvement | Effort | Priority | Files |
+|---|-------------|--------|----------|-------|
+| 1.1 | **Per-version refresh state** -- replace singleton `refreshState` with `Map<version, state>`. Note: concurrent per-version refreshes could exceed Jira rate limits causing 429 errors. Add a concurrency limit (e.g., max 2 concurrent refreshes) or a queue to coordinate Jira API throttling across versions | M | P1 | `server/index.js` |
+| 1.2 | **Refresh timeout** -- add 5-minute timeout to background refresh via AbortController or Promise.race | S | P1 | `server/index.js` |
+| 1.3 | **Refresh polling on client** -- after triggering refresh, poll `GET /refresh/status` and reload candidates on completion | M | P1 | `useReleasePlanning.js`, `DashboardView.vue` |
+| 1.4 | **Clear error state on context change** -- reset `error.value` when switching releases or tabs | S | P1 | `DashboardView.vue` |
+| 1.5 | **DRY BigRocksTable** -- extract shared row template to eliminate 80 lines of duplication | M | P1 | `BigRocksTable.vue` |
+| 1.6 | **DRY PRIORITY_STYLES** -- import from a shared client constants file instead of duplicating | S | P1 | `FeaturesTable.vue`, `RfesTable.vue`, `constants.js` |
+| 1.7 | **Fix force-refresh authorization inconsistency** -- gate `refresh=true` query param behind `requirePM` or remove it. This is not a privilege escalation (stale data already triggers the same refresh automatically), but the auth guard inconsistency with `POST /releases/:version/refresh` should be resolved | S | P1 | `server/index.js` |
+| 1.8 | **Add route-handler integration tests** -- test auth guards, validation, error paths for all 21 routes. Each requires auth setup, mock storage, and assertions | L | P1 | New: `__tests__/server/routes.test.js` |
+| 1.9 | **Add JQL input sanitization (defense-in-depth)** -- validate outcome keys match OUTCOME_KEY_PATTERN before JQL interpolation in pipeline. This is defense-in-depth since CRUD validation and admin seed validation (item 0.2) already guard input | S | P1 | `pipeline.js` |
+| 1.10 | **Automatic refresh retry** -- retry failed background refresh 1-2 times with backoff | S | P1 | `server/index.js` |
+| 1.11 | **PM email normalization (defense-in-depth)** -- add `.toLowerCase()` in `isPM()` as defense-in-depth, even though `shared/server/auth.js` already normalizes `req.userEmail` in all auth paths | S | P2 | `pm-auth.js` |
+
+### Phase 2: Performance & UX Polish (Next Quarter)
+
+| # | Improvement | Effort | Priority | Files |
+|---|-------------|--------|----------|-------|
+| 2.1 | **Batch outcome queries** -- combine multiple outcome keys into single JQL `parent IN (...)` queries | M | P1 | `jira-client.js`, `pipeline.js` |
+| 2.2 | **Split config into per-release files** -- reduce lock contention and I/O for multi-release setups. Note: the backup system (`config-backup.js`) currently backs up the single `config.json` file. The migration must also update the backup system to handle per-release files (back up individual release files, or create a composite backup archive). Include a migration strategy for existing backups | M | P1 | `config.js`, `config-backup.js` |
+| 2.3 | **Optimistic reorder** -- update local state immediately on drag, revert on error | S | P2 | `DashboardView.vue`, `BigRocksTable.vue` |
+| 2.4 | **Add Vue component tests** -- DashboardView, BigRocksTable, BigRockEditPanel | L | P1 | New test files |
+| 2.5 | **Accessibility improvements** -- focus trap in modals, aria-labels on drag handles, table captions | M | P2 | Multiple components |
+| 2.6 | **Pipeline partial-data warnings** -- accumulate warnings when Jira queries fail and surface in UI | M | P2 | `pipeline.js`, `server/index.js`, client |
+| 2.7 | **Remove dead code** -- `batchFetchLinkedIssues`, `discoverCustomFields`, unused `useRockColors`, and `ImportDocDialog.vue` (never imported by any component) | S | P2 | `jira-client.js`, `useRockColors.js`, `ImportDocDialog.vue` |
+| 2.8 | **Conditional caching (ETag)** -- add `ETag` header to candidates endpoint for efficient client polling | M | P2 | `server/index.js` |
+| 2.9 | **`var` to `const`/`let` cleanup** -- normalize variable declarations across server files | S | P2 | Multiple server files |
+| 2.10 | **`executeDocImport` replace mode write amplification** -- replace mode calls `deleteBigRock` N times, each doing a full read-write cycle. Consider a bulk-delete-then-bulk-add pattern to reduce I/O | S | P2 | `doc-import.js` |
+
+### Phase 3: Future Capabilities (Illustrative -- Pending Product Owner Input)
+
+> **Caveat:** The items below are illustrative possibilities, not planned work. There is no evidence from requirements or user feedback that these are needed. They are included to map out the design space, but none should be scheduled without explicit product owner prioritization.
+
+| # | Improvement | Effort | Priority | Files |
+|---|-------------|--------|----------|-------|
+| 3.1 | **Audit log** -- record who changed what and when (Big Rock edits, imports, deletes) | M | P2 | New: `audit.js`, route handlers |
+| 3.2 | **Per-release permissions** -- allow PMs to be assigned to specific releases | M | P2 | `pm-auth.js`, config schema |
+| 3.3 | **Read-only role** -- separate from "no access"; currently all authenticated users can view | S | P2 | `server/index.js` |
+| 3.4 | **Multi-replica support** -- distributed locking via Redis or advisory file locks | L | P2 | `config-lock.js` |
+| 3.5 | **CSV export** -- in addition to Markdown, offer CSV for spreadsheet import | S | P2 | `DashboardView.vue` |
+| 3.6 | **Webhook/event integration** -- notify external systems when Big Rocks change | M | P2 | New module |
+| 3.7 | **Version comparison view** -- side-by-side diff of two releases' Big Rocks | L | P2 | New view |
+
+---
+
+## 10. Files Modified
+
+Summary of all files that would be changed by the recommended improvements, organized by phase.
+
+### Phase 0 (Critical Fixes)
+
+| File | Change |
+|------|--------|
+| `modules/release-planning/client/views/DashboardView.vue` | Fix `.join()` on string in RFE markdown export (line 147) |
+| `modules/release-planning/server/index.js` | Validate seed Big Rocks; wrap all 3 `decodeURIComponent` calls (lines 276, 356, 515); refactor `/permissions` to use canonical `isPM()` |
+| `modules/release-planning/server/pm-auth.js` | Export `isPM()` for use by `/permissions` route |
+
+### Phase 1 (Reliability & Quality)
+
+| File | Change |
+|------|--------|
+| `modules/release-planning/server/index.js` | Per-version refresh state (with concurrency limit); refresh timeout; retry logic; gate `refresh=true` behind `requirePM` |
+| `modules/release-planning/server/pipeline.js` | Assert outcome key format before JQL interpolation (defense-in-depth) |
+| `modules/release-planning/server/pm-auth.js` | Add `.toLowerCase()` defense-in-depth in `isPM()` |
+| `modules/release-planning/client/composables/useReleasePlanning.js` | Add refresh polling logic |
+| `modules/release-planning/client/views/DashboardView.vue` | Clear error on context change; integrate refresh polling |
+| `modules/release-planning/client/components/BigRocksTable.vue` | Extract shared row template |
+| `modules/release-planning/client/components/FeaturesTable.vue` | Import shared PRIORITY_STYLES |
+| `modules/release-planning/client/components/RfesTable.vue` | Import shared PRIORITY_STYLES |
+| `modules/release-planning/__tests__/server/routes.test.js` | **New file** -- integration tests (L effort: 21 routes with auth setup, mock storage, assertions) |
+
+### Phase 2 (Performance & Polish)
+
+| File | Change |
+|------|--------|
+| `modules/release-planning/server/jira-client.js` | Batch outcome queries; remove dead code (`batchFetchLinkedIssues`, `discoverCustomFields`) |
+| `modules/release-planning/server/pipeline.js` | Adapt to batched queries; add warning accumulation |
+| `modules/release-planning/server/config.js` | Per-release file split (with backward compat) |
+| `modules/release-planning/server/config-backup.js` | Update backup system for per-release file format |
+| `modules/release-planning/server/doc-import.js` | Optimize replace-mode write amplification |
+| `modules/release-planning/client/components/ImportDocDialog.vue` | **Delete** -- dead code, never imported |
+| `modules/release-planning/client/composables/useRockColors.js` | Remove if unused (or document intent) |
+| `modules/release-planning/__tests__/client/` | **New directory** -- Vue component tests |
+
+---
+
+## Appendix A: Architecture Diagram
+
+```
+Client (Vue 3 SPA)
+  |
+  |-- DashboardView.vue
+  |     |-- useReleasePlanning() -----> GET /releases
+  |     |-- useReleasePlanning() -----> GET /releases/:v/candidates
+  |     |-- useBigRockEditor() -------> PUT /releases/:v/big-rocks/:name
+  |     |-- loadPermissions() -------> GET /permissions (determines edit UI visibility)
+  |     |-- useFilters() ------------> (client-side filtering)
+  |     |
+  |     |-- BigRocksTable.vue (drag-to-reorder)
+  |     |-- FeaturesTable.vue (tier-grouped)
+  |     |-- RfesTable.vue (tier-grouped)
+  |     |-- FilterBar.vue
+  |     |-- SummaryCards.vue
+  |     |-- BigRockEditPanel.vue (slide-over)
+  |     |-- BigRockDeleteDialog.vue (modal)
+  |     |-- NewReleaseDialog.vue (modal + SmartSheet + Google Doc import)
+  |
+Server (Express, mounted at /api/modules/release-planning/)
+  |
+  |-- index.js (routes)
+  |     |-- config.js (CRUD operations, config read/write)
+  |     |-- validation.js (Big Rock field validation)
+  |     |-- config-lock.js (in-process mutex)
+  |     |-- config-backup.js (timestamped backups)
+  |     |-- pm-auth.js (PM role middleware)
+  |     |-- pipeline.js (3-tier Jira discovery)
+  |     |-- jira-client.js (Jira field extraction, JQL builders)
+  |     |-- doc-import.js (Google Doc import orchestration)
+  |     |-- constants.js (status styles, column defs, cache TTL)
+  |
+  |-- Shared dependencies:
+  |     |-- shared/server/jira.js (Jira HTTP client, auth, pagination)
+  |     |-- shared/server/google-docs.js (Docs API auth, document parsing)
+  |     |-- shared/server/smartsheet.js (SmartSheet API, release discovery)
+  |     |-- shared/server/storage.js (filesystem read/write with path traversal protection)
+  |     |-- shared/server/auth.js (admin auth, allowlist, proxy secret)
+  |
+Storage (filesystem, PVC-mounted)
+  |
+  |-- data/release-planning/config.json (all releases + Big Rocks)
+  |-- data/release-planning/pm-users.json (PM email list)
+  |-- data/release-planning/candidates-cache-{version}.json (per-release)
+  |-- data/release-planning/config-backup-{timestamp}.json (max 10)
+```
+
+## Appendix B: Questions for Product Owner
+
+Before proceeding with Phase 2 and Phase 3 work, the following questions should be answered:
+
+1. **Scale expectations** -- How many concurrent releases will be active? This informs the priority of config splitting and per-version locking.
+2. **Access control granularity** -- Is per-release PM assignment needed, or is a flat PM list sufficient?
+3. **Audit requirements** -- Do PMs/EMs need to see who changed what and when? This would require an audit log feature.
+4. **Integration plans** -- Are there plans to integrate with other modules (e.g., feature-traffic, ai-impact) or external systems beyond Jira?
+5. **Export formats** -- Is CSV export needed alongside Markdown? What about integration with Google Sheets or Confluence?
+6. **Multi-replica deployment** -- Is there a timeline for scaling beyond single-replica? This affects the locking strategy.
+7. **CronJob coverage** -- The daily CronJob (`cronjob-sync-refresh.yaml`) currently triggers roster sync and metrics refresh but does NOT include release-planning data refresh. Should it? This would ensure pipeline caches are fresh each morning without manual intervention.
+
+---
+
+## Revision History
+
+### Rev 2 -- 2026-04-23 (Post-Review Revision)
+
+Revised based on feedback from three independent reviewers (code reviewer, DevOps reviewer, red team/adversarial reviewer). All critical and major findings were addressed.
+
+**Critical findings addressed:**
+
+| ID | Finding | Action Taken |
+|----|---------|--------------|
+| C1 | PM email case-sensitivity bug is not a real P0 -- `shared/server/auth.js` already lowercases `req.userEmail` in all auth paths | Demoted from P0 to P2 defense-in-depth (item 1.11). Updated section 2.1 description to explain why the bug cannot occur. |
+| C2 | JQL injection severity overstated -- requires admin access, and OUTCOME_KEY_PATTERN already validates at CRUD time | Demoted JQL sanitization from P0 to P1 defense-in-depth (item 1.9). Promoted admin seed validation from P1 item 1.9 to P0 item 0.2. |
+| C3 | `GET /permissions` has duplicate PM check bypassing `createRequirePM` | Added as new P0 item 0.4. Added to section 2.1 description. |
+| C4 | `ImportDocDialog.vue` is dead code -- never imported anywhere | Removed items 2.3 and 2.4. Added to dead code removal list (item 2.7). Removed from architecture diagram. |
+| C5 | RFE markdown export `.join()` on a string produces garbled output | Added as new P0 item 0.1. |
+| C6 | Third `decodeURIComponent` at line 515 was missed | Updated item 0.3 and section 4.4 to include all three call sites (lines 276, 356, 515). |
+
+**Major findings addressed:**
+
+| ID | Finding | Action Taken |
+|----|---------|--------------|
+| M1 | Force-refresh "privilege escalation" label is misleading | Re-labeled to "authorization inconsistency", demoted from P0 to P1 (item 1.7). Updated section 4.3 description. |
+| M2 | `closedList` construction count is 4, not 5 | Corrected to 4 (lines 193, 227, 263, 309). |
+| M3 | Test count discrepancy | Verified: 205 `it()` blocks across 13 test files. Corrected from 203. |
+| M4 | Route integration test effort underestimated | Re-estimated from M to L (21 routes, each requiring auth setup, mock storage, assertions). |
+| M5 | Per-version refresh could cause Jira rate limit issues | Added concurrency limit note to item 1.1. |
+| M6 | `isDirty` doesn't check name/fullName/pillar in edit mode | Documented as intentional -- these fields are read-only in the edit panel. Added explanation to section 6.1. |
+| M7 | Phase 3 items are speculative | Added caveat that Phase 3 items are illustrative possibilities pending product owner input, not planned work. |
+
+**Minor findings addressed:**
+
+| ID | Finding | Action Taken |
+|----|---------|--------------|
+| m1 | Tier grouping composable extraction may be over-engineering | Removed from Phase 1 table. Added qualifying note in section 3.1 recommendations. |
+| m2 | Architecture diagram omits `/permissions` endpoint | Added `loadPermissions() --> GET /permissions` to diagram. |
+| m3 | Admin seed could cause vuedraggable duplicate key errors | Added as downstream consequence note in section 2.2. |
+| m4 | `executeDocImport` replace mode has O(N) write amplification | Added as item 2.10. |
+
+**DevOps findings addressed:**
+
+| ID | Finding | Action Taken |
+|----|---------|--------------|
+| D1 | ARM Mac workaround omits `COPY fixtures/` | Added to deployability section as pre-existing gap. |
+| D2 | Module health check should NOT be wired into k8s probes | Updated health check recommendation in section 5.2 and deployability section. |
+| D3 | CronJob doesn't include release-planning refresh | Added to Appendix B question 7. |
+| D4 | `fixtures/` path not in `build-images.yml` triggers | Added to deployability section as pre-existing gap. |
+| D5 | Config split needs backup system migration strategy | Added migration note to item 2.2. |
+
+**Item renumbering:** Phase 0 items 0.1-0.4 are completely new (old items moved to Phase 1). Phase 2 items renumbered after removing 2.3/2.4 and adding 2.10.

--- a/design/2026-04-26-release-plan-health-redesign.md
+++ b/design/2026-04-26-release-plan-health-redesign.md
@@ -1,0 +1,120 @@
+# Release Plan Health Redesign -- Draft Plan
+
+**Date:** 2026-04-26
+**Status:** Draft for review
+
+---
+
+## Summary
+
+Replace the current "Release Health" view with "Release Plan Health". Switch feature sourcing from the feature-traffic index to the Big Rocks candidates pipeline (Tier 1/2/3). Add a phase selector (EA1/EA2/GA) with planning-deadline awareness. Add three planning-specific risk categories; suppress two execution-phase categories in pre-planning mode.
+
+---
+
+## Backend Changes
+
+### 1. `constants.js` -- add risk categories and planning deadline offset
+
+- Add `MISSING_OWNER`, `NO_BIG_ROCK`, `LATE_COMMITMENT` to `RISK_CATEGORIES`
+- Add `PLANNING_DEADLINE_OFFSET_DAYS = 7` constant
+- Add `PLANNING_RISK_CATEGORIES` array (the three new ones) and `EXECUTION_RISK_CATEGORIES` array (`MILESTONE_MISS`, `VELOCITY_LAG`) for suppress/enable logic
+
+### 2. `health-pipeline.js` -- replace feature sourcing
+
+- **Replace** `loadFeaturesForRelease()` with `loadFeaturesFromCandidates(readFromStorage, version)`:
+  - Read the cached candidates response (`release-planning/candidates-{version}.json`) written by `buildCandidateResponse()`
+  - Extract the `features` array (already has `tier`, `bigRock`, `issueKey`, `phase`, `components`, `pm`, `deliveryOwner`, `fixVersion`, `status`)
+  - **Phase filtering**: Accept optional `phase` param (EA1/EA2/GA). If a feature has a phase-specific fixVersion (e.g., `rhoai-3.5-EA2`), include it only in the matching phase view. Otherwise include in all phase views.
+  - Return features in the same shape the rest of the pipeline expects (key, summary, status, etc.). The candidate format is close; map `issueKey` -> `key` and carry `tier` + `bigRock` through.
+- **Add** `computePlanningDeadline(milestones, phase)`: returns the relevant freeze date minus 7 days
+- **Pass** the selected `phase` through to the risk engine so it can suppress/enable categories
+- Update `runHealthPipeline()` signature to accept `phase` param; cache key becomes `health-cache-{version}-{phase}.json`
+
+### 3. `risk-engine.js` -- suppress + augment
+
+- **Accept** `{ phase, planningDeadline }` in opts
+- **Suppress** `MILESTONE_MISS` and `VELOCITY_LAG` when `planningDeadline` is in the future (pre-planning mode)
+- **Add** `MISSING_OWNER`: flag if `deliveryOwner` is empty. Severity: medium.
+- **Add** `NO_BIG_ROCK`: flag if `tier === 3` (no Big Rock association). Severity: low. Message: "Not associated with any Big Rock"
+- **Add** `LATE_COMMITMENT`: flag if today is past the planning deadline and the feature has no fixVersion containing the version string. Severity: high. Message: "No committed fix version {N} days after planning deadline"
+- Existing `DOR_INCOMPLETE`, `BLOCKED`, `UNESTIMATED` checks remain unchanged
+
+### 4. `health-routes.js` -- add phase query param
+
+- All health GET routes accept `?phase=EA1|EA2|GA` query param (default: derive from current date using `computeMilestoneInfo`)
+- Pass phase through to `runHealthPipeline()`
+- Cache key includes phase: `health-cache-{version}-{phase}.json`
+- Refresh route also accepts phase param; triggers pipeline for that phase
+- No structural changes to DoR or override routes (they remain per-feature, phase-independent)
+
+### 5. No changes needed
+
+- `dor-checker.js` -- reuse as-is
+- `rice-scorer.js` -- reuse as-is
+- `jira-enrichment.js` -- reuse as-is (enriches by Jira key, source-agnostic)
+- `audit-log.js` -- reuse as-is
+
+---
+
+## Frontend Changes
+
+### 6. `module.json` -- rename nav item
+
+- Change `"label": "Release Health"` to `"label": "Release Plan Health"`
+
+### 7. `HealthDashboardView.vue` -- add phase selector, rename
+
+- Rename page title: "Release Health Dashboard" -> "Release Plan Health"
+- Add a `PhaseSelector` dropdown (EA1 / EA2 / GA) next to the existing `ReleaseSelector`
+  - Default phase: derived from `summary.currentPhase` (server returns this)
+  - Selection triggers `loadHealth(version, phase)`
+- Display planning deadline: "Planning deadline: {date} ({N} days away)" below the milestone timeline
+- Update empty state text: remove reference to "feature-traffic cache", point to "Big Rocks Planning" instead
+- Export filenames: `plan-health-{version}-{phase}.csv`
+
+### 8. `useReleaseHealth.js` -- pass phase param
+
+- `loadHealth(version, phase)` -- append `?phase=` to URL
+- `triggerHealthRefresh(version, phase)` -- same
+- `checkHealthRefreshStatus(version, phase)` -- same
+- ETag cache key includes phase
+
+### 9. Components -- minimal changes
+
+- `HealthSummaryCards.vue`: add a "Planning deadline" card showing days remaining. No other changes.
+- `FeatureHealthTable.vue`: show `tier` column (Tier 1/2/3 badge). Already has `bigRock` column.
+- `HealthFilterBar.vue`: add tier filter dropdown (Tier 1 / Tier 2 / Tier 3)
+- `MilestoneTimeline.vue`: highlight the selected phase's freeze date. No structural change.
+- New component: `PhaseSelector.vue` -- simple dropdown, ~30 lines. Options derived from milestones data (only show phases that have dates).
+
+---
+
+## New Risk Category Definitions
+
+| Category | Trigger | Severity | When Active |
+|---|---|---|---|
+| `MISSING_OWNER` | `deliveryOwner` is empty | medium | Always |
+| `NO_BIG_ROCK` | `tier === 3` | low | Always |
+| `LATE_COMMITMENT` | Past planning deadline + no fixVersion for this version | high | Post-deadline only |
+
+---
+
+## What We Reuse
+
+- **Risk engine structure** -- same `computeFeatureRisk()` signature, just add/suppress categories
+- **DoR checker** -- entirely unchanged
+- **RICE scorer** -- entirely unchanged
+- **Jira enrichment** -- entirely unchanged (works on Jira keys regardless of source)
+- **Health routes structure** -- same CRUD pattern, just add phase param
+- **All health UI components** -- HealthSummaryCards, FeatureHealthTable, HealthFilterBar, MilestoneTimeline, export logic
+- **ReleaseSelector component** -- unchanged
+- **useReleaseHealth composable** -- same pattern, just pass phase
+
+## What Changes
+
+- Feature sourcing: feature-traffic index -> candidates pipeline output (5 files)
+- Risk engine: +3 categories, suppress 2 conditionally (1 file)
+- Phase selector: new component + wiring (3 files)
+- Naming: "Release Health" -> "Release Plan Health" (2 files)
+
+**Total files touched: ~11. No new backend dependencies.**

--- a/design/release-health-plan.md
+++ b/design/release-health-plan.md
@@ -1,0 +1,1245 @@
+# Release Health: Implementation Plan
+
+**Author:** Architect Agent
+**Date:** 2026-04-26
+**Status:** Revised (review findings addressed)
+**Module:** `release-planning` (existing)
+**Audience:** Implementing agents, lead engineer, DevOps
+
+---
+
+## 1. Executive Summary
+
+### What We Are Building
+
+A new **Release Health** capability within the existing `release-planning` module that provides:
+
+1. **Risk assessment** -- a hybrid model combining release-pulse's phase-aware milestone tracking with release-analysis's velocity-based risk scoring, applied per-feature and per-release.
+2. **Definition of Ready (DoR) checklist** -- a full readiness checker for each feature, combining automated Jira-derived checks (target version set, PM assigned, etc.) with manual toggles for non-automatable items (architectural alignment, licensing review, cross-functional engagement). Persisted per-feature per-release.
+3. **RICE scoring** -- reads Reach, Impact, Confidence, and Effort from Jira custom fields on RHAISTRAT features and surfaces a computed RICE score alongside each feature.
+4. **Health dashboard** -- a read-only view available to all authenticated users showing release-level and feature-level health, risk flags, DoR completion rates, and RICE-prioritized feature lists. Edit capabilities (checklist toggles, manual overrides) restricted to PMs and admins.
+
+### Why
+
+The operational proposal (`design/2026-04-22-release-planning-proposal.md`) identified three systemic issues: late descoping due to unvalidated commitments, lack of execution visibility, and quality gaps from unenforced DoR. This implementation plan delivers the tooling layer for the Planning domain's Refinement and Capacity Validation phases. It gives PMs a single view to answer "is this release healthy?" and "is each feature ready?" -- replacing tribal knowledge and manual spreadsheet tracking.
+
+### Design Principles
+
+- **Extend, don't fork.** New capability lives inside `release-planning`, reusing its per-release config, PM auth, audit log, and storage patterns.
+- **Hybrid data model.** Feature-traffic cache provides baseline data (completion %, epic counts, health, blockers). Targeted Jira queries supplement with risk-specific fields not in the cache (changelog, description presence, story points, dependency links).
+- **Progressive enhancement.** Each phase delivers a usable increment. Phase 1 (data pipeline) works without the frontend. Phase 3 (frontend) works with cached data even if Jira is unavailable.
+- **Read-default, edit-gated.** All authenticated users see the health dashboard. Only PMs/admins can toggle DoR checks or save manual overrides.
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 Module Structure (Extended)
+
+The new capability adds server and client files to the existing `release-planning` module. No new module is created.
+
+```
+modules/release-planning/
+  module.json                          # MODIFIED -- add navItems
+  server/
+    index.js                           # MODIFIED -- register new routes
+    config.js                          # MODIFIED -- add health config fields
+    constants.js                       # MODIFIED -- add health-related constants
+    health/
+      risk-engine.js                   # NEW -- hybrid risk assessment engine
+      dor-checker.js                   # NEW -- automated DoR checks
+      jira-enrichment.js              # NEW -- targeted Jira queries for risk fields
+      rice-scorer.js                   # NEW -- RICE score computation
+      health-pipeline.js              # NEW -- orchestrates enrichment + risk + DoR
+    audit-log.js                       # REUSED -- health actions logged here
+    pm-auth.js                         # REUSED -- edit gating
+    config-lock.js                     # REUSED -- serialized writes
+  client/
+    index.js                           # MODIFIED -- add health view route
+    views/
+      HealthDashboardView.vue          # NEW -- main health dashboard
+    components/
+      HealthSummaryCards.vue            # NEW -- release-level health summary
+      FeatureHealthTable.vue           # NEW -- per-feature health + DoR status
+      FeatureHealthRow.vue             # NEW -- expandable row with DoR checklist
+      DorChecklist.vue                 # NEW -- interactive checklist component
+      RiskBadge.vue                    # NEW -- risk level indicator (green/yellow/red)
+      RiceScoreDisplay.vue             # NEW -- RICE score breakdown
+      HealthFilterBar.vue              # NEW -- filters for health view
+      MilestoneTimeline.vue            # NEW -- visual timeline from Smartsheet
+    composables/
+      useReleaseHealth.js              # NEW -- health data fetching + state
+      useDorChecklist.js               # NEW -- checklist state + save logic
+  __tests__/
+    server/
+      risk-engine.test.js              # NEW
+      dor-checker.test.js              # NEW
+      jira-enrichment.test.js          # NEW
+      rice-scorer.test.js              # NEW
+      health-pipeline.test.js          # NEW
+      health-routes.test.js            # NEW
+    client/
+      health-components.test.js        # NEW
+```
+
+### 2.2 Data Flow Diagram
+
+```mermaid
+flowchart TB
+    subgraph "Data Sources"
+        FT["feature-traffic cache<br/>(index.json + features/*.json)"]
+        JIRA["Jira Cloud API<br/>(redhat.atlassian.net)"]
+        SS["Smartsheet API<br/>(milestone dates)"]
+    end
+
+    subgraph "Health Pipeline (server)"
+        HP["health-pipeline.js<br/>orchestrator"]
+        JE["jira-enrichment.js<br/>targeted queries"]
+        RE["risk-engine.js<br/>hybrid risk model"]
+        DC["dor-checker.js<br/>automated checks"]
+        RS["rice-scorer.js<br/>RICE computation"]
+    end
+
+    subgraph "Storage (data/)"
+        HC["release-planning/<br/>health-cache-{version}.json"]
+        DS["release-planning/<br/>dor-state-{version}.json"]
+        MO["release-planning/<br/>health-overrides-{version}.json"]
+    end
+
+    subgraph "API Layer"
+        R1["GET /health<br/>(read-only, all users)"]
+        R2["PUT /health/dor/:featureKey<br/>(PM/admin only)"]
+        R3["PUT /health/override/:featureKey<br/>(PM/admin only)"]
+        R4["POST /health/refresh<br/>(PM/admin only)"]
+    end
+
+    subgraph "Frontend"
+        HD["HealthDashboardView"]
+        FHT["FeatureHealthTable"]
+        DCL["DorChecklist"]
+    end
+
+    FT --> HP
+    JIRA --> JE
+    SS --> HP
+    JE --> HP
+    HP --> RE
+    HP --> DC
+    HP --> RS
+    RE --> HC
+    DC --> HC
+    RS --> HC
+    DS --> DC
+    MO --> RE
+
+    HC --> R1
+    DS --> R2
+    MO --> R3
+    R4 --> HP
+
+    R1 --> HD
+    R1 --> FHT
+    R2 --> DCL
+    R3 --> FHT
+```
+
+### 2.3 Data Source Strategy
+
+**From feature-traffic index (`index.json`) -- lightweight, no I/O per feature:**
+- `key`, `summary` -- feature identity/title (F-1 partial)
+- `status`, `statusCategory` -- workflow state
+- `targetVersions` -- target release version (F-2)
+- `assignee` -- delivery owner (F-5, string in index)
+- `fixVersions` -- committed fix version
+- `completionPct`, `epicCount`, `issueCount`, `blockerCount`, `health` -- progress metrics
+- `parentKey` -- outcome/Big Rock linkage
+
+**From feature-traffic detail files (`features/*.json`) -- loaded via `loadFeatureDetail()`:**
+- `pm` -- product manager (F-4, object with `displayName` in detail files; NOT reliably present in index)
+- `components` -- team/component assignment (F-6, only in detail files)
+- `releaseType` -- DP/TP/GA phase (F-10, only in detail files)
+- `issueLinks` -- RFE linkage
+- `labels` -- candidate labels (array, not stringified)
+
+> **I/O cost note:** The health pipeline must call `loadFeatureDetail()` for each feature to access `pm`, `components`, `releaseType`, and `labels`. For a release with 100+ features, this means 100+ file reads from `data/feature-traffic/features/`. This is a synchronous filesystem read per feature (via `readFromStorage`), which is acceptable for server-side use -- the same pattern is already used by `cache-reader.js` lines 174, 262, and 315 during the existing candidates pipeline. The detail files are typically 2-5 KB each.
+
+**From targeted Jira enrichment (batched queries):**
+- `description` presence -- non-empty check for F-1 (ADF field; check length > 0)
+- `customfield_10028` (story points) -- estimated scope (F-7)
+- `issuelinks` full list -- dependency identification (F-8)
+- `customfield_10855` changelog -- refinement history (when was target version set?)
+- RICE custom fields on RHAISTRAT parent features:
+  - Reach (`customfield_XXXXX` -- to be confirmed via Jira field discovery)
+  - Impact (`customfield_XXXXX`)
+  - Confidence (`customfield_XXXXX`)
+  - Effort (`customfield_XXXXX`)
+
+**From Smartsheet (via shared/server/smartsheet.js):**
+- EA1/EA2/GA milestone dates for timeline display and days-remaining calculations
+- Freeze dates (EA1 code freeze, EA2 code freeze, GA code freeze) for risk engine phase checks
+
+> **Implementation note:** The existing `discoverReleases()` function (lines 142-149) only returns `{ version, ea1Target, ea2Target, gaTarget }` -- the freeze dates are parsed internally but discarded in the final `.map()`. A new `discoverReleasesWithFreezes()` function must be added to `shared/server/smartsheet.js` that returns all 6 milestones: `{ version, ea1Freeze, ea1Target, ea2Freeze, ea2Target, gaFreeze, gaTarget }`. The health pipeline will call this function instead of `discoverReleases()`. The existing `discoverReleases()` is left unchanged for backward compatibility.
+
+---
+
+## 3. Implementation Phases
+
+### Phase 1: Data Pipeline (Jira Enrichment + Risk Engine)
+
+**Goal:** Server-side pipeline that produces a health assessment for each feature in a release, persisted as a cache file.
+
+**Estimated effort:** 3 sprints (this module has zero Jira integration today -- all Jira enrichment, the two-pass strategy, and rate limit coordination are net-new infrastructure)
+
+#### 1a. Jira Enrichment Module (`server/health/jira-enrichment.js`)
+
+Targeted Jira queries to supplement feature-traffic cache data. Uses the existing `shared/server/jira.js` client (Basic auth, rate limiting, retry).
+
+```javascript
+// Enrichment fields fetched per batch of feature keys (lightweight -- Pass 1)
+const ENRICHMENT_FIELDS = [
+  'description',           // F-1: non-empty check
+  'customfield_10028',     // F-7: story points
+  'issuelinks'             // F-8: dependency links
+].join(',')
+
+// Separate query for RICE fields on RHAISTRAT parent issues
+const RICE_FIELDS = [
+  'customfield_XXXXX',     // Reach (TBD -- discovery needed)
+  'customfield_XXXXX',     // Impact
+  'customfield_XXXXX',     // Confidence
+  'customfield_XXXXX'      // Effort
+].join(',')
+
+// Changelog fields -- fetched ONLY for features needing refinement history (Pass 2)
+// NOTE: changelog data requires the `expand` parameter, NOT a fields entry.
+// See shared/server/jira.js fetchAllJqlResults() which accepts { expand: 'changelog' }.
+// Pattern from person-metrics.js line 380:
+//   fetchAllJqlResults(jiraRequest, jql, FIELDS, { expand: 'changelog' })
+const CHANGELOG_FIELDS = 'summary'  // minimal fields; changelog comes via expand
+```
+
+**Two-pass enrichment strategy (addresses memory and rate limiting):**
+
+- **Pass 1 (lightweight, all features):** Fetch `ENRICHMENT_FIELDS` for all features in batches of 40. Uses `fetchAllJqlResults(jiraRequest, jql, ENRICHMENT_FIELDS)` without changelog expansion. This provides description, story points, and issue links for every feature.
+- **Pass 2 (changelog, targeted subset):** Fetch changelog ONLY for features flagged as potentially risky by Pass 1 -- specifically features that lack a Target Version, are in early workflow states (e.g., "New", "Refinement"), or were flagged with VELOCITY_LAG. Uses `fetchAllJqlResults(jiraRequest, jql, CHANGELOG_FIELDS, { expand: 'changelog' })`. This reduces memory consumption and API cost vs. fetching changelog for all 100+ features.
+- **Batching:** Group feature keys into batches of 40 (matching release-analysis's pattern). Use JQL `key in (KEY-1, KEY-2, ...)` with `fetchAllJqlResults()`. Include 1-second throttle between batches (matching `JIRA_THROTTLE_MS`).
+- **RICE fields:** Separate query for unique `parentKey` values (RHAISTRAT outcomes).
+
+**Output:** Map of `featureKey -> enrichmentData`:
+```javascript
+{
+  "RHAISTRAT-123": {
+    // From Pass 1 (all features):
+    hasDescription: true,
+    storyPoints: 8,
+    dependencyLinks: [
+      { type: "Blocks", direction: "inward", linkedKey: "RHAISTRAT-456", linkedStatus: "In Progress" }
+    ],
+    // From Pass 2 (only for features needing refinement history -- may be null):
+    refinementHistory: [
+      { field: "Target Version", from: null, to: "rhoai-3.5", date: "2026-03-15" }
+    ],
+    // From RICE query (only if enableRice is true and field IDs configured):
+    rice: { reach: 500, impact: 3, confidence: 80, effort: 2 }
+  }
+}
+```
+
+#### 1b. Risk Engine (`server/health/risk-engine.js`)
+
+Hybrid risk model combining:
+
+**Category 1: Milestone Risk (from release-pulse)**
+- Compare current date against SmartSheet milestones (EA1 freeze, EA2 freeze, GA freeze)
+- Flag features whose status does not match the expected phase progress
+- Example: feature still in "Refinement" after EA1 code freeze date = RED
+
+**Category 2: Velocity Risk (from release-analysis)**
+- Uses `completionPct`, `issueCount`, and days-remaining to assess pace
+- Adapts `releaseRiskFromIncompleteAndTime()` pattern from release-analysis
+- Per-feature rather than per-release aggregation
+
+**Category 3: Readiness Risk (from DoR checker)**
+- Percentage of DoR items satisfied
+- Features with < 50% DoR completion = RED, 50-80% = YELLOW, > 80% = GREEN
+
+**Category 4: Dependency Risk**
+- Features with unresolved blocking dependencies (status != Done/Closed)
+- Features blocked by items outside the release scope
+
+**Category 5: Scope Risk**
+- Features with no story points estimate
+- Features with no RFE linkage (customer-facing features without business justification)
+
+**Composite risk score:**
+```javascript
+function computeFeatureRisk(feature, milestones, dorStatus, enrichment) {
+  const flags = []
+
+  // Milestone risk
+  const phase = determineExpectedPhase(milestones, new Date())
+  if (isFeatureBehindPhase(feature, phase)) {
+    flags.push({ category: 'MILESTONE_MISS', severity: 'high',
+      message: `Feature still in "${feature.status}" but ${phase} code freeze has passed` })
+  }
+
+  // Velocity risk
+  if (feature.completionPct < expectedCompletionForPhase(phase)) {
+    flags.push({ category: 'VELOCITY_LAG', severity: feature.completionPct < 25 ? 'high' : 'medium',
+      message: `${feature.completionPct}% complete, expected ${expectedCompletionForPhase(phase)}% by now` })
+  }
+
+  // DoR readiness
+  const dorPct = dorStatus.checkedCount / dorStatus.totalCount * 100
+  if (dorPct < 50) {
+    flags.push({ category: 'DOR_INCOMPLETE', severity: 'high',
+      message: `Only ${Math.round(dorPct)}% of DoR criteria met` })
+  } else if (dorPct < 80) {
+    flags.push({ category: 'DOR_INCOMPLETE', severity: 'medium',
+      message: `${Math.round(dorPct)}% of DoR criteria met (target: 80%)` })
+  }
+
+  // Dependency risk
+  const blocking = (enrichment.dependencyLinks || [])
+    .filter(d => d.direction === 'inward' && d.type === 'Blocks' && !CLOSED_STATUSES.includes(d.linkedStatus))
+  if (blocking.length > 0) {
+    flags.push({ category: 'BLOCKED', severity: 'high',
+      message: `Blocked by ${blocking.length} unresolved issue(s): ${blocking.map(b => b.linkedKey).join(', ')}` })
+  }
+
+  // Scope risk
+  if (!enrichment.storyPoints) {
+    flags.push({ category: 'UNESTIMATED', severity: 'medium',
+      message: 'No story point estimate' })
+  }
+
+  const severity = flags.some(f => f.severity === 'high') ? 'red'
+    : flags.some(f => f.severity === 'medium') ? 'yellow' : 'green'
+
+  return { risk: severity, flags, riskScore: flags.length }
+}
+```
+
+#### 1c. RICE Scorer (`server/health/rice-scorer.js`)
+
+```javascript
+// RICE = (Reach * Impact * Confidence%) / Effort
+function computeRiceScore(rice) {
+  if (!rice || !rice.reach || !rice.impact || !rice.confidence || !rice.effort) {
+    return null  // Incomplete RICE data
+  }
+  const confidence = rice.confidence / 100  // Convert from percentage
+  return Math.round((rice.reach * rice.impact * confidence) / rice.effort)
+}
+```
+
+RICE fields are read from the RHAISTRAT parent feature (outcome key). The field IDs must be discovered and configured before RICE scoring can be enabled.
+
+**RICE field discovery process:**
+
+1. **Admin action via Settings UI:** The release-planning Settings panel will include a "Discover RICE Fields" button that calls a new admin-only endpoint `GET /releases/rice-fields/discover`. This endpoint calls `/rest/api/3/field` on the Jira instance, filters for custom fields matching common RICE naming patterns (e.g., "Reach", "Impact", "Confidence", "Effort", "RICE"), and returns the matching field names and IDs for the admin to select.
+2. **Manual fallback:** If automatic discovery does not find matching fields (e.g., custom field names differ from expected patterns), the admin can manually enter field IDs in the config form. The Settings UI provides text inputs for each of the four RICE field IDs under `customFieldIds`.
+3. **Graceful degradation:** If RICE field IDs are not configured (`enableRice: false` or empty field IDs), the RICE scorer module returns `null` for all features. The `RiceScoreDisplay` component shows "N/A" with a tooltip "RICE scoring not configured". No errors are thrown -- RICE is treated as an optional enhancement.
+4. **Validation:** When an admin saves RICE field IDs, the backend validates them by making a single Jira API call to verify the fields exist on a sample RHAISTRAT issue. Invalid field IDs are rejected with a descriptive error message.
+
+### Phase 2: Backend API Endpoints
+
+**Goal:** REST endpoints for health data access and DoR state management.
+
+**Estimated effort:** 1 sprint
+
+All routes are registered in the existing `server/index.js` via a sub-router pattern to keep the file manageable. The function signature matches the standard module pattern (`registerRoutes(router, context)` in `server/index.js` line 23):
+
+```javascript
+// In server/index.js — mount health routes
+const healthRoutes = require('./health/health-routes')
+healthRoutes(router, context)
+// Access storage via context: const { readFromStorage, writeToStorage } = context.storage
+// Access auth via context: const { requireAuth, requireAdmin } = context
+```
+
+#### New Endpoints
+
+**Read (all authenticated users):**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/releases/:version/health` | Full health assessment for a release |
+| `GET` | `/releases/:version/health/summary` | Aggregate health summary (counts by risk level, DoR completion rate) |
+| `GET` | `/releases/:version/health/feature/:key` | Single feature health detail |
+
+**Write (PM/admin only):**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `PUT` | `/releases/:version/health/dor/:featureKey` | Update DoR checklist state for a feature |
+| `PUT` | `/releases/:version/health/override/:featureKey` | Set manual risk override for a feature |
+| `POST` | `/releases/:version/health/refresh` | Trigger health pipeline refresh |
+| `GET` | `/releases/:version/health/refresh/status` | Poll refresh status |
+
+#### Request/Response Shapes
+
+**GET `/releases/:version/health`**
+
+```json
+{
+  "version": "3.5",
+  "generatedAt": "2026-04-26T12:00:00Z",
+  "milestones": {
+    "ea1Freeze": "2026-05-15",
+    "ea1Target": "2026-06-01",
+    "ea2Freeze": "2026-07-15",
+    "ea2Target": "2026-08-01",
+    "gaFreeze": "2026-09-15",
+    "gaTarget": "2026-10-01"
+  },
+  "summary": {
+    "totalFeatures": 45,
+    "byRisk": { "green": 28, "yellow": 12, "red": 5 },
+    "dorCompletionRate": 72,
+    "averageRiceScore": 340,
+    "blockedCount": 3,
+    "unestimatedCount": 8,
+    "currentPhase": "EA1",
+    "daysToNextMilestone": 19,
+    "nextMilestone": "EA1 Code Freeze"
+  },
+  "features": [
+    {
+      "key": "RHAISTRAT-123",
+      "summary": "Feature title",
+      "status": "In Progress",
+      "priority": "Major",
+      "phase": "GA",
+      "bigRock": "Model Serving Improvements",
+      "tier": 1,
+      "pm": "Jane Smith",
+      "deliveryOwner": "Bob Jones",
+      "components": "Model Serving",
+      "completionPct": 65,
+      "epicCount": 3,
+      "issueCount": 24,
+      "blockerCount": 1,
+      "health": "YELLOW",
+      "risk": {
+        "level": "yellow",
+        "score": 2,
+        "flags": [
+          { "category": "VELOCITY_LAG", "severity": "medium", "message": "65% complete, expected 80% by now" },
+          { "category": "DOR_INCOMPLETE", "severity": "medium", "message": "70% of DoR criteria met (target: 80%)" }
+        ]
+      },
+      "dor": {
+        "checkedCount": 7,
+        "totalCount": 10,
+        "completionPct": 70,
+        "items": [
+          { "id": "F-1", "label": "Clear title and description", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-2", "label": "Target release version set", "type": "automated", "checked": true, "source": "index" },
+          { "id": "F-3", "label": "Acceptance criteria defined", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-4", "label": "PM assigned", "type": "automated", "checked": true, "source": "detail" },
+          { "id": "F-5", "label": "Delivery owner assigned", "type": "automated", "checked": true, "source": "index" },
+          { "id": "F-6", "label": "Component/team assignment", "type": "automated", "checked": true, "source": "detail" },
+          { "id": "F-7", "label": "Estimated scope (story points)", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-8", "label": "No unresolved blocking dependencies", "type": "automated", "checked": true, "source": "jira" },
+          { "id": "F-9", "label": "RFE linkage (if customer-driven)", "type": "manual", "checked": true, "source": "manual" },
+          { "id": "F-10", "label": "Release type/phase specified", "type": "automated", "checked": true, "source": "detail" },
+          { "id": "F-11", "label": "Architectural alignment reviewed", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-12", "label": "Cross-functional engagement confirmed", "type": "manual", "checked": false, "source": "manual" },
+          { "id": "F-13", "label": "Licensing review complete", "type": "manual", "checked": false, "source": "manual" }
+        ]
+      },
+      "rice": {
+        "reach": 500,
+        "impact": 3,
+        "confidence": 80,
+        "effort": 2,
+        "score": 600
+      },
+      "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-123"
+    }
+  ],
+  "_cacheStale": false,
+  "_refreshing": false
+}
+```
+
+**PUT `/releases/:version/health/dor/:featureKey`**
+
+Request:
+```json
+{
+  "items": {
+    "F-3": true,
+    "F-11": false
+  },
+  "notes": "Acceptance criteria documented in linked Google Doc"
+}
+```
+
+Response:
+```json
+{
+  "featureKey": "RHAISTRAT-123",
+  "dor": { "checkedCount": 8, "totalCount": 13, "completionPct": 62 },
+  "updatedAt": "2026-04-26T12:30:00Z",
+  "updatedBy": "jane@redhat.com"
+}
+```
+
+**PUT `/releases/:version/health/override/:featureKey`**
+
+Request:
+```json
+{
+  "riskOverride": "green",
+  "reason": "Team confirmed they can absorb the remaining work before EA2"
+}
+```
+
+Response:
+```json
+{
+  "featureKey": "RHAISTRAT-123",
+  "riskOverride": "green",
+  "reason": "Team confirmed they can absorb the remaining work before EA2",
+  "updatedAt": "2026-04-26T12:35:00Z",
+  "updatedBy": "jane@redhat.com"
+}
+```
+
+### Phase 3: Frontend Views
+
+**Goal:** Health dashboard with interactive DoR checklist.
+
+**Estimated effort:** 2-3 sprints
+
+**Recommendation:** Spawn a UX teammate agent for this phase. The health dashboard involves significant data visualization (risk heatmaps, milestone timelines, DoR progress indicators) and interaction design (expandable rows, inline editing, filter combinations) that benefits from dedicated frontend attention.
+
+#### 3a. Navigation
+
+Update `module.json` to add a new nav item:
+
+```json
+{
+  "navItems": [
+    { "id": "main", "label": "Big Rocks Planning", "icon": "ClipboardList", "default": true },
+    { "id": "health", "label": "Release Health", "icon": "HeartPulse" },
+    { "id": "audit-log", "label": "Audit Log", "icon": "History" }
+  ]
+}
+```
+
+Update `client/index.js` to register the route:
+
+```javascript
+export const routes = {
+  'main': defineAsyncComponent(() => import('./views/DashboardView.vue')),
+  'health': defineAsyncComponent(() => import('./views/HealthDashboardView.vue')),
+  'audit-log': defineAsyncComponent(() => import('./views/AuditLogView.vue')),
+}
+```
+
+#### 3b. Health Dashboard View (`HealthDashboardView.vue`)
+
+**Layout:**
+
+```
++---------------------------------------------------------------+
+| Release Health Dashboard                    [Release v3.5 v]   |
+| Data from 2026-04-26 12:00        [Refresh] [Export]          |
++---------------------------------------------------------------+
+| +----------------------------------------------------------+  |
+| | Milestone Timeline (MilestoneTimeline.vue)                |  |
+| | EA1 Freeze ---- EA1 Release ---- EA2 Freeze ---- GA      |  |
+| |     May 15         Jun 1           Jul 15      Oct 1      |  |
+| |              ^ We are here (19 days to EA1 freeze)        |  |
+| +----------------------------------------------------------+  |
+|                                                               |
+| +----------+ +----------+ +----------+ +----------+          |
+| | GREEN 28 | | YELLOW 12| | RED 5    | | DoR 72%  |          |
+| | features | | features | | features | | complete |          |
+| +----------+ +----------+ +----------+ +----------+          |
+|                                                               |
+| [Risk v] [DoR v] [Big Rock v] [Component v] [Search ____]    |
+|                                                               |
+| Feature Health Table                                          |
+| +---+----------+--------+------+-----+------+------+-------+ |
+| |   | Feature  | Status | Risk | DoR | RICE | Comp | Phase | |
+| +---+----------+--------+------+-----+------+------+-------+ |
+| | > | STRAT-123| In Prog| YEL  | 7/10| 600  | MS   | GA    | |
+| |   +----------------------------------------------------------+
+| |   | DoR Checklist (expandable)                               |
+| |   | [x] Clear title and description  (auto)                 |
+| |   | [x] Target release version set   (auto)                 |
+| |   | [ ] Acceptance criteria defined  (manual) [toggle]      |
+| |   | ...                                                      |
+| |   | Risk Flags:                                              |
+| |   |   VELOCITY_LAG: 65% complete, expected 80%              |
+| |   |   DOR_INCOMPLETE: 70% of DoR met                        |
+| |   +----------------------------------------------------------+
+| | > | STRAT-456| Review | GRN  | 9/10| 340  | Pipeline| TP  | |
+| +---+----------+--------+------+-----+------+------+-------+ |
++---------------------------------------------------------------+
+```
+
+**Key interactions:**
+- Release selector reuses existing `ReleaseSelector.vue`
+- Clicking a row expands to show full DoR checklist and risk flags
+- Manual DoR items have toggles (disabled for non-PM users)
+- Risk level column shows colored badge (reuses StatusBadge pattern)
+- Sortable by any column; filterable by risk level, DoR status, Big Rock, component
+- Export to CSV/Markdown (extends existing export pattern)
+
+#### 3c. Composable (`useReleaseHealth.js`)
+
+```javascript
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const API_BASE = '/modules/release-planning'
+
+const healthData = ref(null)
+const healthLoading = ref(false)
+const healthError = ref(null)
+const healthRefreshing = ref(false)
+
+export function useReleaseHealth() {
+  async function loadHealth(version) { /* ... */ }
+  async function updateDorItem(version, featureKey, items, notes) { /* ... */ }
+  async function setRiskOverride(version, featureKey, level, reason) { /* ... */ }
+  async function triggerHealthRefresh(version) { /* ... */ }
+  async function checkHealthRefreshStatus(version) { /* ... */ }
+
+  return {
+    healthData, healthLoading, healthError, healthRefreshing,
+    loadHealth, updateDorItem, setRiskOverride,
+    triggerHealthRefresh, checkHealthRefreshStatus
+  }
+}
+```
+
+### Phase 4: Integration with Big Rocks and Feature-Traffic
+
+**Goal:** Cross-link health data with existing Big Rocks table and feature-traffic module.
+
+**Estimated effort:** 1 sprint
+
+- **Big Rocks table enrichment:** Add a "Health" column to the existing `BigRocksTable.vue` showing aggregate risk for each Big Rock (worst-case risk across its features).
+- **Feature table enrichment:** Add DoR completion % and risk badge columns to existing `FeaturesTable.vue`.
+- **Cross-navigation:** Click a feature in the health dashboard to navigate to its detail in feature-traffic (`#/feature-traffic/detail?key=RHAISTRAT-123`). Click a Big Rock in the health dashboard to filter the Big Rocks planning view.
+- **Summary cards:** Extend existing `SummaryCards.vue` with a health indicator when health data is available.
+
+### Phase 5: Polish, Testing, Deployment
+
+**Goal:** Comprehensive tests, demo mode support, deployment validation.
+
+**Estimated effort:** 1 sprint
+
+- Unit tests for all server modules (risk-engine, dor-checker, jira-enrichment, rice-scorer, health-pipeline)
+- Route integration tests (following existing `routes.test.js` pattern)
+- Component tests for health dashboard views
+- Demo mode support: fixture data for health cache, DoR state
+- CI validation: kustomize overlay check (no deploy changes expected since this is an existing module)
+- Performance testing: health pipeline with 100+ features
+
+---
+
+## 4. Data Model
+
+### 4.1 Feature Readiness State (Persisted)
+
+**Storage path:** `release-planning/dor-state-{version}.json`
+
+```json
+{
+  "version": "3.5",
+  "updatedAt": "2026-04-26T12:30:00Z",
+  "features": {
+    "RHAISTRAT-123": {
+      "manualChecks": {
+        "F-3": { "checked": true, "updatedBy": "jane@redhat.com", "updatedAt": "2026-04-26T12:30:00Z" },
+        "F-9": { "checked": true, "updatedBy": "jane@redhat.com", "updatedAt": "2026-04-25T10:00:00Z" },
+        "F-11": { "checked": false, "updatedBy": null, "updatedAt": null },
+        "F-12": { "checked": false, "updatedBy": null, "updatedAt": null },
+        "F-13": { "checked": false, "updatedBy": null, "updatedAt": null }
+      },
+      "notes": "Acceptance criteria in linked Google Doc RHOAI-Feature-Spec-123"
+    }
+  }
+}
+```
+
+### 4.2 DoR Checklist Items
+
+**Definition (constant, in `server/health/dor-checker.js`):**
+
+```javascript
+const DOR_ITEMS = [
+  // Automated checks -- derived from index, detail files, or Jira enrichment
+  { id: 'F-1',  label: 'Clear title and description',         type: 'automated', source: 'jira',    check: (f, e) => !!f.summary && e.hasDescription },
+  { id: 'F-2',  label: 'Target release version set',          type: 'automated', source: 'index',   check: (f) => !!f.targetRelease },
+  { id: 'F-4',  label: 'PM assigned',                         type: 'automated', source: 'detail',  check: (f) => !!f.pm },
+  { id: 'F-5',  label: 'Delivery owner assigned',             type: 'automated', source: 'index',   check: (f) => !!f.deliveryOwner },
+  { id: 'F-6',  label: 'Component/team assignment',           type: 'automated', source: 'detail',  check: (f) => f.components && f.components.length > 0 },
+  { id: 'F-7',  label: 'Estimated scope (story points)',      type: 'automated', source: 'jira',    check: (f, e) => e.storyPoints > 0 },
+  { id: 'F-8',  label: 'No unresolved blocking dependencies',  type: 'automated', source: 'jira',
+    // Pass by default. Fails ONLY if there are inward "Blocks" links with a non-closed status.
+    // Rationale: most features have no blocking dependencies, and there is no "no-dependencies"
+    // label convention in this codebase. Checking for the absence of unresolved blockers is
+    // more useful than checking for the presence of any dependency link.
+    check: (f, e) => {
+      const blocking = (e.dependencyLinks || []).filter(d =>
+        d.direction === 'inward' && d.type === 'Blocks' && !CLOSED_STATUSES.includes(d.linkedStatus))
+      return blocking.length === 0
+    }
+  },
+  { id: 'F-10', label: 'Release type/phase specified',        type: 'automated', source: 'detail', check: (f) => !!f.phase },
+
+  // Manual checks -- toggled by PM in the UI
+  { id: 'F-3',  label: 'Acceptance criteria defined',                type: 'manual', source: 'manual' },
+  { id: 'F-9',  label: 'RFE linkage (if customer-driven)',           type: 'manual', source: 'manual' },
+  { id: 'F-11', label: 'Architectural alignment reviewed',           type: 'manual', source: 'manual' },
+  { id: 'F-12', label: 'Cross-functional engagement confirmed',      type: 'manual', source: 'manual' },
+  { id: 'F-13', label: 'Licensing review complete',                  type: 'manual', source: 'manual' }
+]
+```
+
+**Runtime evaluation:**
+
+For each feature, automated checks are evaluated against the feature-traffic data and Jira enrichment data. Manual checks are read from the persisted DoR state file.
+
+> **Important:** DoR checks must operate on raw feature data from `loadIndex()` and `loadFeatureDetail()`, NOT on `mapToCandidate()` output. The `mapToCandidate()` function in `cache-reader.js` stringifies labels via `labels.join(', ')` (line 111) and components via `components.join(', ')` (line 110), which breaks array methods like `labels.includes()`. The health pipeline should use the raw `labels` array from detail files and the raw `components` array for reliable field checks.
+
+The combined result is:
+
+```javascript
+{
+  checkedCount: 7,
+  totalCount: 13,
+  completionPct: 54,
+  items: [
+    { id: 'F-1', label: '...', type: 'automated', checked: true, source: 'jira' },
+    // ... all 13 items with their checked status
+  ]
+}
+```
+
+### 4.3 RICE Score Model
+
+```javascript
+// Stored as part of health cache, computed from Jira custom fields
+{
+  "rice": {
+    "reach": 500,       // Number of users/quarter affected
+    "impact": 3,        // 0.25 (minimal), 0.5 (low), 1 (medium), 2 (high), 3 (massive)
+    "confidence": 80,   // Percentage (0-100)
+    "effort": 2,        // Person-months
+    "score": 600,       // Computed: (500 * 3 * 0.80) / 2 = 600
+    "complete": true     // Whether all 4 input fields are populated
+  }
+}
+```
+
+**Config fields (added to `release-planning/config.json`):**
+
+```javascript
+{
+  // ... existing fields ...
+  "customFieldIds": {
+    // ... existing fields ...
+    "riceReach": "",        // customfield_XXXXX -- discovered via /rest/api/3/field
+    "riceImpact": "",       // customfield_XXXXX
+    "riceConfidence": "",   // customfield_XXXXX
+    "riceEffort": ""        // customfield_XXXXX
+  },
+  "healthConfig": {
+    "enableRice": false,            // Toggle RICE scoring (disabled until field IDs confirmed)
+    "enableJiraEnrichment": true,   // Toggle Jira enrichment queries
+    "enrichmentBatchSize": 40,      // Keys per Jira batch query
+    "enrichmentThrottleMs": 1000,   // Delay between batches
+    "healthRefreshTimeoutMs": 480000, // 8 min (longer than candidates' 5 min due to two-pass enrichment)
+    "riskThresholds": {
+      "velocityGreenMin": 80,       // completionPct >= this for green at GA freeze
+      "velocityYellowMin": 50,      // completionPct >= this for yellow
+      "dorGreenMin": 80,            // DoR % >= this for green
+      "dorYellowMin": 50            // DoR % >= this for yellow
+    },
+    "phaseCompletionExpectations": null  // null = use defaults (see Appendix C). Override per-milestone thresholds here.
+  }
+}
+```
+
+### 4.4 Risk Assessment Results
+
+```javascript
+// Per-feature risk (stored in health cache)
+{
+  "risk": {
+    "level": "yellow",              // green | yellow | red
+    "score": 2,                      // Number of flags
+    "flags": [
+      {
+        "category": "MILESTONE_MISS",  // | VELOCITY_LAG | DOR_INCOMPLETE | BLOCKED | UNESTIMATED | MISSING_RFE
+        "severity": "high",            // high | medium
+        "message": "Feature still in Refinement but EA1 code freeze has passed"
+      }
+    ],
+    "override": null                  // { level, reason, updatedBy, updatedAt } if PM overrode
+  }
+}
+
+// Release-level aggregate (in summary)
+{
+  "summary": {
+    "byRisk": { "green": 28, "yellow": 12, "red": 5 },
+    "riskTrend": "improving",        // improving | stable | degrading (vs. previous refresh)
+    "topRisks": [
+      { "featureKey": "RHAISTRAT-789", "summary": "...", "flags": 4, "level": "red" }
+    ]
+  }
+}
+```
+
+### 4.5 Health Cache (Persisted)
+
+**Storage path:** `release-planning/health-cache-{version}.json`
+
+```json
+{
+  "cachedAt": "2026-04-26T12:00:00Z",
+  "version": "3.5",
+  "milestones": { "ea1Freeze": "...", "ea1Target": "...", "ea2Freeze": "...", "ea2Target": "...", "gaFreeze": "...", "gaTarget": "..." },
+  "summary": { "totalFeatures": 45, "byRisk": {}, "dorCompletionRate": 72, "..." : "..." },
+  "features": [ "... (array of enriched feature objects with risk + dor + rice)" ],
+  "enrichmentStatus": {
+    "jiraQueriesRun": 3,
+    "featuresEnriched": 42,
+    "featuresSkipped": 3,
+    "riceAvailable": false,
+    "warnings": []
+  }
+}
+```
+
+### 4.6 Manual Overrides (Persisted)
+
+**Storage path:** `release-planning/health-overrides-{version}.json`
+
+```json
+{
+  "version": "3.5",
+  "overrides": {
+    "RHAISTRAT-123": {
+      "riskOverride": "green",
+      "reason": "Team confirmed they can absorb remaining work before EA2",
+      "updatedBy": "jane@redhat.com",
+      "updatedAt": "2026-04-26T12:35:00Z"
+    }
+  }
+}
+```
+
+---
+
+## 5. API Design
+
+### 5.1 Complete Endpoint Table
+
+All endpoints are mounted under `/api/modules/release-planning/` (existing module route prefix).
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/releases/:version/health` | `requireAuth` | Full health assessment (stale-while-revalidate) |
+| `GET` | `/releases/:version/health/summary` | `requireAuth` | Aggregate summary only (lighter payload) |
+| `GET` | `/releases/:version/health/feature/:key` | `requireAuth` | Single feature health detail |
+| `PUT` | `/releases/:version/health/dor/:featureKey` | `requirePM` | Update manual DoR checklist items |
+| `PUT` | `/releases/:version/health/override/:featureKey` | `requirePM` | Set risk level override |
+| `DELETE` | `/releases/:version/health/override/:featureKey` | `requirePM` | Remove risk level override |
+| `POST` | `/releases/:version/health/refresh` | `requirePM` | Trigger health pipeline refresh |
+| `GET` | `/releases/:version/health/refresh/status` | `requireAuth` | Poll health refresh status |
+
+### 5.2 Concurrency and Caching Strategy
+
+**Concurrency guard:** Health refreshes share the existing `refreshStates` Map and `MAX_CONCURRENT_REFRESHES = 2` limit defined in `server/index.js` (lines 34-35). Both candidates pipeline refreshes and health pipeline refreshes count toward the same pool of 2. This prevents simultaneous Jira-heavy operations from exceeding rate limits. Health refreshes use a distinct key format in the Map (`health:{version}` vs `candidates:{version}`) so their state can be tracked independently. The health refresh timeout is separate: `HEALTH_REFRESH_TIMEOUT_MS = 480000` (8 minutes), longer than the candidates timeout (`REFRESH_TIMEOUT_MS = 300000`) because the two-pass Jira enrichment requires more time.
+
+**Caching strategy** follows the existing stale-while-revalidate pattern from `server/index.js`:
+
+1. `GET /health` checks `health-cache-{version}.json`
+2. If cache exists and is fresh (< 15 min, matching `CACHE_MAX_AGE_MS`), return it
+3. If cache is stale, return it immediately with `_cacheStale: true` and trigger background refresh
+4. If no cache exists, trigger refresh and return 202 with `_refreshing: true`
+5. `POST /health/refresh` forces a refresh regardless of cache age
+
+**Health cache invalidation:** When Big Rocks are modified (added, edited, deleted, reordered) or release config changes, the existing `invalidateCache()` function is extended to also DELETE the health cache file (`health-cache-{version}.json`). However, unlike the candidates cache, it does NOT trigger a background health refresh. The health cache is rebuilt lazily on the next `GET /health` request via the stale-while-revalidate pattern. This prevents Big Rock edits from triggering expensive Jira enrichment queries. Manual trigger via `POST /health/refresh` forces an immediate refresh.
+
+### 5.3 Validation Rules
+
+**PUT `/releases/:version/health/dor/:featureKey`:**
+- `featureKey` must match `/^[A-Z]+-\d+$/`
+- `items` must be an object with string keys matching defined DoR item IDs (`F-1` through `F-13`)
+- Values must be booleans
+- Only manual-type DoR items can be toggled (automated items are rejected with 400)
+- `notes` must be string, max 2000 characters
+
+**PUT `/releases/:version/health/override/:featureKey`:**
+- `riskOverride` must be one of `green`, `yellow`, `red`
+- `reason` is required, string, max 500 characters
+
+---
+
+## 6. Frontend Design
+
+### 6.1 Component Tree
+
+```
+HealthDashboardView.vue
+  +-- ReleaseSelector.vue (reused)
+  +-- MilestoneTimeline.vue
+  +-- HealthSummaryCards.vue
+  +-- HealthFilterBar.vue
+  +-- FeatureHealthTable.vue
+       +-- FeatureHealthRow.vue (per feature, expandable)
+            +-- RiskBadge.vue
+            +-- RiceScoreDisplay.vue
+            +-- DorChecklist.vue (inline, expanded)
+```
+
+### 6.2 Key Components
+
+**MilestoneTimeline.vue**
+- Horizontal timeline showing EA1 Freeze, EA1 Release, EA2 Freeze, EA2 Release, GA Freeze, GA Release
+- "Today" marker with days-to-next-milestone callout
+- Milestone dates from Smartsheet via the existing `smartsheet/releases` endpoint
+- Responsive: collapses to vertical on narrow viewports
+
+**HealthSummaryCards.vue**
+- Four cards: Green/Yellow/Red feature counts + DoR completion rate
+- Clickable -- filtering the table to the selected risk level
+- Extends the existing `SummaryCards.vue` visual pattern (Tailwind, dark mode)
+
+**FeatureHealthTable.vue**
+- Sortable columns: Feature key, Summary, Status, Risk, DoR %, RICE score, Component, Phase, Tier
+- Expandable rows revealing `DorChecklist.vue` and risk flag details
+- Color-coded risk column (green/yellow/red background, matching `STATUS_STYLES` pattern)
+- Pagination for releases with 50+ features
+
+**DorChecklist.vue**
+- Lists all 13 DoR items
+- Automated items show a lock icon and cannot be toggled
+- Manual items show a toggle switch (disabled when `canEdit` is false)
+- Saves on toggle with debounce (250ms) -- calls `PUT /health/dor/:featureKey`
+- Shows "Last updated by {email} on {date}" for each manual item
+- Notes field (textarea) for per-feature readiness notes
+
+**RiskBadge.vue**
+- Pill-shaped badge: green/yellow/red background
+- Shows flag count as a superscript number
+- Tooltip on hover listing the flag messages
+- If override is set, shows a small "manual" indicator
+
+**RiceScoreDisplay.vue**
+- Shows computed RICE score prominently
+- Expands to show R/I/C/E breakdown on hover or click
+- "N/A" when RICE fields are not populated
+- Links to parent RHAISTRAT issue in Jira
+
+### 6.3 User Flows
+
+**Flow 1: PM reviews release health**
+1. Navigate to Release Planning > Release Health
+2. Select release version from dropdown
+3. View summary cards for overall risk distribution
+4. Review milestone timeline for phase context
+5. Sort table by "Risk" descending to see highest-risk features
+6. Click a red-risk feature row to expand
+7. Review risk flags and DoR checklist
+8. Toggle manual DoR items that have been completed
+9. Optionally set a risk override if the automated assessment is inaccurate
+
+**Flow 2: Engineering lead checks team readiness**
+1. Navigate to Release Planning > Release Health
+2. Filter by Component = "Model Serving"
+3. Sort by DoR % ascending to find least-ready features
+4. Review unmet DoR criteria for each feature
+5. Export filtered list as CSV to share in team standup
+
+**Flow 3: Docs team identifies documentation needs**
+1. Navigate to Release Planning > Release Health
+2. Filter by Phase = "GA" or Phase = "DP"
+3. Sort by RICE score descending (highest-impact features first)
+4. Review features needing documentation attention
+
+---
+
+## 7. Files Modified
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `modules/release-planning/server/health/risk-engine.js` | Hybrid risk assessment engine |
+| `modules/release-planning/server/health/dor-checker.js` | Automated DoR checks + checklist definition |
+| `modules/release-planning/server/health/jira-enrichment.js` | Targeted Jira queries for risk fields |
+| `modules/release-planning/server/health/rice-scorer.js` | RICE score computation |
+| `modules/release-planning/server/health/health-pipeline.js` | Orchestrates enrichment + risk + DoR |
+| `modules/release-planning/server/health/health-routes.js` | Express route handlers for health endpoints |
+| `modules/release-planning/client/views/HealthDashboardView.vue` | Main health dashboard view |
+| `modules/release-planning/client/components/HealthSummaryCards.vue` | Release health summary cards |
+| `modules/release-planning/client/components/FeatureHealthTable.vue` | Feature health table |
+| `modules/release-planning/client/components/FeatureHealthRow.vue` | Expandable feature row |
+| `modules/release-planning/client/components/DorChecklist.vue` | Interactive DoR checklist |
+| `modules/release-planning/client/components/RiskBadge.vue` | Risk level badge |
+| `modules/release-planning/client/components/RiceScoreDisplay.vue` | RICE score display |
+| `modules/release-planning/client/components/HealthFilterBar.vue` | Health-specific filters |
+| `modules/release-planning/client/components/MilestoneTimeline.vue` | Smartsheet milestone timeline |
+| `modules/release-planning/client/composables/useReleaseHealth.js` | Health data composable |
+| `modules/release-planning/client/composables/useDorChecklist.js` | DoR checklist state management |
+| `modules/release-planning/__tests__/server/risk-engine.test.js` | Risk engine unit tests |
+| `modules/release-planning/__tests__/server/dor-checker.test.js` | DoR checker unit tests |
+| `modules/release-planning/__tests__/server/jira-enrichment.test.js` | Jira enrichment tests |
+| `modules/release-planning/__tests__/server/rice-scorer.test.js` | RICE scorer tests |
+| `modules/release-planning/__tests__/server/health-pipeline.test.js` | Pipeline integration tests |
+| `modules/release-planning/__tests__/server/health-routes.test.js` | Route handler tests |
+| `modules/release-planning/__tests__/client/health-components.test.js` | Frontend component tests |
+| `fixtures/release-planning/health-cache-demo.json` | Demo mode fixture |
+| `fixtures/release-planning/dor-state-demo.json` | Demo mode DoR fixture |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `modules/release-planning/module.json` | Add `health` nav item |
+| `modules/release-planning/client/index.js` | Add `health` route mapping |
+| `modules/release-planning/server/index.js` | Mount health routes, extend `invalidateCache()` to delete health cache file (NOT trigger refresh) |
+| `modules/release-planning/server/config.js` | Add `healthConfig` and RICE field IDs to config schema |
+| `modules/release-planning/server/constants.js` | Add health-related constants (DOR IDs, risk categories) |
+| `modules/release-planning/client/components/SummaryCards.vue` | Optional health indicator when health data loaded |
+| `modules/release-planning/client/components/FeaturesTable.vue` | Add DoR % and Risk columns (when health data available) |
+| `modules/release-planning/client/components/BigRocksTable.vue` | Add aggregate health column (when health data available) |
+| `shared/server/smartsheet.js` | Add `discoverReleasesWithFreezes()` function that returns all 6 milestones including freeze dates |
+| `deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml` | Add Step 6: health refresh for all configured releases (after feature-traffic) |
+| `docs/DATA-FORMATS.md` | Document schemas for `health-cache-{version}.json`, `dor-state-{version}.json`, `health-overrides-{version}.json` |
+
+---
+
+## 8. Testability and Deployability
+
+### 8.1 Local Development
+
+```bash
+# Standard local dev setup
+npm run dev:full
+
+# Health pipeline requires:
+# 1. feature-traffic data populated (run feature-traffic refresh first, or use demo mode)
+# 2. Jira credentials in .env (JIRA_EMAIL, JIRA_TOKEN)
+# 3. Smartsheet credentials (SMARTSHEET_API_TOKEN) -- optional, timeline degrades gracefully
+# 4. RICE scoring disabled by default (no custom field IDs needed for MVP)
+```
+
+**Demo mode:** When `DEMO_MODE=true`, the health pipeline returns fixture data from `fixtures/release-planning/health-cache-demo.json`. DoR state is read-only in demo mode (writes blocked by existing demo guard in `server/index.js`).
+
+**Without Jira credentials:** Jira enrichment is skipped. Automated DoR checks that require Jira data (F-1 description, F-7 story points, F-8 dependencies) show as "unknown" rather than "failed". Risk engine runs with reduced accuracy (no MILESTONE_MISS or BLOCKED flags).
+
+### 8.2 Testing Strategy
+
+**Unit tests (Vitest):**
+- `risk-engine.test.js`: Test each risk category independently. Test composite scoring. Test edge cases (no milestones, all DoR complete, no enrichment data).
+- `dor-checker.test.js`: Test each automated check function. Test manual check persistence. Test validation of DoR item updates.
+- `jira-enrichment.test.js`: Mock `jiraRequest()`. Test batching logic. Test error handling (rate limit, network failure). Test field extraction from various Jira response shapes.
+- `rice-scorer.test.js`: Test score computation. Test incomplete RICE data handling. Test boundary values.
+- `health-pipeline.test.js`: Integration test with mocked data sources. Test cache write. Test incremental enrichment.
+- `health-routes.test.js`: Route-level tests following existing `routes.test.js` pattern. Test auth (requireAuth vs requirePM). Test validation. Test ETag handling.
+
+**Component tests (Vitest + jsdom):**
+- `health-components.test.js`: Test DorChecklist toggle behavior. Test FeatureHealthTable sorting/filtering. Test RiskBadge rendering for each risk level. Test read-only mode for non-PM users.
+
+**Manual testing checklist:**
+1. Navigate to Release Health with no data -- see empty state with refresh prompt
+2. Trigger refresh -- see loading indicator, then populated dashboard
+3. Toggle a manual DoR item -- see immediate UI update, verify persistence on page reload
+4. Set a risk override -- see badge update, verify override persists
+5. Filter by risk level -- verify table filtering works
+6. Export to CSV -- verify all columns present
+7. Test with demo mode -- verify fixture data loads correctly
+8. Test without Jira credentials -- verify graceful degradation
+
+### 8.3 CI/CD Impact
+
+**Minimal deployment changes required.** The release health feature is within the existing `release-planning` module. No new Docker images, Kubernetes manifests, environment variables, or secrets.
+
+**CronJob update:** The daily cronjob (`deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml`) must be extended with a Step 6 that triggers health refreshes for all configured releases. This step runs AFTER Step 5 (Feature Traffic refresh) to ensure the feature-traffic cache is fresh before health enrichment begins. The health refresh step iterates over configured releases (via `GET /api/modules/release-planning/config`) and triggers `POST /api/modules/release-planning/releases/{version}/health/refresh` for each, polling completion before moving to the next.
+
+```shell
+# Step 6: Trigger Release Health refresh for all configured releases
+echo "=== Triggering Release Health refresh ==="
+RELEASES=$(curl -sf "$BACKEND/api/modules/release-planning/releases" \
+  -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" | grep -oP '"version"\s*:\s*"\K[^"]+')
+for VER in $RELEASES; do
+  echo "Refreshing health for $VER..."
+  curl -sf -X POST "$BACKEND/api/modules/release-planning/releases/$VER/health/refresh" \
+    -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" || echo "Health refresh for $VER failed (non-fatal)"
+  # Brief pause between releases to avoid Jira rate limits
+  sleep 30
+done
+```
+
+**Rate limiting coordination:** Manual health refreshes should not be triggered during the daily cronjob window (06:00-07:00 UTC). The `POST /health/refresh` endpoint will check the current time and log a warning (but not block) if triggered within this window. The two-pass enrichment strategy (see section 3, Phase 1a) reduces Jira API load vs. fetching changelog for every feature.
+
+The existing CI pipeline (`ci.yml`) will automatically:
+- Lint new files (ESLint via lint-staged)
+- Run new tests (Vitest)
+- Build frontend (Vite -- new components are auto-discovered via import)
+- Validate module manifest (validate-modules script)
+
+The existing build pipeline (`build-images.yml`) will detect changes in `modules/release-planning/` and rebuild both frontend and backend images.
+
+### 8.4 Preprod Validation
+
+1. Deploy to preprod overlay (`deploy/openshift/overlays/preprod/`)
+2. Verify health pipeline runs against real Jira data
+3. Verify Smartsheet milestone dates load correctly
+4. Verify PM auth gates work with OpenShift OAuth proxy
+5. Verify health cache is written to PVC-mounted data directory
+6. Run a full refresh cycle and check server logs for Jira rate limiting
+
+---
+
+## 9. Backward Compatibility
+
+### 9.1 Existing API Stability
+
+**No existing endpoints are modified.** All health endpoints are new paths under `/releases/:version/health/*`. The existing Big Rocks, candidates, and config endpoints continue to work exactly as before.
+
+### 9.2 Config Migration
+
+The `config.js` module already handles forward-compatible config via spread defaults:
+
+```javascript
+const DEFAULT_CONFIG = {
+  // ... existing fields ...
+  // New fields have safe defaults
+  healthConfig: {
+    enableRice: false,
+    enableJiraEnrichment: true,
+    // ...
+  }
+}
+```
+
+When the new code loads an old config file that lacks `healthConfig`, the spread in `getConfig()` fills in defaults automatically. No migration step needed.
+
+### 9.3 Storage File Compatibility
+
+New storage files (`health-cache-*.json`, `dor-state-*.json`, `health-overrides-*.json`) are independent from existing files. They are created on first health refresh and do not affect existing functionality.
+
+### 9.4 Frontend Compatibility
+
+The new `health` nav item appears in the sidebar only after `module.json` is updated. Existing views (`main`, `audit-log`) are unchanged. The new route (`health`) is lazy-loaded via `defineAsyncComponent`, so it adds no bundle size overhead to users who don't visit it.
+
+### 9.5 Release Deletion Cleanup
+
+The existing `DELETE /releases/:version` handler in `server/index.js` must be extended to also delete health-related storage files:
+
+```javascript
+if (deleteFromStorage) {
+  deleteFromStorage(releaseFilePath(version))
+  deleteFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
+  // NEW: clean up health files
+  deleteFromStorage(DATA_PREFIX + '/health-cache-' + version + '.json')
+  deleteFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json')
+  deleteFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json')
+}
+```
+
+---
+
+## 10. Risks and Mitigations
+
+### 10.1 Technical Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **RICE custom field IDs unknown** -- field names/IDs for Reach, Impact, Confidence, Effort on RHAISTRAT may not exist or may differ from expected | Medium | Medium | RICE scoring is disabled by default (`enableRice: false`). Phase 1 includes a Jira field discovery step. If fields don't exist, RICE is omitted without affecting other health features. |
+| **Jira rate limiting during enrichment** -- batched queries for 100+ features may hit rate limits | Medium | Low | Existing retry logic in `shared/server/jira.js` handles 429s with exponential backoff. Batch size (40) and throttle (1s) are configurable. Health pipeline runs in background; users see cached data during refresh. |
+| **Large release cache size** -- health cache with 100+ features, each with 13 DoR items and risk flags, could be large | Low | Low | Estimated ~200KB for 100 features. Well within storage limits. Feature detail is kept minimal (no description content, just boolean `hasDescription`). |
+| **Smartsheet unavailability** -- milestone dates not available if token missing or API down | Medium | Low | Timeline component degrades gracefully (shows "Milestone dates unavailable"). Risk engine falls back to date-free assessment (velocity and DoR risks still work, milestone risk is skipped). |
+
+### 10.2 Data Availability Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **Feature-traffic cache empty** -- health pipeline depends on feature-traffic data | Medium | High | Health pipeline checks for empty index and returns early with a warning message (same pattern as existing pipeline in `pipeline.js`). Users are prompted to run a feature-traffic refresh first. |
+| **Stale feature-traffic data** -- cache may be hours or days old | Medium | Medium | Health dashboard shows `lastRefreshed` timestamp prominently. Health pipeline logs warnings for data older than 24 hours. Automated DoR checks note the data timestamp. |
+| **Jira description field not in ADF format** -- some legacy issues may have wiki-markup descriptions | Low | Low | Description check only tests for non-emptiness (length > 0), not content quality. Works regardless of format. |
+
+### 10.3 Scope Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **Frontend complexity exceeds estimate** -- health dashboard with expandable rows, inline editing, and filter interactions is significant UI work | Medium | Medium | Recommend spawning a dedicated UX agent for Phase 3. Existing Tailwind utilities and component patterns (FilterBar, StatusBadge) reduce boilerplate. Start with read-only view; add editing in a second pass. |
+| **Phasing awareness needed sooner** -- users may want EA1 vs EA2 vs GA breakdowns within a release | Medium | Low | Phase field is already in the data model. Can be added as a filter/grouping option without schema changes. Explicitly deferred from MVP per requirements. |
+| **Manual DoR checks become stale** -- PMs toggle items once and forget to update | Low | Medium | Audit log tracks all DoR changes. "Last updated" timestamp shown per item. Consider a future "DoR freshness" warning for items not updated in 30+ days. |
+
+### 10.4 Dependency Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **Concurrent development on release-planning module** -- this plan modifies `server/index.js` and `config.js` which are actively developed | High | Medium | Health routes are mounted via a separate file (`health-routes.js`), minimizing merge conflicts. Config changes are additive (new fields with defaults). `invalidateCache()` extension is a 3-line change. |
+| **feature-traffic schema changes** -- index.json or feature detail format may evolve | Low | Medium | Cache-reader functions (`loadIndex`, `loadFeatureDetail`) provide abstraction. **Important:** The health pipeline reads raw index/detail data directly rather than using `mapToCandidate()`, because `mapToCandidate()` stringifies labels via `labels.join(', ')` (cache-reader.js line 111), which breaks `labels.includes()` checks. The health pipeline should use `getLabels(item)` from cache-reader helpers or read the raw `labels` array from detail files. |
+
+---
+
+## Appendix A: Risk Category Reference
+
+Mapping from release-pulse categories to the new health model:
+
+| release-pulse Category | Health Model Category | Detection Method |
+|----------------------|---------------------|-----------------|
+| `EA1_MISS` | `MILESTONE_MISS` | Feature status behind expected phase progress at EA1 freeze date |
+| `EA2_AT_RISK` | `VELOCITY_LAG` | Completion % below threshold with EA2 approaching |
+| `UNREFINED_WORK` | `DOR_INCOMPLETE` | DoR completion below threshold |
+| `MISSING_TARGET` | `UNESTIMATED` | No story points, no target version |
+| `MISSING_RFE` | `MISSING_RFE` | Customer-facing feature with no RFE link |
+| (new) | `BLOCKED` | Unresolved blocking dependency links |
+
+## Appendix B: Jira Custom Field Reference
+
+| Field | ID | Source | Used For |
+|-------|----|--------|----------|
+| Target Version | `customfield_10855` | Existing config | DoR F-2, risk milestone check |
+| Product Manager | `customfield_10469` | Existing config | DoR F-4 |
+| Release Type | `customfield_10851` | Existing config | DoR F-10, phase derivation |
+| Story Points | `customfield_10028` | Existing config | DoR F-7, scope estimation |
+| Architect | `customfield_10467` | Existing config | Cross-reference only |
+| RICE Reach | TBD | New config | RICE scoring |
+| RICE Impact | TBD | New config | RICE scoring |
+| RICE Confidence | TBD | New config | RICE scoring |
+| RICE Effort | TBD | New config | RICE scoring |
+
+## Appendix C: Phase-Completion Mapping
+
+Used by the risk engine to determine expected completion percentages at each milestone. These values are configurable via `healthConfig.phaseCompletionExpectations` in the release-planning config (see section 4.3), NOT hardcoded as magic numbers. The defaults below are used when the config does not specify custom values:
+
+```javascript
+// Default phase-completion expectations (stored in healthConfig.phaseCompletionExpectations)
+const DEFAULT_PHASE_COMPLETION_EXPECTATIONS = {
+  // At EA1 code freeze, EA1-scoped features should be near-complete
+  'ea1_freeze': { EA1: 90, EA2: 30, GA: 10 },
+  // At EA1 release, EA1 done, EA2 in progress
+  'ea1_target': { EA1: 100, EA2: 50, GA: 20 },
+  // At EA2 code freeze
+  'ea2_freeze': { EA1: 100, EA2: 90, GA: 40 },
+  // At EA2 release
+  'ea2_target': { EA1: 100, EA2: 100, GA: 60 },
+  // At GA code freeze
+  'ga_freeze':  { EA1: 100, EA2: 100, GA: 90 },
+  // At GA release
+  'ga_target':  { EA1: 100, EA2: 100, GA: 100 }
+}
+```
+
+---
+
+*End of plan. Ready for review.*

--- a/design/release-health-redesign-plan.md
+++ b/design/release-health-redesign-plan.md
@@ -1,0 +1,1335 @@
+# Release Health Dashboard Redesign -- Implementation Plan
+
+**Date:** 2026-04-27
+**Status:** Revised after review
+**Supersedes:** `2026-04-26-release-plan-health-redesign.md` (draft)
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Priority Formula](#priority-formula)
+3. [PR Strategy](#pr-strategy)
+4. [Phase 1: Backend Foundation](#phase-1-backend-foundation)
+5. [Phase 2: Frontend -- Summary Cards, Timeline, and Tabs](#phase-2-frontend----summary-cards-timeline-and-tabs)
+6. [Phase 3: Frontend -- Table Redesign and Filters](#phase-3-frontend----table-redesign-and-filters)
+7. [Phase 4: T-Shirt Size Discovery](#phase-4-t-shirt-size-discovery)
+8. [Testability](#testability)
+9. [Deployability](#deployability)
+10. [Affected APIs and Backward Compatibility](#affected-apis-and-backward-compatibility)
+11. [Review Resolution](#review-resolution)
+
+---
+
+## Overview
+
+Redesign the Release Plan Health dashboard to become the primary planning
+instrument for release management. The current dashboard shows a flat list of
+features with risk badges. The redesign adds:
+
+- **Phase tabs** (EA1 / EA2 / GA) showing phase-scoped feature lists, each
+  with its own timeline window
+- **Summary cards**: RICE Score Present, Owner Assigned, Scope Estimated, DoR
+  Complete
+- **Combined Risk + DoR column** in the feature table (risk color dot + DoR
+  percentage; flag count in tooltip)
+- **Dual timeline markers** showing both planning freeze and code freeze
+- **Component multi-select filter** with removable chip/tag UI
+- **Composite priority score** (RICE 30%, Big Rock 30%, Feature Priority 25%,
+  Inverse Complexity 15%)
+- **T-shirt size discovery** via Jira description parsing
+
+---
+
+## Priority Formula
+
+The composite priority score combines four signals with the user's requested
+weights:
+
+| Signal | Weight | Source | Normalization |
+|---|---|---|---|
+| RICE Score | 30% | `rice-scorer.js` output | Min-max across features in the release (0-1) |
+| Big Rock Membership | 30% | `tier` field from candidates pipeline | Tier 1 = 1.0, Tier 2 = 0.6, Tier 3 = 0.2 |
+| Feature Priority | 25% | Jira `priority` field | Blocker=1.0, Critical=0.8, Major=0.6, Normal=0.4, Minor=0.2 |
+| Inverse Complexity | 15% | T-shirt size (parsed from description) | XS=1.0, S=0.8, M=0.6, L=0.4, XL=0.2, Unknown=0.5 |
+
+**Formula:** `score = (rice_norm * 0.30) + (bigrock_norm * 0.30) + (priority_norm * 0.25) + (complexity_norm * 0.15)`
+
+Score range: 0.0 to 1.0. Displayed as a 0-100 integer.
+
+When RICE data is unavailable for a feature (common early in planning), its
+RICE component uses the release-wide median rather than 0, so features are not
+penalized for missing RICE fields.
+
+---
+
+## PR Strategy
+
+Four PRs, each independently reviewable and deployable. Each builds on the
+previous but the backend PRs are safe to merge independently because the
+frontend changes are purely additive.
+
+| PR | Name | Scope | Depends On |
+|---|---|---|---|
+| **PR 1** | Backend: Smartsheet fix + planning freeze dates + priority scorer | Backend only | None |
+| **PR 2** | Frontend: Phase tabs + summary cards + timeline markers | Frontend + composable | PR 1 (for planning freeze data) |
+| **PR 3** | Frontend: Combined column + component chip filter + table sort | Frontend only | PR 2 |
+| **PR 4** | Backend + Frontend: T-shirt size parsing + inverse complexity | Full stack | PR 1 (for scorer) |
+
+---
+
+## Phase 1: Backend Foundation
+
+**PR 1 -- Backend: Smartsheet fix + planning freeze dates + priority scorer**
+
+### 1.1 Fix Smartsheet completeness filter for backfill
+
+**File:** `shared/server/smartsheet.js`
+**Lines 250-255** -- the `REQUIRED_MILESTONES` filter in `discoverReleasesWithFreezes()`
+
+Currently, `discoverReleasesWithFreezes()` requires ALL 6 milestones (`ea1_freeze`,
+`ea1_target`, `ea2_freeze`, `ea2_target`, `ga_freeze`, `ga_target`) to include
+a version. For upcoming releases, not all milestones may be in Smartsheet yet
+(e.g., GA dates may not be set when EA1 is being planned).
+
+**Change:** Extract the shared sheet-fetch-and-parse logic (column mapping, row
+regex parsing, milestone accumulation, version sorting, and field mapping) from
+`discoverReleasesWithFreezes()` into a private helper `parseSmartsheetReleases(filterFn)`.
+Both functions then call this helper with different filter predicates, eliminating
+~60 lines of copy-paste duplication.
+
+```javascript
+// Private helper -- replaces the duplicated logic
+var REQUIRED_MILESTONES = ['ea1_freeze', 'ea1_target', 'ea2_freeze', 'ea2_target', 'ga_freeze', 'ga_target']
+
+async function parseSmartsheetReleases(filterFn) {
+  var sheet = await fetchSheet()
+
+  var colMap = {}
+  for (var c = 0; c < sheet.columns.length; c++) {
+    colMap[sheet.columns[c].title] = sheet.columns[c].id
+  }
+  var taskCol = colMap['Task Name']
+  var startCol = colMap['Start']
+
+  var milestones = {}
+
+  for (var r = 0; r < sheet.rows.length; r++) {
+    var row = sheet.rows[r]
+    var cells = {}
+    for (var ci = 0; ci < row.cells.length; ci++) {
+      cells[row.cells[ci].columnId] = row.cells[ci].value
+    }
+    var task = cells[taskCol]
+    var startVal = cells[startCol]
+    if (!task || !startVal) continue
+
+    var dateStr = String(startVal).split('T')[0]
+    var m
+
+    m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?Code\s+Freeze/i)
+    if (m) {
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]][m[2].toLowerCase() + '_freeze'] = dateStr
+      continue
+    }
+    m = task.match(/^(\d+\.\d+)\.(EA[12])\s+(?:RHOAI\s+)?RELEASE/i)
+    if (m) {
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]][m[2].toLowerCase() + '_target'] = dateStr
+      continue
+    }
+    m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?Code\s+Freeze$/i)
+    if (m) {
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]].ga_freeze = dateStr
+      continue
+    }
+    m = task.match(/^(\d+\.\d+)\s+(?:RHOAI\s+)?GA$/i)
+    if (m) {
+      if (!milestones[m[1]]) milestones[m[1]] = {}
+      milestones[m[1]].ga_target = dateStr
+      continue
+    }
+  }
+
+  return Object.keys(milestones)
+    .filter(function(version) { return filterFn(milestones[version]) })
+    .sort(function(a, b) {
+      var ap = a.split('.').map(Number)
+      var bp = b.split('.').map(Number)
+      return ap[0] - bp[0] || ap[1] - bp[1]
+    })
+    .map(function(version) {
+      var ms = milestones[version]
+      return {
+        version: version,
+        ea1Freeze: ms.ea1_freeze || null,
+        ea1Target: ms.ea1_target || null,
+        ea2Freeze: ms.ea2_freeze || null,
+        ea2Target: ms.ea2_target || null,
+        gaFreeze: ms.ga_freeze || null,
+        gaTarget: ms.ga_target || null
+      }
+    })
+}
+
+// Refactored -- delegates to shared helper with strict filter
+async function discoverReleasesWithFreezes() {
+  return parseSmartsheetReleases(function(ms) {
+    return REQUIRED_MILESTONES.every(function(key) { return !!ms[key] })
+  })
+}
+
+// New function -- delegates to shared helper with relaxed filter
+async function discoverReleasesPartial() {
+  return parseSmartsheetReleases(function(ms) {
+    return Object.keys(ms).length > 0
+  })
+}
+```
+
+Also refactor `discoverReleases()` to use `parseSmartsheetReleases()` with a
+mapping step that drops freeze fields, keeping only target dates. This
+eliminates the third copy of the same row-parsing logic.
+
+**Then update** `health-pipeline.js` line 293 to call `discoverReleasesPartial()`
+instead of `discoverReleasesWithFreezes()` in `backfillFreezeDatesFromSmartsheet()`:
+
+```javascript
+// health-pipeline.js, line 293
+var releases = await smartsheetClient.discoverReleasesPartial()
+```
+
+This is the only caller that needs the relaxed filter. The pipeline already
+handles null milestone fields gracefully (see `deriveFreezeDates()` on line 355).
+
+### 1.2 Add planning freeze dates to health cache
+
+**File:** `modules/release-planning/server/health/health-pipeline.js`
+
+The health pipeline already computes `planningDeadline` (code freeze - 7 days)
+on line 565 via `computePlanningDeadline()`. However, it only exposes the
+deadline for the selected phase. We need planning freeze dates for ALL phases
+in the milestones output so the frontend timeline can show them.
+
+**Change:** In the cache object built at lines 664-696, add `planningFreezes`
+alongside `milestones`:
+
+```javascript
+// Add after milestones block (line 667-676)
+planningFreezes: milestones ? {
+  ea1: milestones.ea1Freeze ? offsetDate(milestones.ea1Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
+  ea2: milestones.ea2Freeze ? offsetDate(milestones.ea2Freeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null,
+  ga: milestones.gaFreeze ? offsetDate(milestones.gaFreeze, -PLANNING_DEADLINE_OFFSET_DAYS) : null
+} : null,
+```
+
+**Reuse existing date arithmetic:** The `deriveFreezeDates()` function (line 361)
+already contains an `offset(dateStr)` inner function that does the same date
+arithmetic. Extract it to a module-level helper `offsetDate(dateStr, days)` and
+reuse it in both `deriveFreezeDates()` and the new `planningFreezes` block.
+Do NOT add a second copy.
+
+```javascript
+// Extract to module level (replaces the inner function at line 361)
+function offsetDate(dateStr, days) {
+  var d = new Date(dateStr + 'T00:00:00Z')
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().split('T')[0]
+}
+```
+
+Update `deriveFreezeDates()` to call `offsetDate(dateStr, -FREEZE_OFFSET_DAYS)`
+instead of its current inner `offset()` function.
+
+### 1.3 Create composite priority scorer
+
+**New file:** `modules/release-planning/server/health/priority-scorer.js`
+
+```javascript
+/**
+ * Composite priority scoring.
+ *
+ * Combines four signals into a single 0-100 priority score:
+ *   - RICE Score (30%): min-max normalized across all features
+ *   - Big Rock Membership (30%): Tier 1=1.0, Tier 2=0.6, Tier 3=0.2
+ *   - Feature Priority (25%): Blocker=1.0 ... Minor=0.2
+ *   - Inverse Complexity (15%): XS=1.0 ... XL=0.2, Unknown=0.5
+ */
+
+var TIER_SCORES = { 1: 1.0, 2: 0.6, 3: 0.2 }
+
+var PRIORITY_SCORES = {
+  'Blocker': 1.0,
+  'Critical': 0.8,
+  'Major': 0.6,
+  'Normal': 0.4,
+  'Minor': 0.2
+}
+
+var TSHIRT_SCORES = {
+  'XS': 1.0,
+  'S': 0.8,
+  'M': 0.6,
+  'L': 0.4,
+  'XL': 0.2
+}
+
+// Weights are hardcoded per user request. A future iteration could make
+// these configurable via admin settings (stored in data/release-planning/
+// health-config.json), but for now they are fixed constants.
+var WEIGHTS = {
+  rice: 0.30,
+  bigRock: 0.30,
+  priority: 0.25,
+  complexity: 0.15
+}
+
+/**
+ * Compute composite priority scores for a set of features.
+ *
+ * @param {Array<object>} features - Health pipeline features
+ * @returns {Map<string, { score: number, breakdown: object }>}
+ */
+function computePriorityScores(features) {
+  // Collect RICE scores for min-max normalization
+  var riceValues = []
+  for (var i = 0; i < features.length; i++) {
+    if (features[i].rice && features[i].rice.score != null) {
+      riceValues.push(features[i].rice.score)
+    }
+  }
+
+  var riceMin = riceValues.length > 0 ? Math.min.apply(null, riceValues) : 0
+  var riceMax = riceValues.length > 0 ? Math.max.apply(null, riceValues) : 0
+  var riceRange = riceMax - riceMin
+
+  // Compute median for fallback
+  var riceMedian = 0.5
+  if (riceValues.length > 0) {
+    var sorted = riceValues.slice().sort(function(a, b) { return a - b })
+    var mid = Math.floor(sorted.length / 2)
+    var medianRaw = sorted.length % 2 === 0
+      ? (sorted[mid - 1] + sorted[mid]) / 2
+      : sorted[mid]
+    riceMedian = riceRange > 0 ? (medianRaw - riceMin) / riceRange : 0.5
+  }
+
+  var results = new Map()
+
+  for (var j = 0; j < features.length; j++) {
+    var f = features[j]
+
+    // RICE normalization
+    var riceNorm = riceMedian // fallback
+    if (f.rice && f.rice.score != null) {
+      riceNorm = riceRange > 0 ? (f.rice.score - riceMin) / riceRange : 0.5
+    }
+
+    // Big Rock tier
+    var tierNorm = TIER_SCORES[f.tier] || TIER_SCORES[3]
+
+    // Feature priority
+    var priorityNorm = PRIORITY_SCORES[f.priority] || PRIORITY_SCORES['Normal']
+
+    // Inverse complexity (t-shirt size)
+    var complexityNorm = TSHIRT_SCORES[f.tshirtSize] || 0.5
+
+    var score = (riceNorm * WEIGHTS.rice) +
+                (tierNorm * WEIGHTS.bigRock) +
+                (priorityNorm * WEIGHTS.priority) +
+                (complexityNorm * WEIGHTS.complexity)
+
+    results.set(f.key, {
+      score: Math.round(score * 100),
+      breakdown: {
+        rice: Math.round(riceNorm * 100),
+        bigRock: Math.round(tierNorm * 100),
+        priority: Math.round(priorityNorm * 100),
+        complexity: Math.round(complexityNorm * 100)
+      }
+    })
+  }
+
+  return results
+}
+
+module.exports = {
+  computePriorityScores: computePriorityScores,
+  WEIGHTS: WEIGHTS,
+  TIER_SCORES: TIER_SCORES,
+  PRIORITY_SCORES: PRIORITY_SCORES,
+  TSHIRT_SCORES: TSHIRT_SCORES
+}
+```
+
+### 1.4 Integrate priority scorer into health pipeline
+
+**File:** `modules/release-planning/server/health/health-pipeline.js`
+
+After the risk computation loop (after line 658), add:
+
+```javascript
+// Step 6b: Compute composite priority scores
+var priorityScores = computePriorityScores(healthFeatures)
+for (var pi = 0; pi < healthFeatures.length; pi++) {
+  var pKey = healthFeatures[pi].key
+  var pResult = priorityScores.get(pKey)
+  healthFeatures[pi].priorityScore = pResult ? pResult.score : null
+  healthFeatures[pi].priorityBreakdown = pResult ? pResult.breakdown : null
+}
+```
+
+Add the require at the top:
+
+```javascript
+const { computePriorityScores } = require('./priority-scorer')
+```
+
+### 1.5 Ensure per-feature data supports client-side summary card computation
+
+**No new server-side summary counters.** The summary card counts (Owner Assigned,
+Scope Estimated, RICE Complete, DoR Complete) must be phase-scoped. Since the
+"all" view loads all features and phase tabs filter client-side, computing these
+counters server-side (across ALL features) would show incorrect totals when a
+phase tab is selected (e.g., EA1 tab would still show release-wide counts).
+
+Instead, the summary cards will be computed client-side from `phasedFeatures`
+(see section 2.1). The per-feature fields needed for these counts already exist
+or are added elsewhere in this plan:
+
+- **Owner Assigned:** `feature.deliveryOwner` (already present on health features, line 641)
+- **Scope Estimated:** `feature.storyPoints` -- add this field to health features
+  in the feature-building loop (carry from enrichment):
+  ```javascript
+  storyPoints: enrichment ? enrichment.storyPoints || null : null,
+  ```
+- **RICE Complete:** `feature.rice && feature.rice.score != null` (already present)
+- **DoR Complete:** `feature.dor.completionPct >= 80` (already present)
+
+### 1.6 Files changed in PR 1
+
+| File | Action | Summary |
+|---|---|---|
+| `shared/server/smartsheet.js` | Modify | Extract `parseSmartsheetReleases()` helper; refactor `discoverReleasesWithFreezes()` and `discoverReleases()` to use it; add `discoverReleasesPartial()` |
+| `modules/release-planning/server/health/health-pipeline.js` | Modify | Call `discoverReleasesPartial()` in backfill; extract `offsetDate()` to module level; add `planningFreezes` to cache; add `storyPoints` to health features; integrate priority scorer |
+| `modules/release-planning/server/health/priority-scorer.js` | **New** | Composite priority scoring (RICE 30%, Big Rock 30%, Priority 25%, Complexity 15%) |
+| `modules/release-planning/server/constants.js` | No change | Risk categories and constants already in place from prior work |
+
+---
+
+## Phase 2: Frontend -- Summary Cards, Timeline, and Tabs
+
+**PR 2 -- Frontend: Phase tabs + summary cards + timeline markers**
+
+### 2.1 Replace HealthSummaryCards with new card layout
+
+**File:** `modules/release-planning/client/components/HealthSummaryCards.vue`
+
+Replace the current 5-card layout (Green/Yellow/Red/DoR/Planning Deadline) with
+4 new summary cards. The risk breakdown (green/yellow/red) moves into the
+summary text of the On Track card.
+
+**New card layout (4 cards, `grid-cols-2 lg:grid-cols-4`):**
+
+| Card | Label | Value | Subtext | Color |
+|---|---|---|---|---|
+| 1 | RICE Score Present | `cardCounts.riceComplete` / `cardCounts.total` | percentage | indigo |
+| 2 | Owner Assigned | `cardCounts.ownerAssigned` / `cardCounts.total` | percentage | blue |
+| 3 | Scope Estimated | `cardCounts.scopeEstimated` / `cardCounts.total` | percentage | amber |
+| 4 | DoR Complete | `cardCounts.dorComplete` / `cardCounts.total` | percentage | green |
+
+**Client-side computation (phase-scoped):** Card counts are computed from
+`phasedFeatures`, NOT from the server-side `summary` object. This ensures
+that when the user selects the EA1 tab, the cards show counts for EA1
+features only.
+
+```javascript
+var cardCounts = computed(function() {
+  var feats = phasedFeatures.value
+  var total = feats.length
+  var ownerAssigned = 0
+  var scopeEstimated = 0
+  var riceComplete = 0
+  var dorComplete = 0
+
+  for (var i = 0; i < feats.length; i++) {
+    var f = feats[i]
+    if (f.deliveryOwner) ownerAssigned++
+    if (f.storyPoints) scopeEstimated++
+    if (f.rice && f.rice.score != null) riceComplete++
+    if (f.dor && f.dor.completionPct >= 80) dorComplete++
+  }
+
+  return {
+    total: total,
+    ownerAssigned: ownerAssigned,
+    scopeEstimated: scopeEstimated,
+    riceComplete: riceComplete,
+    dorComplete: dorComplete
+  }
+})
+```
+
+Pass `cardCounts` as a prop to `HealthSummaryCards.vue` instead of the
+server-side `summary` object.
+
+Each card shows a count fraction (e.g., "12 / 15") as the primary number and a
+percentage bar beneath. The risk breakdown (green/yellow/red dots with counts)
+moves to a small inline display beneath the page header, similar to how
+`SummaryCards.vue` currently shows the health indicator in the Totals card
+(lines 79-92).
+
+**Remove:** The `@filterByRisk` event emission and the `handleCardClick`
+handler. Risk filtering will be handled by the existing filter bar.
+
+**Keep:** The planning deadline card as a standalone inline indicator beneath
+the timeline (not one of the four cards). This remains phase-sensitive.
+
+### 2.2 Add planning freeze markers to MilestoneTimeline
+
+**File:** `modules/release-planning/client/components/MilestoneTimeline.vue`
+
+**Change the `MILESTONE_ORDER` array** (line 8) to add planning freeze markers:
+
+```javascript
+const MILESTONE_ORDER = [
+  { key: 'ea1PlanFreeze', label: 'EA1 Plan Freeze', color: 'bg-blue-300 dark:bg-blue-300', style: 'dashed' },
+  { key: 'ea1Freeze', label: 'EA1 Code Freeze', color: 'bg-blue-500 dark:bg-blue-400' },
+  { key: 'ea1Target', label: 'EA1 Release', color: 'bg-blue-600 dark:bg-blue-500' },
+  { key: 'ea2PlanFreeze', label: 'EA2 Plan Freeze', color: 'bg-amber-300 dark:bg-amber-300', style: 'dashed' },
+  { key: 'ea2Freeze', label: 'EA2 Code Freeze', color: 'bg-amber-500 dark:bg-amber-400' },
+  { key: 'ea2Target', label: 'EA2 Release', color: 'bg-amber-600 dark:bg-amber-500' },
+  { key: 'gaPlanFreeze', label: 'GA Plan Freeze', color: 'bg-green-300 dark:bg-green-300', style: 'dashed' },
+  { key: 'gaFreeze', label: 'GA Code Freeze', color: 'bg-green-500 dark:bg-green-400' },
+  { key: 'gaTarget', label: 'GA Release', color: 'bg-green-600 dark:bg-green-500' }
+]
+```
+
+**Update the `milestonePoints` computed** to merge `planningFreezes` data:
+
+```javascript
+var milestonePoints = computed(function() {
+  if (!props.milestones) return []
+  var pf = props.planningFreezes || {}
+  var combined = Object.assign({}, props.milestones, {
+    ea1PlanFreeze: pf.ea1 || null,
+    ea2PlanFreeze: pf.ea2 || null,
+    gaPlanFreeze: pf.ga || null
+  })
+  // ... same loop over MILESTONE_ORDER
+})
+```
+
+**Add prop:** `planningFreezes: { type: Object, default: null }`
+
+**Visual distinction:** Planning freeze markers use a dashed border and slightly
+lighter color. Add a `style` field to differentiate:
+
+```html
+<div
+  class="w-3 h-3 rounded-full border-2"
+  :class="[point.color, point.style === 'dashed' ? 'border-dashed border-gray-500' : 'border-white dark:border-gray-800']"
+></div>
+```
+
+**Label collision strategy:** With 9 markers, labels will overlap when dates
+cluster (e.g., planning freeze 7 days before code freeze). Use abbreviated
+labels for planning freeze markers to reduce collision probability:
+
+- "EA1 Plan Freeze" becomes "EA1 PF"
+- "EA2 Plan Freeze" becomes "EA2 PF"
+- "GA Plan Freeze" becomes "GA PF"
+
+Additionally, when two adjacent markers are within 7 days of each other,
+stack their labels vertically (alternate between `top-full` and `bottom-full`
+positioning). Implement this in the `milestonePoints` computed by comparing
+each point's date with its neighbors and assigning a `labelPosition` field
+(`'above'` or `'below'`). The abbreviated labels and vertical stacking
+together keep the timeline legible at any date density.
+
+### 2.3 Add phase tabs to HealthDashboardView
+
+**File:** `modules/release-planning/client/views/HealthDashboardView.vue`
+
+**Tab architecture decision:** Load all phases into a single API response and
+filter client-side. Rationale:
+
+- The candidate pipeline already has all features for a version; phase filtering
+  is a simple fixVersion string check (see `passesPhaseFilter()` in
+  health-pipeline.js lines 63-86)
+- Feature count per release is typically 30-80 (not thousands)
+- Client-side filtering gives instant tab switching with no loading state
+- The server already caches by version+phase; we consolidate to version+`all`
+- Risk and DoR computations are per-feature and phase-independent
+
+**Implementation:**
+
+Replace the current `PhaseSelector` dropdown with inline tabs, following the
+same pattern as `DashboardView.vue` (lines 118-131, 552-576).
+
+```javascript
+// New tab definitions
+var phaseTabs = computed(function() {
+  var tabs = [{ id: 'all', label: 'All Features' }]
+  var ms = milestones.value
+  if (!ms) return tabs
+  if (ms.ea1Freeze || ms.ea1Target) tabs.push({ id: 'EA1', label: 'EA1' })
+  if (ms.ea2Freeze || ms.ea2Target) tabs.push({ id: 'EA2', label: 'EA2' })
+  if (ms.gaFreeze || ms.gaTarget) tabs.push({ id: 'GA', label: 'GA' })
+  return tabs
+})
+
+var activePhase = ref('all')
+```
+
+Remove the import and usage of `PhaseSelector` component.
+
+**Data loading:** On version change, call `loadHealth(version)` with no phase
+parameter (loads all features). Tab switching filters client-side using the
+existing `passesPhaseFilter` logic, ported to the frontend:
+
+```javascript
+// In the composable or view
+var phasedFeatures = computed(function() {
+  if (activePhase.value === 'all') return features.value
+  return features.value.filter(function(f) {
+    return passesPhaseFilter(f, selectedVersion.value, activePhase.value)
+  })
+})
+```
+
+Port the `passesPhaseFilter` function from `health-pipeline.js` (lines 63-86)
+to a client-side utility.
+
+**Planning deadline in the "all" tab:** The server-side `computePlanningDeadline()`
+returns `null` when phase is null/undefined (line 160: `if (!milestones || !phase) return null`).
+This means the `summary.planningDeadline` field will be `null` for the "all" view.
+
+The frontend must compute the planning deadline client-side for the "all" tab.
+Use the `planningFreezes` object from the health data and select the NEAREST
+upcoming planning freeze date across all phases:
+
+```javascript
+var activePlanningDeadline = computed(function() {
+  // For phase-specific tabs, use the server-computed deadline
+  if (activePhase.value !== 'all') {
+    return healthData.value ? healthData.value.summary.planningDeadline : null
+  }
+
+  // For the "all" tab, find the nearest future planning freeze
+  var pf = healthData.value ? healthData.value.planningFreezes : null
+  if (!pf) return null
+
+  var today = new Date()
+  var todayStr = today.toISOString().split('T')[0]
+  var nearest = null
+
+  var phases = ['ea1', 'ea2', 'ga']
+  for (var i = 0; i < phases.length; i++) {
+    var dateStr = pf[phases[i]]
+    if (!dateStr || dateStr < todayStr) continue
+    if (!nearest || dateStr < nearest.date) {
+      var deadlineDate = new Date(dateStr + 'T00:00:00Z')
+      var todayDate = new Date(todayStr + 'T00:00:00Z')
+      nearest = {
+        date: dateStr,
+        daysRemaining: Math.ceil((deadlineDate - todayDate) / (1000 * 60 * 60 * 24))
+      }
+    }
+  }
+
+  return nearest
+})
+```
+
+This ensures the planning deadline indicator beneath the timeline always shows
+the most relevant (closest future) deadline, regardless of which tab is active.
+
+**Tab count badges:** Each tab shows the count of features in that phase, using
+the same badge pattern as `DashboardView.vue` line 571-575.
+
+### 2.4 Wire up health data to MilestoneTimeline
+
+**File:** `modules/release-planning/client/views/HealthDashboardView.vue`
+
+Pass the new `planningFreezes` from the health data:
+
+```html
+<MilestoneTimeline
+  :milestones="milestones"
+  :planningFreezes="planningFreezes"
+/>
+```
+
+```javascript
+var planningFreezes = computed(function() {
+  return healthData.value ? healthData.value.planningFreezes : null
+})
+```
+
+### 2.5 Files changed in PR 2
+
+| File | Action | Summary |
+|---|---|---|
+| `modules/release-planning/client/views/HealthDashboardView.vue` | Modify | Replace PhaseSelector with inline tabs; pass planningFreezes to timeline; compute `cardCounts` and `activePlanningDeadline` client-side from `phasedFeatures`; rewire summary cards |
+| `modules/release-planning/client/components/HealthSummaryCards.vue` | Modify | Replace 5-card layout with 4 readiness cards; accept `cardCounts` prop instead of server `summary` |
+| `modules/release-planning/client/components/MilestoneTimeline.vue` | Modify | Add planning freeze markers with abbreviated labels and label collision strategy; accept `planningFreezes` prop |
+| `modules/release-planning/client/components/PhaseSelector.vue` | Delete | Replaced by inline tabs |
+| `modules/release-planning/client/utils/phase-filter.js` | **New** | Client-side `passesPhaseFilter()` ported from health-pipeline.js |
+| `modules/release-planning/__tests__/client/health-components.test.js` | Modify | Remove PhaseSelector tests (describe block at line 210); add tests for new summary card layout |
+
+---
+
+## Phase 3: Frontend -- Table Redesign and Filters
+
+**PR 3 -- Frontend: Combined column + component chip filter + priority column**
+
+### 3.1 Combine Risk + DoR into a single column
+
+**File:** `modules/release-planning/client/components/FeatureHealthRow.vue`
+
+Replace the separate Risk and DoR columns (currently columns 5 and 6 in
+`FeatureHealthTable.vue` line 24-25) with a single "Health" column.
+
+**Cell content:** Risk color dot + DoR percentage. Flag count shown in tooltip.
+
+```html
+<!-- Health cell (replaces separate Risk and DoR cells) -->
+<td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+  <div class="flex items-center gap-1.5" :title="healthTooltip">
+    <!-- Risk dot (w-2.5 h-2.5 = 10x10px for accessibility) -->
+    <span
+      class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+      role="img"
+      :aria-label="'Risk level: ' + effectiveRisk"
+      :class="{
+        'bg-green-500': effectiveRisk === 'green',
+        'bg-yellow-500': effectiveRisk === 'yellow',
+        'bg-red-500': effectiveRisk === 'red'
+      }"
+    ></span>
+    <!-- DoR percentage -->
+    <span
+      class="text-xs font-medium"
+      :class="dorPctClass"
+    >{{ dorPct }}%</span>
+  </div>
+</td>
+```
+
+**Tooltip content** (via `title` attribute or a custom tooltip component):
+
+```javascript
+var healthTooltip = computed(function() {
+  var lines = []
+  lines.push('Risk: ' + effectiveRisk.charAt(0).toUpperCase() + effectiveRisk.slice(1))
+  lines.push('DoR: ' + dorPct + '% (' + feature.dor.checkedCount + '/' + feature.dor.totalCount + ')')
+  if (riskFlags.length > 0) {
+    lines.push(riskFlags.length + ' risk flag(s):')
+    for (var i = 0; i < riskFlags.length; i++) {
+      lines.push('  - ' + riskFlags[i].category + ': ' + riskFlags[i].message)
+    }
+  }
+  if (riskOverride) {
+    lines.push('Override: ' + riskOverride.riskOverride + ' (' + riskOverride.reason + ')')
+  }
+  return lines.join('\n')
+})
+```
+
+**Update `FeatureHealthTable.vue`** columns array (line 19-30):
+
+```javascript
+var columns = [
+  { key: 'expand', label: '', sortable: false },
+  { key: 'key', label: 'Feature', sortable: true },
+  { key: 'summary', label: 'Summary', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'health', label: 'Health', sortable: true },     // combined Risk + DoR
+  { key: 'priority', label: 'Priority', sortable: true },  // composite score
+  { key: 'rice', label: 'RICE', sortable: true },
+  { key: 'components', label: 'Component', sortable: true },
+  { key: 'owner', label: 'Owner', sortable: true },        // new column
+  { key: 'phase', label: 'Phase', sortable: true },
+  { key: 'tier', label: 'Tier', sortable: true }
+]
+```
+
+**Sorting for the combined health column:** Sort by risk level first (red=0,
+yellow=1, green=2), then by DoR % ascending within the same risk level:
+
+```javascript
+if (key === 'health') {
+  va = RISK_ORDER[getRiskLevel(a)] * 1000 + (1000 - (a.dor ? a.dor.completionPct : 0))
+  vb = RISK_ORDER[getRiskLevel(b)] * 1000 + (1000 - (b.dor ? b.dor.completionPct : 0))
+}
+```
+
+**Sorting for priority:** Sort by composite priority score descending:
+
+```javascript
+if (key === 'priority') {
+  va = a.priorityScore != null ? a.priorityScore : -1
+  vb = b.priorityScore != null ? b.priorityScore : -1
+}
+```
+
+**Expanded row colspan update:** The expanded detail row in `FeatureHealthRow.vue`
+(line 159) currently uses `colspan="10"` matching the existing 10 columns. With
+the redesign, the column count changes: Risk+DoR merge into Health (-1), and
+Priority (+1) and Owner (+1) are added, bringing the total to 11 columns
+(expand, feature, summary, status, health, priority, rice, components, owner,
+phase, tier). Update the colspan to `11`.
+
+### 3.2 Add composite priority score column
+
+**File:** `modules/release-planning/client/components/FeatureHealthRow.vue`
+
+Add a Priority cell that displays the composite score (0-100) with a color
+gradient:
+
+```html
+<td class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-center" :title="priorityTooltip">
+  <span
+    v-if="feature.priorityScore != null"
+    class="inline-block px-1.5 py-0.5 rounded text-[10px] font-bold"
+    :class="priorityScoreClass"
+  >{{ feature.priorityScore }}</span>
+  <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
+</td>
+```
+
+**Tooltip** shows the breakdown:
+
+```javascript
+var priorityTooltip = computed(function() {
+  if (!props.feature.priorityBreakdown) return ''
+  var b = props.feature.priorityBreakdown
+  return 'RICE: ' + b.rice + '% (30w)\n' +
+         'Big Rock: ' + b.bigRock + '% (30w)\n' +
+         'Priority: ' + b.priority + '% (25w)\n' +
+         'Complexity: ' + b.complexity + '% (15w)'
+})
+```
+
+**Color classes:**
+
+```javascript
+var priorityScoreClass = computed(function() {
+  var score = props.feature.priorityScore
+  if (score >= 70) return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  if (score >= 40) return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
+  return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+})
+```
+
+### 3.3 Replace component dropdown with multi-select chips
+
+**File:** `modules/release-planning/client/components/HealthFilterBar.vue`
+
+Replace the single `<select>` for components (lines 73-83) with a multi-select
+chip/tag pattern. Follow the existing pattern from `FilterBar.vue` (lines
+118-158) which already implements a multi-select dropdown for teams.
+
+**New state in `HealthDashboardView.vue`:**
+
+```javascript
+// Replace:
+var componentFilter = ref('')
+// With:
+var selectedComponents = ref([])
+
+// Update filter logic:
+// NOTE: Use a regex split to handle inconsistent comma spacing from Jira
+// (e.g., "Comp1,Comp2" or "Comp1, Comp2" or "Comp1 , Comp2")
+if (selectedComponents.value.length > 0) {
+  var featureComps = f.components
+    ? f.components.split(/\s*,\s*/).filter(Boolean)
+    : []
+  var hasMatch = selectedComponents.value.some(function(comp) {
+    return featureComps.includes(comp)
+  })
+  if (!hasMatch) return false
+}
+
+// Build the component dropdown list by splitting ALL features' components
+// and deduplicating:
+var allComponents = computed(function() {
+  var set = new Set()
+  var feats = features.value || []
+  for (var i = 0; i < feats.length; i++) {
+    if (feats[i].components) {
+      var parts = feats[i].components.split(/\s*,\s*/).filter(Boolean)
+      for (var j = 0; j < parts.length; j++) {
+        set.add(parts[j])
+      }
+    }
+  }
+  return Array.from(set).sort()
+})
+```
+
+**HealthFilterBar.vue changes:**
+
+Replace the component `<select>` with:
+
+```html
+<!-- Component multi-select with chips -->
+<div v-if="components.length > 0" ref="compDropdownRef" class="relative">
+  <button
+    type="button"
+    @click="compOpen = !compOpen"
+    @keydown.escape="compOpen = false"
+    :aria-expanded="compOpen"
+    aria-haspopup="listbox"
+    aria-label="Filter by component"
+    :class="[selectClass, 'flex items-center gap-1.5 cursor-pointer']"
+  >
+    <span class="truncate max-w-[180px]">{{ compLabel }}</span>
+    <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+    </svg>
+  </button>
+  <!-- Dropdown list -->
+  <div
+    v-if="compOpen"
+    role="listbox"
+    class="absolute z-50 mt-1 w-64 max-h-60 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg"
+  >
+    <label
+      v-for="comp in components"
+      :key="comp"
+      class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
+    >
+      <input
+        type="checkbox"
+        :checked="selectedComponents.includes(comp)"
+        @change="toggleComponent(comp)"
+        class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+      />
+      <span class="truncate">{{ comp }}</span>
+    </label>
+  </div>
+</div>
+
+<!-- Selected component chips -->
+<div v-if="selectedComponents.length > 0" class="flex flex-wrap gap-1.5">
+  <span
+    v-for="comp in selectedComponents"
+    :key="comp"
+    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-400"
+  >
+    {{ comp }}
+    <button
+      @click="removeComponent(comp)"
+      class="hover:text-primary-900 dark:hover:text-primary-200"
+      aria-label="Remove component filter"
+    >&times;</button>
+  </span>
+</div>
+```
+
+**Props change in HealthFilterBar:**
+
+```javascript
+// Replace:
+componentFilter: { type: String, default: '' },
+// With:
+selectedComponents: { type: Array, default: () => [] },
+
+// Replace emit:
+'update:componentFilter'
+// With:
+'update:selectedComponents'
+```
+
+### 3.4 Add Owner column to table
+
+**File:** `modules/release-planning/client/components/FeatureHealthRow.vue`
+
+Add an Owner cell (delivery owner) between Component and Phase:
+
+```html
+<td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">
+  {{ feature.deliveryOwner || '-' }}
+</td>
+```
+
+### 3.5 Remove export button
+
+**File:** `modules/release-planning/client/views/HealthDashboardView.vue`
+
+Remove the export button and all associated logic:
+
+- Delete `exportMenuOpen` ref (line 36)
+- Delete `exportCsv()` function (lines 266-305)
+- Delete `exportMarkdown()` function (lines 306-336)
+- Delete `toggleExportMenu()` and `closeExportMenu()` functions (lines 337-342)
+- Remove the export button element and dropdown menu from the template
+
+### 3.6 Files changed in PR 3
+
+| File | Action | Summary |
+|---|---|---|
+| `modules/release-planning/client/components/FeatureHealthTable.vue` | Modify | Replace Risk+DoR columns with combined Health column; add Priority and Owner columns; update sort logic; update expanded row colspan to 11 |
+| `modules/release-planning/client/components/FeatureHealthRow.vue` | Modify | Render combined health cell (risk dot w-2.5 h-2.5 with aria-label), priority score cell, owner cell |
+| `modules/release-planning/client/components/HealthFilterBar.vue` | Modify | Replace component `<select>` with multi-select checkbox dropdown + chip display; build component list from split/deduplicated feature components |
+| `modules/release-planning/client/views/HealthDashboardView.vue` | Modify | Change `componentFilter` from string to array; update filter logic with robust comma split; remove export button and export functions |
+
+---
+
+## Phase 4: T-Shirt Size Discovery
+
+**PR 4 -- Backend + Frontend: T-shirt size parsing + inverse complexity**
+
+### 4.1 T-shirt size discovery approach
+
+T-shirt sizes are applied during feature review but stored in the Jira
+description rather than a dedicated field. The implementer needs to discover the
+exact format by examining real feature descriptions.
+
+**Discovery steps:**
+
+1. Use the Jira enrichment Pass 1 data (which already fetches `description` for
+   all features via `ENRICHMENT_FIELDS` in `constants.js` line 94) to inspect
+   the ADF content of several features known to have t-shirt sizes.
+
+2. Look for common patterns in the description ADF nodes:
+   - `"T-Shirt Size: M"` or `"T-shirt: M"`
+   - Table row with "Size" header and a cell value
+   - Heading node followed by an inline value
+   - Label pattern: `[XS|S|M|L|XL]` appearing as a standalone text node
+
+3. Add a `parseTshirtSize(description)` function that tries multiple patterns
+   and returns one of: `'XS'`, `'S'`, `'M'`, `'L'`, `'XL'`, or `null`.
+
+**Implementation plan:**
+
+### 4.2 Create t-shirt size parser
+
+**New file:** `modules/release-planning/server/health/tshirt-parser.js`
+
+```javascript
+/**
+ * T-shirt size parser.
+ *
+ * Extracts t-shirt sizing from Jira feature descriptions.
+ * The description may be a string (v2 API) or ADF object (v3 API).
+ *
+ * Tries multiple patterns in priority order:
+ *   1. Explicit label: "T-Shirt Size: XL" or "Size: M"
+ *   2. Bracketed: "[M]" or "(L)" as standalone text
+ *   3. Table cell with "size" header
+ */
+
+var VALID_SIZES = ['XS', 'S', 'M', 'L', 'XL']
+
+/**
+ * Extract plain text from an ADF (Atlassian Document Format) node.
+ * @param {object} node - ADF node
+ * @returns {string}
+ */
+function adfToText(node) {
+  if (!node) return ''
+  if (typeof node === 'string') return node
+  if (node.type === 'text') return node.text || ''
+  if (Array.isArray(node.content)) {
+    return node.content.map(adfToText).join('')
+  }
+  return ''
+}
+
+/**
+ * Parse t-shirt size from a Jira description.
+ * @param {*} description - String or ADF object
+ * @returns {string|null} One of 'XS', 'S', 'M', 'L', 'XL', or null
+ */
+function parseTshirtSize(description) {
+  if (!description) return null
+
+  var text = ''
+  if (typeof description === 'string') {
+    text = description
+  } else if (description.type === 'doc') {
+    text = adfToText(description)
+  } else {
+    return null
+  }
+
+  // Pattern 1: "T-Shirt Size: XL" or "Size: M" (case-insensitive)
+  // NOTE: Alternation order matters -- put longer alternatives first (XS, XL)
+  // so "XS" and "XL" match before the single-letter "S" or "L" can greedily
+  // consume the first character. Use a lookahead instead of \b after the match
+  // to avoid false positives like "Size: Small" capturing "S" from "Small".
+  var sizeMatch = text.match(/(?:t-?shirt\s+)?size\s*[:=]\s*(XS|XL|S|M|L)(?=[\s,;.\-)\]|]|$)/i)
+  if (sizeMatch) {
+    return sizeMatch[1].toUpperCase()
+  }
+
+  // Pattern 2: "Complexity: M" or "Effort: L"
+  var complexityMatch = text.match(/(?:complexity|effort)\s*[:=]\s*(XS|XL|S|M|L)(?=[\s,;.\-)\]|]|$)/i)
+  if (complexityMatch) {
+    return complexityMatch[1].toUpperCase()
+  }
+
+  return null
+}
+
+module.exports = {
+  parseTshirtSize: parseTshirtSize,
+  adfToText: adfToText,
+  VALID_SIZES: VALID_SIZES
+}
+```
+
+### 4.3 Integrate t-shirt parsing into Jira enrichment
+
+**File:** `modules/release-planning/server/health/jira-enrichment.js`
+
+In `runPass1()` (line 200), add t-shirt parsing alongside existing enrichment:
+
+```javascript
+enrichmentMap.set(issue.key, {
+  hasDescription: hasDescriptionContent(fields.description),
+  storyPoints: fields.customfield_10028 || null,
+  dependencyLinks: parseIssueLinks(fields.issuelinks),
+  refinementHistory: null,
+  rice: null,
+  tshirtSize: parseTshirtSize(fields.description)  // NEW
+})
+```
+
+Add the require:
+
+```javascript
+const { parseTshirtSize } = require('./tshirt-parser')
+```
+
+### 4.4 Carry t-shirt size through to health features
+
+**File:** `modules/release-planning/server/health/health-pipeline.js`
+
+In the health feature building loop (around line 632), add:
+
+```javascript
+healthFeatures.push({
+  // ... existing fields ...
+  tshirtSize: enrichment ? enrichment.tshirtSize || null : null,  // NEW
+})
+```
+
+The `computePriorityScores()` function already handles `f.tshirtSize` via the
+`TSHIRT_SCORES` map (see Phase 1, section 1.3). Until t-shirt parsing is
+deployed, features default to `complexity_norm = 0.5` ("Unknown").
+
+### 4.5 Display t-shirt size in feature detail
+
+**File:** `modules/release-planning/client/components/FeatureHealthRow.vue`
+
+In the expanded detail metadata grid (lines 223-263), add:
+
+```html
+<div v-if="feature.tshirtSize">
+  <span class="text-gray-500 dark:text-gray-400">Size:</span>
+  <span class="ml-1 text-gray-900 dark:text-gray-100">{{ feature.tshirtSize }}</span>
+</div>
+```
+
+### 4.6 Files changed in PR 4
+
+| File | Action | Summary |
+|---|---|---|
+| `modules/release-planning/server/health/tshirt-parser.js` | **New** | T-shirt size parser with ADF support |
+| `modules/release-planning/server/health/jira-enrichment.js` | Modify | Add `tshirtSize` to Pass 1 enrichment output |
+| `modules/release-planning/server/health/health-pipeline.js` | Modify | Carry `tshirtSize` through to health features |
+| `modules/release-planning/client/components/FeatureHealthRow.vue` | Modify | Show t-shirt size in expanded detail |
+
+---
+
+## Testability
+
+### Existing tests to update
+
+| Test file | Changes needed |
+|---|---|
+| `__tests__/server/health-pipeline.test.js` | Add tests for `discoverReleasesPartial()` usage; verify `planningFreezes` in cache output; verify new summary counters (`ownerAssignedCount`, `scopeEstimatedCount`, etc.); verify `priorityScore` and `priorityBreakdown` on health features |
+| `__tests__/server/risk-engine.test.js` | No changes needed (risk engine unchanged in this work) |
+| `__tests__/server/rice-scorer.test.js` | No changes needed |
+| `__tests__/server/dor-checker.test.js` | No changes needed |
+| `__tests__/server/jira-enrichment.test.js` | Add test verifying `tshirtSize` is populated in Pass 1 output (PR 4) |
+| `__tests__/server/health-routes.test.js` | No structural changes needed; existing phase param tests still valid |
+| `__tests__/server/smartsheet.test.js` | Add tests for `discoverReleasesPartial()`; verify `parseSmartsheetReleases()` shared helper produces consistent results for both callers |
+| `__tests__/client/health-components.test.js` | Update summary card tests for new card layout; update table column assertions; remove PhaseSelector describe block |
+
+### New test files
+
+| Test file | Tests |
+|---|---|
+| `__tests__/server/priority-scorer.test.js` | Test `computePriorityScores()`: verify weights, normalization, median fallback for missing RICE, tier mapping, priority mapping, t-shirt mapping, edge cases (all same RICE, empty features, null fields) |
+| `__tests__/server/tshirt-parser.test.js` | Test `parseTshirtSize()`: ADF input, string input, various patterns ("T-Shirt Size: M", "Size: XL", "Complexity: S"), case insensitivity, no match returns null, edge cases (empty description, description with no size). Include tests for false positives: "Size: Small" should NOT match, "Size: Special" should NOT match |
+| `__tests__/client/phase-filter.test.js` | Test the client-side `passesPhaseFilter()` port to validate it matches server-side behavior. Mirror the test cases from `health-pipeline.test.js` that cover `passesPhaseFilter`. Specifically: no phase returns all features, phase-specific fixVersion only appears in matching tab, features without phase-specific fixVersions appear in all tabs, case insensitivity |
+
+### Test commands
+
+```bash
+# Run all release-planning tests
+npm test -- --testPathPattern='modules/release-planning'
+
+# Run specific test files
+npm test -- modules/release-planning/__tests__/server/priority-scorer.test.js
+npm test -- modules/release-planning/__tests__/server/tshirt-parser.test.js
+npm test -- modules/release-planning/__tests__/server/health-pipeline.test.js
+```
+
+---
+
+## Deployability
+
+### No new dependencies
+
+All changes use existing libraries (Vue 3, Tailwind CSS, Node.js built-ins).
+No new npm packages are required.
+
+### No new environment variables
+
+T-shirt size parsing uses the existing Jira description field fetched by
+`ENRICHMENT_FIELDS` in `constants.js`. No new API tokens or configuration.
+
+### CI/CD
+
+- `ci.yml` -- All PRs pass the existing "Test & Build" required check
+- `build-images.yml` -- Changes to `modules/release-planning/` trigger both
+  backend and frontend image builds (the module has both client/ and server/
+  directories)
+- No kustomize overlay changes needed
+- No new ConfigMap keys
+
+### Rollout safety
+
+- **PR 1 (backend):** New fields (`planningFreezes`, summary counters,
+  `priorityScore`) are additive. The frontend ignores unknown fields until
+  PR 2/3 land. Existing health cache is invalidated on next refresh (normal
+  behavior).
+- **PR 2 (tabs + cards):** Frontend changes only. If health data lacks
+  `planningFreezes`, the timeline falls back to existing behavior (milestone
+  dots only). Summary cards degrade gracefully with `|| 0` defaults.
+- **PR 3 (table + filters):** Frontend changes only. Combined column is a
+  pure display change. Multi-select chips are a superset of the old single-select.
+- **PR 4 (t-shirt):** `tshirtSize` defaults to `null` for features where
+  parsing fails. Priority scorer treats null as `complexity_norm = 0.5`,
+  so the score is valid even without t-shirt data.
+
+### Backward compatibility
+
+No breaking API changes. All new fields are additive additions to the
+existing health cache JSON. The `PhaseSelector.vue` component is removed but
+was only used by `HealthDashboardView.vue` (no external consumers).
+
+---
+
+## Affected APIs and Backward Compatibility
+
+### Modified API responses
+
+| Endpoint | Change | Backward compatible? |
+|---|---|---|
+| `GET /api/modules/release-planning/releases/:version/health` | Response gains: `planningFreezes` object, new `summary` counters, `priorityScore` + `priorityBreakdown` on each feature, `tshirtSize` on each feature | Yes -- all additive fields |
+| `GET /api/modules/release-planning/releases/:version/health/summary` | Summary gains: `ownerAssignedCount`, `scopeEstimatedCount`, `riceCompleteCount`, `dorCompleteCount` | Yes -- additive |
+| `GET /api/modules/release-planning/releases/:version/health/feature/:key` | Feature gains: `priorityScore`, `priorityBreakdown`, `tshirtSize` | Yes -- additive |
+
+### Unchanged APIs
+
+All write endpoints (DoR toggle, risk override, refresh trigger) are unchanged.
+All Big Rocks Planning endpoints are unchanged. All other module APIs are
+unchanged.
+
+### Removed component
+
+`PhaseSelector.vue` is deleted. It was only imported by `HealthDashboardView.vue`.
+No other modules or shared code reference it.
+
+---
+
+## File Change Summary
+
+### New files (3)
+
+| Path | PR |
+|---|---|
+| `modules/release-planning/server/health/priority-scorer.js` | PR 1 |
+| `modules/release-planning/server/health/tshirt-parser.js` | PR 4 |
+| `modules/release-planning/client/utils/phase-filter.js` | PR 2 |
+
+### New test files (3)
+
+| Path | PR |
+|---|---|
+| `modules/release-planning/__tests__/server/priority-scorer.test.js` | PR 1 |
+| `modules/release-planning/__tests__/client/phase-filter.test.js` | PR 2 |
+| `modules/release-planning/__tests__/server/tshirt-parser.test.js` | PR 4 |
+
+### Modified files (10)
+
+| Path | PR(s) | Summary |
+|---|---|---|
+| `shared/server/smartsheet.js` | PR 1 | Extract `parseSmartsheetReleases()` helper; refactor existing functions; add `discoverReleasesPartial()` |
+| `modules/release-planning/server/health/health-pipeline.js` | PR 1, 4 | Backfill fix, extract `offsetDate()` to module level, planning freezes, `storyPoints` on health features, priority integration, tshirtSize |
+| `modules/release-planning/server/health/jira-enrichment.js` | PR 4 | Add `tshirtSize` to Pass 1 |
+| `modules/release-planning/client/views/HealthDashboardView.vue` | PR 2, 3 | Phase tabs, planning freezes, client-side card counts, client-side planning deadline for "all" tab, component filter array, remove export button |
+| `modules/release-planning/client/components/HealthSummaryCards.vue` | PR 2 | 4-card readiness layout |
+| `modules/release-planning/client/components/MilestoneTimeline.vue` | PR 2 | Planning freeze markers |
+| `modules/release-planning/client/components/HealthFilterBar.vue` | PR 3 | Multi-select component chips |
+| `modules/release-planning/client/components/FeatureHealthTable.vue` | PR 3 | Combined Health column, Priority column, Owner column, colspan update to 11 |
+| `modules/release-planning/client/components/FeatureHealthRow.vue` | PR 3, 4 | Combined health cell, priority cell, owner cell, tshirt display |
+
+### Deleted files (1)
+
+| Path | PR |
+|---|---|
+| `modules/release-planning/client/components/PhaseSelector.vue` | PR 2 |
+
+### Test files to update (4)
+
+| Path | PR |
+|---|---|
+| `modules/release-planning/__tests__/server/health-pipeline.test.js` | PR 1 |
+| `modules/release-planning/__tests__/server/smartsheet.test.js` | PR 1 |
+| `modules/release-planning/__tests__/client/health-components.test.js` | PR 2, 3 |
+| `modules/release-planning/__tests__/server/jira-enrichment.test.js` | PR 4 |
+
+---
+
+## Review Resolution
+
+Consolidated findings from three independent reviewers, addressed 2026-04-27.
+
+### Critical Issues
+
+| ID | Finding | Resolution | Section(s) Updated |
+|---|---|---|---|
+| **C1** | `computePlanningDeadline()` returns null for "all" view -- summary cards and planning deadline indicator break | Frontend computes `activePlanningDeadline` client-side for the "all" tab by selecting the nearest upcoming date from `planningFreezes`. Phase-specific tabs still use the server-computed deadline. | 2.3 |
+| **C2** | `discoverReleasesPartial()` duplicates ~60 lines from `discoverReleasesWithFreezes()` | Extracted shared logic into `parseSmartsheetReleases(filterFn)` private helper. Both `discoverReleasesWithFreezes()` and `discoverReleasesPartial()` delegate to it with different filter predicates. Also refactors `discoverReleases()` to use the helper. | 1.1, 1.6 |
+| **C3** | Summary card counters are release-wide, not phase-scoped -- wrong counts in EA1/EA2/GA tabs | Removed server-side summary counters. Card counts are now computed client-side from `phasedFeatures` via a `cardCounts` computed property, ensuring they reflect the active phase tab. Added `storyPoints` to health feature output for scope estimation. | 1.5, 2.1, 2.5 |
+| **C4** | T-shirt size regex false positives: `\b` after single-letter sizes matches "Size: Small" as "S" | Changed alternation order to `(XS|XL|S|M|L)` (longest first) and replaced `\b` with `(?=[\s,;.\-)\]|]|$)` lookahead requiring whitespace, punctuation, or end-of-string after the match. Added false-positive test cases. | 4.2, Testability |
+
+### Major Issues
+
+| ID | Finding | Resolution | Section(s) Updated |
+|---|---|---|---|
+| **M1** | Component filter splits on `', '` but Jira components may lack spaces | Changed split to `/\s*,\s*/` regex. Added `allComponents` computed that splits and deduplicates components from ALL features to build the dropdown list. | 3.3 |
+| **M2** | `offsetDate()` helper duplicates existing `offset()` in `deriveFreezeDates()` | Extract existing inner `offset()` function to module-level `offsetDate(dateStr, days)`. Reused by both `deriveFreezeDates()` and `planningFreezes` block. No duplication. | 1.2 |
+| **M3** | Timeline has 9 markers -- labels overlap when dates cluster | Added label collision strategy: planning freeze markers use abbreviated labels ("EA1 PF", "EA2 PF", "GA PF"). Adjacent markers within 7 days use vertical stacking (alternate above/below). | 2.2 |
+| **M4** | PhaseSelector deleted in PR 2 but its tests in `health-components.test.js` not mentioned | Added `health-components.test.js` to PR 2 files changed table with note to remove PhaseSelector describe block (line 210). | 2.5, Testability |
+| **M5** | Expanded row `colspan` must match new column count | Documented colspan change from 10 to 11 (columns: expand, feature, summary, status, health, priority, rice, components, owner, phase, tier). | 3.1 |
+| **M6** | Risk dot `w-2 h-2` (8x8px) too small for accessibility | Increased to `w-2.5 h-2.5` (10x10px). Added `role="img"` and `aria-label` attribute on the dot element. DoR percentage text already provides supplementary context. | 3.1 |
+
+### Minor Issues
+
+| ID | Finding | Resolution | Section(s) Updated |
+|---|---|---|---|
+| **m1** | Priority weights are hardcoded with no path to configurability | Added a comment to the `WEIGHTS` constant noting future configurability via admin settings, keeping hardcoded for now per user request. | 1.3 |
+| **m2** | Export button removal not mentioned in plan | Added section 3.5 to PR 3 listing all export-related code to remove (refs, functions, template elements). | 3.5, 3.6 |
+| **m3** | Client-side `passesPhaseFilter` port lacks validation tests | Added `__tests__/client/phase-filter.test.js` as a new test file in PR 2. Tests mirror server-side coverage: no-phase, phase-specific fixVersions, non-phase features, case insensitivity. | 2.5, Testability, File Change Summary |


### PR DESCRIPTION
## Summary
- Adds 5 design docs produced by the `/architect` agent for the release planning module and release health feature
- Covers initial proposal, review, health feature plan, and health redesign plan
- Previously untracked in `design/` directory

## Test plan
- [ ] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)