### PR TITLE
fix(ci): make review instructions reference AGENTS.md directly

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -4,44 +4,16 @@ This file defines the review criteria for all code reviews — automated (CI) an
 manual (local `/pr-review` command). All reviewers (human or AI) should apply
 these criteria consistently.
 
-## Hard constraints (from AGENTS.md)
+## Hard constraints
 
-These are non-negotiable. Flag any violation as a blocking issue.
+Read the "Hard Constraints" section in `AGENTS.md` at the repo root. Those
+constraints are the authoritative source — this file does not duplicate them.
+Flag any violation as a **blocking issue**.
 
-1. **No cross-module imports** — Modules import only from `@shared`. Cross-module
-   data access uses `readFromStorage()` (for exported files in `module.json >
-   export.files`) or API calls. Never `import from '../../../modules/other-module'`.
-
-2. **Storage abstractions only** — All data file access must use
-   `readFromStorage` / `writeToStorage`. No raw `fs.readFileSync` or
-   `path.join(__dirname, '../../data/...')` for data files.
-
-3. **App is a display layer** — The app should not perform significant
-   computation. Complex aggregations, bulk data processing, ML scoring, or
-   data enrichment belong in external processes that push results via bulk
-   API endpoints. Flag any PR that adds heavy computation to the backend.
-
-4. **New pages in existing modules** — New views should go in an existing module
-   if the domain overlaps. Only create a new module when it has a genuinely
-   distinct domain. If a PR adds a new module, verify there is no existing
-   module where the feature fits.
-
-5. **No TypeScript** — Plain JavaScript only. CommonJS for server, ES modules
-   for frontend.
-
-6. **OpenAPI annotations required** — Every new or modified route handler needs
-   an `@openapi` JSDoc annotation. CI enforces this.
-
-7. **Documentation in sync** — Documentation changes must land in the same PR
-   as the code they describe:
-   - Data format changes → update `docs/DATA-FORMATS.md` and `fixtures/`
-   - New shared exports → update `shared/API.md`
-   - Module system changes → update `docs/MODULES.md`
-   - API route changes → update the API Routes section in `.claude/CLAUDE.md`
-
-   You have full Edit and Write access to all files in the repo, including
-   `.claude/CLAUDE.md`. If a PR adds, modifies, or removes API endpoints,
-   update the API Routes section yourself as part of your autofix.
+You have full Edit and Write access to all files in the repo, including
+`.claude/CLAUDE.md`. If a PR adds, modifies, or removes API endpoints, update
+the API Routes section in `.claude/CLAUDE.md` yourself as part of your autofix
+(Hard Constraint #7 in AGENTS.md).
 
 ## Review checklist
 
@@ -57,9 +29,9 @@ These are non-negotiable. Flag any violation as a blocking issue.
    level. Flag unnecessary complexity, dead code, or misleading names. Prefer
    clarity over cleverness.
 
-4. **Project conventions** — Adherence to the conventions in `AGENTS.md`:
-   module structure, import style (ESM frontend, CJS backend), `<script setup>`
-   for Vue components, Tailwind for styling, test coverage for changed logic.
+4. **Project conventions** — Adherence to all conventions in `AGENTS.md`
+   (code style, module structure, import style, testing, etc.). If you haven't
+   already, read `AGENTS.md` now.
 
 5. **Performance** — Unnecessary re-renders, N+1 queries, unbounded data
    fetching, missing pagination, expensive operations in hot paths, memory
@@ -80,7 +52,7 @@ Use **FAIL** if ANY of the following remain unfixed in the final PR state:
 - Security vulnerabilities
 - Bugs that will cause runtime errors
 - Breaking changes
-- Violations of any hard constraint listed above
+- Violations of any hard constraint defined in `AGENTS.md`
 
 Use **PASS** only when none of the above remain. Minor suggestions, style nits,
 and issues you successfully fixed via autofix are fine to pass.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -138,8 +138,9 @@ jobs:
                  post a comment explaining that no PR was found and exit.
                - Run `gh pr checkout <PR_NUMBER>` to switch to the PR branch.
 
-            2. **Review** the PR diff. Read `.github/instructions/review.instructions.md`
-               for the full review checklist. Apply all criteria from that file.
+            2. **Review** the PR diff. Read `AGENTS.md` (hard constraints and
+               conventions) and `.github/instructions/review.instructions.md`
+               (review checklist and verdict rules). Apply all criteria from both.
 
             3. **Fix** any issues you find by editing the files directly:
                - Use Edit/Write tools to modify the source files


### PR DESCRIPTION
## Problem

`review.instructions.md` had hand-copied summaries of the hard constraints from `AGENTS.md`. Two issues:

1. **Drift** — constraints could be updated in AGENTS.md without updating the review file, leading to inconsistent enforcement
2. **Missing context** — the reviewer was never told to read AGENTS.md directly, so it only knew what the summaries told it

## Fix

- Replace the duplicated hard constraint list with a directive to read AGENTS.md as the authoritative source
- Update the workflow prompt to explicitly tell the reviewer to read both `AGENTS.md` and `review.instructions.md`
- Keep the review-specific additions (verdict rules, checklist, tone) in `review.instructions.md`

This is the last piece of the review enforcement work from PRs #586, #589, and #591.