### PR TITLE
fix(ci): handle workflow-modifying fork PRs gracefully

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -266,6 +266,25 @@ jobs:
         run: |
           echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
 
+          # Check if PR modifies workflow files
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${PR_NUM}/files \
+            --paginate --jq '.[].filename')
+
+          MODIFIES_WORKFLOWS=false
+          while IFS= read -r file; do
+            if [[ "$file" == .github/workflows/* ]]; then
+              MODIFIES_WORKFLOWS=true
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          if [ "$MODIFIES_WORKFLOWS" = "true" ]; then
+            echo "::warning::PR modifies workflow files - skipping temp branch push due to GitHub security restrictions"
+            echo "::notice::Review will proceed using gh pr diff only (some Read/Grep/Glob tools may not work on PR code)"
+            echo "modifies_workflows=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # The claude-code-action runs `git fetch origin <branchName>` internally,
           # which fails for fork PRs because the branch only exists on the fork.
           # Workaround: push the PR head commit to origin under a namespaced ref
@@ -332,7 +351,7 @@ jobs:
           DISABLE_PROMPT_CACHING: "1"
 
       - name: Cleanup fork PR branch
-        if: always() && steps.fork-setup.outputs.fork_branch
+        if: always() && steps.fork-setup.outputs.fork_branch && steps.fork-setup.outputs.modifies_workflows != 'true'
         run: |
           echo "Cleaning up temporary branch: ${{ steps.fork-setup.outputs.fork_branch }}"
           git push origin --delete "${{ steps.fork-setup.outputs.fork_branch }}" || true


### PR DESCRIPTION
## Context

This is a follow-up to #505, which fixed the immediate security gap where fork PRs bypassed the required "Claude Review" check. However, #505 didn't address the **structural issue** that caused PR #444 to fail: workflow-modifying fork PRs.

## The Problem

When a fork PR modifies `.github/workflows/*` files, the Claude Review workflow fails during setup with this error:

```
refusing to allow a GitHub App to create or update workflow 
.github/workflows/claude-review.yml without workflows permission
```

This happens because:
1. The fork review job tries to push a temporary branch (`claude-review/fork-pr-<number>`) to origin
2. GitHub blocks this when the PR modifies workflow files
3. The `workflows` permission doesn't exist in GitHub Actions (it's not a valid permission)
4. This is an **unsolvable GitHub security restriction**

**Historical evidence:** PR #444 (Apr 30) failed with exactly this error, but was merged anyway because the "Claude Review" check wasn't required at that time.

## The Fix

Detect when fork PRs modify workflow files and **skip the temporary branch push** for those cases:

```bash
# Check if PR modifies workflow files
CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${PR_NUM}/files \
  --paginate --jq '.[].filename')

MODIFIES_WORKFLOWS=false
while IFS= read -r file; do
  if [[ "$file" == .github/workflows/* ]]; then
    MODIFIES_WORKFLOWS=true
    break
  fi
done <<< "$CHANGED_FILES"

if [ "$MODIFIES_WORKFLOWS" = "true" ]; then
  echo "::warning::PR modifies workflow files - skipping temp branch push"
  exit 0  # Skip the temp branch push
fi
```

The review still proceeds using `gh pr diff` only. Some tools (Read/Grep/Glob on PR code) may not work, but the review can still examine the diff and post comments.

## Trade-offs

**Workflow-modifying fork PRs get a limited review:**
- ✅ Can review the diff via `gh pr diff`
- ✅ Can post inline and top-level comments
- ✅ Still satisfies the required "Claude Review" check (after #505)
- ❌ Cannot use Read/Grep/Glob tools on PR code (only base branch)
- ❌ Some context might be missing

**But this is better than the status quo:**
- Before: workflow-modifying fork PRs failed completely, bypassed review
- After: they get a diff-based review with some limitations

## Testing

To test with a workflow-modifying fork PR:
1. Create a fork PR that modifies `.github/workflows/claude-review.yml`
2. Verify the "Setup fork PR branch" step logs a warning and exits successfully
3. Verify the Claude review still runs using `gh pr diff`
4. Verify the cleanup step is skipped (no temp branch to delete)
5. Verify the "Claude Review" check passes and is required for merge

Related to #505, #498, #444

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>