### PR TITLE
fix: health-metrics field-definitions endpoint reads wrong storage key

### DIFF
--- a/modules/health-metrics/server/index.js
+++ b/modules/health-metrics/server/index.js
@@ -507,7 +507,7 @@ module.exports = function registerRoutes(router, context) {
     const fieldDefs = readFromStorage('team-data/field-definitions.json');
     if (!fieldDefs) return res.json({ person: [], team: [] });
     // Return only person-level fields for user-type selection
-    const personFields = (fieldDefs.person || []).filter(f => !f.deleted);
+    const personFields = (fieldDefs.personFields || []).filter(f => !f.deleted);
     res.json({ person: personFields });
   });
 };


### PR DESCRIPTION
## Summary
- The `/api/modules/health-metrics/field-definitions` endpoint was reading `fieldDefs.person` but the stored format uses `personFields` as the key (per `shared/server/field-store.js`)
- This returned an empty field list to the settings UI, preventing admins from configuring `userTypeFieldId`
- Without a configured field, all tracked events were recorded with `userType: "unknown"`, causing every user to show as unknown type on the dashboard

## Test plan
- [x] Existing health-metrics tests pass (28/28)
- [ ] After deploying, verify Settings > Health Metrics shows person fields in the user type dropdown
- [ ] Configure a user type field and confirm new events record the correct user type
- [ ] Optionally force re-aggregation via `POST /api/modules/health-metrics/aggregate` after new events flow in

🤖 Generated with [Claude Code](https://claude.com/claude-code)