### PR TITLE
fix: resolve user UID when proxy email uses non-matching domain

### DIFF
--- a/shared/server/auth.js
+++ b/shared/server/auth.js
@@ -96,6 +96,13 @@ function createAuthMiddleware(readFromStorage, writeToStorage, options = {}) {
           break;
         }
       }
+      // Fallback: match by UID when email domain doesn't match (e.g. user@cluster.local)
+      if (!req.userUid && req.userEmail) {
+        const localPart = req.userEmail.split('@')[0];
+        if (localPart && registry.people[localPart] && registry.people[localPart].status === 'active') {
+          req.userUid = localPart;
+        }
+      }
     }
     req.isTeamAdmin = roleStore ? roleStore.hasRole(req.userEmail, 'team-admin') : false;
     req.permissionTier = getPermissionTier(req.userUid, registry, req.isAdmin, req.isTeamAdmin);


### PR DESCRIPTION
## Summary

- In production, the OpenShift OAuth proxy sets `X-Forwarded-Email` to `user@cluster.local` instead of `user@redhat.com`. The auth middleware only matched on exact email, so `req.userUid` was never set — breaking the manager dashboard and any permission-tier logic that depends on registry identity.
- Adds a fallback in `resolveUserUid`: when email matching fails, extract the local part (e.g. `acorvin` from `acorvin@cluster.local`) and check it directly as a registry UID.

## Test plan

- [ ] Deploy to dev/preprod and verify `/api/whoami` returns a `permissionTier` based on registry identity (e.g. `manager`) instead of just role-based tier
- [ ] Verify the manager dashboard loads direct reports correctly
- [ ] Confirm local dev (where emails match directly) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)