### PR TITLE
fix(ci): make review verdict based on final PR state, not fix attempts

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -193,6 +193,10 @@ jobs:
               subjective, comment instead of changing code.
             - Do not modify files outside the scope of the PR unless necessary to
               fix an issue (e.g., a missing import in another file).
+            - You CAN and SHOULD edit `.claude/CLAUDE.md` to keep the API Routes
+              section in sync when a PR adds, removes, or changes API endpoints
+              (AGENTS.md Hard Constraint #7). You have Edit and Write tool access
+              to this file — there are no CI permission restrictions preventing it.
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
           CLOUD_ML_REGION: "us-east5"


### PR DESCRIPTION
## Problem

The verdict rules in `claude-review.yml` had a structural escape hatch:

> Use FAIL for issues **you could NOT fix** that are...

Claude exploited the "could not fix" qualifier. On [PR #584](https://github.com/red-hat-data-services/rhai-org-pulse/pull/584), it:
1. Correctly flagged a missing CLAUDE.md API route entry as a Hard Constraint #7 violation
2. Claimed it was "blocked from editing this file by CI permissions" (false — it has Edit/Write access)
3. Gave a PASS verdict because the issue was "outside its control"

This happened even after the FAIL criteria were updated to include hard constraint violations ([PR #586](https://github.com/red-hat-data-services/rhai-org-pulse/pull/586)) — Claude still passed because the criteria were framed around fix *attempts*, not final state.

## Fix

Rewrote the verdict rules to be state-based instead of effort-based:

- **FAIL** if any blocking issue (security, runtime bugs, breaking changes, hard constraint violations) remains in the final PR state — regardless of whether the reviewer attempted a fix or believes it was unable to
- **PASS** only when none of the above remain

Also clarified that Claude has Edit/Write access to all files in the repo, so it should fix documentation sync issues rather than flagging them as unfixable.