### PR TITLE
feat(ai-impact): sync feature metadata from Jira and surface approval info

### DIFF
--- a/deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml
+++ b/deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml
@@ -159,6 +159,30 @@ spec:
                     echo "WARNING: Allocation Tracker refresh timed out (non-fatal, continuing)"
                   fi
 
+                  # Step 4b: Sync feature labels from Jira
+                  echo "=== Triggering Feature Jira Sync ==="
+                  curl -sf -X POST "$BACKEND/api/modules/ai-impact/features/sync" \
+                    -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" || echo "Feature Jira sync skipped"
+
+                  ATTEMPTS=0
+                  MAX_ATTEMPTS=30
+                  while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
+                    sleep 10
+                    ATTEMPTS=$((ATTEMPTS + 1))
+                    STATUS=$(curl -sf "$BACKEND/api/modules/ai-impact/features/sync/status" \
+                      -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER")
+                    RUNNING=$(echo "$STATUS" | grep -oE '"running"\s*:\s*true' || true)
+                    if [ -z "$RUNNING" ]; then
+                      echo "Feature Jira sync complete after $ATTEMPTS checks"
+                      break
+                    fi
+                    echo "Still syncing... (attempt $ATTEMPTS/$MAX_ATTEMPTS)"
+                  done
+
+                  if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
+                    echo "WARNING: Feature Jira sync timed out (non-fatal, continuing)"
+                  fi
+
                   # Step 5: Trigger Feature Traffic refresh
                   echo "=== Triggering Feature Traffic refresh ==="
                   curl -sf -X POST "$BACKEND/api/modules/feature-traffic/refresh" \

--- a/modules/ai-impact/__tests__/server/feature-routes.test.js
+++ b/modules/ai-impact/__tests__/server/feature-routes.test.js
@@ -97,6 +97,7 @@ describe('GET /features/status', () => {
     const { res } = await callHandler(routes, 'GET', '/features/status');
     expect(res.json).toHaveBeenCalledWith({
       lastSyncedAt: '2026-04-19T12:00:00Z',
+      lastJiraSyncAt: null,
       totalFeatures: 2,
       totalHistoryEntries: 3
     });
@@ -137,6 +138,8 @@ describe('GET /features', () => {
     const { res } = await callHandler(routes, 'GET', '/features');
     const payload = res.json.mock.calls[0][0];
     expect(payload.features.A.scores).toBeDefined();
+    expect(payload.features.A.approvedBy).toBeNull();
+    expect(payload.features.A.approvedAt).toBeNull();
     expect(payload.features.A.labels).toBeUndefined();
     expect(payload.features.A.runId).toBeUndefined();
     expect(payload.features.A.runTimestamp).toBeUndefined();

--- a/modules/ai-impact/__tests__/server/jira-sync.test.js
+++ b/modules/ai-impact/__tests__/server/jira-sync.test.js
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock shared/server/jira to avoid credential check at require time
+vi.mock('../../../../shared/server/jira', () => ({
+  jiraRequest: vi.fn(),
+  fetchAllJqlResults: vi.fn()
+}));
+
+import { applyJiraFields, syncFeatureData, extractSignOffInfo } from '../../server/features/jira-sync.js';
+
+function makeEntry(overrides = {}) {
+  return {
+    latest: {
+      key: 'RHAISTRAT-100',
+      title: 'Original Title',
+      sourceRfe: 'RHAIRFE-1',
+      priority: 'Major',
+      status: 'Refined',
+      size: 'L',
+      recommendation: 'approve',
+      needsAttention: false,
+      humanReviewStatus: 'awaiting-review',
+      scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2, total: 8 },
+      reviewers: { feasibility: 'approve', testability: 'approve', scope: 'approve', architecture: 'approve' },
+      labels: ['strat-creator-auto-created'],
+      reviewedAt: '2026-04-19T12:00:00Z',
+      ...overrides
+    },
+    history: []
+  };
+}
+
+function makeJiraIssue(key, overrides = {}) {
+  return {
+    key,
+    fields: {
+      summary: 'Updated Title',
+      status: { name: 'In Progress' },
+      priority: { name: 'Critical' },
+      labels: ['strat-creator-auto-created', 'strat-creator-human-sign-off'],
+      ...overrides
+    }
+  };
+}
+
+describe('applyJiraFields', () => {
+  it('returns unchanged when nothing differs', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+    const issue = {
+      key: 'RHAISTRAT-100',
+      fields: {
+        summary: 'Original Title',
+        status: { name: 'Refined' },
+        priority: { name: 'Major' },
+        labels: ['strat-creator-auto-created']
+      }
+    };
+    expect(applyJiraFields(data, issue)).toBe('unchanged');
+  });
+
+  it('returns updated when title/status/priority change but not humanReviewStatus', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+    const issue = {
+      key: 'RHAISTRAT-100',
+      fields: {
+        summary: 'New Title',
+        status: { name: 'In Progress' },
+        priority: { name: 'Critical' },
+        labels: ['strat-creator-auto-created']
+      }
+    };
+    const result = applyJiraFields(data, issue);
+    expect(result).toBe('updated');
+    expect(data.features['RHAISTRAT-100'].latest.title).toBe('New Title');
+    expect(data.features['RHAISTRAT-100'].latest.status).toBe('In Progress');
+    expect(data.features['RHAISTRAT-100'].latest.priority).toBe('Critical');
+    // No history entry created
+    expect(data.features['RHAISTRAT-100'].history).toHaveLength(0);
+  });
+
+  it('returns status_changed and creates history when humanReviewStatus changes', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+    const issue = makeJiraIssue('RHAISTRAT-100');
+    const result = applyJiraFields(data, issue);
+    expect(result).toBe('status_changed');
+    expect(data.features['RHAISTRAT-100'].latest.humanReviewStatus).toBe('approved');
+    expect(data.features['RHAISTRAT-100'].latest.labels).toContain('strat-creator-human-sign-off');
+    // History should have the previous state
+    expect(data.features['RHAISTRAT-100'].history).toHaveLength(1);
+    expect(data.features['RHAISTRAT-100'].history[0].humanReviewStatus).toBe('awaiting-review');
+  });
+
+  it('returns unchanged for unknown feature key', () => {
+    const data = { features: {} };
+    const issue = makeJiraIssue('RHAISTRAT-999');
+    expect(applyJiraFields(data, issue)).toBe('unchanged');
+  });
+
+  it('maps unknown Jira priority to Undefined', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+    const issue = {
+      key: 'RHAISTRAT-100',
+      fields: {
+        summary: 'Original Title',
+        status: { name: 'Refined' },
+        priority: { name: 'Trivial' },
+        labels: ['strat-creator-auto-created']
+      }
+    };
+    applyJiraFields(data, issue);
+    expect(data.features['RHAISTRAT-100'].latest.priority).toBe('Undefined');
+  });
+
+  it('stores approvedBy/approvedAt from changelog when sign-off label is added', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+    const issue = {
+      ...makeJiraIssue('RHAISTRAT-100'),
+      changelog: {
+        histories: [{
+          created: '2026-04-20T10:00:00.000+0000',
+          author: { displayName: 'Jane Smith' },
+          items: [{
+            field: 'labels',
+            fromString: 'strat-creator-auto-created',
+            toString: 'strat-creator-auto-created strat-creator-human-sign-off'
+          }]
+        }]
+      }
+    };
+    applyJiraFields(data, issue);
+    const latest = data.features['RHAISTRAT-100'].latest;
+    expect(latest.approvedBy).toBe('Jane Smith');
+    expect(latest.approvedAt).toBe('2026-04-20T10:00:00.000+0000');
+  });
+
+  it('clears approval info when sign-off label is removed', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry({
+          approvedBy: 'Jane Smith',
+          approvedAt: '2026-04-20T10:00:00.000+0000',
+          humanReviewStatus: 'approved',
+          labels: ['strat-creator-auto-created', 'strat-creator-human-sign-off']
+        })
+      }
+    };
+    const issue = {
+      key: 'RHAISTRAT-100',
+      fields: {
+        summary: 'Original Title',
+        status: { name: 'Refined' },
+        priority: { name: 'Major' },
+        labels: ['strat-creator-auto-created']
+      }
+    };
+    applyJiraFields(data, issue);
+    const latest = data.features['RHAISTRAT-100'].latest;
+    expect(latest.humanReviewStatus).toBe('awaiting-review');
+    expect(latest.approvedBy).toBeUndefined();
+    expect(latest.approvedAt).toBeUndefined();
+  });
+
+  it('preserves scores and recommendation when updating from Jira', () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+    const issue = makeJiraIssue('RHAISTRAT-100');
+    applyJiraFields(data, issue);
+    const latest = data.features['RHAISTRAT-100'].latest;
+    expect(latest.scores.total).toBe(8);
+    expect(latest.recommendation).toBe('approve');
+    expect(latest.reviewedAt).toBe('2026-04-19T12:00:00Z');
+  });
+
+  it('caps history at MAX_HISTORY', () => {
+    const entry = makeEntry();
+    // Fill history to capacity
+    entry.history = Array.from({ length: 20 }, (_, i) => ({
+      scores: { feasibility: 1, testability: 1, scope: 1, architecture: 1, total: 4 },
+      recommendation: 'revise',
+      needsAttention: false,
+      humanReviewStatus: 'awaiting-review',
+      reviewedAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`
+    }));
+    const data = { features: { 'RHAISTRAT-100': entry } };
+    const issue = makeJiraIssue('RHAISTRAT-100');
+    applyJiraFields(data, issue);
+    expect(data.features['RHAISTRAT-100'].history).toHaveLength(20);
+  });
+});
+
+describe('extractSignOffInfo', () => {
+  it('returns null when changelog is missing', () => {
+    expect(extractSignOffInfo(null)).toBeNull();
+    expect(extractSignOffInfo({})).toBeNull();
+    expect(extractSignOffInfo({ histories: [] })).toBeNull();
+  });
+
+  it('extracts author and date when sign-off label is added', () => {
+    const changelog = {
+      histories: [{
+        created: '2026-04-20T10:00:00.000+0000',
+        author: { displayName: 'Jane Smith' },
+        items: [{
+          field: 'labels',
+          fromString: 'strat-creator-auto-created',
+          toString: 'strat-creator-auto-created strat-creator-human-sign-off'
+        }]
+      }]
+    };
+    const result = extractSignOffInfo(changelog);
+    expect(result).toEqual({
+      approvedBy: 'Jane Smith',
+      approvedAt: '2026-04-20T10:00:00.000+0000'
+    });
+  });
+
+  it('returns the latest sign-off when label is toggled multiple times', () => {
+    const changelog = {
+      histories: [
+        {
+          created: '2026-04-18T08:00:00.000+0000',
+          author: { displayName: 'Alice' },
+          items: [{
+            field: 'labels',
+            fromString: 'strat-creator-auto-created',
+            toString: 'strat-creator-auto-created strat-creator-human-sign-off'
+          }]
+        },
+        {
+          created: '2026-04-19T08:00:00.000+0000',
+          author: { displayName: 'Bob' },
+          items: [{
+            field: 'labels',
+            fromString: 'strat-creator-auto-created strat-creator-human-sign-off',
+            toString: 'strat-creator-auto-created'
+          }]
+        },
+        {
+          created: '2026-04-20T08:00:00.000+0000',
+          author: { displayName: 'Charlie' },
+          items: [{
+            field: 'labels',
+            fromString: 'strat-creator-auto-created',
+            toString: 'strat-creator-auto-created strat-creator-human-sign-off'
+          }]
+        }
+      ]
+    };
+    const result = extractSignOffInfo(changelog);
+    expect(result.approvedBy).toBe('Charlie');
+    expect(result.approvedAt).toBe('2026-04-20T08:00:00.000+0000');
+  });
+
+  it('ignores non-label changelog entries', () => {
+    const changelog = {
+      histories: [{
+        created: '2026-04-20T10:00:00.000+0000',
+        author: { displayName: 'Jane' },
+        items: [{
+          field: 'status',
+          fromString: 'New',
+          toString: 'In Progress'
+        }]
+      }]
+    };
+    expect(extractSignOffInfo(changelog)).toBeNull();
+  });
+});
+
+describe('syncFeatureData', () => {
+  it('returns zero counts when no features exist', async () => {
+    const mockFetch = vi.fn();
+    const data = { features: {} };
+    const result = await syncFeatureData(data, mockFetch);
+    expect(result.synced).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches features in batches and applies updates', async () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue([
+      makeJiraIssue('RHAISTRAT-100')
+    ]);
+
+    const result = await syncFeatureData(data, mockFetch);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.synced).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.statusChanged).toBe(1);
+    expect(result.notFound).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('counts features not found in Jira', async () => {
+    const data = {
+      features: {
+        'RHAISTRAT-100': makeEntry()
+      }
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue([]);
+
+    const result = await syncFeatureData(data, mockFetch);
+    expect(result.synced).toBe(0);
+    expect(result.notFound).toBe(1);
+  });
+
+  it('handles batch errors gracefully and continues', async () => {
+    // Create enough features to trigger multiple batches (>50)
+    const features = {};
+    for (let i = 0; i < 60; i++) {
+      features[`RHAISTRAT-${i}`] = makeEntry({ key: `RHAISTRAT-${i}` });
+    }
+    const data = { features };
+
+    const mockFetch = vi.fn()
+      .mockRejectedValueOnce(new Error('Jira unavailable'))
+      .mockRejectedValueOnce(new Error('Jira unavailable'));
+
+    const result = await syncFeatureData(data, mockFetch);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toContain('Batch 1/2 failed');
+    expect(result.errors[1]).toContain('Batch 2/2 failed');
+  });
+});

--- a/modules/ai-impact/client/components/AIImpactSettings.vue
+++ b/modules/ai-impact/client/components/AIImpactSettings.vue
@@ -19,6 +19,8 @@ const featureStatus = ref(null)
 const featureStatusLoading = ref(false)
 const clearingFeatures = ref(false)
 const clearFeaturesResult = ref(null)
+const syncStatus = ref(null)
+const syncTriggering = ref(false)
 
 async function loadConfig() {
   loading.value = true
@@ -89,6 +91,39 @@ async function pollRefreshStatus() {
   setTimeout(poll, 2000)
 }
 
+async function triggerFeatureSync() {
+  syncTriggering.value = true
+  try {
+    const result = await apiRequest('/modules/ai-impact/features/sync', { method: 'POST' })
+    syncStatus.value = result
+    if (result.status === 'started') {
+      pollSyncStatus()
+    }
+  } catch (e) {
+    syncStatus.value = { status: 'error', message: e.message }
+  } finally {
+    syncTriggering.value = false
+  }
+}
+
+async function pollSyncStatus() {
+  const poll = async () => {
+    try {
+      const status = await apiRequest('/modules/ai-impact/features/sync/status')
+      syncStatus.value = status
+      if (status.running) {
+        setTimeout(poll, 3000)
+      } else {
+        // Reload feature status after sync completes
+        loadFeatureStatus()
+      }
+    } catch {
+      // ignore polling errors
+    }
+  }
+  setTimeout(poll, 2000)
+}
+
 async function clearCache() {
   clearingCache.value = true
   clearCacheResult.value = null
@@ -106,6 +141,14 @@ async function clearCache() {
 async function checkRefreshStatus() {
   try {
     refreshStatus.value = await apiRequest('/modules/ai-impact/refresh/status')
+  } catch {
+    // ignore
+  }
+}
+
+async function checkSyncStatus() {
+  try {
+    syncStatus.value = await apiRequest('/modules/ai-impact/features/sync/status')
   } catch {
     // ignore
   }
@@ -166,6 +209,7 @@ async function clearFeatures() {
 onMounted(() => {
   loadConfig()
   checkRefreshStatus()
+  checkSyncStatus()
   loadAssessmentStatus()
   loadFeatureStatus()
 })
@@ -326,39 +370,85 @@ function getAutofixProjectsDisplay() {
       </div>
     </div>
 
-    <!-- Manual Refresh -->
+    <!-- Data Refresh -->
     <div class="border-t border-gray-200 dark:border-gray-700 pt-4">
-      <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Data Refresh</h4>
-      <div class="flex items-center gap-3">
-        <button
-          @click="triggerRefresh"
-          :disabled="refreshTriggering || refreshStatus?.running"
-          class="px-4 py-2 bg-gray-800 text-white rounded-md text-sm hover:bg-gray-900 disabled:opacity-50"
-        >
-          {{ refreshStatus?.running ? 'Refreshing...' : 'Refresh Now' }}
-        </button>
-        <button
-          @click="clearCache"
-          :disabled="clearingCache"
-          class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md text-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
-        >
-          {{ clearingCache ? 'Clearing...' : 'Clear Cached Data' }}
-        </button>
-        <span v-if="clearCacheResult" class="text-sm" :class="clearCacheResult.status === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
-          {{ clearCacheResult.message }}
-        </span>
-        <div v-if="refreshStatus?.lastResult" class="text-sm text-gray-500 dark:text-gray-400">
-          Last refresh:
-          <span :class="refreshStatus.lastResult.status === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
-            {{ refreshStatus.lastResult.status }}
-          </span>
-          <span v-if="refreshStatus.lastResult.message"> &mdash; {{ refreshStatus.lastResult.message }}</span>
-          <span v-if="refreshStatus.lastResult.completedAt">
-            at {{ new Date(refreshStatus.lastResult.completedAt).toLocaleString() }}
-          </span>
+      <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Data Refresh</h4>
+      <div class="space-y-4">
+        <!-- RFE & AutoFix refresh -->
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-2">
+            <div>
+              <h5 class="text-sm font-medium text-gray-800 dark:text-gray-200">RFE & AutoFix Data</h5>
+              <p class="text-xs text-gray-500 dark:text-gray-400">Fetches RFE issues and AutoFix pipeline data from Jira</p>
+            </div>
+            <div class="flex items-center gap-2">
+              <button
+                @click="triggerRefresh"
+                :disabled="refreshTriggering || refreshStatus?.running"
+                class="px-3 py-1.5 bg-gray-800 dark:bg-gray-600 text-white rounded-md text-sm hover:bg-gray-900 dark:hover:bg-gray-500 disabled:opacity-50"
+              >
+                {{ refreshStatus?.running ? 'Refreshing...' : 'Refresh' }}
+              </button>
+              <button
+                @click="clearCache"
+                :disabled="clearingCache"
+                class="px-3 py-1.5 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md text-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                {{ clearingCache ? 'Clearing...' : 'Clear Cache' }}
+              </button>
+            </div>
+          </div>
+          <div v-if="clearCacheResult" class="text-sm mb-1" :class="clearCacheResult.status === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+            {{ clearCacheResult.message }}
+          </div>
+          <div v-if="refreshStatus?.lastResult" class="text-xs text-gray-500 dark:text-gray-400">
+            Last refresh:
+            <span :class="refreshStatus.lastResult.status === 'success' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+              {{ refreshStatus.lastResult.status }}
+            </span>
+            <span v-if="refreshStatus.lastResult.message"> &mdash; {{ refreshStatus.lastResult.message }}</span>
+            <span v-if="refreshStatus.lastResult.completedAt">
+              at {{ new Date(refreshStatus.lastResult.completedAt).toLocaleString() }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Feature Jira Sync -->
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-2">
+            <div>
+              <h5 class="text-sm font-medium text-gray-800 dark:text-gray-200">Feature Jira Sync</h5>
+              <p class="text-xs text-gray-500 dark:text-gray-400">Syncs title, status, priority, and labels (including human sign-off) from Jira for all tracked features</p>
+            </div>
+            <button
+              @click="triggerFeatureSync"
+              :disabled="syncTriggering || syncStatus?.running"
+              class="px-3 py-1.5 bg-gray-800 dark:bg-gray-600 text-white rounded-md text-sm hover:bg-gray-900 dark:hover:bg-gray-500 disabled:opacity-50"
+            >
+              {{ syncStatus?.running ? 'Syncing...' : 'Sync Now' }}
+            </button>
+          </div>
+          <div v-if="syncStatus?.lastResult" class="text-xs text-gray-500 dark:text-gray-400">
+            Last sync:
+            <span :class="{
+              'text-green-600 dark:text-green-400': syncStatus.lastResult.status === 'success',
+              'text-amber-600 dark:text-amber-400': syncStatus.lastResult.status === 'partial',
+              'text-red-600 dark:text-red-400': syncStatus.lastResult.status === 'error'
+            }">
+              {{ syncStatus.lastResult.status }}
+            </span>
+            <span v-if="syncStatus.lastResult.message"> &mdash; {{ syncStatus.lastResult.message }}</span>
+            <span v-if="syncStatus.lastResult.completedAt">
+              at {{ new Date(syncStatus.lastResult.completedAt).toLocaleString() }}
+            </span>
+            <div v-if="syncStatus.lastResult.errors" class="mt-1 text-red-500 dark:text-red-400">
+              <div v-for="(err, i) in syncStatus.lastResult.errors" :key="i">{{ err }}</div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
+
     <!-- Assessment Data -->
     <div class="border-t border-gray-200 dark:border-gray-700 pt-4">
       <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Assessment Data</h4>
@@ -395,12 +485,13 @@ function getAutofixProjectsDisplay() {
       </template>
       <div v-else class="text-sm text-gray-500 dark:text-gray-400">No assessment data available</div>
     </div>
+
     <!-- Feature Review Data -->
     <div class="border-t border-gray-200 dark:border-gray-700 pt-4">
       <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Feature Reviews</h4>
       <div v-if="featureStatusLoading" class="text-sm text-gray-500 dark:text-gray-400">Loading feature status...</div>
       <template v-else-if="featureStatus">
-        <div class="grid grid-cols-3 gap-4 mb-3">
+        <div class="grid grid-cols-4 gap-4 mb-3">
           <div class="bg-gray-50 dark:bg-gray-700 rounded-md p-3">
             <p class="text-xs text-gray-500 dark:text-gray-400">Total Features</p>
             <p class="text-lg font-semibold dark:text-gray-200">{{ featureStatus.totalFeatures }}</p>
@@ -410,9 +501,15 @@ function getAutofixProjectsDisplay() {
             <p class="text-lg font-semibold dark:text-gray-200">{{ featureStatus.totalHistoryEntries }}</p>
           </div>
           <div class="bg-gray-50 dark:bg-gray-700 rounded-md p-3">
-            <p class="text-xs text-gray-500 dark:text-gray-400">Last Synced</p>
+            <p class="text-xs text-gray-500 dark:text-gray-400">Last Pipeline Sync</p>
             <p class="text-sm font-medium dark:text-gray-200">
               {{ featureStatus.lastSyncedAt ? new Date(featureStatus.lastSyncedAt).toLocaleString() : 'Never' }}
+            </p>
+          </div>
+          <div class="bg-gray-50 dark:bg-gray-700 rounded-md p-3">
+            <p class="text-xs text-gray-500 dark:text-gray-400">Last Jira Sync</p>
+            <p class="text-sm font-medium dark:text-gray-200">
+              {{ featureStatus.lastJiraSyncAt ? new Date(featureStatus.lastJiraSyncAt).toLocaleString() : 'Never' }}
             </p>
           </div>
         </div>

--- a/modules/ai-impact/client/components/FeatureDetailPanel.vue
+++ b/modules/ai-impact/client/components/FeatureDetailPanel.vue
@@ -168,6 +168,19 @@ const history = computed(() => featureDetail.value?.history || [])
               </div>
             </div>
 
+            <!-- Approval info -->
+            <div v-if="feature.humanReviewStatus === 'approved' && (feature.approvedBy || featureDetail?.latest?.approvedBy)" class="mb-6 px-3 py-2.5 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
+              <div class="flex items-center gap-2 text-sm text-green-800 dark:text-green-300">
+                <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                <span>
+                  Approved by <span class="font-medium">{{ feature.approvedBy || featureDetail?.latest?.approvedBy }}</span>
+                  <span v-if="feature.approvedAt || featureDetail?.latest?.approvedAt" class="text-green-600 dark:text-green-400">
+                    on {{ new Date(feature.approvedAt || featureDetail?.latest?.approvedAt).toLocaleDateString() }}
+                  </span>
+                </span>
+              </div>
+            </div>
+
             <!-- Source RFE -->
             <div class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
               <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Source RFE</h4>

--- a/modules/ai-impact/server/features/jira-sync.js
+++ b/modules/ai-impact/server/features/jira-sync.js
@@ -1,0 +1,197 @@
+const { jiraRequest, fetchAllJqlResults } = require('../../../../shared/server/jira');
+const { deriveHumanReviewStatus, PRIORITIES } = require('./validation');
+const { readFeatures, writeFeaturesAtomic, trimForHistory, MAX_HISTORY } = require('./storage');
+
+const BATCH_SIZE = 50;
+const BATCH_DELAY_MS = 1000;
+
+/**
+ * In-memory lock to prevent concurrent writes to features.json.
+ * Shared with routes.js via module exports.
+ */
+const featureLock = { held: false };
+
+/**
+ * Acquire the feature write lock. Returns true if acquired, false if already held.
+ */
+function acquireLock() {
+  if (featureLock.held) return false;
+  featureLock.held = true;
+  return true;
+}
+
+function releaseLock() {
+  featureLock.held = false;
+}
+
+/**
+ * Sync feature metadata from Jira for all features in storage.
+ * Reads from storage, syncs from Jira, writes back.
+ *
+ * @param {Function} readFromStorage
+ * @returns {Promise<{synced: number, updated: number, statusChanged: number, notFound: number, errors: string[]}>}
+ */
+async function syncFeaturesFromJira(readFromStorage) {
+  const data = readFeatures(readFromStorage);
+  const result = await syncFeatureData(data);
+  data.lastJiraSyncAt = new Date().toISOString();
+  writeFeaturesAtomic(data);
+  return result;
+}
+
+/**
+ * Core sync logic: fetches Jira data for all features and applies updates.
+ * Operates on the data object in-memory (mutates in place).
+ * Separated from I/O for testability.
+ *
+ * @param {object} data - The full features data object
+ * @param {Function} [fetchFn] - Override for fetchAllJqlResults (for testing)
+ * @returns {Promise<{synced: number, updated: number, statusChanged: number, notFound: number, errors: string[]}>}
+ */
+async function syncFeatureData(data, fetchFn) {
+  const doFetch = fetchFn || fetchAllJqlResults;
+  const keys = Object.keys(data.features);
+
+  if (keys.length === 0) {
+    return { synced: 0, updated: 0, statusChanged: 0, notFound: 0, errors: [] };
+  }
+
+  const counts = { synced: 0, updated: 0, statusChanged: 0, notFound: 0 };
+  const errors = [];
+  const foundKeys = new Set();
+
+  // Batch keys into JQL queries
+  const batches = [];
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    batches.push(keys.slice(i, i + BATCH_SIZE));
+  }
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+
+    if (i > 0) {
+      await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+    }
+
+    const jql = `key in (${batch.join(',')})`;
+    let issues;
+    try {
+      issues = await doFetch(jiraRequest, jql, 'summary,status,priority,labels', { expand: 'changelog' });
+    } catch (err) {
+      errors.push(`Batch ${i + 1}/${batches.length} failed: ${err.message}`);
+      continue;
+    }
+
+    for (const issue of issues) {
+      foundKeys.add(issue.key);
+      const result = applyJiraFields(data, issue);
+      if (result === 'updated') counts.updated++;
+      else if (result === 'status_changed') { counts.statusChanged++; counts.updated++; }
+    }
+
+    counts.synced += issues.length;
+  }
+
+  // Count features not found in Jira
+  counts.notFound = keys.filter(k => !foundKeys.has(k)).length;
+
+  return { ...counts, errors };
+}
+
+const SIGN_OFF_LABEL = 'strat-creator-human-sign-off';
+
+/**
+ * Extract who added the human sign-off label and when, from the Jira changelog.
+ *
+ * @param {object} changelog - Jira issue changelog (from expand=changelog)
+ * @returns {{ approvedBy: string, approvedAt: string } | null}
+ */
+function extractSignOffInfo(changelog) {
+  if (!changelog?.histories) return null;
+  let latest = null;
+  for (const history of changelog.histories) {
+    for (const item of history.items) {
+      if (item.field !== 'labels') continue;
+      const before = (item.fromString || '').split(/\s+/).filter(Boolean);
+      const after = (item.toString || '').split(/\s+/).filter(Boolean);
+      if (after.includes(SIGN_OFF_LABEL) && !before.includes(SIGN_OFF_LABEL)) {
+        const date = new Date(history.created);
+        if (!latest || date > new Date(latest.approvedAt)) {
+          latest = {
+            approvedBy: history.author?.displayName || null,
+            approvedAt: history.created
+          };
+        }
+      }
+    }
+  }
+  return latest;
+}
+
+/**
+ * Apply Jira fields to an existing feature entry. Mutates data in place.
+ * Only creates a history entry when humanReviewStatus changes.
+ *
+ * @param {object} data - The full features data object
+ * @param {object} issue - Jira issue from the API
+ * @returns {'unchanged' | 'updated' | 'status_changed'}
+ */
+function applyJiraFields(data, issue) {
+  const entry = data.features[issue.key];
+  if (!entry) return 'unchanged';
+
+  const latest = entry.latest;
+  const fields = issue.fields;
+
+  // Extract fields from Jira response (nested objects)
+  const title = typeof fields.summary === 'string' ? fields.summary : latest.title;
+  const status = fields.status?.name || latest.status;
+  const rawPriority = fields.priority?.name || latest.priority;
+  const priority = PRIORITIES.includes(rawPriority) ? rawPriority : 'Undefined';
+  const labels = Array.isArray(fields.labels) ? fields.labels : latest.labels;
+
+  // Extract sign-off info from changelog
+  const signOffInfo = extractSignOffInfo(issue.changelog);
+
+  // Check if anything changed
+  const titleChanged = title !== latest.title;
+  const statusChanged = status !== latest.status;
+  const priorityChanged = priority !== latest.priority;
+  const labelsChanged = JSON.stringify([...labels].sort()) !== JSON.stringify([...(latest.labels || [])].sort());
+  const approvalChanged = (signOffInfo?.approvedBy || null) !== (latest.approvedBy || null);
+
+  if (!titleChanged && !statusChanged && !priorityChanged && !labelsChanged && !approvalChanged) {
+    return 'unchanged';
+  }
+
+  // Derive new humanReviewStatus
+  const newHumanReviewStatus = deriveHumanReviewStatus(labels);
+  const reviewStatusChanged = newHumanReviewStatus !== latest.humanReviewStatus;
+
+  // If humanReviewStatus changed, snapshot current state into history
+  if (reviewStatusChanged) {
+    const history = [trimForHistory(latest), ...entry.history];
+    entry.history = history.slice(0, MAX_HISTORY);
+  }
+
+  // Update mutable fields
+  latest.title = title;
+  latest.status = status;
+  latest.priority = priority;
+  latest.labels = labels;
+  latest.humanReviewStatus = newHumanReviewStatus;
+
+  // Update approval info
+  if (signOffInfo) {
+    latest.approvedBy = signOffInfo.approvedBy;
+    latest.approvedAt = signOffInfo.approvedAt;
+  } else if (newHumanReviewStatus !== 'approved') {
+    // Clear approval info if sign-off label was removed
+    latest.approvedBy = undefined;
+    latest.approvedAt = undefined;
+  }
+
+  return reviewStatusChanged ? 'status_changed' : 'updated';
+}
+
+module.exports = { syncFeaturesFromJira, syncFeatureData, applyJiraFields, extractSignOffInfo, featureLock, acquireLock, releaseLock };

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -7,12 +7,56 @@ const {
   getLatestProjection,
   countHistoryEntries
 } = require('./storage');
+const { syncFeaturesFromJira, acquireLock, releaseLock } = require('./jira-sync');
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true';
 const jsonLimit = express.json({ limit: '10mb' });
 
 // Max entries in a single bulk request
 const BULK_CAP = 5000;
+
+// ─── Sync state (in-memory) ───
+
+const syncState = {
+  running: false,
+  startedAt: null,
+  lastResult: null
+};
+
+/**
+ * Run the Jira sync in the background. Updates syncState.
+ * @param {Function} readFromStorage
+ */
+async function runSync(readFromStorage) {
+  if (syncState.running) return;
+  if (!acquireLock()) {
+    console.warn('[ai-impact] Feature sync skipped: write lock held');
+    return;
+  }
+
+  syncState.running = true;
+  syncState.startedAt = new Date().toISOString();
+
+  try {
+    const result = await syncFeaturesFromJira(readFromStorage);
+    syncState.lastResult = {
+      status: result.errors.length > 0 ? 'partial' : 'success',
+      message: `Synced ${result.synced} features: ${result.updated} updated (${result.statusChanged} review status changes), ${result.notFound} not found in Jira`,
+      errors: result.errors.length > 0 ? result.errors : undefined,
+      completedAt: new Date().toISOString()
+    };
+  } catch (err) {
+    console.error('[ai-impact] Feature Jira sync failed:', err);
+    syncState.lastResult = {
+      status: 'error',
+      message: err.message,
+      completedAt: new Date().toISOString()
+    };
+  } finally {
+    syncState.running = false;
+    releaseLock();
+  }
+}
 
 /**
  * Register feature routes on the module router.
@@ -32,9 +76,28 @@ module.exports = function registerFeatureRoutes(router, context) {
     const data = readFeatures(readFromStorage);
     res.json({
       lastSyncedAt: data.lastSyncedAt,
+      lastJiraSyncAt: data.lastJiraSyncAt || null,
       totalFeatures: data.totalFeatures,
       totalHistoryEntries: countHistoryEntries(data)
     });
+  });
+
+  // GET /features/sync/status — sync state for polling
+  router.get('/features/sync/status', function(req, res) {
+    res.json(syncState);
+  });
+
+  // POST /features/sync (Admin) — trigger Jira label sync
+  router.post('/features/sync', requireAdmin, async function(req, res) {
+    if (DEMO_MODE) {
+      return res.json({ status: 'skipped', message: 'Sync disabled in demo mode' });
+    }
+    if (syncState.running) {
+      return res.json({ status: 'already_running' });
+    }
+
+    res.json({ status: 'started' });
+    runSync(readFromStorage);
   });
 
   // POST /features/bulk (Admin) — bulk upsert features
@@ -82,6 +145,15 @@ module.exports = function registerFeatureRoutes(router, context) {
       unchanged: counts.unchanged,
       errors
     });
+
+    // Fire-and-forget: sync labels from Jira after bulk ingest.
+    // Delay to allow remaining batches from the same pipeline push to complete.
+    if (counts.created > 0 || counts.updated > 0) {
+      setTimeout(() => {
+        console.log('[ai-impact] Triggering post-ingest Jira sync');
+        runSync(readFromStorage);
+      }, 10000);
+    }
   });
 
   // DELETE /features (Admin) — clear all feature data

--- a/modules/ai-impact/server/features/storage.js
+++ b/modules/ai-impact/server/features/storage.js
@@ -132,7 +132,9 @@ function getLatestProjection(data) {
       humanReviewStatus: entry.latest.humanReviewStatus,
       scores: entry.latest.scores,
       reviewers: entry.latest.reviewers,
-      reviewedAt: entry.latest.reviewedAt
+      reviewedAt: entry.latest.reviewedAt,
+      approvedBy: entry.latest.approvedBy || null,
+      approvedAt: entry.latest.approvedAt || null
     };
   }
   return {

--- a/modules/ai-impact/server/features/validation.js
+++ b/modules/ai-impact/server/features/validation.js
@@ -179,4 +179,4 @@ function validateFeature(body) {
   };
 }
 
-module.exports = { validateFeature, DIMENSIONS, PRIORITIES, RECOMMENDATIONS };
+module.exports = { validateFeature, deriveHumanReviewStatus, DIMENSIONS, PRIORITIES, RECOMMENDATIONS };


### PR DESCRIPTION
## Summary

- **Jira sync for features**: Fetches updated labels, status, priority, and title from Jira for all tracked RHAISTRAT features. Batches queries (50 per JQL) with rate limiting. Extracts `approvedBy` and `approvedAt` from Jira changelog when the `strat-creator-human-sign-off` label is added.
- **Sync triggers**: Manual button in AI Impact Settings, automatic fire-and-forget sync after bulk ingest (10s delay), and daily cron job step.
- **Approval info in UI**: Feature detail modal shows a green "Approved by **Name** on **date**" banner for approved features.
- **Settings overhaul**: AI Impact settings now has separate "RFE & AutoFix Data" and "Feature Jira Sync" cards, with sync status display and last sync timestamp in the Feature Reviews table.

## Changes

| File | Description |
|------|-------------|
| `server/features/jira-sync.js` | New module: `syncFeatureData`, `applyJiraFields`, `extractSignOffInfo`, in-memory mutex |
| `server/features/routes.js` | `POST /features/sync`, `GET /features/sync/status`, post-ingest fire-and-forget sync |
| `server/features/storage.js` | `getLatestProjection` includes `approvedBy`/`approvedAt` |
| `server/features/validation.js` | Export `deriveHumanReviewStatus` for reuse |
| `client/components/FeatureDetailPanel.vue` | Approval info banner |
| `client/components/AIImpactSettings.vue` | Overhauled data refresh section, sync UI |
| `cronjob-sync-refresh.yaml` | Step 4b: Feature Jira Sync with polling |
| `__tests__/server/jira-sync.test.js` | 17 tests for sync logic and changelog extraction |
| `__tests__/server/feature-routes.test.js` | Updated projection assertions |

## Test plan

- [x] 31 tests pass (`npm test` — jira-sync + feature-routes)
- [x] Lint clean
- [x] Loaded 161 features locally, triggered sync, verified `approvedBy`/`approvedAt` populated from Jira
- [x] Verified approval banner renders in feature detail modal (e.g. RHAISTRAT-1579)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)