### PR TITLE
refactor(release-planning): extract composables and fix health override inconsistency

### DIFF
--- a/modules/release-planning/__tests__/client/use-click-outside.test.js
+++ b/modules/release-planning/__tests__/client/use-click-outside.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+// Mock Vue lifecycle hooks
+var mountedHooks = []
+var unmountedHooks = []
+
+vi.mock('vue', async () => {
+  var actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    onMounted: function(fn) { mountedHooks.push(fn) },
+    onUnmounted: function(fn) { unmountedHooks.push(fn) }
+  }
+})
+
+import { useClickOutside } from '../../client/composables/useClickOutside'
+
+describe('useClickOutside', function() {
+  beforeEach(function() {
+    mountedHooks = []
+    unmountedHooks = []
+  })
+
+  afterEach(function() {
+    // Run unmount hooks to clean up listeners
+    unmountedHooks.forEach(function(fn) { fn() })
+  })
+
+  it('calls handler on document click when no element ref', function() {
+    var called = 0
+    useClickOutside(null, function() { called++ })
+
+    // Simulate mount
+    mountedHooks.forEach(function(fn) { fn() })
+
+    document.dispatchEvent(new Event('click'))
+    expect(called).toBe(1)
+
+    document.dispatchEvent(new Event('click'))
+    expect(called).toBe(2)
+  })
+
+  it('calls handler when click is outside the element', function() {
+    var container = document.createElement('div')
+    document.body.appendChild(container)
+    var elementRef = ref(container)
+    var called = 0
+
+    useClickOutside(elementRef, function() { called++ })
+    mountedHooks.forEach(function(fn) { fn() })
+
+    // Click outside
+    var outsideEl = document.createElement('div')
+    document.body.appendChild(outsideEl)
+    var event = new Event('click', { bubbles: true })
+    Object.defineProperty(event, 'target', { value: outsideEl })
+    document.dispatchEvent(event)
+
+    expect(called).toBe(1)
+
+    // Cleanup
+    document.body.removeChild(container)
+    document.body.removeChild(outsideEl)
+  })
+
+  it('does not call handler when click is inside the element', function() {
+    var container = document.createElement('div')
+    var child = document.createElement('span')
+    container.appendChild(child)
+    document.body.appendChild(container)
+    var elementRef = ref(container)
+    var called = 0
+
+    useClickOutside(elementRef, function() { called++ })
+    mountedHooks.forEach(function(fn) { fn() })
+
+    // Click inside
+    var event = new Event('click', { bubbles: true })
+    Object.defineProperty(event, 'target', { value: child })
+    document.dispatchEvent(event)
+
+    expect(called).toBe(0)
+
+    // Cleanup
+    document.body.removeChild(container)
+  })
+
+  it('removes listener on unmount', function() {
+    var called = 0
+    useClickOutside(null, function() { called++ })
+
+    mountedHooks.forEach(function(fn) { fn() })
+    document.dispatchEvent(new Event('click'))
+    expect(called).toBe(1)
+
+    // Unmount
+    unmountedHooks.forEach(function(fn) { fn() })
+    unmountedHooks = []
+
+    document.dispatchEvent(new Event('click'))
+    expect(called).toBe(1) // should not increment
+  })
+
+  it('calls handler when element ref is null', function() {
+    var elementRef = ref(null)
+    var called = 0
+
+    useClickOutside(elementRef, function() { called++ })
+    mountedHooks.forEach(function(fn) { fn() })
+
+    document.dispatchEvent(new Event('click'))
+    expect(called).toBe(1)
+  })
+})

--- a/modules/release-planning/__tests__/client/use-filters-big-rocks.test.js
+++ b/modules/release-planning/__tests__/client/use-filters-big-rocks.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useFilters } from '../../client/composables/useFilters'
+
+var sampleBigRocks = [
+  { name: 'MaaS', pillar: 'Inference', owner: 'Pat Johnson', architect: 'Alex', notes: '', fullName: 'Model as a Service' },
+  { name: 'Gen AI Studio', pillar: 'Agents', owner: 'Morgan Lee', architect: 'Sam', notes: 'Priority', fullName: '' },
+  { name: 'Eval Hub', pillar: 'Inference', owner: 'Taylor', architect: '', notes: '', fullName: 'Evaluation Hub' }
+]
+
+describe('filteredBigRocks', function() {
+  it('returns all big rocks when no filters active', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+    expect(result.filteredBigRocks.value).toEqual(sampleBigRocks)
+  })
+
+  it('filters by pillar', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.selectedPillar.value = 'Inference'
+    expect(result.filteredBigRocks.value).toHaveLength(2)
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['MaaS', 'Eval Hub'])
+  })
+
+  it('filters by search query (name)', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.searchQuery.value = 'maas'
+    expect(result.filteredBigRocks.value).toHaveLength(1)
+    expect(result.filteredBigRocks.value[0].name).toBe('MaaS')
+  })
+
+  it('filters by search query (owner)', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.searchQuery.value = 'morgan'
+    expect(result.filteredBigRocks.value).toHaveLength(1)
+    expect(result.filteredBigRocks.value[0].name).toBe('Gen AI Studio')
+  })
+
+  it('filters by search query (fullName)', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.searchQuery.value = 'evaluation'
+    expect(result.filteredBigRocks.value).toHaveLength(1)
+    expect(result.filteredBigRocks.value[0].name).toBe('Eval Hub')
+  })
+
+  it('filters by search query (notes)', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.searchQuery.value = 'priority'
+    expect(result.filteredBigRocks.value).toHaveLength(1)
+    expect(result.filteredBigRocks.value[0].name).toBe('Gen AI Studio')
+  })
+
+  it('combines pillar and search filters', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.selectedPillar.value = 'Inference'
+    result.searchQuery.value = 'eval'
+    expect(result.filteredBigRocks.value).toHaveLength(1)
+    expect(result.filteredBigRocks.value[0].name).toBe('Eval Hub')
+  })
+
+  it('returns empty when pillar matches nothing', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.selectedPillar.value = 'NonExistent'
+    expect(result.filteredBigRocks.value).toHaveLength(0)
+  })
+
+  it('returns empty when bigRocks is null', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(null)
+    var result = useFilters(features, rfes, bigRocks)
+    expect(result.filteredBigRocks.value).toEqual([])
+  })
+
+  it('clearFilters resets pillar and shows all rocks', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.selectedPillar.value = 'Inference'
+    expect(result.filteredBigRocks.value).toHaveLength(2)
+
+    result.clearFilters()
+    expect(result.filteredBigRocks.value).toEqual(sampleBigRocks)
+  })
+})

