### PR TITLE
feat(product-builds): add product builds module

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -305,6 +305,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/ai-impact/component-onboarding/:key` — single component onboarding entry + history
 - `/api/modules/ai-impact/component-onboarding/status` — component onboarding data status (admin)
 - `/api/modules/product-builds/config` — AIPCC Dashboard API configuration (admin)
+- `/api/modules/product-builds/health` — AIPCC Dashboard API connectivity check
 - `/api/modules/product-builds/products/:key` — product details (proxied)
 - `/api/modules/product-builds/drops` — list drops with filtering/pagination (proxied)
 - `/api/modules/product-builds/drops/:key` — drop details (proxied)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,6 +39,7 @@ npm run dev:full       # Starts Vite (5173) + Express (3001)
 | `PRODUCT_PAGES_TOKEN` | Personal bearer token for Product Pages (local dev fallback). Used when OAuth env vars are not set. |
 | `FEATURE_TRAFFIC_GITLAB_TOKEN` | GitLab PAT with `read_api` scope for releases execution pipeline. Overrides `GITLAB_TOKEN` for CI artifact fetching. |
 | `AUTH_EMAIL_DOMAIN` | Override email domain for role matching (e.g. `cluster.local`). When set, role assignments normalize emails to this domain. Env var takes precedence over `authEmailDomain` in site-config.json. |
+| `PRODUCT_BUILDS_API_URL` | Base URL of the AIPCC Dashboard API server. Can also be configured via Settings UI. |
 | `DEMO_MODE` / `VITE_DEMO_MODE` | Set both to `true` for fixture data (no credentials needed). |
 
 ## Key Concepts
@@ -303,6 +304,17 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/ai-impact/component-onboarding` — all component onboarding entries (latest projection)
 - `/api/modules/ai-impact/component-onboarding/:key` — single component onboarding entry + history
 - `/api/modules/ai-impact/component-onboarding/status` — component onboarding data status (admin)
+- `/api/modules/product-builds/config` — AIPCC Dashboard API configuration (admin)
+- `/api/modules/product-builds/products/:key` — product details (proxied)
+- `/api/modules/product-builds/drops` — list drops with filtering/pagination (proxied)
+- `/api/modules/product-builds/drops/:key` — drop details (proxied)
+- `/api/modules/product-builds/drops/:key/changelog` — drop changelog (proxied)
+- `/api/modules/product-builds/drops/:key/metrics` — drop Konflux release metrics (proxied)
+- `/api/modules/product-builds/series` — list product series/versions (proxied)
+- `/api/modules/product-builds/artifacts` — list artifacts with filtering/pagination (proxied)
+- `/api/modules/product-builds/artifacts/:key` — artifact details (proxied)
+- `/api/modules/product-builds/artifacts/:key/wheels` — wheel collections for a container artifact (proxied)
+- `/api/modules/product-builds/artifacts/:key/containers` — containers using a wheels-collection or base-image (proxied)
 - `/api/health-metrics/tracking/status` — opt-out status
 - `/api/health-metrics/dashboard` — aggregated dashboard (admin/viewer)
 - `/api/health-metrics/pages` — per-page stats (admin/viewer)
