### PR TITLE
feat: add RFE Builder Lessons Learned tile under Agent Eval Harness

### DIFF
--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -213,6 +213,24 @@
           </a>
         </div>
       </div>
+
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">RFE Builder Lessons Learned</h3>
+        <div class="flex flex-wrap gap-4">
+          <a
+            v-for="link in rfeBuilderLessonsLearnedLinks"
+            :key="link.label"
+            :href="link.url"
+            target="_blank"
+            rel="noopener"
+            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
+          >
+            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
+            <span>{{ link.label }}</span>
+            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
+          </a>
+        </div>
+      </div>
     </template>
 
     <!-- Help & Debug tab -->
@@ -470,6 +488,12 @@ const agentEvalHarnessLinks = [
   { label: 'Enablement Recording', icon: Video, url: 'https://drive.google.com/file/d/1SVPwRZzo2U1ohnlTtgjlyOvXHrJB1Jxu/view' },
   { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/15vhrPqtu-uzxQC4v3whN8YQL1NK46kqNULhZff3uC8E/edit?slide=id.g3d8e714406d_0_0#slide=id.g3d8e714406d_0_0' },
   { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1HJJBt2Psnqy7JWx26UUP0fENJqDPAZBDhFcHpHt6sjM/edit?tab=t.tcc7ue9usok7' }
+]
+
+const rfeBuilderLessonsLearnedLinks = [
+  { label: 'Lessons Learned Recording', icon: Video, url: 'https://drive.google.com/file/d/15UWUdbITmkccmxeW8U1oIxlS3Wei2j3g/view' },
+  { label: 'Lessons Learned Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/1XhMa0hn6no4ALO2W7y8HthqF0iQh3b9z9vXja7BMKao/edit?slide=id.slide_01#slide=id.slide_01' },
+  { label: 'Lessons Learned Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1glUr8WhghdDmri1KKSCJutMjfzxnueoZuYGFjg2OwxI/edit?tab=t.q557l4ag5zjk' }
 ]
 
 // --- Help & Debug state ---


### PR DESCRIPTION
Add a new enablement card in the Other Enablement section of the Docs tab with links to the Lessons Learned recording, slides, and notes.

Closes #474

Generated with [Claude Code](https://claude.ai/code)