--- a/modules/release-planning/__tests__/client/use-health-aggregation.test.js
+++ b/modules/release-planning/__tests__/client/use-health-aggregation.test.js
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useHealthAggregation } from '../../client/composables/useHealthAggregation'
+
+function makeHealthData(features) {
+  return { features: features, summary: { total: features.length } }
+}
+
+function makeFeature(key, rfe, bigRock) {
+  return { issueKey: key, rfe: rfe || null, bigRock: bigRock || null }
+}
+
+function makeHealthFeature(key, level, flags, override) {
+  var result = {
+    key: key,
+    risk: {
+      level: level,
+      score: flags ? flags.length : 0,
+      flags: flags || []
+    },
+    dor: { completionPct: 50 }
+  }
+  if (override) {
+    result.risk.override = override
+  }
+  return result
+}
+
+describe('useHealthAggregation', function() {
+  describe('healthByKey', function() {
+    it('maps health features by key', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'green', []),
+        makeHealthFeature('FEAT-2', 'red', [{ category: 'BLOCKED' }])
+      ]))
+      var features = ref([])
+      var rfes = ref([])
+      var bigRocks = ref([])
+
+      var result = useHealthAggregation(hd, features, rfes, bigRocks)
+      expect(Object.keys(result.healthByKey.value)).toEqual(['FEAT-1', 'FEAT-2'])
+      expect(result.healthByKey.value['FEAT-1'].risk.level).toBe('green')
+      expect(result.healthByKey.value['FEAT-2'].risk.level).toBe('red')
+    })
+
+    it('returns empty object when healthData is null', function() {
+      var result = useHealthAggregation(ref(null), ref([]), ref([]), ref([]))
+      expect(result.healthByKey.value).toEqual({})
+    })
+
+    it('returns empty object when healthData has no features', function() {
+      var result = useHealthAggregation(ref({}), ref([]), ref([]), ref([]))
+      expect(result.healthByKey.value).toEqual({})
+    })
+  })
+
+  describe('healthSummary', function() {
+    it('returns summary from health data', function() {
+      var hd = ref({ features: [], summary: { total: 5, byRisk: { red: 1 } } })
+      var result = useHealthAggregation(hd, ref([]), ref([]), ref([]))
+      expect(result.healthSummary.value).toEqual({ total: 5, byRisk: { red: 1 } })
+    })
+
+    it('returns null when healthData is null', function() {
+      var result = useHealthAggregation(ref(null), ref([]), ref([]), ref([]))
+      expect(result.healthSummary.value).toBe(null)
+    })
+  })
+
+  describe('rfeKeyToHealth', function() {
+    it('maps RFE keys to worst feature health', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'green', []),
+        makeHealthFeature('FEAT-2', 'red', [{ category: 'BLOCKED' }])
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', 'RFE-100', null),
+        makeFeature('FEAT-2', 'RFE-100', null)
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.rfeKeyToHealth.value['RFE-100'].risk.level).toBe('red')
+    })
+
+    it('respects risk overrides (M5 fix)', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', [{ category: 'BLOCKED' }], { riskOverride: 'green', reason: 'PM override' })
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', 'RFE-100', null)
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      // With override, the effective level should be green, not red
+      expect(result.rfeKeyToHealth.value['RFE-100'].risk.level).toBe('green')
+    })
+
+    it('picks worst override-adjusted level across features for same RFE', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', [], { riskOverride: 'green', reason: 'OK' }),
+        makeHealthFeature('FEAT-2', 'yellow', [])
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', 'RFE-100', null),
+        makeFeature('FEAT-2', 'RFE-100', null)
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      // FEAT-1 is green (overridden), FEAT-2 is yellow (no override) -- worst is yellow
+      expect(result.rfeKeyToHealth.value['RFE-100'].risk.level).toBe('yellow')
+    })
+
+    it('skips features without rfe', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', [])
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', null, null)
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(Object.keys(result.rfeKeyToHealth.value)).toEqual([])
+    })
+
+    it('returns empty when no health data', function() {
+      var features = ref([makeFeature('FEAT-1', 'RFE-100', null)])
+      var result = useHealthAggregation(ref(null), features, ref([]), ref([]))
+      expect(result.rfeKeyToHealth.value).toEqual({})
+    })
+  })
+
+  describe('rockHealth', function() {
+    it('aggregates worst health per big rock', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'green', []),
+        makeHealthFeature('FEAT-2', 'yellow', [{ category: 'EA1_MISS' }]),
+        makeHealthFeature('FEAT-3', 'red', [{ category: 'BLOCKED' }, { category: 'UNESTIMATED' }])
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', null, 'Rock A'),
+        makeFeature('FEAT-2', null, 'Rock A'),
+        makeFeature('FEAT-3', null, 'Rock B')
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.rockHealth.value['Rock A'].worstLevel).toBe('yellow')
+      expect(result.rockHealth.value['Rock A'].featureCount).toBe(2)
+      expect(result.rockHealth.value['Rock B'].worstLevel).toBe('red')
+      expect(result.rockHealth.value['Rock B'].featureCount).toBe(1)
+    })
+
+    it('respects risk overrides for rock health', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', [{ category: 'BLOCKED' }], { riskOverride: 'green', reason: 'OK' })
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', null, 'Rock A')
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.rockHealth.value['Rock A'].worstLevel).toBe('green')
+    })
+
+    it('skips features without bigRock', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', [])
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', null, null)
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(Object.keys(result.rockHealth.value)).toEqual([])
+    })
+
+    it('returns empty when no health data', function() {
+      var result = useHealthAggregation(ref(null), ref([]), ref([]), ref([]))
+      expect(result.rockHealth.value).toEqual({})
+    })
+  })
+
+  describe('rockFeatures', function() {
+    it('groups features by big rock with health detail', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'green', []),
+        makeHealthFeature('FEAT-2', 'red', [{ category: 'BLOCKED' }])
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', null, 'Rock A'),
+        makeFeature('FEAT-2', null, 'Rock A')
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      var rf = result.rockFeatures.value['Rock A']
+      expect(rf).toHaveLength(2)
+      expect(rf[0]).toEqual({
+        key: 'FEAT-1',
+        level: 'green',
+        flagCount: 0,
+        flagCategories: []
+      })
+      expect(rf[1]).toEqual({
+        key: 'FEAT-2',
+        level: 'red',
+        flagCount: 1,
+        flagCategories: ['BLOCKED']
+      })
+    })
+
+    it('defaults to green when feature has no health data', function() {
+      var hd = ref(makeHealthData([]))
+      var features = ref([
+        makeFeature('FEAT-1', null, 'Rock A')
+      ])
+
+      // healthByKey will be empty, so rockFeatures should also be empty
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.rockFeatures.value).toEqual({})
+    })
+
+    it('uses overridden level in feature detail', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', [{ category: 'BLOCKED' }], { riskOverride: 'yellow', reason: 'OK' })
+      ]))
+      var features = ref([
+        makeFeature('FEAT-1', null, 'Rock A')
+      ])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.rockFeatures.value['Rock A'][0].level).toBe('yellow')
+    })
+  })
+
+  describe('reactivity', function() {
+    it('updates when healthData changes', function() {
+      var hd = ref(null)
+      var features = ref([makeFeature('FEAT-1', 'RFE-100', 'Rock A')])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.healthByKey.value).toEqual({})
+
+      hd.value = makeHealthData([makeHealthFeature('FEAT-1', 'red', [])])
+      expect(result.healthByKey.value['FEAT-1'].risk.level).toBe('red')
+      expect(result.rockHealth.value['Rock A'].worstLevel).toBe('red')
+    })
+
+    it('updates when features change', function() {
+      var hd = ref(makeHealthData([
+        makeHealthFeature('FEAT-1', 'red', []),
+        makeHealthFeature('FEAT-2', 'green', [])
+      ]))
+      var features = ref([makeFeature('FEAT-1', null, 'Rock A')])
+
+      var result = useHealthAggregation(hd, features, ref([]), ref([]))
+      expect(result.rockHealth.value['Rock A'].featureCount).toBe(1)
+
+      features.value = [
+        makeFeature('FEAT-1', null, 'Rock A'),
+        makeFeature('FEAT-2', null, 'Rock A')
+      ]
+      expect(result.rockHealth.value['Rock A'].featureCount).toBe(2)
+    })
+  })
+})

