### PR TITLE
feat(upstream-pulse): add sticky period selector across all pages

### DIFF
--- a/modules/upstream-pulse/client/components/PeriodSelector.vue
+++ b/modules/upstream-pulse/client/components/PeriodSelector.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700/60 rounded-lg p-0.5">
+    <button
+      v-for="opt in options"
+      :key="opt.value"
+      @click="$emit('update:modelValue', opt.value)"
+      class="px-2.5 py-1.5 rounded-md text-[13px] font-medium transition-all duration-200"
+      :class="modelValue === opt.value
+        ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
+        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+    >{{ opt.label }}</button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  modelValue: { type: String, required: true },
+  options: {
+    type: Array,
+    default: () => [
+      { label: '30d', value: '30' },
+      { label: '60d', value: '60' },
+      { label: '90d', value: '90' },
+      { label: 'All', value: '0' },
+    ],
+  },
+})
+
+defineEmits(['update:modelValue'])
+</script>

--- a/modules/upstream-pulse/client/components/StickyPageHeader.vue
+++ b/modules/upstream-pulse/client/components/StickyPageHeader.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="sticky top-16 z-[9] -mx-6 lg:-mx-8 px-6 lg:px-8 pt-2 pb-3 bg-gray-50 dark:bg-gray-900">
+    <div class="relative flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 bg-white dark:bg-gray-800 rounded-2xl shadow-[0_1px_2px_rgba(0,0,0,0.04),0_4px_16px_-2px_rgba(0,0,0,0.08)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2),0_4px_16px_-2px_rgba(0,0,0,0.35)] ring-1 ring-gray-950/[0.05] dark:ring-white/[0.08] px-4 py-3 overflow-hidden">
+      <div v-if="loading" class="absolute inset-x-0 bottom-0 h-[3px] bg-blue-100/50 dark:bg-blue-900/30">
+        <div class="h-full w-2/5 bg-blue-500 rounded-full shadow-[0_0_8px_2px_rgba(59,130,246,0.5)] animate-[slideRight_1.2s_ease-in-out_infinite]"></div>
+      </div>
+      <div class="min-w-0">
+        <h2 class="text-lg font-bold text-gray-900 dark:text-gray-100 truncate">{{ title }}</h2>
+        <p v-if="subtitle" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">{{ subtitle }}</p>
+        <slot name="subtitle-extra" />
+      </div>
+      <div class="flex items-center gap-2.5 shrink-0">
+        <PeriodSelector v-model="selectedDays" />
+        <slot name="extra" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import PeriodSelector from './PeriodSelector.vue'
+
+const props = defineProps({
+  title: { type: String, required: true },
+  subtitle: { type: String, default: '' },
+  modelValue: { type: String, required: true },
+  loading: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const selectedDays = computed({
+  get: () => props.modelValue,
+  set: (v) => emit('update:modelValue', v),
+})
+</script>
+
+<style scoped>
+@keyframes slideRight {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(350%); }
+}
+</style>

--- a/modules/upstream-pulse/client/views/Dashboard.vue
+++ b/modules/upstream-pulse/client/views/Dashboard.vue
@@ -76,17 +76,7 @@
           </div>
           <div class="w-px h-6 bg-gray-200 dark:bg-gray-700 mx-3 shrink-0"></div>
           <div class="flex items-center gap-2.5 shrink-0">
-            <div class="flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700/60 rounded-lg p-0.5">
-              <button
-                v-for="opt in periodOptions"
-                :key="opt.value"
-                @click="selectedDays = opt.value"
-                class="px-2.5 py-1.5 rounded-md text-[13px] font-medium transition-all duration-200"
-                :class="selectedDays === opt.value
-                  ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
-              >{{ opt.label }}</button>
-            </div>
+            <PeriodSelector v-model="selectedDays" />
             <div v-if="periodLabel" class="hidden xl:flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-750/40 pl-2 pr-2.5 py-1 rounded-lg">
               <CalendarIcon :size="12" />
               <span>{{ periodLabel }}</span>
@@ -581,6 +571,7 @@ import AddProjectModal from '../components/AddProjectModal.vue'
 import { StatCardSkeleton, ContributionCardSkeleton, OrgCardSkeleton, ProjectCardSkeleton, ContributorRowSkeleton } from '../components/SkeletonLoaders.vue'
 import { useGovernanceCards, uniqueRoles } from '../composables/useGovernanceCards.js'
 import { getStrategicTier } from '../composables/useStrategicClassification.js'
+import PeriodSelector from '../components/PeriodSelector.vue'
 
 const nav = inject('moduleNav')
 const { isAdmin } = useAuth()
@@ -588,13 +579,6 @@ const showAddProject = ref(false)
 const MODULE_API = '/modules/upstream-pulse'
 
 const DASHBOARD_ORG_LIMIT = 4
-
-const periodOptions = [
-  { label: '30d', value: '30' },
-  { label: '60d', value: '60' },
-  { label: '90d', value: '90' },
-  { label: 'All', value: '0' },
-]
 
 const selectedDays = ref('30')
 const loading = ref(true)

--- a/modules/upstream-pulse/client/views/Insights.vue
+++ b/modules/upstream-pulse/client/views/Insights.vue
@@ -1,25 +1,11 @@
 <template>
   <div>
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
-      <div>
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Insights</h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Trends and impact analysis for your team's upstream presence</p>
-      </div>
-      <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
-        <button
-          v-for="opt in periodOptions"
-          :key="opt.value"
-          @click="selectedDays = opt.value"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200"
-          :class="selectedDays === opt.value
-            ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
-            : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'"
-        >
-          {{ opt.label }}
-        </button>
-      </div>
-    </div>
+    <StickyPageHeader
+      v-model="selectedDays"
+      title="Insights"
+      subtitle="Trends and impact analysis for your team's upstream presence"
+      :loading="loading"
+    />
 
     <!-- Loading skeleton -->
     <div v-if="loading" class="space-y-8">
@@ -69,15 +55,9 @@ import { ChartSkeleton } from '../components/SkeletonLoaders.vue'
 import ContributionTrendChart from '../components/ContributionTrendChart.vue'
 import ContributionMixChart from '../components/ContributionMixChart.vue'
 import ImpactBanner from '../components/ImpactBanner.vue'
+import StickyPageHeader from '../components/StickyPageHeader.vue'
 
 const MODULE_API = '/modules/upstream-pulse'
-
-const periodOptions = [
-  { label: '30d', value: '30' },
-  { label: '60d', value: '60' },
-  { label: '90d', value: '90' },
-  { label: 'All', value: '0' },
-]
 
 const selectedDays = ref('30')
 const loading = ref(true)

--- a/modules/upstream-pulse/client/views/OrgDetail.vue
+++ b/modules/upstream-pulse/client/views/OrgDetail.vue
@@ -7,82 +7,70 @@
       <span class="text-gray-900 dark:text-gray-100 font-medium">{{ displayName }}</span>
     </nav>
 
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
-      <div>
-        <div class="flex items-center gap-2 mb-1 flex-wrap">
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ displayName }}</h2>
-
-          <!-- Engagement Status Badge with Tooltip -->
-          <div v-if="dashboard" class="relative group/engagement">
-            <span
-              :class="engagementStatus.classes"
-              :title="engagementStatus.description"
-              :aria-label="engagementStatus.description"
-              class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border"
-            >
-              {{ engagementStatus.label }}
-            </span>
-            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/engagement:opacity-100 group-hover/engagement:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
-              {{ engagementStatus.description }}
-              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
-            </div>
-          </div>
-
-          <!-- Strategic Leadership Badge with Tooltip -->
-          <div v-if="strategicLeadership" class="relative group/leadership">
-            <span
-              class="px-3 py-1 rounded-full text-xs font-semibold"
-              :class="getStrategicBadgeClass(strategicLeadership)"
-              :title="getStrategicDescription(strategicLeadership)"
-              :aria-label="getStrategicDescription(strategicLeadership)"
-            >
-              {{ getStrategicLabel(strategicLeadership) }}
-            </span>
-            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/leadership:opacity-100 group-hover/leadership:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
-              {{ getStrategicDescription(strategicLeadership) }}
-              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
-            </div>
-          </div>
-
-          <!-- Strategic Participation Badge with Tooltip -->
-          <div v-if="strategicParticipation" class="relative group/participation">
-            <span
-              class="px-3 py-1 rounded-full text-xs font-semibold"
-              :class="getStrategicBadgeClass(strategicParticipation)"
-              :title="getStrategicDescription(strategicParticipation)"
-              :aria-label="getStrategicDescription(strategicParticipation)"
-            >
-              {{ getStrategicLabel(strategicParticipation) }}
-            </span>
-            <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/participation:opacity-100 group-hover/participation:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
-              {{ getStrategicDescription(strategicParticipation) }}
-              <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
-            </div>
-          </div>
+    <!-- Badges -->
+    <div v-if="dashboard || strategicLeadership || strategicParticipation" class="flex items-center gap-2 flex-wrap mb-2">
+      <!-- Engagement Status Badge with Tooltip -->
+      <div v-if="dashboard" class="relative group/engagement">
+        <span
+          :class="engagementStatus.classes"
+          :title="engagementStatus.description"
+          :aria-label="engagementStatus.description"
+          class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border"
+        >
+          {{ engagementStatus.label }}
+        </span>
+        <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/engagement:opacity-100 group-hover/engagement:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+          {{ engagementStatus.description }}
+          <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
         </div>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Team engagement in {{ displayName }} projects</p>
       </div>