@@ -381,6 +393,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/ai-impact/test-plans/bulk` — bulk upsert test plans (admin)
 - `/api/modules/ai-impact/test-plans/sync` — trigger test plan Jira sync (admin)
 - `/api/modules/ai-impact/component-onboarding/bulk` — bulk upsert component onboarding data (admin)
+- `/api/modules/product-builds/config` — save AIPCC Dashboard API configuration (admin)
 - `/api/health-metrics/track` — record page view (rate-limited)
 - `/api/health-metrics/tracking/opt-out` — opt out (authenticated)
 - `/api/health-metrics/config` — update config (admin)

--- a/modules/product-builds/__tests__/server/proxy.test.js
+++ b/modules/product-builds/__tests__/server/proxy.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { proxyGet, buildUpstreamUrl } = require('../../server/proxy')
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: null,
+    _headers: {},
+    status(code) { res._status = code; return res },
+    json(data) { res._json = data; return res },
+    set(key, val) { res._headers[key] = val; return res }
+  }
+  return res
+}
+
+describe('buildUpstreamUrl', () => {
+  it('appends path to base URL', () => {
+    expect(buildUpstreamUrl('https://api.example.com', '/products', {}))
+      .toBe('https://api.example.com/products')
+  })
+
+  it('appends query parameters', () => {
+    const url = buildUpstreamUrl('https://api.example.com', '/drops', { product_key: 'rhaiis', limit: '10' })
+    expect(url).toContain('product_key=rhaiis')
+    expect(url).toContain('limit=10')
+  })
+
+  it('skips empty/null/undefined query values', () => {
+    const url = buildUpstreamUrl('https://api.example.com', '/drops', { product_key: 'rhaiis', series: '', empty: null, undef: undefined })
+    expect(url).toContain('product_key=rhaiis')
+    expect(url).not.toContain('series')
+    expect(url).not.toContain('empty')
+    expect(url).not.toContain('undef')
+  })
+})
+
+describe('proxyGet', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('returns 503 when baseUrl is empty', async () => {
+    const res = makeRes()
+    await proxyGet('', '/products', {}, res)
+    expect(res._status).toBe(503)
+    expect(res._json.error).toContain('not configured')
+  })
+
+  it('proxies successful upstream response', async () => {
+    const upstream = { ok: true, status: 200, json: () => Promise.resolve([{ key: 'rhaiis' }]) }
+    globalThis.fetch = vi.fn().mockResolvedValue(upstream)
+
+    const res = makeRes()
+    await proxyGet('https://api.example.com', '/products', {}, res)
+
+    expect(globalThis.fetch).toHaveBeenCalledOnce()
+    expect(res._status).toBe(200)
+    expect(res._json).toEqual([{ key: 'rhaiis' }])
+  })
+
+  it('passes upstream error status through', async () => {
+    const upstream = { ok: false, status: 404, json: () => Promise.resolve({ detail: 'not found' }) }
+    globalThis.fetch = vi.fn().mockResolvedValue(upstream)
+
+    const res = makeRes()
+    await proxyGet('https://api.example.com', '/products/missing', {}, res)
+
+    expect(res._status).toBe(404)
+    expect(res._json.detail).toBe('not found')
+  })
+
+  it('returns 502 on fetch error', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const res = makeRes()
+    await proxyGet('https://api.example.com', '/products', {}, res)
+
+    expect(res._status).toBe(502)
+    expect(res._json.error).toContain('Failed to reach')
+  })
+
+  it('returns 504 on timeout', async () => {
+    const err = new Error('timeout')
+    err.name = 'TimeoutError'
+    globalThis.fetch = vi.fn().mockRejectedValue(err)
+
+    const res = makeRes()
+    await proxyGet('https://api.example.com', '/products', {}, res)
+
+    expect(res._status).toBe(504)
+    expect(res._json.error).toContain('timed out')
+  })
+})

--- a/modules/product-builds/__tests__/server/proxy.test.js
+++ b/modules/product-builds/__tests__/server/proxy.test.js
@@ -54,7 +54,8 @@ describe('proxyGet', () => {
   })
 
   it('proxies successful upstream response', async () => {
-    const upstream = { ok: true, status: 200, json: () => Promise.resolve([{ key: 'rhaiis' }]) }
+    const headers = new Map()
+    const upstream = { ok: true, status: 200, headers, json: () => Promise.resolve([{ key: 'rhaiis' }]) }
     globalThis.fetch = vi.fn().mockResolvedValue(upstream)
 
     const res = makeRes()
@@ -65,8 +66,33 @@ describe('proxyGet', () => {
     expect(res._json).toEqual([{ key: 'rhaiis' }])
   })
 
+  it('forwards pagination headers from upstream', async () => {
+    const headers = new Map([['X-Total-Count', '42'], ['X-Total-Pages', '3']])
+    const upstream = { ok: true, status: 200, headers, json: () => Promise.resolve([]) }
+    globalThis.fetch = vi.fn().mockResolvedValue(upstream)
+
+    const res = makeRes()
+    await proxyGet('https://api.example.com', '/drops', { product_key: 'rhaiis' }, res)
+
+    expect(res._headers['X-Total-Count']).toBe('42')
+    expect(res._headers['X-Total-Pages']).toBe('3')
+  })
+
+  it('handles missing pagination headers gracefully', async () => {
+    const headers = new Map()
+    const upstream = { ok: true, status: 200, headers, json: () => Promise.resolve([]) }
+    globalThis.fetch = vi.fn().mockResolvedValue(upstream)
+
+    const res = makeRes()
+    await proxyGet('https://api.example.com', '/drops', {}, res)
+
+    expect(res._headers['X-Total-Count']).toBeUndefined()
+    expect(res._headers['X-Total-Pages']).toBeUndefined()
+  })
+
   it('passes upstream error status through', async () => {
-    const upstream = { ok: false, status: 404, json: () => Promise.resolve({ detail: 'not found' }) }
+    const headers = new Map()
+    const upstream = { ok: false, status: 404, headers, json: () => Promise.resolve({ detail: 'not found' }) }
     globalThis.fetch = vi.fn().mockResolvedValue(upstream)
 
     const res = makeRes()

--- a/modules/product-builds/__tests__/server/routes.test.js
+++ b/modules/product-builds/__tests__/server/routes.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const registerRoutes = require('../../server/index')
+
+function makeStorage(data = {}) {
+  const store = { ...data }
+  return {
+    readFromStorage(key) {
+      return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
+    },
+    writeToStorage(key, value) {
+      store[key] = value
+    }
+  }
+}
+
+function makeRouter() {
+  const routes = { get: {}, post: {} }
+  return {
+    get: vi.fn(function(path, ...handlers) {
+      routes.get[path] = handlers
+    }),
+    post: vi.fn(function(path, ...handlers) {
+      routes.post[path] = handlers
+    }),
+    _routes: routes
+  }
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: null,
+    status(code) { res._status = code; return res },
+    json(data) { res._json = data; return res }
+  }
+  return res
+}
+
+describe('product-builds routes', () => {
+  let router, requireAdmin, context, storage
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.PRODUCT_BUILDS_API_URL
+
+    storage = makeStorage()
+    router = makeRouter()
+    requireAdmin = vi.fn()
+    context = { storage, requireAdmin }
+    registerRoutes(router, context)
+  })
+
+  describe('route registration', () => {
+    it('registers all expected GET routes', () => {
+      const paths = Object.keys(router._routes.get)
+      expect(paths).toContain('/config')
+      expect(paths).toContain('/products/:key')
+      expect(paths).toContain('/drops')
+      expect(paths).toContain('/drops/:key')
+      expect(paths).toContain('/drops/:key/changelog')
+      expect(paths).toContain('/drops/:key/metrics')
+      expect(paths).toContain('/series')
+      expect(paths).toContain('/artifacts')
+      expect(paths).toContain('/artifacts/:key')
+      expect(paths).toContain('/artifacts/:key/wheels')
+      expect(paths).toContain('/artifacts/:key/containers')
+    })
+
+    it('registers POST config route', () => {
+      const paths = Object.keys(router._routes.post)
+      expect(paths).toContain('/config')
+    })
+
+    it('protects config routes with requireAdmin', () => {
+      const getHandlers = router._routes.get['/config']
+      expect(getHandlers[0]).toBe(requireAdmin)
+
+      const postHandlers = router._routes.post['/config']
+      expect(postHandlers[0]).toBe(requireAdmin)
+    })
+  })
+
+  describe('GET /config', () => {
+    it('returns default config when nothing saved', () => {
+      const handler = router._routes.get['/config'].at(-1)
+      const res = makeRes()
+      handler({}, res)
+      expect(res._json).toEqual({ baseUrl: '' })
+    })
+
+    it('returns saved config', () => {
+      storage.writeToStorage('product-builds/config.json', { baseUrl: 'https://api.example.com' })
+      const handler = router._routes.get['/config'].at(-1)
+      const res = makeRes()
+      handler({}, res)
+      expect(res._json.baseUrl).toBe('https://api.example.com')
+    })
+
+    it('falls back to env var', () => {
+      process.env.PRODUCT_BUILDS_API_URL = 'https://env.example.com'
+      const handler = router._routes.get['/config'].at(-1)
+      const res = makeRes()
+      handler({}, res)
+      expect(res._json.baseUrl).toBe('https://env.example.com')
+    })
+  })
+
+  describe('POST /config', () => {
+    it('saves valid URL', () => {
+      const handler = router._routes.post['/config'].at(-1)
+      const res = makeRes()
+      handler({ body: { baseUrl: 'https://api.example.com' } }, res)
+      expect(res._json.status).toBe('ok')
+      expect(res._json.baseUrl).toBe('https://api.example.com')
+    })
+
+    it('rejects non-HTTP URL', () => {
+      const handler = router._routes.post['/config'].at(-1)
+      const res = makeRes()
+      handler({ body: { baseUrl: 'ftp://bad.example.com' } }, res)
+      expect(res._status).toBe(400)
+    })
+
+    it('accepts empty URL to clear config', () => {
+      const handler = router._routes.post['/config'].at(-1)
+      const res = makeRes()
+      handler({ body: { baseUrl: '' } }, res)
+      expect(res._json.status).toBe('ok')
+      expect(res._json.baseUrl).toBe('')
+    })
+
+    it('rejects non-string baseUrl', () => {
+      const handler = router._routes.post['/config'].at(-1)
+      const res = makeRes()
+      handler({ body: { baseUrl: 123 } }, res)
+      expect(res._status).toBe(400)
+    })
+  })
+})

--- a/modules/product-builds/client/components/ProductBuildsSettings.vue
+++ b/modules/product-builds/client/components/ProductBuildsSettings.vue
@@ -44,9 +44,7 @@ async function checkHealth() {
   checkingHealth.value = true
   healthStatus.value = null
   try {
-    const data = await apiRequest('/healthz')
-    const fastapi = data.dependencies?.['aipcc-dashboard-api']
-    healthStatus.value = fastapi || { status: 'unknown' }
+    healthStatus.value = await apiRequest('/modules/product-builds/health')
   } catch {
     healthStatus.value = { status: 'unavailable' }
   } finally {
@@ -74,7 +72,7 @@ onMounted(loadConfig)
           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
         />
         <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-          Base URL of the FastAPI dashboard server. Can also be set via <code class="font-mono">PRODUCT_BUILDS_API_URL</code> env var.
+          Base URL of the AIPCC Dashboard API server. Can also be set via <code class="font-mono">PRODUCT_BUILDS_API_URL</code> env var.
         </p>
       </div>
 

--- a/modules/product-builds/client/components/ProductBuildsSettings.vue
+++ b/modules/product-builds/client/components/ProductBuildsSettings.vue
@@ -1,0 +1,121 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const config = ref({ baseUrl: '' })
+const loading = ref(true)
+const saving = ref(false)
+const saveError = ref(null)
+const saveSuccess = ref(false)
+const healthStatus = ref(null)
+const checkingHealth = ref(false)
+
+async function loadConfig() {
+  loading.value = true
+  try {
+    config.value = await apiRequest('/modules/product-builds/config')
+  } catch {
+    config.value = { baseUrl: '' }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfig() {
+  saving.value = true
+  saveError.value = null
+  saveSuccess.value = false
+  try {
+    await apiRequest('/modules/product-builds/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseUrl: config.value.baseUrl })
+    })
+    saveSuccess.value = true
+    setTimeout(() => { saveSuccess.value = false }, 3000)
+  } catch (e) {
+    saveError.value = e.message
+  } finally {
+    saving.value = false
+  }
+}
+
+async function checkHealth() {
+  checkingHealth.value = true
+  healthStatus.value = null
+  try {
+    const data = await apiRequest('/healthz')
+    const fastapi = data.dependencies?.['aipcc-dashboard-api']
+    healthStatus.value = fastapi || { status: 'unknown' }
+  } catch {
+    healthStatus.value = { status: 'unavailable' }
+  } finally {
+    checkingHealth.value = false
+  }
+}
+
+onMounted(loadConfig)
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div v-if="loading" class="text-gray-500 dark:text-gray-400">Loading configuration...</div>
+
+    <template v-else>
+      <!-- API URL -->
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Product Builds API URL
+        </label>
+        <input
+          v-model="config.baseUrl"
+          type="url"
+          placeholder="https://dashboard.example.com"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        />
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          Base URL of the FastAPI dashboard server. Can also be set via <code class="font-mono">PRODUCT_BUILDS_API_URL</code> env var.
+        </p>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex items-center gap-3">
+        <button
+          @click="saveConfig"
+          :disabled="saving"
+          class="px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 transition-colors"
+        >
+          {{ saving ? 'Saving...' : 'Save' }}
+        </button>
+        <button
+          @click="checkHealth"
+          :disabled="checkingHealth || !config.baseUrl"
+          class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+        >
+          {{ checkingHealth ? 'Checking...' : 'Test Connection' }}
+        </button>
+      </div>
+
+      <!-- Save feedback -->
+      <div v-if="saveSuccess" class="rounded-md bg-green-50 dark:bg-green-900/20 p-3">
+        <p class="text-sm text-green-700 dark:text-green-300">Configuration saved.</p>
+      </div>
+      <div v-if="saveError" class="rounded-md bg-red-50 dark:bg-red-900/20 p-3">
+        <p class="text-sm text-red-700 dark:text-red-300">{{ saveError }}</p>
+      </div>
+
+      <!-- Health status -->
+      <div v-if="healthStatus" class="rounded-md p-3" :class="healthStatus.status === 'ok' ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'">
+        <p class="text-sm" :class="healthStatus.status === 'ok' ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'">
+          <template v-if="healthStatus.status === 'ok'">
+            Connected successfully
+            <span v-if="healthStatus.latency" class="text-xs ml-1">({{ healthStatus.latency }}ms)</span>
+          </template>
+          <template v-else>
+            Unable to reach Product Builds API
+          </template>
+        </p>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/product-builds/client/composables/useArtifacts.js
+++ b/modules/product-builds/client/composables/useArtifacts.js
@@ -1,0 +1,73 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const BASE = '/modules/product-builds'
+
+export function useArtifacts() {
+  const artifacts = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function loadArtifacts(filters = {}) {
+    loading.value = true
+    error.value = null
+
+    const params = new URLSearchParams()
+    for (const [key, value] of Object.entries(filters)) {
+      if (value !== undefined && value !== null && value !== '') {
+        params.set(key, value)
+      }
+    }
+
+    try {
+      const data = await apiRequest(`${BASE}/artifacts?${params}`)
+      artifacts.value = Array.isArray(data) ? data : []
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { artifacts, loading, error, loadArtifacts }
+}
+
+export function useArtifactDetail() {
+  const artifact = ref(null)
+  const wheels = ref([])
+  const containers = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function loadArtifact(key) {
+    loading.value = true
+    error.value = null
+    try {
+      artifact.value = await apiRequest(`${BASE}/artifacts/${encodeURIComponent(key)}`)
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadWheels(key) {
+    try {
+      const data = await apiRequest(`${BASE}/artifacts/${encodeURIComponent(key)}/wheels`)
+      wheels.value = Array.isArray(data) ? data : []
+    } catch {
+      wheels.value = []
+    }
+  }
+
+  async function loadContainers(key) {
+    try {
+      const data = await apiRequest(`${BASE}/artifacts/${encodeURIComponent(key)}/containers`)
+      containers.value = Array.isArray(data) ? data : []
+    } catch {
+      containers.value = []
+    }
+  }
+
+  return { artifact, wheels, containers, loading, error, loadArtifact, loadWheels, loadContainers }
+}

--- a/modules/product-builds/client/composables/useDrops.js
+++ b/modules/product-builds/client/composables/useDrops.js
@@ -1,0 +1,107 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const BASE = '/modules/product-builds'
+
+export function useProduct() {
+  const product = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function loadProduct(key) {
+    loading.value = true
+    error.value = null
+    try {
+      product.value = await apiRequest(`${BASE}/products/${encodeURIComponent(key)}`)
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { product, loading, error, loadProduct }
+}
+
+export function useDrops() {
+  const drops = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function loadDrops(productKey, filters = {}) {
+    loading.value = true
+    error.value = null
+
+    const params = new URLSearchParams()
+    params.set('product_key', productKey)
+    if (filters.series) params.set('series', filters.series)
+    if (filters.artifact_type) params.set('artifact_type', filters.artifact_type)
+    if (filters.supported_only) params.set('supported_only', 'true')
+    if (filters.limit) params.set('limit', filters.limit)
+    if (filters.offset) params.set('offset', filters.offset)
+
+    try {
+      const data = await apiRequest(`${BASE}/drops?${params}`)
+      drops.value = Array.isArray(data) ? data : []
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { drops, loading, error, loadDrops }
+}
+
+export function useDropDetail() {
+  const drop = ref(null)
+  const changelog = ref(null)
+  const metrics = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function loadDrop(key) {
+    loading.value = true
+    error.value = null
+    try {
+      drop.value = await apiRequest(`${BASE}/drops/${encodeURIComponent(key)}`)
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadChangelog(key) {
+    try {
+      changelog.value = await apiRequest(`${BASE}/drops/${encodeURIComponent(key)}/changelog`)
+    } catch {
+      changelog.value = null
+    }
+  }
+
+  async function loadMetrics(key) {
+    try {
+      metrics.value = await apiRequest(`${BASE}/drops/${encodeURIComponent(key)}/metrics`)
+    } catch {
+      metrics.value = null
+    }
+  }
+
+  return { drop, changelog, metrics, loading, error, loadDrop, loadChangelog, loadMetrics }
+}
+
+export function useSeries() {
+  const series = ref([])
+
+  async function loadSeries(productKey) {
+    try {
+      const data = await apiRequest(`${BASE}/series?product_key=${encodeURIComponent(productKey)}`)
+      series.value = Array.isArray(data) ? data : []
+    } catch {
+      series.value = []
+    }
+  }
+
+  return { series, loadSeries }
+}

--- a/modules/product-builds/client/index.js
+++ b/modules/product-builds/client/index.js
@@ -1,0 +1,14 @@
+import { defineAsyncComponent } from 'vue'
+
+const RhaiisProductView = defineAsyncComponent(() => import('./views/RhaiisProductView.vue'))
+const PlaceholderProductView = defineAsyncComponent(() => import('./views/PlaceholderProductView.vue'))
+
+export const routes = {
+  'rhaiis': RhaiisProductView,
+  'rhel-ai': PlaceholderProductView,
+  'base-images': PlaceholderProductView,
+  'builder-images': PlaceholderProductView,
+  'wheel-collections': PlaceholderProductView,
+  'drop-detail': defineAsyncComponent(() => import('./views/DropDetailView.vue')),
+  'artifact-detail': defineAsyncComponent(() => import('./views/ArtifactDetailView.vue')),
+}

--- a/modules/product-builds/client/utils/formatting.js
+++ b/modules/product-builds/client/utils/formatting.js
@@ -1,0 +1,74 @@
+export function formatDate(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  })
+}
+
+export function envBadgeClass(env) {
+  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+export const ARCH_COLORS = {
+  x86_64: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  aarch64: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  ppc64le: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  s390x: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
+}
+
+export function archBadgeClass(arch) {
+  return ARCH_COLORS[arch?.toLowerCase()] || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+export function konfluxStateBadgeClass(state) {
+  const s = (state || '').toLowerCase()
+  if (s === 'succeeded') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (s === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  if (s === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  if (s === 'pending') return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+export const TEST_STATUS_MAP = {
+  testpassed: { label: 'Passed', cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+  testfail: { label: 'Failed', cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
+  inprogress: { label: 'Running', cls: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  pending: { label: 'Pending', cls: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
+}
+
+export function testStatusBadgeClass(status) {
+  return TEST_STATUS_MAP[status?.toLowerCase()]?.cls || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+export function testStatusLabel(status) {
+  return TEST_STATUS_MAP[status?.toLowerCase()]?.label || status
+}
+
+export function formatDuration(start, end) {
+  const ms = new Date(end) - new Date(start)
+  if (ms < 0) return null
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (h > 0) return `${h}h ${m}m ${s}s`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+export function getAcceleratorInfo(art) {
+  const labels = art?.labels || {}
+  let accel = art?.variant ? art.variant.split('-')[0] : null
+  let runtime = null
+  if (accel) {
+    runtime = labels[`com.redhat.aiplatform.${accel}_version`] || null
+  }
+  return {
+    accel,
+    runtime,
+    python: labels['com.redhat.aiplatform.python'] || null,
+    baseImage: labels['com.redhat.aiplatform.image'] || null
+  }
+}

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -1,0 +1,762 @@
+<script setup>
+import { ref, reactive, computed, watch, onMounted, inject } from 'vue'
+import { useArtifactDetail } from '../composables/useArtifacts'
+
+const nav = inject('moduleNav')
+const { artifact, wheels, containers, loading, error, loadArtifact, loadWheels, loadContainers } = useArtifactDetail()
+
+const currentArtifactKey = computed(() => nav.params.value.key)
+const copiedValue = ref(null)
+const otherLabelsExpanded = ref(false)
+const wheelsWithPackages = ref([])
+const packagesShowAll = reactive(new Set())
+const buildSequenceFilter = ref('new')
+
+async function loadAll(key) {
+  if (!key) return
+  wheelsWithPackages.value = []
+  packagesShowAll.clear()
+  otherLabelsExpanded.value = false
+  buildSequenceFilter.value = 'new'
+  await loadArtifact(key)
+  loadContainers(key)
+  if (artifact.value?.type === 'containers') {
+    await loadWheels(key)
+    fetchWheelPackages()
+  } else {
+    loadWheels(key)
+  }
+}
+
+watch(currentArtifactKey, (key) => loadAll(key))
+onMounted(() => loadAll(currentArtifactKey.value))
+
+async function fetchWheelPackages() {
+  if (!wheels.value.length) return
+  const parsed = wheels.value.map(w => {
+    try {
+      const p = JSON.parse(w.constraints_file || '{}')
+      return { key: w.key, variant: w.variant, main: p.main || [], all: p.all || [] }
+    } catch { return { key: w.key, variant: w.variant, main: [], all: [] } }
+  })
+  wheelsWithPackages.value = parsed
+}
+
+function toggleShowAll(wheelKey) {
+  if (packagesShowAll.has(wheelKey)) {
+    packagesShowAll.delete(wheelKey)
+  } else {
+    packagesShowAll.add(wheelKey)
+  }
+}
+
+function canonicalizeName(name) {
+  return name.toLowerCase().replace(/[-_.]+/g, '-')
+}
+
+const buildSequence = computed(() => {
+  const json = artifact.value?.build_sequence_summary
+  if (!json) return null
+  try {
+    const entries = JSON.parse(json)
+    if (!Array.isArray(entries)) return null
+    const newBuilds = []
+    const prebuilt = []
+    const skipped = []
+    for (const e of entries) {
+      if (e.skipped) skipped.push(e)
+      else if (e.prebuilt) prebuilt.push(e)
+      else newBuilds.push(e)
+    }
+    return { newBuilds, prebuilt, skipped, all: entries, total: entries.length }
+  } catch { return null }
+})
+
+const installableNames = computed(() => {
+  const json = artifact.value?.constraints_file
+  if (!json) return new Set()
+  try {
+    const parsed = JSON.parse(json)
+    const all = parsed.all || []
+    return new Set(all.map(e => canonicalizeName(e.split('==')[0].split('>=')[0].split('<=')[0].split('!=')[0].split('~=')[0].trim())))
+  } catch { return new Set() }
+})
+
+const installableCount = computed(() => {
+  if (!buildSequence.value || installableNames.value.size === 0) return 0
+  return buildSequence.value.all.filter(e => installableNames.value.has(canonicalizeName(e.name))).length
+})
+
+const filteredBuildEntries = computed(() => {
+  if (!buildSequence.value) return []
+  const f = buildSequenceFilter.value
+  return buildSequence.value.all
+    .filter(e => {
+      if (f === 'all') return true
+      if (f === 'installable') return installableNames.value.has(canonicalizeName(e.name))
+      const cat = e.skipped ? 'skipped' : e.prebuilt ? 'prebuilt' : 'new'
+      return cat === f
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+function entryCategory(entry) {
+  if (entry.skipped) return 'skipped'
+  if (entry.prebuilt) return 'prebuilt'
+  return 'new'
+}
+
+const CATEGORY_META = {
+  new: { label: 'New Builds', tooltip: 'Built from source for this release', iconPath: 'M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z' },
+  prebuilt: { label: 'Pre-built', tooltip: 'Reused from a previous build (not rebuilt)', iconPath: 'M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4' },
+  skipped: { label: 'Skipped', tooltip: 'Already existed, build was skipped', iconPath: 'M13 5l7 7-7 7M5 5l7 7-7 7' },
+}
+
+function downloadBuildSequenceAsJson() {
+  const json = artifact.value?.build_sequence_summary
+  if (!json) return
+  const key = (artifact.value?.key || 'build-sequence').replace(/[^a-zA-Z0-9\-_+.]/g, '_').substring(0, 100)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${key}-build-sequence.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function downloadDependencyGraphAsJson() {
+  const json = artifact.value?.dependency_graph
+  if (!json) return
+  const key = (artifact.value?.key || 'dependency-graph').replace(/[^a-zA-Z0-9\-_+.]/g, '_').substring(0, 100)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${key}-graph.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function navigateToArtifact(key) {
+  nav.navigateTo('artifact-detail', { key })
+}
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  })
+}
+
+function envBadgeClass(env) {
+  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+const ARCH_COLORS = {
+  x86_64: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  aarch64: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  ppc64le: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  s390x: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
+}
+
+function archBadgeClass(arch) {
+  return ARCH_COLORS[arch?.toLowerCase()] || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+function getAcceleratorInfo(art) {
+  const labels = art?.labels || {}
+  let accel = art?.variant ? art.variant.split('-')[0] : null
+  let runtime = null
+  if (accel) {
+    runtime = labels[`com.redhat.aiplatform.${accel}_version`] || null
+  }
+  return {
+    accel,
+    runtime,
+    python: labels['com.redhat.aiplatform.python'] || null,
+    baseImage: labels['com.redhat.aiplatform.image'] || null
+  }
+}
+
+function getReleaseNotesUrl(art) {
+  if (!art || art.type !== 'wheels-collections' || !art.key) return null
+  let repoUrl = null
+  if (art.git_repository) {
+    repoUrl = typeof art.git_repository === 'string' ? art.git_repository : art.git_repository?.url
+  }
+  if (!repoUrl) {
+    const labels = art.labels || {}
+    repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
+  }
+  if (!repoUrl || typeof repoUrl !== 'string') return null
+  const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
+  return `${baseUrl}/-/releases/${art.key}`
+}
+
+function copyToClipboard(value) {
+  navigator.clipboard.writeText(value)
+  copiedValue.value = value
+  setTimeout(() => { copiedValue.value = null }, 1500)
+}
+
+function getCommitUrl(art) {
+  const commit = art?.commit || art?.labels?.['git.commit'] || art?.labels?.['org.opencontainers.image.revision'] || art?.labels?.['vcs-ref']
+  if (!commit) return null
+
+  let repoUrl = null
+  if (art.type === 'wheels-collections') {
+    repoUrl = 'https://gitlab.com/redhat/rhel-ai/rhaiis/pipeline'
+  } else {
+    if (art.git_repository) {
+      repoUrl = typeof art.git_repository === 'string' ? art.git_repository : art.git_repository?.url
+    }
+    if (!repoUrl) {
+      const labels = art.labels || {}
+      repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
+    }
+  }
+  if (!repoUrl || typeof repoUrl !== 'string') return null
+  const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
+  return `${baseUrl}/-/commit/${commit}`
+}
+
+function getDigestUrl(art) {
+  if (!art?.sha_digest || !art?.key) return null
+  if (art.key.startsWith('quay.io/')) {
+    const path = art.key.replace('quay.io/', '').split(':')[0]
+    return `https://quay.io/repository/${path}/manifest/${art.sha_digest}`
+  }
+  return null
+}
+
+function sbomState(art) {
+  const links = art?.sbom_links
+  if (!links || !Array.isArray(links)) return null
+  if (links.length === 0) return 'empty'
+  if (links.length === 1 && !links[0].name && !links[0].atlas_url) return 'incompatible'
+  return 'valid'
+}
+
+function isContainerType(art) {
+  return art?.type === 'containers' || art?.type === 'base-images'
+}
+
+function konfluxStateBadgeClass(state) {
+  const s = state?.toLowerCase()
+  if (s === 'succeeded') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (s === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  if (s === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  if (s === 'pending') return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+const TEST_STATUS_MAP = {
+  testpassed: { label: 'Passed', cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+  testfail: { label: 'Failed', cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
+  inprogress: { label: 'Running', cls: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  pending: { label: 'Pending', cls: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
+}
+
+function testStatusBadgeClass(status) {
+  return TEST_STATUS_MAP[status?.toLowerCase()]?.cls || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+function testStatusLabel(status) {
+  return TEST_STATUS_MAP[status?.toLowerCase()]?.label || status
+}
+
+function formatDuration(start, end) {
+  const ms = new Date(end) - new Date(start)
+  if (ms < 0) return '—'
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (h > 0) return `${h}h ${m}m ${s}s`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+function formatDateTime(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString()
+}
+
+function downloadPackagesAsJson() {
+  const grouped = new Map()
+  for (const w of wheelsWithPackages.value) {
+    const sorted = [...w.all].sort()
+    const k = JSON.stringify(sorted)
+    if (grouped.has(k)) {
+      grouped.get(k).wheel_keys.push(w.key)
+    } else {
+      grouped.set(k, { wheel_keys: [w.key], total_packages: sorted.length, packages: sorted })
+    }
+  }
+  const json = JSON.stringify({
+    artifact_key: artifact.value?.key,
+    collections: [...grouped.values()],
+    exported_at: new Date().toISOString(),
+  }, null, 2)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${(artifact.value?.key || 'artifact').replace(/[/:.]/g, '_')}_packages.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+const LABELS_ALREADY_DISPLAYED = [
+  'com.redhat.aiplatform.python',
+  'com.redhat.aiplatform.image',
+  'com.redhat.aiplatform.accelerator',
+  'com.redhat.aiplatform.cuda_version',
+  'com.redhat.aiplatform.rocm_version',
+]
+
+const IMPORTANT_LABEL_KEYS = [
+  'version', 'build-date', 'vcs-ref', 'description', 'maintainer',
+  'org.opencontainers.image.version', 'org.opencontainers.image.created',
+  'org.opencontainers.image.revision', 'org.opencontainers.image.source',
+  'org.opencontainers.image.description', 'org.opencontainers.image.authors',
+  'org.opencontainers.image.vendor', 'org.opencontainers.image.licenses',
+  'com.redhat.component', 'com.redhat.license_terms',
+]
+
+const DEDUP_MAP = {
+  'vcs-ref': 'org.opencontainers.image.revision',
+  'description': 'org.opencontainers.image.description',
+  'version': 'org.opencontainers.image.version',
+  'build-date': 'org.opencontainers.image.created',
+  'git.commit': 'org.opencontainers.image.revision',
+  'io.k8s.description': 'org.opencontainers.image.description',
+  'vendor': 'org.opencontainers.image.vendor',
+  'git.url': 'org.opencontainers.image.source',
+  'url': 'org.opencontainers.image.source',
+}
+
+const TIMESTAMP_LABELS = ['build-date', 'created', 'org.opencontainers.image.created']
+const URL_LABELS = ['com.redhat.license_terms', 'url', 'git.url', 'org.opencontainers.image.source']
+
+function formatLabelValue(key, value) {
+  if (TIMESTAMP_LABELS.includes(key)) {
+    try {
+      const d = new Date(value)
+      if (!isNaN(d.getTime())) return d.toLocaleString()
+    } catch { /* ignore invalid dates */ }
+  }
+  return typeof value === 'object' ? JSON.stringify(value) : String(value)
+}
+
+function isUrlLabel(key, value) {
+  if (URL_LABELS.includes(key)) return true
+  const s = String(value)
+  return s.startsWith('http://') || s.startsWith('https://')
+}
+
+function filterLabels(labels, includeImportant) {
+  return Object.entries(labels)
+    .filter(([key, value]) => {
+      if (value === null || value === undefined || value === '') return false
+      if (LABELS_ALREADY_DISPLAYED.includes(key)) return false
+      if (DEDUP_MAP[key] && labels[DEDUP_MAP[key]]) return false
+      return includeImportant ? IMPORTANT_LABEL_KEYS.includes(key) : !IMPORTANT_LABEL_KEYS.includes(key)
+    })
+    .sort(([a], [b]) => a.localeCompare(b))
+}
+
+const importantLabels = computed(() => {
+  if (!isContainerType(artifact.value) || !artifact.value?.labels) return []
+  return filterLabels(artifact.value.labels, true)
+})
+
+const otherLabels = computed(() => {
+  if (!isContainerType(artifact.value) || !artifact.value?.labels) return []
+  return filterLabels(artifact.value.labels, false)
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Back button -->
+    <button
+      @click="nav.goBack()"
+      class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+    >&larr; Back</button>
+
+    <!-- Loading / Error -->
+    <div v-if="loading && !artifact" class="text-sm text-gray-500 dark:text-gray-400">Loading artifact…</div>
+    <div v-if="error" class="text-sm text-red-600 dark:text-red-400">{{ error }}</div>
+
+    <template v-if="artifact">
+      <!-- Header -->
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100 break-all">{{ artifact.key }}</h1>
+        <div v-if="artifact.series" class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400">
+          <span>Series: <span class="text-gray-900 dark:text-gray-100">{{ artifact.series }}</span></span>
+        </div>
+      </div>
+
+      <!-- Details grid -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Details</h3>
+        <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          <div v-if="artifact.variant">
+            <dt class="text-gray-500 dark:text-gray-400">Variant</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ artifact.variant }}</dd>
+          </div>
+          <div v-if="artifact.environments?.length">
+            <dt class="text-gray-500 dark:text-gray-400">Environments</dt>
+            <dd class="mt-0.5 flex gap-1 flex-wrap">
+              <span
+                v-for="env in artifact.environments"
+                :key="env"
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                :class="envBadgeClass(env)"
+              >{{ env }}</span>
+            </dd>
+          </div>
+          <div v-if="artifact.drop_keys?.length">
+            <dt class="text-gray-500 dark:text-gray-400">Drop</dt>
+            <dd class="mt-0.5 space-y-1">
+              <div v-for="dk in artifact.drop_keys" :key="dk" class="flex items-center gap-1">
+                <button @click="nav.navigateTo('drop-detail', { key: dk })" class="text-primary-600 dark:text-blue-400 hover:underline text-left break-all">{{ dk }}</button>
+                <button @click="copyToClipboard(dk)" class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                  <svg v-if="copiedValue === dk" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                  <svg v-else class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                </button>
+              </div>
+            </dd>
+          </div>
+          <div v-if="artifact.commit">
+            <dt class="text-gray-500 dark:text-gray-400">Commit</dt>
+            <dd class="mt-0.5 flex items-center gap-1">
+              <a v-if="getCommitUrl(artifact)" :href="getCommitUrl(artifact)" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline">{{ artifact.commit }}</a>
+              <span v-else class="text-gray-900 dark:text-gray-100 font-mono text-xs">{{ artifact.commit }}</span>
+              <button @click="copyToClipboard(artifact.commit)" class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                <svg v-if="copiedValue === artifact.commit" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                <svg v-else class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+              </button>
+            </dd>
+          </div>
+          <div v-if="artifact.source_branch">
+            <dt class="text-gray-500 dark:text-gray-400">Branch</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ artifact.source_branch }}</dd>
+          </div>
+          <div v-if="artifact.archs?.length">
+            <dt class="text-gray-500 dark:text-gray-400">Architectures</dt>
+            <dd class="mt-0.5 flex gap-1 flex-wrap">
+              <span
+                v-for="arch in artifact.archs"
+                :key="arch"
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                :class="archBadgeClass(arch)"
+              >{{ arch }}</span>
+            </dd>
+          </div>
+          <div v-if="getAcceleratorInfo(artifact).accel">
+            <dt class="text-gray-500 dark:text-gray-400">Accelerator</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ getAcceleratorInfo(artifact).accel }}</dd>
+          </div>
+          <div v-if="getAcceleratorInfo(artifact).runtime">
+            <dt class="text-gray-500 dark:text-gray-400">{{ getAcceleratorInfo(artifact).accel?.toUpperCase() }} Runtime</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ getAcceleratorInfo(artifact).runtime }}</dd>
+          </div>
+          <div v-if="getAcceleratorInfo(artifact).python">
+            <dt class="text-gray-500 dark:text-gray-400">Python</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ getAcceleratorInfo(artifact).python }}</dd>
+          </div>
+          <div v-if="getAcceleratorInfo(artifact).baseImage">
+            <dt class="text-gray-500 dark:text-gray-400">Base Image</dt>
+            <dd class="mt-0.5 flex items-center gap-1">
+              <button @click="navigateToArtifact(getAcceleratorInfo(artifact).baseImage)" class="text-primary-600 dark:text-blue-400 hover:underline text-sm break-all text-left">{{ getAcceleratorInfo(artifact).baseImage }}</button>
+              <button @click="copyToClipboard(getAcceleratorInfo(artifact).baseImage)" class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                <svg v-if="copiedValue === getAcceleratorInfo(artifact).baseImage" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                <svg v-else class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+              </button>
+            </dd>
+          </div>
+          <div v-if="getReleaseNotesUrl(artifact)">
+            <dt class="text-gray-500 dark:text-gray-400">Release Notes</dt>
+            <dd class="mt-0.5">
+              <a :href="getReleaseNotesUrl(artifact)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1 text-sm">
+                Open GitLab Release Page
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+              </a>
+            </dd>
+          </div>
+          <div v-if="artifact.created_at">
+            <dt class="text-gray-500 dark:text-gray-400">Created</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ formatDate(artifact.created_at) }}</dd>
+          </div>
+          <div v-if="artifact.sha_digest">
+            <dt class="text-gray-500 dark:text-gray-400">Digest</dt>
+            <dd class="mt-0.5 flex items-start gap-1">
+              <a v-if="getDigestUrl(artifact)" :href="getDigestUrl(artifact)" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline break-all">{{ artifact.sha_digest }}</a>
+              <span v-else class="text-gray-900 dark:text-gray-100 font-mono text-xs break-all">{{ artifact.sha_digest }}</span>
+              <button @click="copyToClipboard(artifact.sha_digest)" class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                <svg v-if="copiedValue === artifact.sha_digest" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                <svg v-else class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+              </button>
+            </dd>
+          </div>
+          <div v-if="isContainerType(artifact) && sbomState(artifact) === 'valid'">
+            <dt class="text-gray-500 dark:text-gray-400">Atlas SBOMs</dt>
+            <dd class="mt-0.5">
+              <ul class="list-disc pl-5 space-y-1">
+                <li v-for="(sbom, i) in artifact.sbom_links" :key="i">
+                  <a :href="sbom.atlas_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline text-sm break-all">{{ sbom.name || sbom.atlas_url }}</a>
+                </li>
+              </ul>
+            </dd>
+          </div>
+          <div v-else-if="isContainerType(artifact) && sbomState(artifact) === 'incompatible'">
+            <dt class="text-gray-500 dark:text-gray-400">Atlas SBOMs</dt>
+            <dd class="mt-0.5 text-xs text-red-600 dark:text-red-400">Incompatible (Legacy SBOM - cannot be resolved)</dd>
+          </div>
+          <div v-else-if="isContainerType(artifact) && sbomState(artifact) === 'empty'">
+            <dt class="text-gray-500 dark:text-gray-400">Atlas SBOMs</dt>
+            <dd class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">No SBOM links available</dd>
+          </div>
+        </dl>
+      </div>
+
+      <!-- Konflux Build Information -->
+      <div v-if="artifact.konflux_data" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Konflux Build Information</h3>
+        <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          <div v-if="artifact.konflux_data.component_name">
+            <dt class="text-gray-500 dark:text-gray-400">Component</dt>
+            <dd class="text-gray-900 dark:text-gray-100 mt-0.5">{{ artifact.konflux_data.component_name }}</dd>
+          </div>
+          <div v-if="artifact.konflux_data.pipelinerun_name">
+            <dt class="text-gray-500 dark:text-gray-400">Pipeline Run</dt>
+            <dd class="mt-0.5">
+              <a v-if="artifact.konflux_data.pipelinerun_url" :href="artifact.konflux_data.pipelinerun_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline break-all">{{ artifact.konflux_data.pipelinerun_name }}</a>
+              <span v-else class="text-gray-900 dark:text-gray-100">{{ artifact.konflux_data.pipelinerun_name }}</span>
+            </dd>
+          </div>
+          <div v-if="artifact.konflux_data.snapshot_name">
+            <dt class="text-gray-500 dark:text-gray-400">Snapshot</dt>
+            <dd class="mt-0.5">
+              <a v-if="artifact.konflux_data.snapshot_url" :href="artifact.konflux_data.snapshot_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline break-all">{{ artifact.konflux_data.snapshot_name }}</a>
+              <span v-else class="text-gray-900 dark:text-gray-100">{{ artifact.konflux_data.snapshot_name }}</span>
+            </dd>
+          </div>
+          <div v-if="artifact.konflux_data.releases && artifact.konflux_data.releases.length > 0" class="md:col-span-2">
+            <dt class="text-gray-500 dark:text-gray-400">Releases</dt>
+            <dd class="mt-0.5">
+              <ul class="list-disc pl-5 space-y-2">
+                <li v-for="(rel, i) in artifact.konflux_data.releases" :key="i">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <a v-if="rel.url" :href="rel.url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ rel.name }}</a>
+                    <span v-else class="text-gray-900 dark:text-gray-100">{{ rel.name }}</span>
+                    <span v-if="rel.release_plan" class="text-gray-400 dark:text-gray-500 text-xs" :title="'Konflux ReleasePlan applied for this release'">({{ rel.release_plan }})</span>
+                    <span v-if="rel.state" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium" :class="konfluxStateBadgeClass(rel.state)">{{ rel.state }}</span>
+                  </div>
+                  <div v-if="rel.created_at" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Created: {{ formatDateTime(rel.created_at) }}</div>
+                </li>
+              </ul>
+            </dd>
+          </div>
+          <div v-else-if="artifact.konflux_data.releases && artifact.konflux_data.releases.length === 0">
+            <dt class="text-gray-500 dark:text-gray-400">Releases</dt>
+            <dd class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">No releases found</dd>
+          </div>
+          <div v-if="artifact.konflux_data.tests && artifact.konflux_data.tests.length > 0" class="md:col-span-2">
+            <dt class="text-gray-500 dark:text-gray-400">Integration Tests</dt>
+            <dd class="mt-0.5">
+              <ul class="list-disc pl-5 space-y-2">
+                <li v-for="(test, i) in artifact.konflux_data.tests" :key="i">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <a v-if="test.pipelinerun_url" :href="test.pipelinerun_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ test.scenario }}</a>
+                    <span v-else class="text-gray-900 dark:text-gray-100">{{ test.scenario }}</span>
+                    <span v-if="test.status" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium" :class="testStatusBadgeClass(test.status)">{{ testStatusLabel(test.status) }}</span>
+                    <span v-if="test.is_optional" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400">optional</span>
+                  </div>
+                  <div v-if="test.completion_time && test.start_time" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Duration: {{ formatDuration(test.start_time, test.completion_time) }}</div>
+                  <div v-else-if="test.start_time" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Started: {{ formatDateTime(test.start_time) }}</div>
+                </li>
+              </ul>
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <!-- Container Image Labels -->
+      <div v-if="importantLabels.length || otherLabels.length" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <template v-if="importantLabels.length">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Container Image Labels</h3>
+          <div class="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+            <template v-for="[key, value] in importantLabels" :key="key">
+              <div class="font-semibold text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ key }}</div>
+              <div class="break-all">
+                <a v-if="isUrlLabel(key, value)" :href="formatLabelValue(key, value)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ formatLabelValue(key, value) }}</a>
+                <span v-else class="text-gray-700 dark:text-gray-300">{{ formatLabelValue(key, value) }}</span>
+              </div>
+            </template>
+          </div>
+        </template>
+
+        <div v-if="otherLabels.length" :class="importantLabels.length ? 'mt-4' : ''">
+          <button
+            @click="otherLabelsExpanded = !otherLabelsExpanded"
+            class="text-sm text-primary-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+          >
+            <svg class="w-3 h-3 transition-transform" :class="otherLabelsExpanded ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+            {{ otherLabelsExpanded ? `Hide all other labels (${otherLabels.length})` : `Show all other labels (${otherLabels.length})` }}
+          </button>
+          <div v-if="otherLabelsExpanded" class="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm mt-3">
+            <template v-for="[key, value] in otherLabels" :key="key">
+              <div class="font-semibold text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ key }}</div>
+              <div class="break-all">
+                <a v-if="isUrlLabel(key, value)" :href="formatLabelValue(key, value)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ formatLabelValue(key, value) }}</a>
+                <span v-else class="text-gray-700 dark:text-gray-300">{{ formatLabelValue(key, value) }}</span>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <!-- Package Dependencies (containers) -->
+      <div v-if="artifact.type === 'containers' && wheelsWithPackages.length" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center gap-2 mb-3">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Package Dependencies</h3>
+          <button @click="downloadPackagesAsJson" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" title="Download packages as JSON">
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+          </button>
+        </div>
+        <div v-for="w in wheelsWithPackages" :key="w.key" class="mb-4 last:mb-0">
+          <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            <button @click="navigateToArtifact(w.key)" class="text-primary-600 dark:text-blue-400 hover:underline break-all text-left">{{ w.key }}</button>
+          </div>
+          <div v-if="w.all.length === 0" class="text-xs text-gray-400 dark:text-gray-500">No packages</div>
+          <template v-else>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="pkg in (packagesShowAll.has(w.key) ? w.all : w.main)"
+                :key="pkg"
+                class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+              >{{ pkg }}</span>
+            </div>
+            <div v-if="w.all.length > w.main.length" class="flex items-center gap-1.5 mt-2">
+              <button
+                @click="toggleShowAll(w.key)"
+                class="text-xs text-primary-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
+              >
+                {{ packagesShowAll.has(w.key) ? 'Show less' : `Show all (${w.all.length} packages)` }}
+                <svg class="w-3 h-3 transition-transform" :class="{ 'rotate-180': packagesShowAll.has(w.key) }" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+              </button>
+              <svg class="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 cursor-help" fill="currentColor" viewBox="0 0 20 20" title="Packages shown by default are the key dependencies required for the wheel collection to function properly."><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" /></svg>
+            </div>
+          </template>
+        </div>
+      </div>
+      <div v-else-if="artifact.type === 'containers' && !wheels.length && !loading" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <p class="text-sm text-gray-500 dark:text-gray-400">No package dependencies found for this container.</p>
+      </div>
+
+      <!-- Used in Containers (wheel collections / base images) -->
+      <div v-if="(artifact.type === 'wheels-collections' || artifact.type === 'base-images') && containers.length" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Used in Containers</h3>
+        <ul class="list-disc pl-5 space-y-2">
+          <li v-for="c in containers" :key="c.key" class="text-sm">
+            <button @click="navigateToArtifact(c.key)" class="text-primary-600 dark:text-blue-400 hover:underline break-all text-left">{{ c.key }}</button>
+            <span v-if="c.variant" class="text-gray-500 dark:text-gray-400 ml-2">({{ c.variant }})</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Packages (wheel collections) -->
+      <div v-if="artifact.type === 'wheels-collections' && buildSequence" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center gap-2 mb-3">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Packages</h3>
+          <button @click="downloadBuildSequenceAsJson" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" title="Download build sequence as JSON">
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+          </button>
+        </div>
+
+        <!-- Filter chips -->
+        <div class="flex gap-2 mb-4 flex-wrap items-center">
+          <span class="text-xs text-gray-400 dark:text-gray-500 mr-1">Show:</span>
+          <button
+            @click="buildSequenceFilter = 'all'"
+            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium border transition-colors"
+            :class="buildSequenceFilter === 'all'
+              ? 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700'
+              : 'bg-white text-gray-600 border-gray-300 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'"
+          >All ({{ buildSequence.total }})</button>
+          <button
+            v-for="cat in ['new', 'prebuilt', 'skipped']"
+            :key="cat"
+            @click="buildSequenceFilter = cat"
+            class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium border transition-colors"
+            :class="buildSequenceFilter === cat
+              ? 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700'
+              : 'bg-white text-gray-600 border-gray-300 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'"
+            :title="CATEGORY_META[cat].tooltip"
+          >
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="CATEGORY_META[cat].iconPath" /></svg>
+            {{ CATEGORY_META[cat].label }} ({{ buildSequence[cat === 'new' ? 'newBuilds' : cat].length }})
+          </button>
+          <button
+            v-if="installableNames.size > 0"
+            @click="buildSequenceFilter = 'installable'"
+            class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium border transition-colors"
+            :class="buildSequenceFilter === 'installable'
+              ? 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700'
+              : 'bg-white text-gray-600 border-gray-300 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'"
+            title="Only show packages that would be installed (appear in constraints)"
+          >
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+            Installable ({{ installableCount }})
+          </button>
+        </div>
+
+        <!-- Package grid -->
+        <p v-if="filteredBuildEntries.length === 0" class="text-sm text-gray-400 dark:text-gray-500 italic">No packages match the selected filter.</p>
+        <div v-else class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-1.5 font-mono text-[13px]">
+          <div
+            v-for="(entry, i) in filteredBuildEntries"
+            :key="i"
+            class="flex items-center gap-1.5 py-1"
+          >
+            <svg
+              class="w-3 h-3 shrink-0 cursor-help"
+              :class="{
+                'text-blue-500 dark:text-blue-400': entryCategory(entry) === 'new',
+                'text-cyan-500 dark:text-cyan-400': entryCategory(entry) === 'prebuilt',
+                'text-gray-400 dark:text-gray-500': entryCategory(entry) === 'skipped',
+              }"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            ><title>{{ CATEGORY_META[entryCategory(entry)].tooltip }}</title><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="CATEGORY_META[entryCategory(entry)].iconPath" /></svg>
+            <svg
+              v-if="installableNames.size > 0 && installableNames.has(canonicalizeName(entry.name))"
+              class="w-3 h-3 shrink-0 text-green-500 dark:text-green-400 cursor-help"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            ><title>In installable set (appears in constraints)</title><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+            <span class="text-gray-800 dark:text-gray-200">{{ entry.name }}=={{ entry.version }}</span>
+          </div>
+        </div>
+      </div>
+      <div v-else-if="artifact.type === 'wheels-collections' && !artifact.build_sequence_summary && !loading" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <p class="text-sm text-gray-500 dark:text-gray-400">No package information found for this wheel collection.</p>
+      </div>
+
+      <!-- Dependency Graph (wheel collections) -->
+      <div v-if="artifact.type === 'wheels-collections' && artifact.dependency_graph" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center gap-2 mb-3">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Dependency Graph</h3>
+          <button @click="downloadDependencyGraphAsJson" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" title="Download graph as JSON">
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+          </button>
+        </div>
+        <p class="text-sm text-gray-500 dark:text-gray-400 italic">Not implemented yet</p>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, inject } from 'vue'
 import { useArtifactDetail } from '../composables/useArtifacts'
