### PR TITLE
feat: tabbed feature detail page with RFE integration

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -113,6 +113,21 @@ Navigation produces URLs like: `#/<module-slug>/<view-id>?key=value`
 
 Example: `#/my-module/detail?id=123`
 
+### Cross-Module Navigation
+
+To navigate to another module's view, use the shared `useModuleLink` composable:
+
+```javascript
+import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
+
+const { navigateTo: crossNavigate } = useModuleLink()
+
+// Navigate to another module's view
+crossNavigate('feature-traffic', 'feature-detail', { key: 'RHAISTRAT-123' })
+```
+
+This produces a hash URL like `#/feature-traffic/feature-detail?key=RHAISTRAT-123` and updates `window.location.hash`. Use intra-module `moduleNav.navigateTo()` for navigation within your own module.
+
 ## Backend Entry (`server/index.js`)
 
 ```javascript

--- a/modules/ai-impact/__tests__/client/RFEReviewNavigation.test.js
+++ b/modules/ai-impact/__tests__/client/RFEReviewNavigation.test.js
@@ -100,17 +100,15 @@ describe('RFEReviewView navigation', () => {
     });
   }
 
-  it('navigates to Feature Traffic when RFE has linked feature', async () => {
+  it('opens modal when RFE has linked feature', async () => {
     const wrapper = mountView();
     const phaseContent = wrapper.findComponent(PhaseContentStub);
 
     phaseContent.vm.$emit('selectRFE', { key: 'RHAIRFE-1', summary: 'RFE with feature' });
     await nextTick();
 
-    expect(mockCrossNavigate).toHaveBeenCalledWith('feature-traffic', 'feature-detail', {
-      key: 'RHAISTRAT-10',
-      fromRfe: 'RHAIRFE-1'
-    });
+    expect(mockCrossNavigate).not.toHaveBeenCalled();
+    expect(moduleNav.navigateTo).toHaveBeenCalledWith('rfe-review', { select: 'RHAIRFE-1' });
   });
 
   it('opens modal when RFE has no linked feature', async () => {

--- a/modules/ai-impact/__tests__/client/RFEReviewNavigation.test.js
+++ b/modules/ai-impact/__tests__/client/RFEReviewNavigation.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock all dependencies before imports
+const mockApiRequest = vi.fn();
+vi.mock('@shared/client/services/api.js', () => ({
+  apiRequest: (...args) => mockApiRequest(...args)
+}));
+
+vi.mock('vue-chartjs', () => ({
+  Bar: { template: '<div />' },
+  Line: { template: '<div />' }
+}));
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  CategoryScale: {},
+  LinearScale: {},
+  BarElement: {},
+  PointElement: {},
+  LineElement: {},
+  Title: {},
+  Tooltip: {},
+  Legend: {}
+}));
+
+// Track cross-module navigation calls
+const mockCrossNavigate = vi.fn();
+vi.mock('@shared/client/composables/useModuleLink.js', () => ({
+  useModuleLink: () => ({
+    navigateTo: mockCrossNavigate,
+    linkTo: vi.fn()
+  })
+}));
+
+// Mock LoadingOverlay
+vi.mock('@shared/client/components/LoadingOverlay.vue', () => ({
+  default: { template: '<div><slot /></div>', props: ['message'] }
+}));
+
+import { mount } from '@vue/test-utils';
+import { ref, nextTick, defineComponent } from 'vue';
+import RFEReviewView from '../../client/views/RFEReviewView.vue';
+
+// Mock composables
+vi.mock('../../client/composables/useAIImpact.js', () => ({
+  useAIImpact: () => ({
+    rfeData: ref({ issues: [
+      { key: 'RHAIRFE-1', summary: 'RFE with feature', created: '2026-01-01', aiInvolvement: 'created', creatorDisplayName: 'Alice', priority: 'Major', status: 'New' },
+      { key: 'RHAIRFE-2', summary: 'RFE without feature', created: '2026-01-01', aiInvolvement: 'none', creatorDisplayName: 'Bob', priority: 'Minor', status: 'New' }
+    ], jiraHost: 'https://jira.example.com', fetchedAt: '2026-01-01' }),
+    loading: ref(false),
+    error: ref(null),
+    load: vi.fn()
+  })
+}));
+
+vi.mock('../../client/composables/useAssessments.js', () => ({
+  useAssessments: () => ({
+    assessments: ref({}),
+    loadAssessments: vi.fn(),
+    loadAssessmentDetail: vi.fn()
+  })
+}));
+
+vi.mock('../../client/composables/useFeatures.js', () => ({
+  useFeatures: () => ({
+    features: ref({
+      'RHAISTRAT-10': { key: 'RHAISTRAT-10', title: 'Linked Feature', sourceRfe: 'RHAIRFE-1', status: 'In Progress' }
+    }),
+    loadFeatures: vi.fn()
+  })
+}));
+
+const PhaseContentStub = defineComponent({
+  name: 'PhaseContent',
+  template: '<div class="phase-content"><slot /></div>',
+  props: ['phase', 'loading', 'error', 'rfeData', 'metrics', 'trendData', 'breakdown', 'filteredRFEs', 'timeWindow', 'filter', 'searchQuery', 'chartExpanded', 'assessments', 'filteredAssessments', 'sortBy', 'passFailFilter', 'priorityFilter', 'statusFilter', 'selectedRFE', 'rfeToFeature'],
+  emits: ['selectRFE', 'retry', 'update:timeWindow', 'update:filter', 'update:searchQuery', 'update:chartExpanded', 'update:sortBy', 'update:passFailFilter', 'update:priorityFilter', 'update:statusFilter']
+});
+
+describe('RFEReviewView navigation', () => {
+  const moduleNav = {
+    navigateTo: vi.fn(),
+    params: ref({})
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mountView() {
+    return mount(RFEReviewView, {
+      global: {
+        provide: { moduleNav },
+        stubs: {
+          PhaseContent: PhaseContentStub,
+          RFEDetailModal: { template: '<div class="rfe-modal" />', props: ['show', 'rfe', 'phases', 'jiraHost', 'assessment', 'loadAssessmentDetail'] },
+          AIImpactGuide: { template: '<div />' }
+        }
+      }
+    });
+  }
+
+  it('navigates to Feature Traffic when RFE has linked feature', async () => {
+    const wrapper = mountView();
+    const phaseContent = wrapper.findComponent(PhaseContentStub);
+
+    phaseContent.vm.$emit('selectRFE', { key: 'RHAIRFE-1', summary: 'RFE with feature' });
+    await nextTick();
+
+    expect(mockCrossNavigate).toHaveBeenCalledWith('feature-traffic', 'feature-detail', {
+      key: 'RHAISTRAT-10',
+      fromRfe: 'RHAIRFE-1'
+    });
+  });
+
+  it('opens modal when RFE has no linked feature', async () => {
+    const wrapper = mountView();
+    const phaseContent = wrapper.findComponent(PhaseContentStub);
+
+    phaseContent.vm.$emit('selectRFE', { key: 'RHAIRFE-2', summary: 'RFE without feature' });
+    await nextTick();
+
+    expect(mockCrossNavigate).not.toHaveBeenCalled();
+    expect(moduleNav.navigateTo).toHaveBeenCalledWith('rfe-review', { select: 'RHAIRFE-2' });
+  });
+
+  it('passes rfeToFeature prop to PhaseContent', () => {
+    const wrapper = mountView();
+    const phaseContent = wrapper.findComponent(PhaseContentStub);
+
+    expect(phaseContent.props('rfeToFeature')).toEqual({
+      'RHAIRFE-1': { key: 'RHAISTRAT-10', summary: 'Linked Feature', status: 'In Progress', fixVersions: [] }
+    });
+  });
+});

--- a/modules/ai-impact/client/components/PhaseContent.vue
+++ b/modules/ai-impact/client/components/PhaseContent.vue
@@ -24,7 +24,8 @@ const props = defineProps({
   passFailFilter: { type: String, default: 'all' },
   priorityFilter: { type: String, default: 'all' },
   statusFilter: { type: String, default: 'all' },
-  selectedRFE: { type: Object, default: null }
+  selectedRFE: { type: Object, default: null },
+  rfeToFeature: { type: Object, default: () => ({}) }
 })
 
 const emit = defineEmits([
@@ -126,6 +127,7 @@ const isEmpty = computed(() => !props.rfeData?.fetchedAt)
           :priorityFilter="priorityFilter"
           :statusFilter="statusFilter"
           :selectedRFE="selectedRFE"
+          :rfeToFeature="rfeToFeature"
           @update:filter="emit('update:filter', $event)"
           @update:searchQuery="emit('update:searchQuery', $event)"
           @update:sortBy="emit('update:sortBy', $event)"

--- a/modules/ai-impact/client/components/RFEList.vue
+++ b/modules/ai-impact/client/components/RFEList.vue
@@ -12,7 +12,8 @@ const props = defineProps({
   sortBy: { type: String, default: 'default' },
   passFailFilter: { type: String, default: 'all' },
   priorityFilter: { type: String, default: 'all' },
-  statusFilter: { type: String, default: 'all' }
+  statusFilter: { type: String, default: 'all' },
+  rfeToFeature: { type: Object, default: () => ({}) }
 })
 
 const emit = defineEmits(['update:filter', 'update:searchQuery', 'update:sortBy', 'update:passFailFilter', 'update:priorityFilter', 'update:statusFilter', 'selectRFE'])
@@ -217,6 +218,7 @@ function handleSelectRFE(rfe) {
         :rfe="rfe"
         :selected="selectedRFE?.key === rfe.key"
         :assessment="assessments[rfe.key] || null"
+        :hasLinkedFeature="!!rfeToFeature[rfe.key]"
         @select="handleSelectRFE"
       />
     </div>

--- a/modules/ai-impact/client/components/RFEListItem.vue
+++ b/modules/ai-impact/client/components/RFEListItem.vue
@@ -2,7 +2,8 @@
 defineProps({
   rfe: { type: Object, required: true },
   selected: { type: Boolean, default: false },
-  assessment: { type: Object, default: null }
+  assessment: { type: Object, default: null },
+  hasLinkedFeature: { type: Boolean, default: false }
 })
 
 const emit = defineEmits(['select'])
@@ -79,7 +80,16 @@ function getInvolvementClass(involvement) {
           </span>
         </div>
       </div>
-      <div class="flex items-center shrink-0">
+      <div class="flex items-center gap-1 shrink-0">
+        <span
+          v-if="hasLinkedFeature"
+          class="text-blue-500 dark:text-blue-400"
+          title="View Feature"
+        >
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </span>
         <svg class="h-4 w-4 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
         </svg>

--- a/modules/ai-impact/client/views/FeatureReviewView.vue
+++ b/modules/ai-impact/client/views/FeatureReviewView.vue
@@ -2,12 +2,14 @@
 import { ref, watch, inject } from 'vue'
 import { useFeatures } from '../composables/useFeatures.js'
 import { useAIImpact } from '../composables/useAIImpact.js'
+import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
 import { PHASES } from '../constants.js'
 import FeatureReviewContent from '../components/FeatureReviewContent.vue'
 import FeatureDetailPanel from '../components/FeatureDetailPanel.vue'
 import AIImpactGuide from '../components/AIImpactGuide.vue'
 
 const moduleNav = inject('moduleNav')
+const { navigateTo: crossNavigate } = useModuleLink()
 
 const selectedFeature = ref(null)
 const searchQuery = ref('')
@@ -29,9 +31,12 @@ function handleRetry() {
 }
 
 function handleSelectFeature(feature) {
-  selectedFeature.value = feature
   if (feature) {
-    moduleNav.navigateTo('feature-review', { select: feature.key })
+    // Navigate to the consolidated Feature Traffic Feature page
+    crossNavigate('feature-traffic', 'feature-detail', {
+      key: feature.key,
+      fromFeatureReview: '1'
+    })
   }
 }
 

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -3,12 +3,14 @@ import { ref, computed, watch, inject } from 'vue'
 import { useAIImpact } from '../composables/useAIImpact.js'
 import { useAssessments } from '../composables/useAssessments.js'
 import { useFeatures } from '../composables/useFeatures.js'
+import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
 import { PHASES } from '../constants.js'
 import PhaseContent from '../components/PhaseContent.vue'
 import RFEDetailModal from '../components/RFEDetailModal.vue'
 import AIImpactGuide from '../components/AIImpactGuide.vue'
 
 const moduleNav = inject('moduleNav')
+const { navigateTo: crossNavigate } = useModuleLink()
 
 const selectedRFE = ref(null)
 const notFoundRFE = ref(null)
@@ -93,8 +95,16 @@ function handleRetry() {
 }
 
 function handleSelectRFE(rfe) {
-  selectedRFE.value = rfe
-  if (rfe) {
+  const linkedFeature = rfeToFeature.value[rfe.key]
+  if (linkedFeature) {
+    // Navigate to Feature Traffic Feature page
+    crossNavigate('feature-traffic', 'feature-detail', {
+      key: linkedFeature.key,
+      fromRfe: rfe.key
+    })
+  } else {
+    // No linked feature — fall back to showing the modal
+    selectedRFE.value = rfe
     moduleNav.navigateTo('rfe-review', { select: rfe.key })
   }
 }
@@ -105,7 +115,7 @@ function handleCloseModal() {
 }
 
 function handleNavigateToFeature(featureKey) {
-  moduleNav.navigateTo('feature-review', { select: featureKey })
+  crossNavigate('feature-traffic', 'feature-detail', { key: featureKey })
 }
 
 // Handle incoming select param (cross-link from Feature Review)
@@ -150,6 +160,7 @@ watch([() => moduleNav.params.value, rfeData], ([params]) => {
       :priorityFilter="priorityFilter"
       :statusFilter="statusFilter"
       :selectedRFE="selectedRFE"
+      :rfeToFeature="rfeToFeature"
       @update:timeWindow="timeWindow = $event"
       @update:filter="filter = $event"
       @update:searchQuery="searchQuery = $event"

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -95,18 +95,8 @@ function handleRetry() {
 }
 
 function handleSelectRFE(rfe) {
-  const linkedFeature = rfeToFeature.value[rfe.key]
-  if (linkedFeature) {
-    // Navigate to Feature Traffic Feature page
-    crossNavigate('feature-traffic', 'feature-detail', {
-      key: linkedFeature.key,
-      fromRfe: rfe.key
-    })
-  } else {
-    // No linked feature — fall back to showing the modal
-    selectedRFE.value = rfe
-    moduleNav.navigateTo('rfe-review', { select: rfe.key })
-  }
+  selectedRFE.value = rfe
+  moduleNav.navigateTo('rfe-review', { select: rfe.key })
 }
 
 function handleCloseModal() {
@@ -115,7 +105,10 @@ function handleCloseModal() {
 }
 
 function handleNavigateToFeature(featureKey) {
-  crossNavigate('feature-traffic', 'feature-detail', { key: featureKey })
+  crossNavigate('feature-traffic', 'feature-detail', {
+    key: featureKey,
+    fromRfe: selectedRFE.value?.key
+  })
 }
 
 // Handle incoming select param (cross-link from Feature Review)

--- a/modules/feature-traffic/__tests__/client/AIReviewSection.test.js
+++ b/modules/feature-traffic/__tests__/client/AIReviewSection.test.js
@@ -67,35 +67,6 @@ describe('AIReviewSection', () => {
     expect(wrapper.text()).toContain('testability');
   });
 
-  it('renders source RFE assessment when present', () => {
-    const wrapper = mount(AIReviewSection, {
-      props: {
-        featureReview: {
-          latest: {
-            recommendation: 'approve',
-            sourceRfe: 'RHAIRFE-123',
-            scores: { total: 7 },
-            reviewers: {}
-          },
-          history: []
-        },
-        rfeAssessment: {
-          latest: {
-            total: 8,
-            passFail: 'PASS',
-            scores: { what: 2, why: 2, how: 2, task: 1, size: 1 }
-          },
-          history: []
-        },
-        jiraHost: 'https://redhat.atlassian.net'
-      }
-    });
-    expect(wrapper.text()).toContain('Source RFE');
-    expect(wrapper.text()).toContain('RHAIRFE-123');
-    expect(wrapper.text()).toContain('8');
-    expect(wrapper.text()).toContain('PASS');
-  });
-
   it('renders feature review history', () => {
     const wrapper = mount(AIReviewSection, {
       props: {
@@ -117,22 +88,4 @@ describe('AIReviewSection', () => {
     expect(wrapper.text()).toContain('3/8');
   });
 
-  it('shows empty RFE assessment message when sourceRfe exists but no assessment', () => {
-    const wrapper = mount(AIReviewSection, {
-      props: {
-        featureReview: {
-          latest: {
-            recommendation: 'approve',
-            sourceRfe: 'RHAIRFE-999',
-            scores: { total: 6 },
-            reviewers: {}
-          },
-          history: []
-        },
-        rfeAssessment: null
-      }
-    });
-    expect(wrapper.text()).toContain('Source RFE');
-    expect(wrapper.text()).toContain('No RFE assessment data available');
-  });
 });

--- a/modules/feature-traffic/__tests__/client/AIReviewSection.test.js
+++ b/modules/feature-traffic/__tests__/client/AIReviewSection.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AIReviewSection from '../../client/components/AIReviewSection.vue';
+
+// Mock chart.js to avoid canvas errors in tests
+vi.mock('vue-chartjs', () => ({
+  Line: { template: '<div class="mock-line-chart" />' }
+}));
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  CategoryScale: {},
+  LinearScale: {},
+  PointElement: {},
+  LineElement: {},
+  Tooltip: {}
+}));
+
+describe('AIReviewSection', () => {
+  it('shows loading state', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: { loading: true }
+    });
+    expect(wrapper.text()).toContain('Loading AI review data');
+  });
+
+  it('shows error state', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: { error: 'Server error' }
+    });
+    expect(wrapper.text()).toContain('Server error');
+  });
+
+  it('shows empty state when no feature review data', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: { featureReview: null }
+    });
+    expect(wrapper.text()).toContain('No AI review data available for this feature');
+  });
+
+  it('renders feature review data', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: {
+        featureReview: {
+          latest: {
+            recommendation: 'approve',
+            humanReviewStatus: 'approved',
+            approvedBy: 'Jane Doe',
+            approvedAt: '2026-05-01T00:00:00Z',
+            scores: { total: 7, feasibility: 2, testability: 2, scope: 2, architecture: 1 },
+            reviewers: { feasibility: 'approve', testability: 'approve', scope: 'approve', architecture: 'revise' },
+            priority: 'Major',
+            size: 'L',
+            status: 'New'
+          },
+          history: []
+        }
+      }
+    });
+    expect(wrapper.text()).toContain('AI Review');
+    expect(wrapper.text()).toContain('Approve');
+    expect(wrapper.text()).toContain('Approved');
+    expect(wrapper.text()).toContain('7/8');
+    expect(wrapper.text()).toContain('Major');
+    expect(wrapper.text()).toContain('Jane Doe');
+    // Dimension scores
+    expect(wrapper.text()).toContain('feasibility');
+    expect(wrapper.text()).toContain('testability');
+  });
+
+  it('renders source RFE assessment when present', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: {
+        featureReview: {
+          latest: {
+            recommendation: 'approve',
+            sourceRfe: 'RHAIRFE-123',
+            scores: { total: 7 },
+            reviewers: {}
+          },
+          history: []
+        },
+        rfeAssessment: {
+          latest: {
+            total: 8,
+            passFail: 'PASS',
+            scores: { what: 2, why: 2, how: 2, task: 1, size: 1 }
+          },
+          history: []
+        },
+        jiraHost: 'https://redhat.atlassian.net'
+      }
+    });
+    expect(wrapper.text()).toContain('Source RFE');
+    expect(wrapper.text()).toContain('RHAIRFE-123');
+    expect(wrapper.text()).toContain('8');
+    expect(wrapper.text()).toContain('PASS');
+  });
+
+  it('renders feature review history', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: {
+        featureReview: {
+          latest: {
+            recommendation: 'approve',
+            scores: { total: 7 },
+            reviewers: {}
+          },
+          history: [
+            { reviewedAt: '2026-04-01T00:00:00Z', scores: { total: 5 }, recommendation: 'revise' },
+            { reviewedAt: '2026-03-01T00:00:00Z', scores: { total: 3 }, recommendation: 'reject' }
+          ]
+        }
+      }
+    });
+    expect(wrapper.text()).toContain('Score History');
+    expect(wrapper.text()).toContain('5/8');
+    expect(wrapper.text()).toContain('3/8');
+  });
+
+  it('shows empty RFE assessment message when sourceRfe exists but no assessment', () => {
+    const wrapper = mount(AIReviewSection, {
+      props: {
+        featureReview: {
+          latest: {
+            recommendation: 'approve',
+            sourceRfe: 'RHAIRFE-999',
+            scores: { total: 6 },
+            reviewers: {}
+          },
+          history: []
+        },
+        rfeAssessment: null
+      }
+    });
+    expect(wrapper.text()).toContain('Source RFE');
+    expect(wrapper.text()).toContain('No RFE assessment data available');
+  });
+});

--- a/modules/feature-traffic/__tests__/client/ai-review-helpers.test.js
+++ b/modules/feature-traffic/__tests__/client/ai-review-helpers.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRecommendationClass,
+  getRecommendationLabel,
+  getRecommendationTooltip,
+  getScoreClass,
+  getReviewStatusClass,
+  getReviewStatusLabel,
+  getReviewStatusTooltip
+} from '../../client/utils/ai-review-helpers.js';
+
+describe('ai-review-helpers', () => {
+  describe('getRecommendationClass', () => {
+    it('returns green for approve', () => {
+      expect(getRecommendationClass('approve')).toContain('bg-green');
+    });
+    it('returns amber for revise', () => {
+      expect(getRecommendationClass('revise')).toContain('bg-amber');
+    });
+    it('returns red for reject', () => {
+      expect(getRecommendationClass('reject')).toContain('bg-red');
+    });
+    it('returns gray for unknown', () => {
+      expect(getRecommendationClass('unknown')).toContain('bg-gray');
+    });
+  });
+
+  describe('getRecommendationLabel', () => {
+    it('returns Approve for approve', () => {
+      expect(getRecommendationLabel('approve')).toBe('Approve');
+    });
+    it('returns Needs Revision for revise', () => {
+      expect(getRecommendationLabel('revise')).toBe('Needs Revision');
+    });
+    it('returns Reject for reject', () => {
+      expect(getRecommendationLabel('reject')).toBe('Reject');
+    });
+    it('returns raw value for unknown', () => {
+      expect(getRecommendationLabel('custom')).toBe('custom');
+    });
+    it('returns N/A for falsy', () => {
+      expect(getRecommendationLabel(null)).toBe('N/A');
+    });
+  });
+
+  describe('getRecommendationTooltip', () => {
+    it('returns tooltip for approve', () => {
+      expect(getRecommendationTooltip('approve')).toContain('approval');
+    });
+    it('returns tooltip for revise', () => {
+      expect(getRecommendationTooltip('revise')).toContain('flagged');
+    });
+    it('returns tooltip for reject', () => {
+      expect(getRecommendationTooltip('reject')).toContain('significant concerns');
+    });
+    it('returns empty string for unknown', () => {
+      expect(getRecommendationTooltip('unknown')).toBe('');
+    });
+  });
+
+  describe('getScoreClass', () => {
+    it('returns green for score 2', () => {
+      expect(getScoreClass(2)).toContain('green');
+    });
+    it('returns amber for score 1', () => {
+      expect(getScoreClass(1)).toContain('amber');
+    });
+    it('returns red for score 0', () => {
+      expect(getScoreClass(0)).toContain('red');
+    });
+  });
+
+  describe('getReviewStatusClass', () => {
+    it('returns green for approved', () => {
+      expect(getReviewStatusClass('approved')).toContain('bg-green');
+    });
+    it('returns amber for needs-review', () => {
+      expect(getReviewStatusClass('needs-review')).toContain('bg-amber');
+    });
+    it('returns yellow for awaiting-review', () => {
+      expect(getReviewStatusClass('awaiting-review')).toContain('bg-yellow');
+    });
+    it('returns gray for unknown', () => {
+      expect(getReviewStatusClass('unknown')).toContain('bg-gray');
+    });
+  });
+
+  describe('getReviewStatusLabel', () => {
+    it('returns Approved for approved', () => {
+      expect(getReviewStatusLabel('approved')).toBe('Approved');
+    });
+    it('returns Flagged for needs-review', () => {
+      expect(getReviewStatusLabel('needs-review')).toBe('Flagged');
+    });
+    it('returns Awaiting Sign-off for awaiting-review', () => {
+      expect(getReviewStatusLabel('awaiting-review')).toBe('Awaiting Sign-off');
+    });
+    it('returns Awaiting Sign-off for unknown', () => {
+      expect(getReviewStatusLabel('unknown')).toBe('Awaiting Sign-off');
+    });
+  });
+
+  describe('getReviewStatusTooltip', () => {
+    it('returns tooltip for approved', () => {
+      expect(getReviewStatusTooltip('approved')).toContain('signed off');
+    });
+    it('returns tooltip for needs-review', () => {
+      expect(getReviewStatusTooltip('needs-review')).toContain('flagged');
+    });
+    it('returns tooltip for awaiting-review', () => {
+      expect(getReviewStatusTooltip('awaiting-review')).toContain('human');
+    });
+    it('returns tooltip for unknown', () => {
+      expect(getReviewStatusTooltip('unknown')).toContain('not yet been reviewed');
+    });
+  });
+});

--- a/modules/feature-traffic/__tests__/client/useAIReview.test.js
+++ b/modules/feature-traffic/__tests__/client/useAIReview.test.js
@@ -13,9 +13,8 @@ describe('useAIReview', () => {
   });
 
   it('initializes with empty state', () => {
-    const { aiReview, rfeAssessment, aiReviewLoading, aiReviewError } = useAIReview();
+    const { aiReview, aiReviewLoading, aiReviewError } = useAIReview();
     expect(aiReview.value).toBeNull();
-    expect(rfeAssessment.value).toBeNull();
     expect(aiReviewLoading.value).toBe(false);
     expect(aiReviewError.value).toBeNull();
   });
@@ -35,26 +34,18 @@ describe('useAIReview', () => {
     expect(aiReviewLoading.value).toBe(false);
   });
 
-  it('fetches RFE assessment when sourceRfe exists', async () => {
+  it('does not fetch RFE assessment separately', async () => {
     const featureData = {
       latest: { recommendation: 'approve', sourceRfe: 'RHAIRFE-456' },
       history: []
     };
-    const rfeData = {
-      latest: { total: 8, passFail: 'PASS', scores: {} },
-      history: []
-    };
-    mockApiRequest
-      .mockResolvedValueOnce(featureData)
-      .mockResolvedValueOnce(rfeData);
+    mockApiRequest.mockResolvedValue(featureData);
 
-    const { aiReview, rfeAssessment, loadAIReview } = useAIReview();
+    const { aiReview, loadAIReview } = useAIReview();
     await loadAIReview('RHAISTRAT-123');
 
-    expect(mockApiRequest).toHaveBeenCalledTimes(2);
-    expect(mockApiRequest).toHaveBeenCalledWith('/modules/ai-impact/assessments/RHAIRFE-456');
+    expect(mockApiRequest).toHaveBeenCalledTimes(1);
     expect(aiReview.value).toEqual(featureData);
-    expect(rfeAssessment.value).toEqual(rfeData);
   });
 
   it('handles 404 gracefully (no AI Impact data)', async () => {
@@ -78,25 +69,6 @@ describe('useAIReview', () => {
     await loadAIReview('RHAISTRAT-123');
 
     expect(aiReviewError.value).toBe('Server error');
-  });
-
-  it('handles RFE fetch 404 gracefully', async () => {
-    const featureData = {
-      latest: { recommendation: 'approve', sourceRfe: 'RHAIRFE-456' },
-      history: []
-    };
-    const rfeErr = new Error('Not Found');
-    rfeErr.status = 404;
-    mockApiRequest
-      .mockResolvedValueOnce(featureData)
-      .mockRejectedValueOnce(rfeErr);
-
-    const { aiReview, rfeAssessment, aiReviewError, loadAIReview } = useAIReview();
-    await loadAIReview('RHAISTRAT-123');
-
-    expect(aiReview.value).toEqual(featureData);
-    expect(rfeAssessment.value).toBeNull();
-    expect(aiReviewError.value).toBeNull();
   });
 
   it('manages loading state', async () => {

--- a/modules/feature-traffic/__tests__/client/useAIReview.test.js
+++ b/modules/feature-traffic/__tests__/client/useAIReview.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApiRequest = vi.fn();
+vi.mock('@shared/client/services/api.js', () => ({
+  apiRequest: (...args) => mockApiRequest(...args)
+}));
+
+import { useAIReview } from '../../client/composables/useAIReview.js';
+
+describe('useAIReview', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset();
+  });
+
+  it('initializes with empty state', () => {
+    const { aiReview, rfeAssessment, aiReviewLoading, aiReviewError } = useAIReview();
+    expect(aiReview.value).toBeNull();
+    expect(rfeAssessment.value).toBeNull();
+    expect(aiReviewLoading.value).toBe(false);
+    expect(aiReviewError.value).toBeNull();
+  });
+
+  it('loads feature review data on happy path', async () => {
+    const featureData = {
+      latest: { recommendation: 'approve', scores: { total: 7 } },
+      history: []
+    };
+    mockApiRequest.mockResolvedValue(featureData);
+
+    const { aiReview, aiReviewLoading, loadAIReview } = useAIReview();
+    await loadAIReview('RHAISTRAT-123');
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/modules/ai-impact/features/RHAISTRAT-123');
+    expect(aiReview.value).toEqual(featureData);
+    expect(aiReviewLoading.value).toBe(false);
+  });
+
+  it('fetches RFE assessment when sourceRfe exists', async () => {
+    const featureData = {
+      latest: { recommendation: 'approve', sourceRfe: 'RHAIRFE-456' },
+      history: []
+    };
+    const rfeData = {
+      latest: { total: 8, passFail: 'PASS', scores: {} },
+      history: []
+    };
+    mockApiRequest
+      .mockResolvedValueOnce(featureData)
+      .mockResolvedValueOnce(rfeData);
+
+    const { aiReview, rfeAssessment, loadAIReview } = useAIReview();
+    await loadAIReview('RHAISTRAT-123');
+
+    expect(mockApiRequest).toHaveBeenCalledTimes(2);
+    expect(mockApiRequest).toHaveBeenCalledWith('/modules/ai-impact/assessments/RHAIRFE-456');
+    expect(aiReview.value).toEqual(featureData);
+    expect(rfeAssessment.value).toEqual(rfeData);
+  });
+
+  it('handles 404 gracefully (no AI Impact data)', async () => {
+    const err = new Error('Not Found');
+    err.status = 404;
+    mockApiRequest.mockRejectedValue(err);
+
+    const { aiReview, aiReviewError, loadAIReview } = useAIReview();
+    await loadAIReview('RHAISTRAT-999');
+
+    expect(aiReview.value).toBeNull();
+    expect(aiReviewError.value).toBeNull();
+  });
+
+  it('sets error for non-404 failures', async () => {
+    const err = new Error('Server error');
+    err.status = 500;
+    mockApiRequest.mockRejectedValue(err);
+
+    const { aiReviewError, loadAIReview } = useAIReview();
+    await loadAIReview('RHAISTRAT-123');
+
+    expect(aiReviewError.value).toBe('Server error');
+  });
+
+  it('handles RFE fetch 404 gracefully', async () => {
+    const featureData = {
+      latest: { recommendation: 'approve', sourceRfe: 'RHAIRFE-456' },
+      history: []
+    };
+    const rfeErr = new Error('Not Found');
+    rfeErr.status = 404;
+    mockApiRequest
+      .mockResolvedValueOnce(featureData)
+      .mockRejectedValueOnce(rfeErr);
+
+    const { aiReview, rfeAssessment, aiReviewError, loadAIReview } = useAIReview();
+    await loadAIReview('RHAISTRAT-123');
+
+    expect(aiReview.value).toEqual(featureData);
+    expect(rfeAssessment.value).toBeNull();
+    expect(aiReviewError.value).toBeNull();
+  });
+
+  it('manages loading state', async () => {
+    mockApiRequest.mockResolvedValue({ latest: {}, history: [] });
+
+    const { aiReviewLoading, loadAIReview } = useAIReview();
+    const promise = loadAIReview('RHAISTRAT-123');
+    expect(aiReviewLoading.value).toBe(true);
+    await promise;
+    expect(aiReviewLoading.value).toBe(false);
+  });
+
+  it('resets state before each load', async () => {
+    const featureData = { latest: { recommendation: 'approve' }, history: [] };
+    mockApiRequest.mockResolvedValue(featureData);
+
+    const { aiReview, loadAIReview } = useAIReview();
+    await loadAIReview('RHAISTRAT-1');
+    expect(aiReview.value).toBeTruthy();
+
+    const err = new Error('Not Found');
+    err.status = 404;
+    mockApiRequest.mockRejectedValue(err);
+    await loadAIReview('RHAISTRAT-2');
+    expect(aiReview.value).toBeNull();
+  });
+});

--- a/modules/feature-traffic/client/components/AIAssessmentBreakdown.vue
+++ b/modules/feature-traffic/client/components/AIAssessmentBreakdown.vue
@@ -1,0 +1,108 @@
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  assessment: { type: Object, required: true },
+  detail: { type: Object, default: null }
+})
+
+const expandedCriteria = ref({})
+
+function toggleCriterion(name) {
+  expandedCriteria.value[name] = !expandedCriteria.value[name]
+}
+
+const CRITERIA_LABELS = {
+  what: 'What',
+  why: 'Why',
+  how: 'How',
+  task: 'Task',
+  size: 'Size'
+}
+
+function getScoreClass(score) {
+  if (score === 2) return 'bg-green-500'
+  if (score === 1) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+function getPassFailClass(passFail) {
+  return passFail === 'PASS'
+    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-300 dark:border-green-700'
+    : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300 border-red-300 dark:border-red-700'
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- Total Score Badge -->
+    <div class="flex items-center gap-3">
+      <div
+        class="flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm font-semibold"
+        :class="getPassFailClass(assessment.passFail)"
+      >
+        <span class="text-lg">{{ assessment.total }}</span>
+        <span class="text-xs font-normal">/10</span>
+        <span class="ml-1 text-xs font-medium uppercase">{{ assessment.passFail }}</span>
+      </div>
+    </div>
+
+    <!-- Criterion Rows -->
+    <div class="space-y-1">
+      <div
+        v-for="(label, key) in CRITERIA_LABELS"
+        :key="key"
+        class="rounded-md"
+      >
+        <button
+          class="w-full flex items-center justify-between px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors"
+          :class="{ 'cursor-default': !detail?.latest?.criterionNotes?.[key] }"
+          @click="detail?.latest?.criterionNotes?.[key] ? toggleCriterion(key) : null"
+        >
+          <span class="flex items-center gap-3">
+            <span class="font-medium dark:text-gray-200 w-12">{{ label }}</span>
+            <!-- Score dots -->
+            <span class="flex gap-1">
+              <span
+                v-for="i in 2"
+                :key="i"
+                class="w-3 h-3 rounded-full"
+                :class="i <= assessment.scores[key] ? getScoreClass(assessment.scores[key]) : 'bg-gray-200 dark:bg-gray-600'"
+              />
+            </span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ assessment.scores[key] }}/2</span>
+          </span>
+          <svg
+            v-if="detail?.latest?.criterionNotes?.[key]"
+            class="h-3.5 w-3.5 text-gray-400 transition-transform"
+            :class="{ 'rotate-180': expandedCriteria[key] }"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        <!-- Expandable justification -->
+        <div
+          v-if="expandedCriteria[key] && detail?.latest?.criterionNotes?.[key]"
+          class="px-3 pb-2 pl-8 text-xs text-gray-600 dark:text-gray-400"
+        >
+          {{ detail.latest.criterionNotes[key] }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Anti-patterns -->
+    <div v-if="assessment.antiPatterns && assessment.antiPatterns.length > 0" class="pt-1">
+      <p class="text-xs text-gray-500 dark:text-gray-400 mb-1.5">Anti-patterns detected</p>
+      <div class="flex flex-wrap gap-1.5">
+        <span
+          v-for="pattern in assessment.antiPatterns"
+          :key="pattern"
+          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+        >
+          {{ pattern }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/modules/feature-traffic/client/components/AIAssessmentHistory.vue
+++ b/modules/feature-traffic/client/components/AIAssessmentHistory.vue
@@ -1,0 +1,143 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { Line } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip
+} from 'chart.js'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip)
+
+const props = defineProps({
+  history: { type: Array, default: () => [] },
+  currentTotal: { type: Number, default: 0 },
+  currentAssessedAt: { type: String, default: '' },
+  currentScores: { type: Object, default: null }
+})
+
+const expanded = ref(false)
+
+// Combine current + history for the sparkline, sorted oldest-first
+const allEntries = computed(() => {
+  const current = { total: props.currentTotal, assessedAt: props.currentAssessedAt, scores: props.currentScores }
+  const entries = [current, ...props.history]
+  return entries.sort((a, b) => new Date(a.assessedAt) - new Date(b.assessedAt))
+})
+
+const chartData = computed(() => ({
+  labels: allEntries.value.map(e =>
+    new Date(e.assessedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  ),
+  datasets: [{
+    data: allEntries.value.map(e => e.total),
+    borderColor: '#6366f1',
+    backgroundColor: 'rgba(99, 102, 241, 0.1)',
+    fill: true,
+    tension: 0.3,
+    pointRadius: 3,
+    pointBackgroundColor: allEntries.value.map(e =>
+      e.total >= 5 ? '#10b981' : '#ef4444'
+    )
+  }]
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => `Score: ${ctx.parsed.y}/10`
+      }
+    }
+  },
+  scales: {
+    x: { ticks: { font: { size: 9 } } },
+    y: { min: 0, max: 10, ticks: { font: { size: 9 }, stepSize: 2 } }
+  }
+}
+
+const CRITERIA = ['what', 'why', 'how', 'task', 'size']
+
+// Compute diffs between consecutive entries (newest-first for display)
+const diffs = computed(() => {
+  if (allEntries.value.length < 2) return []
+  const result = []
+  // Iterate newest to oldest
+  const reversed = [...allEntries.value].reverse()
+  for (let i = 0; i < reversed.length - 1; i++) {
+    const newer = reversed[i]
+    const older = reversed[i + 1]
+    if (!newer.scores || !older.scores) continue
+    const changes = {}
+    for (const c of CRITERIA) {
+      const diff = (newer.scores[c] || 0) - (older.scores[c] || 0)
+      if (diff !== 0) changes[c] = diff
+    }
+    result.push({
+      date: new Date(newer.assessedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+      totalDiff: newer.total - older.total,
+      changes
+    })
+  }
+  return result
+})
+</script>
+
+<template>
+  <div v-if="history.length > 0">
+    <button
+      @click="expanded = !expanded"
+      class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+    >
+      <svg
+        class="h-3.5 w-3.5 transition-transform"
+        :class="{ 'rotate-90': expanded }"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+      Score History ({{ history.length }} prior {{ history.length === 1 ? 'assessment' : 'assessments' }})
+    </button>
+
+    <div v-if="expanded" class="mt-3 space-y-3">
+      <!-- Sparkline -->
+      <div class="h-[100px] bg-gray-50 dark:bg-gray-700/50 rounded-md p-2">
+        <Line :data="chartData" :options="chartOptions" />
+      </div>
+
+      <!-- Diff details -->
+      <div v-if="diffs.length > 0" class="space-y-2">
+        <div
+          v-for="(diff, i) in diffs"
+          :key="i"
+          class="text-xs text-gray-600 dark:text-gray-400"
+        >
+          <span class="font-medium">{{ diff.date }}:</span>
+          <span
+            class="ml-1"
+            :class="diff.totalDiff > 0 ? 'text-green-600 dark:text-green-400' : diff.totalDiff < 0 ? 'text-red-600 dark:text-red-400' : ''"
+          >
+            {{ diff.totalDiff > 0 ? '+' : '' }}{{ diff.totalDiff }} total
+          </span>
+          <template v-if="Object.keys(diff.changes).length > 0">
+            <span class="mx-1">&mdash;</span>
+            <span
+              v-for="(change, criterion) in diff.changes"
+              :key="criterion"
+              class="mr-2"
+              :class="change > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'"
+            >
+              {{ criterion }}: {{ change > 0 ? '+' : '' }}{{ change }}
+            </span>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/modules/feature-traffic/client/components/AIFeedbackText.vue
+++ b/modules/feature-traffic/client/components/AIFeedbackText.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  text: { type: String, default: '' }
+})
+
+/**
+ * Parse text into structured lines for safe rendering.
+ * Supports:
+ * - Bullet points (lines starting with - or *)
+ * - Inline bold (**text**)
+ * - Line breaks
+ * No v-html is used anywhere.
+ */
+const feedbackLines = computed(() => {
+  if (!props.text) return []
+  return props.text.split('\n').map(line => {
+    const trimmed = line.trimStart()
+    const isBullet = trimmed.startsWith('- ') || trimmed.startsWith('* ')
+    return {
+      type: isBullet ? 'bullet' : 'text',
+      text: isBullet ? trimmed.slice(2) : line,
+      segments: parseInlineBold(isBullet ? trimmed.slice(2) : line)
+    }
+  })
+})
+
+/**
+ * Split text into segments of bold and normal text.
+ * Handles **bold** markers without v-html.
+ */
+function parseInlineBold(text) {
+  const segments = []
+  const regex = /\*\*(.+?)\*\*/g
+  let lastIndex = 0
+  let match
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ bold: false, text: text.slice(lastIndex, match.index) })
+    }
+    segments.push({ bold: true, text: match[1] })
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ bold: false, text: text.slice(lastIndex) })
+  }
+
+  if (segments.length === 0 && text) {
+    segments.push({ bold: false, text })
+  }
+
+  return segments
+}
+</script>
+
+<template>
+  <div class="text-sm text-gray-700 dark:text-gray-300 space-y-0.5">
+    <template v-for="(line, i) in feedbackLines" :key="i">
+      <div v-if="line.type === 'bullet'" class="pl-4 flex">
+        <span class="mr-2 text-gray-400">&bull;</span>
+        <span>
+          <template v-for="(seg, j) in line.segments" :key="j">
+            <strong v-if="seg.bold">{{ seg.text }}</strong>
+            <span v-else>{{ seg.text }}</span>
+          </template>
+        </span>
+      </div>
+      <div v-else-if="line.text.trim() === ''" class="h-2" />
+      <div v-else>
+        <template v-for="(seg, j) in line.segments" :key="j">
+          <strong v-if="seg.bold">{{ seg.text }}</strong>
+          <span v-else>{{ seg.text }}</span>
+        </template>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/feature-traffic/client/components/AIInfoBubble.vue
+++ b/modules/feature-traffic/client/components/AIInfoBubble.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+defineProps({
+  text: { type: String, required: true }
+})
+
+const TOOLTIP_W = 256 // w-64
+const GAP = 8
+
+const open = ref(false)
+const el = ref(null)
+const tooltipStyle = ref({})
+const vPos = ref('above')
+const arrowLeft = ref('50%')
+
+function toggle(e) {
+  e.stopPropagation()
+  if (open.value) {
+    open.value = false
+    return
+  }
+  if (el.value) {
+    const rect = el.value.getBoundingClientRect()
+    const centerX = rect.left + rect.width / 2
+
+    // Vertical: prefer above, fall back to below
+    const above = rect.top > 100
+    vPos.value = above ? 'above' : 'below'
+
+    // Horizontal: center on icon, but clamp to viewport
+    let left = centerX - TOOLTIP_W / 2
+    left = Math.max(GAP, Math.min(left, window.innerWidth - TOOLTIP_W - GAP))
+
+    // Arrow tracks the icon center relative to the tooltip left edge
+    arrowLeft.value = Math.max(12, Math.min(centerX - left, TOOLTIP_W - 12)) + 'px'
+
+    tooltipStyle.value = {
+      position: 'fixed',
+      left: left + 'px',
+      top: above ? (rect.top - GAP) + 'px' : (rect.bottom + GAP) + 'px',
+      transform: above ? 'translateY(-100%)' : 'none',
+      width: TOOLTIP_W + 'px',
+      zIndex: 9999
+    }
+  }
+  open.value = true
+}
+
+function onClickOutside(e) {
+  if (el.value && !el.value.contains(e.target)) {
+    open.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('click', onClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', onClickOutside))
+</script>
+
+<template>
+  <span class="inline-flex" ref="el">
+    <button
+      @click="toggle"
+      class="ml-1 inline-flex items-center justify-center w-4 h-4 rounded-full text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+      aria-label="More info"
+    >
+      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+      </svg>
+    </button>
+    <Teleport to="body">
+      <Transition name="fade">
+        <div
+          v-if="open"
+          :style="tooltipStyle"
+          class="px-3 py-2 text-xs text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg"
+        >
+          <!-- Arrow above tooltip (tooltip is below icon) -->
+          <div v-if="vPos === 'below'" class="absolute bottom-full mb-px" :style="{ left: arrowLeft, transform: 'translateX(-50%)' }">
+            <div class="w-2 h-2 bg-white dark:bg-gray-700 border-l border-t border-gray-200 dark:border-gray-600 rotate-45 translate-y-1" />
+          </div>
+          {{ text }}
+          <!-- Arrow below tooltip (tooltip is above icon) -->
+          <div v-if="vPos === 'above'" class="absolute top-full -mt-px" :style="{ left: arrowLeft, transform: 'translateX(-50%)' }">
+            <div class="w-2 h-2 bg-white dark:bg-gray-700 border-r border-b border-gray-200 dark:border-gray-600 rotate-45 -translate-y-1" />
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+  </span>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/modules/feature-traffic/client/components/AIReviewSection.vue
+++ b/modules/feature-traffic/client/components/AIReviewSection.vue
@@ -9,16 +9,11 @@ import {
   getReviewStatusTooltip
 } from '../utils/ai-review-helpers.js'
 import AIInfoBubble from './AIInfoBubble.vue'
-import AIFeedbackText from './AIFeedbackText.vue'
-import AIAssessmentBreakdown from './AIAssessmentBreakdown.vue'
-import AIAssessmentHistory from './AIAssessmentHistory.vue'
 
 defineProps({
   featureReview: { type: Object, default: null },
-  rfeAssessment: { type: Object, default: null },
   loading: { type: Boolean, default: false },
-  error: { type: String, default: null },
-  jiraHost: { type: String, default: null }
+  error: { type: String, default: null }
 })
 
 const DIMENSIONS = ['feasibility', 'testability', 'scope', 'architecture']
@@ -159,58 +154,6 @@ const DIMENSIONS = ['feasibility', 'testability', 'scope', 'architecture']
         </div>
       </div>
 
-      <!-- Source RFE Section -->
-      <div v-if="featureReview.latest?.sourceRfe" class="border-t border-gray-200 dark:border-gray-700 pt-4">
-        <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
-          Source RFE
-          <a
-            v-if="jiraHost"
-            :href="`${jiraHost}/browse/${featureReview.latest.sourceRfe}`"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="ml-2 font-mono text-blue-600 dark:text-blue-400 hover:underline normal-case"
-          >
-            {{ featureReview.latest.sourceRfe }}
-            <svg class="inline h-3 w-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-            </svg>
-          </a>
-          <span v-else class="ml-2 font-mono normal-case dark:text-gray-300">{{ featureReview.latest.sourceRfe }}</span>
-        </h4>
-
-        <!-- RFE Assessment -->
-        <template v-if="rfeAssessment?.latest">
-          <div class="space-y-4">
-            <AIAssessmentBreakdown
-              :assessment="rfeAssessment.latest"
-              :detail="rfeAssessment"
-            />
-
-            <!-- Verdict -->
-            <div v-if="rfeAssessment.latest.verdict" class="pt-2">
-              <h5 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Verdict</h5>
-              <p class="text-sm text-gray-700 dark:text-gray-300">{{ rfeAssessment.latest.verdict }}</p>
-            </div>
-
-            <!-- Feedback -->
-            <div v-if="rfeAssessment.latest.feedback">
-              <h5 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Feedback</h5>
-              <AIFeedbackText :text="rfeAssessment.latest.feedback" />
-            </div>
-
-            <!-- Assessment History -->
-            <AIAssessmentHistory
-              :history="rfeAssessment.history || []"
-              :currentTotal="rfeAssessment.latest.total"
-              :currentAssessedAt="rfeAssessment.latest.assessedAt"
-              :currentScores="rfeAssessment.latest.scores"
-            />
-          </div>
-        </template>
-        <div v-else class="text-sm text-gray-400 dark:text-gray-500 italic">
-          No RFE assessment data available.
-        </div>
-      </div>
     </template>
   </div>
 </template>

--- a/modules/feature-traffic/client/components/AIReviewSection.vue
+++ b/modules/feature-traffic/client/components/AIReviewSection.vue
@@ -1,0 +1,216 @@
+<script setup>
+import {
+  getRecommendationClass,
+  getRecommendationLabel,
+  getRecommendationTooltip,
+  getScoreClass,
+  getReviewStatusClass,
+  getReviewStatusLabel,
+  getReviewStatusTooltip
+} from '../utils/ai-review-helpers.js'
+import AIInfoBubble from './AIInfoBubble.vue'
+import AIFeedbackText from './AIFeedbackText.vue'
+import AIAssessmentBreakdown from './AIAssessmentBreakdown.vue'
+import AIAssessmentHistory from './AIAssessmentHistory.vue'
+
+defineProps({
+  featureReview: { type: Object, default: null },
+  rfeAssessment: { type: Object, default: null },
+  loading: { type: Boolean, default: false },
+  error: { type: String, default: null },
+  jiraHost: { type: String, default: null }
+})
+
+const DIMENSIONS = ['feasibility', 'testability', 'scope', 'architecture']
+</script>
+
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">AI Review</h2>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
+      Loading AI review data...
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-lg p-3 text-red-700 dark:text-red-400 text-sm">
+      {{ error }}
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!featureReview" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-8 text-center">
+      <p class="text-sm text-gray-500 dark:text-gray-400">No AI review data available for this feature.</p>
+    </div>
+
+    <!-- Feature review data -->
+    <template v-else>
+      <!-- Metadata grid -->
+      <div class="grid grid-cols-3 gap-4 mb-6 text-sm">
+        <div>
+          <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">AI Recommendation</p>
+          <span class="inline-flex items-center">
+            <span
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+              :class="getRecommendationClass(featureReview.latest?.recommendation)"
+            >
+              {{ getRecommendationLabel(featureReview.latest?.recommendation) }}
+            </span>
+            <AIInfoBubble :text="getRecommendationTooltip(featureReview.latest?.recommendation)" />
+          </span>
+        </div>
+        <div>
+          <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Review Status</p>
+          <span class="inline-flex items-center">
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium"
+              :class="getReviewStatusClass(featureReview.latest?.humanReviewStatus)"
+            >
+              <svg v-if="featureReview.latest?.humanReviewStatus === 'needs-review'" class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+              {{ getReviewStatusLabel(featureReview.latest?.humanReviewStatus) }}
+            </span>
+            <AIInfoBubble :text="getReviewStatusTooltip(featureReview.latest?.humanReviewStatus)" />
+          </span>
+        </div>
+        <div>
+          <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Score</p>
+          <p class="font-bold" :class="getScoreClass(Math.round((featureReview.latest?.scores?.total || 0) / 2))">
+            {{ featureReview.latest?.scores?.total || 0 }}/8
+          </p>
+        </div>
+        <div>
+          <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Priority</p>
+          <span class="inline-flex items-center px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-xs capitalize dark:text-gray-300">
+            {{ featureReview.latest?.priority || 'N/A' }}
+          </span>
+        </div>
+        <div>
+          <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Size</p>
+          <p class="font-medium dark:text-gray-200">{{ featureReview.latest?.size || 'N/A' }}</p>
+        </div>
+        <div>
+          <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Status</p>
+          <p class="font-medium dark:text-gray-200">{{ featureReview.latest?.status || 'N/A' }}</p>
+        </div>
+      </div>
+
+      <!-- Approval info -->
+      <div v-if="featureReview.latest?.humanReviewStatus === 'approved' && featureReview.latest?.approvedBy" class="mb-6 px-3 py-2.5 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
+        <div class="flex items-center gap-2 text-sm text-green-800 dark:text-green-300">
+          <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+          <span>
+            Approved by <span class="font-medium">{{ featureReview.latest.approvedBy }}</span>
+            <span v-if="featureReview.latest.approvedAt" class="text-green-600 dark:text-green-400">
+              on {{ new Date(featureReview.latest.approvedAt).toLocaleDateString() }}
+            </span>
+          </span>
+        </div>
+      </div>
+
+      <!-- Dimension Scores -->
+      <div class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
+        <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Dimension Scores</h4>
+        <div class="grid grid-cols-2 gap-2">
+          <div
+            v-for="dim in DIMENSIONS"
+            :key="dim"
+            class="p-3 rounded-lg border border-gray-200 dark:border-gray-600"
+          >
+            <p class="text-xs text-gray-500 dark:text-gray-400 capitalize mb-1">{{ dim }}</p>
+            <div class="flex items-center justify-between">
+              <span class="text-lg font-bold" :class="getScoreClass(featureReview.latest?.scores?.[dim])">
+                {{ featureReview.latest?.scores?.[dim] ?? 0 }}/2
+              </span>
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                :class="getRecommendationClass(featureReview.latest?.reviewers?.[dim])"
+              >
+                {{ featureReview.latest?.reviewers?.[dim] === 'approve' ? 'Pass' : featureReview.latest?.reviewers?.[dim] === 'revise' ? 'Revise' : featureReview.latest?.reviewers?.[dim] === 'reject' ? 'Fail' : getRecommendationLabel(featureReview.latest?.reviewers?.[dim]) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Feature Review History -->
+      <div v-if="featureReview.history?.length > 0" class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
+        <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Score History</h4>
+        <div class="space-y-2">
+          <div
+            v-for="(entry, idx) in featureReview.history"
+            :key="idx"
+            class="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700 last:border-0"
+          >
+            <span class="text-xs text-gray-500 dark:text-gray-400">
+              {{ new Date(entry.reviewedAt).toLocaleDateString() }}
+            </span>
+            <div class="flex items-center gap-2">
+              <span class="text-sm font-medium" :class="getScoreClass(Math.round((entry.scores?.total || 0) / 2))">
+                {{ entry.scores?.total || 0 }}/8
+              </span>
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                :class="getRecommendationClass(entry.recommendation)"
+              >
+                {{ getRecommendationLabel(entry.recommendation) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Source RFE Section -->
+      <div v-if="featureReview.latest?.sourceRfe" class="border-t border-gray-200 dark:border-gray-700 pt-4">
+        <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+          Source RFE
+          <a
+            v-if="jiraHost"
+            :href="`${jiraHost}/browse/${featureReview.latest.sourceRfe}`"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="ml-2 font-mono text-blue-600 dark:text-blue-400 hover:underline normal-case"
+          >
+            {{ featureReview.latest.sourceRfe }}
+            <svg class="inline h-3 w-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
+          <span v-else class="ml-2 font-mono normal-case dark:text-gray-300">{{ featureReview.latest.sourceRfe }}</span>
+        </h4>
+
+        <!-- RFE Assessment -->
+        <template v-if="rfeAssessment?.latest">
+          <div class="space-y-4">
+            <AIAssessmentBreakdown
+              :assessment="rfeAssessment.latest"
+              :detail="rfeAssessment"
+            />
+
+            <!-- Verdict -->
+            <div v-if="rfeAssessment.latest.verdict" class="pt-2">
+              <h5 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Verdict</h5>
+              <p class="text-sm text-gray-700 dark:text-gray-300">{{ rfeAssessment.latest.verdict }}</p>
+            </div>
+
+            <!-- Feedback -->
+            <div v-if="rfeAssessment.latest.feedback">
+              <h5 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Feedback</h5>
+              <AIFeedbackText :text="rfeAssessment.latest.feedback" />
+            </div>
+
+            <!-- Assessment History -->
+            <AIAssessmentHistory
+              :history="rfeAssessment.history || []"
+              :currentTotal="rfeAssessment.latest.total"
+              :currentAssessedAt="rfeAssessment.latest.assessedAt"
+              :currentScores="rfeAssessment.latest.scores"
+            />
+          </div>
+        </template>
+        <div v-else class="text-sm text-gray-400 dark:text-gray-500 italic">
+          No RFE assessment data available.
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/feature-traffic/client/composables/useAIReview.js
+++ b/modules/feature-traffic/client/composables/useAIReview.js
@@ -2,8 +2,7 @@ import { ref } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 
 export function useAIReview() {
-  const aiReview = ref(null)         // Feature review data (RHAISTRAT)
-  const rfeAssessment = ref(null)    // Linked RFE assessment (RHAIRFE)
+  const aiReview = ref(null)
   const aiReviewLoading = ref(false)
   const aiReviewError = ref(null)
 
@@ -11,26 +10,11 @@ export function useAIReview() {
     aiReviewLoading.value = true
     aiReviewError.value = null
     aiReview.value = null
-    rfeAssessment.value = null
 
     try {
-      // 1. Fetch AI Impact feature review
-      const featureData = await apiRequest(
+      aiReview.value = await apiRequest(
         `/modules/ai-impact/features/${encodeURIComponent(featureKey)}`
       )
-      aiReview.value = featureData
-
-      // 2. If it has a linked RFE, fetch the RFE assessment
-      const sourceRfe = featureData?.latest?.sourceRfe
-      if (sourceRfe) {
-        try {
-          rfeAssessment.value = await apiRequest(
-            `/modules/ai-impact/assessments/${encodeURIComponent(sourceRfe)}`
-          )
-        } catch {
-          // 404 expected if RFE hasn't been assessed yet
-        }
-      }
     } catch (e) {
       // 404 = no AI Impact data for this feature (expected).
       // Also handles the case where the AI Impact module is disabled —
@@ -45,5 +29,5 @@ export function useAIReview() {
     }
   }
 
-  return { aiReview, rfeAssessment, aiReviewLoading, aiReviewError, loadAIReview }
+  return { aiReview, aiReviewLoading, aiReviewError, loadAIReview }
 }

--- a/modules/feature-traffic/client/composables/useAIReview.js
+++ b/modules/feature-traffic/client/composables/useAIReview.js
@@ -1,0 +1,49 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+export function useAIReview() {
+  const aiReview = ref(null)         // Feature review data (RHAISTRAT)
+  const rfeAssessment = ref(null)    // Linked RFE assessment (RHAIRFE)
+  const aiReviewLoading = ref(false)
+  const aiReviewError = ref(null)
+
+  async function loadAIReview(featureKey) {
+    aiReviewLoading.value = true
+    aiReviewError.value = null
+    aiReview.value = null
+    rfeAssessment.value = null
+
+    try {
+      // 1. Fetch AI Impact feature review
+      const featureData = await apiRequest(
+        `/modules/ai-impact/features/${encodeURIComponent(featureKey)}`
+      )
+      aiReview.value = featureData
+
+      // 2. If it has a linked RFE, fetch the RFE assessment
+      const sourceRfe = featureData?.latest?.sourceRfe
+      if (sourceRfe) {
+        try {
+          rfeAssessment.value = await apiRequest(
+            `/modules/ai-impact/assessments/${encodeURIComponent(sourceRfe)}`
+          )
+        } catch {
+          // 404 expected if RFE hasn't been assessed yet
+        }
+      }
+    } catch (e) {
+      // 404 = no AI Impact data for this feature (expected).
+      // Also handles the case where the AI Impact module is disabled —
+      // when disabled, its routes are not mounted (module-loader.js:194)
+      // and Express returns a default 404. apiRequest sets e.status on
+      // the Error object in both cases.
+      if (e.status !== 404) {
+        aiReviewError.value = e.message
+      }
+    } finally {
+      aiReviewLoading.value = false
+    }
+  }
+
+  return { aiReview, rfeAssessment, aiReviewLoading, aiReviewError, loadAIReview }
+}

--- a/modules/feature-traffic/client/utils/ai-review-helpers.js
+++ b/modules/feature-traffic/client/utils/ai-review-helpers.js
@@ -1,0 +1,59 @@
+export function getRecommendationClass(rec) {
+  switch (rec) {
+    case 'approve': return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+    case 'revise': return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+    case 'reject': return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'
+    default: return 'bg-gray-100 text-gray-600'
+  }
+}
+
+export function getRecommendationLabel(rec) {
+  switch (rec) {
+    case 'approve': return 'Approve'
+    case 'revise': return 'Needs Revision'
+    case 'reject': return 'Reject'
+    default: return rec || 'N/A'
+  }
+}
+
+export function getReviewStatusClass(status) {
+  switch (status) {
+    case 'approved': return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+    case 'needs-review': return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
+    case 'awaiting-review': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200'
+    default: return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+  }
+}
+
+export function getReviewStatusLabel(status) {
+  switch (status) {
+    case 'approved': return 'Approved'
+    case 'needs-review': return 'Flagged'
+    case 'awaiting-review': return 'Awaiting Sign-off'
+    default: return 'Awaiting Sign-off'
+  }
+}
+
+export function getReviewStatusTooltip(status) {
+  switch (status) {
+    case 'approved': return 'A human engineer has reviewed and signed off on this feature. No further action needed.'
+    case 'needs-review': return 'The AI pipeline flagged concerns. Open in Jira, add feedback in the Staff Engineer Input section of the description, then remove the strat-creator-needs-attention label to unblock re-refinement.'
+    case 'awaiting-review': return 'This feature passed AI review but still needs a human to review and sign off. Open in Jira and add the strat-creator-human-sign-off label when ready.'
+    default: return 'This feature has not yet been reviewed by a human. Open in Jira to review and sign off.'
+  }
+}
+
+export function getRecommendationTooltip(rec) {
+  switch (rec) {
+    case 'approve': return 'All AI reviewers recommend approval. The feature still needs human sign-off.'
+    case 'revise': return 'One or more AI reviewers flagged issues to address before this feature is ready.'
+    case 'reject': return 'AI reviewers found significant concerns. This feature needs rework before proceeding.'
+    default: return ''
+  }
+}
+
+export function getScoreClass(score) {
+  if (score === 2) return 'text-green-600 dark:text-green-400'
+  if (score === 1) return 'text-amber-600 dark:text-amber-400'
+  return 'text-red-600 dark:text-red-400'
+}

--- a/modules/feature-traffic/client/views/FeatureDetailView.vue
+++ b/modules/feature-traffic/client/views/FeatureDetailView.vue
@@ -11,7 +11,7 @@ import AIReviewSection from '../components/AIReviewSection.vue'
 
 const nav = inject('moduleNav')
 const { feature, loading, error, loadFeature } = useFeatureDetail()
-const { aiReview, rfeAssessment, aiReviewLoading, aiReviewError, loadAIReview } = useAIReview()
+const { aiReview, aiReviewLoading, aiReviewError, loadAIReview } = useAIReview()
 const { navigateTo: crossNavigate } = useModuleLink()
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse/'
@@ -88,6 +88,8 @@ function renderStatusNotes(notes) {
 }
 
 const ownerStatusColor = computed(() => feature.value?.ownerStatusColor || null)
+
+const sourceRfeKey = computed(() => aiReview.value?.latest?.sourceRfe || null)
 
 const featureKey = computed(() => nav.params.value.key)
 
@@ -328,6 +330,24 @@ onMounted(() => {
               <span v-if="feature.assignee">Owner: <span class="text-gray-700 dark:text-gray-300">{{ feature.assignee.displayName }}</span></span>
               <span v-if="feature.pm">PM: <span class="text-gray-700 dark:text-gray-300">{{ feature.pm.displayName }}</span></span>
               <span v-if="feature.releaseType">Release type: <span class="text-gray-700 dark:text-gray-300">{{ feature.releaseType }}</span></span>
+              <span v-if="sourceRfeKey" class="flex items-center gap-1">
+                Source RFE:
+                <button
+                  class="font-mono text-primary-600 dark:text-blue-400 hover:underline"
+                  @click="crossNavigate('ai-impact', 'rfe-review', { select: sourceRfeKey })"
+                >{{ sourceRfeKey }}</button>
+                <a
+                  :href="JIRA_BASE + sourceRfeKey"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                  title="Open in Jira"
+                >
+                  <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+              </span>
               <span>Created: {{ formatDate(feature.created) }}</span>
               <span>Updated: {{ formatDate(feature.updated) }}</span>
               <span
@@ -632,10 +652,8 @@ onMounted(() => {
       <div v-if="tabActivated['ai-review']" v-show="activeTab === 'ai-review'">
         <AIReviewSection
           :featureReview="aiReview"
-          :rfeAssessment="rfeAssessment"
           :loading="aiReviewLoading"
           :error="aiReviewError"
-          :jiraHost="JIRA_BASE.replace('/browse/', '')"
         />
       </div>
 

--- a/modules/feature-traffic/client/views/FeatureDetailView.vue
+++ b/modules/feature-traffic/client/views/FeatureDetailView.vue
@@ -1,13 +1,18 @@
 <script setup>
 import { onMounted, inject, computed } from 'vue'
 import { useFeatureDetail } from '../composables/useFeatureTraffic'
+import { useAIReview } from '../composables/useAIReview.js'
+import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
 import StatusBadge from '../components/StatusBadge.vue'
 import TrafficMap from '../components/TrafficMap.vue'
 import EpicBreakdown from '../components/EpicBreakdown.vue'
 import SignoffSection from '../components/SignoffSection.vue'
+import AIReviewSection from '../components/AIReviewSection.vue'
 
 const nav = inject('moduleNav')
 const { feature, loading, error, loadFeature } = useFeatureDetail()
+const { aiReview, rfeAssessment, aiReviewLoading, aiReviewError, loadAIReview } = useAIReview()
+const { navigateTo: crossNavigate } = useModuleLink()
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse/'
 
@@ -101,8 +106,17 @@ const hasDeliveryInsight = computed(() => {
   return Array.isArray(t.stages) && t.stages.length > 0
 })
 
+const fromRfe = computed(() => nav.params.value.fromRfe)
+const fromFeatureReview = computed(() => nav.params.value.fromFeatureReview)
+
 function goBack() {
-  nav.navigateTo('overview')
+  if (fromRfe.value) {
+    crossNavigate('ai-impact', 'rfe-review', { select: fromRfe.value })
+  } else if (fromFeatureReview.value) {
+    crossNavigate('ai-impact', 'feature-review')
+  } else {
+    nav.navigateTo('overview')
+  }
 }
 
 const trafficSignals = computed(() => feature.value?.trafficSignals || null)
@@ -228,6 +242,7 @@ function formatDate(iso) {
 onMounted(() => {
   if (featureKey.value) {
     loadFeature(featureKey.value)
+    loadAIReview(featureKey.value)
   }
 })
 </script>
@@ -239,7 +254,7 @@ onMounted(() => {
       class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white flex items-center gap-1"
       @click="goBack"
     >
-      &larr; Back to Overview
+      &larr; {{ fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : 'Back to Overview' }}
     </button>
 
     <!-- Loading -->
@@ -379,6 +394,15 @@ onMounted(() => {
           {{ ageDays(feature.created) }} days active
         </div>
       </div>
+
+      <!-- AI Review Section -->
+      <AIReviewSection
+        :featureReview="aiReview"
+        :rfeAssessment="rfeAssessment"
+        :loading="aiReviewLoading"
+        :error="aiReviewError"
+        :jiraHost="JIRA_BASE.replace('/browse/', '')"
+      />
 
       <!-- Traffic Signals (blockers / warnings / flowing) -->
       <div

--- a/modules/feature-traffic/client/views/FeatureDetailView.vue
+++ b/modules/feature-traffic/client/views/FeatureDetailView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, inject, computed } from 'vue'
+import { onMounted, inject, computed, ref, watch, nextTick } from 'vue'
 import { useFeatureDetail } from '../composables/useFeatureTraffic'
 import { useAIReview } from '../composables/useAIReview.js'
 import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
@@ -239,6 +239,46 @@ function formatDate(iso) {
   return new Date(iso).toLocaleDateString()
 }
 
+// --- Tabs ---
+const activeTab = ref('ai-review')
+const tabActivated = ref({ 'ai-review': true, 'traffic-signals': false, epics: false, 'source-code': false })
+
+const TAB_ICONS = {
+  'traffic-signals': '<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />',
+  'ai-review': '<path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714a2.25 2.25 0 00.659 1.591L19 14.5M14.25 3.104c.251.023.501.05.75.082M19 14.5l-2.47 2.47a2.25 2.25 0 01-1.59.659H9.06a2.25 2.25 0 01-1.591-.659L5 14.5m14 0V5a2 2 0 00-2-2H7a2 2 0 00-2 2v9.5" />',
+  epics: '<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />',
+  'source-code': '<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" />',
+}
+
+const visibleTabs = computed(() => {
+  const tabs = [
+    { id: 'ai-review', label: 'AI Review', icon: TAB_ICONS['ai-review'] },
+    { id: 'traffic-signals', label: 'Traffic Signals', icon: TAB_ICONS['traffic-signals'] },
+    { id: 'epics', label: 'Epics', icon: TAB_ICONS.epics },
+    { id: 'source-code', label: 'Source Code', icon: TAB_ICONS['source-code'] },
+  ]
+  return tabs
+})
+
+const VALID_TABS = ['traffic-signals', 'ai-review', 'epics', 'source-code']
+let updatingFromUrl = false
+
+watch(activeTab, (tab) => {
+  tabActivated.value[tab] = true
+  if (!updatingFromUrl) {
+    nav.updateParams({ tab: tab === 'ai-review' ? undefined : tab })
+  }
+})
+
+watch(() => nav.params.value?.tab, (tabParam) => {
+  const tab = tabParam && VALID_TABS.includes(tabParam) ? tabParam : 'ai-review'
+  if (activeTab.value !== tab) {
+    updatingFromUrl = true
+    activeTab.value = tab
+    nextTick(() => { updatingFromUrl = false })
+  }
+}, { immediate: true })
+
 onMounted(() => {
   if (featureKey.value) {
     loadFeature(featureKey.value)
@@ -312,8 +352,16 @@ onMounted(() => {
         <SignoffSection v-if="signoffValidation" collapsible :validation="signoffValidation" />
       </div>
 
-      <!-- Progress Summary -->
-      <div v-if="metricsData" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+      <!-- Progress Summary (always visible above tabs) -->
+      <div v-if="feature.status === 'New'" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <div class="flex items-center gap-3 text-gray-500 dark:text-gray-400 text-sm">
+          <svg class="h-5 w-5 text-gray-400 dark:text-gray-500 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          This feature is in <span class="font-medium text-gray-700 dark:text-gray-300">New</span> status. Progress tracking will appear once work begins.
+        </div>
+      </div>
+      <div v-else-if="metricsData" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
         <div class="flex flex-col md:flex-row items-start md:items-center gap-6">
           <!-- Donut chart -->
           <div class="flex-shrink-0">
@@ -395,236 +443,204 @@ onMounted(() => {
         </div>
       </div>
 
-      <!-- AI Review Section -->
-      <AIReviewSection
-        :featureReview="aiReview"
-        :rfeAssessment="rfeAssessment"
-        :loading="aiReviewLoading"
-        :error="aiReviewError"
-        :jiraHost="JIRA_BASE.replace('/browse/', '')"
-      />
-
-      <!-- Traffic Signals (blockers / warnings / flowing) -->
-      <div
-        v-if="trafficSignals"
-        class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
-      >
-        <div class="px-5 py-3 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-baseline justify-between gap-2">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Traffic Signals</h2>
-          <span
-            v-if="trafficSignals.generatedAt"
-            class="text-[10px] text-gray-400 dark:text-gray-500 tabular-nums"
+      <!-- Tab Bar -->
+      <div class="border-b-2 border-gray-200 dark:border-gray-700">
+        <nav class="flex gap-8">
+          <button
+            v-for="tab in visibleTabs"
+            :key="tab.id"
+            @click="activeTab = tab.id"
+            class="flex items-center gap-2 pb-3 pt-1 text-base font-medium border-b-2 -mb-[2px] transition-colors"
+            :class="activeTab === tab.id
+              ? 'border-primary-600 text-primary-600 dark:border-primary-400 dark:text-primary-400'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
           >
-            Derived {{ formatSignalTime(trafficSignals.generatedAt) }}
-            <span v-if="trafficSignals.source" class="text-gray-400"> · {{ trafficSignals.source }}</span>
-          </span>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-gray-200 dark:divide-gray-700">
-          <!-- Blockers / risks -->
-          <div class="p-4 bg-red-50/80 dark:bg-red-500/5">
-            <div class="flex items-center gap-2 text-red-700 dark:text-red-400 font-semibold text-sm mb-3">
-              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-red-200/80 dark:bg-red-900/40 text-xs" aria-hidden="true">!</span>
-              Blockers / risks
-            </div>
-            <ul v-if="(trafficSignals.blockers || []).length" class="space-y-3">
-              <li v-for="(item, idx) in trafficSignals.blockers" :key="'b-' + idx" class="space-y-1">
-                <div class="text-sm font-medium text-red-800 dark:text-red-300">
-                  <template v-for="(part, pi) in splitIssueLinkParts(item.title)" :key="'bt-' + idx + '-' + pi">
-                    <a
-                      v-if="part.kind === 'key'"
-                      :href="issueHref(part.key)"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
-                    >{{ part.key }}</a>
-                    <span v-else>{{ part.text }}</span>
-                  </template>
-                </div>
-                <p class="text-xs text-red-900/80 dark:text-red-200/80 mt-0.5 leading-relaxed">
-                  <template v-for="(part, pi) in splitIssueLinkParts(item.detail)" :key="'bd-' + idx + '-' + pi">
-                    <a
-                      v-if="part.kind === 'key'"
-                      :href="issueHref(part.key)"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
-                    >{{ part.key }}</a>
-                    <span v-else>{{ part.text }}</span>
-                  </template>
-                </p>
-                <div v-if="signalIssueKeys(item).length" class="flex flex-wrap gap-1 mt-1">
-                  <a
-                    v-for="ik in signalIssueKeys(item)"
-                    :key="ik"
-                    :href="issueHref(ik)"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono leading-none transition-colors"
-                    :class="trafficIssueChipClass('blocker')"
-                  >{{ ik }}</a>
-                </div>
-              </li>
-            </ul>
-            <p v-else class="text-xs text-red-600/70 dark:text-red-400/60 italic">No blockers identified from ticket data.</p>
+            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" v-html="tab.icon"></svg>
+            {{ tab.label }}
+          </button>
+        </nav>
+      </div>
+
+      <!-- Tab Panels -->
+
+      <!-- Traffic Signals Tab -->
+      <div v-if="tabActivated['traffic-signals']" v-show="activeTab === 'traffic-signals'">
+        <div
+          v-if="trafficSignals"
+          class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="px-5 py-3 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-baseline justify-between gap-2">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Traffic Signals</h2>
+            <span
+              v-if="trafficSignals.generatedAt"
+              class="text-[10px] text-gray-400 dark:text-gray-500 tabular-nums"
+            >
+              Derived {{ formatSignalTime(trafficSignals.generatedAt) }}
+              <span v-if="trafficSignals.source" class="text-gray-400"> · {{ trafficSignals.source }}</span>
+            </span>
           </div>
-          <!-- Warnings -->
-          <div class="p-4 bg-amber-50/80 dark:bg-amber-500/5">
-            <div class="flex items-center gap-2 text-amber-800 dark:text-amber-400 font-semibold text-sm mb-3">
-              <span class="inline-flex h-6 w-6 items-center justify-center rounded bg-amber-200/80 dark:bg-amber-900/40 text-xs" aria-hidden="true">▲</span>
-              Warnings
+          <div class="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-gray-200 dark:divide-gray-700">
+            <!-- Blockers / risks -->
+            <div class="p-4 bg-red-50/80 dark:bg-red-500/5">
+              <div class="flex items-center gap-2 text-red-700 dark:text-red-400 font-semibold text-sm mb-3">
+                <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-red-200/80 dark:bg-red-900/40 text-xs" aria-hidden="true">!</span>
+                Blockers / risks
+              </div>
+              <ul v-if="(trafficSignals.blockers || []).length" class="space-y-3">
+                <li v-for="(item, idx) in trafficSignals.blockers" :key="'b-' + idx" class="space-y-1">
+                  <div class="text-sm font-medium text-red-800 dark:text-red-300">
+                    <template v-for="(part, pi) in splitIssueLinkParts(item.title)" :key="'bt-' + idx + '-' + pi">
+                      <a
+                        v-if="part.kind === 'key'"
+                        :href="issueHref(part.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
+                      >{{ part.key }}</a>
+                      <span v-else>{{ part.text }}</span>
+                    </template>
+                  </div>
+                  <p class="text-xs text-red-900/80 dark:text-red-200/80 mt-0.5 leading-relaxed">
+                    <template v-for="(part, pi) in splitIssueLinkParts(item.detail)" :key="'bd-' + idx + '-' + pi">
+                      <a
+                        v-if="part.kind === 'key'"
+                        :href="issueHref(part.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
+                      >{{ part.key }}</a>
+                      <span v-else>{{ part.text }}</span>
+                    </template>
+                  </p>
+                  <div v-if="signalIssueKeys(item).length" class="flex flex-wrap gap-1 mt-1">
+                    <a
+                      v-for="ik in signalIssueKeys(item)"
+                      :key="ik"
+                      :href="issueHref(ik)"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono leading-none transition-colors"
+                      :class="trafficIssueChipClass('blocker')"
+                    >{{ ik }}</a>
+                  </div>
+                </li>
+              </ul>
+              <p v-else class="text-xs text-red-600/70 dark:text-red-400/60 italic">No blockers identified from ticket data.</p>
             </div>
-            <ul v-if="(trafficSignals.warnings || []).length" class="space-y-3">
-              <li v-for="(item, idx) in trafficSignals.warnings" :key="'w-' + idx" class="space-y-1">
-                <div class="text-sm font-medium text-amber-900 dark:text-amber-300">
-                  <template v-for="(part, pi) in splitIssueLinkParts(item.title)" :key="'wt-' + idx + '-' + pi">
+            <!-- Warnings -->
+            <div class="p-4 bg-amber-50/80 dark:bg-amber-500/5">
+              <div class="flex items-center gap-2 text-amber-800 dark:text-amber-400 font-semibold text-sm mb-3">
+                <span class="inline-flex h-6 w-6 items-center justify-center rounded bg-amber-200/80 dark:bg-amber-900/40 text-xs" aria-hidden="true">▲</span>
+                Warnings
+              </div>
+              <ul v-if="(trafficSignals.warnings || []).length" class="space-y-3">
+                <li v-for="(item, idx) in trafficSignals.warnings" :key="'w-' + idx" class="space-y-1">
+                  <div class="text-sm font-medium text-amber-900 dark:text-amber-300">
+                    <template v-for="(part, pi) in splitIssueLinkParts(item.title)" :key="'wt-' + idx + '-' + pi">
+                      <a
+                        v-if="part.kind === 'key'"
+                        :href="issueHref(part.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
+                      >{{ part.key }}</a>
+                      <span v-else>{{ part.text }}</span>
+                    </template>
+                  </div>
+                  <p class="text-xs text-amber-900/80 dark:text-amber-100/80 mt-0.5 leading-relaxed">
+                    <template v-for="(part, pi) in splitIssueLinkParts(item.detail)" :key="'wd-' + idx + '-' + pi">
+                      <a
+                        v-if="part.kind === 'key'"
+                        :href="issueHref(part.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
+                      >{{ part.key }}</a>
+                      <span v-else>{{ part.text }}</span>
+                    </template>
+                  </p>
+                  <div v-if="signalIssueKeys(item).length" class="flex flex-wrap gap-1 mt-1">
                     <a
-                      v-if="part.kind === 'key'"
-                      :href="issueHref(part.key)"
+                      v-for="ik in signalIssueKeys(item)"
+                      :key="ik"
+                      :href="issueHref(ik)"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
-                    >{{ part.key }}</a>
-                    <span v-else>{{ part.text }}</span>
-                  </template>
-                </div>
-                <p class="text-xs text-amber-900/80 dark:text-amber-100/80 mt-0.5 leading-relaxed">
-                  <template v-for="(part, pi) in splitIssueLinkParts(item.detail)" :key="'wd-' + idx + '-' + pi">
-                    <a
-                      v-if="part.kind === 'key'"
-                      :href="issueHref(part.key)"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
-                    >{{ part.key }}</a>
-                    <span v-else>{{ part.text }}</span>
-                  </template>
-                </p>
-                <div v-if="signalIssueKeys(item).length" class="flex flex-wrap gap-1 mt-1">
-                  <a
-                    v-for="ik in signalIssueKeys(item)"
-                    :key="ik"
-                    :href="issueHref(ik)"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono leading-none transition-colors"
-                    :class="trafficIssueChipClass('warning')"
-                  >{{ ik }}</a>
-                </div>
-              </li>
-            </ul>
-            <p v-else class="text-xs text-amber-700/70 dark:text-amber-400/60 italic">No warnings identified from ticket data.</p>
-          </div>
-          <!-- Flowing well -->
-          <div class="p-4 bg-green-50/80 dark:bg-green-500/5">
-            <div class="flex items-center gap-2 text-green-800 dark:text-green-400 font-semibold text-sm mb-3">
-              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-200/80 dark:bg-green-900/40 text-xs" aria-hidden="true">✓</span>
-              Flowing well
+                      class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono leading-none transition-colors"
+                      :class="trafficIssueChipClass('warning')"
+                    >{{ ik }}</a>
+                  </div>
+                </li>
+              </ul>
+              <p v-else class="text-xs text-amber-700/70 dark:text-amber-400/60 italic">No warnings identified from ticket data.</p>
             </div>
-            <ul v-if="(trafficSignals.flowing || []).length" class="space-y-3">
-              <li v-for="(item, idx) in trafficSignals.flowing" :key="'f-' + idx" class="space-y-1">
-                <div class="text-sm font-medium text-green-900 dark:text-green-300">
-                  <template v-for="(part, pi) in splitIssueLinkParts(item.title)" :key="'ft-' + idx + '-' + pi">
+            <!-- Flowing well -->
+            <div class="p-4 bg-green-50/80 dark:bg-green-500/5">
+              <div class="flex items-center gap-2 text-green-800 dark:text-green-400 font-semibold text-sm mb-3">
+                <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-200/80 dark:bg-green-900/40 text-xs" aria-hidden="true">✓</span>
+                Flowing well
+              </div>
+              <ul v-if="(trafficSignals.flowing || []).length" class="space-y-3">
+                <li v-for="(item, idx) in trafficSignals.flowing" :key="'f-' + idx" class="space-y-1">
+                  <div class="text-sm font-medium text-green-900 dark:text-green-300">
+                    <template v-for="(part, pi) in splitIssueLinkParts(item.title)" :key="'ft-' + idx + '-' + pi">
+                      <a
+                        v-if="part.kind === 'key'"
+                        :href="issueHref(part.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
+                      >{{ part.key }}</a>
+                      <span v-else>{{ part.text }}</span>
+                    </template>
+                  </div>
+                  <p class="text-xs text-green-900/80 dark:text-green-100/80 mt-0.5 leading-relaxed">
+                    <template v-for="(part, pi) in splitIssueLinkParts(item.detail)" :key="'fd-' + idx + '-' + pi">
+                      <a
+                        v-if="part.kind === 'key'"
+                        :href="issueHref(part.key)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
+                      >{{ part.key }}</a>
+                      <span v-else>{{ part.text }}</span>
+                    </template>
+                  </p>
+                  <div v-if="signalIssueKeys(item).length" class="flex flex-wrap gap-1 mt-1">
                     <a
-                      v-if="part.kind === 'key'"
-                      :href="issueHref(part.key)"
+                      v-for="ik in signalIssueKeys(item)"
+                      :key="ik"
+                      :href="issueHref(ik)"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
-                    >{{ part.key }}</a>
-                    <span v-else>{{ part.text }}</span>
-                  </template>
-                </div>
-                <p class="text-xs text-green-900/80 dark:text-green-100/80 mt-0.5 leading-relaxed">
-                  <template v-for="(part, pi) in splitIssueLinkParts(item.detail)" :key="'fd-' + idx + '-' + pi">
-                    <a
-                      v-if="part.kind === 'key'"
-                      :href="issueHref(part.key)"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-primary-600 dark:text-blue-400 hover:underline font-mono"
-                    >{{ part.key }}</a>
-                    <span v-else>{{ part.text }}</span>
-                  </template>
-                </p>
-                <div v-if="signalIssueKeys(item).length" class="flex flex-wrap gap-1 mt-1">
-                  <a
-                    v-for="ik in signalIssueKeys(item)"
-                    :key="ik"
-                    :href="issueHref(ik)"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono leading-none transition-colors"
-                    :class="trafficIssueChipClass('flowing')"
-                  >{{ ik }}</a>
-                </div>
-              </li>
-            </ul>
-            <p v-else class="text-xs text-green-700/70 dark:text-green-400/60 italic">Nothing highlighted yet.</p>
+                      class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono leading-none transition-colors"
+                      :class="trafficIssueChipClass('flowing')"
+                    >{{ ik }}</a>
+                  </div>
+                </li>
+              </ul>
+              <p v-else class="text-xs text-green-700/70 dark:text-green-400/60 italic">Nothing highlighted yet.</p>
+            </div>
           </div>
+        </div>
+        <div v-else class="text-center py-12 text-gray-500 dark:text-gray-400 text-sm">
+          No traffic signal data available for this feature.
         </div>
       </div>
 
-      <div
-        v-if="validationErrors.length"
-        class="bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg p-4"
-      >
-        <div class="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
-          Component hygiene (epic not on feature)
-        </div>
-        <p class="text-xs text-amber-900/80 dark:text-amber-100/80 mb-2">
-          Repos are derived from the feature's Jira components only. Epics that list a component
-          the feature does not include should be fixed in Jira.
-        </p>
-        <ul class="list-disc list-inside text-sm text-amber-900 dark:text-amber-100 space-y-1">
-          <li v-for="(err, idx) in validationErrors" :key="idx">
-            <span class="font-mono">{{ err.epicKey }}</span> — <span class="font-medium">{{ err.component }}</span>
-          </li>
-        </ul>
-      </div>
-
-      <div
-        v-if="unknownFeatureComponents.length"
-        class="bg-rose-50 dark:bg-rose-500/10 border border-rose-200 dark:border-rose-500/30 rounded-lg p-4"
-      >
-        <div class="text-sm font-semibold text-rose-800 dark:text-rose-200 mb-1">Unmapped Jira components</div>
-        <p class="text-xs text-rose-900/80 dark:text-rose-100/80">
-          Add these to
-          <code class="px-1 rounded bg-rose-100/80 dark:bg-rose-900/40">feature-traffic/context/rhoai-components.yaml</code> or fix the feature in Jira:
-        </p>
-        <p class="text-sm mt-1 font-mono text-rose-800 dark:text-rose-200">{{ unknownFeatureComponents.join(', ') }}</p>
-      </div>
-
-      <div
-        v-if="hasDeliveryInsight"
-        class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
-      >
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Delivery view (heuristic)</h2>
-        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-          Dashboard &amp; backend integration is inferred from component roles, not from every API surface.
-        </p>
-        <ul class="text-sm text-gray-700 dark:text-gray-300 space-y-1 list-disc list-inside">
-          <li v-if="deliveryIntegration?.dashboardConsumesBackend">
-            Dashboard is treated as consumer of feature backend APIs.
-          </li>
-          <li v-if="deliveryIntegration?.notebookIntegration">Notebook / workbench integration (parallel to dashboard when applicable).</li>
-          <li v-if="deliveryIntegration?.stages?.length">
-            Stages: {{ (deliveryIntegration.stages || []).join(' → ') }}
-          </li>
-        </ul>
-      </div>
-
-      <!-- Traffic map — hidden via SHOW_DELIVERY_PIPELINE; markup kept for easy restore -->
-      <div v-if="SHOW_DELIVERY_PIPELINE">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Delivery Pipeline</h2>
-        <TrafficMap
-          :repos="feature.topology?.repos || []"
-          :epics="feature.epics || []"
-          :health="feature.metrics?.health || 'YELLOW'"
+      <!-- AI Review Tab -->
+      <div v-if="tabActivated['ai-review']" v-show="activeTab === 'ai-review'">
+        <AIReviewSection
+          :featureReview="aiReview"
+          :rfeAssessment="rfeAssessment"
+          :loading="aiReviewLoading"
+          :error="aiReviewError"
+          :jiraHost="JIRA_BASE.replace('/browse/', '')"
         />
       </div>
 
-      <!-- Epic breakdown -->
-      <div>
+      <!-- Epics Tab -->
+      <div v-if="tabActivated.epics" v-show="activeTab === 'epics'">
         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
           Epic Breakdown
           <span class="text-sm font-normal text-gray-500 dark:text-gray-400">({{ (feature.epics || []).length }} epics)</span>
@@ -632,40 +648,113 @@ onMounted(() => {
         <EpicBreakdown :epics="feature.epics || []" />
       </div>
 
-      <!-- Repo breakdown -->
-      <div v-if="(feature.topology?.repos || []).length > 0">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Repository Breakdown</h2>
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-gray-200 dark:border-gray-700">
-                <th class="px-4 py-2 text-left text-gray-500 dark:text-gray-400">Repository</th>
-                <th class="px-4 py-2 text-left text-gray-500 dark:text-gray-400">Components</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="repo in feature.topology.repos"
-                :key="repo.url"
-                class="border-b border-gray-100 dark:border-gray-800"
-              >
-                <td class="px-4 py-2">
-                  <a
-                    :href="'https://' + repo.url"
-                    class="text-primary-600 dark:text-blue-400 hover:underline text-xs"
-                    target="_blank"
-                  >{{ repo.url }}</a>
-                </td>
-                <td class="px-4 py-2">
-                  <span
-                    v-for="c in (repo.components || [])"
-                    :key="c"
-                    class="inline-block px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs mr-1 mb-1"
-                  >{{ c }}</span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+      <!-- Source Code Tab -->
+      <div v-if="tabActivated['source-code']" v-show="activeTab === 'source-code'" class="space-y-6">
+        <!-- Component mismatches -->
+        <div
+          v-if="validationErrors.length"
+          class="bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg p-4"
+        >
+          <div class="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
+            Component mismatches
+          </div>
+          <p class="text-xs text-amber-900/80 dark:text-amber-100/80 mb-2">
+            Repositories are derived from the feature's Jira components. These epics reference a component
+            not listed on the feature — fix in Jira to ensure correct repo mapping.
+          </p>
+          <ul class="list-disc list-inside text-sm text-amber-900 dark:text-amber-100 space-y-1">
+            <li v-for="(err, idx) in validationErrors" :key="idx">
+              <span class="font-mono">{{ err.epicKey }}</span> — <span class="font-medium">{{ err.component }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Unmapped components -->
+        <div
+          v-if="unknownFeatureComponents.length"
+          class="bg-rose-50 dark:bg-rose-500/10 border border-rose-200 dark:border-rose-500/30 rounded-lg p-4"
+        >
+          <div class="text-sm font-semibold text-rose-800 dark:text-rose-200 mb-1">Unmapped components</div>
+          <p class="text-xs text-rose-900/80 dark:text-rose-100/80">
+            These Jira components have no known repository mapping. Add them to
+            <code class="px-1 rounded bg-rose-100/80 dark:bg-rose-900/40">feature-traffic/context/rhoai-components.yaml</code> or correct the feature in Jira:
+          </p>
+          <p class="text-sm mt-1 font-mono text-rose-800 dark:text-rose-200">{{ unknownFeatureComponents.join(', ') }}</p>
+        </div>
+
+        <!-- Integration view -->
+        <div
+          v-if="hasDeliveryInsight"
+          class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
+        >
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Integration patterns</h2>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            Inferred from Jira component roles — how the feature's repositories connect.
+          </p>
+          <ul class="text-sm text-gray-700 dark:text-gray-300 space-y-1 list-disc list-inside">
+            <li v-if="deliveryIntegration?.dashboardConsumesBackend">
+              Dashboard is treated as consumer of feature backend APIs.
+            </li>
+            <li v-if="deliveryIntegration?.notebookIntegration">Notebook / workbench integration (parallel to dashboard when applicable).</li>
+            <li v-if="deliveryIntegration?.stages?.length">
+              Stages: {{ (deliveryIntegration.stages || []).join(' → ') }}
+            </li>
+          </ul>
+        </div>
+
+        <!-- Traffic map — hidden via SHOW_DELIVERY_PIPELINE; markup kept for easy restore -->
+        <div v-if="SHOW_DELIVERY_PIPELINE">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Delivery Pipeline</h2>
+          <TrafficMap
+            :repos="feature.topology?.repos || []"
+            :epics="feature.epics || []"
+            :health="feature.metrics?.health || 'YELLOW'"
+          />
+        </div>
+
+        <!-- Repo breakdown -->
+        <div v-if="(feature.topology?.repos || []).length > 0">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Repository Breakdown</h2>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 dark:border-gray-700">
+                  <th class="px-4 py-2 text-left text-gray-500 dark:text-gray-400">Repository</th>
+                  <th class="px-4 py-2 text-left text-gray-500 dark:text-gray-400">Components</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="repo in feature.topology.repos"
+                  :key="repo.url"
+                  class="border-b border-gray-100 dark:border-gray-800"
+                >
+                  <td class="px-4 py-2">
+                    <a
+                      :href="'https://' + repo.url"
+                      class="text-primary-600 dark:text-blue-400 hover:underline text-xs"
+                      target="_blank"
+                    >{{ repo.url }}</a>
+                  </td>
+                  <td class="px-4 py-2">
+                    <span
+                      v-for="c in (repo.components || [])"
+                      :key="c"
+                      class="inline-block px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs mr-1 mb-1"
+                    >{{ c }}</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Empty state when no source code data -->
+        <div
+          v-if="!validationErrors.length && !unknownFeatureComponents.length && !hasDeliveryInsight && !(feature.topology?.repos || []).length"
+          class="text-center py-12 text-gray-500 dark:text-gray-400 text-sm"
+        >
+          No repository or component data available for this feature.
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Summary

- Refactor the Feature Traffic feature detail page to use a tabbed layout (matching team detail page style)
- Tabs: **AI Review** (default), **Traffic Signals**, **Epics**, **Source Code**
- Header and progress summary stay above the tabs as persistent context
- Show placeholder for progress summary when feature status is "New"
- Move source RFE link to the feature header metadata row — clicking navigates to the RFE Review page with the detail modal open, external link icon opens Jira
- Fix RFE Review page so clicking an RFE always opens the detail modal (previously it navigated away when a linked feature existed)
- Simplify AI Review tab by removing the RFE assessment breakdown (users navigate to the full RFE review via the header link instead)
- Deep-linkable tabs via `&tab=` URL param

## Test plan

- [ ] Navigate to a feature detail page — verify AI Review tab is shown by default
- [ ] Switch between all four tabs — verify content renders correctly
- [ ] Verify tab state persists in URL (`&tab=traffic-signals`, `&tab=epics`, `&tab=source-code`)
- [ ] Verify a "New" status feature shows the placeholder instead of the progress summary
- [ ] Click the source RFE link in the header — verify it navigates to RFE Review with the modal open
- [ ] Click the external link icon next to the source RFE — verify it opens Jira
- [ ] On the RFE Review page, click an RFE that has a linked feature — verify the modal opens (not a navigation)
- [ ] From the RFE modal, click the linked feature — verify it navigates to the feature detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)