-      <div class="flex items-center gap-3">
-        <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
-          <button
-            v-for="opt in periodOptions"
-            :key="opt.value"
-            @click="selectedDays = opt.value"
-            class="px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200"
-            :class="selectedDays === opt.value
-              ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
-              : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'"
-          >
-            {{ opt.label }}
-          </button>
+
+      <!-- Strategic Leadership Badge with Tooltip -->
+      <div v-if="strategicLeadership" class="relative group/leadership">
+        <span
+          class="px-3 py-1 rounded-full text-xs font-semibold"
+          :class="getStrategicBadgeClass(strategicLeadership)"
+          :title="getStrategicDescription(strategicLeadership)"
+          :aria-label="getStrategicDescription(strategicLeadership)"
+        >
+          {{ getStrategicLabel(strategicLeadership) }}
+        </span>
+        <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/leadership:opacity-100 group-hover/leadership:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+          {{ getStrategicDescription(strategicLeadership) }}
+          <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
         </div>
-        <div v-if="dashboard?.summary" class="hidden lg:flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-3 py-1.5 rounded-lg">
-          <CalendarIcon :size="14" />
-          <span>{{ periodLabel }}</span>
+      </div>
+
+      <!-- Strategic Participation Badge with Tooltip -->
+      <div v-if="strategicParticipation" class="relative group/participation">
+        <span
+          class="px-3 py-1 rounded-full text-xs font-semibold"
+          :class="getStrategicBadgeClass(strategicParticipation)"
+          :title="getStrategicDescription(strategicParticipation)"
+          :aria-label="getStrategicDescription(strategicParticipation)"
+        >
+          {{ getStrategicLabel(strategicParticipation) }}
+        </span>
+        <div class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover/participation:opacity-100 group-hover/participation:visible transition-all duration-200 pointer-events-none whitespace-nowrap z-50">
+          {{ getStrategicDescription(strategicParticipation) }}
+          <div class="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900 dark:border-t-gray-700"></div>
         </div>
       </div>
     </div>
