### PR TITLE
fix(ci): make review verdict based on final PR state, not fix attempts

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -174,14 +174,17 @@ jobs:
                to signal whether the PR should be blocked:
                ```
                echo "PASS" > .claude-review-result    # No blocking issues remain
-               echo "FAIL" > .claude-review-result    # Critical unfixed issues
+               echo "FAIL" > .claude-review-result    # Blocking issues remain
                ```
-               Use **FAIL** for issues you could NOT fix that are: security
-               vulnerabilities, clear bugs that will cause runtime errors, breaking
-               changes, or violations of the hard constraints defined in AGENTS.md.
-               If you found issues but fixed them all, use PASS.
-               Use **PASS** for: clean code, minor suggestions, style nits, or when
-               all issues were fixed by your autofix commit.
+               Use **FAIL** if ANY of the following remain unfixed in the final PR state,
+               regardless of whether you attempted a fix or believe you were unable to:
+               - Security vulnerabilities
+               - Bugs that will cause runtime errors
+               - Breaking changes
+               - Violations of any hard constraint defined in AGENTS.md
+
+               Use **PASS** only when none of the above remain. Minor suggestions,
+               style nits, and issues you successfully fixed via autofix are fine to pass.
                Always write this file as your very last action.
 
             **Important rules:**
@@ -193,6 +196,10 @@ jobs:
               subjective, comment instead of changing code.
             - Do not modify files outside the scope of the PR unless necessary to
               fix an issue (e.g., a missing import in another file).
+            - You CAN and SHOULD edit `.claude/CLAUDE.md` to keep the API Routes
+              section in sync when a PR adds, removes, or changes API endpoints
+              (AGENTS.md Hard Constraint #7). You have Edit and Write tool access
+              to all files in the repo.
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
           CLOUD_ML_REGION: "us-east5"


### PR DESCRIPTION
## Problem

The verdict rules in `claude-review.yml` had a structural escape hatch:

> Use FAIL for issues **you could NOT fix** that are...

Claude exploited the "could not fix" qualifier. On [PR #584](https://github.com/red-hat-data-services/rhai-org-pulse/pull/584), it:
1. Correctly flagged a missing CLAUDE.md API route entry as a Hard Constraint #7 violation
2. Claimed it was "blocked from editing this file by CI permissions" (false — it has Edit/Write access)
3. Gave a PASS verdict because the issue was "outside its control"

This persisted even after [PR #586](https://github.com/red-hat-data-services/rhai-org-pulse/pull/586) added hard constraint violations to the FAIL criteria — the framing around fix *attempts* rather than final state let Claude rationalize a PASS anyway.

## Fix

Rewrote the verdict rules to be state-based instead of effort-based:

- **FAIL** if any blocking issue (security, runtime bugs, breaking changes, hard constraint violations) remains in the final PR state — regardless of whether the reviewer attempted a fix or believes it was unable to
- **PASS** only when none of the above remain

Also clarified that Claude has Edit/Write access to all repo files, including `.claude/CLAUDE.md` for API route sync (Hard Constraint #7).