### PR TITLE
feat(team-tracker): show RFE assessment scores in backlog table

### DIFF
--- a/modules/team-tracker/__tests__/client/RfeBacklogTable.test.js
+++ b/modules/team-tracker/__tests__/client/RfeBacklogTable.test.js
@@ -102,4 +102,43 @@ describe('RfeBacklogTable', () => {
     const badges = wrapper.findAll('.rounded-full')
     expect(badges.length).toBeGreaterThan(0)
   })
+
+  it('renders PASS assessment with score', () => {
+    const assessments = {
+      'RHAIRFE-100': { total: 8, passFail: 'PASS', scores: {}, assessedAt: '2025-07-01' }
+    }
+    const wrapper = mount(RfeBacklogTable, { props: { issues: sampleIssues, rfeConfig, assessments } })
+    expect(wrapper.text()).toContain('8/10')
+    expect(wrapper.text()).toContain('✓')
+  })
+
+  it('renders FAIL assessment with score', () => {
+    const assessments = {
+      'RHAIRFE-200': { total: 3, passFail: 'FAIL', scores: {}, assessedAt: '2025-07-01' }
+    }
+    const wrapper = mount(RfeBacklogTable, { props: { issues: sampleIssues, rfeConfig, assessments } })
+    expect(wrapper.text()).toContain('3/10')
+    expect(wrapper.text()).toContain('✗')
+  })
+
+  it('renders N/A for unassessed RFEs', () => {
+    const wrapper = mount(RfeBacklogTable, { props: { issues: sampleIssues, rfeConfig, assessments: {} } })
+    expect(wrapper.text()).toContain('N/A')
+  })
+
+  it('sorts by assessment score', async () => {
+    const assessments = {
+      'RHAIRFE-100': { total: 8, passFail: 'PASS', scores: {}, assessedAt: '2025-07-01' },
+      'RHAIRFE-200': { total: 3, passFail: 'FAIL', scores: {}, assessedAt: '2025-07-01' },
+      'RHAIRFE-50': { total: 6, passFail: 'PASS', scores: {}, assessedAt: '2025-07-01' }
+    }
+    const wrapper = mount(RfeBacklogTable, { props: { issues: sampleIssues, rfeConfig, assessments } })
+    const assessmentHeader = wrapper.findAll('th').find(th => th.text().includes('Assessment'))
+    await assessmentHeader.trigger('click')
+    const rows = wrapper.findAll('tbody tr')
+    // Ascending: 3, 6, 8
+    expect(rows[0].text()).toContain('RHAIRFE-200')
+    expect(rows[1].text()).toContain('RHAIRFE-50')
+    expect(rows[2].text()).toContain('RHAIRFE-100')
+  })
 })