+
+    <StickyPageHeader
+      v-model="selectedDays"
+      :title="displayName"
+      :subtitle="`Team engagement in ${displayName} projects`"
+      :loading="loading"
+    >
+      <template #extra>
+        <div v-if="dashboard?.summary" class="hidden lg:flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-750/40 pl-2 pr-2.5 py-1 rounded-lg">
+          <CalendarIcon :size="12" />
+          <span>{{ periodLabel }}</span>
+        </div>
+      </template>
+    </StickyPageHeader>
 
     <!-- Loading skeleton -->
     <div v-if="loading">
@@ -521,17 +509,11 @@ import ContributionTrendChart from '../components/ContributionTrendChart.vue'
 import ImpactBanner from '../components/ImpactBanner.vue'
 import { useGovernanceCards, uniqueRoles } from '../composables/useGovernanceCards.js'
 import { getStrategicLabel, getStrategicBadgeClass, getStrategicDescription, getEngagementStatus } from '../composables/useStrategicClassification.js'
+import StickyPageHeader from '../components/StickyPageHeader.vue'
 
 const nav = inject('moduleNav')
 
 const MODULE_API = '/modules/upstream-pulse'
-
-const periodOptions = [
-  { label: '30d', value: '30' },
-  { label: '60d', value: '60' },
-  { label: '90d', value: '90' },
-  { label: 'All', value: '0' },
-]
 
 const githubOrg = computed(() => nav.params.value?.org || '')
 const displayName = ref('')

