### PR TITLE
ui: collapse other sidebar sections when expanding one (accordion)

### DIFF
--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -348,15 +348,25 @@ onBeforeUnmount(() => {
   document.removeEventListener('click', onClickOutside)
 })
 
-// Auto-expand active module section
+// Auto-expand active module section (collapse others for accordion behavior)
 watch(() => props.activeModule, (newVal) => {
   if (newVal && props.builtInManifests.some(m => m.slug === newVal)) {
+    for (const key of Object.keys(expandedSections.value)) {
+      expandedSections.value[key] = false
+    }
     expandedSections.value[newVal] = true
   }
 }, { immediate: true })
 
 function toggleSection(sectionId) {
-  expandedSections.value[sectionId] = !expandedSections.value[sectionId]
+  const wasExpanded = expandedSections.value[sectionId]
+  // Collapse all sections, then toggle the clicked one (accordion behavior)
+  for (const key of Object.keys(expandedSections.value)) {
+    expandedSections.value[key] = false
+  }
+  if (!wasExpanded) {
+    expandedSections.value[sectionId] = true
+  }
 }
 
 function resolveIcon(iconName) {


### PR DESCRIPTION
## Summary
- Changes sidebar navigation to accordion behavior — only one module section can be expanded at a time
- Clicking a section header collapses any previously open section before expanding the new one
- Navigating to a module (via route) also collapses other sections automatically

## Test plan
- [ ] Expand a module section in the sidebar, then click a different module section — the first should collapse
- [ ] Click an already-expanded section — it should collapse (no section open)
- [ ] Navigate to a module via URL/route change — its section expands and others collapse
- [ ] Verify collapsed sidebar mode still works correctly (no sections shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)