### PR TITLE
fix(release-planning): use config-defined Big Rock names in health filter

### DIFF
--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -162,6 +162,9 @@ function phaseFeatureCount(tabId) {
 // ─── Filter options ───
 
 var bigRockOptions = computed(function() {
+  if (healthData.value && healthData.value.bigRockNames && healthData.value.bigRockNames.length > 0) {
+    return healthData.value.bigRockNames.slice().sort()
+  }
   var rocks = {}
   for (var i = 0; i < features.value.length; i++) {
     var rock = features.value[i].bigRock

--- a/modules/release-planning/server/health/health-pipeline.js
+++ b/modules/release-planning/server/health/health-pipeline.js
@@ -129,7 +129,7 @@ function loadFeaturesFromCandidates(readFromStorage, version, phase) {
 
   if (!cached || !cached.data || !cached.data.features) {
     warnings.push('No candidates found -- run a Big Rocks refresh first')
-    return { features: [], warnings: warnings }
+    return { features: [], bigRockNames: [], warnings: warnings }
   }
 
   var candidates = cached.data.features
@@ -146,7 +146,11 @@ function loadFeaturesFromCandidates(readFromStorage, version, phase) {
     features.push(mapCandidateToHealthFeature(candidate))
   }
 
-  return { features: features, warnings: warnings }
+  var bigRockNames = cached.data.filterOptions && cached.data.filterOptions.rocks
+    ? cached.data.filterOptions.rocks
+    : []
+
+  return { features: features, bigRockNames: bigRockNames, warnings: warnings }
 }
 
 /**
@@ -596,11 +600,13 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   // Step 1: Load features from Big Rocks candidates cache
   var featureResult = loadFeaturesFromCandidates(readFromStorage, version, phase)
   var features = featureResult.features
+  var bigRockNames = featureResult.bigRockNames
   warnings = warnings.concat(featureResult.warnings)
 
   if (features.length === 0) {
     console.warn('[health] No features found for version ' + version + ' phase ' + phaseKey)
     var emptyCache = buildEmptyCache(version, warnings)
+    emptyCache.bigRockNames = bigRockNames
     writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', emptyCache)
     return emptyCache
   }
@@ -775,6 +781,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       nextMilestone: milestoneInfo.nextMilestone,
       planningDeadline: planningDeadline
     },
+    bigRockNames: bigRockNames,
     features: healthFeatures,
     enrichmentStatus: {
       jiraQueriesRun: enrichResult.stats.pass1 + enrichResult.stats.pass2,


### PR DESCRIPTION
The health dashboard's "Big Rocks" dropdown filter was built by scanning
bigRock fields on the features in the health cache, while the Outcomes
tab displayed Big Rocks directly from the release config. This meant
Big Rocks with no features yet (newly added or with unlinked outcomes)
appeared on the Outcomes tab but were missing from the health filter
dropdown — making it look like those Big Rocks didn't exist in the
release plan when filtering by them on the health page. Conversely,
stale Big Rock names could linger in the health filter after being
renamed or removed from the config.

Now the health pipeline carries the authoritative Big Rock name list
from the candidates cache (sourced from release config) into the health
cache, and the frontend prefers that list with a fallback for
backward compatibility with pre-existing caches.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
