### PR TITLE
ci: add claimed label check to Claude issue assistant

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -36,33 +36,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Configure git identity
-        run: |
-          git config user.name "claude-issue-assistant[bot]"
-          git config user.email "claude-issue-assistant[bot]@users.noreply.github.com"
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
       - name: Check for claimed label
         id: check-claimed
         run: |
           LABELS=$(gh issue view ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --json labels \
-            --jq '[.labels[].name] | join(",")')
-          if echo "$LABELS" | grep -qi "claimed"; then
+            --jq '.labels[].name')
+          if echo "$LABELS" | grep -qxi "claimed"; then
             echo "is_claimed=true" >> "$GITHUB_OUTPUT"
             echo "Issue has 'claimed' label — standing down"
           else
@@ -79,6 +60,29 @@ jobs:
             --body "This issue is marked as **claimed** — someone is already working on it. I'll step back. Remove the \`claimed\` label if you'd like me to help."
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Set up Node.js
+        if: steps.check-claimed.outputs.is_claimed != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check-claimed.outputs.is_claimed != 'true'
+        run: npm ci
+
+      - name: Configure git identity
+        if: steps.check-claimed.outputs.is_claimed != 'true'
+        run: |
+          git config user.name "claude-issue-assistant[bot]"
+          git config user.email "claude-issue-assistant[bot]@users.noreply.github.com"
+
+      - name: Authenticate to Google Cloud
+        if: steps.check-claimed.outputs.is_claimed != 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Claude Issue Assistant
         if: steps.check-claimed.outputs.is_claimed != 'true'

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -55,7 +55,33 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
+      - name: Check for claimed label
+        id: check-claimed
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels \
+            --jq '[.labels[].name] | join(",")')
+          if echo "$LABELS" | grep -qi "claimed"; then
+            echo "is_claimed=true" >> "$GITHUB_OUTPUT"
+            echo "Issue has 'claimed' label — standing down"
+          else
+            echo "is_claimed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Notify if claimed (comment trigger only)
+        if: steps.check-claimed.outputs.is_claimed == 'true' && github.event_name == 'issue_comment'
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "This issue is marked as **claimed** — someone is already working on it. I'll step back. Remove the \`claimed\` label if you'd like me to help."
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
       - name: Claude Issue Assistant
+        if: steps.check-claimed.outputs.is_claimed != 'true'
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
@@ -155,6 +181,12 @@ jobs:
             - `enhancement` (color: a2eeef) — feature requests
             - `question` (color: d876e3) — questions about the codebase
             - `needs-clarification` (color: fbca04) — waiting for more info from author
+            - `claimed` (color: 0075ca) — someone is actively working on this; do NOT implement
+
+            **IMPORTANT: Never apply the `claimed` label yourself.** It is applied
+            externally by contributors to signal they are handling an issue. If you
+            see it, stand down. You will not reach this point if the label is already
+            set (the workflow exits before running you), but be aware of its meaning.
 
             ## Important rules
 


### PR DESCRIPTION
## Summary

Adds a generic `claimed` label mechanism that any contributor can use to signal they're actively working on an issue. When the label is present, the Claude issue assistant steps back immediately rather than duplicating work.

## Behavior

- **New issue opened** with `claimed` label → Claude skips entirely (silent)
- **`@claude` comment** on a claimed issue → Claude posts a polite note explaining the issue is claimed and exits
- **Claude never applies `claimed` itself** — it is always set externally

## Why

Standard OSS claim convention. Makes it safe for external contributors, automation, or the repo maintainer to work on an issue without racing against the Claude action.

## Changes

- Added `Check for claimed label` step before the Claude action
- Added `Notify if claimed` step for comment-triggered runs
- Updated Claude's prompt to document the label's meaning
- Claude is instructed never to apply `claimed` itself