### PR TITLE
fix(release-planning): always show all release buckets in Milestone Coverage

### DIFF
--- a/modules/release-planning/__tests__/client/use-release-distribution.test.js
+++ b/modules/release-planning/__tests__/client/use-release-distribution.test.js
@@ -26,15 +26,18 @@ describe('useReleaseDistribution', function() {
     ])
   })
 
-  it('omits releases with zero count', function() {
+  it('includes all release buckets even with zero count', function() {
     var features = ref([
       { fixVersion: 'rhoai-3.5.GA' },
       { fixVersion: 'rhoai-3.5.GA' }
     ])
     var result = useReleaseDistribution(features)
     var labels = result.releaseDistribution.value.map(function(r) { return r.label })
-    expect(labels).toEqual(['GA'])
-    expect(labels).not.toContain('EA1')
+    expect(labels).toEqual(['EA1', 'EA2', 'GA', '--'])
+    var ga = result.releaseDistribution.value.find(function(r) { return r.label === 'GA' })
+    expect(ga.count).toBe(2)
+    var ea1 = result.releaseDistribution.value.find(function(r) { return r.label === 'EA1' })
+    expect(ea1.count).toBe(0)
   })
 
   it('returns null when features is empty', function() {
@@ -51,9 +54,11 @@ describe('useReleaseDistribution', function() {
     ])
     var result = useReleaseDistribution(features)
     var dist = result.releaseDistribution.value
-    expect(dist).toHaveLength(2)
+    expect(dist).toHaveLength(4)
     expect(dist[0]).toEqual({ label: 'EA1', count: 3, pct: 75, barColor: 'bg-blue-500' })
     expect(dist[1]).toEqual({ label: 'EA2', count: 1, pct: 25, barColor: 'bg-amber-500' })
+    expect(dist[2]).toEqual({ label: 'GA', count: 0, pct: 0, barColor: 'bg-emerald-500' })
+    expect(dist[3]).toEqual({ label: '--', count: 0, pct: 0, barColor: 'bg-gray-400' })
   })
 
   it('features with base version only go to None bucket', function() {
@@ -66,6 +71,8 @@ describe('useReleaseDistribution', function() {
     var dist = result.releaseDistribution.value
     expect(dist).toEqual([
       { label: 'EA1', count: 1, pct: 33, barColor: 'bg-blue-500' },
+      { label: 'EA2', count: 0, pct: 0, barColor: 'bg-amber-500' },
+      { label: 'GA', count: 0, pct: 0, barColor: 'bg-emerald-500' },
       { label: '--', count: 2, pct: 67, barColor: 'bg-gray-400' }
     ])
   })

--- a/modules/release-planning/client/composables/useReleaseDistribution.js
+++ b/modules/release-planning/client/composables/useReleaseDistribution.js
@@ -44,14 +44,12 @@ export function useReleaseDistribution(features) {
     for (var j = 0; j < keys.length; j++) {
       var k = keys[j]
       var count = buckets[k]
-      if (count > 0) {
-        result.push({
-          label: k === 'None' ? '--' : k,
-          count: count,
-          pct: Math.round((count / total) * 100),
-          barColor: BAR_COLORS[k]
-        })
-      }
+      result.push({
+        label: k === 'None' ? '--' : k,
+        count: count,
+        pct: Math.round((count / total) * 100),
+        barColor: BAR_COLORS[k]
+      })
     }
     return result
   })


### PR DESCRIPTION
## Summary

- EA1, EA2, GA, and None entries now appear in the doughnut chart legend even when their count is 0
- Previously, zero-count buckets were omitted, which made it unclear whether a release phase existed

## Test plan

- [x] Updated `use-release-distribution.test.js` — all 5 tests pass
- [x] Component tests pass (33 tests)
- [ ] Visual QA: verify all 4 legend entries appear in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)