### PR TITLE
feat: add Backups tab to About page with staleness warning

### DIFF
--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -922,6 +922,40 @@ app.get('/api/modules', function(req, res) {
 
 const diagnosticsRegistry = {};
 const messageRegistry = require('../shared/server/message-registry');
+
+// Register backup staleness message provider (admin-only warning when latest backup > 48h old)
+const BACKUP_STALE_HOURS = 48;
+messageRegistry.registerProvider('backup-staleness', async function(userContext) {
+  if (!userContext.isAdmin) return [];
+  if (!process.env.AWS_BACKUP_BUCKET) return [];
+  try {
+    const backups = await backup.listBackups();
+    if (backups.length === 0) {
+      return [{
+        id: 'backup:no-backups',
+        type: 'warning',
+        text: 'No data backups found. Trigger a backup from About > Backups to protect against data loss.',
+        link: { label: 'Go to Backups', href: '#/about?tab=backups' }
+      }];
+    }
+    const latest = backups[0];
+    const ageMs = Date.now() - new Date(latest.lastModified).getTime();
+    const ageHours = ageMs / (1000 * 60 * 60);
+    if (ageHours > BACKUP_STALE_HOURS) {
+      const ageDays = Math.floor(ageHours / 24);
+      const ageLabel = ageDays >= 1 ? `${ageDays} day${ageDays === 1 ? '' : 's'}` : `${Math.floor(ageHours)} hours`;
+      return [{
+        id: 'backup:stale',
+        type: 'warning',
+        text: `Data backup is overdue — last backup was ${ageLabel} ago.`,
+        link: { label: 'Go to Backups', href: '#/about?tab=backups' }
+      }];
+    }
+    return [];
+  } catch {
+    return [];
+  }
+});
 const moduleContext = { storage: storageModule, requireAuth: authMiddleware, requireAdmin, requireTeamAdmin, roleStore, registerDiagnostics: null };
 
 const persistedState = loadModuleState(storageModule);

--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -713,7 +713,7 @@ const backupDotClass = computed(() => {
 })
 
 watch(activeTab, (val) => {
-  if (val === 'backups' && backupsList.value.length === 0 && !backupsLoading.value) {
+  if (val === 'backups' && isAdmin.value && backupsList.value.length === 0 && !backupsLoading.value) {
     fetchBackups()
   }
 })

--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -271,6 +271,74 @@
       <SiteUsageTab />
     </template>
 
+    <!-- Backups tab -->
+    <template v-if="activeTab === 'backups' && isAdmin">
+      <!-- Status card -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Backup Status</h3>
+          <button
+            @click="triggerBackup"
+            :disabled="backupInProgress"
+            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <DatabaseBackup :size="16" />
+            {{ backupInProgress ? 'Backing up...' : 'Back Up Now' }}
+          </button>
+        </div>
+
+        <div v-if="backupsLoading" class="text-sm text-gray-500 dark:text-gray-400">Loading backup status...</div>
+        <div v-else-if="backupsError" class="text-sm text-red-600 dark:text-red-400">{{ backupsError }}</div>
+        <div v-else-if="backupsList.length === 0" class="text-sm text-gray-500 dark:text-gray-400">
+          No backups found. Trigger a backup to protect against data loss.
+        </div>
+        <div v-else>
+          <div class="flex items-center gap-3">
+            <span class="text-sm text-gray-700 dark:text-gray-300">
+              Last backup: <span class="font-medium">{{ formatBackupDate(backupsList[0].lastModified) }}</span>
+              <span class="text-gray-500 dark:text-gray-400">({{ formatBackupSize(backupsList[0].sizeBytes) }})</span>
+            </span>
+            <span
+              class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-semibold"
+              :class="backupStatusClasses"
+            >
+              <span class="w-1.5 h-1.5 rounded-full" :class="backupDotClass"></span>
+              {{ backupStatusLabel }}
+            </span>
+          </div>
+        </div>
+
+        <p v-if="backupSuccess" class="mt-3 text-sm text-green-600 dark:text-green-400">{{ backupSuccess }}</p>
+      </div>
+
+      <!-- Backup list -->
+      <div v-if="backupsList.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Available Backups</h3>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 dark:border-gray-700">
+                <th class="text-left py-2 pr-4 text-gray-500 dark:text-gray-400 font-medium">Date</th>
+                <th class="text-left py-2 pr-4 text-gray-500 dark:text-gray-400 font-medium">Size</th>
+                <th class="text-left py-2 text-gray-500 dark:text-gray-400 font-medium">Key</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="b in backupsList"
+                :key="b.key"
+                class="border-b border-gray-100 dark:border-gray-700/50 last:border-0"
+              >
+                <td class="py-2 pr-4 text-gray-900 dark:text-gray-100">{{ formatBackupDate(b.lastModified) }}</td>
+                <td class="py-2 pr-4 text-gray-600 dark:text-gray-400">{{ formatBackupSize(b.sizeBytes) }}</td>
+                <td class="py-2 text-gray-500 dark:text-gray-400 font-mono text-xs truncate max-w-xs" :title="b.key">{{ b.key }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+
     <!-- Help & Debug tab -->
     <template v-if="activeTab === 'help'">
       <!-- Build Info -->
@@ -453,7 +521,8 @@ import {
   Milestone,
   Bug,
   MessageSquarePlus,
-  FileCode2
+  FileCode2,
+  DatabaseBackup
 } from 'lucide-vue-next'
 import { useAuth } from '@shared/client'
 import SiteUsageTab from './health-metrics/SiteUsageTab.vue'
@@ -476,6 +545,9 @@ const tabs = computed(() => {
   ]
   if (canViewMetrics.value) {
     base.push({ id: 'usage', label: 'Site Usage', icon: BarChart3Icon })
+  }
+  if (props.isAdmin || authIsAdmin.value) {
+    base.push({ id: 'backups', label: 'Backups', icon: DatabaseBackup })
   }
   base.push({ id: 'help', label: 'Help & Debug', icon: Wrench })
   return base
@@ -555,6 +627,97 @@ const rfeBuilderLessonsLearnedLinks = [
   { label: 'Lessons Learned Notes', icon: StickyNote, url: 'https://docs.google.com/document/d/1glUr8WhghdDmri1KKSCJutMjfzxnueoZuYGFjg2OwxI/edit?tab=t.q557l4ag5zjk' }
 ]
 
+// --- Backups state ---
+const backupsList = ref([])
+const backupsLoading = ref(false)
+const backupsError = ref(null)
+const backupInProgress = ref(false)
+const backupSuccess = ref(null)
+
+const isAdmin = computed(() => props.isAdmin || authIsAdmin.value)
+
+async function fetchBackups() {
+  backupsLoading.value = true
+  backupsError.value = null
+  try {
+    const res = await fetch('/api/admin/backup')
+    if (!res.ok) throw new Error('Failed to load backups')
+    const data = await res.json()
+    backupsList.value = data.backups || []
+  } catch (err) {
+    backupsError.value = err.message
+  } finally {
+    backupsLoading.value = false
+  }
+}
+
+async function triggerBackup() {
+  backupInProgress.value = true
+  backupSuccess.value = null
+  backupsError.value = null
+  try {
+    const res = await fetch('/api/admin/backup', { method: 'POST' })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body.error || 'Backup failed')
+    }
+    backupSuccess.value = 'Backup completed successfully.'
+    await fetchBackups()
+    setTimeout(() => { backupSuccess.value = null }, 5000)
+  } catch (err) {
+    backupsError.value = err.message
+  } finally {
+    backupInProgress.value = false
+  }
+}
+
+function formatBackupDate(dateStr) {
+  if (!dateStr) return 'Unknown'
+  return new Date(dateStr).toLocaleString()
+}
+
+function formatBackupSize(bytes) {
+  if (!bytes) return 'Unknown'
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
+  return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
+}
+
+const backupAgeHours = computed(() => {
+  if (backupsList.value.length === 0) return null
+  const latest = backupsList.value[0]
+  return (Date.now() - new Date(latest.lastModified).getTime()) / (1000 * 60 * 60)
+})
+
+const backupStatusLabel = computed(() => {
+  const h = backupAgeHours.value
+  if (h === null) return ''
+  if (h < 24) return 'Healthy'
+  if (h < 48) return 'Aging'
+  return 'Overdue'
+})
+
+const backupStatusClasses = computed(() => {
+  const h = backupAgeHours.value
+  if (h === null) return ''
+  if (h < 24) return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
+  if (h < 48) return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300'
+  return 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300'
+})
+
+const backupDotClass = computed(() => {
+  const h = backupAgeHours.value
+  if (h === null) return ''
+  if (h < 24) return 'bg-green-500'
+  if (h < 48) return 'bg-yellow-500'
+  return 'bg-red-500'
+})
+
+watch(activeTab, (val) => {
+  if (val === 'backups' && backupsList.value.length === 0 && !backupsLoading.value) {
+    fetchBackups()
+  }
+})
+
 // --- Help & Debug state ---
 const buildInfo = ref({})
 const redactLevel = ref('minimal')
@@ -572,6 +735,9 @@ onMounted(async function () {
     }
   } catch {
     // Build info will show defaults
+  }
+  if (activeTab.value === 'backups' && isAdmin.value) {
+    fetchBackups()
   }
 })
 


### PR DESCRIPTION
## Summary

- Adds an admin-only **Backups** tab to the About page showing:
  - Last backup timestamp and size with a colored status badge (green: <24h, yellow: 24–48h, red: >48h)
  - Table of all available S3 backups (date, size, key)
  - "Back Up Now" button that triggers `POST /api/admin/backup`
- Registers a **backup staleness message provider** that surfaces a dismissible warning banner to admins when the latest backup is >48 hours old or no backups exist, with a link to the Backups tab

## Test plan

- [ ] Verify the Backups tab only appears for admin users
- [ ] Verify backup list loads when tab is opened
- [ ] Verify "Back Up Now" triggers a backup and refreshes the list
- [ ] Verify status badge shows correct color based on backup age
- [ ] Verify staleness warning banner appears when backup is >48h old
- [ ] Verify banner links to `#/about?tab=backups` and the tab activates
- [ ] Verify banner is dismissible and stays dismissed for the session
- [ ] Verify no errors when `AWS_BACKUP_BUCKET` is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)