### PR TITLE
feat(release-planning): add three-gate summary cards and filters

### DIFF
--- a/fixtures/release-planning/health-cache-demo.json
+++ b/fixtures/release-planning/health-cache-demo.json
@@ -37,10 +37,10 @@
       "dodPassed": 5,
       "stratSignedOff": 7,
       "riceComplete": 12,
-      "ownerAssigned": 0,
-      "versionSet": 0,
-      "unblocked": 0,
-      "escalatedBlockers": 0
+      "ownerAssigned": 11,
+      "versionSet": 10,
+      "unblocked": 10,
+      "escalatedBlockers": 1
     },
     "stratCreatorCoverage": {
       "signedOff": 7,
@@ -91,7 +91,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "David Kim"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "committed"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": {
         "reach": 2000,
@@ -128,7 +147,7 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "committed"
     },
     {
       "key": "RHOAIENG-1002",
@@ -171,7 +190,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "James Park"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "targeted"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": {
         "reach": 1500,
@@ -208,7 +246,7 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "targeted"
     },
     {
       "key": "RHOAIENG-1003",
@@ -262,7 +300,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Priya Sharma"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "committed"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": null,
       "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1003",
@@ -292,7 +349,7 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "committed"
     },
     {
       "key": "RHOAIENG-1004",
@@ -341,7 +398,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Rachel Green"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "targeted"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": false,
+            "detail": "RHOAIENG-1001"
+          }
+        ]
       },
       "rice": {
         "reach": 800,
@@ -378,7 +454,7 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "targeted"
     },
     {
       "key": "RHOAIENG-1005",
@@ -437,7 +513,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Linda Zhang"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "committed"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": null,
       "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1005",
@@ -467,7 +562,7 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "committed"
     },
     {
       "key": "RHOAIENG-1006",
@@ -526,7 +621,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Chris Evans"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": false,
+            "detail": "No fixVersion or targetVersion"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": {
         "reach": 3000,
@@ -625,7 +739,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": false,
+            "detail": null
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "targeted"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": null,
       "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1007",
@@ -655,7 +788,7 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "targeted"
     },
     {
       "key": "RHOAIENG-1008",
@@ -715,7 +848,27 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Priya Sharma"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "committed"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": false,
+            "detail": "RHOAIENG-1002",
+            "escalated": true
+          }
+        ]
       },
       "rice": {
         "reach": 1200,
@@ -752,7 +905,7 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "committed"
     },
     {
       "key": "RHAISTRAT-2001",
@@ -806,7 +959,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "John Smith"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "committed"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": null,
       "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-2001",
@@ -836,7 +1008,7 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "committed"
     },
     {
       "key": "RHAISTRAT-2006",
@@ -879,7 +1051,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Dave Evans"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "targeted"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": {
         "reach": 1800,
@@ -916,7 +1107,7 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Initiative",
-      "versionStatus": "none"
+      "versionStatus": "targeted"
     },
     {
       "key": "RHAISTRAT-2013",
@@ -975,7 +1166,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Iris Lee"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": false,
+            "detail": "No fixVersion or targetVersion"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": null,
       "jiraUrl": "https://redhat.atlassian.net/browse/RHAISTRAT-2013",
@@ -1060,7 +1270,26 @@
             "detail": "rice-disabled"
           }
         ],
