### PR TITLE
feat(ai-impact): deep-linkable URLs for RFE/feature modals

### DIFF
--- a/modules/ai-impact/client/views/FeatureReviewView.vue
+++ b/modules/ai-impact/client/views/FeatureReviewView.vue
@@ -48,7 +48,7 @@ function handleNavigateToRFE(rfeKey) {
 watch(() => moduleNav.params.value, (params) => {
   if (params?.select && Object.keys(features.value).length > 0) {
     const feature = Object.values(features.value).find(f => f.key === params.select)
-    if (feature) {
+    if (feature && selectedFeature.value?.key !== feature.key) {
       searchQuery.value = ''
       recommendationFilter.value = 'all'
       priorityFilter.value = 'all'

--- a/modules/ai-impact/client/views/FeatureReviewView.vue
+++ b/modules/ai-impact/client/views/FeatureReviewView.vue
@@ -28,6 +28,18 @@ function handleRetry() {
   loadFeatures()
 }
 
+function handleSelectFeature(feature) {
+  selectedFeature.value = feature
+  if (feature) {
+    moduleNav.navigateTo('feature-review', { select: feature.key })
+  }
+}
+
+function handleCloseModal() {
+  selectedFeature.value = null
+  moduleNav.navigateTo('feature-review')
+}
+
 function handleNavigateToRFE(rfeKey) {
   moduleNav.navigateTo('rfe-review', { select: rfeKey })
 }
@@ -77,7 +89,7 @@ watch(() => Object.keys(features.value).length, () => {
       @update:priorityFilter="priorityFilter = $event"
       @update:humanReviewFilter="humanReviewFilter = $event"
       @update:sortBy="sortBy = $event"
-      @selectFeature="selectedFeature = $event"
+      @selectFeature="handleSelectFeature"
       @retry="handleRetry"
     />
 
@@ -87,7 +99,7 @@ watch(() => Object.keys(features.value).length, () => {
       :phases="PHASES"
       :jiraHost="rfeData?.jiraHost"
       :loadFeatureDetail="loadFeatureDetail"
-      @close="selectedFeature = null"
+      @close="handleCloseModal"
       @navigateToRFE="handleNavigateToRFE"
     />
 

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -113,7 +113,7 @@ function handleNavigateToFeature(featureKey) {
 watch([() => moduleNav.params.value, rfeData], ([params]) => {
   if (params?.select && rfeData.value?.issues) {
     const rfe = rfeData.value.issues.find(r => r.key === params.select)
-    if (rfe) {
+    if (rfe && selectedRFE.value?.key !== rfe.key) {
       filter.value = 'all'
       searchQuery.value = ''
       passFailFilter.value = 'all'
@@ -121,7 +121,7 @@ watch([() => moduleNav.params.value, rfeData], ([params]) => {
       statusFilter.value = 'all'
       selectedRFE.value = rfe
       notFoundRFE.value = null
-    } else {
+    } else if (!rfe) {
       notFoundRFE.value = params.select
     }
   }

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -92,6 +92,18 @@ function handleRetry() {
   loadAssessments()
 }
 
+function handleSelectRFE(rfe) {
+  selectedRFE.value = rfe
+  if (rfe) {
+    moduleNav.navigateTo('rfe-review', { select: rfe.key })
+  }
+}
+
+function handleCloseModal() {
+  selectedRFE.value = null
+  moduleNav.navigateTo('rfe-review')
+}
+
 function handleNavigateToFeature(featureKey) {
   moduleNav.navigateTo('feature-review', { select: featureKey })
 }
@@ -146,7 +158,7 @@ watch([() => moduleNav.params.value, rfeData], ([params]) => {
       @update:passFailFilter="passFailFilter = $event"
       @update:priorityFilter="priorityFilter = $event"
       @update:statusFilter="statusFilter = $event"
-      @selectRFE="selectedRFE = $event"
+      @selectRFE="handleSelectRFE"
       @retry="handleRetry"
     />
 
@@ -196,7 +208,7 @@ watch([() => moduleNav.params.value, rfeData], ([params]) => {
       :jiraHost="rfeData?.jiraHost"
       :assessment="assessments[selectedRFE?.key] || null"
       :loadAssessmentDetail="loadAssessmentDetail"
-      @close="selectedRFE = null"
+      @close="handleCloseModal"
       @navigateToFeature="handleNavigateToFeature"
     />
 


### PR DESCRIPTION
## Summary
- Selecting an RFE or feature from the list now updates the URL hash with `?select=KEY`, making the current view state shareable and bookmarkable (e.g., `#/ai-impact/rfe-review?select=RHAIRFE-1234`)
- Closing the detail modal clears the `select` param from the URL so a page refresh won't re-open it
- Initial page load with a `?select=KEY` param was already supported — this change completes the round-trip by keeping the URL in sync with UI state

## Test plan
- [ ] Navigate to RFE Review, click an RFE — verify URL updates to include `?select=<key>`
- [ ] Copy the URL, open in a new tab — verify the modal opens automatically after data loads
- [ ] Close the modal — verify `?select` is removed from the URL
- [ ] Refresh after closing — verify the modal does not re-open
- [ ] Same flow for Feature Review
- [ ] Cross-module navigation (RFE → Feature, Feature → RFE) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)