### PR TITLE
fix(ci): add safety net to catch unfixed hard constraint violations in review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -200,16 +200,40 @@ jobs:
             exit 0
           fi
 
+          BLOCKED=false
+
           # Check the verdict file Claude was instructed to write
           if [ -f .claude-review-result ]; then
             RESULT=$(tr -d '[:space:]' < .claude-review-result)
             if [ "$RESULT" = "FAIL" ]; then
-              echo "::error::Claude review found critical issues that must be addressed before merging"
-              exit 1
+              echo "::error::Claude review verdict: FAIL"
+              BLOCKED=true
             fi
           fi
 
+          # Safety net: check Claude's own comment for unfixed issues it reported
+          # but didn't reflect in its verdict. Fetch the most recent claude bot
+          # comment and look for the "Issues found but NOT fixed" section.
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          if [ -n "$PR_NUM" ]; then
+            LATEST_COMMENT=$(gh pr view "$PR_NUM" --json comments \
+              --jq '[.comments[] | select(.author.login == "claude")] | last | .body // ""')
+            if echo "$LATEST_COMMENT" | grep -qi "Issues found but NOT fixed"; then
+              # Check if any unfixed issue references a hard constraint
+              if echo "$LATEST_COMMENT" | grep -qi "Hard Constraint"; then
+                echo "::error::Claude reported unfixed hard constraint violation(s) but did not set FAIL verdict"
+                BLOCKED=true
+              fi
+            fi
+          fi
+
+          if [ "$BLOCKED" = "true" ]; then
+            exit 1
+          fi
+
           echo "Claude review passed"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   # Read-only review for fork PRs — never executes fork code
   claude-review-fork:


### PR DESCRIPTION
## Problem

Claude consistently writes PASS even when it reports unfixed hard constraint violations. Four prompt-level fixes have failed (#586, #589, #591, #592) — Claude identifies the issue, says it can't fix it, and rationalizes a PASS.

The root cause: the `claude-code-action` protects `.claude/` from writes (security feature — prevents untrusted PR code from injecting agent instructions). So when Hard Constraint #7 requires updating `.claude/CLAUDE.md`, Claude genuinely can't do it, and it won't FAIL itself for something it considers out of its control.

## Fix

Stop relying solely on Claude's self-assessed verdict. The "Check review result" step now has a safety net:

1. Still checks the verdict file (respects a proper FAIL)
2. **Also** parses Claude's latest PR comment for "Issues found but NOT fixed" sections that reference a "Hard Constraint"
3. If found, fails the check regardless of the verdict

This is a deterministic shell check — no LLM judgment involved in the gate decision.

## What this catches

Any review where Claude reports an unfixed hard constraint violation but writes PASS — exactly the scenario that's happened five times on PR #584.