### PR TITLE
fix: include teams array in global allocation summary

### DIFF
--- a/modules/team-tracker/__tests__/server/allocation/orchestration.test.js
+++ b/modules/team-tracker/__tests__/server/allocation/orchestration.test.js
@@ -437,9 +437,12 @@ describe('performRefresh', () => {
     const org1Call = writeCalls.find(c => c[0] === 'summaries/org-org1.json');
     expect(org1Call[1].teams).toHaveLength(2);
 
-    // Global summary should include org details
+    // Global summary should include org details and all teams
     const globalCall = writeCalls.find(c => c[0] === 'summaries/global.json');
     expect(globalCall[1].orgs).toHaveLength(2);
+    expect(globalCall[1].teams).toHaveLength(3);
+    expect(globalCall[1].teams[0]).toHaveProperty('orgKey');
+    expect(globalCall[1].teams[0]).toHaveProperty('teamName');
   });
 
   it('skips teams with no allocation boards', async () => {

--- a/modules/team-tracker/client/reports/AllocationReport.vue
+++ b/modules/team-tracker/client/reports/AllocationReport.vue
@@ -36,7 +36,7 @@ function selectOrg(org) {
 }
 
 function openTeam(team) {
-  const orgKey = summary.value?.orgKey || selectedOrg.value
+  const orgKey = team.orgKey || summary.value?.orgKey || selectedOrg.value
   if (orgKey) {
     nav.navigateTo('team-detail', { teamKey: `${orgKey}::${team.teamName}`, tab: 'allocation' })
   }

--- a/modules/team-tracker/server/allocation/orchestration.js
+++ b/modules/team-tracker/server/allocation/orchestration.js
@@ -355,6 +355,15 @@ async function performRefresh({ teams, hardRefresh, fetchSprints, fetchSprintIss
   writeStorage('summaries/global.json', {
     lastUpdated: new Date().toISOString(),
     ...globalSummary,
+    teams: teamResults.map(t => ({
+      teamId: t.teamId,
+      teamName: t.teamName,
+      orgKey: t.orgKey,
+      totalPoints: t.totalPoints,
+      totalCount: t.totalCount,
+      boardCount: t.boardCount,
+      percentages: t.percentages
+    })),
     orgs: orgSummaries.map(o => ({
       orgKey: o.orgKey,
       totalPoints: o.totalPoints,


### PR DESCRIPTION
The global allocation summary was missing a `teams` array, causing the 40/40/20 report to show no teams when "All" orgs was selected. Added all teams (with orgKey) to the global summary and updated openTeam() to use team-level orgKey for navigation.

Fixes #585

Generated with [Claude Code](https://claude.ai/code)