### PR TITLE
refactor(about): fully deduplicate Docs tab from shared enablement data

### DIFF
--- a/shared/client/enablement-links.js
+++ b/shared/client/enablement-links.js
@@ -67,6 +67,12 @@ export const enablementCategories = [
   },
 ]
 
+export const enablementSections = [
+  { id: 'ai-sdlc', label: 'AI SDLC Materials' },
+  { id: 'ai-workflows', label: 'AI Workflows Enablement' },
+  { id: 'other', label: 'Other Enablement' },
+]
+
 export function getAIImpactEnablementCategories() {
   return enablementCategories.filter(c =>
     ['rfe-builder', 'strat-builder', 'ai-quality'].includes(c.id)

--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -133,137 +133,47 @@
 
     <!-- Docs tab -->
     <template v-if="activeTab === 'docs'">
-      <!-- AI SDLC Materials -->
-      <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-3">AI SDLC Materials</h2>
+      <template v-for="(section, sIdx) in docsSections" :key="section.id">
+        <h2
+          class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-3"
+          :class="{ 'mt-8': sIdx > 0 }"
+        >
+          {{ section.label }}
+        </h2>
 
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          RFE Builder
-          <a href="https://app.slack.com/client/E030G10V24F/C0AMPLH0Y9G" target="_blank" rel="noopener" class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">#wg-rhai-rfe-builder</a>
-        </h3>
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-for="link in rfeLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
-          >
-            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
-            <span>{{ link.label }}</span>
-            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
-          </a>
+        <div
+          v-for="cat in section.categories"
+          :key="cat.id"
+          class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6"
+        >
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            {{ cat.title }}
+            <a
+              v-if="cat.slackChannel"
+              :href="cat.slackChannel.url"
+              target="_blank"
+              rel="noopener"
+              class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {{ cat.slackChannel.name }}
+            </a>
+          </h3>
+          <div class="flex flex-wrap gap-4">
+            <a
+              v-for="link in cat.resolvedLinks"
+              :key="link.url"
+              :href="link.url"
+              target="_blank"
+              rel="noopener"
+              class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
+            >
+              <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
+              <span>{{ link.label }}</span>
+              <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
+            </a>
+          </div>
         </div>
-      </div>
-
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          STRAT Builder
-          <a href="https://app.slack.com/client/E030G10V24F/C0APA0E2J3Z" target="_blank" rel="noopener" class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">#wg-rhai-strat-refine-review</a>
-        </h3>
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-for="link in stratBuilderLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
-          >
-            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
-            <span>{{ link.label }}</span>
-            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
-          </a>
-        </div>
-      </div>
-
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          AI Quality
-          <a href="https://app.slack.com/client/E030G10V24F/C0ANMTUF5FW" target="_blank" rel="noopener" class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">#wg-rhai-quality-eng-builder</a>
-        </h3>
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-for="link in aiQualityLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
-          >
-            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
-            <span>{{ link.label }}</span>
-            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
-          </a>
-        </div>
-      </div>
-
-      <!-- AI Workflows Enablement -->
-      <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mt-8 mb-3">AI Workflows Enablement</h2>
-
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Jira Autofix
-          <a href="https://app.slack.com/client/E030G10V24F/C0ASJ32PJ0N" target="_blank" rel="noopener" class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">#wg-rhai-ai-first-code-autofix</a>
-        </h3>
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-for="link in jiraAutofixLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
-          >
-            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
-            <span>{{ link.label }}</span>
-            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
-          </a>
-        </div>
-      </div>
-
-      <!-- Other Enablement -->
-      <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mt-8 mb-3">Other Enablement</h2>
-
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          Agent Eval Harness
-          <a href="https://app.slack.com/client/E030G10V24F/C0B01HA68KC" target="_blank" rel="noopener" class="ml-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">#wg-agent-eval-harness</a>
-        </h3>
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-for="link in agentEvalHarnessLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
-          >
-            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
-            <span>{{ link.label }}</span>
-            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
-          </a>
-        </div>
-      </div>
-
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">RFE Builder Lessons Learned</h3>
-        <div class="flex flex-wrap gap-4">
-          <a
-            v-for="link in rfeBuilderLessonsLearnedLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
-          >
-            <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
-            <span>{{ link.label }}</span>
-            <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
-          </a>
-        </div>
-      </div>
+      </template>
     </template>
 
     <!-- Site Usage tab -->
@@ -526,7 +436,7 @@ import {
 } from 'lucide-vue-next'
 import { useAuth } from '@shared/client'
 import SiteUsageTab from './health-metrics/SiteUsageTab.vue'
-import { enablementCategories } from '@shared/client/enablement-links.js'
+import { enablementCategories, enablementSections } from '@shared/client/enablement-links.js'
 
 const { isAdmin: authIsAdmin, roles } = useAuth()
 
@@ -593,18 +503,19 @@ const issueTemplates = [
 
 const iconMap = { Video, Presentation, StickyNote, Play }
 
-function resolveLinks(categoryId) {
-  const cat = enablementCategories.find(c => c.id === categoryId)
-  if (!cat) return []
-  return cat.links.map(l => ({ ...l, icon: iconMap[l.icon] || Video }))
+function resolveIcon(name) {
+  return iconMap[name] || Video
 }
 
-const rfeLinks = resolveLinks('rfe-builder')
-const stratBuilderLinks = resolveLinks('strat-builder')
-const aiQualityLinks = resolveLinks('ai-quality')
-const jiraAutofixLinks = resolveLinks('jira-autofix')
-const agentEvalHarnessLinks = resolveLinks('agent-eval-harness')
-const rfeBuilderLessonsLearnedLinks = resolveLinks('rfe-builder-lessons-learned')
+const docsSections = enablementSections.map(s => ({
+  ...s,
+  categories: enablementCategories
+    .filter(c => c.section === s.id)
+    .map(c => ({
+      ...c,
+      resolvedLinks: c.links.map(l => ({ ...l, icon: resolveIcon(l.icon) })),
+    })),
+}))
 
 // --- Backups state ---
 const backupsList = ref([])


### PR DESCRIPTION
## Summary

Addresses the review feedback from #573: the Docs tab in AboutView.vue was still hardcoding category titles and Slack channel URLs even though `enablement-links.js` already contained that data.

## Changes

- **`enablement-links.js`** — Added `enablementSections` array with section labels ("AI SDLC Materials", "AI Workflows Enablement", "Other Enablement")
- **`AboutView.vue`** — Replaced 6 hardcoded category blocks (~140 lines) with a data-driven loop (~50 lines) that iterates over sections and categories from the shared data

Now if a Slack channel URL, category title, or section name changes, it only needs updating in `enablement-links.js`. Zero duplication.

## Testing

All 2567 tests pass. ESLint clean.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>