### PR TITLE
feat(release-planning): add risk health popovers

### DIFF
--- a/fixtures/release-planning/health-cache-demo.json
+++ b/fixtures/release-planning/health-cache-demo.json
@@ -11,8 +11,8 @@
   },
   "phase": "all",
   "summary": {
-    "totalFeatures": 8,
-    "byRisk": { "green": 2, "yellow": 3, "red": 3 },
+    "totalFeatures": 12,
+    "byRisk": { "green": 3, "yellow": 4, "red": 5 },
     "dorCompletionRate": 62,
     "averageRiceScore": 310,
     "blockedCount": 1,
@@ -403,11 +403,145 @@
       },
       "rice": { "reach": 1200, "impact": 3, "confidence": 75, "effort": 10, "score": 270, "complete": true },
       "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1008"
+    },
+    {
+      "key": "RHAISTRAT-2001",
+      "summary": "Support vLLM multi-node inference",
+      "status": "In Progress",
+      "priority": "Major",
+      "phase": "EA1",
+      "bigRock": "MaaS",
+      "tier": 1,
+      "pm": "Jane Doe",
+      "deliveryOwner": "John Smith",
+      "components": ["Serving"],
+      "completionPct": 60,
+      "epicCount": 2,
+      "issueCount": 12,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "yellow",
+        "score": 2,
+        "flags": [
+          { "category": "DOR_INCOMPLETE", "severity": "medium", "message": "DoR completion at 55% (below 80% threshold)" },
+          { "category": "UNESTIMATED", "severity": "medium", "message": "No story point estimate" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 7,
+        "totalCount": 13,
+        "completionPct": 55,
+        "items": []
+      },
+      "rice": null,
+      "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-2001"
+    },
+    {
+      "key": "RHAISTRAT-2006",
+      "summary": "Prompt playground with model comparison",
+      "status": "In Progress",
+      "priority": "Critical",
+      "phase": "EA1",
+      "bigRock": "Gen AI Studio",
+      "tier": 1,
+      "pm": "Sarah Lee",
+      "deliveryOwner": "Dave Evans",
+      "components": ["GenAI Studio"],
+      "completionPct": 70,
+      "epicCount": 3,
+      "issueCount": 18,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "green",
+        "score": 0,
+        "flags": [],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 11,
+        "totalCount": 13,
+        "completionPct": 85,
+        "items": []
+      },
+      "rice": { "reach": 1800, "impact": 3, "confidence": 90, "effort": 6, "score": 810, "complete": true },
+      "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-2006"
+    },
+    {
+      "key": "RHAISTRAT-2013",
+      "summary": "Model evaluation benchmarking suite",
+      "status": "In Progress",
+      "priority": "Major",
+      "phase": "EA1",
+      "bigRock": "Eval Hub",
+      "tier": 1,
+      "pm": "Nancy Kim",
+      "deliveryOwner": "Iris Lee",
+      "components": ["Evaluation"],
+      "completionPct": 35,
+      "epicCount": 2,
+      "issueCount": 10,
+      "blockerCount": 0,
+      "health": "",
+      "risk": {
+        "level": "red",
+        "score": 3,
+        "flags": [
+          { "category": "VELOCITY_LAG", "severity": "high", "message": "Completion at 35% vs expected 80% for EA1 at Pre-EA1" },
+          { "category": "DOR_INCOMPLETE", "severity": "high", "message": "DoR completion at 38% (below 50% threshold)" },
+          { "category": "MISSING_OWNER", "severity": "medium", "message": "No delivery owner assigned" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 5,
+        "totalCount": 13,
+        "completionPct": 38,
+        "items": []
+      },
+      "rice": null,
+      "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-2013"
+    },
+    {
+      "key": "RHAISTRAT-2016",
+      "summary": "MCP catalog and registry backend",
+      "status": "In Progress",
+      "priority": "Critical",
+      "phase": "EA1",
+      "bigRock": "AI Hub incl MCP",
+      "tier": 1,
+      "pm": "Oscar Park",
+      "deliveryOwner": "Karen Quinn",
+      "components": ["Platform", "Registry"],
+      "completionPct": 50,
+      "epicCount": 3,
+      "issueCount": 20,
+      "blockerCount": 1,
+      "health": "",
+      "risk": {
+        "level": "red",
+        "score": 2,
+        "flags": [
+          { "category": "BLOCKED", "severity": "high", "message": "Blocked by dependency on auth service" },
+          { "category": "DOR_INCOMPLETE", "severity": "medium", "message": "DoR completion at 46% (below 80% threshold)" }
+        ],
+        "override": null
+      },
+      "dor": {
+        "checkedCount": 6,
+        "totalCount": 13,
+        "completionPct": 46,
+        "items": []
+      },
+      "rice": { "reach": 2500, "impact": 3, "confidence": 70, "effort": 8, "score": 656, "complete": true },
+      "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-2016"
     }
   ],
   "enrichmentStatus": {
     "jiraQueriesRun": 3,
-    "featuresEnriched": 8,
+    "featuresEnriched": 12,
     "featuresSkipped": 0,
     "riceAvailable": true,
     "warnings": []

--- a/modules/release-planning/__tests__/client/risk-popover.test.js
+++ b/modules/release-planning/__tests__/client/risk-popover.test.js
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import RiskPopover from '../../client/components/RiskPopover.vue'
+import BigRockHealthPopover from '../../client/components/BigRockHealthPopover.vue'
+
+// ─── RiskPopover ───
+
+describe('RiskPopover', function() {
+  it('renders slot content', function() {
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'green', flags: [], flagCount: 0 },
+      slots: { default: '<span class="trigger">dot</span>' }
+    })
+    expect(wrapper.find('.trigger').exists()).toBe(true)
+    expect(wrapper.text()).toContain('dot')
+  })
+
+  it('does not show popover by default', function() {
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'green', flags: [], flagCount: 0 },
+      slots: { default: '<span>dot</span>' }
+    })
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+  })
+
+  it('does not show popover for green level with no flags', async function() {
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'green', flags: [], flagCount: 0 },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows popover for green level with override', async function() {
+    var override = { riskOverride: 'green', reason: 'Manually reviewed' }
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'green', flags: [], flagCount: 0, override: override },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Override: green')
+    wrapper.unmount()
+  })
+
+  it('shows red level with flags', async function() {
+    var flags = [
+      { category: 'MILESTONE_MISS', severity: 'high', message: 'Behind EA1 FREEZE' },
+      { category: 'VELOCITY_LAG', severity: 'medium', message: '12% complete' }
+    ]
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'red', flags: flags, flagCount: 2 },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Risk: Red')
+    expect(wrapper.text()).toContain('2 flags')
+    expect(wrapper.text()).toContain('MILESTONE_MISS')
+    expect(wrapper.text()).toContain('(high)')
+    expect(wrapper.text()).toContain('Behind EA1 FREEZE')
+    expect(wrapper.text()).toContain('VELOCITY_LAG')
+    expect(wrapper.text()).toContain('(medium)')
+    wrapper.unmount()
+  })
+
+  it('shows 1 flag without plural', async function() {
+    var flags = [{ category: 'DOR_INCOMPLETE', severity: 'medium', message: '45% met' }]
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'yellow', flags: flags, flagCount: 1 },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('1 flag)')
+    expect(wrapper.text()).not.toContain('1 flags')
+    wrapper.unmount()
+  })
+
+  it('shows override section when present', async function() {
+    var override = {
+      riskOverride: 'yellow',
+      reason: 'PM discussed with eng',
+      updatedBy: 'jsmith@redhat.com',
+      updatedAt: '2026-04-28T00:00:00.000Z'
+    }
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'red', flags: [{ category: 'BLOCKED', severity: 'high', message: 'Blocked' }], flagCount: 1, override: override },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Override: yellow')
+    expect(wrapper.text()).toContain('PM discussed with eng')
+    expect(wrapper.text()).toContain('jsmith@redhat.com')
+    wrapper.unmount()
+  })
+
+  it('does not show override section when null', async function() {
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'red', flags: [{ category: 'BLOCKED', severity: 'high', message: 'Blocked' }], flagCount: 1, override: null },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).not.toContain('Override:')
+    wrapper.unmount()
+  })
+
+  it('shows DoR summary in full variant', async function() {
+    var dor = { completionPct: 45, checkedCount: 5, totalCount: 11 }
+    var flags = [{ category: 'DOR_INCOMPLETE', severity: 'medium', message: '45% met' }]
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'yellow', flags: flags, flagCount: 1, dor: dor, variant: 'full' },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('DoR: 45%')
+    expect(wrapper.text()).toContain('5/11 items')
+    wrapper.unmount()
+  })
+
+  it('does not show DoR in compact variant', async function() {
+    var dor = { completionPct: 45, checkedCount: 5, totalCount: 11 }
+    var flags = [{ category: 'DOR_INCOMPLETE', severity: 'medium', message: '45% met' }]
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'yellow', flags: flags, flagCount: 1, dor: dor, variant: 'compact' },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).not.toContain('DoR:')
+    wrapper.unmount()
+  })
+
+  it('displays override level in header when override present', async function() {
+    var override = { riskOverride: 'green', reason: 'test' }
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'red', flags: [], flagCount: 0, override: override },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Risk: Green')
+    wrapper.unmount()
+  })
+
+  it('shows close button only when pinned', async function() {
+    var flags = [{ category: 'BLOCKED', severity: 'high', message: 'Blocked' }]
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'red', flags: flags, flagCount: 1 },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    var closeBtn = wrapper.find('[aria-label="Close popover"]')
+    expect(closeBtn.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('has aria-expanded attribute on trigger', function() {
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'green', flags: [], flagCount: 0 },
+      slots: { default: '<span>dot</span>' }
+    })
+    expect(wrapper.find('[aria-expanded]').exists()).toBe(true)
+  })
+
+  it('uses role="dialog" on popover', async function() {
+    var flags = [{ category: 'BLOCKED', severity: 'high', message: 'Blocked' }]
+    var wrapper = mount(RiskPopover, {
+      props: { level: 'red', flags: flags, flagCount: 1 },
+      slots: { default: '<span>dot</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+// ─── BigRockHealthPopover ───
+
+describe('BigRockHealthPopover', function() {
+  it('renders slot content', function() {
+    var wrapper = mount(BigRockHealthPopover, {
+      props: { worstLevel: 'green', features: [], totalFlags: 0 },
+      slots: { default: '<span class="badge">OK</span>' }
+    })
+    expect(wrapper.find('.badge').exists()).toBe(true)
+  })
+
+  it('shows per-feature breakdown when pinned (only flagged features)', async function() {
+    var features = [
+      { key: 'RHOAI-1234', level: 'red', flagCount: 2, flagCategories: ['MILESTONE_MISS', 'VELOCITY_LAG'] },
+      { key: 'RHOAI-5678', level: 'yellow', flagCount: 1, flagCategories: ['DOR_INCOMPLETE'] },
+      { key: 'RHOAI-9012', level: 'green', flagCount: 0, flagCategories: [] }
+    ]
+    var wrapper = mount(BigRockHealthPopover, {
+      props: { worstLevel: 'red', features: features, totalFlags: 3 },
+      slots: { default: '<span>Critical</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Health: Critical')
+    expect(wrapper.text()).toContain('2 features')
+    expect(wrapper.text()).toContain('RHOAI-1234')
+    expect(wrapper.text()).toContain('Red')
+    expect(wrapper.text()).toContain('2 flags')
+    expect(wrapper.text()).toContain('MILESTONE_MISS, VELOCITY_LAG')
+    expect(wrapper.text()).toContain('RHOAI-5678')
+    expect(wrapper.text()).not.toContain('RHOAI-9012')
+    wrapper.unmount()
+  })
+
+  it('shows +N more for >10 flagged features', async function() {
+    var features = []
+    for (var i = 0; i < 12; i++) {
+      features.push({ key: 'F-' + (i + 1), level: 'yellow', flagCount: 1, flagCategories: ['DOR'] })
+    }
+    var wrapper = mount(BigRockHealthPopover, {
+      props: { worstLevel: 'yellow', features: features, totalFlags: 12 },
+      slots: { default: '<span>At Risk</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('+2 more features')
+    expect(wrapper.text()).toContain('F-1')
+    expect(wrapper.text()).toContain('F-10')
+    expect(wrapper.text()).not.toContain('F-11')
+    wrapper.unmount()
+  })
+
+  it('does not show popover when all features are green', async function() {
+    var features = [
+      { key: 'F-1', level: 'green', flagCount: 0, flagCategories: [] }
+    ]
+    var wrapper = mount(BigRockHealthPopover, {
+      props: { worstLevel: 'green', features: features, totalFlags: 0 },
+      slots: { default: '<span>OK</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('shows correct label for yellow level', async function() {
+    var wrapper = mount(BigRockHealthPopover, {
+      props: { worstLevel: 'yellow', features: [{ key: 'F-1', level: 'yellow', flagCount: 1, flagCategories: ['DOR'] }], totalFlags: 1 },
+      slots: { default: '<span>At Risk</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('Health: At Risk')
+    wrapper.unmount()
+  })
+
+  it('shows singular "feature" for 1 flagged feature', async function() {
+    var wrapper = mount(BigRockHealthPopover, {
+      props: { worstLevel: 'yellow', features: [{ key: 'F-1', level: 'yellow', flagCount: 1, flagCategories: ['DOR'] }], totalFlags: 1 },
+      slots: { default: '<span>At Risk</span>' },
+      attachTo: document.body
+    })
+    await wrapper.find('[role="button"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('1 feature)')
+    expect(wrapper.text()).not.toContain('1 features')
+    wrapper.unmount()
+  })
+})

--- a/modules/release-planning/client/components/BigRockHealthPopover.vue
+++ b/modules/release-planning/client/components/BigRockHealthPopover.vue
@@ -1,0 +1,123 @@
+<script setup>
+import { computed } from 'vue'
+import { usePopover } from '../composables/usePopover'
+
+var MAX_FEATURES = 10
+
+const props = defineProps({
+  worstLevel: { type: String, default: 'green' },
+  features: { type: Array, default: () => [] },
+  totalFlags: { type: Number, default: 0 }
+})
+
+var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismiss, onKeyDown } = usePopover()
+
+var levelLabel = computed(function() {
+  var l = props.worstLevel
+  if (l === 'red') return 'Critical'
+  if (l === 'yellow') return 'At Risk'
+  return 'OK'
+})
+
+var levelDotClass = computed(function() {
+  var l = props.worstLevel
+  if (l === 'red') return 'bg-red-500'
+  if (l === 'yellow') return 'bg-yellow-500'
+  return 'bg-green-500'
+})
+
+var headerBorderClass = computed(function() {
+  var l = props.worstLevel
+  if (l === 'red') return 'border-red-200 dark:border-red-500/30'
+  if (l === 'yellow') return 'border-yellow-200 dark:border-yellow-500/30'
+  return 'border-green-200 dark:border-green-500/30'
+})
+
+var flaggedFeatures = computed(function() {
+  return props.features.filter(function(f) { return f.flagCount > 0 })
+})
+
+var displayedFeatures = computed(function() {
+  return flaggedFeatures.value.slice(0, MAX_FEATURES)
+})
+
+var remainingCount = computed(function() {
+  return Math.max(0, flaggedFeatures.value.length - MAX_FEATURES)
+})
+
+function featureLevelLabel(level) {
+  if (level === 'red') return 'Red'
+  if (level === 'yellow') return 'Yellow'
+  return 'Green'
+}
+
+function featureLevelClass(level) {
+  if (level === 'red') return 'text-red-600 dark:text-red-400'
+  if (level === 'yellow') return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-green-600 dark:text-green-400'
+}
+</script>
+
+<template>
+  <span
+    class="relative inline-flex"
+    :data-popover-trigger="popoverId"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    @click="onClick"
+    @keydown="onKeyDown"
+    :aria-expanded="isVisible"
+    tabindex="0"
+    role="button"
+  >
+    <slot />
+
+    <div
+      v-if="isVisible && flaggedFeatures.length > 0"
+      :data-popover-id="popoverId"
+      role="dialog"
+      aria-live="polite"
+      class="absolute z-50 left-0 top-full mt-1 w-96 max-w-[min(384px,90vw)] bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
+      <!-- Header -->
+      <div class="flex items-center justify-between px-3 py-2 border-b" :class="headerBorderClass">
+        <div class="flex items-center gap-1.5">
+          <span class="w-2 h-2 rounded-full flex-shrink-0" :class="levelDotClass"></span>
+          <span class="font-semibold text-gray-900 dark:text-gray-100">Health: {{ levelLabel }}</span>
+          <span class="text-gray-500 dark:text-gray-400">({{ flaggedFeatures.length }} feature{{ flaggedFeatures.length !== 1 ? 's' : '' }})</span>
+        </div>
+        <button
+          v-if="isPinned"
+          @click.stop="dismiss"
+          class="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+          aria-label="Close popover"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Feature list -->
+      <div class="px-3 py-2 max-h-64 overflow-y-auto">
+        <div class="space-y-2">
+          <div v-for="f in displayedFeatures" :key="f.key">
+            <div class="flex items-baseline gap-1.5">
+              <span class="font-mono text-gray-900 dark:text-gray-100">{{ f.key }}</span>
+              <span class="font-semibold" :class="featureLevelClass(f.level)">{{ featureLevelLabel(f.level) }}</span>
+              <span v-if="f.flagCount > 0" class="text-gray-500 dark:text-gray-400">({{ f.flagCount }} flag{{ f.flagCount !== 1 ? 's' : '' }})</span>
+            </div>
+            <div class="text-gray-500 dark:text-gray-400 mt-0.5 pl-0.5">
+              {{ f.flagCategories.join(', ') }}
+            </div>
+          </div>
+          <div v-if="remainingCount > 0" class="text-gray-500 dark:text-gray-400 pt-1 border-t border-gray-200 dark:border-gray-700">
+            +{{ remainingCount }} more feature{{ remainingCount !== 1 ? 's' : '' }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
+</template>

--- a/modules/release-planning/client/components/BigRockRow.vue
+++ b/modules/release-planning/client/components/BigRockRow.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { computed } from 'vue'
+import BigRockHealthPopover from './BigRockHealthPopover.vue'
 
 const props = defineProps({
   rock: { type: Object, required: true },
   jiraBaseUrl: { type: String, default: '' },
   health: { type: Object, default: null },
-  hasHealth: { type: Boolean, default: false }
+  hasHealth: { type: Boolean, default: false },
+  rockFeatures: { type: Array, default: () => [] }
 })
 
 const healthBadgeClass = computed(function() {
@@ -51,14 +53,19 @@ const healthBadgeClass = computed(function() {
   <td class="px-3 py-2 text-center border border-gray-300 dark:border-gray-600">
     <span class="font-semibold text-gray-700 dark:text-gray-300">{{ rock.rfeCount }}</span>
   </td>
-  <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 max-w-xs truncate border border-gray-300 dark:border-gray-600">{{ rock.notes }}</td>
   <td v-if="hasHealth" class="px-3 py-2 text-center border border-gray-300 dark:border-gray-600">
-    <span
+    <BigRockHealthPopover
       v-if="health"
-      class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
-      :class="healthBadgeClass"
-      :title="health.totalFlags + ' risk flag(s) across ' + health.featureCount + ' feature(s)'"
-    >{{ health.worstLevel === 'green' ? 'OK' : health.worstLevel === 'yellow' ? 'At Risk' : 'Critical' }}</span>
+      :worstLevel="health.worstLevel"
+      :features="rockFeatures"
+      :totalFlags="health.totalFlags"
+    >
+      <span
+        class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
+        :class="[healthBadgeClass, health.totalFlags > 0 ? 'cursor-help' : '']"
+      >{{ health.worstLevel === 'green' ? 'OK' : health.worstLevel === 'yellow' ? 'At Risk' : 'Critical' }}</span>
+    </BigRockHealthPopover>
     <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
   </td>
+  <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 max-w-xs truncate border border-gray-300 dark:border-gray-600">{{ rock.notes }}</td>
 </template>

--- a/modules/release-planning/client/components/BigRocksTable.vue
+++ b/modules/release-planning/client/components/BigRocksTable.vue
@@ -33,9 +33,32 @@ const rockHealth = computed(function() {
     result[rockName].featureCount++
     result[rockName].totalFlags += (h.risk.score || 0)
     var level = h.risk.override ? (h.risk.override.riskOverride || h.risk.level) : h.risk.level
-    if ((RISK_SEVERITY[level] || 2) < (RISK_SEVERITY[result[rockName].worstLevel] || 2)) {
+    if ((RISK_SEVERITY[level] != null ? RISK_SEVERITY[level] : 2) < (RISK_SEVERITY[result[rockName].worstLevel] != null ? RISK_SEVERITY[result[rockName].worstLevel] : 2)) {
       result[rockName].worstLevel = level
     }
+  }
+  return result
+})
+
+const rockFeatures = computed(function() {
+  if (!hasHealth.value) return {}
+  var result = {}
+  for (var i = 0; i < props.features.length; i++) {
+    var f = props.features[i]
+    var rockName = f.bigRock
+    if (!rockName) continue
+    var h = props.healthByKey[f.issueKey]
+    if (!result[rockName]) result[rockName] = []
+    var level = h && h.risk
+      ? (h.risk.override ? h.risk.override.riskOverride || h.risk.level : h.risk.level)
+      : 'green'
+    var flags = h && h.risk ? h.risk.flags || [] : []
+    result[rockName].push({
+      key: f.issueKey,
+      level: level,
+      flagCount: flags.length,
+      flagCategories: flags.map(function(fl) { return fl.category })
+    })
   }
   return result
 })
@@ -118,7 +141,7 @@ function onDragEnd() {
                   &#x2807;
                 </span>
               </td>
-              <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" />
+              <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" :rockFeatures="rockFeatures[rock.name] || []" />
               <td class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
                 <button
                   @click="handleDeleteClick($event, rock)"
@@ -139,7 +162,7 @@ function onDragEnd() {
             :key="rock.name"
             class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
           >
-            <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" />
+            <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" :rockFeatures="rockFeatures[rock.name] || []" />
           </tr>
           <tr v-if="!bigRocks || bigRocks.length === 0">
             <td :colspan="hasHealth ? 10 : 9" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">

--- a/modules/release-planning/client/components/FeatureHealthRow.vue
+++ b/modules/release-planning/client/components/FeatureHealthRow.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import RiceScoreDisplay from './RiceScoreDisplay.vue'
 import DorChecklist from './DorChecklist.vue'
 import StatusBadge from './StatusBadge.vue'
+import RiskPopover from './RiskPopover.vue'
 
 const props = defineProps({
   feature: { type: Object, required: true },
@@ -54,23 +55,6 @@ var dorPctClass = computed(function() {
   if (dorPct.value >= 80) return 'text-green-600 dark:text-green-400'
   if (dorPct.value >= 50) return 'text-yellow-600 dark:text-yellow-400'
   return 'text-red-600 dark:text-red-400'
-})
-
-var healthTooltip = computed(function() {
-  var lines = []
-  lines.push('Risk: ' + effectiveRisk.value.charAt(0).toUpperCase() + effectiveRisk.value.slice(1))
-  var dor = props.feature.dor
-  lines.push('DoR: ' + dorPct.value + '% (' + (dor ? dor.checkedCount : 0) + '/' + (dor ? dor.totalCount : 0) + ')')
-  if (riskFlags.value.length > 0) {
-    lines.push(riskFlags.value.length + ' risk flag(s):')
-    for (var i = 0; i < riskFlags.value.length; i++) {
-      lines.push('  - ' + riskFlags.value[i].category + ': ' + riskFlags.value[i].message)
-    }
-  }
-  if (riskOverride.value) {
-    lines.push('Override: ' + riskOverride.value.riskOverride + ' (' + riskOverride.value.reason + ')')
-  }
-  return lines.join('\n')
 })
 
 var priorityScoreClass = computed(function() {
@@ -156,17 +140,27 @@ var flagSeverityClass = {
     </td>
     <!-- Health (combined Risk + DoR) -->
     <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
-      <div class="flex items-center gap-1.5" :title="healthTooltip">
-        <span
-          class="w-2.5 h-2.5 rounded-full flex-shrink-0"
-          role="img"
-          :aria-label="'Risk level: ' + effectiveRisk"
-          :class="{
-            'bg-green-500': effectiveRisk === 'green',
-            'bg-yellow-500': effectiveRisk === 'yellow',
-            'bg-red-500': effectiveRisk === 'red'
-          }"
-        ></span>
+      <div class="flex items-center gap-1.5">
+        <RiskPopover
+          :level="riskLevel"
+          :flags="riskFlags"
+          :flagCount="riskFlags.length"
+          :override="riskOverride"
+          :dor="feature.dor"
+          variant="full"
+        >
+          <span
+            class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+            :class="{
+              'cursor-help': riskFlags.length > 0 || riskOverride,
+              'bg-green-500': effectiveRisk === 'green',
+              'bg-yellow-500': effectiveRisk === 'yellow',
+              'bg-red-500': effectiveRisk === 'red'
+            }"
+            role="img"
+            :aria-label="'Risk level: ' + effectiveRisk"
+          ></span>
+        </RiskPopover>
         <span
           class="text-xs font-medium"
           :class="dorPctClass"

--- a/modules/release-planning/client/components/FeaturesTable.vue
+++ b/modules/release-planning/client/components/FeaturesTable.vue
@@ -1,6 +1,7 @@
 <script setup>
 import StatusBadge from './StatusBadge.vue'
 import RiskBadge from './RiskBadge.vue'
+import RiskPopover from './RiskPopover.vue'
 import TierSeparator from './TierSeparator.vue'
 import { computed } from 'vue'
 import { PRIORITY_STYLES } from '../constants'
@@ -92,13 +93,22 @@ const groupedFeatures = computed(() => {
               </td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600"><StatusBadge :status="item.data.status" /></td>
               <td v-if="hasHealth" class="px-3 py-2 border border-gray-300 dark:border-gray-600">
-                <RiskBadge
+                <RiskPopover
                   v-if="healthByKey[item.data.issueKey]"
                   :level="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.level : 'green'"
-                  :flagCount="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.score : 0"
                   :flags="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.flags : []"
+                  :flagCount="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.flags.length : 0"
                   :override="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.override : null"
-                />
+                  :dor="healthByKey[item.data.issueKey].dor || null"
+                  variant="full"
+                >
+                  <RiskBadge
+                    :level="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.level : 'green'"
+                    :flagCount="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.flags.length : 0"
+                    :flags="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.flags : []"
+                    :override="healthByKey[item.data.issueKey].risk ? healthByKey[item.data.issueKey].risk.override : null"
+                  />
+                </RiskPopover>
                 <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
               </td>
               <td v-if="hasHealth" class="px-3 py-2 border border-gray-300 dark:border-gray-600 text-xs text-center">

--- a/modules/release-planning/client/components/RfesTable.vue
+++ b/modules/release-planning/client/components/RfesTable.vue
@@ -1,5 +1,7 @@
 <script setup>
 import StatusBadge from './StatusBadge.vue'
+import RiskBadge from './RiskBadge.vue'
+import RiskPopover from './RiskPopover.vue'
 import TierSeparator from './TierSeparator.vue'
 import { computed } from 'vue'
 import { PRIORITY_STYLES } from '../constants'
@@ -8,10 +10,17 @@ const props = defineProps({
   rfes: { type: Array, default: () => [] },
   bigRocks: { type: Array, default: () => [] },
   jiraBaseUrl: { type: String, default: '' },
-  summary: { type: Object, default: null }
+  summary: { type: Object, default: null },
+  rfeKeyToHealth: { type: Object, default: () => ({}) }
 })
 
-const COL_COUNT = 8
+const hasHealth = computed(function() {
+  return Object.keys(props.rfeKeyToHealth).length > 0
+})
+
+const COL_COUNT = computed(function() {
+  return hasHealth.value ? 9 : 8
+})
 
 const tierCounts = computed(() => {
   const counts = {}
@@ -49,6 +58,7 @@ const groupedRfes = computed(() => {
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Big Rock</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">RFE</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Status</th>
+            <th v-if="hasHealth" scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Risk</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Priority</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Title</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Components</th>
@@ -78,6 +88,25 @@ const groupedRfes = computed(() => {
                 >{{ item.data.issueKey }}</a>
               </td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600"><StatusBadge :status="item.data.status" /></td>
+              <td v-if="hasHealth" class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+                <RiskPopover
+                  v-if="rfeKeyToHealth[item.data.issueKey]"
+                  :level="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.level : 'green'"
+                  :flags="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.flags : []"
+                  :flagCount="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.flags.length : 0"
+                  :override="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.override : null"
+                  :dor="rfeKeyToHealth[item.data.issueKey].dor || null"
+                  variant="full"
+                >
+                  <RiskBadge
+                    :level="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.level : 'green'"
+                    :flagCount="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.flags.length : 0"
+                    :flags="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.flags : []"
+                    :override="rfeKeyToHealth[item.data.issueKey].risk ? rfeKeyToHealth[item.data.issueKey].risk.override : null"
+                  />
+                </RiskPopover>
+                <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
+              </td>
               <td class="px-3 py-2 border border-gray-300 dark:border-gray-600">
                 <span
                   v-if="item.data.priority"

--- a/modules/release-planning/client/components/RiskBadge.vue
+++ b/modules/release-planning/client/components/RiskBadge.vue
@@ -27,26 +27,12 @@ const levelLabel = computed(function() {
   return 'Green'
 })
 
-const tooltipText = computed(function() {
-  var lines = []
-  if (props.override) {
-    lines.push('Manual override: ' + props.override.riskOverride)
-    if (props.override.reason) lines.push('Reason: ' + props.override.reason)
-  }
-  if (props.flags && props.flags.length > 0) {
-    for (var i = 0; i < props.flags.length; i++) {
-      lines.push(props.flags[i].category + ': ' + props.flags[i].message)
-    }
-  }
-  return lines.join('\n')
-})
 </script>
 
 <template>
   <span
     class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs font-medium relative"
     :class="badgeClasses"
-    :title="tooltipText"
   >
     {{ levelLabel }}
     <sup
@@ -56,7 +42,6 @@ const tooltipText = computed(function() {
     <span
       v-if="override"
       class="ml-0.5 text-[9px] opacity-70"
-      title="Manually overridden"
     >M</span>
   </span>
 </template>

--- a/modules/release-planning/client/components/RiskPopover.vue
+++ b/modules/release-planning/client/components/RiskPopover.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { usePopover } from '../composables/usePopover'
 
 const props = defineProps({
@@ -16,8 +16,6 @@ var hasContent = computed(function() {
 })
 
 var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismiss, onKeyDown } = usePopover()
-
-var popoverRef = ref(null)
 
 var displayLevel = computed(function() {
   if (props.override) return props.override.riskOverride || props.level
@@ -73,7 +71,6 @@ function formatDate(iso) {
 
     <div
       v-if="isVisible && hasContent"
-      ref="popoverRef"
       :data-popover-id="popoverId"
       role="dialog"
       aria-live="polite"

--- a/modules/release-planning/client/components/RiskPopover.vue
+++ b/modules/release-planning/client/components/RiskPopover.vue
@@ -1,0 +1,139 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { usePopover } from '../composables/usePopover'
+
+const props = defineProps({
+  level: { type: String, default: 'green' },
+  flags: { type: Array, default: () => [] },
+  flagCount: { type: Number, default: 0 },
+  override: { type: Object, default: null },
+  dor: { type: Object, default: null },
+  variant: { type: String, default: 'full' }
+})
+
+var hasContent = computed(function() {
+  return (props.flags && props.flags.length > 0) || props.override
+})
+
+var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismiss, onKeyDown } = usePopover()
+
+var popoverRef = ref(null)
+
+var displayLevel = computed(function() {
+  if (props.override) return props.override.riskOverride || props.level
+  return props.level
+})
+
+var levelLabel = computed(function() {
+  var l = displayLevel.value
+  if (l === 'red') return 'Red'
+  if (l === 'yellow') return 'Yellow'
+  return 'Green'
+})
+
+var levelDotClass = computed(function() {
+  var l = displayLevel.value
+  if (l === 'red') return 'bg-red-500'
+  if (l === 'yellow') return 'bg-yellow-500'
+  return 'bg-green-500'
+})
+
+var headerBorderClass = computed(function() {
+  var l = displayLevel.value
+  if (l === 'red') return 'border-red-200 dark:border-red-500/30'
+  if (l === 'yellow') return 'border-yellow-200 dark:border-yellow-500/30'
+  return 'border-green-200 dark:border-green-500/30'
+})
+
+var severityClasses = {
+  high: 'text-red-700 dark:text-red-400',
+  medium: 'text-yellow-700 dark:text-yellow-400',
+  low: 'text-gray-500 dark:text-gray-400'
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString()
+}
+</script>
+
+<template>
+  <span
+    class="relative inline-flex"
+    :data-popover-trigger="popoverId"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    @click="onClick"
+    @keydown="onKeyDown"
+    :aria-expanded="isVisible"
+    tabindex="0"
+    role="button"
+  >
+    <slot />
+
+    <div
+      v-if="isVisible && hasContent"
+      ref="popoverRef"
+      :data-popover-id="popoverId"
+      role="dialog"
+      aria-live="polite"
+      class="absolute z-50 left-0 top-full mt-1 w-96 max-w-[min(384px,90vw)] bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
+      <!-- Header -->
+      <div class="flex items-center justify-between px-3 py-2 border-b" :class="headerBorderClass">
+        <div class="flex items-center gap-1.5">
+          <span class="w-2 h-2 rounded-full flex-shrink-0" :class="levelDotClass"></span>
+          <span class="font-semibold text-gray-900 dark:text-gray-100">Risk: {{ levelLabel }}</span>
+          <span v-if="flagCount > 0" class="text-gray-500 dark:text-gray-400">({{ flagCount }} flag{{ flagCount !== 1 ? 's' : '' }})</span>
+        </div>
+        <button
+          v-if="isPinned"
+          @click.stop="dismiss"
+          class="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+          aria-label="Close popover"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Override section -->
+      <div
+        v-if="override"
+        class="px-3 py-2 border-b border-gray-200 dark:border-gray-700 bg-amber-50 dark:bg-amber-500/10"
+      >
+        <div class="text-amber-700 dark:text-amber-400 font-semibold">
+          Override: {{ override.riskOverride }}
+          <span v-if="override.reason" class="font-normal"> -- "{{ override.reason }}"</span>
+        </div>
+        <div v-if="override.updatedBy" class="text-gray-500 dark:text-gray-400 mt-0.5">
+          by {{ override.updatedBy }}<span v-if="override.updatedAt"> on {{ formatDate(override.updatedAt) }}</span>
+        </div>
+      </div>
+
+      <!-- Flags body -->
+      <div class="px-3 py-2 max-h-64 overflow-y-auto">
+        <div class="space-y-2">
+          <div v-for="(flag, idx) in flags" :key="idx">
+            <div class="flex items-baseline gap-1">
+              <span class="font-semibold text-gray-900 dark:text-gray-100">{{ flag.category }}</span>
+              <span class="text-[10px]" :class="severityClasses[flag.severity] || severityClasses.medium">({{ flag.severity }})</span>
+            </div>
+            <div class="text-gray-600 dark:text-gray-400 mt-0.5 pl-0.5">{{ flag.message }}</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DoR summary (full variant) -->
+      <div
+        v-if="variant === 'full' && dor"
+        class="px-3 py-2 border-t border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400"
+      >
+        DoR: {{ dor.completionPct }}% ({{ dor.checkedCount }}/{{ dor.totalCount }} items)
+      </div>
+    </div>
+  </span>
+</template>

--- a/modules/release-planning/client/composables/usePopover.js
+++ b/modules/release-planning/client/composables/usePopover.js
@@ -1,0 +1,123 @@
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+
+var activePinnedId = ref(null)
+var idCounter = 0
+
+export function usePopover(options) {
+  var opts = options || {}
+  var hoverDelay = opts.hoverDelay != null ? opts.hoverDelay : 150
+  var leaveDelay = opts.leaveDelay != null ? opts.leaveDelay : 100
+
+  var myId = ++idCounter
+  var isVisible = ref(false)
+  var isPinned = ref(false)
+  var hoverTimeout = null
+  var leaveTimeout = null
+
+  function clearTimers() {
+    if (hoverTimeout) {
+      clearTimeout(hoverTimeout)
+      hoverTimeout = null
+    }
+    if (leaveTimeout) {
+      clearTimeout(leaveTimeout)
+      leaveTimeout = null
+    }
+  }
+
+  function onMouseEnter() {
+    if (isPinned.value) return
+    if (leaveTimeout) {
+      clearTimeout(leaveTimeout)
+      leaveTimeout = null
+    }
+    hoverTimeout = setTimeout(function() {
+      isVisible.value = true
+      hoverTimeout = null
+    }, hoverDelay)
+  }
+
+  function onMouseLeave() {
+    if (isPinned.value) return
+    if (hoverTimeout) {
+      clearTimeout(hoverTimeout)
+      hoverTimeout = null
+    }
+    leaveTimeout = setTimeout(function() {
+      isVisible.value = false
+      leaveTimeout = null
+    }, leaveDelay)
+  }
+
+  function onClick(event) {
+    if (event) event.stopPropagation()
+    clearTimers()
+    if (isPinned.value) {
+      dismiss()
+    } else {
+      isPinned.value = true
+      isVisible.value = true
+      activePinnedId.value = myId
+    }
+  }
+
+  function dismiss() {
+    isPinned.value = false
+    isVisible.value = false
+    clearTimers()
+    if (activePinnedId.value === myId) {
+      activePinnedId.value = null
+    }
+  }
+
+  function onKeyDown(event) {
+    if (event.key === 'Escape' && isPinned.value) {
+      dismiss()
+    }
+    if ((event.key === 'Enter' || event.key === ' ') && !isPinned.value) {
+      event.preventDefault()
+      onClick()
+    }
+  }
+
+  function handleOutsideClick(event) {
+    if (!isPinned.value) return
+    var popoverEl = document.querySelector('[data-popover-id="' + myId + '"]')
+    var triggerEl = document.querySelector('[data-popover-trigger="' + myId + '"]')
+    if (popoverEl && popoverEl.contains(event.target)) return
+    if (triggerEl && triggerEl.contains(event.target)) return
+    dismiss()
+  }
+
+  onMounted(function() {
+    document.addEventListener('click', handleOutsideClick)
+  })
+
+  var stopWatch = watch(activePinnedId, function(newId) {
+    if (newId !== myId && isPinned.value) {
+      isPinned.value = false
+      isVisible.value = false
+      clearTimers()
+    }
+  })
+
+  onBeforeUnmount(function() {
+    clearTimers()
+    document.removeEventListener('click', handleOutsideClick)
+    stopWatch()
+    if (activePinnedId.value === myId) {
+      activePinnedId.value = null
+    }
+  })
+
+  return {
+    isVisible: isVisible,
+    isPinned: isPinned,
+    popoverId: myId,
+    onMouseEnter: onMouseEnter,
+    onMouseLeave: onMouseLeave,
+    onClick: onClick,
+    dismiss: dismiss,
+    onKeyDown: onKeyDown
+  }
+}

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -96,6 +96,28 @@ const healthByKey = computed(function() {
 const healthSummary = computed(function() {
   return healthData.value ? healthData.value.summary : null
 })
+
+var RISK_SEVERITY = { red: 0, yellow: 1, green: 2 }
+
+function isWorse(levelA, levelB) {
+  return (RISK_SEVERITY[levelA] != null ? RISK_SEVERITY[levelA] : 2) < (RISK_SEVERITY[levelB] != null ? RISK_SEVERITY[levelB] : 2)
+}
+
+const rfeKeyToHealth = computed(function() {
+  if (!features.value || Object.keys(healthByKey.value).length === 0) return {}
+  var map = {}
+  for (var i = 0; i < features.value.length; i++) {
+    var f = features.value[i]
+    if (!f.rfe) continue
+    var h = healthByKey.value[f.issueKey]
+    if (!h || !h.risk) continue
+    var existing = map[f.rfe]
+    if (!existing || isWorse(h.risk.level, existing.risk.level)) {
+      map[f.rfe] = { risk: h.risk, dor: h.dor || null }
+    }
+  }
+  return map
+})
 const warning = computed(() => candidates.value ? candidates.value.warning : null)
 const pipelineWarnings = computed(() => candidates.value ? candidates.value.pipelineWarnings || [] : [])
 const canEdit = computed(() => !demoMode.value && permissions.value && permissions.value.canEdit)
@@ -656,6 +678,7 @@ onUnmounted(function() {
           :bigRocks="bigRocks"
           :jiraBaseUrl="jiraBaseUrl"
           :summary="summary"
+          :rfeKeyToHealth="rfeKeyToHealth"
         />
       </div>
     </template>


### PR DESCRIPTION
## Summary
- Add interactive hover/click popovers for risk health data across Big Rocks, Features, and RFEs tables
- New `RiskPopover` component shows risk flags, DoR status, and overrides for individual features
- New `BigRockHealthPopover` component shows per-feature health breakdown for Big Rock badges
- New `usePopover` composable handles hover delay, click-to-pin, escape/outside-click dismiss, and singleton coordination
- Fix critical bug where Big Rock health badges always showed "OK" for red-level risks (`RISK_SEVERITY["red"]` is `0`, and `0 || 2` evaluates to `2` due to JavaScript falsy zero)
- Add Risk column to RFEs table showing worst risk from linked features
- Expand health fixture with RHAISTRAT-keyed entries for demo mode coverage

## Test plan
- [x] 20 unit tests covering RiskPopover and BigRockHealthPopover behavior
- [x] Verify Big Rocks health badges show correct levels (Critical/At Risk/OK)
- [x] Verify hover shows popover with flag details, click pins it
- [x] Verify green/no-flag items suppress the popover entirely
- [x] Verify RFE Risk column appears when health data is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)