### PR TITLE
feat(release-analysis): add predictive delivery dates to component cards

### DIFF
--- a/modules/release-analysis/client/components/ComponentDetailRow.vue
+++ b/modules/release-analysis/client/components/ComponentDetailRow.vue
@@ -11,7 +11,7 @@
         : 'hover:bg-gray-50/60 dark:hover:bg-gray-800/20'"
       @click="toggleExpand"
     >
-      <!-- Top row: name + project chips + expand caret -->
+      <!-- Top row: name + project chips + predicted date + expand caret -->
       <div class="flex items-start justify-between gap-2 mb-3">
         <div class="flex items-center gap-2 min-w-0 flex-wrap">
           <span class="font-semibold text-gray-800 dark:text-gray-100 text-base leading-tight truncate">{{ comp.name }}</span>
@@ -21,6 +21,15 @@
             :key="proj"
             class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/40 border border-indigo-200/70 dark:border-indigo-700/50 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-indigo-600 dark:text-indigo-300"
           >{{ proj }}</span>
+          <span
+            v-if="comp.predictedDate"
+            class="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[10px] font-semibold tabular-nums"
+            :class="isPredictedLate ? 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border border-red-200/70 dark:border-red-700/50' : 'bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300 border border-teal-200/70 dark:border-teal-700/50'"
+            :title="'Predicted completion based on velocity and total workload (release + other open work)'"
+          >
+            <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" /></svg>
+            Predicted: {{ formatPredictedDate(comp.predictedDate) }}
+          </span>
         </div>
         <span
           class="transition-transform duration-200 text-[10px] shrink-0 mt-0.5"
