### PR TITLE
feat(release-planning): add UX enhancements for Big Rocks editing

### DIFF
--- a/modules/release-planning/__tests__/client/big-rock-edit-panel.test.js
+++ b/modules/release-planning/__tests__/client/big-rock-edit-panel.test.js
@@ -382,6 +382,249 @@ describe('BigRockEditPanel', function() {
     })
   })
 
+  describe('unsaved-changes confirmation', function() {
+    it('shows discard prompt when cancelling with dirty edits', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      // Make a change to trigger dirty state
+      var ownerInput = wrapper.find('#rock-owner')
+      await ownerInput.setValue('changed@redhat.com')
+      await nextTick()
+
+      // Click Cancel
+      var cancelBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Cancel' })
+      await cancelBtn.trigger('click')
+      await nextTick()
+
+      // Should show discard prompt instead of emitting cancel
+      expect(wrapper.emitted('cancel')).toBeFalsy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('You have unsaved changes. Discard?')
+      wrapper.unmount()
+    })
+
+    it('shows discard prompt when clicking close button with dirty edits', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      var ownerInput = wrapper.find('#rock-owner')
+      await ownerInput.setValue('changed@redhat.com')
+      await nextTick()
+
+      var closeBtn = wrapper.find('[aria-label="Close panel"]')
+      await closeBtn.trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('cancel')).toBeFalsy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('shows discard prompt when clicking backdrop with dirty edits', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      var ownerInput = wrapper.find('#rock-owner')
+      await ownerInput.setValue('changed@redhat.com')
+      await nextTick()
+
+      var backdrop = wrapper.find('.fixed.inset-0.bg-black\\/30')
+      await backdrop.trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('cancel')).toBeFalsy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('emits cancel when Discard is clicked in the prompt', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      var ownerInput = wrapper.find('#rock-owner')
+      await ownerInput.setValue('changed@redhat.com')
+      await nextTick()
+
+      // Trigger the discard prompt
+      var cancelBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Cancel' })
+      await cancelBtn.trigger('click')
+      await nextTick()
+
+      // Click Discard
+      var discardBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Discard' })
+      await discardBtn.trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('cancel')).toBeTruthy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('hides prompt when Keep Editing is clicked', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      var ownerInput = wrapper.find('#rock-owner')
+      await ownerInput.setValue('changed@redhat.com')
+      await nextTick()
+
+      // Trigger the discard prompt
+      var cancelBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Cancel' })
+      await cancelBtn.trigger('click')
+      await nextTick()
+
+      // Click Keep Editing
+      var keepBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Keep Editing' })
+      await keepBtn.trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('cancel')).toBeFalsy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false)
+      // Panel should still be open
+      expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+      wrapper.unmount()
+    })
+
+    it('emits cancel directly when form is not dirty', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      // No changes made -- form is clean
+      var cancelBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Cancel' })
+      await cancelBtn.trigger('click')
+
+      // Should emit cancel without showing prompt
+      expect(wrapper.emitted('cancel')).toBeTruthy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('does not show prompt when saving is in progress', async function() {
+      editor.openForEdit(sampleRock)
+      var wrapper = mountPanel()
+
+      var ownerInput = wrapper.find('#rock-owner')
+      await ownerInput.setValue('changed@redhat.com')
+      await nextTick()
+
+      // Set saving state
+      editor.setSaving(true)
+      await nextTick()
+
+      // Cancel button is disabled when saving, so no prompt should appear
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('shows discard prompt for new rock with content', async function() {
+      editor.openForNew()
+      var wrapper = mountPanel()
+
+      var nameInput = wrapper.find('#rock-name')
+      await nameInput.setValue('New Rock')
+      await nextTick()
+
+      var cancelBtn = wrapper.findAll('button').find(function(b) { return b.text() === 'Cancel' })
+      await cancelBtn.trigger('click')
+      await nextTick()
+
+      expect(wrapper.emitted('cancel')).toBeFalsy()
+      expect(wrapper.find('[role="alertdialog"]').exists()).toBe(true)
+      wrapper.unmount()
+    })
+  })
+
+  describe('paste-to-add outcome keys', function() {
+    beforeEach(function() {
+      editor.openForNew()
+    })
+
+    it('adds multiple comma-separated keys on paste', async function() {
+      var wrapper = mountPanel()
+      var input = wrapper.find('#rock-outcome-key')
+
+      // Simulate paste event with comma-separated keys
+      var pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+      pasteEvent.clipboardData = { getData: function() { return 'KEY-1, KEY-2, KEY-3' } }
+      input.element.dispatchEvent(pasteEvent)
+      await nextTick()
+
+      expect(editor.formData.value.outcomeKeys).toEqual(['KEY-1', 'KEY-2', 'KEY-3'])
+      wrapper.unmount()
+    })
+
+    it('adds multiple newline-separated keys on paste', async function() {
+      var wrapper = mountPanel()
+      var input = wrapper.find('#rock-outcome-key')
+
+      var pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+      pasteEvent.clipboardData = { getData: function() { return 'KEY-1\nKEY-2\nKEY-3' } }
+      input.element.dispatchEvent(pasteEvent)
+      await nextTick()
+
+      expect(editor.formData.value.outcomeKeys).toEqual(['KEY-1', 'KEY-2', 'KEY-3'])
+      wrapper.unmount()
+    })
+
+    it('skips duplicates when pasting', async function() {
+      editor.formData.value.outcomeKeys = ['KEY-1']
+      await nextTick()
+
+      var wrapper = mountPanel()
+      var input = wrapper.find('#rock-outcome-key')
+
+      var pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+      pasteEvent.clipboardData = { getData: function() { return 'KEY-1, KEY-2' } }
+      input.element.dispatchEvent(pasteEvent)
+      await nextTick()
+
+      expect(editor.formData.value.outcomeKeys).toEqual(['KEY-1', 'KEY-2'])
+      wrapper.unmount()
+    })
+
+    it('trims whitespace and uppercases pasted keys', async function() {
+      var wrapper = mountPanel()
+      var input = wrapper.find('#rock-outcome-key')
+
+      var pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+      pasteEvent.clipboardData = { getData: function() { return '  key-a , key-b  ' } }
+      input.element.dispatchEvent(pasteEvent)
+      await nextTick()
+
+      expect(editor.formData.value.outcomeKeys).toEqual(['KEY-A', 'KEY-B'])
+      wrapper.unmount()
+    })
+
+    it('skips empty segments in pasted text', async function() {
+      var wrapper = mountPanel()
+      var input = wrapper.find('#rock-outcome-key')
+
+      var pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+      pasteEvent.clipboardData = { getData: function() { return 'KEY-1,,, KEY-2' } }
+      input.element.dispatchEvent(pasteEvent)
+      await nextTick()
+
+      expect(editor.formData.value.outcomeKeys).toEqual(['KEY-1', 'KEY-2'])
+      wrapper.unmount()
+    })
+
+    it('does not intercept single-key paste (no separator)', async function() {
+      var wrapper = mountPanel()
+      var input = wrapper.find('#rock-outcome-key')
+
+      // Paste with no comma/newline -- should NOT be intercepted
+      var pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+      pasteEvent.clipboardData = { getData: function() { return 'SINGLE-KEY' } }
+      input.element.dispatchEvent(pasteEvent)
+      await nextTick()
+
+      // Should not have been added directly (browser default paste behavior)
+      expect(editor.formData.value.outcomeKeys).toEqual([])
+      wrapper.unmount()
+    })
+  })
+
   describe('accessibility', function() {
     beforeEach(function() {
       editor.openForEdit(sampleRock)

--- a/modules/release-planning/__tests__/client/components.test.js
+++ b/modules/release-planning/__tests__/client/components.test.js
@@ -191,6 +191,33 @@ describe('BigRocksTable', () => {
       expect(th.attributes('scope')).toBe('col')
     }
   })
+
+  it('shows skeleton rows when loading is true', () => {
+    const wrapper = mount(BigRocksTable, {
+      props: { bigRocks: [], canEdit: false, loading: true }
+    })
+    // Should show skeleton rows, not the empty state
+    expect(wrapper.text()).not.toContain('No Big Rocks configured')
+    const skeletonRows = wrapper.findAll('.animate-pulse')
+    expect(skeletonRows.length).toBe(3)
+  })
+
+  it('hides skeleton and shows data when loading is false', () => {
+    const wrapper = mount(BigRocksTable, {
+      props: { bigRocks, canEdit: false, loading: false }
+    })
+    expect(wrapper.findAll('.animate-pulse').length).toBe(0)
+    expect(wrapper.text()).toContain('Rock A')
+    expect(wrapper.text()).toContain('Rock B')
+  })
+
+  it('shows empty state when loading is false and no rocks', () => {
+    const wrapper = mount(BigRocksTable, {
+      props: { bigRocks: [], canEdit: false, loading: false }
+    })
+    expect(wrapper.text()).toContain('No Big Rocks configured')
+    expect(wrapper.findAll('.animate-pulse').length).toBe(0)
+  })
 })
 
 describe('FilterBar', () => {

--- a/modules/release-planning/client/components/BigRockEditPanel.vue
+++ b/modules/release-planning/client/components/BigRockEditPanel.vue
@@ -25,15 +25,12 @@ function addOutcomeKey() {
 
 function parseAndAddKeys(text) {
   var keys = text.split(/[,\n\r]+/)
-  var added = 0
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i].trim().toUpperCase()
     if (!key) continue
     if (formData.value.outcomeKeys.includes(key)) continue
     formData.value.outcomeKeys.push(key)
-    added++
   }
-  return added
 }
 
 function handlePaste(event) {

--- a/modules/release-planning/client/components/BigRockEditPanel.vue
+++ b/modules/release-planning/client/components/BigRockEditPanel.vue
@@ -5,14 +5,15 @@ import { useFocusTrap } from '../composables/useFocusTrap'
 
 const emit = defineEmits(['save', 'cancel'])
 
-const { isOpen, formData, saving, saveError, fieldErrors, isNewRock } = useBigRockEditor()
+const { isOpen, formData, saving, saveError, fieldErrors, isNewRock, isDirty } = useBigRockEditor()
 
 const outcomeKeyInput = ref('')
 const panelRef = ref(null)
-const { handleKeydown } = useFocusTrap(panelRef, isOpen, function() { emit('cancel') })
+const showDiscardPrompt = ref(false)
+const { handleKeydown } = useFocusTrap(panelRef, isOpen, function() { attemptCancel() })
 
 function addOutcomeKey() {
-  const key = outcomeKeyInput.value.trim().toUpperCase()
+  var key = outcomeKeyInput.value.trim().toUpperCase()
   if (!key) return
   if (formData.value.outcomeKeys.includes(key)) {
     outcomeKeyInput.value = ''
@@ -20,6 +21,30 @@ function addOutcomeKey() {
   }
   formData.value.outcomeKeys.push(key)
   outcomeKeyInput.value = ''
+}
+
+function parseAndAddKeys(text) {
+  var keys = text.split(/[,\n\r]+/)
+  var added = 0
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i].trim().toUpperCase()
+    if (!key) continue
+    if (formData.value.outcomeKeys.includes(key)) continue
+    formData.value.outcomeKeys.push(key)
+    added++
+  }
+  return added
+}
+
+function handlePaste(event) {
+  var pasted = (event.clipboardData || window.clipboardData).getData('text')
+  if (!pasted) return
+  // Only intercept if the pasted text contains separators (comma or newline)
+  if (/[,\n\r]/.test(pasted)) {
+    event.preventDefault()
+    parseAndAddKeys(pasted)
+    outcomeKeyInput.value = ''
+  }
 }
 
 function removeOutcomeKey(index) {
@@ -37,8 +62,22 @@ function handleSave() {
   emit('save')
 }
 
-function handleCancel() {
+function attemptCancel() {
+  if (saving.value) return
+  if (isDirty.value) {
+    showDiscardPrompt.value = true
+    return
+  }
   emit('cancel')
+}
+
+function confirmDiscard() {
+  showDiscardPrompt.value = false
+  emit('cancel')
+}
+
+function keepEditing() {
+  showDiscardPrompt.value = false
 }
 
 function handleRetry() {
@@ -52,7 +91,7 @@ function handleRetry() {
     <div
       v-if="isOpen"
       class="fixed inset-0 bg-black/30 z-40"
-      @click="handleCancel"
+      @click="attemptCancel"
     />
   </Transition>
 
@@ -73,7 +112,7 @@ function handleRetry() {
           {{ isNewRock ? 'Add Big Rock' : 'Edit Big Rock' }}
         </h2>
         <button
-          @click="handleCancel"
+          @click="attemptCancel"
           aria-label="Close panel"
           class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
         >
@@ -187,6 +226,7 @@ function handleRetry() {
               v-model="outcomeKeyInput"
               type="text"
               @keydown="handleOutcomeKeydown"
+              @paste="handlePaste"
               class="flex-1 px-3 py-2 border rounded-md text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               :class="fieldErrors.outcomeKeys ? 'border-red-300 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'"
               placeholder="e.g., RHAISTRAT-1513 (press Enter)"
@@ -222,7 +262,7 @@ function handleRetry() {
       <!-- Footer -->
       <div class="flex items-center justify-end gap-3 px-5 py-4 border-t border-gray-200 dark:border-gray-700">
         <button
-          @click="handleCancel"
+          @click="attemptCancel"
           :disabled="saving"
           class="px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
         >
@@ -240,6 +280,39 @@ function handleRetry() {
           </svg>
           {{ saving ? 'Saving...' : 'Save' }}
         </button>
+      </div>
+    </div>
+  </Transition>
+
+  <!-- Discard changes confirmation -->
+  <Transition name="fade">
+    <div
+      v-if="showDiscardPrompt"
+      class="fixed inset-0 bg-black/40 z-[60] flex items-center justify-center"
+      @click.self="keepEditing"
+    >
+      <div
+        role="alertdialog"
+        aria-labelledby="discard-title"
+        aria-describedby="discard-desc"
+        class="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-5 max-w-sm mx-4 border border-gray-200 dark:border-gray-700"
+      >
+        <h3 id="discard-title" class="text-sm font-semibold text-gray-900 dark:text-gray-100">Unsaved changes</h3>
+        <p id="discard-desc" class="mt-1 text-sm text-gray-600 dark:text-gray-400">You have unsaved changes. Discard?</p>
+        <div class="mt-4 flex justify-end gap-3">
+          <button
+            @click="keepEditing"
+            class="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Keep Editing
+          </button>
+          <button
+            @click="confirmDiscard"
+            class="px-3 py-1.5 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700"
+          >
+            Discard
+          </button>
+        </div>
       </div>
     </div>
   </Transition>

--- a/modules/release-planning/client/components/BigRocksTable.vue
+++ b/modules/release-planning/client/components/BigRocksTable.vue
@@ -8,7 +8,8 @@ const props = defineProps({
   jiraBaseUrl: { type: String, default: '' },
   canEdit: { type: Boolean, default: false },
   rockHealth: { type: Object, default: () => ({}) },
-  rockFeatures: { type: Object, default: () => ({}) }
+  rockFeatures: { type: Object, default: () => ({}) },
+  loading: { type: Boolean, default: false }
 })
 
 const hasHealth = computed(function() {
@@ -109,14 +110,32 @@ function onDragEnd() {
           </template>
         </draggable>
         <tbody v-else>
-          <tr
-            v-for="rock in bigRocks"
-            :key="rock.name"
-            class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
-          >
-            <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" :rockFeatures="rockFeatures[rock.name] || []" />
-          </tr>
-          <tr v-if="!bigRocks || bigRocks.length === 0">
+          <!-- Skeleton loading rows -->
+          <template v-if="loading">
+            <tr v-for="n in 3" :key="'skeleton-' + n">
+              <td :colspan="hasHealth ? 10 : 9" class="px-3 py-4 border border-gray-300 dark:border-gray-600">
+                <div class="animate-pulse flex items-center gap-4">
+                  <div class="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div class="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div class="h-4 flex-1 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div class="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div class="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+                </div>
+              </td>
+            </tr>
+          </template>
+          <!-- Data rows -->
+          <template v-else-if="bigRocks && bigRocks.length > 0">
+            <tr
+              v-for="rock in bigRocks"
+              :key="rock.name"
+              class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+            >
+              <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" :rockFeatures="rockFeatures[rock.name] || []" />
+            </tr>
+          </template>
+          <!-- Empty state -->
+          <tr v-else>
             <td :colspan="hasHealth ? 10 : 9" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
               No Big Rocks configured.
             </td>

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -368,12 +368,12 @@ onMounted(async function() {
       {{ error }}
     </div>
 
-    <!-- Loading -->
-    <div v-if="loading" class="text-center py-12 text-gray-500">
+    <!-- Initial loading (no data yet) -->
+    <div v-if="loading && !candidates" class="text-center py-12 text-gray-500">
       Loading release planning data...
     </div>
 
-    <template v-else-if="candidates">
+    <template v-if="candidates">
       <!-- Summary -->
       <SummaryCards :summary="summary" :healthSummary="healthSummary" />
 

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -467,6 +467,7 @@ onMounted(async function() {
           :canEdit="canEdit"
           :rockHealth="rockHealth"
           :rockFeatures="rockFeatures"
+          :loading="loading"
           @editRock="handleEditRock"
           @addRock="handleAddRock"
           @deleteRock="handleDeleteRock"


### PR DESCRIPTION
## Summary
- **Unsaved-changes confirmation:** BigRockEditPanel now prompts "You have unsaved changes. Discard?" when the user clicks Cancel, close, or backdrop with pending edits (uses existing `isDirty` from `useBigRockEditor`)
- **Paste-to-add outcome keys:** Pasting comma-separated or newline-separated Jira keys into the outcome key input parses and adds multiple keys at once (with dedup and trimming)
- **Table loading skeleton:** BigRocksTable shows 3 animated skeleton rows during release switches instead of the "No Big Rocks configured" flash

## Files changed
| File | Change |
|------|--------|
| `client/components/BigRockEditPanel.vue` | Unsaved-changes prompt + paste handler |
| `client/components/BigRocksTable.vue` | Loading skeleton state |
| `client/views/DashboardView.vue` | Pass `loading` prop to BigRocksTable |
| `__tests__/client/big-rock-edit-panel.test.js` | 14 new tests |
| `__tests__/client/components.test.js` | 3 new tests |

## Test plan
- [x] All 2272 tests pass (17 new)
- [x] ESLint clean
- [x] Unsaved-changes prompt tested: Cancel/close/backdrop dirty paths, Discard/Keep Editing, clean cancel passthrough
- [x] Paste-to-add tested: comma-separated, newline-separated, duplicates, empty segments, single-key passthrough
- [x] Loading skeleton tested: visible when loading, hidden when loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)