### PR TITLE
fix: add BookOpen icon to sidebar icon map

### DIFF
--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -262,6 +262,7 @@ import {
   Info,
   KeyRound,
   ClipboardList,
+  BookOpen,
   History,
   Hospital,
   LayoutDashboard
@@ -303,6 +304,7 @@ const ICON_MAP = {
   'activity': Activity,
   'network': Network,
   'clipboard-list': ClipboardList,
+  BookOpen,
   ClipboardList,
   History,
   Hospital,


### PR DESCRIPTION
## Summary
- The AI Factory Guide nav item specified `BookOpen` as its icon in `module.json`, but it wasn't registered in the sidebar `ICON_MAP`, causing it to silently fall back to the default `BarChart3` (bar chart) icon
- Adds `BookOpen` to both the lucide import and the `ICON_MAP` in `AppSidebar.vue`

## Test plan
- [ ] Verify the AI Factory Guide nav item renders an open book icon instead of a bar chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)