@@ -296,6 +305,18 @@ function isStrategicExpanded(key) {
 const total = computed(() =>
   (props.comp.issues_to_do || 0) + (props.comp.issues_doing || 0) + (props.comp.issues_done || 0)
 )
+
+const isPredictedLate = computed(() => {
+  if (!props.comp.predictedDate || !props.comp.forecast?.T) return false
+  const dueDate = new Date()
+  dueDate.setDate(dueDate.getDate() + props.comp.forecast.T)
+  return new Date(props.comp.predictedDate) > dueDate
+})
+
+function formatPredictedDate(isoDate) {
+  const d = new Date(isoDate + 'T00:00:00')
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
 
 function pct(part, whole) {
   if (!whole || part <= 0) return '0%'

--- a/modules/release-analysis/client/components/MonteCarloChart.vue
+++ b/modules/release-analysis/client/components/MonteCarloChart.vue
@@ -41,7 +41,7 @@
         </div>
 
         <p class="text-[10px] text-gray-400 dark:text-gray-500 text-center">
-          {{ ITERATIONS.toLocaleString() }} Monte Carlo simulations · Throughput: {{ props.velocity }} issues / 14d · Remaining: {{ props.notDoneCount }} issues
+          {{ ITERATIONS.toLocaleString() }} simulations per release, worst-case per iteration<template v-if="props.componentForecasts.length"> · {{ props.componentForecasts.length }} component(s) simulated</template><template v-else> · Throughput: {{ props.velocity }} issues / 14d</template> · {{ props.notDoneCount }} remaining issues<template v-if="props.componentForecasts.length">. Risk-adjusted velocity: {{ props.componentForecasts.length }} red (-40%).</template>
         </p>
       </template>
     </template>
@@ -73,7 +73,8 @@ const props = defineProps({
   dueDate: { type: String, required: true },
   deadlineLabel: { type: String, default: 'Due Date' },
   codeFreezeDate: { type: String, default: null },
-  releaseDate: { type: String, default: null }
+  releaseDate: { type: String, default: null },
+  componentForecasts: { type: Array, default: () => [] }
 })
 
 // ── Date helpers ──
@@ -128,13 +129,27 @@ let pendingIdleId = null
 function runSimulation() {
   if (!canSimulate.value) { sim.value = null; return }
 
-  const scale = 14 / props.velocity
-  const n = props.notDoneCount
-
+  const components = props.componentForecasts
   const completionDays = new Array(ITERATIONS)
-  for (let i = 0; i < ITERATIONS; i++) {
-    completionDays[i] = Math.min(Math.ceil(gammaSample(n, scale)), MAX_DAYS)
+
+  if (components && components.length > 0) {
+    for (let i = 0; i < ITERATIONS; i++) {
+      let maxDays = 0
+      for (const comp of components) {
+        const scale = 14 / comp.velocity
+        const days = Math.min(Math.ceil(gammaSample(comp.totalWorkload, scale)), MAX_DAYS)
+        if (days > maxDays) maxDays = days
+      }
+      completionDays[i] = maxDays
+    }
+  } else {
+    const scale = 14 / props.velocity
+    const n = props.notDoneCount
+    for (let i = 0; i < ITERATIONS; i++) {
+      completionDays[i] = Math.min(Math.ceil(gammaSample(n, scale)), MAX_DAYS)
+    }
   }
+
   completionDays.sort((a, b) => a - b)
 
   const t = getToday()
@@ -168,7 +183,7 @@ const cancelIdle = typeof cancelIdleCallback === 'function'
   : (id) => clearTimeout(id)
 
 watch(
-  () => [props.notDoneCount, props.velocity, props.dueDate],
+  () => [props.notDoneCount, props.velocity, props.dueDate, props.componentForecasts],
   () => {
     if (pendingIdleId != null) cancelIdle(pendingIdleId)
     pendingIdleId = scheduleIdle(() => { pendingIdleId = null; runSimulation() })

--- a/modules/release-analysis/client/components/MonteCarloChart.vue
+++ b/modules/release-analysis/client/components/MonteCarloChart.vue
@@ -41,7 +41,7 @@
         </div>
 
         <p class="text-[10px] text-gray-400 dark:text-gray-500 text-center">
-          {{ ITERATIONS.toLocaleString() }} simulations per release, worst-case per iteration<template v-if="props.componentForecasts.length"> · {{ props.componentForecasts.length }} component(s) simulated</template><template v-else> · Throughput: {{ props.velocity }} issues / 14d</template> · {{ props.notDoneCount }} remaining issues<template v-if="props.componentForecasts.length">. Risk-adjusted velocity: {{ props.componentForecasts.length }} red (-40%).</template>
+          {{ ITERATIONS.toLocaleString() }} simulations, per-component critical path<template v-if="props.componentForecasts.length"> · {{ props.componentForecasts.length }} component(s) simulated</template><template v-else> · Throughput: {{ props.velocity }} issues / 14d</template> · {{ props.notDoneCount }} remaining issues
         </p>
       </template>
     </template>

--- a/modules/release-analysis/client/components/ProductReleaseCard.vue
+++ b/modules/release-analysis/client/components/ProductReleaseCard.vue
@@ -43,8 +43,9 @@
         </span>
         <span
           v-if="predictedDate"
-          class="inline-flex items-center gap-1 text-xs text-teal-600 dark:text-teal-400"
-          title="95% confidence predicted completion date (Monte Carlo)"
+          class="inline-flex items-center gap-1 text-xs font-medium"
+          :class="isReleasePredictedLate ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'"
+          title="Predicted completion based on slowest component's velocity and workload"
         >
           Predicted {{ predictedDate }}
         </span>
@@ -268,6 +269,7 @@
             :deadline-label="mcInputs.activeTarget === 'codeFreeze' ? 'Code Freeze' : 'GA'"
             :code-freeze-date="mcInputs.codeFreezeDate"
             :release-date="mcInputs.releaseDate"
+            :component-forecasts="mcComponentForecasts"
           />
         </div>
       </details>
@@ -280,7 +282,6 @@ import { computed, ref } from 'vue'
 import MonteCarloChart from './MonteCarloChart.vue'
 import ComponentDetailRow from './ComponentDetailRow.vue'
 import { extractProduct } from '../composables/useReleaseFilter'
-import { gammaSample } from '../utils/monteCarlo'
 
 const FORECAST_WINDOW = 14
 const STRATEGIC_TYPES = new Set(['feature', 'initiative', 'spike'])
@@ -377,6 +378,17 @@ function computeForecast(remaining, componentNames) {
   }
 }
 
+function computePredictedDate(releaseRemaining, otherWorkload, velocity) {
+  if (releaseRemaining === 0) return null
+  if (!velocity || velocity <= 0) return null
+  const totalWorkload = releaseRemaining + otherWorkload
+  const windowsNeeded = totalWorkload / velocity
+  const daysNeeded = Math.ceil(windowsNeeded * FORECAST_WINDOW)
+  const predicted = new Date()
+  predicted.setDate(predicted.getDate() + daysNeeded)
+  return predicted.toISOString().slice(0, 10)
+}
+
 const projectFilteredIssues = computed(() => {
   const all = releaseIssues.value
   if (!props.selectedProjects.size) return all
@@ -455,6 +467,9 @@ const componentList = computed(() => {
       const currentReleaseOpen = c.issues_to_do + c.issues_doing
       const globalOtherWorkload = Math.max(0, globalTotalOpen - currentReleaseOpen)
 
+      const forecast = computeForecast(remaining, [c.name])
+      const predictedDate = computePredictedDate(remaining, globalOtherWorkload, forecast.velocity)
+
       return {
         name: c.name,
         projects: [...c.projects].sort(),
@@ -464,7 +479,8 @@ const componentList = computed(() => {
         currentReleaseLoad,
         globalTotalOpen,
         globalOtherWorkload,
-        forecast: computeForecast(remaining, [c.name]),
+        forecast,
+        predictedDate,
         strategicItems,
         otherItems,
         otherCounts: countByBucket(otherItems)
@@ -482,8 +498,16 @@ const componentList = computed(() => {
     })
 })
 
-const atRiskComponents = computed(() => componentList.value.filter(c => c.forecast.paceStatus === 'At Risk'))
-const nonRiskComponents = computed(() => componentList.value.filter(c => c.forecast.paceStatus !== 'At Risk'))
+function isComponentAtRisk(comp) {
+  const gaDate = props.release?.dueDate
+  if (comp.predictedDate && gaDate) {
+    return comp.predictedDate > gaDate
+  }
+  return comp.forecast.paceStatus === 'At Risk'
+}
+
+const atRiskComponents = computed(() => componentList.value.filter(isComponentAtRisk))
+const nonRiskComponents = computed(() => componentList.value.filter(c => !isComponentAtRisk(c)))
 
 const releaseForecast = computed(() => {
   const allNames = componentList.value.map(c => c.name)
@@ -496,7 +520,7 @@ const releaseForecast = computed(() => {
   }
   const forecast = computeForecast(totalRemaining, allNames)
 
-  const atRisk = componentList.value.filter(c => c.forecast.paceStatus === 'At Risk')
+  const atRisk = componentList.value.filter(isComponentAtRisk)
   if (atRisk.length > 0 && forecast.paceStatus !== 'At Risk') {
     forecast.paceStatus = 'At Risk'
     forecast.level = 'Low'
@@ -521,30 +545,35 @@ const issueSum = computed(() => {
 
 const releaseHasNoIssues = computed(() => issueSum.value === 0)
 
-// ── Lightweight Monte Carlo for header predicted date ──
-
-const MC_ITERATIONS = 1000
-const MC_MAX_DAYS = 730
+const mcComponentForecasts = computed(() => {
+  return componentList.value
+    .filter(c => c.forecast.remaining > 0 && c.forecast.velocity > 0)
+    .map(c => ({
+      name: c.name,
+      totalWorkload: c.forecast.remaining + c.globalOtherWorkload,
+      velocity: c.forecast.velocity
+    }))
+})
 
 const predictedDate = computed(() => {
-  const mc = props.mcInputs
-  if (!mc || mc.notDoneCount <= 0 || mc.totalVelocity <= 0) return null
+  const dates = componentList.value
+    .map(c => c.predictedDate)
+    .filter(Boolean)
+  if (!dates.length) return null
+  const maxDate = dates.reduce((a, b) => a > b ? a : b)
+  const d = new Date(maxDate + 'T00:00:00')
+  return d.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', year: 'numeric' })
+})
 
-  const scale = 14 / mc.totalVelocity
-  const n = mc.notDoneCount
-  const completionDays = new Array(MC_ITERATIONS)
-  for (let i = 0; i < MC_ITERATIONS; i++) {
-    completionDays[i] = Math.min(Math.ceil(gammaSample(n, scale)), MC_MAX_DAYS)
-  }
-  completionDays.sort((a, b) => a - b)
-
-  const p95Days = completionDays[Math.ceil(MC_ITERATIONS * 0.95) - 1]
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const p95Date = new Date(today)
-  p95Date.setDate(p95Date.getDate() + p95Days)
-
-  return p95Date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', year: 'numeric' })
+const isReleasePredictedLate = computed(() => {
+  const gaDate = props.release?.dueDate
+  if (!gaDate) return false
+  const dates = componentList.value
+    .map(c => c.predictedDate)
+    .filter(Boolean)
+  if (!dates.length) return false
+  const maxDate = dates.reduce((a, b) => a > b ? a : b)
+  return maxDate > gaDate
 })
 
 const releaseRiskTitle = computed(() => {

--- a/modules/release-analysis/client/components/ReleaseVersionGroup.vue
+++ b/modules/release-analysis/client/components/ReleaseVersionGroup.vue
@@ -206,8 +206,8 @@ function buildComponentForecasts(releases) {
   const componentMap = {}
 
   for (const r of releases) {
-    if (!r.issues) continue
-    for (const issue of r.issues) {
+    const issues = Array.isArray(r.issues) && r.issues.length ? r.issues : (Array.isArray(r.features) ? r.features : [])
+    for (const issue of issues) {
       if (issue.statusBucket === 'done') continue
       const names = issue.components?.length ? issue.components : ['(No component)']
       for (const name of names) {

--- a/modules/release-analysis/client/components/ReleaseVersionGroup.vue
+++ b/modules/release-analysis/client/components/ReleaseVersionGroup.vue
@@ -120,7 +120,7 @@
                 Probability at Release
               </p>
               <p class="text-2xl font-bold tabular-nums" :class="pValueClass">{{ groupForecast.pAtDeadline }}%</p>
-              <p class="text-[11px] mt-0.5" :class="pSubClass">{{ formatDueDate(group.earliestRelease) }}</p>
+              <p class="text-[11px] mt-0.5" :class="pSubClass">{{ formatDueDate(group.earliestRelease || group.earliestDue) }}</p>
             </div>
 
             <div class="rounded-lg border border-amber-200 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/20 px-4 py-3">
@@ -136,12 +136,8 @@
             </div>
           </div>
           <p class="text-[9px] text-gray-400 dark:text-gray-500 mt-2">
-            1,000 simulations per release, worst-case per iteration.
-            {{ groupForecast.productCount }} release(s) simulated · {{ groupForecast.totalRemaining }} remaining issues.
-            <template v-if="groupForecast.redCount || groupForecast.yellowCount">
-              Risk-adjusted velocity:
-              <template v-if="groupForecast.redCount">{{ groupForecast.redCount }} red (-40%)</template><template v-if="groupForecast.redCount && groupForecast.yellowCount">, </template><template v-if="groupForecast.yellowCount">{{ groupForecast.yellowCount }} yellow (-20%)</template>.
-            </template>
+            1,000 simulations, per-component critical path (slowest component determines release).
+            {{ groupForecast.componentCount }} component(s) simulated · {{ groupForecast.totalRemaining }} total workload (release + other open work).
           </p>
         </div>
 
@@ -197,72 +193,91 @@ const completionPct = computed(() => {
   return Math.round((props.group.totals.issues_done / totalIssues.value) * 100)
 })
 
-// ── Monte Carlo simulation (per-product independent, take max per iteration) ──
+// ── Monte Carlo simulation (per-component critical path, take max per iteration) ──
+
+const FORECAST_WINDOW = 14
 
 function getToday() { const d = new Date(); d.setHours(0, 0, 0, 0); return d }
 function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() + days); return d }
-function daysBetween(from, to) { return Math.ceil((to - from) / (1000 * 60 * 60 * 24)) }
 
-/**
- * Risk-adjusted velocity discount: at-risk products historically underperform
- * their baseline throughput due to blockers, scope creep, and quality issues.
- */
-const RISK_VELOCITY_FACTOR = { red: 0.6, yellow: 0.8, green: 1.0 }
+function buildComponentForecasts(releases) {
+  const cv = props.componentVelocity || {}
+  const gw = props.componentGlobalWorkload || {}
+  const componentMap = {}
 
-const groupForecast = computed(() => {
-  const products = []
-  let redCount = 0
-  let yellowCount = 0
-  for (const r of props.group.releases) {
-    const mc = props.mcInputsMap.get(r.releaseNumber)
-    if (mc && mc.notDoneCount > 0 && mc.totalVelocity > 0) {
-      const risk = r.risk || 'green'
-      const factor = RISK_VELOCITY_FACTOR[risk] ?? 1.0
-      products.push({
-        notDoneCount: mc.notDoneCount,
-        velocity: mc.totalVelocity * factor,
-        risk
-      })
-      if (risk === 'red') redCount++
-      else if (risk === 'yellow') yellowCount++
+  for (const r of releases) {
+    if (!r.issues) continue
+    for (const issue of r.issues) {
+      if (issue.statusBucket === 'done') continue
+      const names = issue.components?.length ? issue.components : ['(No component)']
+      for (const name of names) {
+        if (!componentMap[name]) componentMap[name] = { remaining: 0 }
+        componentMap[name].remaining++
+      }
     }
   }
-  if (!products.length) return null
 
-  const deadline = props.group.earliestRelease
+  const components = []
+  for (const [name, data] of Object.entries(componentMap)) {
+    const velocity = cv[name]?.velocity || 0
+    if (velocity <= 0 || data.remaining <= 0) continue
+    const globalEntry = gw[name]
+    const globalTotalOpen = globalEntry?.totalOpen || 0
+    const otherWorkload = Math.max(0, globalTotalOpen - data.remaining)
+    components.push({
+      name,
+      totalWorkload: data.remaining + otherWorkload,
+      velocity
+    })
+  }
+  return components
+}
+
+const groupForecast = computed(() => {
+  const components = buildComponentForecasts(props.group.releases)
+  if (!components.length) return null
+
+  const deadline = props.group.earliestRelease || props.group.earliestDue
   if (!deadline) return null
 
   const today = getToday()
-  const dueObj = new Date(deadline + 'T00:00:00')
-  const daysToDeadline = daysBetween(today, dueObj)
+
+  const onTrackCount = components.filter(comp => {
+    const windowsNeeded = comp.totalWorkload / comp.velocity
+    const daysNeeded = Math.ceil(windowsNeeded * FORECAST_WINDOW)
+    const predictedISO = addDays(today, daysNeeded).toISOString().slice(0, 10)
+    return predictedISO <= deadline
+  }).length
+
+  const pAtDeadline = Math.round((onTrackCount / components.length) * 100)
 
   const groupCompletionDays = new Array(ITERATIONS)
   for (let i = 0; i < ITERATIONS; i++) {
     let maxDays = 0
-    for (const p of products) {
-      const scale = 14 / p.velocity
-      const days = Math.min(Math.ceil(gammaSample(p.notDoneCount, scale)), MAX_DAYS)
+    for (const comp of components) {
+      const scale = FORECAST_WINDOW / comp.velocity
+      const days = Math.min(Math.ceil(gammaSample(comp.totalWorkload, scale)), MAX_DAYS)
       if (days > maxDays) maxDays = days
     }
     groupCompletionDays[i] = maxDays
   }
   groupCompletionDays.sort((a, b) => a - b)
 
-  const completedByDeadline = groupCompletionDays.filter(d => d <= daysToDeadline).length
-  const pAtDeadline = Math.round((completedByDeadline / ITERATIONS) * 100)
   const p85Days = groupCompletionDays[Math.ceil(ITERATIONS * 0.85) - 1]
   const p95Days = groupCompletionDays[Math.ceil(ITERATIONS * 0.95) - 1]
 
+  const totalRemaining = components.reduce((s, c) => s + c.totalWorkload, 0)
+
   return {
     pAtDeadline,
+    onTrackCount,
     p85Days,
     p85Date: addDays(today, p85Days),
     p95Days,
     p95Date: addDays(today, p95Days),
-    productCount: products.length,
-    totalRemaining: products.reduce((s, p) => s + p.notDoneCount, 0),
-    redCount,
-    yellowCount
+    productCount: props.group.releases.length,
+    totalRemaining,
+    componentCount: components.length
   }
 })
 


### PR DESCRIPTION
## Summary
- Adds velocity-based predicted completion dates on each component card header, factoring in both release remaining issues and "Other Open Work" to give a true capacity-aware forecast.
- Routes components to the "At Risk" section when their predicted date exceeds the release GA date.
- Updates the Monte Carlo simulation (both per-release and group-level) to use per-component critical-path logic — each iteration simulates all components independently and takes the max (slowest component determines release delivery).
- Replaces the release-level "Probability at Release" with a deterministic formula: (on-track components / total components) × 100.

## Test plan
- [ ] Verify predicted dates appear on component cards in the Release Analysis tab
- [ ] Confirm components with predicted date > GA date appear in the "At Risk" section
- [ ] Check that the release header "Predicted" date matches the latest component predicted date
- [ ] Validate Monte Carlo 85%/95% confidence dates are consistent with component predictions
- [ ] Verify "Probability at Release" reflects component on-track ratio


Made with [Cursor](https://cursor.com)