### PR TITLE
fix(ci): move verdict rules into review.instructions.md

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -32,9 +32,16 @@ These are non-negotiable. Flag any violation as a blocking issue.
 6. **OpenAPI annotations required** — Every new or modified route handler needs
    an `@openapi` JSDoc annotation. CI enforces this.
 
-7. **Documentation in sync** — Data format changes must update
-   `docs/DATA-FORMATS.md` and `fixtures/`. New shared exports must update
-   `shared/API.md`. Module changes must update `docs/MODULES.md`.
+7. **Documentation in sync** — Documentation changes must land in the same PR
+   as the code they describe:
+   - Data format changes → update `docs/DATA-FORMATS.md` and `fixtures/`
+   - New shared exports → update `shared/API.md`
+   - Module system changes → update `docs/MODULES.md`
+   - API route changes → update the API Routes section in `.claude/CLAUDE.md`
+
+   You have full Edit and Write access to all files in the repo, including
+   `.claude/CLAUDE.md`. If a PR adds, modifies, or removes API endpoints,
+   update the API Routes section yourself as part of your autofix.
 
 ## Review checklist
 
@@ -62,6 +69,25 @@ These are non-negotiable. Flag any violation as a blocking issue.
    have an `@openapi` JSDoc annotation. The CI `validate:openapi` step
    enforces a minimum operation count; adding a route without its annotation
    will cause the build to fail.
+
+## Verdict rules
+
+When used in CI, the reviewer writes a verdict file (`echo "PASS" > .claude-review-result`
+or `echo "FAIL" > .claude-review-result`). The verdict is based on the **final
+state of the PR** after any autofixes, not on whether you attempted a fix.
+
+Use **FAIL** if ANY of the following remain unfixed in the final PR state:
+- Security vulnerabilities
+- Bugs that will cause runtime errors
+- Breaking changes
+- Violations of any hard constraint listed above
+
+Use **PASS** only when none of the above remain. Minor suggestions, style nits,
+and issues you successfully fixed via autofix are fine to pass.
+
+Do not rationalize a PASS by claiming you were unable to fix an issue. If a
+blocking issue exists, the verdict is FAIL regardless of the reason it wasn't
+fixed.
 
 ## Review tone
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -170,21 +170,8 @@ jobs:
                  your autofix commit. Mention this in your summary so the PR author
                  knows to re-run CI if needed.
 
-            5. **Set review verdict**: After completing your review, write a result file
-               to signal whether the PR should be blocked:
-               ```
-               echo "PASS" > .claude-review-result    # No blocking issues remain
-               echo "FAIL" > .claude-review-result    # Blocking issues remain
-               ```
-               Use **FAIL** if ANY of the following remain unfixed in the final PR state,
-               regardless of whether you attempted a fix or believe you were unable to:
-               - Security vulnerabilities
-               - Bugs that will cause runtime errors
-               - Breaking changes
-               - Violations of any hard constraint defined in AGENTS.md
-
-               Use **PASS** only when none of the above remain. Minor suggestions,
-               style nits, and issues you successfully fixed via autofix are fine to pass.
+            5. **Set review verdict**: Follow the "Verdict rules" section in
+               `.github/instructions/review.instructions.md` to write your result file.
                Always write this file as your very last action.
 
             **Important rules:**
@@ -196,10 +183,7 @@ jobs:
               subjective, comment instead of changing code.
             - Do not modify files outside the scope of the PR unless necessary to
               fix an issue (e.g., a missing import in another file).
-            - You CAN and SHOULD edit `.claude/CLAUDE.md` to keep the API Routes
-              section in sync when a PR adds, removes, or changes API endpoints
-              (AGENTS.md Hard Constraint #7). You have Edit and Write tool access
-              to all files in the repo.
+
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
           CLOUD_ML_REGION: "us-east5"


### PR DESCRIPTION
## Problem

Three consecutive reviews on [PR #584](https://github.com/red-hat-data-services/rhai-org-pulse/pull/584) exposed a structural issue: Claude was ignoring the verdict criteria defined in the inline workflow prompt. Each time it:

1. Correctly flagged a Hard Constraint #7 violation (missing CLAUDE.md API route)
2. Hallucinated a permission restriction ("blocked from editing by CI permissions")
3. Gave a PASS verdict despite the unfixed blocking issue

This persisted through two prompt fixes ([#586](https://github.com/red-hat-data-services/rhai-org-pulse/pull/586), [#589](https://github.com/red-hat-data-services/rhai-org-pulse/pull/589)) because the verdict rules were in the inline YAML prompt, but Claude's actual review behavior comes from `review.instructions.md` — the file it reads and trusts.

## Fix

Move everything into `review.instructions.md` as the single source of truth:

- **Verdict rules** — FAIL if any blocking issue remains in the final PR state, regardless of whether the reviewer attempted a fix. Explicitly prohibits rationalizing a PASS.
- **Hard Constraint #7** — expanded to explicitly list `.claude/CLAUDE.md` API route sync, with a clear statement that Edit/Write access covers all repo files.
- **Inline prompt** — simplified to just reference the file for verdict rules.

## Why this should work

The review prompt tells Claude to `Read .github/instructions/review.instructions.md for the full review checklist`. That's where it gets its behavior from — the inline YAML prompt is supplementary. By putting the verdict rules and permissions in the file Claude actually reads, they should carry real weight.