### PR TITLE
fix(release-planning): UX polish for Outcomes dashboard

### DIFF
--- a/modules/release-planning/__tests__/client/components.test.js
+++ b/modules/release-planning/__tests__/client/components.test.js
@@ -114,8 +114,9 @@ describe('SummaryCards', () => {
     const wrapper = mount(SummaryCards, {
       props: { summary, tier1HealthSummary: null, releaseDistribution: null }
     })
-    expect(wrapper.text()).toContain('Health data loading...')
-    // No aria-label dots container rendered
+    expect(wrapper.find('[aria-label="Loading health data"]').exists()).toBe(true)
+    expect(wrapper.findAll('.animate-pulse').length).toBeGreaterThanOrEqual(3)
+    // No health bars rendered
     expect(wrapper.find('[aria-label*="on track"]').exists()).toBe(false)
   })
 

--- a/modules/release-planning/client/components/SummaryCards.vue
+++ b/modules/release-planning/client/components/SummaryCards.vue
@@ -63,7 +63,7 @@ var totalFeatures = computed(function() {
 </script>
 
 <template>
-  <div v-if="summary" class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-5xl">
+  <div v-if="summary" class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-5xl mx-auto">
     <!-- Card 1: Feature Summary -->
     <div class="p-4 rounded-lg bg-green-50 dark:bg-green-500/10 border border-green-200 dark:border-green-500/30">
       <div class="text-sm font-semibold text-green-700 dark:text-green-400">Feature Summary</div>
@@ -132,8 +132,12 @@ var totalFeatures = computed(function() {
           <span class="w-8 text-right font-semibold text-red-700 dark:text-red-400">{{ tier1HealthSummary.byRisk.red || 0 }}</span>
         </div>
       </div>
-      <div v-else class="mt-3 pt-2 border-t border-amber-200/50 dark:border-amber-500/20 text-xs text-amber-600/50 dark:text-amber-400/50 italic">
-        Health data loading...
+      <div v-else class="space-y-1.5 mt-3 pt-2 border-t border-amber-200/50 dark:border-amber-500/20" aria-label="Loading health data">
+        <div v-for="n in 3" :key="n" class="flex items-center gap-2">
+          <div class="w-16 h-3 rounded bg-amber-200/50 dark:bg-amber-500/10 animate-pulse"></div>
+          <div class="flex-1 h-2 rounded-full bg-amber-200/50 dark:bg-amber-500/10 animate-pulse"></div>
+          <div class="w-8 h-3 rounded bg-amber-200/50 dark:bg-amber-500/10 animate-pulse"></div>
+        </div>
       </div>
     </div>
 

--- a/modules/release-planning/client/views/DashboardView.vue
+++ b/modules/release-planning/client/views/DashboardView.vue
@@ -380,9 +380,6 @@ onMounted(async function() {
       <!-- Summary -->
       <SummaryCards :summary="summary" :tier1HealthSummary="tier1HealthSummary" :releaseDistribution="releaseDistribution" />
 
-      <!-- Recent Activity -->
-      <RecentActivity :version="selectedVersion" />
-
       <!-- Tabs -->
       <div>
         <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700">
@@ -410,7 +407,7 @@ onMounted(async function() {
               >{{ tabCount(tab.id) }}</span>
             </button>
           </div>
-          <div class="relative pb-2" @click.stop @keydown.escape="closeExportMenu">
+          <div class="relative pb-2 pl-3 ml-3 border-l border-gray-200 dark:border-gray-700" @click.stop @keydown.escape="closeExportMenu">
             <button
               @click="toggleExportMenu"
               :aria-expanded="exportMenuOpen"
@@ -495,6 +492,9 @@ onMounted(async function() {
           :rfeKeyToHealth="rfeKeyToHealth"
         />
       </div>
+
+      <!-- Recent Activity -->
+      <RecentActivity :version="selectedVersion" />
     </template>
 
     <!-- No releases configured -->


### PR DESCRIPTION
## Summary
- Center summary cards on page (mx-auto) so they don't float left when narrower than the full-width table below
- Move Recent Activity section below tab content to keep the primary flow (cards → tabs → table) uninterrupted
- Replace italic "Health data loading..." text with skeleton shimmer bars in the Outcome Health card
- Add visual divider (left border) between tab row and Export button to clarify Export is an action, not a tab

## Test plan
- [x] All 33 component tests pass (`npx vitest run modules/release-planning/__tests__/client/components.test.js`)
- [ ] Visual check in demo mode: summary cards centered, Recent Activity at bottom, skeleton shimmer on health card load, Export button visually separated from tabs


🤖 Generated with [Claude Code](https://claude.com/claude-code)