### PR TITLE
feat: add STRAT Builder enablement links to About → Docs

### DIFF
--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -162,7 +162,20 @@
           STRAT Builder
           <a href="https://app.slack.com/client/E030G10V24F/C0APA0E2J3Z" target="_blank" rel="noopener" class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">#wg-rhai-strat-refine-review</a>
         </h3>
-        <p class="text-sm text-gray-500 dark:text-gray-400">Content coming soon.</p>
+        <div class="flex flex-wrap gap-4">
+          <a
+            v-for="link in stratBuilderLinks"
+            :key="link.label"
+            :href="link.url"
+            target="_blank"
+            rel="noopener"
+            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
+          >
+            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
+            <span>{{ link.label }}</span>
+            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
+          </a>
+        </div>
       </div>
 
       <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
@@ -490,6 +503,12 @@ const rfeLinks = [
   { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/1O-F8naJxAfYtcXjTJHySYjeLtrKfb1OHhtyhoItya0s/edit?usp=sharing' },
   { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1pTpIvKkYns2aG5g0ueOxy6P8j1m_yNnD13XBB35NgWQ/edit?usp=sharing' },
   { label: 'Demo', icon: Play, url: 'https://drive.google.com/file/d/1ANaZOeUorSMqlFm3WzfK1xRPvld2TGM-/view' }
+]
+
+const stratBuilderLinks = [
+  { label: 'Enablement Recording', icon: Video, url: 'https://drive.google.com/file/d/1dXtifXiAsbnZtfiU9-vKUCEvfLX5ANvg/view' },
+  { label: 'Enablement Slides', icon: Presentation, url: 'https://docs.google.com/presentation/d/1oBIyJo30MSuig9Q1Qokq-6yclm_OL9htbWV91_YWMFs/edit?slide=id.g3dc5b8ade0b_0_14#slide=id.g3dc5b8ade0b_0_14' },
+  { label: 'Enablement Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1n-UEt0RloVmEDmjO4E3EoEQPLJTNVwPvao4Uvf3XD4U/edit?tab=t.uwq8408i1mre' }
 ]
 
 const aiQualityLinks = [


### PR DESCRIPTION
Replace the "Content coming soon" placeholder in the STRAT Builder tile with enablement recording, slides, and notes links.

Closes #494

Generated with [Claude Code](https://claude.ai/code)