### PR TITLE
fix(ci): remove invalid 'workflows' permission from Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  workflows: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Problem

The Claude Review workflow has been failing on **all PRs** since April 29 with:

```
Error at line 23, column 3: "Unexpected value 'workflows'"
```

This prevents the required "Claude Review" status check from ever running, blocking all PR merges (including #454).

## Root Cause

Commit 1e89365 added `workflows: write` permission to `.github/workflows/claude-review.yml`, but **`workflows` is not a valid GitHub Actions permission**.

Valid permissions are:
- `actions`, `checks`, `contents`, `deployments`, `id-token`, `issues`, `metadata`, `packages`, `pages`, `pull-requests`, `repository-projects`, `security-events`, `statuses`, `discussions`

## Fix

Remove the invalid `workflows: write` line from the permissions block.

## Testing

Once merged, the Claude Review workflow should execute successfully on PRs instead of failing during initialization.

## Impact

This unblocks all pending PRs that are waiting for the Claude Review check, including:
- #454 (duplicate EA tags fix)
- Any other PRs blocked by this check

---

Fixes the workflow validation error introduced in 1e893658269952c38d5bd2da2da1867ffafb492b