### PR TITLE
fix(ci): switch review verdict to structured JSON output

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -44,22 +44,29 @@ the API Routes section in `.claude/CLAUDE.md` yourself as part of your autofix
 
 ## Verdict rules
 
-When used in CI, the reviewer writes a verdict file (`echo "PASS" > .claude-review-result`
-or `echo "FAIL" > .claude-review-result`). The verdict is based on the **final
+When used in CI, the reviewer populates a structured JSON output with two fields:
+`verdict` (`"PASS"` or `"FAIL"`) and `unfixed_blocking_issues` (an array of
+objects with `category` and `description`). The verdict is based on the **final
 state of the PR** after any autofixes, not on whether you attempted a fix.
 
-Use **FAIL** if ANY of the following remain unfixed in the final PR state:
+Set `verdict` to `"FAIL"` if ANY of the following remain unfixed in the final
+PR state:
 - Security vulnerabilities
 - Bugs that will cause runtime errors
 - Breaking changes
 - Violations of any hard constraint defined in `AGENTS.md`
 
-Use **PASS** only when none of the above remain. Minor suggestions, style nits,
-and issues you successfully fixed via autofix are fine to pass.
+List every unfixed blocking issue in `unfixed_blocking_issues` with a `category`
+(e.g. `"hard-constraint-7"`, `"security"`, `"bug"`, `"breaking-change"`) and a
+`description` of the issue.
+
+Set `verdict` to `"PASS"` with an empty `unfixed_blocking_issues` array only
+when none of the above remain. Minor suggestions, style nits, and issues you
+successfully fixed via autofix are fine to pass.
 
 Do not rationalize a PASS by claiming you were unable to fix an issue. If a
-blocking issue exists, the verdict is FAIL regardless of the reason it wasn't
-fixed.
+blocking issue exists that you cannot fix (e.g. write-protected files), the
+verdict is still FAIL — the PR author must fix it themselves.
 
 ## Review tone
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -121,12 +121,11 @@ jobs:
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
-        continue-on-error: true
         with:
           use_vertex: "true"
           track_progress: true
           display_report: "true"
-          claude_args: '--model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git diff:*),Bash(git status:*),Bash(npm test:*),Bash(npm run lint:*),Read,Glob,Grep,Edit,Write"'
+          claude_args: '--model claude-opus-4-6 --json-schema ''{"type":"object","properties":{"verdict":{"enum":["PASS","FAIL"]},"unfixed_blocking_issues":{"type":"array","items":{"type":"object","properties":{"category":{"type":"string"},"description":{"type":"string"}},"required":["category","description"]}}},"required":["verdict","unfixed_blocking_issues"]}'' --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git diff:*),Bash(git status:*),Bash(npm test:*),Bash(npm run lint:*),Read,Glob,Grep,Edit,Write"'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -172,8 +171,8 @@ jobs:
                  knows to re-run CI if needed.
 
             5. **Set review verdict**: Follow the "Verdict rules" section in
-               `.github/instructions/review.instructions.md` to write your result file.
-               Always write this file as your very last action.
+               `.github/instructions/review.instructions.md` to populate the
+               structured output. This is your very last action.
 
             **Important rules:**
             - Never force push. Only push to the current PR branch via `git push origin HEAD`.
@@ -193,20 +192,21 @@ jobs:
 
       - name: Check review result
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.claude-review.outputs.structured_output }}
         run: |
-          # If the Claude action itself crashed, warn but don't block the PR
-          if [ "${{ steps.claude-review.outcome }}" = "failure" ]; then
-            echo "::warning::Claude review action failed (infrastructure issue) — not blocking PR"
-            exit 0
+          if [ -z "$STRUCTURED_OUTPUT" ] || [ "$STRUCTURED_OUTPUT" = "null" ]; then
+            echo "::error::No structured output from Claude review"
+            exit 1
           fi
 
-          # Check the verdict file Claude was instructed to write
-          if [ -f .claude-review-result ]; then
-            RESULT=$(tr -d '[:space:]' < .claude-review-result)
-            if [ "$RESULT" = "FAIL" ]; then
-              echo "::error::Claude review found critical issues that must be addressed before merging"
-              exit 1
-            fi
+          VERDICT=$(echo "$STRUCTURED_OUTPUT" | jq -r '.verdict')
+          ISSUE_COUNT=$(echo "$STRUCTURED_OUTPUT" | jq '.unfixed_blocking_issues | length')
+
+          if [ "$VERDICT" = "FAIL" ] || [ "$ISSUE_COUNT" -gt 0 ]; then
+            echo "::error::Claude review found blocking issues that must be addressed:"
+            echo "$STRUCTURED_OUTPUT" | jq -r '.unfixed_blocking_issues[] | "  - [\(.category)] \(.description)"'
+            exit 1
           fi
 
           echo "Claude review passed"


### PR DESCRIPTION
## Summary
- Replaces the file-based verdict (`.claude-review-result`) with `claude-code-action`'s `--json-schema` structured output
- Removes `continue-on-error: true` — if the review action crashes, the PR is blocked
- Uses `env:` block for shell variable passing to prevent injection from JSON strings containing quotes

## Problem
Claude inconsistently writes PASS even when it reports unfixed hard constraint violations. Four prompt-level fixes (#586, #589, #591, #592) failed to solve this. The file-based verdict is an unstructured LLM judgment call with no validation.

## Approach
The `claude-code-action` supports `--json-schema` for validated structured output. The review now returns:
```json
{
  "verdict": "PASS" | "FAIL",
  "unfixed_blocking_issues": [
    { "category": "hard-constraint-7", "description": "..." }
  ]
}
```

A deterministic shell step checks both `verdict` AND `unfixed_blocking_issues.length` (belt-and-suspenders). This catches self-contradictions where Claude sets PASS but populates the issues array.

## What changes
| Before | After |
|--------|-------|
| Claude writes PASS/FAIL to a file | Claude returns validated JSON via structured output |
| `continue-on-error: true` — crashes silently pass | No continue-on-error — crashes block the PR |
| Direct `${{ }}` interpolation in shell | `env:` block prevents shell injection |
| Verdict is pure LLM judgment | Schema-validated output + deterministic check |

## Test plan
- [ ] Open a PR with a known hard constraint violation and verify the check fails
- [ ] Open a clean PR and verify the check passes
- [ ] Verify `track_progress` and `display_report` still work with `--json-schema`

Supersedes #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)