### PR TITLE
fix(release-planning): resolve pipeline warnings and data persistence bug

### DIFF
--- a/modules/release-planning/__tests__/server/cache-reader.test.js
+++ b/modules/release-planning/__tests__/server/cache-reader.test.js
@@ -228,6 +228,48 @@ describe('findTier1Features', () => {
     const results = findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(0)
   })
+
+  it('populates stats object when provided', () => {
+    const index = {
+      features: [
+        makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'In Progress' }),
+        makeFeatureIndex('RHAISTRAT-101', { parentKey: 'KEY-1', targetVersions: null, status: 'In Progress' }),
+        makeFeatureIndex('RHAISTRAT-102', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Closed' }),
+        makeFeatureIndex('RHAISTRAT-103', { parentKey: 'OTHER', targetVersions: ['rhoai-3.5'], status: 'New' })
+      ],
+      rfes: []
+    }
+    const details = [
+      makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
+    ]
+    const readFromStorage = createMockStorage(details)
+    const stats = {}
+
+    const results = findTier1Features(readFromStorage, index, ['KEY-1'], stats)
+
+    expect(results).toHaveLength(1)
+    expect(stats.totalMatches).toBe(3)
+    expect(stats.noTargetVersion).toBe(1)
+    expect(stats.closedFiltered).toBe(1)
+  })
+
+  it('works unchanged when stats parameter is not provided', () => {
+    const index = {
+      features: [
+        makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'In Progress' })
+      ],
+      rfes: []
+    }
+    const details = [
+      makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'] })
+    ]
+    const readFromStorage = createMockStorage(details)
+
+    // Call without stats parameter -- should work exactly as before
+    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    expect(results).toHaveLength(1)
+    expect(results[0].key).toBe('RHAISTRAT-100')
+  })
 })
 
 describe('findTier1Rfes', () => {

--- a/modules/release-planning/__tests__/server/invalidate-cache.test.js
+++ b/modules/release-planning/__tests__/server/invalidate-cache.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// These mocks are needed for registerRoutes to load without errors,
+// but the real pipeline.js is used (vi.mock does not intercept CJS require
+// for the pipeline module inside index.js in this test environment).
+vi.mock('../../server/config-lock', () => ({
+  withConfigLock: vi.fn(function(fn) { return fn() })
+}))
+
+vi.mock('../../server/config-backup', () => ({
+  backupConfig: vi.fn()
+}))
+
+vi.mock('../../server/doc-import', () => ({
+  previewDocImport: vi.fn(),
+  executeDocImport: vi.fn()
+}))
+
+vi.mock('../../../shared/server/smartsheet', () => ({
+  isConfigured: vi.fn().mockReturnValue(false),
+  discoverReleases: vi.fn()
+}))
+
+const registerRoutes = require('../../server/index')
+
+function makeStorage(data) {
+  const store = {}
+  if (data) {
+    for (const k in data) store[k] = data[k]
+  }
+  return {
+    readFromStorage: function(key) {
+      return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
+    },
+    writeToStorage: function(key, value) {
+      store[key] = value
+    },
+    listStorageFiles: vi.fn().mockReturnValue([]),
+    deleteFromStorage: vi.fn(function(key) {
+      delete store[key]
+    }),
+    _store: store
+  }
+}
+
+function makeRouter() {
+  const routes = {}
+  function reg(method) {
+    return function(path) {
+      const handlers = Array.prototype.slice.call(arguments, 1)
+      routes[method + ' ' + path] = handlers
+    }
+  }
+  return {
+    get: vi.fn(reg('GET')),
+    post: vi.fn(reg('POST')),
+    put: vi.fn(reg('PUT')),
+    delete: vi.fn(reg('DELETE')),
+    use: vi.fn(),
+    _routes: routes
+  }
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: null,
+    _headers: {},
+    _ended: false,
+    status: function(code) { res._status = code; return res },
+    json: function(data) { res._json = data; return res },
+    set: function(key, value) { res._headers[key] = value; return res },
+    end: function() { res._ended = true; return res },
+    send: function(body) {
+      if (typeof body === 'string') {
+        try { res._json = JSON.parse(body) } catch { res._json = body }
+      } else {
+        res._json = body
+      }
+      return res
+    }
+  }
+  return res
+}
+
+function makeReq(overrides) {
+  return Object.assign({ isAdmin: true, userEmail: 'admin@test.com', body: {}, params: {}, query: {}, headers: {} }, overrides)
+}
+
+function callRoute(routes, method, path, req) {
+  const key = method + ' ' + path
+  const handlers = routes[key]
+  if (!handlers) throw new Error('No route registered: ' + key)
+  const handler = handlers[handlers.length - 1]
+  const res = makeRes()
+  const result = handler(req || makeReq(), res)
+  if (result && typeof result.then === 'function') {
+    return result.then(function() { return res })
+  }
+  return res
+}
+
+const VALID_ROCK = {
+  name: 'Test Rock',
+  fullName: 'Test Rock Full',
+  pillar: 'Platform',
+  state: '',
+  owner: 'Owner',
+  architect: '',
+  outcomeKeys: ['KEY-1'],
+  notes: '',
+  description: ''
+}
+
+describe('invalidateCache behavior', function() {
+  let router, storage, context
+
+  beforeEach(function() {
+    vi.clearAllMocks()
+    storage = makeStorage({
+      'release-planning/config.json': { releases: { '3.5': { release: '3.5' } } },
+      'release-planning/releases/3.5.json': { release: '3.5', bigRocks: [VALID_ROCK] },
+      'release-planning/pm-users.json': { emails: ['pm@test.com'] },
+      'feature-traffic/index.json': { features: [], rfes: [] }
+    })
+    router = makeRouter()
+    context = {
+      storage: storage,
+      requireAuth: function(req, res, next) { next() },
+      requireAdmin: function(req, res, next) { next() },
+      registerDiagnostics: vi.fn()
+    }
+    registerRoutes(router, context)
+  })
+
+  it('after Big Rock edit, GET returns data (not empty 202)', async function() {
+    // Pre-populate candidates cache
+    storage._store['release-planning/candidates-cache-3.5.json'] = {
+      cachedAt: new Date().toISOString(),
+      data: {
+        version: '3.5',
+        features: [{ issueKey: 'EXISTING-1', bigRock: 'Test Rock' }],
+        rfes: [],
+        bigRocks: [{ name: 'Test Rock' }],
+        summary: { totalFeatures: 1, totalRfes: 0 }
+      }
+    }
+
+    // PUT to update a Big Rock (triggers invalidateCache)
+    const putReq = makeReq({
+      params: { version: '3.5', name: 'Test Rock' },
+      body: Object.assign({}, VALID_ROCK, { notes: 'Updated' })
+    })
+    await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', putReq)
+
+    // Wait for background refresh to settle
+    await new Promise(function(resolve) { setTimeout(resolve, 50) })
+
+    // GET candidates -- should return data (not 202 with empty arrays)
+    const getReq = makeReq({ params: { version: '3.5' }, query: {} })
+    const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', getReq)
+
+    expect(res._status).toBe(200)
+    expect(res._json.features).toBeDefined()
+    // Must NOT be a 202 no-cache response
+    expect(res._json._noCache).toBeUndefined()
+  })
+
+  it('after background refresh completes, cache has no _invalidatedAt', async function() {
+    // Pre-populate candidates cache
+    storage._store['release-planning/candidates-cache-3.5.json'] = {
+      cachedAt: new Date().toISOString(),
+      data: {
+        version: '3.5',
+        features: [{ issueKey: 'OLD-1' }],
+        rfes: [],
+        bigRocks: [],
+        summary: null
+      }
+    }
+
+    // Trigger a refresh
+    const refreshReq = makeReq({ params: { version: '3.5' } })
+    callRoute(router._routes, 'POST', '/releases/:version/refresh', refreshReq)
+
+    // Wait for the background refresh promise to settle
+    await new Promise(function(resolve) { setTimeout(resolve, 50) })
+
+    // The cache should now contain fresh data without _invalidatedAt
+    const cached = storage._store['release-planning/candidates-cache-3.5.json']
+    expect(cached).toBeDefined()
+    expect(cached.data).toBeDefined()
+    expect(cached._invalidatedAt).toBeUndefined()
+    expect(cached.cachedAt).toBeDefined()
+  })
+
+  it('health caches ARE deleted on invalidation, candidates cache is NOT', async function() {
+    // Pre-populate health cache files and candidates cache
+    storage._store['release-planning/health-cache-3.5-all.json'] = { data: 'health-all' }
+    storage._store['release-planning/health-cache-3.5-EA1.json'] = { data: 'health-ea1' }
+    storage._store['release-planning/health-cache-3.5-EA2.json'] = { data: 'health-ea2' }
+    storage._store['release-planning/health-cache-3.5-GA.json'] = { data: 'health-ga' }
+    storage._store['release-planning/candidates-cache-3.5.json'] = {
+      cachedAt: new Date().toISOString(),
+      data: { features: [], rfes: [], bigRocks: [], summary: null }
+    }
+
+    // PUT to trigger invalidation
+    const putReq = makeReq({
+      params: { version: '3.5', name: 'Test Rock' },
+      body: Object.assign({}, VALID_ROCK, { notes: 'trigger invalidation' })
+    })
+    await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', putReq)
+
+    // Health caches should be deleted via deleteFromStorage
+    expect(storage.deleteFromStorage).toHaveBeenCalledWith('release-planning/health-cache-3.5-all.json')
+    expect(storage.deleteFromStorage).toHaveBeenCalledWith('release-planning/health-cache-3.5-EA1.json')
+    expect(storage.deleteFromStorage).toHaveBeenCalledWith('release-planning/health-cache-3.5-EA2.json')
+    expect(storage.deleteFromStorage).toHaveBeenCalledWith('release-planning/health-cache-3.5-GA.json')
+
+    // Candidates cache should NOT have been deleted via deleteFromStorage
+    const deleteArgs = storage.deleteFromStorage.mock.calls.map(function(c) { return c[0] })
+    expect(deleteArgs).not.toContain('release-planning/candidates-cache-3.5.json')
+  })
+
+  it('outcome summary cache is deleted on invalidation', async function() {
+    // Pre-populate outcome summary cache
+    storage._store['release-planning/outcome-summaries-cache-3.5.json'] = { 'KEY-1': 'Summary' }
+    storage._store['release-planning/candidates-cache-3.5.json'] = {
+      cachedAt: new Date().toISOString(),
+      data: { features: [], rfes: [], bigRocks: [], summary: null }
+    }
+
+    // PUT to trigger invalidation
+    const putReq = makeReq({
+      params: { version: '3.5', name: 'Test Rock' },
+      body: Object.assign({}, VALID_ROCK, { notes: 'trigger' })
+    })
+    await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', putReq)
+
+    expect(storage.deleteFromStorage).toHaveBeenCalledWith('release-planning/outcome-summaries-cache-3.5.json')
+  })
+
+  it('_invalidatedAt marker is written to candidates cache during invalidation', async function() {
+    // This test needs the writeToStorage spy set up BEFORE registerRoutes,
+    // because invalidateCache captures writeToStorage at registration time.
+    var markerWritten = false
+    var spyStorage = makeStorage({
+      'release-planning/config.json': { releases: { '3.5': { release: '3.5' } } },
+      'release-planning/releases/3.5.json': { release: '3.5', bigRocks: [VALID_ROCK] },
+      'release-planning/pm-users.json': { emails: ['pm@test.com'] },
+      'feature-traffic/index.json': { features: [], rfes: [] },
+      'release-planning/candidates-cache-3.5.json': {
+        cachedAt: new Date().toISOString(),
+        data: { features: [], rfes: [], bigRocks: [], summary: null }
+      }
+    })
+    var origWrite = spyStorage.writeToStorage
+    spyStorage.writeToStorage = function(key, value) {
+      if (key === 'release-planning/candidates-cache-3.5.json' && value && value._invalidatedAt) {
+        markerWritten = true
+      }
+      origWrite(key, value)
+    }
+
+    var spyRouter = makeRouter()
+    registerRoutes(spyRouter, {
+      storage: spyStorage,
+      requireAuth: function(req, res, next) { next() },
+      requireAdmin: function(req, res, next) { next() },
+      registerDiagnostics: vi.fn()
+    })
+
+    // PUT to trigger invalidation
+    const putReq = makeReq({
+      params: { version: '3.5', name: 'Test Rock' },
+      body: Object.assign({}, VALID_ROCK, { notes: 'trigger' })
+    })
+    await callRoute(spyRouter._routes, 'PUT', '/releases/:version/big-rocks/:name', putReq)
+
+    // The _invalidatedAt marker was written (even if later overwritten by refresh)
+    expect(markerWritten).toBe(true)
+  })
+})

--- a/modules/release-planning/__tests__/server/pipeline.test.js
+++ b/modules/release-planning/__tests__/server/pipeline.test.js
@@ -277,7 +277,8 @@ describe('runPipeline', () => {
 
     expect(result.features).toHaveLength(0)
     expect(result.rocksWithoutOutcomes).toContain('NoOutcome')
-    expect(result.warnings).toEqual(
+    // TBD rocks are tracked in rocksWithoutOutcomes but NOT in warnings
+    expect(result.warnings).not.toEqual(
       expect.arrayContaining([expect.stringContaining('NoOutcome')])
     )
   })
@@ -309,7 +310,61 @@ describe('runPipeline', () => {
     )
   })
 
-  it('accumulates warnings for missing outcomes and empty index', () => {
+  it('provides diagnostic detail when rock has outcomes but no qualifying features', () => {
+    const index = {
+      features: [
+        makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
+        makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.4'], status: 'In Progress' }),
+        makeFeatureIndex('RHAISTRAT-101', { parentKey: 'KEY-1', targetVersions: null, status: 'New' }),
+        makeFeatureIndex('RHAISTRAT-102', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Closed' })
+      ],
+      rfes: []
+    }
+    const details = [
+      makeFeatureDetail('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.4'] }),
+      makeFeatureDetail('RHAISTRAT-102', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Closed' })
+    ]
+    const readFromStorage = createMockStorage(index, details)
+
+    const config = makeConfig()
+    const bigRocks = [
+      { priority: 1, name: 'TestRock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
+    ]
+
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+
+    // Should have a diagnostic warning with filter breakdown
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('candidate(s) with matching parentKey')])
+    )
+    // Should mention specific filter reasons
+    const diagWarning = result.warnings.find(function(w) { return w.indexOf('candidate(s) with matching parentKey') !== -1 })
+    expect(diagWarning).toBeDefined()
+    expect(diagWarning).toContain('excluded')
+  })
+
+  it('warns about missing parentKey when no features match at all', () => {
+    const index = {
+      features: [
+        makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' })
+      ],
+      rfes: []
+    }
+    const readFromStorage = createMockStorage(index)
+
+    const config = makeConfig()
+    const bigRocks = [
+      { priority: 1, name: 'EmptyRock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
+    ]
+
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('no features with matching parentKey found in the index')])
+    )
+  })
+
+  it('accumulates warnings for empty index', () => {
     const index = { features: [], rfes: [] }
     const readFromStorage = createMockStorage(index)
 
@@ -320,12 +375,36 @@ describe('runPipeline', () => {
 
     const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
 
-    expect(result.warnings.length).toBeGreaterThanOrEqual(2)
     expect(result.warnings).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('Feature-traffic index is empty'),
-        expect.stringContaining('KEY-999')
+        expect.stringContaining('Feature-traffic index is empty')
       ])
+    )
+  })
+
+  it('returns missingOutcomes array listing keys not found in index', () => {
+    const index = {
+      features: [
+        makeFeatureIndex('KEY-1', { summary: 'Outcome Found' })
+      ],
+      rfes: []
+    }
+    const readFromStorage = createMockStorage(index)
+
+    const config = makeConfig()
+    const bigRocks = [
+      { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1', 'KEY-999', 'KEY-888'], pillar: 'Platform' }
+    ]
+
+    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+
+    expect(result.missingOutcomes).toBeDefined()
+    expect(result.missingOutcomes).toContain('KEY-999')
+    expect(result.missingOutcomes).toContain('KEY-888')
+    expect(result.missingOutcomes).not.toContain('KEY-1')
+    // Missing outcomes should NOT be in warnings (downgraded to info)
+    expect(result.warnings).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('not found in feature-traffic data')])
     )
   })
 