--- a/modules/release-planning/__tests__/client/use-refresh-polling.test.js
+++ b/modules/release-planning/__tests__/client/use-refresh-polling.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+// Mock Vue lifecycle hooks so the composable can register them without a component
+var mountedHooks = []
+var unmountedHooks = []
+
+vi.mock('vue', async () => {
+  var actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    onMounted: function(fn) { mountedHooks.push(fn) },
+    onUnmounted: function(fn) { unmountedHooks.push(fn) }
+  }
+})
+
+import { useRefreshPolling } from '../../client/composables/useRefreshPolling'
+
+describe('useRefreshPolling', function() {
+  beforeEach(function() {
+    vi.useFakeTimers()
+    mountedHooks = []
+    unmountedHooks = []
+  })
+
+  afterEach(function() {
+    // Run all unmount hooks to clean up timers
+    unmountedHooks.forEach(function(fn) { fn() })
+    vi.useRealTimers()
+  })
+
+  it('starts polling when refreshing becomes true', async function() {
+    var refreshing = ref(false)
+    var checkCount = 0
+    var completeCount = 0
+
+    useRefreshPolling(
+      refreshing,
+      async function() { checkCount++; return { running: true } },
+      function() { completeCount++ }
+    )
+
+    // Trigger the watch
+    refreshing.value = true
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(checkCount).toBe(1)
+    expect(completeCount).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(checkCount).toBe(2)
+  })
+
+  it('stops polling and calls onComplete when status.running is false', async function() {
+    var refreshing = ref(false)
+    var completed = false
+    var callCount = 0
+
+    useRefreshPolling(
+      refreshing,
+      async function() {
+        callCount++
+        return { running: callCount < 2 }
+      },
+      function() { completed = true }
+    )
+
+    refreshing.value = true
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(callCount).toBe(1)
+    expect(completed).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(callCount).toBe(2)
+    expect(completed).toBe(true)
+
+    // Should not poll again after stopping
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(callCount).toBe(2)
+  })
+
+  it('uses custom interval', async function() {
+    var refreshing = ref(false)
+    var checkCount = 0
+
+    useRefreshPolling(
+      refreshing,
+      async function() { checkCount++; return { running: true } },
+      function() {},
+      { interval: 1000 }
+    )
+
+    refreshing.value = true
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(checkCount).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(checkCount).toBe(2)
+  })
+
+  it('cleans up on unmount', async function() {
+    var refreshing = ref(false)
+    var checkCount = 0
+
+    useRefreshPolling(
+      refreshing,
+      async function() { checkCount++; return { running: true } },
+      function() {}
+    )
+
+    // Start polling via watch
+    refreshing.value = true
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(checkCount).toBe(1)
+
+    // Unmount
+    unmountedHooks.forEach(function(fn) { fn() })
+    unmountedHooks = [] // prevent double cleanup in afterEach
+
+    // Should not poll after unmount
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(checkCount).toBe(1)
+  })
+
+  it('returns start and stop functions', function() {
+    var refreshing = ref(false)
+    var result = useRefreshPolling(
+      refreshing,
+      async function() { return { running: false } },
+      function() {}
+    )
+
+    expect(typeof result.start).toBe('function')
+    expect(typeof result.stop).toBe('function')
+  })
+})