--- a/modules/upstream-pulse/client/views/Portfolio.vue
+++ b/modules/upstream-pulse/client/views/Portfolio.vue
@@ -1,25 +1,11 @@
 <template>
   <div>
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
-      <div>
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Portfolio</h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Organizations and projects your team is tracking</p>
-      </div>
-      <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
-        <button
-          v-for="opt in periodOptions"
-          :key="opt.value"
-          @click="selectedDays = opt.value"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200"
-          :class="selectedDays === opt.value
-            ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
-            : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'"
-        >
-          {{ opt.label }}
-        </button>
-      </div>
-    </div>
+    <StickyPageHeader
+      v-model="selectedDays"
+      title="Portfolio"
+      subtitle="Organizations and projects your team is tracking"
+      :loading="loading"
+    />
 
     <!-- Loading -->
     <div v-if="loading">
@@ -515,6 +501,7 @@ import { useAuth } from '@shared/client/composables/useAuth'
 import OrgActivityCard from '../components/OrgActivityCard.vue'
 import AddProjectModal from '../components/AddProjectModal.vue'
 import { OrgCardSkeleton, StatCardSkeleton, TableRowSkeleton } from '../components/SkeletonLoaders.vue'
+import StickyPageHeader from '../components/StickyPageHeader.vue'
 import { getEngagementStatus } from '../composables/useStrategicClassification.js'
 
 const nav = inject('moduleNav')
@@ -522,13 +509,6 @@ const { isAdmin } = useAuth()
 const showAddProject = ref(false)
 
 const MODULE_API = '/modules/upstream-pulse'
-
-const periodOptions = [
-  { label: '30d', value: '30' },
-  { label: '60d', value: '60' },
-  { label: '90d', value: '90' },
-  { label: 'All', value: '0' },
-]
 
 const orgSortOptions = [
   { label: 'Contributions', value: 'contributionCount' },

--- a/modules/upstream-pulse/client/views/ProjectDetail.vue
+++ b/modules/upstream-pulse/client/views/ProjectDetail.vue
@@ -11,41 +11,29 @@
       <span class="text-gray-900 dark:text-gray-100 font-medium">{{ projectName }}</span>
     </nav>
 
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
-      <div>
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ projectName }}</h2>
+    <StickyPageHeader
+      v-model="selectedDays"
+      :title="projectName"
+      :loading="loading"
+    >
+      <template v-if="projectInfo?.githubOrg && projectInfo?.githubRepo" #subtitle-extra>
         <a
-          v-if="projectInfo?.githubOrg && projectInfo?.githubRepo"
           :href="`https://github.com/${projectInfo.githubOrg}/${projectInfo.githubRepo}`"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 flex items-center gap-1 mt-0.5"
+          class="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 flex items-center gap-1 mt-0.5"
         >
           {{ projectInfo.githubOrg }}/{{ projectInfo.githubRepo }}
           <ExternalLinkIcon :size="12" />
         </a>
