### PR TITLE
fix(ci): include AGENTS.md hard constraint violations in review FAIL criteria

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -176,9 +176,10 @@ jobs:
                echo "PASS" > .claude-review-result    # No blocking issues remain
                echo "FAIL" > .claude-review-result    # Critical unfixed issues
                ```
-               Use **FAIL** only for issues you could NOT fix that are: security
-               vulnerabilities, clear bugs that will cause runtime errors, or breaking
-               changes. If you found issues but fixed them all, use PASS.
+               Use **FAIL** for issues you could NOT fix that are: security
+               vulnerabilities, clear bugs that will cause runtime errors, breaking
+               changes, or violations of the hard constraints defined in AGENTS.md.
+               If you found issues but fixed them all, use PASS.
                Use **PASS** for: clean code, minor suggestions, style nits, or when
                all issues were fixed by your autofix commit.
                Always write this file as your very last action.


### PR DESCRIPTION
## Summary

The Claude Review verdict rules only listed three categories as FAIL-worthy:
- Security vulnerabilities
- Clear bugs that will cause runtime errors
- Breaking changes

Meanwhile, `review.instructions.md` says hard constraint violations are **blocking issues**. This mismatch meant Claude would correctly *flag* a hard constraint violation but still give a **PASS** verdict — the required status check wouldn't block the PR.

## What changed

Added "violations of the hard constraints defined in AGENTS.md" to the FAIL criteria in `claude-review.yml`, aligning the verdict rules with the review checklist.

## Context

Discovered via [PR #584](https://github.com/red-hat-data-services/rhai-org-pulse/pull/584), where Claude flagged a missing CLAUDE.md API route entry as a Hard Constraint #7 violation but still gave a PASS verdict.