--- a/modules/release-planning/server/cache-reader.js
+++ b/modules/release-planning/server/cache-reader.js
@@ -155,20 +155,34 @@ function rfeLinksToOutcome(issueLinks, outcomeSet) {
  * Find Tier 1 features: children of outcome keys with matching target version.
  * Uses parentKey from the index to identify outcome children.
  */
-function findTier1Features(readFromStorage, index, outcomeKeys) {
+function findTier1Features(readFromStorage, index, outcomeKeys, stats) {
   const outcomeSet = new Set(outcomeKeys)
   const results = []
+
+  if (stats) {
+    stats.totalMatches = 0
+    stats.closedFiltered = 0
+    stats.noTargetVersion = 0
+  }
 
   const features = index.features || []
   for (let i = 0; i < features.length; i++) {
     const f = features[i]
     if (!f.parentKey || !outcomeSet.has(f.parentKey)) continue
 
+    if (stats) stats.totalMatches++
+
     const versions = getTargetVersions(f)
-    if (versions.length === 0) continue
+    if (versions.length === 0) {
+      if (stats) stats.noTargetVersion++
+      continue
+    }
 
     const status = f.status || ''
-    if (CLOSED_STATUSES.indexOf(status) !== -1) continue
+    if (CLOSED_STATUSES.indexOf(status) !== -1) {
+      if (stats) stats.closedFiltered++
+      continue
+    }
 
     // Load detail for components and issueLinks
     const detail = loadFeatureDetail(readFromStorage, f.key)

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -7,6 +7,7 @@ const { withConfigLock } = require('./config-lock')
 const { backupConfig } = require('./config-backup')
 const { validateBigRock } = require('./validation')
 const { createRequirePM, getPMUsers, addPMUser, removePMUser, isPM } = require('./pm-auth')
+const { getOutcomeSummaries } = require('./outcome-fetch')
 const { previewDocImport, executeDocImport } = require('./doc-import')
 const { logAudit, getAuditLog } = require('./audit-log')
 const smartsheetClient = require('../../../shared/server/smartsheet')
@@ -104,6 +105,9 @@ module.exports = function registerRoutes(router, context) {
       return
     }
 
+    console.log('[release-planning] Background refresh started for ' + version)
+    var refreshStartTime = Date.now()
+
     function doRefresh(attempt) {
       const pipeline = new Promise(function(resolve) { resolve(runPipeline(config, bigRocks, version, readFromStorage)) })
       const timeout = new Promise(function(_, reject) {
@@ -112,19 +116,40 @@ module.exports = function registerRoutes(router, context) {
 
       Promise.race([pipeline, timeout])
         .then(function(result) {
-          const response = buildCandidateResponse(result, version, bigRocks, false)
-          writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', {
-            cachedAt: new Date().toISOString(),
-            data: response
-          })
-          refreshStates.set(version, {
-            running: false,
-            lastResult: {
-              status: 'success',
-              version: version,
-              message: 'Pipeline completed: ' + result.features.length + ' features, ' + result.rfes.length + ' RFEs',
-              completedAt: new Date().toISOString()
-            }
+          // Jira fallback: fetch missing outcome summaries asynchronously
+          var fallback
+          if (result.missingOutcomes && result.missingOutcomes.length > 0) {
+            fallback = getOutcomeSummaries(result.missingOutcomes, version, readFromStorage, writeToStorage)
+              .then(function(fetched) {
+                // Merge fetched summaries into the pipeline result
+                for (var key in fetched) {
+                  result.outcomeSummaries[key] = fetched[key]
+                }
+              })
+              .catch(function(err) {
+                console.warn('[release-planning] Jira outcome summary fallback failed: ' + err.message)
+              })
+          } else {
+            fallback = Promise.resolve()
+          }
+
+          return fallback.then(function() {
+            const response = buildCandidateResponse(result, version, bigRocks, false)
+            writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', {
+              cachedAt: new Date().toISOString(),
+              data: response
+            })
+            var elapsed = ((Date.now() - refreshStartTime) / 1000).toFixed(1)
+            console.log('[release-planning] Background refresh completed for ' + version + ': ' + result.features.length + ' features, ' + result.rfes.length + ' RFEs in ' + elapsed + 's')
+            refreshStates.set(version, {
+              running: false,
+              lastResult: {
+                status: 'success',
+                version: version,
+                message: 'Pipeline completed: ' + result.features.length + ' features, ' + result.rfes.length + ' RFEs',
+                completedAt: new Date().toISOString()
+              }
+            })
           })
         })
         .catch(function(err) {
@@ -134,6 +159,15 @@ module.exports = function registerRoutes(router, context) {
             return
           }
           console.error('[release-planning] Background refresh failed for ' + version + ':', err)
+
+          // Remove _invalidatedAt marker so cache reverts to normal
+          // stale-while-revalidate behavior (15-min cycle)
+          var staleCache = readFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
+          if (staleCache && staleCache._invalidatedAt) {
+            delete staleCache._invalidatedAt
+            writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', staleCache)
+          }
+
           refreshStates.set(version, {
             running: false,
             lastResult: {
@@ -213,8 +247,9 @@ module.exports = function registerRoutes(router, context) {
     if (hasCachedData) {
       const age = Date.now() - new Date(cached.cachedAt).getTime()
       const isStale = age >= CACHE_MAX_AGE_MS
+      const isInvalidated = !!cached._invalidatedAt
 
-      if (isStale) {
+      if (isStale || isInvalidated) {
         triggerBackgroundRefresh(version)
       }
 
@@ -233,7 +268,7 @@ module.exports = function registerRoutes(router, context) {
 
       return sendJsonWithETag(req, res, {
         ...data,
-        _cacheStale: isStale,
+        _cacheStale: isStale || isInvalidated,
         _refreshing: getRefreshState(version).running
       })
     }
@@ -303,16 +338,30 @@ module.exports = function registerRoutes(router, context) {
   // ─── Cache Invalidation Helper ───
 
   function invalidateCache(version) {
-    // Delete the candidates cache file so next GET re-fetches
+    // Do NOT delete the candidates cache -- let triggerBackgroundRefresh
+    // overwrite it atomically when the rebuild completes. This prevents
+    // serving empty 202 responses during the rebuild window.
+    //
+    // DO delete health caches -- they are rebuilt lazily by GET /health,
+    // not by triggerBackgroundRefresh. Keeping stale health data would
+    // serve wrong feature associations for up to 15 minutes.
     if (deleteFromStorage) {
-      deleteFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
-      // Delete all phase-specific health caches -- rebuilt lazily on next GET /health request
       var healthPhases = ['all', 'EA1', 'EA2', 'GA']
       for (var hp = 0; hp < healthPhases.length; hp++) {
         deleteFromStorage(`${DATA_PREFIX}/health-cache-${version}-${healthPhases[hp]}.json`)
       }
+      // Delete outcome summary cache so it's re-fetched with current keys
+      deleteFromStorage(`${DATA_PREFIX}/outcome-summaries-cache-${version}.json`)
     }
-    // Trigger background refresh to rebuild the candidates cache
+
+    // Mark the existing cache as invalidated so the GET endpoint knows
+    // a refresh is pending, without deleting the data.
+    var cached = readFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
+    if (cached) {
+      cached._invalidatedAt = new Date().toISOString()
+      writeToStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`, cached)
+    }
+
     triggerBackgroundRefresh(version)
   }
 

--- a/modules/release-planning/server/outcome-fetch.js
+++ b/modules/release-planning/server/outcome-fetch.js
@@ -38,7 +38,7 @@ async function fetchOutcomeSummaries(keys) {
   if (safeKeys.length === 0) return {}
 
   var jql = 'key in (' + safeKeys.join(',') + ')'
-  var params = new URLSearchParams({ jql: jql, fields: 'summary', maxResults: String(keys.length) })
+  var params = new URLSearchParams({ jql: jql, fields: 'summary', maxResults: String(safeKeys.length) })
   var data = await jiraRequest('/rest/api/3/search/jql?' + params)
 
   var summaries = {}

--- a/modules/release-planning/server/outcome-fetch.js
+++ b/modules/release-planning/server/outcome-fetch.js
@@ -1,0 +1,104 @@
+/**
+ * Fallback fetcher for outcome summaries not found in the feature-traffic index.
+ *
+ * When outcome keys (RHAISTRAT-* issues) are not present in the feature-traffic
+ * pipeline data, this module fetches their summaries directly from the Jira API.
+ * Results are cached to data/release-planning/outcome-summaries-cache-{version}.json.
+ */
+
+const { jiraRequest } = require('../../../shared/server/jira')
+
+const DATA_PREFIX = 'release-planning'
+
+/**
+ * Check whether Jira credentials are configured.
+ * @returns {boolean}
+ */
+function hasJiraCredentials() {
+  return !!(process.env.JIRA_TOKEN && process.env.JIRA_EMAIL)
+}
+
+/**
+ * Fetch summaries for the given issue keys from Jira.
+ * Uses a single JQL query: key in (KEY-1, KEY-2, ...) with fields=summary.
+ *
+ * @param {string[]} keys - Issue keys to look up
+ * @returns {Promise<Object>} Map of key -> summary string
+ */
+const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/
+
+async function fetchOutcomeSummaries(keys) {
+  if (!keys || keys.length === 0) return {}
+  if (!hasJiraCredentials()) {
+    console.log('[release-planning] Jira credentials not configured, skipping outcome summary fetch')
+    return {}
+  }
+
+  var safeKeys = keys.filter(function(k) { return typeof k === 'string' && ISSUE_KEY_PATTERN.test(k) })
+  if (safeKeys.length === 0) return {}
+
+  var jql = 'key in (' + safeKeys.join(',') + ')'
+  var params = new URLSearchParams({ jql: jql, fields: 'summary', maxResults: String(keys.length) })
+  var data = await jiraRequest('/rest/api/3/search/jql?' + params)
+
+  var summaries = {}
+  if (data && data.issues) {
+    for (var i = 0; i < data.issues.length; i++) {
+      var issue = data.issues[i]
+      summaries[issue.key] = issue.fields && issue.fields.summary || ''
+    }
+  }
+
+  return summaries
+}
+
+/**
+ * Load cached outcome summaries for a version, or fetch from Jira if not cached.
+ *
+ * @param {string[]} keys - Missing outcome keys
+ * @param {string} version - Release version (for cache scoping)
+ * @param {Function} readFromStorage
+ * @param {Function} writeToStorage
+ * @returns {Promise<Object>} Map of key -> summary string
+ */
+async function getOutcomeSummaries(keys, version, readFromStorage, writeToStorage) {
+  if (!keys || keys.length === 0) return {}
+
+  var cachePath = DATA_PREFIX + '/outcome-summaries-cache-' + version + '.json'
+  var cached = readFromStorage(cachePath)
+
+  // Check if all keys are already cached
+  if (cached) {
+    var allCached = true
+    for (var i = 0; i < keys.length; i++) {
+      if (cached[keys[i]] === undefined) {
+        allCached = false
+        break
+      }
+    }
+    if (allCached) {
+      var result = {}
+      for (var j = 0; j < keys.length; j++) {
+        result[keys[j]] = cached[keys[j]]
+      }
+      return result
+    }
+  }
+
+  // Fetch from Jira
+  var fetched = await fetchOutcomeSummaries(keys)
+
+  if (Object.keys(fetched).length > 0) {
+    // Merge into cache
+    var merged = cached || {}
+    for (var key in fetched) {
+      merged[key] = fetched[key]
+    }
+    writeToStorage(cachePath, merged)
+    console.log('[release-planning] Fetched ' + Object.keys(fetched).length + ' outcome summaries from Jira')
+  }
+
+  return fetched
+}
+
+module.exports = { fetchOutcomeSummaries: fetchOutcomeSummaries, getOutcomeSummaries: getOutcomeSummaries, hasJiraCredentials: hasJiraCredentials }

--- a/modules/release-planning/server/pipeline.js
+++ b/modules/release-planning/server/pipeline.js
@@ -35,9 +35,7 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   const warnings = []
 
   for (let w = 0; w < rocksWithout.length; w++) {
-    const msg = 'Big Rock "' + rocksWithout[w].name + '" has no outcome keys and was skipped'
-    warnings.push(msg)
-    console.warn('[release-planning] ' + msg)
+    console.log('[release-planning] Big Rock "' + rocksWithout[w].name + '" has no outcome keys — skipped (tracked in rocksWithoutOutcomes)')
   }
 
   // Defense-in-depth: filter outcome keys that don't match the expected pattern
@@ -70,10 +68,10 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   // Fetch outcome summaries from cache
   const outcomeSummaries = findOutcomeSummaries(index, allOutcomeKeys)
 
-  // Warn about outcome keys not found in index
+  // Track outcome keys not found in the feature-traffic index (info-level, not a warning)
   const missingOutcomes = allOutcomeKeys.filter(function(key) { return !outcomeSummaries[key] })
   if (missingOutcomes.length > 0) {
-    warnings.push(missingOutcomes.length + ' outcome key(s) not found in feature-traffic data: ' + missingOutcomes.join(', '))
+    console.log('[release-planning] ' + missingOutcomes.length + ' outcome key(s) not in feature-traffic index: ' + missingOutcomes.join(', '))
   }
 
   // Phase A: Discover children for each rock's outcomes
@@ -87,8 +85,11 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     const rock = rocksWithOutcomes[ri]
     let rockChildCount = 0
 
-    // Find Tier 1 features for this rock's outcomes
-    const rawFeatures = findTier1Features(readFromStorage, index, rock.outcomeKeys)
+    // Find Tier 1 features for this rock's outcomes (with stats tracking)
+    var rockStats = { totalMatches: 0, closedFiltered: 0, noTargetVersion: 0 }
+    const rawFeatures = findTier1Features(readFromStorage, index, rock.outcomeKeys, rockStats)
+    var rockTerminalFiltered = 0
+    var rockReleaseMismatch = 0
     for (let fi = 0; fi < rawFeatures.length; fi++) {
       const feat = rawFeatures[fi]
       const candidate = mapToCandidate(feat, rock.name, 'outcome')
@@ -96,12 +97,14 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
       // Filter by release match
       if (!candidate.targetRelease.includes(release)) {
         skippedCount++
+        rockReleaseMismatch++
         continue
       }
 
       // Filter terminal statuses
       if (TERMINAL_STATUSES.indexOf(candidate.status) !== -1) {
         terminalFilteredCount++
+        rockTerminalFiltered++
         continue
       }
 
@@ -138,7 +141,18 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     }
 
     if (rockChildCount === 0 && rock.outcomeKeys.length > 0) {
-      const msg = 'Big Rock "' + rock.name + '" has outcomes (' + rock.outcomeKeys.join(', ') + ') but no qualifying features or RFEs for this release'
+      var msg
+      if (rockStats.totalMatches === 0) {
+        msg = 'Big Rock "' + rock.name + '" has outcomes (' + rock.outcomeKeys.join(', ') + ') but no features with matching parentKey found in the index. Check parent-child links in Jira.'
+      } else {
+        var parts = []
+        parts.push(rockStats.totalMatches + ' candidate(s) with matching parentKey')
+        if (rockStats.closedFiltered > 0) parts.push(rockStats.closedFiltered + ' excluded (closed status)')
+        if (rockStats.noTargetVersion > 0) parts.push(rockStats.noTargetVersion + ' excluded (no target version)')
+        if (rockReleaseMismatch > 0) parts.push(rockReleaseMismatch + ' excluded (wrong release)')
+        if (rockTerminalFiltered > 0) parts.push(rockTerminalFiltered + ' excluded (terminal status)')
+        msg = 'Big Rock "' + rock.name + '" has outcomes (' + rock.outcomeKeys.join(', ') + ') but no qualifying features: ' + parts.join(', ')
+      }
       warnings.push(msg)
       console.warn('[release-planning] ' + msg)
     }
@@ -279,6 +293,7 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     skippedCount: skippedCount,
     terminalFilteredCount: terminalFilteredCount,
     rocksWithoutOutcomes: rocksWithout.map(function(r) { return r.name }),
+    missingOutcomes: missingOutcomes,
     warnings: warnings
   }
 }


### PR DESCRIPTION
## Summary

- **Fix 8 pipeline warnings** in the Big Rocks Planning Dashboard that create noise and obscure genuine issues
- **Fix data persistence bug** where edited Big Rock fields disappear after saving in production

## Changes

### Pipeline Warnings (3 categories)

- **5 "no outcome keys" warnings**: Downgraded to info-level logging — TBD Big Rocks are normal and shouldn't produce warnings
- **"12 outcome keys not found" warning**: Added Jira API fallback (`outcome-fetch.js`) to fetch missing outcome summaries directly when they're absent from the feature-traffic index. Results cached per-version. Warning downgraded to info-level
- **2 "no qualifying features" warnings**: Enhanced with diagnostic detail showing exactly why features were filtered (closed status, no target version, wrong release, terminal status, or no parentKey match)

### Data Persistence Bug

Root cause: `invalidateCache()` deleted the candidates cache file before the background rebuild completed. The frontend would fetch during the rebuild window and receive a 202 with empty data, making edits appear to vanish.

Fix:
- Stop deleting the candidates cache — write an `_invalidatedAt` marker instead
- Serve stale-but-present data during rebuild (better than empty data)
- Keep health cache + outcome summary cache deletion (rebuilt lazily)
- If all refresh retries fail, remove the marker so normal 15-min staleness cycling resumes

### Security

- Added defense-in-depth JQL input validation in `fetchOutcomeSummaries()` via `ISSUE_KEY_PATTERN` regex

## Files Changed

| File | Change |
|------|--------|
| `modules/release-planning/server/pipeline.js` | Warning downgrades, `missingOutcomes` return field, diagnostic stats |
| `modules/release-planning/server/cache-reader.js` | Optional `stats` param on `findTier1Features` (return type unchanged) |
| `modules/release-planning/server/index.js` | Cache persistence fix, Jira fallback in `triggerBackgroundRefresh`, logging |
| `modules/release-planning/server/outcome-fetch.js` | **New** — Jira API fallback for missing outcome summaries |
| `modules/release-planning/__tests__/server/pipeline.test.js` | Updated + new tests for warnings, missingOutcomes, diagnostics |
| `modules/release-planning/__tests__/server/cache-reader.test.js` | New stats parameter tests |
| `modules/release-planning/__tests__/server/invalidate-cache.test.js` | **New** — 5 test cases for cache invalidation behavior |

## Test plan

- [x] All 1945 tests pass
- [x] Lint clean
- [ ] Deploy to preprod and verify:
  - [ ] Pipeline warnings reduced from 8 to ~2 (only actionable "no qualifying features" remain)
  - [ ] Edit a Big Rock → immediately refresh → data is stale-but-present (not empty 202)
  - [ ] Check server logs for new diagnostic logging
- [ ] Verify in prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)