-        "warnings": []
+        "warnings": [
+          {
+            "id": "DoR-W1",
+            "label": "Owner Assigned",
+            "passed": true,
+            "detail": "Karen Quinn"
+          },
+          {
+            "id": "DoR-W2",
+            "label": "Version Set",
+            "passed": true,
+            "detail": "committed"
+          },
+          {
+            "id": "DoR-W3",
+            "label": "Blockers Resolved",
+            "passed": true,
+            "detail": null
+          }
+        ]
       },
       "rice": {
         "reach": 2500,
@@ -1097,7 +1326,7 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "committed"
     }
   ],
   "enrichmentStatus": {

--- a/modules/release-planning/__tests__/client/health-components.test.js
+++ b/modules/release-planning/__tests__/client/health-components.test.js
@@ -62,10 +62,14 @@ describe('RiskBadge', function() {
 describe('HealthSummaryCards', function() {
   var cardCounts = {
     total: 15,
-    riceComplete: 12,
-    ownerAssigned: 10,
-    dodComplete: 8,
-    readyForExecution: 6
+    dorPassed: 12,
+    dodPassed: 8,
+    stratSignedOff: 10,
+    riceComplete: 13,
+    ownerAssigned: 11,
+    versionSet: 14,
+    unblocked: 12,
+    escalatedBlockers: 2
   }
 
   it('renders nothing when cardCounts is null', function() {
@@ -73,29 +77,46 @@ describe('HealthSummaryCards', function() {
     expect(wrapper.text()).toBe('')
   })
 
-  it('renders 4 readiness cards', function() {
+  it('renders 4 primary cards with three-gate labels', function() {
     var wrapper = mount(HealthSummaryCards, { props: { cardCounts: cardCounts } })
-    expect(wrapper.text()).toContain('RICE Score Present')
-    expect(wrapper.text()).toContain('Owner Assigned')
-    expect(wrapper.text()).toContain('DoD Complete')
-    expect(wrapper.text()).toContain('Ready for Execution')
+    expect(wrapper.text()).toContain('DoR Passed')
+    expect(wrapper.text()).toContain('DoD Passed')
+    expect(wrapper.text()).toContain('Strategy Signed Off')
+    expect(wrapper.text()).toContain('RICE Complete')
   })
 
-  it('shows count fractions for each card', function() {
+  it('shows count fractions for primary cards', function() {
     var wrapper = mount(HealthSummaryCards, { props: { cardCounts: cardCounts } })
     expect(wrapper.text()).toContain('12')
-    expect(wrapper.text()).toContain('10')
     expect(wrapper.text()).toContain('8')
-    expect(wrapper.text()).toContain('6')
+    expect(wrapper.text()).toContain('10')
+    expect(wrapper.text()).toContain('13')
     expect(wrapper.text()).toContain('/ 15')
   })
 
-  it('shows percentage for each card', function() {
+  it('shows percentage for primary cards', function() {
     var wrapper = mount(HealthSummaryCards, { props: { cardCounts: cardCounts } })
     expect(wrapper.text()).toContain('80%')  // 12/15
-    expect(wrapper.text()).toContain('67%')  // 10/15
     expect(wrapper.text()).toContain('53%')  // 8/15
-    expect(wrapper.text()).toContain('40%')  // 6/15
+    expect(wrapper.text()).toContain('67%')  // 10/15
+    expect(wrapper.text()).toContain('87%')  // 13/15
+  })
+
+  it('hides detail cards by default', function() {
+    var wrapper = mount(HealthSummaryCards, { props: { cardCounts: cardCounts } })
+    expect(wrapper.text()).not.toContain('Version Set')
+    expect(wrapper.text()).toContain('Show details')
+  })
+
+  it('shows detail cards when toggle clicked', async function() {
+    var wrapper = mount(HealthSummaryCards, { props: { cardCounts: cardCounts } })
+    var toggle = wrapper.findAll('button').filter(function(b) { return b.text().includes('details') })
+    await toggle[0].trigger('click')
+    expect(wrapper.text()).toContain('Owner Assigned')
+    expect(wrapper.text()).toContain('Version Set')
+    expect(wrapper.text()).toContain('Unblocked')
+    expect(wrapper.text()).toContain('Escalated Blockers')
+    expect(wrapper.text()).toContain('Hide details')
   })
 
   it('renders planning deadline when provided', function() {
@@ -115,15 +136,8 @@ describe('HealthSummaryCards', function() {
     expect(wrapper.text()).not.toContain('Planning Deadline')
   })
 
-  it('does not emit filterByRisk events', function() {
-    var wrapper = mount(HealthSummaryCards, { props: { cardCounts: cardCounts } })
-    var buttons = wrapper.findAll('button')
-    // Cards are divs, not buttons -- no click interaction
-    expect(buttons.length).toBe(0)
-  })
-
   it('handles zero total gracefully', function() {
-    var zeroCounts = { total: 0, riceComplete: 0, ownerAssigned: 0, dodComplete: 0, readyForExecution: 0 }
+    var zeroCounts = { total: 0, dorPassed: 0, dodPassed: 0, stratSignedOff: 0, riceComplete: 0, ownerAssigned: 0, versionSet: 0, unblocked: 0, escalatedBlockers: 0 }
     var wrapper = mount(HealthSummaryCards, { props: { cardCounts: zeroCounts } })
     expect(wrapper.text()).toContain('0')
     expect(wrapper.text()).toContain('/ 0')
@@ -260,6 +274,46 @@ describe('HealthFilterBar', function() {
     await wrapper.find('input[type="text"]').setValue('test query')
     expect(wrapper.emitted('update:searchQuery')).toBeDefined()
     expect(wrapper.emitted('update:searchQuery')[0][0]).toBe('test query')
+  })
+
+  it('renders planning status filter dropdown', function() {
+    var wrapper = mount(HealthFilterBar)
+    var selects = wrapper.findAll('select')
+    var planningSelect = selects.filter(function(s) { return s.attributes('aria-label') === 'Filter by planning status' })
+    expect(planningSelect.length).toBe(1)
+    expect(planningSelect[0].text()).toContain('All Statuses')
+    expect(planningSelect[0].text()).toContain('Not Ready')
+    expect(planningSelect[0].text()).toContain('In Planning')
+    expect(planningSelect[0].text()).toContain('Ready for Execution')
+  })
+
+  it('emits update:planningStatusFilter on change', async function() {
+    var wrapper = mount(HealthFilterBar)
+    var selects = wrapper.findAll('select')
+    var planningSelect = selects.filter(function(s) { return s.attributes('aria-label') === 'Filter by planning status' })
+    await planningSelect[0].setValue('not-ready')
+    expect(wrapper.emitted('update:planningStatusFilter')).toBeDefined()
+    expect(wrapper.emitted('update:planningStatusFilter')[0][0]).toBe('not-ready')
+  })
+
+  it('renders risk level filter dropdown', function() {
+    var wrapper = mount(HealthFilterBar)
+    var selects = wrapper.findAll('select')
+    var riskSelect = selects.filter(function(s) { return s.attributes('aria-label') === 'Filter by risk level' })
+    expect(riskSelect.length).toBe(1)
+    expect(riskSelect[0].text()).toContain('All Risk Levels')
+    expect(riskSelect[0].text()).toContain('Green')
+    expect(riskSelect[0].text()).toContain('Yellow')
+    expect(riskSelect[0].text()).toContain('Red')
+  })
+
+  it('emits update:riskLevelFilter on change', async function() {
+    var wrapper = mount(HealthFilterBar)
+    var selects = wrapper.findAll('select')
+    var riskSelect = selects.filter(function(s) { return s.attributes('aria-label') === 'Filter by risk level' })
+    await riskSelect[0].setValue('red')
+    expect(wrapper.emitted('update:riskLevelFilter')).toBeDefined()
+    expect(wrapper.emitted('update:riskLevelFilter')[0][0]).toBe('red')
   })
 })
 

--- a/modules/release-planning/__tests__/client/use-health-aggregation.test.js
+++ b/modules/release-planning/__tests__/client/use-health-aggregation.test.js
@@ -147,8 +147,12 @@ describe('useHealthAggregation', function() {
       var result = useHealthAggregation(hd, features, ref([]), ref([]))
       expect(result.rockHealth.value['Rock A'].worstLevel).toBe('yellow')
       expect(result.rockHealth.value['Rock A'].featureCount).toBe(2)
+      expect(result.rockHealth.value['Rock A'].dorPassedCount).toBe(2)
+      expect(result.rockHealth.value['Rock A'].dodPassedCount).toBe(1)
       expect(result.rockHealth.value['Rock B'].worstLevel).toBe('red')
       expect(result.rockHealth.value['Rock B'].featureCount).toBe(1)
+      expect(result.rockHealth.value['Rock B'].dorPassedCount).toBe(1)
+      expect(result.rockHealth.value['Rock B'].dodPassedCount).toBe(0)
     })
 
     it('respects risk overrides for rock health', function() {

--- a/modules/release-planning/client/components/HealthFilterBar.vue
+++ b/modules/release-planning/client/components/HealthFilterBar.vue
@@ -5,6 +5,8 @@ var props = defineProps({
   bigRockFilter: { type: String, default: '' },
   selectedComponents: { type: Array, default: () => [] },
   searchQuery: { type: String, default: '' },
+  planningStatusFilter: { type: String, default: '' },
+  riskLevelFilter: { type: String, default: '' },
   bigRocks: { type: Array, default: () => [] },
   components: { type: Array, default: () => [] },
   hasActiveFilters: { type: Boolean, default: false }
@@ -14,6 +16,8 @@ var emit = defineEmits([
   'update:bigRockFilter',
   'update:selectedComponents',
   'update:searchQuery',
+  'update:planningStatusFilter',
+  'update:riskLevelFilter',
   'clearFilters'
 ])
 
@@ -79,6 +83,30 @@ onUnmounted(function() {
     >
       <option value="">All Big Rocks</option>
       <option v-for="rock in bigRocks" :key="rock" :value="rock">{{ rock }}</option>
+    </select>
+
+    <select
+      :value="planningStatusFilter"
+      @change="$emit('update:planningStatusFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by planning status"
+    >
+      <option value="">All Statuses</option>
+      <option value="not-ready">Not Ready</option>
+      <option value="in-planning">In Planning</option>
+      <option value="ready-for-execution">Ready for Execution</option>
+    </select>
+
+    <select
+      :value="riskLevelFilter"
+      @change="$emit('update:riskLevelFilter', $event.target.value)"
+      :class="selectClass"
+      aria-label="Filter by risk level"
+    >
+      <option value="">All Risk Levels</option>
+      <option value="green">Green</option>
+      <option value="yellow">Yellow</option>
+      <option value="red">Red</option>
     </select>
 
     <!-- Component multi-select with chips -->

--- a/modules/release-planning/client/components/HealthSummaryCards.vue
+++ b/modules/release-planning/client/components/HealthSummaryCards.vue
@@ -1,38 +1,30 @@
 <script setup>
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 
 const props = defineProps({
   cardCounts: { type: Object, default: null },
   planningDeadline: { type: Object, default: null }
 })
 
-var cards = computed(function() {
-  var c = props.cardCounts || { total: 0, riceComplete: 0, ownerAssigned: 0, dodComplete: 0, readyForExecution: 0 }
+var showDetails = ref(false)
+
+var primaryCards = computed(function() {
+  var c = props.cardCounts || { total: 0, dorPassed: 0, dodPassed: 0, stratSignedOff: 0, riceComplete: 0 }
   return [
-    {
-      label: 'RICE Score Present',
-      count: c.riceComplete,
-      total: c.total,
-      color: 'indigo'
-    },
-    {
-      label: 'Owner Assigned',
-      count: c.ownerAssigned,
-      total: c.total,
-      color: 'blue'
-    },
-    {
-      label: 'DoD Complete',
-      count: c.dodComplete,
-      total: c.total,
-      color: 'amber'
-    },
-    {
-      label: 'Ready for Execution',
-      count: c.readyForExecution,
-      total: c.total,
-      color: 'green'
-    }
+    { label: 'DoR Passed', count: c.dorPassed, total: c.total, color: 'indigo' },
+    { label: 'DoD Passed', count: c.dodPassed, total: c.total, color: 'amber' },
+    { label: 'Strategy Signed Off', count: c.stratSignedOff, total: c.total, color: 'blue' },
+    { label: 'RICE Complete', count: c.riceComplete, total: c.total, color: 'green' }
+  ]
+})
+
+var detailCards = computed(function() {
+  var c = props.cardCounts || { total: 0, ownerAssigned: 0, versionSet: 0, unblocked: 0, escalatedBlockers: 0 }
+  return [
+    { label: 'Owner Assigned', count: c.ownerAssigned, total: c.total, color: 'blue' },
+    { label: 'Version Set', count: c.versionSet, total: c.total, color: 'indigo' },
+    { label: 'Unblocked', count: c.unblocked, total: c.total, color: 'green' },
+    { label: 'Escalated Blockers', count: c.escalatedBlockers, total: c.total, color: 'red', invert: true }
   ]
 })
 
@@ -73,6 +65,14 @@ var colorClasses = {
     subtext: 'text-green-600/70 dark:text-green-400/70',
     barBg: 'bg-green-200 dark:bg-green-500/20',
     bar: 'bg-green-500 dark:bg-green-400'
+  },
+  red: {
+    bg: 'bg-red-50 dark:bg-red-500/10',
+    border: 'border-red-200 dark:border-red-500/30',
+    text: 'text-red-700 dark:text-red-400',
+    subtext: 'text-red-600/70 dark:text-red-400/70',
+    barBg: 'bg-red-200 dark:bg-red-500/20',
+    bar: 'bg-red-500 dark:bg-red-400'
   }
 }
 
@@ -87,10 +87,10 @@ var deadlineColorClass = computed(function() {
 
 <template>
   <div v-if="cardCounts" class="space-y-3">
-    <!-- Readiness cards -->
+    <!-- Primary cards (Row 1) -->
     <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
       <div
-        v-for="card in cards"
+        v-for="card in primaryCards"
         :key="card.label"
         class="p-4 rounded-lg border"
         :class="[colorClasses[card.color].bg, colorClasses[card.color].border]"
@@ -102,6 +102,45 @@ var deadlineColorClass = computed(function() {
         </div>
         <div class="text-xs mt-0.5" :class="colorClasses[card.color].subtext">{{ pct(card.count, card.total) }}%</div>
         <div class="mt-2 w-full rounded-full h-1.5" :class="colorClasses[card.color].barBg">
+          <div
+            class="h-1.5 rounded-full transition-all"
+            :class="colorClasses[card.color].bar"
+            :style="{ width: Math.min(pct(card.count, card.total), 100) + '%' }"
+          ></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detail toggle -->
+    <button
+      @click="showDetails = !showDetails"
+      class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 flex items-center gap-1"
+    >
+      <svg
+        class="w-3.5 h-3.5 transition-transform"
+        :class="showDetails ? 'rotate-90' : ''"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+      {{ showDetails ? 'Hide' : 'Show' }} details
+    </button>
+
+    <!-- Detail cards (Row 2) -->
+    <div v-if="showDetails" class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div
+        v-for="card in detailCards"
+        :key="card.label"
+        class="p-4 rounded-lg border"
+        :class="[colorClasses[card.color].bg, colorClasses[card.color].border]"
+      >
+        <div class="text-sm font-semibold" :class="colorClasses[card.color].text">{{ card.label }}</div>
+        <div class="mt-2">
+          <span class="text-2xl font-bold" :class="colorClasses[card.color].text">{{ card.count }}</span>
+          <span v-if="!card.invert" class="text-sm ml-0.5" :class="colorClasses[card.color].subtext">/ {{ card.total }}</span>
+        </div>
+        <div v-if="!card.invert" class="text-xs mt-0.5" :class="colorClasses[card.color].subtext">{{ pct(card.count, card.total) }}%</div>
+        <div v-if="!card.invert" class="mt-2 w-full rounded-full h-1.5" :class="colorClasses[card.color].barBg">
           <div
             class="h-1.5 rounded-full transition-all"
             :class="colorClasses[card.color].bar"

--- a/modules/release-planning/client/composables/useHealthAggregation.js
+++ b/modules/release-planning/client/composables/useHealthAggregation.js
@@ -85,10 +85,12 @@ export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
       if (!h || !h.risk) continue
 
       if (!result[rockName]) {
-        result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0 }
+        result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0, dorPassedCount: 0, dodPassedCount: 0 }
       }
       result[rockName].featureCount++
       result[rockName].totalFlags += (h.risk.score || 0)
+      if (h.dor && h.dor.passed) result[rockName].dorPassedCount++
+      if (h.dod && h.dod.passed) result[rockName].dodPassedCount++
       var level = effectiveLevel(h)
       if (isWorse(level, result[rockName].worstLevel)) {
         result[rockName].worstLevel = level

--- a/modules/release-planning/client/views/HealthDashboardView.vue
+++ b/modules/release-planning/client/views/HealthDashboardView.vue
@@ -9,6 +9,7 @@ import MilestoneTimeline from '../components/MilestoneTimeline.vue'
 import HealthFilterBar from '../components/HealthFilterBar.vue'
 import FeatureHealthTable from '../components/FeatureHealthTable.vue'
 import RiceFieldConfig from '../components/RiceFieldConfig.vue'
+import HealthSummaryCards from '../components/HealthSummaryCards.vue'
 
 var {
   healthData, healthLoading, healthError, healthRefreshing, healthCacheStale,
@@ -32,6 +33,8 @@ var showRiceConfig = ref(false)
 var bigRockFilter = ref('')
 var selectedComponents = ref([])
 var searchQuery = ref('')
+var planningStatusFilter = ref('')
+var riskLevelFilter = ref('')
 
 // Refresh polling
 var refreshPollTimer = null
@@ -71,6 +74,14 @@ var jiraBaseUrl = computed(function() {
 
 var enrichmentStatus = computed(function() {
   return healthData.value ? healthData.value.enrichmentStatus : null
+})
+
+var summaryCardCounts = computed(function() {
+  return healthData.value && healthData.value.summary ? healthData.value.summary.cardCounts : null
+})
+
+var planningDeadline = computed(function() {
+  return healthData.value && healthData.value.summary ? healthData.value.summary.planningDeadline : null
 })
 
 // ─── Phase tabs ───
@@ -210,18 +221,29 @@ var filteredFeatures = computed(function() {
       if (searchFields.indexOf(q) === -1) return false
     }
 
+    // Planning status filter
+    if (planningStatusFilter.value && f.planningStatus !== planningStatusFilter.value) return false
+
+    // Risk level filter
+    if (riskLevelFilter.value) {
+      var effectiveLevel = f.risk && f.risk.override ? (f.risk.override.riskOverride || f.risk.level) : (f.risk ? f.risk.level : 'green')
+      if (effectiveLevel !== riskLevelFilter.value) return false
+    }
+
     return true
   })
 })
 
 var hasActiveFilters = computed(function() {
-  return !!(bigRockFilter.value || selectedComponents.value.length > 0 || searchQuery.value)
+  return !!(bigRockFilter.value || selectedComponents.value.length > 0 || searchQuery.value || planningStatusFilter.value || riskLevelFilter.value)
 })
 
 function clearFilters() {
   bigRockFilter.value = ''
   selectedComponents.value = []
   searchQuery.value = ''
+  planningStatusFilter.value = ''
+  riskLevelFilter.value = ''
 }
 
 // ─── Data refresh ───
@@ -376,6 +398,9 @@ onUnmounted(function() {
       <!-- Milestone Timeline -->
       <MilestoneTimeline :milestones="milestones" :planningFreezes="planningFreezes" />
 
+      <!-- Summary Cards -->
+      <HealthSummaryCards :cardCounts="summaryCardCounts" :planningDeadline="planningDeadline" />
+
       <!-- Phase Tabs -->
       <div>
         <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700">
@@ -446,6 +471,8 @@ onUnmounted(function() {
         v-model:bigRockFilter="bigRockFilter"
         v-model:selectedComponents="selectedComponents"
         v-model:searchQuery="searchQuery"
+        v-model:planningStatusFilter="planningStatusFilter"
+        v-model:riskLevelFilter="riskLevelFilter"
         :bigRocks="bigRockOptions"
         :components="componentOptions"
         :hasActiveFilters="hasActiveFilters"


### PR DESCRIPTION
## Summary

PR 3 of 3 in the three-gate planning model rollout (after #500 and #501).

- **Summary Cards**: Wire `HealthSummaryCards` to three-gate data — primary row shows DoR Passed, DoD Passed, Strategy Signed Off, RICE Complete counts; collapsible detail row shows Owner Assigned, Version Set, Unblocked, Escalated Blockers
- **Filters**: Add planning status (Not Ready / In Planning / Ready for Execution) and risk level (Green / Yellow / Red) filter dropdowns to `HealthFilterBar`, wired into `HealthDashboardView`
- **Rock Health Aggregation**: Add `dorPassedCount` and `dodPassedCount` to per-rock health aggregation in `useHealthAggregation`
- **Demo Fixture**: Populate DoR warnings and realistic versionStatus values so summary cards display non-zero counts

## Test plan

- [x] All 2306 tests pass (`npm test`)
- [x] Lint passes (pre-commit hook)
- [x] Demo mode verified: summary cards render with correct counts, filters work
- [ ] Visual verification: summary cards between timeline and phase tabs
- [ ] Visual verification: detail row toggle (Show/Hide details)
- [ ] Visual verification: planning status and risk level filters filter the feature table
- [ ] Visual verification: Clear Filters resets all filters including new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)