+import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo } from '../utils/formatting'
 
 const nav = inject('moduleNav')
 const { artifact, wheels, containers, loading, error, loadArtifact, loadWheels, loadContainers } = useArtifactDetail()
 
 const currentArtifactKey = computed(() => nav.params.value.key)
+const productKey = computed(() => nav.params.value.product || '')
 const copiedValue = ref(null)
 const otherLabelsExpanded = ref(false)
 const wheelsWithPackages = ref([])
@@ -139,46 +141,7 @@ function downloadDependencyGraphAsJson() {
 }
 
 function navigateToArtifact(key) {
-  nav.navigateTo('artifact-detail', { key })
-}
-
-function formatDate(iso) {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
-  })
-}
-
-function envBadgeClass(env) {
-  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-const ARCH_COLORS = {
-  x86_64: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-  aarch64: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-  ppc64le: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-  s390x: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
-}
-
-function archBadgeClass(arch) {
-  return ARCH_COLORS[arch?.toLowerCase()] || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-function getAcceleratorInfo(art) {
-  const labels = art?.labels || {}
-  let accel = art?.variant ? art.variant.split('-')[0] : null
-  let runtime = null
-  if (accel) {
-    runtime = labels[`com.redhat.aiplatform.${accel}_version`] || null
-  }
-  return {
-    accel,
-    runtime,
-    python: labels['com.redhat.aiplatform.python'] || null,
-    baseImage: labels['com.redhat.aiplatform.image'] || null
-  }
+  nav.navigateTo('artifact-detail', { key, product: productKey.value })
 }
 
 function getReleaseNotesUrl(art) {
@@ -242,42 +205,6 @@ function sbomState(art) {
 
 function isContainerType(art) {
   return art?.type === 'containers' || art?.type === 'base-images'
-}
-
-function konfluxStateBadgeClass(state) {
-  const s = state?.toLowerCase()
-  if (s === 'succeeded') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (s === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-  if (s === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-  if (s === 'pending') return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-const TEST_STATUS_MAP = {
-  testpassed: { label: 'Passed', cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
-  testfail: { label: 'Failed', cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
-  inprogress: { label: 'Running', cls: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
-  pending: { label: 'Pending', cls: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
-}
-
-function testStatusBadgeClass(status) {
-  return TEST_STATUS_MAP[status?.toLowerCase()]?.cls || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-function testStatusLabel(status) {
-  return TEST_STATUS_MAP[status?.toLowerCase()]?.label || status
-}
-
-function formatDuration(start, end) {
-  const ms = new Date(end) - new Date(start)
-  if (ms < 0) return '—'
-  const totalSec = Math.floor(ms / 1000)
-  const h = Math.floor(totalSec / 3600)
-  const m = Math.floor((totalSec % 3600) / 60)
-  const s = totalSec % 60
-  if (h > 0) return `${h}h ${m}m ${s}s`
-  if (m > 0) return `${m}m ${s}s`
-  return `${s}s`
 }
 
 function formatDateTime(iso) {
@@ -424,7 +351,7 @@ const otherLabels = computed(() => {
             <dt class="text-gray-500 dark:text-gray-400">Drop</dt>
             <dd class="mt-0.5 space-y-1">
               <div v-for="dk in artifact.drop_keys" :key="dk" class="flex items-center gap-1">
-                <button @click="nav.navigateTo('drop-detail', { key: dk })" class="text-primary-600 dark:text-blue-400 hover:underline text-left break-all">{{ dk }}</button>
+                <button @click="nav.navigateTo('drop-detail', { key: dk, product: productKey.value })" class="text-primary-600 dark:text-blue-400 hover:underline text-left break-all">{{ dk }}</button>
                 <button @click="copyToClipboard(dk)" class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
                   <svg v-if="copiedValue === dk" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
                   <svg v-else class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -1,0 +1,709 @@
+<script setup>
+import { onMounted, inject, ref, computed, reactive, watch } from 'vue'
+import { useDropDetail } from '../composables/useDrops'
+import { useArtifacts } from '../composables/useArtifacts'
+import { apiRequest } from '@shared/client/services/api'
+
+const BASE = '/modules/product-builds'
+const nav = inject('moduleNav')
+const { drop, changelog, metrics, loading, error, loadDrop, loadChangelog, loadMetrics } = useDropDetail()
+const { artifacts, loading: artifactsLoading, error: artifactsError, loadArtifacts } = useArtifacts()
+
+const activeTab = ref('artifacts')
+const currentDropKey = computed(() => nav.params.value.key)
+const wheelsData = reactive(new Map())
+const wheelsRaw = new Map()
+const packagesPopup = ref(null)
+const packagesShowAll = reactive(new Set())
+
+const productKey = computed(() => {
+  const hash = window.location.hash || ''
+  const parts = hash.replace('#/', '').split('?')[0].split('/')
+  return parts[1] || ''
+})
+
+function extractAccelerator(variant) {
+  if (!variant) return null
+  const first = variant.toLowerCase().split('-')[0]
+  const match = first.match(/^[a-z]+/)
+  return match ? match[0] : null
+}
+
+function isGenericDrop(name) {
+  if (!name) return false
+  const n = name.toLowerCase()
+  if (/^v\d+(\.\d+)*-\d{6,}$/.test(n)) return true
+  if (/^v\d+(?:\.\d+)+(?:\.\d{6,})$/.test(n)) return true
+  if (/^v\d{6,}$/.test(n)) return true
+  if (/^preview-\d{6,}$/.test(n)) return true
+  if (/^[A-Z]+-\d+$/i.test(name)) return true
+  return false
+}
+
+const NO_WARNING_PRODUCTS = new Set(['rhel-ai'])
+
+const dropCommit = computed(() => {
+  const first = artifacts.value.find(a => a.commit)
+  return first || null
+})
+
+const acceleratorWarning = computed(() => {
+  if (!drop.value || NO_WARNING_PRODUCTS.has(productKey.value)) return null
+  if (isGenericDrop(drop.value.name)) return null
+  const accels = new Set(artifacts.value.map(a => extractAccelerator(a.variant)).filter(Boolean))
+  if (accels.size <= 1) return null
+  return [...accels].join(', ')
+})
+
+const NO_WHEELS_PRODUCTS = new Set(['rhel-ai', 'builder-images'])
+
+async function fetchWheelsForArtifacts() {
+  if (NO_WHEELS_PRODUCTS.has(productKey.value)) return
+  await Promise.all(
+    artifacts.value
+      .filter(a => a.type === 'containers')
+      .map(async (a) => {
+        try {
+          const data = await apiRequest(`${BASE}/artifacts/${encodeURIComponent(a.key)}/wheels`)
+          const wheels = Array.isArray(data) ? data : []
+          if (wheels.length > 0) {
+            const parsed = wheels.map(w => {
+              try {
+                const p = JSON.parse(w.constraints_file || '{}')
+                return { key: w.key, main: p.main || [], all: p.all || [] }
+              } catch { return { key: w.key, main: [], all: [] } }
+            })
+            const count = parsed.reduce((sum, w) => sum + w.all.length, 0)
+            wheelsData.set(a.key, count)
+            wheelsRaw.set(a.key, parsed)
+          }
+        } catch { /* skip */ }
+      })
+  )
+}
+
+watch(artifacts, (val) => {
+  if (val.length > 0) fetchWheelsForArtifacts()
+})
+
+async function loadAll(key) {
+  if (!key) return
+  wheelsData.clear()
+  wheelsRaw.clear()
+  expandedRows.clear()
+  activeTab.value = 'artifacts'
+  await loadDrop(key)
+  loadArtifacts({ drop_key: key })
+  loadChangelog(key)
+  loadMetrics(key)
+}
+
+watch(currentDropKey, (key) => loadAll(key))
+onMounted(() => loadAll(currentDropKey.value))
+
+function navigateToArtifact(artifactKey) {
+  nav.navigateTo('artifact-detail', { key: artifactKey })
+}
+
+function navigateToDrop(key) {
+  nav.navigateTo('drop-detail', { key })
+}
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  })
+}
+
+function envBadgeClass(env) {
+  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+const ARCH_COLORS = {
+  x86_64: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  aarch64: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  ppc64le: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  s390x: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
+}
+
+function archBadgeClass(arch) {
+  return ARCH_COLORS[arch?.toLowerCase()] || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+function getQuayDirectTagUrl(key) {
+  if (!key || !key.startsWith('quay.io/')) return null
+  const withoutRegistry = key.replace('quay.io/', '')
+  const [path, tag] = withoutRegistry.split(':')
+  if (!tag) return null
+  return `https://quay.io/repository/${path}/tag/${tag}`
+}
+
+function getQuayAllTagsUrl(key) {
+  if (!key || !key.startsWith('quay.io/')) return null
+  const withoutRegistry = key.replace('quay.io/', '')
+  const [path, tag] = withoutRegistry.split(':')
+  const url = `https://quay.io/repository/${path}?tab=tags`
+  return tag ? `${url}&tag=${tag}` : url
+}
+
+function getRegistryUrl(key) {
+  if (!key) return null
+  if (key.startsWith('quay.io/')) {
+    const path = key.replace('quay.io/', '').split(':')[0]
+    return `https://quay.io/repository/${path}?tab=tags`
+  }
+  if (key.startsWith('registry.redhat.io/')) {
+    const path = key.replace('registry.redhat.io/', '').split(':')[0]
+    return `https://catalog.redhat.com/en/search?searchType=All&q=${encodeURIComponent(path)}&p=1`
+  }
+  return null
+}
+
+function getCommitUrl(artifact) {
+  if (!artifact?.commit) return null
+  const labels = artifact.labels || {}
+  const repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['vcs-url']
+  if (!repoUrl) return null
+  const clean = repoUrl.replace(/\.git$/, '')
+  return `${clean}/commit/${artifact.commit}`
+}
+
+function downloadPackagesAsJson(artifactKey) {
+  const parsed = wheelsRaw.get(artifactKey)
+  if (!parsed) return
+  const grouped = new Map()
+  for (const w of parsed) {
+    const sorted = [...w.all].sort()
+    const k = JSON.stringify(sorted)
+    if (grouped.has(k)) {
+      grouped.get(k).wheel_keys.push(w.key)
+    } else {
+      grouped.set(k, { wheel_keys: [w.key], total_packages: sorted.length, packages: sorted })
+    }
+  }
+  const json = JSON.stringify({ artifact_key: artifactKey, collections: [...grouped.values()], exported_at: new Date().toISOString() }, null, 2)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${artifactKey.replace(/[/:.]/g, '_')}_packages.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function showPackages(artifactKey, event) {
+  event.stopPropagation()
+  const raw = wheelsRaw.get(artifactKey)
+  if (!raw) return
+  packagesShowAll.clear()
+  packagesPopup.value = { artifactKey, wheels: raw }
+}
+
+function toggleShowAll(wheelKey) {
+  if (packagesShowAll.has(wheelKey)) {
+    packagesShowAll.delete(wheelKey)
+  } else {
+    packagesShowAll.add(wheelKey)
+  }
+}
+
+const copiedKey = ref(null)
+const expandedRows = reactive(new Set())
+const copiedJson = ref(null)
+
+function copyKey(key, event) {
+  event.stopPropagation()
+  navigator.clipboard.writeText(key)
+  copiedKey.value = key
+  setTimeout(() => { copiedKey.value = null }, 1500)
+}
+
+function toggleRow(key, event) {
+  event.stopPropagation()
+  if (expandedRows.has(key)) {
+    expandedRows.delete(key)
+  } else {
+    expandedRows.add(key)
+  }
+}
+
+function copyArtifactJson(art, event) {
+  event.stopPropagation()
+  navigator.clipboard.writeText(JSON.stringify(art, null, 2))
+  copiedJson.value = art.key
+  setTimeout(() => { copiedJson.value = null }, 1500)
+}
+
+function getAcceleratorInfo(artifact) {
+  const labels = artifact?.labels || {}
+  let accel = artifact?.variant ? artifact.variant.split('-')[0] : 'unknown'
+  let runtime = null
+  if (accel !== 'unknown') {
+    runtime = labels[`com.redhat.aiplatform.${accel}_version`] || null
+  }
+  return {
+    accel: accel || 'unknown',
+    runtime: runtime || 'unknown',
+    python: labels['com.redhat.aiplatform.python'] || 'unknown',
+    baseImage: labels['com.redhat.aiplatform.image'] || null
+  }
+}
+
+function getDigestUrl(artifact) {
+  if (!artifact?.sha_digest || !artifact?.key) return null
+  if (!artifact.key.startsWith('quay.io/')) return null
+  const path = artifact.key.replace('quay.io/', '').split(':')[0]
+  return `https://quay.io/repository/${path}/manifest/${artifact.sha_digest}`
+}
+
+function konfluxStateBadgeClass(state) {
+  const s = (state || '').toLowerCase()
+  if (s === 'succeeded') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (s === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  if (s === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  if (s === 'pending') return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+const TEST_STATUS_MAP = {
+  testpassed: { label: 'Passed', cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+  testfail: { label: 'Failed', cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
+  inprogress: { label: 'Running', cls: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  pending: { label: 'Pending', cls: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
+}
+
+function testStatusLabel(status) {
+  return TEST_STATUS_MAP[status?.toLowerCase()]?.label || status
+}
+
+function testStatusBadgeClass(status) {
+  return TEST_STATUS_MAP[status?.toLowerCase()]?.cls || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+function formatDuration(start, end) {
+  const diffMs = new Date(end) - new Date(start)
+  if (diffMs < 0) return null
+  const totalSeconds = Math.floor(diffMs / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}
+
+const totalColumns = 7
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Back button -->
+    <button
+      @click="nav.goBack()"
+      class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+    >&larr; Back</button>
+
+    <!-- Loading / Error -->
+    <div v-if="loading && !drop" class="text-sm text-gray-500 dark:text-gray-400">Loading drop…</div>
+    <div v-if="error" class="text-sm text-red-600 dark:text-red-400">{{ error }}</div>
+
+    <template v-if="drop">
+      <!-- Header -->
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Drop: {{ drop.name }}</h1>
+        <div class="flex items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
+          <span>Version: <span class="text-gray-900 dark:text-gray-100">{{ drop.product_version }}</span></span>
+          <span v-if="drop.git_branch">&middot; Branch: <span class="text-gray-900 dark:text-gray-100">{{ drop.git_branch }}</span></span>
+          <span v-if="dropCommit">&middot; Commit:
+            <a
+              v-if="getCommitUrl(dropCommit)"
+              :href="getCommitUrl(dropCommit)"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="font-mono text-primary-600 dark:text-blue-400 hover:underline"
+            >{{ dropCommit.commit.slice(0, 8) }}</a>
+            <span v-else class="font-mono text-gray-900 dark:text-gray-100">{{ dropCommit.commit.slice(0, 8) }}</span>
+          </span>
+        </div>
+        <div v-if="drop.environments?.length" class="flex gap-1 mt-2">
+          <span
+            v-for="env in drop.environments"
+            :key="env"
+            class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+            :class="envBadgeClass(env)"
+          >{{ env }}</span>
+        </div>
+      </div>
+
+      <!-- Release timing -->
+      <div v-if="drop.release_timings?.length" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Release Timeline</h3>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div v-for="timing in drop.release_timings" :key="timing.phase">
+            <p class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ timing.phase }}</p>
+            <p class="text-sm text-gray-900 dark:text-gray-100 mt-0.5">{{ formatDate(timing.timestamp) }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="border-b border-gray-200 dark:border-gray-700">
+        <nav class="flex gap-4">
+          <button
+            v-for="tab in ['artifacts', 'changelog', 'metrics']"
+            :key="tab"
+            @click="activeTab = tab"
+            class="py-2 text-sm font-medium border-b-2 transition-colors"
+            :class="activeTab === tab
+              ? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+          >{{ tab.charAt(0).toUpperCase() + tab.slice(1) }}</button>
+        </nav>
+      </div>
+
+      <!-- Artifacts tab -->
+      <div v-if="activeTab === 'artifacts'">
+        <div v-if="artifactsLoading" class="text-sm text-gray-500 dark:text-gray-400">Loading artifacts…</div>
+        <div v-else-if="artifactsError" class="text-sm text-red-600 dark:text-red-400">{{ artifactsError }}</div>
+        <div v-else-if="artifacts.length === 0" class="text-sm text-gray-500 dark:text-gray-400">No artifacts for this drop.</div>
+        <div v-else class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[30%]">Artifact Key</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[7%]">Links</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[10%]">Architectures</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[10%]">Environments</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[10%]">Packages</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[15%]">Created</th>
+                <th class="w-[5%]"></th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <template v-for="art in artifacts" :key="art.key">
+                <tr
+                  @click="toggleRow(art.key, $event)"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+                >
+                  <td class="px-4 py-3">
+                    <div class="flex items-center gap-1.5">
+                      <span
+                        class="text-sm font-medium text-primary-600 dark:text-blue-400 truncate hover:underline"
+                        @click.stop="navigateToArtifact(art.key)"
+                      >{{ art.key }}</span>
+                      <button
+                        @click="copyKey(art.key, $event)"
+                        class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                        title="Copy artifact key"
+                      >
+                        <svg v-if="copiedKey === art.key" class="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                        <svg v-else class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                      </button>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3" @click.stop>
+                    <div class="flex items-center gap-1.5">
+                      <a
+                        v-if="getQuayDirectTagUrl(art.key)"
+                        :href="getQuayDirectTagUrl(art.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
+                        title="Direct link to this tag"
+                      >
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                      </a>
+                      <a
+                        v-if="getQuayAllTagsUrl(art.key)"
+                        :href="getQuayAllTagsUrl(art.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50"
+                        title="View all tags (old Quay.io UI)"
+                      >all tags</a>
+                      <a
+                        v-if="!getQuayDirectTagUrl(art.key) && getRegistryUrl(art.key)"
+                        :href="getRegistryUrl(art.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
+                        title="View in registry"
+                      >
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                      </a>
+                      <span v-if="!getQuayDirectTagUrl(art.key) && !getQuayAllTagsUrl(art.key) && !getRegistryUrl(art.key)" class="text-gray-400 dark:text-gray-500">—</span>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3">
+                    <div class="flex gap-1 flex-wrap">
+                      <span
+                        v-for="arch in (art.archs || [])"
+                        :key="arch"
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                        :class="archBadgeClass(arch)"
+                      >{{ arch }}</span>
+                      <span v-if="!(art.archs || []).length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3">
+                    <div class="flex gap-1 flex-wrap">
+                      <span
+                        v-for="env in (art.environments || [])"
+                        :key="env"
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                        :class="envBadgeClass(env)"
+                      >{{ env }}</span>
+                      <span v-if="!(art.environments || []).length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3 text-sm" @click.stop>
+                    <div v-if="wheelsData.has(art.key)" class="inline-flex items-center gap-1">
+                      <button
+                        @click="showPackages(art.key, $event)"
+                        class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50 cursor-pointer transition-colors"
+                      >
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
+                        {{ wheelsData.get(art.key) }} packages
+                      </button>
+                      <button
+                        @click="downloadPackagesAsJson(art.key)"
+                        class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                        title="Download packages as JSON"
+                      >
+                        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+                      </button>
+                    </div>
+                    <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(art.created_at) }}</td>
+                  <td class="px-4 py-3 text-center" @click.stop>
+                    <button
+                      @click="toggleRow(art.key, $event)"
+                      class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                      :aria-label="expandedRows.has(art.key) ? 'Collapse row' : 'Expand row'"
+                    >
+                      <svg
+                        class="w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform"
+                        :class="{ 'rotate-90': expandedRows.has(art.key) }"
+                        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                      ><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    </button>
+                  </td>
+                </tr>
+
+                <!-- Expanded detail row -->
+                <tr v-if="expandedRows.has(art.key)" class="bg-gray-50/50 dark:bg-gray-900/30">
+                  <td :colspan="totalColumns" class="px-6 py-4">
+                    <div class="relative">
+                      <!-- Copy JSON button -->
+                      <button
+                        @click="copyArtifactJson(art, $event)"
+                        class="absolute top-0 right-0 p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                        title="Copy raw JSON"
+                      >
+                        <svg v-if="copiedJson === art.key" class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                        <svg v-else class="w-4 h-4 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                      </button>
+
+                      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm">
+                        <!-- Left column: Platform / Runtime -->
+                        <div class="space-y-2">
+                          <h4 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Platform / Runtime Information</h4>
+                          <div class="text-gray-700 dark:text-gray-300"><span class="font-medium text-gray-900 dark:text-gray-100">Variant:</span> {{ art.variant || 'unknown' }}</div>
+                          <div class="text-gray-700 dark:text-gray-300"><span class="font-medium text-gray-900 dark:text-gray-100">Accelerator:</span> {{ getAcceleratorInfo(art).accel }}</div>
+                          <div class="text-gray-700 dark:text-gray-300"><span class="font-medium text-gray-900 dark:text-gray-100">{{ getAcceleratorInfo(art).accel.toUpperCase() }} Runtime:</span> {{ getAcceleratorInfo(art).runtime }}</div>
+                          <div class="text-gray-700 dark:text-gray-300"><span class="font-medium text-gray-900 dark:text-gray-100">Python:</span> {{ getAcceleratorInfo(art).python }}</div>
+                          <div v-if="getAcceleratorInfo(art).baseImage" class="text-gray-700 dark:text-gray-300">
+                            <span class="font-medium text-gray-900 dark:text-gray-100">Base Image:</span>
+                            <span class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer ml-1" @click.stop="navigateToArtifact(getAcceleratorInfo(art).baseImage)">{{ getAcceleratorInfo(art).baseImage }}</span>
+                            <button @click="copyKey(getAcceleratorInfo(art).baseImage, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">
+                              <svg v-if="copiedKey === getAcceleratorInfo(art).baseImage" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                              <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                            </button>
+                          </div>
+                          <div v-if="art.alternative_names?.length" class="mt-3">
+                            <span class="font-medium text-gray-900 dark:text-gray-100">Alternative Names:</span>
+                            <div v-for="name in art.alternative_names" :key="name" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
+                              - <span class="font-mono text-xs">{{ name }}</span>
+                              <button @click="copyKey(name, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">
+                                <svg v-if="copiedKey === name" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                                <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                              </button>
+                            </div>
+                          </div>
+                          <div v-if="art.drop_keys?.length" class="mt-3">
+                            <span class="font-medium text-gray-900 dark:text-gray-100">Linked Drops:</span>
+                            <div v-for="dk in art.drop_keys" :key="dk" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
+                              - <span class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer font-mono text-xs" @click.stop="navigateToDrop(dk)">{{ dk }}</span>
+                            </div>
+                          </div>
+                        </div>
+
+                        <!-- Right column: Build / Technical -->
+                        <div class="space-y-2">
+                          <h4 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Build / Technical Information</h4>
+                          <div class="text-gray-700 dark:text-gray-300"><span class="font-medium text-gray-900 dark:text-gray-100">Created:</span> {{ formatDate(art.created_at) }}</div>
+                          <div v-if="art.source_branch" class="text-gray-700 dark:text-gray-300"><span class="font-medium text-gray-900 dark:text-gray-100">Source branch:</span> {{ art.source_branch }}</div>
+                          <div class="text-gray-700 dark:text-gray-300">
+                            <span class="font-medium text-gray-900 dark:text-gray-100">Commit:</span>
+                            <template v-if="art.commit">
+                              <a v-if="getCommitUrl(art)" :href="getCommitUrl(art)" target="_blank" rel="noopener noreferrer" class="font-mono text-primary-600 dark:text-blue-400 hover:underline ml-1" @click.stop>{{ art.commit }}</a>
+                              <span v-else class="font-mono ml-1">{{ art.commit }}</span>
+                              <button @click="copyKey(art.commit, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">
+                                <svg v-if="copiedKey === art.commit" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                                <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                              </button>
+                            </template>
+                            <span v-else class="ml-1">unknown</span>
+                          </div>
+                          <div class="text-gray-700 dark:text-gray-300">
+                            <span class="font-medium text-gray-900 dark:text-gray-100">Digest:</span>
+                            <template v-if="art.sha_digest">
+                              <a v-if="getDigestUrl(art)" :href="getDigestUrl(art)" target="_blank" rel="noopener noreferrer" class="font-mono text-primary-600 dark:text-blue-400 hover:underline ml-1 break-all" @click.stop>{{ art.sha_digest }}</a>
+                              <span v-else class="font-mono ml-1 break-all">{{ art.sha_digest }}</span>
+                              <button @click="copyKey(art.sha_digest, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">
+                                <svg v-if="copiedKey === art.sha_digest" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                                <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                              </button>
+                            </template>
+                            <span v-else class="ml-1">no digest available</span>
+                          </div>
+
+                          <!-- SBOM Links -->
+                          <template v-if="(art.type === 'containers' || art.type === 'base-images') && art.sbom_links">
+                            <div v-if="art.sbom_links.length > 0 && !(art.sbom_links.length === 1 && !art.sbom_links[0].name && !art.sbom_links[0].atlas_url)" class="mt-3">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Atlas SBOMs:</span>
+                              <div v-for="(sbom, i) in art.sbom_links" :key="i" class="ml-3 mt-0.5">
+                                - <a :href="sbom.atlas_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline" @click.stop>{{ sbom.name || sbom.atlas_url }}</a>
+                              </div>
+                            </div>
+                            <div v-else-if="art.sbom_links.length === 1 && !art.sbom_links[0].name && !art.sbom_links[0].atlas_url" class="mt-3">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Atlas SBOMs:</span>
+                              <span class="text-red-600 dark:text-red-400 text-xs ml-1">Incompatible (Legacy SBOM - cannot be resolved)</span>
+                            </div>
+                            <div v-else-if="art.sbom_links.length === 0" class="mt-3">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Atlas SBOMs:</span>
+                              <span class="text-gray-400 dark:text-gray-500 text-xs ml-1">No SBOM links available</span>
+                            </div>
+                          </template>
+
+                          <!-- Konflux Data -->
+                          <template v-if="art.konflux_data">
+                            <div v-if="art.konflux_data.component_name" class="mt-3 text-gray-700 dark:text-gray-300">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Konflux Component:</span> {{ art.konflux_data.component_name }}
+                            </div>
+                            <div v-if="art.konflux_data.pipelinerun_name" class="text-gray-700 dark:text-gray-300">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Konflux Pipeline Run:</span>
+                              <a v-if="art.konflux_data.pipelinerun_url" :href="art.konflux_data.pipelinerun_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline ml-1" @click.stop>{{ art.konflux_data.pipelinerun_name }}</a>
+                              <span v-else class="ml-1">{{ art.konflux_data.pipelinerun_name }}</span>
+                            </div>
+                            <div v-if="art.konflux_data.snapshot_name" class="text-gray-700 dark:text-gray-300">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Konflux Snapshot:</span>
+                              <a v-if="art.konflux_data.snapshot_url" :href="art.konflux_data.snapshot_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline ml-1" @click.stop>{{ art.konflux_data.snapshot_name }}</a>
+                              <span v-else class="ml-1">{{ art.konflux_data.snapshot_name }}</span>
+                            </div>
+                            <div v-if="art.konflux_data.releases?.length" class="mt-2">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Konflux Releases:</span>
+                              <div v-for="(rel, ri) in art.konflux_data.releases" :key="ri" class="ml-3 mt-0.5 flex items-center gap-1.5 flex-wrap">
+                                <span>-</span>
+                                <a v-if="rel.url" :href="rel.url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline" @click.stop>{{ rel.name }}</a>
+                                <span v-else>{{ rel.name }}</span>
+                                <span v-if="rel.release_plan" class="text-gray-400 dark:text-gray-500 text-xs">({{ rel.release_plan }})</span>
+                                <span v-if="rel.state" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium" :class="konfluxStateBadgeClass(rel.state)">{{ rel.state }}</span>
+                              </div>
+                            </div>
+                            <div v-if="art.konflux_data.tests?.length" class="mt-2">
+                              <span class="font-medium text-gray-900 dark:text-gray-100">Integration Tests:</span>
+                              <div v-for="(test, ti) in art.konflux_data.tests" :key="ti" class="ml-3 mt-0.5 flex items-center gap-1.5 flex-wrap">
+                                <span>-</span>
+                                <a v-if="test.pipelinerun_url" :href="test.pipelinerun_url" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline" @click.stop>{{ test.scenario }}</a>
+                                <span v-else>{{ test.scenario }}</span>
+                                <span v-if="test.status" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium" :class="testStatusBadgeClass(test.status)">{{ testStatusLabel(test.status) }}</span>
+                                <span v-if="test.completion_time && test.start_time" class="text-gray-400 dark:text-gray-500 text-xs">({{ formatDuration(test.start_time, test.completion_time) }})</span>
+                              </div>
+                            </div>
+                          </template>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+          <div v-if="acceleratorWarning" class="px-4 py-3 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <svg class="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" /></svg>
+            <span>This drop includes artifacts built for <span class="font-medium">{{ acceleratorWarning }}</span> accelerators. This can happen when multiple accelerator builds share the same commit.</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Changelog tab -->
+      <div v-if="activeTab === 'changelog'">
+        <div v-if="!changelog || !changelog.changelogs || Object.keys(changelog.changelogs).length === 0" class="text-sm text-gray-500 dark:text-gray-400">
+          No changelog available — this may be the first drop or data is still being computed.
+        </div>
+        <div v-else class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div v-for="(commits, repo) in changelog.changelogs" :key="repo" class="mb-4 last:mb-0">
+            <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">{{ repo }}</h4>
+            <ul class="space-y-1">
+              <li v-for="(commit, i) in commits" :key="i" class="text-sm text-gray-600 dark:text-gray-300">
+                <span class="font-mono text-xs text-gray-400 dark:text-gray-500 mr-2">{{ (commit.sha || '').slice(0, 7) }}</span>
+                {{ commit.message || commit }}
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- Metrics tab -->
+      <div v-if="activeTab === 'metrics'">
+        <div v-if="!metrics" class="text-sm text-gray-500 dark:text-gray-400">No metrics available.</div>
+        <pre v-else class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-sm text-gray-700 dark:text-gray-300 overflow-x-auto">{{ JSON.stringify(metrics, null, 2) }}</pre>
+      </div>
+    </template>
+
+    <!-- Packages popup -->
+    <teleport to="body">
+      <div v-if="packagesPopup" class="fixed inset-0 z-50 flex items-center justify-center" @click="packagesPopup = null">
+        <div class="absolute inset-0 bg-black/40"></div>
+        <div class="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 w-full max-w-2xl max-h-[80vh] flex flex-col" @click.stop>
+          <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Package Dependencies</h3>
+            <button @click="packagesPopup = null" class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+              <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+          </div>
+          <div class="overflow-y-auto px-5 py-4 space-y-5">
+            <div v-for="w in packagesPopup.wheels" :key="w.key">
+              <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-2">{{ w.key }}</div>
+              <div v-if="w.all.length === 0" class="text-xs text-gray-400 dark:text-gray-500">No packages</div>
+              <template v-else>
+                <div class="flex flex-wrap gap-1">
+                  <span
+                    v-for="pkg in (packagesShowAll.has(w.key) ? w.all : w.main)"
+                    :key="pkg"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                  >{{ pkg }}</span>
+                </div>
+                <div v-if="w.all.length > w.main.length" class="flex items-center gap-1.5 mt-2">
+                  <button
+                    @click="toggleShowAll(w.key)"
+                    class="text-xs text-primary-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
+                  >
+                    {{ packagesShowAll.has(w.key) ? 'Show less' : `Show all (${w.all.length} packages)` }}
+                    <svg class="w-3 h-3 transition-transform" :class="{ 'rotate-180': packagesShowAll.has(w.key) }" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+                  </button>
+                  <svg class="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 cursor-help" fill="currentColor" viewBox="0 0 20 20" title="Packages shown by default are the key dependencies required for the wheel collection to function properly."><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" /></svg>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </div>
+    </teleport>
+  </div>
+</template>

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -3,6 +3,7 @@ import { onMounted, inject, ref, computed, reactive, watch } from 'vue'
 import { useDropDetail } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { apiRequest } from '@shared/client/services/api'
+import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration } from '../utils/formatting'
 
 const BASE = '/modules/product-builds'
 const nav = inject('moduleNav')
@@ -12,15 +13,11 @@ const { artifacts, loading: artifactsLoading, error: artifactsError, loadArtifac
 const activeTab = ref('artifacts')
 const currentDropKey = computed(() => nav.params.value.key)
 const wheelsData = reactive(new Map())
-const wheelsRaw = new Map()
+const wheelsRaw = reactive(new Map())
 const packagesPopup = ref(null)
 const packagesShowAll = reactive(new Set())
 
-const productKey = computed(() => {
-  const hash = window.location.hash || ''
-  const parts = hash.replace('#/', '').split('?')[0].split('/')
-  return parts[1] || ''
-})
+const productKey = computed(() => nav.params.value.product || '')
 
 function extractAccelerator(variant) {
   if (!variant) return null
@@ -102,35 +99,11 @@ watch(currentDropKey, (key) => loadAll(key))
 onMounted(() => loadAll(currentDropKey.value))
 
 function navigateToArtifact(artifactKey) {
-  nav.navigateTo('artifact-detail', { key: artifactKey })
+  nav.navigateTo('artifact-detail', { key: artifactKey, product: productKey.value })
 }
 
 function navigateToDrop(key) {
-  nav.navigateTo('drop-detail', { key })
-}
-
-function formatDate(iso) {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
-  })
-}
-
-function envBadgeClass(env) {
-  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-const ARCH_COLORS = {
-  x86_64: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-  aarch64: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-  ppc64le: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-  s390x: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
-}
-
-function archBadgeClass(arch) {
-  return ARCH_COLORS[arch?.toLowerCase()] || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+  nav.navigateTo('drop-detail', { key, product: productKey.value })
 }
 
 function getQuayDirectTagUrl(key) {
@@ -257,42 +230,6 @@ function getDigestUrl(artifact) {
   if (!artifact.key.startsWith('quay.io/')) return null
   const path = artifact.key.replace('quay.io/', '').split(':')[0]
   return `https://quay.io/repository/${path}/manifest/${artifact.sha_digest}`
-}
-
-function konfluxStateBadgeClass(state) {
-  const s = (state || '').toLowerCase()
-  if (s === 'succeeded') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (s === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-  if (s === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-  if (s === 'pending') return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-const TEST_STATUS_MAP = {
-  testpassed: { label: 'Passed', cls: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
-  testfail: { label: 'Failed', cls: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
-  inprogress: { label: 'Running', cls: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
-  pending: { label: 'Pending', cls: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
-}
-
-function testStatusLabel(status) {
-  return TEST_STATUS_MAP[status?.toLowerCase()]?.label || status
-}
-
-function testStatusBadgeClass(status) {
-  return TEST_STATUS_MAP[status?.toLowerCase()]?.cls || 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-function formatDuration(start, end) {
-  const diffMs = new Date(end) - new Date(start)
-  if (diffMs < 0) return null
-  const totalSeconds = Math.floor(diffMs / 1000)
-  const hours = Math.floor(totalSeconds / 3600)
-  const minutes = Math.floor((totalSeconds % 3600) / 60)
-  const seconds = totalSeconds % 60
-  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`
-  if (minutes > 0) return `${minutes}m ${seconds}s`
-  return `${seconds}s`
 }
 
 const totalColumns = 7

--- a/modules/product-builds/client/views/PlaceholderProductView.vue
+++ b/modules/product-builds/client/views/PlaceholderProductView.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const PRODUCT_LABELS = {
+  'rhel-ai': 'RHEL AI',
+  'base-images': 'Base Images',
+  'builder-images': 'Builder Images',
+  'wheel-collections': 'Wheel Collections',
+}
+
+function getKey() {
+  const hash = window.location.hash || ''
+  const parts = hash.replace('#/', '').split('?')[0].split('/')
+  return parts[1] || ''
+}
+
+const productKey = ref(getKey())
+const productLabel = ref(PRODUCT_LABELS[productKey.value] || productKey.value)
+
+function onHashChange() {
+  productKey.value = getKey()
+  productLabel.value = PRODUCT_LABELS[productKey.value] || productKey.value
+}
+
+onMounted(() => window.addEventListener('hashchange', onHashChange))
+onUnmounted(() => window.removeEventListener('hashchange', onHashChange))
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">{{ productLabel }}</h1>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 text-center">
+      <p class="text-sm text-gray-500 dark:text-gray-400">This product view is not yet implemented.</p>
+    </div>
+  </div>
+</template>

--- a/modules/product-builds/client/views/RhaiisProductView.vue
+++ b/modules/product-builds/client/views/RhaiisProductView.vue
@@ -1,0 +1,294 @@
+<script setup>
+import { ref, onMounted, inject, computed, watch } from 'vue'
+import { useProduct, useDrops, useSeries } from '../composables/useDrops'
+import { useArtifacts } from '../composables/useArtifacts'
+
+const nav = inject('moduleNav')
+const { product, loading: productLoading, error: productError, loadProduct } = useProduct()
+const { drops, loading: dropsLoading, error: dropsError, loadDrops } = useDrops()
+const { series, loadSeries } = useSeries()
+const { artifacts, loading: artifactsLoading, error: artifactsError, loadArtifacts } = useArtifacts()
+
+const activeTab = ref('series')
+const selectedSeries = ref('')
+
+const PRODUCT_CONFIG = {
+  rhaiis: { artifactTypeFilter: 'containers' }
+}
+
+const IMPLEMENTED_PRODUCTS = new Set(['rhaiis'])
+
+const productKey = computed(() => {
+  const hash = window.location.hash || ''
+  const parts = hash.replace('#/', '').split('?')[0].split('/')
+  return parts[1] || ''
+})
+
+const artifactTypeFilter = computed(() => {
+  return PRODUCT_CONFIG[productKey.value]?.artifactTypeFilter || ''
+})
+
+const isImplemented = computed(() => IMPLEMENTED_PRODUCTS.has(productKey.value))
+
+async function load() {
+  const key = productKey.value
+  if (!key || !isImplemented.value) return
+  const filters = { limit: 1000 }
+  if (artifactTypeFilter.value) filters.artifact_type = artifactTypeFilter.value
+  await Promise.all([
+    loadProduct(key),
+    loadDrops(key, filters),
+    loadSeries(key)
+  ])
+}
+
+watch(selectedSeries, (val) => {
+  const key = productKey.value
+  if (!key) return
+  const filters = { series: val || undefined, limit: 1000 }
+  if (artifactTypeFilter.value) filters.artifact_type = artifactTypeFilter.value
+  loadDrops(key, filters)
+})
+
+onMounted(load)
+
+function loadArtifactsTab() {
+  const key = productKey.value
+  if (!key) return
+  const filters = { product_key: key }
+  if (artifactTypeFilter.value) filters.type = artifactTypeFilter.value
+  loadArtifacts(filters)
+}
+
+watch(activeTab, (tab) => {
+  if (tab === 'artifacts' && artifacts.value.length === 0) {
+    loadArtifactsTab()
+  }
+})
+
+function navigateToDrop(dropKey) {
+  nav.navigateTo('drop-detail', { key: dropKey })
+}
+
+function navigateToArtifact(artifactKey) {
+  nav.navigateTo('artifact-detail', { key: artifactKey })
+}
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  })
+}
+
+function envBadgeClass(env) {
+  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+const groupedDrops = computed(() => {
+  const seriesOrder = Object.fromEntries(series.value.map((s, i) => [s, i]))
+  const map = new Map()
+  for (const drop of drops.value) {
+    const s = drop.product_version || 'Unknown'
+    if (!map.has(s)) map.set(s, [])
+    map.get(s).push(drop)
+  }
+  for (const [, list] of map) {
+    list.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+  }
+  const groups = Array.from(map, ([s, drops]) => ({ series: s, drops }))
+  groups.sort((a, b) => {
+    const ai = seriesOrder[a.series] ?? Infinity
+    const bi = seriesOrder[b.series] ?? Infinity
+    return ai - bi
+  })
+  return groups
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Header -->
+    <div>
+      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+        {{ product?.product_name || product?.short_name || productKey }}
+      </h1>
+      <p v-if="product" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        Overview of {{ product.short_name || productKey }} product series and their available drops
+      </p>
+    </div>
+
+    <!-- Loading / Error -->
+    <div v-if="productLoading && !product" class="text-sm text-gray-500 dark:text-gray-400">Loading product…</div>
+    <div v-if="productError" class="text-sm text-red-600 dark:text-red-400">{{ productError }}</div>
+
+    <template v-if="product">
+      <!-- Tabs -->
+      <div class="border-b border-gray-200 dark:border-gray-700">
+        <nav class="flex gap-4">
+          <button
+            v-for="tab in ['series', 'artifacts']"
+            :key="tab"
+            @click="activeTab = tab"
+            class="py-2 text-sm font-medium border-b-2 transition-colors"
+            :class="activeTab === tab
+              ? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+          >{{ tab.charAt(0).toUpperCase() + tab.slice(1) }}</button>
+        </nav>
+      </div>
+
+      <!-- Series tab -->
+      <div v-if="activeTab === 'series'" class="space-y-4">
+        <!-- Series filter -->
+        <div class="flex items-center justify-end">
+          <select
+            v-if="series.length > 0"
+            v-model="selectedSeries"
+            class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+          >
+            <option value="">All series</option>
+            <option v-for="s in series" :key="s" :value="s">{{ s }}</option>
+          </select>
+        </div>
+
+        <div v-if="dropsLoading" class="text-sm text-gray-500 dark:text-gray-400">Loading drops…</div>
+        <div v-else-if="dropsError" class="text-sm text-red-600 dark:text-red-400">{{ dropsError }}</div>
+        <div v-else-if="drops.length === 0" class="text-sm text-gray-500 dark:text-gray-400">No drops found.</div>
+
+        <!-- All series: grouped tables with series name as header -->
+        <template v-if="!selectedSeries">
+          <div v-for="group in groupedDrops" :key="group.series" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <div class="px-4 py-3 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+              <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ group.series }}</h3>
+            </div>
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead class="bg-gray-50 dark:bg-gray-900/30">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[35%]">Drop</th>
+                  <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[10%]">Branch</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[25%]">Environment</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[30%]">Date</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                <tr
+                  v-for="drop in group.drops"
+                  :key="drop.key"
+                  @click="navigateToDrop(drop.key)"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+                >
+                  <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400">{{ drop.name }}</td>
+                  <td class="px-4 py-3 text-center">
+                    <span
+                      v-if="drop.git_branch"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold text-purple-700 bg-purple-50 border border-purple-200 dark:text-purple-300 dark:bg-purple-900/20 dark:border-purple-700"
+                      :title="'Tag was cut from the \'' + drop.git_branch + '\' branch'"
+                    >{{ drop.git_branch }}</span>
+                  </td>
+                  <td class="px-4 py-3">
+                    <div class="flex gap-1">
+                      <span
+                        v-for="env in (drop.environments || [])"
+                        :key="env"
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                        :class="envBadgeClass(env)"
+                      >{{ env }}</span>
+                    </div>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(drop.created_at) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </template>
+
+        <!-- Single series selected: flat table, no series column -->
+        <div v-else class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[35%]">Drop</th>
+                <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[10%]">Branch</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[25%]">Environment</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[30%]">Date</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="drop in drops"
+                :key="drop.key"
+                @click="navigateToDrop(drop.key)"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+              >
+                <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400">{{ drop.name }}</td>
+                <td class="px-4 py-3 text-center">
+                  <span
+                    v-if="drop.git_branch"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold text-purple-700 bg-purple-50 border border-purple-200 dark:text-purple-300 dark:bg-purple-900/20 dark:border-purple-700"
+                    :title="'Tag was cut from the \'' + drop.git_branch + '\' branch'"
+                  >{{ drop.git_branch }}</span>
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex gap-1">
+                    <span
+                      v-for="env in (drop.environments || [])"
+                      :key="env"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                      :class="envBadgeClass(env)"
+                    >{{ env }}</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(drop.created_at) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Artifacts tab -->
+      <div v-if="activeTab === 'artifacts'">
+        <div v-if="artifactsLoading" class="text-sm text-gray-500 dark:text-gray-400">Loading artifacts…</div>
+        <div v-else-if="artifactsError" class="text-sm text-red-600 dark:text-red-400">{{ artifactsError }}</div>
+        <div v-else-if="artifacts.length === 0" class="text-sm text-gray-500 dark:text-gray-400">No artifacts found.</div>
+        <div v-else class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Key</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Variant</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Architectures</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Environments</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="art in artifacts"
+                :key="art.key"
+                @click="navigateToArtifact(art.key)"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+              >
+                <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 max-w-xs truncate">{{ art.key }}</td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ art.variant || '—' }}</td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ (art.archs || []).join(', ') || '—' }}</td>
+                <td class="px-4 py-3">
+                  <div class="flex gap-1">
+                    <span
+                      v-for="env in (art.environments || [])"
+                      :key="env"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                      :class="envBadgeClass(env)"
+                    >{{ env }}</span>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/product-builds/client/views/RhaiisProductView.vue
+++ b/modules/product-builds/client/views/RhaiisProductView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, inject, computed, watch } from 'vue'
 import { useProduct, useDrops, useSeries } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
+import { formatDate, envBadgeClass } from '../utils/formatting'
 
 const nav = inject('moduleNav')
 const { product, loading: productLoading, error: productError, loadProduct } = useProduct()
@@ -12,52 +13,27 @@ const { artifacts, loading: artifactsLoading, error: artifactsError, loadArtifac
 const activeTab = ref('series')
 const selectedSeries = ref('')
 
-const PRODUCT_CONFIG = {
-  rhaiis: { artifactTypeFilter: 'containers' }
-}
-
-const IMPLEMENTED_PRODUCTS = new Set(['rhaiis'])
-
-const productKey = computed(() => {
-  const hash = window.location.hash || ''
-  const parts = hash.replace('#/', '').split('?')[0].split('/')
-  return parts[1] || ''
-})
-
-const artifactTypeFilter = computed(() => {
-  return PRODUCT_CONFIG[productKey.value]?.artifactTypeFilter || ''
-})
-
-const isImplemented = computed(() => IMPLEMENTED_PRODUCTS.has(productKey.value))
+const productKey = 'rhaiis'
+const artifactTypeFilter = 'containers'
 
 async function load() {
-  const key = productKey.value
-  if (!key || !isImplemented.value) return
-  const filters = { limit: 1000 }
-  if (artifactTypeFilter.value) filters.artifact_type = artifactTypeFilter.value
+  const filters = { limit: 1000, artifact_type: artifactTypeFilter }
   await Promise.all([
-    loadProduct(key),
-    loadDrops(key, filters),
-    loadSeries(key)
+    loadProduct(productKey),
+    loadDrops(productKey, filters),
+    loadSeries(productKey)
   ])
 }
 
 watch(selectedSeries, (val) => {
-  const key = productKey.value
-  if (!key) return
-  const filters = { series: val || undefined, limit: 1000 }
-  if (artifactTypeFilter.value) filters.artifact_type = artifactTypeFilter.value
-  loadDrops(key, filters)
+  const filters = { series: val || undefined, limit: 1000, artifact_type: artifactTypeFilter }
+  loadDrops(productKey, filters)
 })
 
 onMounted(load)
 
 function loadArtifactsTab() {
-  const key = productKey.value
-  if (!key) return
-  const filters = { product_key: key }
-  if (artifactTypeFilter.value) filters.type = artifactTypeFilter.value
-  loadArtifacts(filters)
+  loadArtifacts({ product_key: productKey, type: artifactTypeFilter })
 }
 
 watch(activeTab, (tab) => {
@@ -67,25 +43,11 @@ watch(activeTab, (tab) => {
 })
 
 function navigateToDrop(dropKey) {
-  nav.navigateTo('drop-detail', { key: dropKey })
+  nav.navigateTo('drop-detail', { key: dropKey, product: productKey })
 }
 
 function navigateToArtifact(artifactKey) {
-  nav.navigateTo('artifact-detail', { key: artifactKey })
-}
-
-function formatDate(iso) {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleString('en-US', {
-    year: 'numeric', month: 'short', day: 'numeric',
-    hour: '2-digit', minute: '2-digit'
-  })
-}
-
-function envBadgeClass(env) {
-  if (env === 'production') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (env === 'stage') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+  nav.navigateTo('artifact-detail', { key: artifactKey, product: productKey })
 }
 
 const groupedDrops = computed(() => {

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -1,0 +1,23 @@
+{
+  "name": "Product Builds",
+  "slug": "product-builds",
+  "description": "Product drops, artifacts, and release statistics from CI/CD dashboard",
+  "icon": "Factory",
+  "order": 20,
+  "defaultEnabled": true,
+  "requires": [],
+  "client": {
+    "entry": "./client/index.js",
+    "navItems": [
+      { "id": "rhaiis", "label": "RHAIIS", "icon": "PackageOpen", "default": true },
+      { "id": "rhel-ai", "label": "RHEL AI", "icon": "PackageOpen" },
+      { "id": "base-images", "label": "Base Images", "icon": "PackageOpen" },
+      { "id": "builder-images", "label": "Builder Images", "icon": "PackageOpen" },
+      { "id": "wheel-collections", "label": "Wheel Collections", "icon": "PackageOpen" }
+    ],
+    "settingsComponent": "./client/components/ProductBuildsSettings.vue"
+  },
+  "server": {
+    "entry": "./server/index.js"
+  }
+}

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -73,6 +73,39 @@ module.exports = function registerRoutes(router, context) {
     res.json({ status: 'ok', baseUrl: trimmed });
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/health:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Check AIPCC Dashboard API connectivity
+   *     responses:
+   *       200:
+   *         description: Health status with latency
+   */
+  router.get('/health', async function(req, res) {
+    const { baseUrl } = getConfig(readFromStorage);
+    if (!baseUrl) {
+      return res.json({ status: 'not_configured' });
+    }
+    const start = Date.now();
+    try {
+      const upstream = await fetch(baseUrl, {
+        signal: AbortSignal.timeout(5000),
+        headers: { 'Accept': 'application/json' }
+      });
+      res.json({
+        status: upstream.ok ? 'ok' : 'degraded',
+        latency: Date.now() - start
+      });
+    } catch {
+      res.json({
+        status: 'unavailable',
+        latency: Date.now() - start
+      });
+    }
+  });
+
   // --- Helper to get baseUrl for proxy ---
 
   function upstream(upstreamPath, req, res) {

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -1,0 +1,98 @@
+const { proxyGet } = require('./proxy');
+
+const CONFIG_PATH = 'product-builds/config.json';
+
+const DEFAULT_CONFIG = {
+  baseUrl: ''
+};
+
+function getConfig(readFromStorage) {
+  const saved = readFromStorage(CONFIG_PATH);
+  if (saved && typeof saved === 'object' && !saved._deleted && saved.baseUrl) {
+    return { ...DEFAULT_CONFIG, ...saved };
+  }
+  const envUrl = process.env.PRODUCT_BUILDS_API_URL;
+  if (envUrl) {
+    return { ...DEFAULT_CONFIG, baseUrl: envUrl };
+  }
+  return { ...DEFAULT_CONFIG };
+}
+
+module.exports = function registerRoutes(router, context) {
+  const { storage, requireAdmin } = context;
+  const { readFromStorage, writeToStorage } = storage;
+
+  // --- Config routes (admin) ---
+
+  router.get('/config', requireAdmin, function(req, res) {
+    res.json(getConfig(readFromStorage));
+  });
+
+  router.post('/config', requireAdmin, function(req, res) {
+    const { baseUrl } = req.body;
+    if (typeof baseUrl !== 'string') {
+      return res.status(400).json({ error: 'baseUrl must be a string' });
+    }
+    const trimmed = baseUrl.trim();
+    if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+      return res.status(400).json({ error: 'baseUrl must be an HTTP or HTTPS URL' });
+    }
+    writeToStorage(CONFIG_PATH, { baseUrl: trimmed });
+    res.json({ status: 'ok', baseUrl: trimmed });
+  });
+
+  // --- Helper to get baseUrl for proxy ---
+
+  function upstream(upstreamPath, req, res) {
+    const { baseUrl } = getConfig(readFromStorage);
+    return proxyGet(baseUrl, upstreamPath, req.query, res);
+  }
+
+  // --- Proxy routes ---
+
+  // Products
+  router.get('/products/:key', function(req, res) {
+    upstream(`/products/${encodeURIComponent(req.params.key)}`, req, res);
+  });
+
+  // Drops
+  router.get('/drops', function(req, res) {
+    upstream('/drops', req, res);
+  });
+
+  router.get('/drops/:key', function(req, res) {
+    upstream(`/drops/${encodeURIComponent(req.params.key)}`, req, res);
+  });
+
+  router.get('/drops/:key/changelog', function(req, res) {
+    upstream(`/drops/${encodeURIComponent(req.params.key)}/changelog`, req, res);
+  });
+
+  router.get('/drops/:key/metrics', function(req, res) {
+    upstream(`/drops/${encodeURIComponent(req.params.key)}/metrics`, req, res);
+  });
+
+  // Series
+  router.get('/series', function(req, res) {
+    upstream('/series', req, res);
+  });
+
+  // Artifacts
+  router.get('/artifacts', function(req, res) {
+    upstream('/artifacts', req, res);
+  });
+
+  router.get('/artifacts/:key', function(req, res) {
+    upstream(`/artifacts/${encodeURIComponent(req.params.key)}`, req, res);
+  });
+
+  router.get('/artifacts/:key/wheels', function(req, res) {
+    upstream(`/artifacts/${encodeURIComponent(req.params.key)}/wheels`, req, res);
+  });
+
+  router.get('/artifacts/:key/containers', function(req, res) {
+    upstream(`/artifacts/${encodeURIComponent(req.params.key)}/containers`, req, res);
+  });
+};
+
+module.exports.getConfig = getConfig;

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -24,10 +24,42 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Config routes (admin) ---
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/config:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get product builds configuration (admin)
+   *     responses:
+   *       200:
+   *         description: Current configuration including AIPCC Dashboard API base URL
+   */
   router.get('/config', requireAdmin, function(req, res) {
     res.json(getConfig(readFromStorage));
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/config:
+   *   post:
+   *     tags: [Product Builds]
+   *     summary: Save product builds configuration (admin)
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               baseUrl:
+   *                 type: string
+   *                 description: Base URL of the AIPCC Dashboard API server
+   *     responses:
+   *       200:
+   *         description: Configuration saved
+   *       400:
+   *         description: Invalid baseUrl (must be HTTP/HTTPS or empty string)
+   */
   router.post('/config', requireAdmin, function(req, res) {
     const { baseUrl } = req.body;
     if (typeof baseUrl !== 'string') {
@@ -48,48 +80,294 @@ module.exports = function registerRoutes(router, context) {
     return proxyGet(baseUrl, upstreamPath, req.query, res);
   }
 
-  // --- Proxy routes ---
+  // --- Proxy routes (AIPCC Dashboard API) ---
 
-  // Products
+  /**
+   * @openapi
+   * /api/modules/product-builds/products/{key}:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get product details
+   *     description: Retrieves a single product by its key, including supported versions, Konflux namespace, and sync status.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Product key (e.g. rhaiis, rhel-ai)
+   *     responses:
+   *       200:
+   *         description: Product object with key, product_name, short_name, supported_versions, drop_strategy, sync status
+   *       404:
+   *         description: Product not found
+   *       503:
+   *         description: AIPCC Dashboard API not configured
+   */
   router.get('/products/:key', function(req, res) {
     upstream(`/products/${encodeURIComponent(req.params.key)}`, req, res);
   });
 
-  // Drops
+  /**
+   * @openapi
+   * /api/modules/product-builds/drops:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: List drops with filtering and pagination
+   *     description: Retrieves drops with filtering by series, version pattern, artifact type, publication status, and date range. Pagination via X-Total-Count and X-Total-Pages response headers.
+   *     parameters:
+   *       - name: product_key
+   *         in: query
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Product key to filter drops
+   *       - name: series
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by product version series
+   *       - name: artifact_type
+   *         in: query
+   *         schema:
+   *           type: string
+   *           enum: [base-images, containers, disk-images, wheels-collections]
+   *         description: Filter to drops containing this artifact type
+   *       - name: supported_only
+   *         in: query
+   *         schema:
+   *           type: boolean
+   *         description: Only return drops for supported product versions
+   *       - name: limit
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 1000
+   *           default: 50
+   *       - name: offset
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           minimum: 0
+   *           default: 0
+   *     responses:
+   *       200:
+   *         description: Array of Drop objects (key, name, product_key, product_version, git_branch, environments, release_timings, created_at)
+   */
   router.get('/drops', function(req, res) {
     upstream('/drops', req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/drops/{key}:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get drop details
+   *     description: Retrieves a single drop by its key, including release timings, environments, and git branch.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique drop key
+   *     responses:
+   *       200:
+   *         description: Drop object
+   *       404:
+   *         description: Drop not found
+   */
   router.get('/drops/:key', function(req, res) {
     upstream(`/drops/${encodeURIComponent(req.params.key)}`, req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/drops/{key}/changelog:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get drop changelog
+   *     description: Returns commits between this drop and the previous drop, aggregated across all repositories.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique drop key
+   *     responses:
+   *       200:
+   *         description: Object with drop_key and changelogs (commits grouped by repository)
+   *       404:
+   *         description: Drop not found
+   */
   router.get('/drops/:key/changelog', function(req, res) {
     upstream(`/drops/${encodeURIComponent(req.params.key)}/changelog`, req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/drops/{key}/metrics:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get drop metrics
+   *     description: Computes Konflux release statistics for a drop, aggregating build and release metrics including timeline, counts, and per-component release status.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique drop key
+   *     responses:
+   *       200:
+   *         description: Aggregated build and release metrics for the drop
+   *       404:
+   *         description: Drop not found
+   */
   router.get('/drops/:key/metrics', function(req, res) {
     upstream(`/drops/${encodeURIComponent(req.params.key)}/metrics`, req, res);
   });
 
-  // Series
+  /**
+   * @openapi
+   * /api/modules/product-builds/series:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: List product series (versions)
+   *     description: Returns unique series (product_versions) for a product, sorted by semantic version.
+   *     parameters:
+   *       - name: product_key
+   *         in: query
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Product key to get series for
+   *     responses:
+   *       200:
+   *         description: Array of series name strings
+   */
   router.get('/series', function(req, res) {
     upstream('/series', req, res);
   });
 
-  // Artifacts
+  /**
+   * @openapi
+   * /api/modules/product-builds/artifacts:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: List artifacts with filtering and pagination
+   *     description: Retrieves artifacts with optional filtering by product, drop, series, type, accelerator, environment, and architecture. Pagination headers X-Total-Count and X-Total-Pages are forwarded from the AIPCC Dashboard API.
+   *     parameters:
+   *       - name: product_key
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Return artifacts for drops of this product
+   *       - name: drop_key
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Return artifacts for this specific drop
+   *       - name: type
+   *         in: query
+   *         schema:
+   *           type: string
+   *           enum: [base-images, containers, disk-images, wheels-collections]
+   *         description: Filter by artifact type
+   *       - name: limit
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 1000
+   *           default: 50
+   *       - name: offset
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           minimum: 0
+   *           default: 0
+   *     responses:
+   *       200:
+   *         description: Array of Artifact objects (key, type, variant, archs, environments, commit, created_at, sha_digest, labels, konflux_data, constraints_file, build_sequence_summary)
+   */
   router.get('/artifacts', function(req, res) {
     upstream('/artifacts', req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/artifacts/{key}:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get artifact details
+   *     description: Retrieves a single artifact by its unique key, including labels, Konflux build data, SBOM links, constraints file, and build sequence summary.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique artifact key (e.g. quay.io/org/image:tag)
+   *     responses:
+   *       200:
+   *         description: Full Artifact object
+   *       404:
+   *         description: Artifact not found
+   */
   router.get('/artifacts/:key', function(req, res) {
     upstream(`/artifacts/${encodeURIComponent(req.params.key)}`, req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/artifacts/{key}/wheels:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get wheel collections for an artifact
+   *     description: Returns wheels-collections artifacts that are dependencies of the specified container artifact.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Artifact key of the container
+   *     responses:
+   *       200:
+   *         description: Array of wheel-collection Artifact objects
+   *       404:
+   *         description: Artifact not found
+   */
   router.get('/artifacts/:key/wheels', function(req, res) {
     upstream(`/artifacts/${encodeURIComponent(req.params.key)}/wheels`, req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/artifacts/{key}/containers:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get containers using an artifact
+   *     description: Returns container artifacts that depend on the specified wheels-collection or base-image artifact.
+   *     parameters:
+   *       - name: key
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Artifact key of the wheels-collection or base-image
+   *     responses:
+   *       200:
+   *         description: Array of container Artifact objects
+   *       400:
+   *         description: Artifact is not a wheels-collection or base-image
+   *       404:
+   *         description: Artifact not found
+   */
   router.get('/artifacts/:key/containers', function(req, res) {
     upstream(`/artifacts/${encodeURIComponent(req.params.key)}/containers`, req, res);
   });

--- a/modules/product-builds/server/proxy.js
+++ b/modules/product-builds/server/proxy.js
@@ -1,0 +1,41 @@
+const TIMEOUT_MS = 30_000;
+
+function buildUpstreamUrl(baseUrl, path, query) {
+  const url = new URL(path, baseUrl);
+  if (query && typeof query === 'object') {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+  return url.toString();
+}
+
+async function proxyGet(baseUrl, upstreamPath, query, res) {
+  if (!baseUrl) {
+    return res.status(503).json({
+      error: 'Product Builds API not configured. Set the base URL in Settings.'
+    });
+  }
+
+  const url = buildUpstreamUrl(baseUrl, upstreamPath, query);
+
+  try {
+    const upstream = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { 'Accept': 'application/json' }
+    });
+
+    const body = await upstream.json();
+    res.status(upstream.status).json(body);
+  } catch (err) {
+    if (err.name === 'TimeoutError') {
+      return res.status(504).json({ error: 'Upstream request timed out' });
+    }
+    console.error(`[product-builds] Proxy error for ${upstreamPath}:`, err.message);
+    res.status(502).json({ error: 'Failed to reach Product Builds API' });
+  }
+}
+
+module.exports = { proxyGet, buildUpstreamUrl };

--- a/modules/product-builds/server/proxy.js
+++ b/modules/product-builds/server/proxy.js
@@ -28,6 +28,10 @@ async function proxyGet(baseUrl, upstreamPath, query, res) {
     });
 
     const body = await upstream.json();
+    const totalCount = upstream.headers.get('X-Total-Count');
+    const totalPages = upstream.headers.get('X-Total-Pages');
+    if (totalCount) res.set('X-Total-Count', totalCount);
+    if (totalPages) res.set('X-Total-Pages', totalPages);
     res.status(upstream.status).json(body);
   } catch (err) {
     if (err.name === 'TimeoutError') {

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -161,36 +161,8 @@ app.get('/healthz', function(req, res) {
  *                   type: string
  *                   example: ok
  */
-app.get('/api/healthz', async function(req, res) {
-  const result = { status: 'ok', dependencies: {} };
-
-  // Check Product Builds FastAPI connectivity
-  try {
-    const { getConfig } = require('../modules/product-builds/server/index.js');
-    const config = getConfig(readFromStorage);
-    if (config.baseUrl) {
-      const start = Date.now();
-      try {
-        const upstream = await fetch(config.baseUrl, {
-          signal: AbortSignal.timeout(5000),
-          headers: { 'Accept': 'application/json' }
-        });
-        result.dependencies['aipcc-dashboard-api'] = {
-          status: upstream.ok ? 'ok' : 'degraded',
-          latency: Date.now() - start
-        };
-      } catch {
-        result.dependencies['aipcc-dashboard-api'] = {
-          status: 'unavailable',
-          latency: Date.now() - start
-        };
-      }
-    }
-  } catch {
-    // Module not loaded or not configured — skip
-  }
-
-  res.json(result);
+app.get('/api/healthz', function(req, res) {
+  res.json({ status: 'ok' });
 });
 
 /**

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -161,8 +161,36 @@ app.get('/healthz', function(req, res) {
  *                   type: string
  *                   example: ok
  */
-app.get('/api/healthz', function(req, res) {
-  res.json({ status: 'ok' });
+app.get('/api/healthz', async function(req, res) {
+  const result = { status: 'ok', dependencies: {} };
+
+  // Check Product Builds FastAPI connectivity
+  try {
+    const { getConfig } = require('../modules/product-builds/server/index.js');
+    const config = getConfig(readFromStorage);
+    if (config.baseUrl) {
+      const start = Date.now();
+      try {
+        const upstream = await fetch(config.baseUrl, {
+          signal: AbortSignal.timeout(5000),
+          headers: { 'Accept': 'application/json' }
+        });
+        result.dependencies['aipcc-dashboard-api'] = {
+          status: upstream.ok ? 'ok' : 'degraded',
+          latency: Date.now() - start
+        };
+      } catch {
+        result.dependencies['aipcc-dashboard-api'] = {
+          status: 'unavailable',
+          latency: Date.now() - start
+        };
+      }
+    }
+  } catch {
+    // Module not loaded or not configured — skip
+  }
+
+  res.json(result);
 });
 
 /**

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -229,8 +229,11 @@
 import {
   Home,
   BarChart3,
+  Box,
   Briefcase,
   Building2,
+  Factory,
+  PackageOpen,
   ChartColumnStacked,
   FolderOpen,
   FolderTree,
@@ -273,8 +276,11 @@ import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 
 const ICON_MAP = {
   BarChart3,
+  Box,
   Briefcase,
   Building2,
+  Factory,
+  PackageOpen,
   ChartColumnStacked,
   FolderOpen,
   FolderTree,


### PR DESCRIPTION
Introduces a new module that proxies requests to an external API server (AIPCC dashboard) to display products, drops, and artifacts. Includes RHAIIS product view with series/drops tables, drop detail with expandable artifact rows and package popups, and artifact detail with Konflux build info, container labels, package dependencies, and build sequence display for wheel collections.