### PR TITLE
feat: add AI Quality tile to AI SDLC Materials docs section

### DIFF
--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -154,6 +154,24 @@
         </div>
       </div>
 
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">AI Quality</h3>
+        <div class="flex flex-wrap gap-4">
+          <a
+            v-for="link in aiQualityLinks"
+            :key="link.label"
+            :href="link.url"
+            target="_blank"
+            rel="noopener"
+            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
+          >
+            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
+            <span>{{ link.label }}</span>
+            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
+          </a>
+        </div>
+      </div>
+
       <!-- AI Workflows Enablement -->
       <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mt-8 mb-3">AI Workflows Enablement</h2>
 
@@ -434,6 +452,12 @@ const rfeLinks = [
   { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/1O-F8naJxAfYtcXjTJHySYjeLtrKfb1OHhtyhoItya0s/edit?usp=sharing' },
   { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1pTpIvKkYns2aG5g0ueOxy6P8j1m_yNnD13XBB35NgWQ/edit?usp=sharing' },
   { label: 'Demo', icon: Play, url: 'https://drive.google.com/file/d/1ANaZOeUorSMqlFm3WzfK1xRPvld2TGM-/view' }
+]
+
+const aiQualityLinks = [
+  { label: 'Enablement Recording', icon: Video, url: 'https://drive.google.com/file/d/1jlsw8rVpRRo1Y1kkKhJ7LHDy3N6C_Uxp/view' },
+  { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/1XuLna0_2DHX7EzepJHk03PpQF1urFoF39xaq9N-G6rY/edit?slide=id.g3d48d3b5671_0_5160#slide=id.g3d48d3b5671_0_5160' },
+  { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1B006LrfEAUf_wb6Hr7PZJnpg2oW2bAQdxNmYcbLJo30/edit?tab=t.iqa6kux2ki3f' }
 ]
 
 const jiraAutofixLinks = [


### PR DESCRIPTION
Adds a new AI Quality card under the AI SDLC Materials section with links to Enablement Recording, Enablement Slides, and Enablement Notes.

Closes #437

Generated with [Claude Code](https://claude.ai/code)