--- a/modules/team-tracker/__tests__/client/TeamBacklogTab.test.js
+++ b/modules/team-tracker/__tests__/client/TeamBacklogTab.test.js
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import TeamBacklogTab from '../../client/components/TeamBacklogTab.vue'
+
+vi.mock('@shared/client/services/api.js', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ assessments: {} })
+}))
 
 const sampleIssues = [
   { key: 'RFE-1', summary: 'Feature A', components: ['KServe', 'ModelMesh'], status: 'New', statusCategory: 'To Do', priority: 'Major', created: '2025-06-01' },

--- a/modules/team-tracker/client/components/RfeBacklogTable.vue
+++ b/modules/team-tracker/client/components/RfeBacklogTable.vue
@@ -75,6 +75,24 @@
             </td>
             <td class="px-4 py-3 whitespace-nowrap text-gray-600 dark:text-gray-400">{{ issue.priority }}</td>
             <td class="px-4 py-3 whitespace-nowrap text-gray-500 dark:text-gray-400">{{ formatDate(issue.created) }}</td>
+            <td class="px-4 py-3 whitespace-nowrap">
+              <span
+                v-if="assessments[issue.key]"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold"
+                :class="assessments[issue.key].passFail === 'PASS'
+                  ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+                  : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'"
+              >
+                {{ assessments[issue.key].passFail === 'PASS' ? '✓' : '✗' }}
+                {{ assessments[issue.key].total }}/10
+              </span>
+              <span
+                v-else
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-gray-100 dark:bg-gray-700 border border-dashed border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500"
+              >
+                N/A
+              </span>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -94,7 +112,8 @@ import { ref, computed } from 'vue'
 
 const props = defineProps({
   issues: { type: Array, default: () => [] },
-  rfeConfig: { type: Object, default: () => ({}) }
+  rfeConfig: { type: Object, default: () => ({}) },
+  assessments: { type: Object, default: () => ({}) }
 })
 
 const columns = [
@@ -104,6 +123,7 @@ const columns = [
   { key: 'status', label: 'Status' },
   { key: 'priority', label: 'Priority' },
   { key: 'created', label: 'Created' },
+  { key: 'assessment', label: 'Assessment' },
 ]
 
 const PRIORITY_ORDER = { Blocker: 0, Critical: 1, Major: 2, Normal: 3, Minor: 4, Trivial: 5 }
@@ -142,6 +162,11 @@ const sortedIssues = computed(() => {
       case 'status': return dir * a.status.localeCompare(b.status)
       case 'priority': return dir * ((PRIORITY_ORDER[a.priority] ?? 99) - (PRIORITY_ORDER[b.priority] ?? 99))
       case 'created': return dir * a.created.localeCompare(b.created)
+      case 'assessment': {
+        const aScore = props.assessments[a.key]?.total ?? -1
+        const bScore = props.assessments[b.key]?.total ?? -1
+        return dir * (aScore - bScore)
+      }
       default: return 0
     }
   })

--- a/modules/team-tracker/client/components/TeamBacklogTab.vue
+++ b/modules/team-tracker/client/components/TeamBacklogTab.vue
@@ -16,13 +16,14 @@
           </span>
         </h3>
       </div>
-      <RfeBacklogTable :issues="rfeIssues" :rfeConfig="rfeConfig" />
+      <RfeBacklogTable :issues="rfeIssues" :rfeConfig="rfeConfig" :assessments="assessments" />
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { ref, computed, watch } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
 import ComponentList from './ComponentList.vue'
 import RfeBacklogTable from './RfeBacklogTable.vue'
 
@@ -31,6 +32,23 @@ const props = defineProps({
   rfeIssues: { type: Array, default: () => [] },
   rfeConfig: { type: Object, default: () => ({}) }
 })
+
+const assessments = ref({})
+
+async function loadAssessments() {
+  try {
+    const data = await apiRequest('/modules/ai-impact/assessments')
+    assessments.value = data.assessments || {}
+  } catch {
+    // AI Impact module may be disabled or unavailable — degrade gracefully
+    assessments.value = {}
+  }
+}
+
+// Fetch assessments when RFE issues are available
+watch(() => props.rfeIssues, (issues) => {
+  if (issues.length > 0) loadAssessments()
+}, { immediate: true })
 
 const rfeCounts = computed(() => {
   const counts = {}


### PR DESCRIPTION
## Summary

Adds an **Assessment** column to the RFE backlog table on team profile pages, showing pass/fail status and quality scores from the AI Impact module.

## Changes

- **TeamBacklogTab.vue**: Fetches assessments from `/api/modules/ai-impact/assessments` and passes them as a prop to `RfeBacklogTable`. Degrades gracefully if AI Impact is unavailable.
- **RfeBacklogTable.vue**: Accepts new `assessments` prop. Renders a sortable Assessment column with:
  - ✓ 8/10 (green badge) for PASS
  - ✗ 3/10 (red badge) for FAIL  
  - N/A (gray dashed) for unassessed
- **Tests**: Added 4 new tests for assessment rendering + sorting; updated TeamBacklogTab test with API mock.

## Design Decision

Went with **Option C** (prop-based) — TeamBacklogTab fetches assessment data and passes it down, keeping RfeBacklogTable as a pure display component. This:
- Keeps module coupling at the orchestration layer, not the display layer
- Degrades cleanly if AI Impact is disabled (empty object → all N/A)
- Makes the table easy to test without API mocking

Follows up on #446 which wired RFE key links to navigate to AI Impact.