### PR TITLE
fix(release-analysis): fix Other Open Work metric and version grouping

### DIFF
--- a/modules/release-analysis/client/components/ComponentDetailRow.vue
+++ b/modules/release-analysis/client/components/ComponentDetailRow.vue
@@ -50,7 +50,7 @@
           <p class="text-[10px] text-indigo-500 dark:text-indigo-400 mb-0.5 leading-tight font-medium">Release Load</p>
           <p class="text-sm font-bold text-indigo-700 dark:text-indigo-300 tabular-nums">{{ comp.currentReleaseLoad }}</p>
         </div>
-        <div class="rounded-lg bg-orange-50/70 dark:bg-orange-900/20 border border-orange-200/60 dark:border-orange-700/40 px-2.5 py-2 text-center" title="Currently open (unclosed) issues assigned to this component in other fixVersions or with no version assigned">
+        <div class="rounded-lg bg-orange-50/70 dark:bg-orange-900/20 border border-orange-200/60 dark:border-orange-700/40 px-2.5 py-2 text-center" title="Currently open (unclosed) issues assigned to this component in other fixVersions (excludes issues with no version assigned)">
           <p class="text-[10px] text-orange-500 dark:text-orange-400 mb-0.5 leading-tight font-medium">Other Open Work</p>
           <p class="text-sm font-bold tabular-nums" :class="comp.globalOtherWorkload > 0 ? 'text-orange-700 dark:text-orange-300' : 'text-gray-400 dark:text-gray-500'">{{ comp.globalOtherWorkload }}</p>
         </div>

--- a/modules/release-analysis/client/composables/useReleaseFilter.js
+++ b/modules/release-analysis/client/composables/useReleaseFilter.js
@@ -12,6 +12,14 @@ export function extractVersion(releaseNumber) {
   return dash > 0 ? s.slice(dash + 1) : s
 }
 