--- a/modules/release-planning/client/components/BigRocksTable.vue
+++ b/modules/release-planning/client/components/BigRocksTable.vue
@@ -2,64 +2,17 @@
 import { ref, watch, computed } from 'vue'
 import draggable from 'vuedraggable'
 import BigRockRow from './BigRockRow.vue'
-import { RISK_SEVERITY } from '../utils/risk-levels'
 
 const props = defineProps({
   bigRocks: { type: Array, default: () => [] },
   jiraBaseUrl: { type: String, default: '' },
   canEdit: { type: Boolean, default: false },
-  healthByKey: { type: Object, default: () => ({}) },
-  features: { type: Array, default: () => [] }
+  rockHealth: { type: Object, default: () => ({}) },
+  rockFeatures: { type: Object, default: () => ({}) }
 })
 
 const hasHealth = computed(function() {
-  return Object.keys(props.healthByKey).length > 0
-})
-
-const rockHealth = computed(function() {
-  if (!hasHealth.value) return {}
-  var result = {}
-  for (var i = 0; i < props.features.length; i++) {
-    var f = props.features[i]
-    var rockName = f.bigRock
-    if (!rockName) continue
-    var h = props.healthByKey[f.issueKey]
-    if (!h || !h.risk) continue
-
-    if (!result[rockName]) {
-      result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0 }
-    }
-    result[rockName].featureCount++
-    result[rockName].totalFlags += (h.risk.score || 0)
-    var level = h.risk.override ? (h.risk.override.riskOverride || h.risk.level) : h.risk.level
-    if ((RISK_SEVERITY[level] != null ? RISK_SEVERITY[level] : 2) < (RISK_SEVERITY[result[rockName].worstLevel] != null ? RISK_SEVERITY[result[rockName].worstLevel] : 2)) {
-      result[rockName].worstLevel = level
-    }
-  }
-  return result
-})
-
-const rockFeatures = computed(function() {
-  if (!hasHealth.value) return {}
-  var result = {}
-  for (var i = 0; i < props.features.length; i++) {
-    var f = props.features[i]
-    var rockName = f.bigRock
-    if (!rockName) continue
-    var h = props.healthByKey[f.issueKey]
-    if (!result[rockName]) result[rockName] = []
-    var level = h && h.risk
-      ? (h.risk.override ? h.risk.override.riskOverride || h.risk.level : h.risk.level)
-      : 'green'
-    var flags = h && h.risk ? h.risk.flags || [] : []
-    result[rockName].push({
-      key: f.issueKey,
-      level: level,
-      flagCount: flags.length,
-      flagCategories: flags.map(function(fl) { return fl.category })
-    })
-  }
-  return result
+  return Object.keys(props.rockHealth).length > 0
 })
 
 const emit = defineEmits(['editRock', 'addRock', 'deleteRock', 'reorder'])