-      </div>
-      <div class="flex items-center gap-3">
-        <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
-          <button
-            v-for="opt in periodOptions"
-            :key="opt.value"
-            @click="selectedDays = opt.value"
-            class="px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200"
-            :class="selectedDays === opt.value
-              ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
-              : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'"
-          >
-            {{ opt.label }}
-          </button>
-        </div>
-        <div v-if="dashboard?.summary" class="hidden lg:flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-3 py-1.5 rounded-lg">
-          <CalendarIcon :size="14" />
+      </template>
+      <template #extra>
+        <div v-if="dashboard?.summary" class="hidden lg:flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-750/40 pl-2 pr-2.5 py-1 rounded-lg">
+          <CalendarIcon :size="12" />
           <span>{{ periodLabel }}</span>
         </div>
-      </div>
-    </div>
+      </template>
+    </StickyPageHeader>
 
     <!-- Collection progress banner -->
     <div v-if="showJobsBanner" class="mb-6 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700/60 overflow-hidden">
@@ -456,18 +444,12 @@ import StatCard from '../components/StatCard.vue'
 import ContributionTypeCard from '../components/ContributionTypeCard.vue'
 import LeadershipCard from '../components/LeadershipCard.vue'
 import ContributionTrendChart from '../components/ContributionTrendChart.vue'
+import StickyPageHeader from '../components/StickyPageHeader.vue'
 import { useGovernanceCards, uniqueRoles } from '../composables/useGovernanceCards.js'
 
 const nav = inject('moduleNav')
 
 const MODULE_API = '/modules/upstream-pulse'
-
-const periodOptions = [
-  { label: '30d', value: '30' },
-  { label: '60d', value: '60' },
-  { label: '90d', value: '90' },
-  { label: 'All', value: '0' },
-]
 
 const projectId = computed(() => nav.params.value?.projectId || '')
 const fromOrg = computed(() => nav.params.value?.org || '')

--- a/modules/upstream-pulse/client/views/Strategy.vue
+++ b/modules/upstream-pulse/client/views/Strategy.vue
@@ -1,25 +1,11 @@
 <template>
   <div>
-    <!-- Header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 gap-4">
-      <div>
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Strategy</h2>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Track progress against upstream strategic goals</p>
-      </div>
-      <div class="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
-        <button
-          v-for="opt in periodOptions"
-          :key="opt.value"
-          @click="selectedDays = opt.value"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200"
-          :class="selectedDays === opt.value
-            ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 shadow-sm'
-            : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'"
-        >
-          {{ opt.label }}
-        </button>
-      </div>
-    </div>
+    <StickyPageHeader
+      v-model="selectedDays"
+      title="Strategy"
+      subtitle="Track progress against upstream strategic goals"
+      :loading="loading"
+    />
 
     <!-- Loading -->
     <div v-if="loading">
@@ -247,6 +233,7 @@ import {
 } from 'lucide-vue-next'
 import { apiRequest } from '@shared/client/services/api'
 import { StatCardSkeleton, TableRowSkeleton } from '../components/SkeletonLoaders.vue'
+import StickyPageHeader from '../components/StickyPageHeader.vue'
 import {
   getStrategicTier, TIER_CONFIG,
   getStrategicLabel, getStrategicBadgeClass,
@@ -256,13 +243,6 @@ const nav = inject('moduleNav')
 const MODULE_API = '/modules/upstream-pulse'
 
 const tierOrder = ['increasing', 'sustaining', 'evaluating']
-
-const periodOptions = [
-  { label: '30d', value: '30' },
-  { label: '60d', value: '60' },
-  { label: '90d', value: '90' },
-  { label: 'All', value: '0' },
-]
 
 const selectedDays = ref('30')
 const selectedTier = ref(null)


### PR DESCRIPTION
Extract duplicated period selector into shared PeriodSelector and StickyPageHeader components so the time-range control stays pinned below the shell header on every page, always accessible while scrolling.