+/**
+ * Normalize a version string for grouping so that punctuation/spacing
+ * differences (e.g. "3.5.EA1" vs "3.5 EA1") map to the same group key.
+ */
+export function normalizeVersionKey(version) {
+  return (version || '').replace(/[\s.]+/g, '.').toLowerCase()
+}
+
 
 function aggregateRisk(releases) {
   if (releases.some(r => r.risk === 'red')) return 'red'
@@ -48,16 +56,23 @@ export function useReleaseFilter(allReleases) {
     [...new Set(allReleases.value.map(r => extractProduct(r.releaseNumber)).filter(Boolean))].sort()
   )
 
-  const allVersions = computed(() =>
-    [...new Set(allReleases.value.map(r => extractVersion(r.releaseNumber)).filter(Boolean))]
-      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-  )
+  const allVersions = computed(() => {
+    const seen = new Map()
+    for (const r of allReleases.value) {
+      const raw = extractVersion(r.releaseNumber)
+      if (!raw) continue
+      const key = normalizeVersionKey(raw)
+      if (!seen.has(key)) seen.set(key, raw)
+    }
+    return [...seen.values()].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+  })
 
   const visibleProducts = computed(() => {
     if (!selectedVersions.size) return allProducts.value
+    const selKeys = new Set([...selectedVersions].map(normalizeVersionKey))
     return [...new Set(
       allReleases.value
-        .filter(r => selectedVersions.has(extractVersion(r.releaseNumber)))
+        .filter(r => selKeys.has(normalizeVersionKey(extractVersion(r.releaseNumber))))
         .map(r => extractProduct(r.releaseNumber))
         .filter(Boolean)
     )].sort()
@@ -65,12 +80,15 @@ export function useReleaseFilter(allReleases) {
 
   const visibleVersions = computed(() => {
     if (!selectedProducts.size) return allVersions.value
-    return [...new Set(
-      allReleases.value
-        .filter(r => selectedProducts.has(extractProduct(r.releaseNumber)))
-        .map(r => extractVersion(r.releaseNumber))
-        .filter(Boolean)
-    )].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    const seen = new Map()
+    for (const r of allReleases.value) {
+      if (!selectedProducts.has(extractProduct(r.releaseNumber))) continue
+      const raw = extractVersion(r.releaseNumber)
+      if (!raw) continue
+      const key = normalizeVersionKey(raw)
+      if (!seen.has(key)) seen.set(key, raw)
+    }
+    return [...seen.values()].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
   })
 
   watch(visibleProducts, (available) => {
@@ -96,23 +114,32 @@ export function useReleaseFilter(allReleases) {
   }
 
   const filteredReleases = computed(() => {
+    const selVerKeys = selectedVersions.size
+      ? new Set([...selectedVersions].map(normalizeVersionKey))
+      : null
     return allReleases.value.filter(r => {
       if (selectedProducts.size && !selectedProducts.has(extractProduct(r.releaseNumber))) return false
-      if (selectedVersions.size && !selectedVersions.has(extractVersion(r.releaseNumber))) return false
+      if (selVerKeys && !selVerKeys.has(normalizeVersionKey(extractVersion(r.releaseNumber)))) return false
       return true
     })
   })
 
   const groupedByVersion = computed(() => {
     const map = new Map()
+    const displayVersion = new Map()
     for (const r of filteredReleases.value) {
-      const majorVer = extractVersion(r.releaseNumber)
-      if (!map.has(majorVer)) map.set(majorVer, [])
-      map.get(majorVer).push(r)
+      const rawVer = extractVersion(r.releaseNumber)
+      const groupKey = normalizeVersionKey(rawVer)
+      if (!map.has(groupKey)) {
+        map.set(groupKey, [])
+        displayVersion.set(groupKey, rawVer)
+      }
+      map.get(groupKey).push(r)
     }
 
     const groups = []
-    for (const [version, releases] of map) {
+    for (const [groupKey, releases] of map) {
+      const version = displayVersion.get(groupKey)
       const earliest = releases.reduce((min, r) => {
         const d = new Date(r.dueDate)
         return d < min ? d : min

--- a/modules/release-analysis/client/composables/useReleaseFilter.js
+++ b/modules/release-analysis/client/composables/useReleaseFilter.js
@@ -12,14 +12,9 @@ export function extractVersion(releaseNumber) {
   return dash > 0 ? s.slice(dash + 1) : s
 }
 
-/**
- * Normalize a version string for grouping so that punctuation/spacing
- * differences (e.g. "3.5.EA1" vs "3.5 EA1") map to the same group key.
- */
 export function normalizeVersionKey(version) {
   return (version || '').replace(/[\s.]+/g, '.').toLowerCase()
 }
-
 
 function aggregateRisk(releases) {
   if (releases.some(r => r.risk === 'red')) return 'red'
@@ -98,8 +93,9 @@ export function useReleaseFilter(allReleases) {
   })
 
   watch(visibleVersions, (available) => {
+    const availableKeys = new Set(available.map(normalizeVersionKey))
     for (const v of [...selectedVersions]) {
-      if (!available.includes(v)) selectedVersions.delete(v)
+      if (!availableKeys.has(normalizeVersionKey(v))) selectedVersions.delete(v)
     }
   })
 

--- a/modules/release-analysis/server/index.js
+++ b/modules/release-analysis/server/index.js
@@ -774,22 +774,22 @@ async function fetchHistoricalComponentVelocity(config) {
 }
 
 /**
- * Fetches all unclosed (statusCategory != Done) work-item issues per component
- * across ALL fixVersions (or no version). Returns a map of
+ * Fetches unclosed (statusCategory != Done) work-item issues per component
+ * that have a fixVersion assigned. Returns a map of
  * { componentName: { totalOpen, openByVersion: { versionName: count } } }.
  *
- * This powers the "True Capacity" view — letting leadership see total open
- * workload on a component team, not just what's in the target release.
+ * "Other Open Work" on a release card = totalOpen − currentReleaseOpen,
+ * i.e. versioned open work on other releases.
  */
 async function fetchComponentGlobalWorkload(config) {
   const typeList = VELOCITY_WORK_TYPES.map(t => `"${t}"`).join(',')
 
   let jql
   if (config.jiraAllProjects) {
-    jql = `issuetype in (${typeList}) AND statusCategory != Done AND created >= -1y ORDER BY key ASC`
+    jql = `issuetype in (${typeList}) AND statusCategory != Done AND fixVersion is not EMPTY ORDER BY key ASC`
   } else {
     if (!config.projectKeys.length) return {}
-    jql = `project in (${config.projectKeys.join(',')}) AND issuetype in (${typeList}) AND statusCategory != Done AND created >= -1y ORDER BY key ASC`
+    jql = `project in (${config.projectKeys.join(',')}) AND issuetype in (${typeList}) AND statusCategory != Done AND fixVersion is not EMPTY ORDER BY key ASC`
   }
 
   let allIssues
@@ -808,7 +808,9 @@ async function fetchComponentGlobalWorkload(config) {
     if (!components.length) continue
 
     const versions = extractFixVersions(issue)
-    const versionLabel = versions.length ? versions[0] : '(none)'
+    if (!versions.length) continue
+
+    const versionLabel = versions[0]
 
     for (const comp of components) {
       if (!workload[comp]) workload[comp] = { totalOpen: 0, openByVersion: {} }


### PR DESCRIPTION
## Summary
- **Fixed "Other Open Work" always showing 0**: The global workload JQL query used `created >= -1y` which is unsupported by the Jira v3 search API, silently returning 0 issues. Removed the broken date filter and added `fixVersion is not EMPTY` so the metric only counts versioned open work on other releases (excluding unversioned/backlog items).
- **Fixed RHAII releases not grouping with RHOAI/RHELAI**: Version grouping now normalizes punctuation/spacing differences (e.g. "3.5.EA1" vs "3.5 EA1") so releases from all products appear in the same version group. This also applies to version filter chips.

## Changes
- `modules/release-analysis/server/index.js` — Removed broken `created >= -1y` from `fetchComponentGlobalWorkload` JQL; added `fixVersion is not EMPTY`; skip issues without fix versions in aggregation loop
- `modules/release-analysis/client/composables/useReleaseFilter.js` — Added `normalizeVersionKey()` for grouping; updated `groupedByVersion`, `allVersions`, `visibleVersions`, `visibleProducts`, and `filteredReleases` to use normalized version matching
- `modules/release-analysis/client/components/ComponentDetailRow.vue` — Updated tooltip text

## Test plan
- [ ] Verify "Other Open Work" shows non-zero values for components with open issues in other releases
- [ ] Verify RHAII-3.5 EA1 release card appears in the same version group as rhoai-3.5.EA1 and rhelai-3.5.EA1
- [ ] Verify version filter chips correctly filter across equivalent version strings
- [ ] Run `npm run lint` and `npm test` — both pass

Made with [Cursor](https://cursor.com)