### PR TITLE
fix: manager dashboard tutorial not auto-launching

### DIFF
--- a/modules/team-tracker/client/views/ManagerDashboardView.vue
+++ b/modules/team-tracker/client/views/ManagerDashboardView.vue
@@ -1207,8 +1207,10 @@ function handleLaunchTutorial() {
   launchTutorial({ onTabClick: (tabId) => { activeTab.value = tabId }, nav })
 }
 
+let initialLoadHandled = false
 watch(loading, (isLoading, wasLoading) => {
-  if (wasLoading && !isLoading && !error.value && !reason.value) {
+  if (!initialLoadHandled && wasLoading && !isLoading && !error.value && !reason.value) {
+    initialLoadHandled = true
     const opts = { onTabClick: (tabId) => { activeTab.value = tabId }, nav }
     if (nav?.params.value?.tutorial === '1') {
       launchTutorial(opts)
@@ -1216,7 +1218,7 @@ watch(loading, (isLoading, wasLoading) => {
       checkFirstVisit(opts)
     }
   }
-}, { once: true })
+})
 
 onMounted(() => {
   load()


### PR DESCRIPTION
## Summary

- The `{ once: true }` Vue watcher on `loading` fired on the initial `false→true` transition (when `load()` starts), which fails the `wasLoading && !isLoading` condition. The watcher was then removed before it could see the `true→false` transition when data actually loaded.
- Replaces `{ once: true }` with a manual `initialLoadHandled` flag so the watcher survives to see the load complete and trigger the tutorial or first-visit check.

## Test plan

- [ ] Navigate to `#/team-tracker/manager-dashboard?tutorial=1` in a fresh/private browser window — tutorial should auto-launch
- [ ] Navigate to the dashboard normally — first-visit check should still work
- [ ] Subsequent visits should not re-trigger the tutorial

🤖 Generated with [Claude Code](https://claude.com/claude-code)