### PR TITLE
fix(release-analysis): prevent duplicate EA tags in Product Pages release labels (AIPCC-15208)

### DIFF
--- a/modules/release-analysis/__tests__/server/milestone-dedup.test.js
+++ b/modules/release-analysis/__tests__/server/milestone-dedup.test.js
@@ -1,28 +1,5 @@
 import { describe, it, expect } from 'vitest'
-
-/**
- * Regression test for duplicate EA tags in release numbers.
- * Bug: milestoneToReleaseNumber would append EA tag even when shortname already contained it,
- * resulting in release numbers like "RHAI-3.5.EA1.EA1" instead of "RHAI-3.5.EA1".
- *
- * This is a white-box test - we copy the function here to test it directly.
- */
-
-function milestoneToReleaseNumber(shortname, milestoneName) {
-  const eaMatch = milestoneName.match(/\b(EA\d?)\b/i)
-  if (eaMatch) {
-    const eaTag = eaMatch[1].toUpperCase()
-    // Check if shortname already ends with this EA tag (case-insensitive)
-    const endsWithEa = new RegExp(`[.\\-_]${eaTag}$`, 'i').test(shortname)
-    if (endsWithEa) {
-      // Already has the EA tag, return as-is
-      return shortname
-    }
-    return `${shortname}.${eaTag}`
-  }
-  // GA milestone → use the parent shortname as-is
-  return shortname
-}
+import { milestoneToReleaseNumber } from '../../server/product-pages.js'
 
 describe('milestoneToReleaseNumber - EA tag deduplication', () => {
   describe('normal cases (no duplication)', () => {
@@ -76,7 +53,6 @@ describe('milestoneToReleaseNumber - EA tag deduplication', () => {
 
   describe('edge cases', () => {
     it('does not match EA1 in the middle of shortname', () => {
-      // "EA1" appears in the middle, not at the end - should still append
       expect(milestoneToReleaseNumber('RHAI-EA1-3.5', 'RHAI 3.5 EA1'))
         .toBe('RHAI-EA1-3.5.EA1')
     })

--- a/modules/release-analysis/__tests__/server/milestone-dedup.test.js
+++ b/modules/release-analysis/__tests__/server/milestone-dedup.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Regression test for duplicate EA tags in release numbers.
+ * Bug: milestoneToReleaseNumber would append EA tag even when shortname already contained it,
+ * resulting in release numbers like "RHAI-3.5.EA1.EA1" instead of "RHAI-3.5.EA1".
+ *
+ * This is a white-box test - we copy the function here to test it directly.
+ */
+
+function milestoneToReleaseNumber(shortname, milestoneName) {
+  const eaMatch = milestoneName.match(/\b(EA\d?)\b/i)
+  if (eaMatch) {
+    const eaTag = eaMatch[1].toUpperCase()
+    // Check if shortname already ends with this EA tag (case-insensitive)
+    const endsWithEa = new RegExp(`[.\\-_]${eaTag}$`, 'i').test(shortname)
+    if (endsWithEa) {
+      // Already has the EA tag, return as-is
+      return shortname
+    }
+    return `${shortname}.${eaTag}`
+  }
+  // GA milestone → use the parent shortname as-is
+  return shortname
+}
+
+describe('milestoneToReleaseNumber - EA tag deduplication', () => {
+  describe('normal cases (no duplication)', () => {
+    it('appends EA1 when shortname does not contain it', () => {
+      expect(milestoneToReleaseNumber('rhelai-3.4', 'rhelai-3.4 EA1 release'))
+        .toBe('rhelai-3.4.EA1')
+    })
+
+    it('appends EA2 when shortname does not contain it', () => {
+      expect(milestoneToReleaseNumber('RHAIIS-3.4', 'rhaiis-3.4 EA2 GA'))
+        .toBe('RHAIIS-3.4.EA2')
+    })
+
+    it('returns shortname as-is for GA milestone', () => {
+      expect(milestoneToReleaseNumber('rhelai-3.4', 'rhelai-3.4 GA'))
+        .toBe('rhelai-3.4')
+    })
+
+    it('handles EA without digit', () => {
+      expect(milestoneToReleaseNumber('product-1.0', 'product-1.0 EA release'))
+        .toBe('product-1.0.EA')
+    })
+  })
+
+  describe('deduplication cases (prevent RHAI-3.5.EA1.EA1)', () => {
+    it('does not append EA1 when shortname already ends with .EA1', () => {
+      expect(milestoneToReleaseNumber('RHAI-3.5.EA1', 'RHAI 3.5 EA1 release'))
+        .toBe('RHAI-3.5.EA1')
+    })
+
+    it('does not append EA2 when shortname already ends with .EA2', () => {
+      expect(milestoneToReleaseNumber('RHAI-3.5.EA2', 'RHAI 3.5 EA2 GA'))
+        .toBe('RHAI-3.5.EA2')
+    })
+
+    it('handles dash separator (shortname ends with -EA1)', () => {
+      expect(milestoneToReleaseNumber('product-3.5-EA1', 'product 3.5 EA1'))
+        .toBe('product-3.5-EA1')
+    })
+
+    it('handles underscore separator (shortname ends with _EA1)', () => {
+      expect(milestoneToReleaseNumber('product-3.5_EA1', 'product 3.5 EA1'))
+        .toBe('product-3.5_EA1')
+    })
+
+    it('is case-insensitive (shortname has .ea1, milestone has EA1)', () => {
+      expect(milestoneToReleaseNumber('rhai-3.5.ea1', 'RHAI 3.5 EA1'))
+        .toBe('rhai-3.5.ea1')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('does not match EA1 in the middle of shortname', () => {
+      // "EA1" appears in the middle, not at the end - should still append
+      expect(milestoneToReleaseNumber('RHAI-EA1-3.5', 'RHAI 3.5 EA1'))
+        .toBe('RHAI-EA1-3.5.EA1')
+    })
+
+    it('handles multiple EA tags in milestone name (uses first match)', () => {
+      expect(milestoneToReleaseNumber('rhelai-3.4', 'rhelai-3.4 EA1 EA2 release'))
+        .toBe('rhelai-3.4.EA1')
+    })
+
+    it('handles EA without digit when shortname ends with .EA', () => {
+      expect(milestoneToReleaseNumber('product-1.0.EA', 'product EA'))
+        .toBe('product-1.0.EA')
+    })
+  })
+})

--- a/modules/release-analysis/__tests__/server/product-pages.test.js
+++ b/modules/release-analysis/__tests__/server/product-pages.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import * as productPages from '../../server/product-pages.js'
+
+describe('product-pages', () => {
+  describe('extractGaDate', () => {
+    it('extracts GA date from major_milestones with GA (not EA) in name', () => {
+      const release = {
+        major_milestones: [
+          { name: 'RHAI 3.5 EA1', date_finish: '2026-05-01' },
+          { name: 'RHAI 3.5 GA', date_finish: '2026-08-01' }
+        ]
+      }
+      expect(productPages.extractGaDate(release)).toBe('2026-08-01')
+    })
+
+    it('ignores EA milestones when extracting GA date', () => {
+      const release = {
+        major_milestones: [
+          { name: 'RHAI 3.5 EA1 release', date_finish: '2026-05-01' }
+        ],
+        ga_date: '2026-08-01'
+      }
+      expect(productPages.extractGaDate(release)).toBe('2026-08-01')
+    })
+
+    it('falls back to ga_date field when no GA milestone exists', () => {
+      const release = {
+        ga_date: '2026-08-01'
+      }
+      expect(productPages.extractGaDate(release)).toBe('2026-08-01')
+    })
+
+    it('returns null when no GA date can be found', () => {
+      const release = {}
+      expect(productPages.extractGaDate(release)).toBeNull()
+    })
+  })
+
+  describe('extractCodeFreezeDate', () => {
+    it('extracts code freeze date from major_milestones', () => {
+      const release = {
+        major_milestones: [
+          { name: 'Code Freeze', date_finish: '2026-07-15' },
+          { name: 'RHAI 3.5 GA', date_finish: '2026-08-01' }
+        ]
+      }
+      expect(productPages.extractCodeFreezeDate(release)).toBe('2026-07-15')
+    })
+
+    it('prefers EA-scoped code freeze when eaTag is provided', () => {
+      const release = {
+        major_milestones: [
+          { name: 'EA1 Code Freeze', date_finish: '2026-05-01' },
+          { name: 'Code Freeze', date_finish: '2026-07-15' }
+        ]
+      }
+      expect(productPages.extractCodeFreezeDate(release, 'EA1')).toBe('2026-05-01')
+    })
+
+    it('handles various code freeze name formats', () => {
+      const release = {
+        major_milestones: [
+          { name: 'Code-Freeze', date_finish: '2026-07-15' }
+        ]
+      }
+      expect(productPages.extractCodeFreezeDate(release)).toBe('2026-07-15')
+    })
+
+    it('returns null when no code freeze milestone exists', () => {
+      const release = {
+        major_milestones: [
+          { name: 'RHAI 3.5 GA', date_finish: '2026-08-01' }
+        ]
+      }
+      expect(productPages.extractCodeFreezeDate(release)).toBeNull()
+    })
+  })
+
+  describe('milestone expansion and deduplication', () => {
+    // This tests the fix for duplicate EA tags (RHAI-3.5.EA1.EA1)
+    // We test indirectly through the behavior of expandReleaseMilestones
+    // which calls milestoneToReleaseNumber internally
+
+    it('should not create duplicate EA tags in release numbers', () => {
+      // Simulating Product Pages data that would cause duplicates:
+      // - shortname already has .EA1
+      // - milestone name also has EA1
+      // The milestoneToReleaseNumber function should detect this and not append again
+
+      // We can't directly test milestoneToReleaseNumber since it's not exported,
+      // but we can verify the behavior through the public API by checking that
+      // release numbers don't have patterns like "RHAI-3.5.EA1.EA1"
+
+      // This is a regression test - if the bug returns, release numbers will have
+      // duplicate EA tags visible in the analysis output
+      expect(true).toBe(true) // Placeholder - actual test would need fetchProductsByShortname mock
+    })
+  })
+})

--- a/modules/release-analysis/__tests__/server/product-pages.test.js
+++ b/modules/release-analysis/__tests__/server/product-pages.test.js
@@ -75,25 +75,4 @@ describe('product-pages', () => {
       expect(productPages.extractCodeFreezeDate(release)).toBeNull()
     })
   })
-
-  describe('milestone expansion and deduplication', () => {
-    // This tests the fix for duplicate EA tags (RHAI-3.5.EA1.EA1)
-    // We test indirectly through the behavior of expandReleaseMilestones
-    // which calls milestoneToReleaseNumber internally
-
-    it('should not create duplicate EA tags in release numbers', () => {
-      // Simulating Product Pages data that would cause duplicates:
-      // - shortname already has .EA1
-      // - milestone name also has EA1
-      // The milestoneToReleaseNumber function should detect this and not append again
-
-      // We can't directly test milestoneToReleaseNumber since it's not exported,
-      // but we can verify the behavior through the public API by checking that
-      // release numbers don't have patterns like "RHAI-3.5.EA1.EA1"
-
-      // This is a regression test - if the bug returns, release numbers will have
-      // duplicate EA tags visible in the analysis output
-      expect(true).toBe(true) // Placeholder - actual test would need fetchProductsByShortname mock
-    })
-  })
 })

--- a/modules/release-analysis/server/product-pages.js
+++ b/modules/release-analysis/server/product-pages.js
@@ -428,5 +428,6 @@ module.exports = {
   getAuthStatus,
   extractGaDate,
   extractCodeFreezeDate,
+  milestoneToReleaseNumber,
   _resetForTesting
 }

--- a/modules/release-analysis/server/product-pages.js
+++ b/modules/release-analysis/server/product-pages.js
@@ -260,11 +260,20 @@ function expandReleaseMilestones(r, productName) {
  * e.g. (rhelai-3.4, "rhelai-3.4 EA1 release") → "rhelai-3.4.EA1"
  *      (rhelai-3.4, "rhelai-3.4 GA") → "rhelai-3.4"
  *      (RHAIIS-3.4, "rhaiis-3.4 EA2 GA") → "RHAIIS-3.4.EA2"
+ *
+ * Prevents duplicate EA tags when shortname already includes the EA suffix.
  */
 function milestoneToReleaseNumber(shortname, milestoneName) {
   const eaMatch = milestoneName.match(/\b(EA\d?)\b/i)
   if (eaMatch) {
-    return `${shortname}.${eaMatch[1].toUpperCase()}`
+    const eaTag = eaMatch[1].toUpperCase()
+    // Check if shortname already ends with this EA tag (case-insensitive)
+    const endsWithEa = new RegExp(`[.\\-_]${eaTag}$`, 'i').test(shortname)
+    if (endsWithEa) {
+      // Already has the EA tag, return as-is
+      return shortname
+    }
+    return `${shortname}.${eaTag}`
   }
   // GA milestone → use the parent shortname as-is
   return shortname


### PR DESCRIPTION
## Problem

Production Release Analysis displays duplicate EA tags in release labels (e.g., **"RHAI 3.5.EA1.EA1"** instead of **"RHAI 3.5.EA1"**). Local dev environment shows clean labels.

**Screenshots comparison:**
- Local dev: Clean labels (`RHAI 3.5 EA1`, `RHAI 3.5 EA2`)
- Production: Duplicate tags (`RHAI 3.5.EA1.EA1`, `RHAI 3.5.EA2.EA2`)

## Root Cause

The `milestoneToReleaseNumber` function in `modules/release-analysis/server/product-pages.js` (lines 264-271) always appends EA tags without checking if the Product Pages shortname already contains the EA suffix.

When Product Pages returns:
- shortname: `"RHAI-3.5.EA1"` (already has EA1)
- milestone name: `"RHAI 3.5 EA1 release"` (contains EA1)

The function creates: `"RHAI-3.5.EA1" + "." + "EA1"` → **`"RHAI-3.5.EA1.EA1"`** ❌

## Solution

Added deduplication logic to check if shortname already ends with the EA tag before appending it:

```javascript
function milestoneToReleaseNumber(shortname, milestoneName) {
  const eaMatch = milestoneName.match(/\b(EA\d?)\b/i)
  if (eaMatch) {
    const eaTag = eaMatch[1].toUpperCase()
    // Check if shortname already ends with this EA tag (case-insensitive)
    const endsWithEa = new RegExp(`[.\\-_]${eaTag}$`, 'i').test(shortname)
    if (endsWithEa) {
      return shortname  // Already has the EA tag
    }
    return `${shortname}.${eaTag}`
  }
  return shortname
}
```

## Test Coverage

Added comprehensive tests in `modules/release-analysis/__tests__/server/milestone-dedup.test.js`:
- ✅ Normal cases (append EA tag when not present)
- ✅ Deduplication cases (don't append when already present)
- ✅ Edge cases (EA in middle, multiple separators, case sensitivity)

All 12 tests passing.

## Impact

- **Visual**: Cleaner release labels in Release Analysis module
- **Data quality**: Prevents confusion between releases
- **UX**: Easier to identify which EA/GA phase a release is in

## Related

- Jira: [AIPCC-15208](https://redhat.atlassian.net/browse/AIPCC-15208)
- Parent Epic: [AIPCC-13855](https://redhat.atlassian.net/browse/AIPCC-13855) (Org Pulse Feature Backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)