### PR TITLE
feat: add Unique Users card to Site Usage dashboard

### DIFF
--- a/server/health-metrics/aggregator.js
+++ b/server/health-metrics/aggregator.js
@@ -1,5 +1,6 @@
 function aggregateEvents(events, month) {
   const pages = {};
+  const allEmails = new Set();
 
   for (const event of events) {
     const pageId = event.page;
@@ -15,6 +16,7 @@ function aggregateEvents(events, month) {
     const p = pages[pageId];
     p.views++;
     p._emails.add(event.email);
+    allEmails.add(event.email);
 
     const ut = event.userType || 'unknown';
     p.byUserType[ut] = (p.byUserType[ut] || 0) + 1;
@@ -31,6 +33,7 @@ function aggregateEvents(events, month) {
   return {
     month,
     generatedAt: new Date().toISOString(),
+    uniqueUsers: allEmails.size,
     pages,
   };
 }

--- a/server/health-metrics/routes.js
+++ b/server/health-metrics/routes.js
@@ -328,11 +328,24 @@ function createHealthMetricsRouter(context) {
 
     // Merge aggregates into summary
     let totalViews = 0;
+    let totalUniqueUsers = 0;
     const pageStats = {};
     const userTypeTotals = {};
     const dailyData = {};
 
     for (const agg of aggregates) {
+      // Use top-level uniqueUsers when available (new format),
+      // fall back to max per-page uniqueUsers (lower bound for old aggregates)
+      if (agg.uniqueUsers != null) {
+        totalUniqueUsers += agg.uniqueUsers;
+      } else {
+        let maxPerPage = 0;
+        for (const data of Object.values(agg.pages || {})) {
+          if (data.uniqueUsers > maxPerPage) maxPerPage = data.uniqueUsers;
+        }
+        totalUniqueUsers += maxPerPage;
+      }
+
       for (const [pageId, data] of Object.entries(agg.pages || {})) {
         totalViews += data.views;
         if (!pageStats[pageId]) {
@@ -366,6 +379,7 @@ function createHealthMetricsRouter(context) {
 
     res.json({
       totalViews,
+      uniqueUsers: totalUniqueUsers,
       activePages: Object.keys(pageStats).length,
       topPages,
       userTypes: userTypeTotals,

--- a/src/__tests__/health-metrics/SiteUsageTab.test.js
+++ b/src/__tests__/health-metrics/SiteUsageTab.test.js
@@ -19,6 +19,7 @@ vi.mock('../../components/health-metrics/useMetricsDashboard.js', () => ({
     error: ref(null),
     fetchDashboard: vi.fn(),
     totalViews: ref(1500),
+    uniqueUsers: ref(42),
     activePages: ref(8),
     topPages: ref([
       { pageId: 'team-tracker::home', views: 523, uniqueUsers: 34, byUserType: {}, byPermissionTier: {} },
@@ -53,6 +54,8 @@ describe('SiteUsageTab', () => {
   });
 
   it('displays summary cards', () => {
+    expect(wrapper.text()).toContain('Unique Users');
+    expect(wrapper.text()).toContain('42');
     expect(wrapper.text()).toContain('Total Views');
     expect(wrapper.text()).toContain('1,500');
     expect(wrapper.text()).toContain('Active Pages');

--- a/src/components/health-metrics/SiteUsageTab.vue
+++ b/src/components/health-metrics/SiteUsageTab.vue
@@ -18,7 +18,11 @@
     </div>
 
     <!-- Summary cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Unique Users</div>
+        <div class="text-3xl font-bold text-gray-900 dark:text-white mt-1">{{ uniqueUsers.toLocaleString() }}</div>
+      </div>
       <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
         <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Total Views</div>
         <div class="text-3xl font-bold text-gray-900 dark:text-white mt-1">{{ totalViews.toLocaleString() }}</div>
@@ -101,6 +105,7 @@ const {
   error,
   fetchDashboard,
   totalViews,
+  uniqueUsers,
   activePages,
   topPages,
   userTypes,

--- a/src/components/health-metrics/useMetricsDashboard.js
+++ b/src/components/health-metrics/useMetricsDashboard.js
@@ -64,6 +64,7 @@ export function useMetricsDashboard() {
   }
 
   const totalViews = computed(() => dashboardData.value?.totalViews || 0)
+  const uniqueUsers = computed(() => dashboardData.value?.uniqueUsers || 0)
   const activePages = computed(() => dashboardData.value?.activePages || 0)
   const topPages = computed(() => dashboardData.value?.topPages || [])
   const userTypes = computed(() => dashboardData.value?.userTypes || {})
@@ -80,6 +81,7 @@ export function useMetricsDashboard() {
     fetchPageDetail,
     fetchUserTypes,
     totalViews,
+    uniqueUsers,
     activePages,
     topPages,
     userTypes,


### PR DESCRIPTION
## Summary
- Adds a **Unique Users** summary card as the first card on the Site Usage tab (About page)
- Aggregates now track a top-level `uniqueUsers` count (de-duplicated across pages within each monthly aggregate)
- Dashboard API returns `uniqueUsers` in the response, with a fallback for pre-existing aggregates that lack the field
- Summary card grid updated from 3 to 4 columns

## Test plan
- [x] All health-metrics tests pass (28/28)
- [ ] Verify Unique Users card renders on the Site Usage tab
- [ ] Verify count updates correctly when date range changes
- [ ] Verify backward compatibility with old aggregates (should use max per-page unique users as fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)