### PR TITLE
fix(release-planning): rename Big Rocks Planning to Outcomes

### DIFF
--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -482,7 +482,7 @@ onUnmounted(function() {
     <!-- Header -->
     <div class="flex items-center justify-between flex-wrap gap-4">
       <div>
-        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Big Rocks Planning Dashboard</h1>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Outcomes Dashboard</h1>
         <p v-if="candidates && candidates.lastRefreshed" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Data from {{ formatDate(candidates.lastRefreshed) }}
         </p>

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -536,7 +536,7 @@ onUnmounted(function() {
     <!-- No releases configured -->
     <div v-else-if="!healthLoading && releases.length === 0" class="text-center py-12">
       <p class="text-gray-500 dark:text-gray-400">No releases configured.</p>
-      <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Configure releases in the Big Rocks Planning view first.</p>
+      <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Configure releases in the Outcomes view first.</p>
     </div>
 
     <!-- No data yet, not loading -->

--- a/modules/release-planning/module.json
+++ b/modules/release-planning/module.json
@@ -8,7 +8,7 @@
   "client": {
     "entry": "./client/index.js",
     "navItems": [
-      { "id": "main", "label": "Big Rocks Planning", "icon": "ClipboardList", "default": true },
+      { "id": "main", "label": "Outcomes", "icon": "ClipboardList", "default": true },
       { "id": "health", "label": "Release Plan Health", "icon": "HeartPulse" },
       { "id": "audit-log", "label": "Audit Log", "icon": "History" }
     ]


### PR DESCRIPTION
## Summary
- Renames the sidebar nav label from "Big Rocks Planning" to "Outcomes"
- Renames the page heading from "Big Rocks Planning Dashboard" to "Outcomes Dashboard"

## Test plan
- [x] All 2068 tests pass
- [ ] Verify sidebar shows "Outcomes" instead of "Big Rocks Planning"
- [ ] Verify page heading says "Outcomes Dashboard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)