--- a/modules/release-planning/client/components/FilterBar.vue
+++ b/modules/release-planning/client/components/FilterBar.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed } from 'vue'
+import { useClickOutside } from '../composables/useClickOutside'
 
 const props = defineProps({
   filterOptions: { type: Object, default: () => ({}) },
@@ -45,18 +46,8 @@ function toggleTeam(team) {
   emit('update:selectedTeams', current)
 }
 
-function handleClickOutside(event) {
-  if (teamsDropdownRef.value && !teamsDropdownRef.value.contains(event.target)) {
-    teamsOpen.value = false
-  }
-}
-
-onMounted(function() {
-  document.addEventListener('click', handleClickOutside)
-})
-
-onUnmounted(function() {
-  document.removeEventListener('click', handleClickOutside)
+useClickOutside(teamsDropdownRef, function() {
+  teamsOpen.value = false
 })
 </script>
 

--- a/modules/release-planning/client/composables/useClickOutside.js
+++ b/modules/release-planning/client/composables/useClickOutside.js
@@ -1,0 +1,31 @@
+import { onMounted, onUnmounted } from 'vue'
+
+/**
+ * Composable that calls a handler when a click occurs outside a given element.
+ *
+ * If no element ref is provided, the handler is called on every document click
+ * (useful for closing menus where the toggle button uses @click.stop).
+ *
+ * @param {import('vue').Ref<HTMLElement|null>} [elementRef] - template ref to the container element
+ * @param {Function} handler - called when a click outside the element is detected
+ */
+export function useClickOutside(elementRef, handler) {
+  function listener(event) {
+    // If no element ref or the element doesn't exist yet, always fire
+    if (!elementRef || !elementRef.value) {
+      handler(event)
+      return
+    }
+    // If click is inside the element, ignore
+    if (elementRef.value.contains(event.target)) return
+    handler(event)
+  }
+
+  onMounted(function() {
+    document.addEventListener('click', listener)
+  })
+
+  onUnmounted(function() {
+    document.removeEventListener('click', listener)
+  })
+}

--- a/modules/release-planning/client/composables/useFilters.js
+++ b/modules/release-planning/client/composables/useFilters.js
@@ -69,8 +69,8 @@ export function useFilters(features, rfes, bigRocks) {
     return bigRocks.value.filter(function(rock) {
       if (selectedPillar.value && rock.pillar !== selectedPillar.value) return false
       if (searchQuery.value) {
-        var q = searchQuery.value.toLowerCase()
-        var matchesSearch =
+        const q = searchQuery.value.toLowerCase()
+        const matchesSearch =
           (rock.name && rock.name.toLowerCase().includes(q)) ||
           (rock.fullName && rock.fullName.toLowerCase().includes(q)) ||
           (rock.owner && rock.owner.toLowerCase().includes(q)) ||

--- a/modules/release-planning/client/composables/useFilters.js
+++ b/modules/release-planning/client/composables/useFilters.js
@@ -63,6 +63,26 @@ export function useFilters(features, rfes, bigRocks) {
     return rfes.value.filter(matchesFilters)
   })
 
+  const filteredBigRocks = computed(() => {
+    if (!bigRocks.value) return []
+    if (!selectedPillar.value && !searchQuery.value) return bigRocks.value
+    return bigRocks.value.filter(function(rock) {
+      if (selectedPillar.value && rock.pillar !== selectedPillar.value) return false
+      if (searchQuery.value) {
+        var q = searchQuery.value.toLowerCase()
+        var matchesSearch =
+          (rock.name && rock.name.toLowerCase().includes(q)) ||
+          (rock.fullName && rock.fullName.toLowerCase().includes(q)) ||
+          (rock.owner && rock.owner.toLowerCase().includes(q)) ||
+          (rock.architect && rock.architect.toLowerCase().includes(q)) ||
+          (rock.pillar && rock.pillar.toLowerCase().includes(q)) ||
+          (rock.notes && rock.notes.toLowerCase().includes(q))
+        if (!matchesSearch) return false
+      }
+      return true
+    })
+  })
+
   const hasActiveFilters = computed(() => {
     return !!(selectedPillar.value || selectedRock.value || selectedStatus.value ||
       selectedPriority.value || selectedTeams.value.length > 0 || searchQuery.value)
@@ -86,6 +106,7 @@ export function useFilters(features, rfes, bigRocks) {
     searchQuery,
     filteredFeatures,
     filteredRfes,
+    filteredBigRocks,
     hasActiveFilters,
     clearFilters
   }

--- a/modules/release-planning/client/composables/useHealthAggregation.js
+++ b/modules/release-planning/client/composables/useHealthAggregation.js
@@ -1,0 +1,132 @@
+import { computed } from 'vue'
+import { RISK_SEVERITY, isWorse } from '../utils/risk-levels'
+
+/**
+ * Composable that aggregates health data across features, RFEs, and big rocks.
+ *
+ * Accepts reactive refs as parameters (not singleton composables) to preserve
+ * Vue reactivity chains and avoid duplicate state.
+ *
+ * The M5 behavioral fix is applied here: rfeKeyToHealth now respects risk
+ * overrides, consistent with how rockHealth has always worked.
+ *
+ * @param {import('vue').Ref} healthData - reactive ref to health API response
+ * @param {import('vue').Ref} features - reactive ref to features array
+ * @param {import('vue').Ref} rfes - reactive ref to RFEs array (reserved for future use)
+ * @param {import('vue').Ref} bigRocks - reactive ref to big rocks array (reserved for future use)
+ * @returns {{ healthByKey, rfeKeyToHealth, rockHealth, rockFeatures, healthSummary }}
+ */
+export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
+  /**
+   * Map of feature issueKey -> health object from the health API.
+   */
+  var healthByKey = computed(function() {
+    if (!healthData.value || !healthData.value.features) return {}
+    var map = {}
+    for (var i = 0; i < healthData.value.features.length; i++) {
+      var f = healthData.value.features[i]
+      map[f.key] = f
+    }
+    return map
+  })
+
+  /**
+   * Summary from the health API response.
+   */
+  var healthSummary = computed(function() {
+    return healthData.value ? healthData.value.summary : null
+  })
+
+  /**
+   * Resolve effective risk level from a health entry, respecting overrides.
+   * This is the standardized logic (M5 fix) -- both rfeKeyToHealth and
+   * rockHealth now use this same function.
+   */
+  function effectiveLevel(h) {
+    if (!h || !h.risk) return null
+    return h.risk.override
+      ? (h.risk.override.riskOverride || h.risk.level)
+      : h.risk.level
+  }
+
+  /**
+   * Map of RFE issueKey -> worst health among features that reference it.
+   * Now respects risk overrides (M5 fix -- previously DashboardView ignored them).
+   */
+  var rfeKeyToHealth = computed(function() {
+    if (!features.value || Object.keys(healthByKey.value).length === 0) return {}
+    var map = {}
+    for (var i = 0; i < features.value.length; i++) {
+      var f = features.value[i]
+      if (!f.rfe) continue
+      var h = healthByKey.value[f.issueKey]
+      if (!h || !h.risk) continue
+      var level = effectiveLevel(h)
+      var existing = map[f.rfe]
+      if (!existing || isWorse(level, effectiveLevel(existing))) {
+        map[f.rfe] = { risk: { ...h.risk, level: level }, dor: h.dor || null }
+      }
+    }
+    return map
+  })
+
+  /**
+   * Per-big-rock aggregated health: worst risk level, total flags, feature count.
+   * Respects risk overrides.
+   */
+  var rockHealth = computed(function() {
+    if (Object.keys(healthByKey.value).length === 0) return {}
+    var result = {}
+    for (var i = 0; i < features.value.length; i++) {
+      var f = features.value[i]
+      var rockName = f.bigRock
+      if (!rockName) continue
+      var h = healthByKey.value[f.issueKey]
+      if (!h || !h.risk) continue
+
+      if (!result[rockName]) {
+        result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0 }
+      }
+      result[rockName].featureCount++
+      result[rockName].totalFlags += (h.risk.score || 0)
+      var level = effectiveLevel(h)
+      if ((RISK_SEVERITY[level] != null ? RISK_SEVERITY[level] : 2) < (RISK_SEVERITY[result[rockName].worstLevel] != null ? RISK_SEVERITY[result[rockName].worstLevel] : 2)) {
+        result[rockName].worstLevel = level
+      }
+    }
+    return result
+  })
+
+  /**
+   * Per-big-rock feature detail: key, effective level, flag count, flag categories.
+   * Respects risk overrides.
+   */
+  var rockFeatures = computed(function() {
+    if (Object.keys(healthByKey.value).length === 0) return {}
+    var result = {}
+    for (var i = 0; i < features.value.length; i++) {
+      var f = features.value[i]
+      var rockName = f.bigRock
+      if (!rockName) continue
+      var h = healthByKey.value[f.issueKey]
+      if (!result[rockName]) result[rockName] = []
+      var level = h && h.risk ? effectiveLevel(h) : 'green'
+      var flags = h && h.risk ? h.risk.flags || [] : []
+      result[rockName].push({
+        key: f.issueKey,
+        level: level,
+        flagCount: flags.length,
+        flagCategories: flags.map(function(fl) { return fl.category })
+      })
+    }
+    return result
+  })
+
+  return {
+    healthByKey: healthByKey,
+    rfeKeyToHealth: rfeKeyToHealth,
+    rockHealth: rockHealth,
+    rockFeatures: rockFeatures,
+    healthSummary: healthSummary
+  }
+}

--- a/modules/release-planning/client/composables/useHealthAggregation.js
+++ b/modules/release-planning/client/composables/useHealthAggregation.js
@@ -1,5 +1,5 @@
 import { computed } from 'vue'
-import { RISK_SEVERITY, isWorse } from '../utils/risk-levels'
+import { isWorse } from '../utils/risk-levels'
 
 /**
  * Composable that aggregates health data across features, RFEs, and big rocks.
@@ -90,7 +90,7 @@ export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
       result[rockName].featureCount++
       result[rockName].totalFlags += (h.risk.score || 0)
       var level = effectiveLevel(h)
-      if ((RISK_SEVERITY[level] != null ? RISK_SEVERITY[level] : 2) < (RISK_SEVERITY[result[rockName].worstLevel] != null ? RISK_SEVERITY[result[rockName].worstLevel] : 2)) {
+      if (isWorse(level, result[rockName].worstLevel)) {
         result[rockName].worstLevel = level
       }
     }

--- a/modules/release-planning/client/composables/useRefreshPolling.js
+++ b/modules/release-planning/client/composables/useRefreshPolling.js
@@ -1,0 +1,48 @@
+import { watch, onUnmounted } from 'vue'
+
+/**
+ * Composable that encapsulates the poll/stop pattern for refresh status checking.
+ *
+ * Watches a reactive `refreshing` ref and starts polling when it becomes true.
+ * When the server reports the refresh is complete, calls `onComplete` and stops.
+ *
+ * @param {import('vue').Ref<boolean>} refreshing - reactive ref indicating whether a refresh is in progress
+ * @param {Function} checkStatus - async function that returns { running: boolean }
+ * @param {Function} onComplete - called when a refresh finishes (e.g. reload data)
+ * @param {Object} [options]
+ * @param {number} [options.interval=3000] - polling interval in ms
+ */
+export function useRefreshPolling(refreshing, checkStatus, onComplete, options) {
+  var interval = (options && options.interval) || 3000
+  var timer = null
+
+  function start() {
+    stop()
+    timer = setInterval(async function() {
+      var status = await checkStatus()
+      if (!status.running) {
+        stop()
+        if (onComplete) onComplete()
+      }
+    }, interval)
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  watch(refreshing, function(isRefreshing) {
+    if (isRefreshing) {
+      start()
+    }
+  })
+
+  onUnmounted(function() {
+    stop()
+  })
+
+  return { start: start, stop: stop }
+}

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -1,10 +1,12 @@
 <script setup>
-import { ref, computed, inject, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, inject, onMounted, watch } from 'vue'
 import { useReleasePlanning, useReleases } from '../composables/useReleasePlanning'
 import { useReleaseHealth } from '../composables/useReleaseHealth'
 import { useBigRockEditor } from '../composables/useBigRockEditor'
 import { useFilters } from '../composables/useFilters'
-import { isWorse } from '../utils/risk-levels'
+import { useHealthAggregation } from '../composables/useHealthAggregation'
+import { useRefreshPolling } from '../composables/useRefreshPolling'
+import { useClickOutside } from '../composables/useClickOutside'
 import { exportMarkdown as exportMd, exportCsv as exportCsvFile } from '../utils/outcomes-export'
 import { formatDate } from '@shared/client'
 import SummaryCards from '../components/SummaryCards.vue'
@@ -49,32 +51,10 @@ const newReleaseDialogOpen = ref(false)
 // Seed state
 const seeding = ref(false)
 
-// Refresh polling
-let refreshPollTimer = null
-
-function startRefreshPolling() {
-  stopRefreshPolling()
-  refreshPollTimer = setInterval(async function() {
-    const status = await checkRefreshStatus()
-    if (!status.running) {
-      stopRefreshPolling()
-      if (selectedVersion.value) {
-        loadCandidates(selectedVersion.value)
-      }
-    }
-  }, 3000)
-}
-
-function stopRefreshPolling() {
-  if (refreshPollTimer) {
-    clearInterval(refreshPollTimer)
-    refreshPollTimer = null
-  }
-}
-
-watch(refreshing, function(isRefreshing) {
-  if (isRefreshing) {
-    startRefreshPolling()
+// Refresh polling -- composable handles watch + cleanup
+useRefreshPolling(refreshing, checkRefreshStatus, function() {
+  if (selectedVersion.value) {
+    loadCandidates(selectedVersion.value)
   }
 })
 
@@ -86,35 +66,13 @@ const filterOptions = computed(() => candidates.value ? candidates.value.filterO
 const jiraBaseUrl = computed(() => candidates.value ? candidates.value.jiraBaseUrl || '' : '')
 const demoMode = computed(() => candidates.value ? candidates.value.demoMode : false)
 
-const healthByKey = computed(function() {
-  if (!healthData.value || !healthData.value.features) return {}
-  var map = {}
-  for (var i = 0; i < healthData.value.features.length; i++) {
-    var f = healthData.value.features[i]
-    map[f.key] = f
-  }
-  return map
-})
-
-const healthSummary = computed(function() {
-  return healthData.value ? healthData.value.summary : null
-})
-
-const rfeKeyToHealth = computed(function() {
-  if (!features.value || Object.keys(healthByKey.value).length === 0) return {}
-  var map = {}
-  for (var i = 0; i < features.value.length; i++) {
-    var f = features.value[i]
-    if (!f.rfe) continue
-    var h = healthByKey.value[f.issueKey]
-    if (!h || !h.risk) continue
-    var existing = map[f.rfe]
-    if (!existing || isWorse(h.risk.level, existing.risk.level)) {
-      map[f.rfe] = { risk: h.risk, dor: h.dor || null }
-    }
-  }
-  return map
-})
+const {
+  healthByKey,
+  rfeKeyToHealth,
+  rockHealth,
+  rockFeatures,
+  healthSummary
+} = useHealthAggregation(healthData, features, rfes, bigRocks)
 const warning = computed(() => candidates.value ? candidates.value.warning : null)
 const pipelineWarnings = computed(() => candidates.value ? candidates.value.pipelineWarnings || [] : [])
 const canEdit = computed(() => !demoMode.value && permissions.value && permissions.value.canEdit)
@@ -128,6 +86,7 @@ const {
   searchQuery,
   filteredFeatures,
   filteredRfes,
+  filteredBigRocks,
   hasActiveFilters,
   clearFilters
 } = useFilters(features, rfes, bigRocks)
@@ -142,7 +101,7 @@ const tabs = [
 
 const featureCount = computed(() => filteredFeatures.value.length)
 const rfeCount = computed(() => filteredRfes.value.length)
-const bigRockCount = computed(() => bigRocks.value.length)
+const bigRockCount = computed(() => filteredBigRocks.value.length)
 
 function tabCount(tabId) {
   if (tabId === 'features') return featureCount.value
@@ -165,7 +124,7 @@ function getExportData() {
   return {
     activeTab: activeTab.value,
     selectedVersion: selectedVersion.value,
-    bigRocks: bigRocks.value,
+    bigRocks: filteredBigRocks.value,
     filteredFeatures: filteredFeatures.value,
     filteredRfes: filteredRfes.value
   }
@@ -329,12 +288,12 @@ watch(activeTab, function() {
   error.value = null
 })
 
-function handleClickOutside() {
+// Close export menu on outside click (composable handles mount/unmount)
+useClickOutside(null, function() {
   exportMenuOpen.value = false
-}
+})
 
 onMounted(async function() {
-  document.addEventListener('click', handleClickOutside)
   loadPermissions()
   await loadReleases()
   if (releases.value.length > 0) {
@@ -347,11 +306,6 @@ onMounted(async function() {
       activeTab.value = 'features'
     }
   }
-})
-
-onUnmounted(function() {
-  document.removeEventListener('click', handleClickOutside)
-  stopRefreshPolling()
 })
 </script>
 
@@ -508,11 +462,11 @@ onUnmounted(function() {
       <!-- Tab content -->
       <div v-if="activeTab === 'big-rocks'" id="panel-big-rocks" role="tabpanel" aria-labelledby="tab-big-rocks">
         <BigRocksTable
-          :bigRocks="bigRocks"
+          :bigRocks="filteredBigRocks"
           :jiraBaseUrl="jiraBaseUrl"
           :canEdit="canEdit"
-          :healthByKey="healthByKey"
-          :features="features"
+          :rockHealth="rockHealth"
+          :rockFeatures="rockFeatures"
           @editRock="handleEditRock"
           @addRock="handleAddRock"
           @deleteRock="handleDeleteRock"


### PR DESCRIPTION
## Summary
- **M5 fix:** Extract health aggregation into `useHealthAggregation` composable — standardizes `rfeKeyToHealth` to respect risk overrides, fixing a **user-visible inconsistency** where the RFEs tab ignored overrides but the Big Rocks tab respected them
- Extract refresh polling logic into `useRefreshPolling` composable
- Extract click-outside pattern into `useClickOutside` composable (used by DashboardView export menu + FilterBar teams dropdown)
- **M4 fix:** Add `filteredBigRocks` to `useFilters` — Big Rocks tab now filters by pillar and search query
- BigRocksTable receives pre-computed `rockHealth`/`rockFeatures` as props instead of computing internally

## Behavioral changes
- RFEs tab health badges now reflect risk overrides (previously showed computed risk only)
- Big Rocks tab now responds to pillar filter and search query

## Files changed
| File | Change |
|------|--------|
| `client/composables/useHealthAggregation.js` | **New** — centralized health aggregation |
| `client/composables/useRefreshPolling.js` | **New** — poll/stop pattern |
| `client/composables/useClickOutside.js` | **New** — document click listener |
| `client/views/DashboardView.vue` | Remove ~80 lines of inline logic |
| `client/components/BigRocksTable.vue` | Receive health as props, remove internal computation |
| `client/components/FilterBar.vue` | Use useClickOutside |
| `client/composables/useFilters.js` | Add filteredBigRocks |
| 4 new test files | 39 tests |

## Test plan
- [x] All 2255 tests pass (39 new)
- [x] ESLint clean
- [x] M5 override fix verified with dedicated tests
- [x] filteredBigRocks verified with 10 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)