### PR TITLE
feat: add scope restrictions to API tokens

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,6 +166,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/site-config` — site configuration
 - `/api/messages` — app-wide messages (computed + stored)
 - `/api/tokens` — current user's API tokens
+- `/api/token-scopes` — available scope catalog and presets
 - `/api/admin/tokens` — all API tokens (admin)
 - `/api/roster` — org/team structure with members
 - `/api/team/:teamKey/metrics` — team member metrics
@@ -270,6 +271,8 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/health-metrics/viewers` — add viewer (admin)
 
 **PATCH:**
+- `/api/tokens/:id/scopes` — update own token scopes
+- `/api/admin/tokens/:id/scopes` — update any token scopes (admin)
 - `/api/modules/team-tracker/structure/teams/:teamId` — rename team (admin/team-admin)
 - `/api/modules/team-tracker/structure/field-definitions/person/:fieldId` — edit field def (admin/team-admin)
 - `/api/modules/team-tracker/structure/field-definitions/team/:fieldId` — edit field def (admin/team-admin)

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -734,6 +734,7 @@ Stores hashed API tokens for bearer-token authentication. Created on first token
       "tokenHash": "sha256-hex-of-full-token",
       "tokenPrefix": "tt_a1b2c3d4",
       "ownerEmail": "user@redhat.com",
+      "scopes": ["roster:read", "metrics:read"],
       "createdAt": "2026-04-03T12:00:00Z",
       "expiresAt": "2026-07-03T12:00:00Z",
       "lastUsedAt": "2026-04-03T14:30:00Z"
@@ -745,6 +746,7 @@ Stores hashed API tokens for bearer-token authentication. Created on first token
 **Notes:**
 - Raw tokens are never stored — only SHA-256 hashes.
 - `tokenPrefix` stores the first 11 characters (e.g., `tt_a1b2c3d4`) for identification.
+- `scopes` controls which API endpoints the token can access. Values: an array of scope strings (e.g., `["roster:read", "metrics:write"]`), `["*"]` for wildcard full access, `[]` for no access (except `tokens:manage`), or `null` for legacy full access. Legacy tokens without a `scopes` field are treated as `null` (full access). `tokens:manage` is always implicitly granted.
 - `expiresAt` is `null` for non-expiring tokens.
 - `lastUsedAt` is `null` until first use, then updated (throttled to once per 60 seconds).
 

--- a/modules/ai-impact/__tests__/server/assessment-routes.test.js
+++ b/modules/ai-impact/__tests__/server/assessment-routes.test.js
@@ -28,7 +28,8 @@ function makeContext(storageData = null) {
     storage: {
       readFromStorage: vi.fn().mockReturnValue(storageData)
     },
-    requireAdmin: (req, res, next) => next()
+    requireAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next()
   };
 }
 

--- a/modules/ai-impact/__tests__/server/feature-routes.test.js
+++ b/modules/ai-impact/__tests__/server/feature-routes.test.js
@@ -32,7 +32,8 @@ function makeContext(storageData = null) {
     storage: {
       readFromStorage: vi.fn().mockReturnValue(storageData)
     },
-    requireAdmin: (req, res, next) => next()
+    requireAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next()
   };
 }
 

--- a/modules/ai-impact/server/assessments/routes.js
+++ b/modules/ai-impact/server/assessments/routes.js
@@ -27,13 +27,13 @@ const BULK_CAP = 5000;
  * @param {object} context - Module context with storage and auth middleware
  */
 module.exports = function registerAssessmentRoutes(router, context) {
-  const { storage, requireAdmin } = context;
+  const { storage, requireAdmin, requireScope } = context;
   const { readFromStorage } = storage;
 
   // ─── 1. Static routes FIRST ───
 
   // GET /assessments/status (Admin) — assessment data status for settings page
-  router.get('/assessments/status', requireAdmin, function(req, res) {
+  router.get('/assessments/status', requireAdmin, requireScope('ai-impact:read'), function(req, res) {
     const data = readAssessments(readFromStorage);
     res.json({
       lastSyncedAt: data.lastSyncedAt,
@@ -43,7 +43,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // POST /assessments/bulk (Admin) — bulk upsert assessments
-  router.post('/assessments/bulk', requireAdmin, jsonLimit, function(req, res) {
+  router.post('/assessments/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }
@@ -90,7 +90,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // DELETE /assessments (Admin) — clear all assessment data
-  router.delete('/assessments', requireAdmin, function(req, res) {
+  router.delete('/assessments', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }
@@ -100,7 +100,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // GET /assessments — list all latest assessments (slim projection)
-  router.get('/assessments', function(req, res) {
+  router.get('/assessments', requireScope('ai-impact:read'), function(req, res) {
     const data = readAssessments(readFromStorage);
     res.json(getLatestProjection(data));
   });
@@ -108,7 +108,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   // ─── 2. Parameterized routes AFTER ───
 
   // GET /assessments/:key — single RFE assessment + history
-  router.get('/assessments/:key', function(req, res) {
+  router.get('/assessments/:key', requireScope('ai-impact:read'), function(req, res) {
     const data = readAssessments(readFromStorage);
     const entry = data.assessments[req.params.key];
     if (!entry) {
@@ -121,7 +121,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // PUT /assessments/:key (Admin) — upsert single assessment
-  router.put('/assessments/:key', requireAdmin, jsonLimit, function(req, res) {
+  router.put('/assessments/:key', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -66,13 +66,13 @@ async function runSync(readFromStorage) {
  * @param {object} context - Module context with storage and auth middleware
  */
 module.exports = function registerFeatureRoutes(router, context) {
-  const { storage, requireAdmin } = context;
+  const { storage, requireAdmin, requireScope } = context;
   const { readFromStorage } = storage;
 
   // ─── 1. Static routes FIRST ───
 
   // GET /features/status (Admin) — feature data status for settings page
-  router.get('/features/status', requireAdmin, function(req, res) {
+  router.get('/features/status', requireAdmin, requireScope('ai-impact:read'), function(req, res) {
     const data = readFeatures(readFromStorage);
     res.json({
       lastSyncedAt: data.lastSyncedAt,
@@ -83,12 +83,12 @@ module.exports = function registerFeatureRoutes(router, context) {
   });
 
   // GET /features/sync/status — sync state for polling
-  router.get('/features/sync/status', function(req, res) {
+  router.get('/features/sync/status', requireScope('ai-impact:read'), function(req, res) {
     res.json(syncState);
   });
 
   // POST /features/sync (Admin) — trigger Jira label sync
-  router.post('/features/sync', requireAdmin, async function(req, res) {
+  router.post('/features/sync', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Sync disabled in demo mode' });
     }
@@ -101,7 +101,7 @@ module.exports = function registerFeatureRoutes(router, context) {
   });
 
   // POST /features/bulk (Admin) — bulk upsert features
-  router.post('/features/bulk', requireAdmin, jsonLimit, function(req, res) {
+  router.post('/features/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Feature ingest disabled in demo mode' });
     }
@@ -157,7 +157,7 @@ module.exports = function registerFeatureRoutes(router, context) {
   });
 
   // DELETE /features (Admin) — clear all feature data
-  router.delete('/features', requireAdmin, function(req, res) {
+  router.delete('/features', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Feature ingest disabled in demo mode' });
     }
@@ -167,7 +167,7 @@ module.exports = function registerFeatureRoutes(router, context) {
   });
 
   // GET /features — list all features (slim projection)
-  router.get('/features', function(req, res) {
+  router.get('/features', requireScope('ai-impact:read'), function(req, res) {
     const data = readFeatures(readFromStorage);
     res.json(getLatestProjection(data));
   });
@@ -175,7 +175,7 @@ module.exports = function registerFeatureRoutes(router, context) {
   // ─── 2. Parameterized routes AFTER ───
 
   // GET /features/:key — single feature + history
-  router.get('/features/:key', function(req, res) {
+  router.get('/features/:key', requireScope('ai-impact:read'), function(req, res) {
     const data = readFeatures(readFromStorage);
     const entry = data.features[req.params.key];
     if (!entry) {
@@ -188,7 +188,7 @@ module.exports = function registerFeatureRoutes(router, context) {
   });
 
   // PUT /features/:key (Admin) — upsert single feature
-  router.put('/features/:key', requireAdmin, jsonLimit, function(req, res) {
+  router.put('/features/:key', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Feature ingest disabled in demo mode' });
     }

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -1,5 +1,5 @@
 module.exports = function registerRoutes(router, context) {
-  const { storage, requireAdmin } = context;
+  const { storage, requireAdmin, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
 
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
@@ -34,7 +34,7 @@ module.exports = function registerRoutes(router, context) {
 
   const VALID_TIME_WINDOWS = ['week', 'month', '3months'];
 
-  router.get('/rfe-data', function(req, res) {
+  router.get('/rfe-data', requireScope('ai-impact:read'), function(req, res) {
     const timeWindow = VALID_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow
       : 'month';
@@ -69,7 +69,7 @@ module.exports = function registerRoutes(router, context) {
 
   const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'month', '3months'];
 
-  router.get('/autofix-data', function(req, res) {
+  router.get('/autofix-data', requireScope('ai-impact:read'), function(req, res) {
     const timeWindow = VALID_AUTOFIX_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow
       : 'month';
@@ -130,7 +130,7 @@ module.exports = function registerRoutes(router, context) {
     };
   }
 
-  router.get('/doc-data', function(req, res) {
+  router.get('/doc-data', requireScope('ai-impact:read'), function(req, res) {
     const rawData = readFromStorage('ai-impact/doc-data.json');
     if (!rawData || !rawData.issues) {
       return res.json({
@@ -158,11 +158,11 @@ module.exports = function registerRoutes(router, context) {
     });
   });
 
-  router.get('/config', requireAdmin, function(req, res) {
+  router.get('/config', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
     res.json(getConfig(readFromStorage));
   });
 
-  router.post('/config', requireAdmin, function(req, res) {
+  router.post('/config', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
     try {
       saveConfig(writeToStorage, req.body);
       res.json({ status: 'saved' });
@@ -171,18 +171,18 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.delete('/cache', requireAdmin, function(req, res) {
+  router.delete('/cache', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
     writeToStorage('ai-impact/rfe-data.json', null);
     writeToStorage('ai-impact/autofix-data.json', null);
     writeToStorage('ai-impact/doc-data.json', null);
     res.json({ status: 'cleared' });
   });
 
-  router.get('/refresh/status', function(req, res) {
+  router.get('/refresh/status', requireScope('ai-impact:read'), function(req, res) {
     res.json(refreshState);
   });
 
-  router.post('/refresh', requireAdmin, async function(req, res) {
+  router.post('/refresh', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' });
     }

--- a/modules/feature-traffic/__tests__/server/routes.test.js
+++ b/modules/feature-traffic/__tests__/server/routes.test.js
@@ -56,6 +56,7 @@ describe('feature-traffic routes', () => {
     context = {
       storage,
       requireAdmin,
+      requireScope: () => (req, res, next) => next(),
       registerDiagnostics: vi.fn()
     }
     registerRoutes(router, context)
@@ -80,15 +81,15 @@ describe('feature-traffic routes', () => {
 
   describe('requireAdmin middleware', () => {
     it('gates POST /refresh behind requireAdmin', () => {
-      expect(router.post).toHaveBeenCalledWith('/refresh', requireAdmin, expect.any(Function))
+      expect(router.post).toHaveBeenCalledWith('/refresh', requireAdmin, expect.any(Function), expect.any(Function))
     })
 
     it('gates GET /config behind requireAdmin', () => {
-      expect(router.get).toHaveBeenCalledWith('/config', requireAdmin, expect.any(Function))
+      expect(router.get).toHaveBeenCalledWith('/config', requireAdmin, expect.any(Function), expect.any(Function))
     })
 
     it('gates POST /config behind requireAdmin', () => {
-      expect(router.post).toHaveBeenCalledWith('/config', requireAdmin, expect.any(Function))
+      expect(router.post).toHaveBeenCalledWith('/config', requireAdmin, expect.any(Function), expect.any(Function))
     })
   })
 
@@ -114,7 +115,7 @@ describe('feature-traffic routes', () => {
         'feature-traffic/last-fetch.json': { status: 'success', timestamp: '2026-04-08T06:00:00Z' }
       })
       const r = makeRouter()
-      registerRoutes(r, { storage: storageWithData, requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: storageWithData, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.get['/status'].at(-1)
       const res = makeRes()
@@ -134,7 +135,7 @@ describe('feature-traffic routes', () => {
         'feature-traffic/config.json': { enabled: true }
       })
       const r = makeRouter()
-      registerRoutes(r, { storage: storageWithConfig, requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: storageWithConfig, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/refresh'].at(-1)
 
@@ -160,7 +161,7 @@ describe('feature-traffic routes', () => {
 
       const storageForConfig = makeStorage()
       const r = makeRouter()
-      registerRoutes(r, { storage: storageForConfig, requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: storageForConfig, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const postHandler = r._routes.post['/config'].at(-1)
       const res1 = makeRes()
@@ -191,7 +192,7 @@ describe('feature-traffic routes', () => {
 
     it('rejects http:// in gitlabBaseUrl', async () => {
       const r = makeRouter()
-      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
       const res = makeRes()
@@ -207,7 +208,7 @@ describe('feature-traffic routes', () => {
 
     it('rejects invalid refreshIntervalHours', async () => {
       const r = makeRouter()
-      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
 
@@ -228,7 +229,7 @@ describe('feature-traffic routes', () => {
 
     it('rejects non-string fields', async () => {
       const r = makeRouter()
-      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
       const res = makeRes()
@@ -241,7 +242,7 @@ describe('feature-traffic routes', () => {
 
     it('rejects non-boolean enabled', async () => {
       const r = makeRouter()
-      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), registerDiagnostics: vi.fn() })
+      registerRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
       const res = makeRes()

--- a/modules/feature-traffic/server/index.js
+++ b/modules/feature-traffic/server/index.js
@@ -10,7 +10,7 @@ const {
 const DATA_PREFIX = 'feature-traffic';
 
 module.exports = function registerRoutes(router, context) {
-  const { storage } = context;
+  const { storage, requireScope } = context;
 
   function readDataFile(relativePath) {
     return storage.readFromStorage(`${DATA_PREFIX}/${relativePath}`);
@@ -20,7 +20,7 @@ module.exports = function registerRoutes(router, context) {
   initScheduler(storage);
 
   // GET /features — list all features with summary metrics
-  router.get('/features', function(req, res) {
+  router.get('/features', requireScope('feature-traffic:read'), function(req, res) {
     const index = readDataFile('index.json');
     if (!index || !index.features) {
       return res.json({
@@ -74,7 +74,7 @@ module.exports = function registerRoutes(router, context) {
   });
 
   // GET /features/:key — full feature detail
-  router.get('/features/:key', function(req, res) {
+  router.get('/features/:key', requireScope('feature-traffic:read'), function(req, res) {
     const key = req.params.key.toUpperCase();
 
     // Validate key format (RHAISTRAT in production, TEST* in demo mode)
@@ -91,7 +91,7 @@ module.exports = function registerRoutes(router, context) {
   });
 
   // GET /status — data freshness and sync info
-  router.get('/status', function(req, res) {
+  router.get('/status', requireScope('feature-traffic:read'), function(req, res) {
     const index = readDataFile('index.json');
     const lastFetch = readDataFile('last-fetch.json');
     const config = loadConfig(storage);
@@ -135,7 +135,7 @@ module.exports = function registerRoutes(router, context) {
   });
 
   // GET /versions — list unique fix versions across all features
-  router.get('/versions', function(req, res) {
+  router.get('/versions', requireScope('feature-traffic:read'), function(req, res) {
     const index = readDataFile('index.json');
     if (!index || !index.features) {
       return res.json({ versions: [] });
@@ -152,7 +152,7 @@ module.exports = function registerRoutes(router, context) {
   });
 
   // POST /refresh — trigger manual data refresh (admin only)
-  router.post('/refresh', context.requireAdmin, async function(req, res) {
+  router.post('/refresh', context.requireAdmin, requireScope('feature-traffic:write'), async function(req, res) {
     try {
       const result = await manualRefresh(storage);
       if (result.httpStatus === 429) {
@@ -165,7 +165,7 @@ module.exports = function registerRoutes(router, context) {
   });
 
   // GET /config — get current fetch configuration (admin only)
-  router.get('/config', context.requireAdmin, function(req, res) {
+  router.get('/config', context.requireAdmin, requireScope('feature-traffic:write'), function(req, res) {
     const config = loadConfig(storage);
     res.json({
       ...config,
@@ -175,7 +175,7 @@ module.exports = function registerRoutes(router, context) {
   });
 
   // POST /config — save fetch configuration (admin only)
-  router.post('/config', context.requireAdmin, async function(req, res) {
+  router.post('/config', context.requireAdmin, requireScope('feature-traffic:write'), async function(req, res) {
     try {
       const result = await onConfigSave(storage, req.body);
       res.json(result);

--- a/modules/release-analysis/__tests__/server/conforma.test.js
+++ b/modules/release-analysis/__tests__/server/conforma.test.js
@@ -77,7 +77,7 @@ describe('conforma backend routes', () => {
 
     // Register routes
     const registerConformaRoutes = require('../../server/conforma.js')
-    registerConformaRoutes(router, { storage, requireAuth, requireAdmin })
+    registerConformaRoutes(router, { storage, requireAuth, requireAdmin, requireScope: () => (req, res, next) => next() })
   })
 
   describe('GET /conforma/status', () => {
@@ -211,7 +211,7 @@ describe('conforma backend routes — demo mode', () => {
     const mock = makeRouter()
     router = mock.router
     const registerConformaRoutes = require('../../server/conforma.js')
-    registerConformaRoutes(router, { storage, requireAuth, requireAdmin })
+    registerConformaRoutes(router, { storage, requireAuth, requireAdmin, requireScope: () => (req, res, next) => next() })
   })
 
   afterEach(() => {

--- a/modules/release-analysis/server/conforma.js
+++ b/modules/release-analysis/server/conforma.js
@@ -12,11 +12,11 @@ function validateRelease(r) {
 }
 
 module.exports = function registerConformaRoutes(router, context) {
-  const { storage, requireAuth, requireAdmin } = context
+  const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage, deleteFromStorage } = storage
 
   // GET /conforma/status
-  router.get('/conforma/status', requireAuth, function (req, res) {
+  router.get('/conforma/status', requireAuth, requireScope('release-analysis:read'), function (req, res) {
     const data = readFromStorage(STORAGE_KEY)
     if (!data) return res.json({ status: 'no_data' })
     res.json({
@@ -27,7 +27,7 @@ module.exports = function registerConformaRoutes(router, context) {
   })
 
   // GET /conforma/releases — list all
-  router.get('/conforma/releases', requireAuth, function (req, res) {
+  router.get('/conforma/releases', requireAuth, requireScope('release-analysis:read'), function (req, res) {
     const data = readFromStorage(STORAGE_KEY)
     if (!data) {
       return res.status(404).json({ error: 'No conforma data available. Run the ingestion pipeline.' })
@@ -41,7 +41,7 @@ module.exports = function registerConformaRoutes(router, context) {
   })
 
   // GET /conforma/releases/:version — single release
-  router.get('/conforma/releases/:version', requireAuth, function (req, res) {
+  router.get('/conforma/releases/:version', requireAuth, requireScope('release-analysis:read'), function (req, res) {
     const data = readFromStorage(STORAGE_KEY)
     if (!data) {
       return res.status(404).json({ error: 'No conforma data available.' })
@@ -54,7 +54,7 @@ module.exports = function registerConformaRoutes(router, context) {
   })
 
   // POST /conforma/bulk — ingest releases (admin only, called by pipeline)
-  router.post('/conforma/bulk', requireAdmin, function (req, res) {
+  router.post('/conforma/bulk', requireAdmin, requireScope('release-analysis:write'), function (req, res) {
     if (process.env.DEMO_MODE === 'true') {
       return res.json({ status: 'skipped', message: 'Conforma ingest disabled in demo mode.' })
     }
@@ -95,7 +95,7 @@ module.exports = function registerConformaRoutes(router, context) {
   })
 
   // DELETE /conforma — clear all data (admin only)
-  router.delete('/conforma', requireAdmin, function (req, res) {
+  router.delete('/conforma', requireAdmin, requireScope('release-analysis:write'), function (req, res) {
     if (process.env.DEMO_MODE === 'true') {
       return res.status(400).json({ error: 'Cannot delete in demo mode.' })
     }

--- a/modules/release-analysis/server/index.js
+++ b/modules/release-analysis/server/index.js
@@ -983,7 +983,7 @@ const CACHE_MAX_AGE_MS = 60 * 60 * 1000 // 1 hour
 module.exports = function registerRoutes(router, context) {
   registerConformaRoutes(router, context)
 
-  const { storage, requireAuth, requireAdmin } = context
+  const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage } = storage
 
   let refreshState = { running: false, lastResult: null }
@@ -1017,7 +1017,7 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Config routes ---
 
-  router.get('/config', requireAdmin, function(req, res) {
+  router.get('/config', requireAdmin, requireScope('release-analysis:write'), function(req, res) {
     const saved = readFromStorage('release-analysis/config.json')
     const hasStoredConfig = saved && typeof saved === 'object' && !saved._deleted
     const config = getConfig(readFromStorage)
@@ -1028,7 +1028,7 @@ module.exports = function registerRoutes(router, context) {
     res.json({ config, source: hasStoredConfig ? 'stored' : 'env' })
   })
 
-  router.post('/config', requireAdmin, function(req, res) {
+  router.post('/config', requireAdmin, requireScope('release-analysis:write'), function(req, res) {
     try {
       saveConfig(writeToStorage, req.body)
       res.json({ status: 'saved' })
@@ -1037,7 +1037,7 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
-  router.delete('/config', requireAdmin, function(req, res) {
+  router.delete('/config', requireAdmin, requireScope('release-analysis:write'), function(req, res) {
     deleteConfig(writeToStorage)
     const config = getConfig(readFromStorage)
     res.json({ config, source: 'env' })
@@ -1045,7 +1045,7 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Product Pages routes ---
 
-  router.get('/product-pages/products', requireAdmin, async function(req, res) {
+  router.get('/product-pages/products', requireAdmin, requireScope('release-analysis:write'), async function(req, res) {
     try {
       const config = getConfig(readFromStorage)
       const authStatus = getAuthStatus()
@@ -1059,11 +1059,11 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Refresh routes ---
 
-  router.get('/refresh/status', requireAuth, function(req, res) {
+  router.get('/refresh/status', requireAuth, requireScope('release-analysis:read'), function(req, res) {
     res.json(refreshState)
   })
 
-  router.post('/refresh', requireAdmin, function(req, res) {
+  router.post('/refresh', requireAdmin, requireScope('release-analysis:write'), function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' })
     }
@@ -1076,7 +1076,7 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Analysis route (stale-while-revalidate) ---
 
-  router.get('/analysis', requireAuth, function(req, res) {
+  router.get('/analysis', requireAuth, requireScope('release-analysis:read'), function(req, res) {
     try {
       const forceRefresh = req.query.refresh === 'true'
       const cached = readFromStorage('release-analysis/analysis-cache.json')
@@ -1125,7 +1125,7 @@ module.exports = function registerRoutes(router, context) {
     }
   }
 
-  router.post('/admin/releases', requireAdmin, function(req, res) {
+  router.post('/admin/releases', requireAdmin, requireScope('release-analysis:write'), function(req, res) {
     try {
       const releases = Array.isArray(req.body?.releases) ? req.body.releases : null
       if (!releases || releases.length === 0) {

--- a/modules/release-planning/__tests__/server/health-routes.test.js
+++ b/modules/release-planning/__tests__/server/health-routes.test.js
@@ -153,6 +153,7 @@ describe('health routes', function() {
       storage: storage,
       requireAuth: function(req, res, next) { next() },
       requirePM: function(req, res, next) { next() },
+      requireScope: function() { return function(req, res, next) { next() } },
       refreshStates: refreshStates,
       MAX_CONCURRENT_REFRESHES: 2,
       sendJsonWithETag: function(req, res, data, statusCode) {

--- a/modules/release-planning/__tests__/server/invalidate-cache.test.js
+++ b/modules/release-planning/__tests__/server/invalidate-cache.test.js
@@ -128,6 +128,7 @@ describe('invalidateCache behavior', function() {
       storage: storage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },
+      requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     }
     registerRoutes(router, context)
@@ -268,6 +269,7 @@ describe('invalidateCache behavior', function() {
       storage: spyStorage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },
+      requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     })
 

--- a/modules/release-planning/__tests__/server/routes.test.js
+++ b/modules/release-planning/__tests__/server/routes.test.js
@@ -147,6 +147,7 @@ describe('release-planning routes', function() {
       storage: storage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },
+      requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     }
     registerRoutes(router, context)
@@ -193,6 +194,7 @@ describe('release-planning routes', function() {
       expect(router.post).toHaveBeenCalledWith(
         '/releases/:version/refresh',
         expect.any(Function),
+        expect.any(Function),
         expect.any(Function)
       )
     })
@@ -200,6 +202,7 @@ describe('release-planning routes', function() {
     it('uses requireAuth on GET /audit-log', function() {
       expect(router.get).toHaveBeenCalledWith(
         '/audit-log',
+        expect.any(Function),
         expect.any(Function),
         expect.any(Function)
       )

--- a/modules/release-planning/server/health/health-routes.js
+++ b/modules/release-planning/server/health/health-routes.js
@@ -69,6 +69,7 @@ function healthRoutes(router, context) {
   var writeToStorage = storage.writeToStorage
   var requireAuth = context.requireAuth
   var requirePM = context.requirePM
+  var requireScope = context.requireScope
   var refreshStates = context.refreshStates
   var MAX_CONCURRENT_REFRESHES = context.MAX_CONCURRENT_REFRESHES
   var sendJsonWithETag = context.sendJsonWithETag
@@ -106,7 +107,7 @@ function healthRoutes(router, context) {
 
   // ─── GET /releases/:version/health ───
 
-  router.get('/releases/:version/health', requireAuth, function(req, res) {
+  router.get('/releases/:version/health', requireAuth, requireScope('release-planning:read'), function(req, res) {
     var version = req.params.version
     var phase = parsePhase(req)
     if (!isValidVersion(version)) {
@@ -175,7 +176,7 @@ function healthRoutes(router, context) {
 
   // ─── GET /releases/:version/health/summary ───
 
-  router.get('/releases/:version/health/summary', requireAuth, function(req, res) {
+  router.get('/releases/:version/health/summary', requireAuth, requireScope('release-planning:read'), function(req, res) {
     var version = req.params.version
     var phase = parsePhase(req)
     if (!isValidVersion(version)) {
@@ -221,7 +222,7 @@ function healthRoutes(router, context) {
 
   // ─── GET /releases/:version/health/feature/:key ───
 
-  router.get('/releases/:version/health/feature/:key', requireAuth, function(req, res) {
+  router.get('/releases/:version/health/feature/:key', requireAuth, requireScope('release-planning:read'), function(req, res) {
     var version = req.params.version
     var key = req.params.key
     var phase = parsePhase(req)
@@ -276,7 +277,7 @@ function healthRoutes(router, context) {
 
   // ─── PUT /releases/:version/health/override/:featureKey ───
 
-  router.put('/releases/:version/health/override/:featureKey', requirePM, function(req, res) {
+  router.put('/releases/:version/health/override/:featureKey', requirePM, requireScope('release-planning:write'), function(req, res) {
     var version = req.params.version
     var featureKey = req.params.featureKey
     if (!isValidVersion(version)) {
@@ -342,7 +343,7 @@ function healthRoutes(router, context) {
 
   // ─── DELETE /releases/:version/health/override/:featureKey ───
 
-  router.delete('/releases/:version/health/override/:featureKey', requirePM, function(req, res) {
+  router.delete('/releases/:version/health/override/:featureKey', requirePM, requireScope('release-planning:write'), function(req, res) {
     var version = req.params.version
     var featureKey = req.params.featureKey
     if (!isValidVersion(version)) {
@@ -379,7 +380,7 @@ function healthRoutes(router, context) {
 
   // ─── GET /releases/:version/health/snapshot/:phase ───
 
-  router.get('/releases/:version/health/snapshot/:phase', requireAuth, function(req, res) {
+  router.get('/releases/:version/health/snapshot/:phase', requireAuth, requireScope('release-planning:read'), function(req, res) {
     var version = req.params.version
     var phase = (req.params.phase || '').toUpperCase()
     if (!isValidVersion(version)) {
@@ -399,7 +400,7 @@ function healthRoutes(router, context) {
 
   // ─── POST /releases/:version/health/snapshot/:phase ───
 
-  router.post('/releases/:version/health/snapshot/:phase', requirePM, function(req, res) {
+  router.post('/releases/:version/health/snapshot/:phase', requirePM, requireScope('release-planning:write'), function(req, res) {
     var version = req.params.version
     var phase = (req.params.phase || '').toUpperCase()
     if (!isValidVersion(version)) {
@@ -454,7 +455,7 @@ function healthRoutes(router, context) {
 
   // ─── POST /releases/:version/health/refresh ───
 
-  router.post('/releases/:version/health/refresh', requirePM, function(req, res) {
+  router.post('/releases/:version/health/refresh', requirePM, requireScope('release-planning:write'), function(req, res) {
     var version = req.params.version
     var phase = parsePhase(req)
     if (!isValidVersion(version)) {
@@ -484,7 +485,7 @@ function healthRoutes(router, context) {
 
   // ─── GET /releases/:version/health/refresh/status ───
 
-  router.get('/releases/:version/health/refresh/status', requireAuth, function(req, res) {
+  router.get('/releases/:version/health/refresh/status', requireAuth, requireScope('release-planning:read'), function(req, res) {
     var version = req.params.version
     var phase = parsePhase(req)
     if (!isValidVersion(version)) {
@@ -661,7 +662,7 @@ function healthRoutes(router, context) {
     return fields
   }
 
-  router.get('/releases/health-admin/jira-fields', requirePM, async function(req, res) {
+  router.get('/releases/health-admin/jira-fields', requirePM, requireScope('release-planning:write'), async function(req, res) {
     var query = (req.query.query || '').toLowerCase()
     if (!query || query.length < 2) {
       return res.status(400).json({ error: 'Query must be at least 2 characters' })
@@ -693,7 +694,7 @@ function healthRoutes(router, context) {
 
   // ─── RICE admin: save config ───
 
-  router.put('/releases/health-admin/config', requirePM, function(req, res) {
+  router.put('/releases/health-admin/config', requirePM, requireScope('release-planning:write'), function(req, res) {
     var config = getConfig(readFromStorage)
 
     if (req.body.riceFieldIds) {
@@ -733,7 +734,7 @@ function healthRoutes(router, context) {
 
   // ─── RICE admin: test configured field IDs ───
 
-  router.post('/releases/health-admin/rice-test', requirePM, async function(req, res) {
+  router.post('/releases/health-admin/rice-test', requirePM, requireScope('release-planning:write'), async function(req, res) {
     var config = getConfig(readFromStorage)
     var ids = config.customFieldIds || {}
     var fieldIds = [ids.riceReach, ids.riceImpact, ids.riceConfidence, ids.riceEffort].filter(Boolean)
@@ -774,7 +775,7 @@ function healthRoutes(router, context) {
 
   // ─── RICE admin: get config ───
 
-  router.get('/releases/health-admin/config', requirePM, function(req, res) {
+  router.get('/releases/health-admin/config', requirePM, requireScope('release-planning:write'), function(req, res) {
     var config = getConfig(readFromStorage)
     res.json({
       customFieldIds: config.customFieldIds || {},
@@ -785,7 +786,7 @@ function healthRoutes(router, context) {
 
   // ─── GET /releases/:version/health/milestones/debug ───
 
-  router.get('/releases/:version/health/milestones/debug', requirePM, async function(req, res) {
+  router.get('/releases/:version/health/milestones/debug', requirePM, requireScope('release-planning:write'), async function(req, res) {
     var version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })

--- a/modules/release-planning/server/index.js
+++ b/modules/release-planning/server/index.js
@@ -23,7 +23,7 @@ function isValidVersion(version) {
 }
 
 module.exports = function registerRoutes(router, context) {
-  const { storage, requireAuth, requireAdmin } = context
+  const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage } = storage
   const listStorageFiles = storage.listStorageFiles || null
   const deleteFromStorage = storage.deleteFromStorage || null
@@ -188,13 +188,14 @@ module.exports = function registerRoutes(router, context) {
     storage: storage,
     requireAuth: requireAuth,
     requirePM: requirePM,
+    requireScope: requireScope,
     refreshStates: refreshStates,
     MAX_CONCURRENT_REFRESHES: MAX_CONCURRENT_REFRESHES,
     sendJsonWithETag: sendJsonWithETag
   })
 
   // GET /releases
-  router.get('/releases', requireAuth, function(req, res) {
+  router.get('/releases', requireAuth, requireScope('release-planning:read'), function(req, res) {
     if (DEMO_MODE) {
       const demoConfig = loadFixture('config.json')
       if (demoConfig && demoConfig.releases) {
@@ -214,7 +215,7 @@ module.exports = function registerRoutes(router, context) {
   })
 
   // GET /releases/:version/candidates
-  router.get('/releases/:version/candidates', requireAuth, function(req, res) {
+  router.get('/releases/:version/candidates', requireAuth, requireScope('release-planning:read'), function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -287,7 +288,7 @@ module.exports = function registerRoutes(router, context) {
   })
 
   // POST /releases/:version/refresh
-  router.post('/releases/:version/refresh', requirePM, function(req, res) {
+  router.post('/releases/:version/refresh', requirePM, requireScope('release-planning:write'), function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -309,7 +310,7 @@ module.exports = function registerRoutes(router, context) {
   })
 
   // GET /refresh/status
-  router.get('/refresh/status', requireAuth, function(req, res) {
+  router.get('/refresh/status', requireAuth, requireScope('release-planning:read'), function(req, res) {
     const version = req.query && req.query.version
     if (version) {
       return res.json(getRefreshState(version))
@@ -330,7 +331,7 @@ module.exports = function registerRoutes(router, context) {
   })
 
   // GET /config
-  router.get('/config', requireAdmin, function(req, res) {
+  router.get('/config', requireAdmin, requireScope('release-planning:write'), function(req, res) {
     const config = getConfig(readFromStorage)
     res.json(config)
   })
@@ -367,7 +368,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── GET /permissions ───
 
-  router.get('/permissions', requireAuth, function(req, res) {
+  router.get('/permissions', requireAuth, requireScope('release-planning:read'), function(req, res) {
     res.json({
       canEdit: !!req.isAdmin || isPM(req.userEmail, readFromStorage)
     })
@@ -376,7 +377,7 @@ module.exports = function registerRoutes(router, context) {
   // ─── PUT /releases/:version/big-rocks/reorder ───
   // Must be registered BEFORE the :name route so Express doesn't match "reorder" as a name param.
 
-  router.put('/releases/:version/big-rocks/reorder', requirePM, async function(req, res) {
+  router.put('/releases/:version/big-rocks/reorder', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -406,7 +407,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── PUT /releases/:version/big-rocks/:name ───
 
-  router.put('/releases/:version/big-rocks/:name', requirePM, async function(req, res) {
+  router.put('/releases/:version/big-rocks/:name', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -457,7 +458,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── POST /releases/:version/big-rocks ───
 
-  router.post('/releases/:version/big-rocks', requirePM, async function(req, res) {
+  router.post('/releases/:version/big-rocks', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -502,7 +503,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── DELETE /releases/:version/big-rocks/:name ───
 
-  router.delete('/releases/:version/big-rocks/:name', requirePM, async function(req, res) {
+  router.delete('/releases/:version/big-rocks/:name', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -548,7 +549,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── POST /releases ───
 
-  router.post('/releases', requirePM, async function(req, res) {
+  router.post('/releases', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.body && req.body.version
     const cloneFrom = req.body && req.body.cloneFrom
 
@@ -587,7 +588,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── DELETE /releases/:version ───
 
-  router.delete('/releases/:version', requireAdmin, async function(req, res) {
+  router.delete('/releases/:version', requireAdmin, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -627,7 +628,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── POST /jira/validate-keys ───
 
-  router.post('/jira/validate-keys', requirePM, function(req, res) {
+  router.post('/jira/validate-keys', requirePM, requireScope('release-planning:write'), function(req, res) {
     const keys = req.body && req.body.keys
     if (!Array.isArray(keys) || keys.length === 0) {
       return res.status(400).json({ error: 'keys must be a non-empty array' })
@@ -659,12 +660,12 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── PM User Management ───
 
-  router.get('/pm-users', requireAdmin, function(req, res) {
+  router.get('/pm-users', requireAdmin, requireScope('release-planning:write'), function(req, res) {
     const emails = getPMUsers(readFromStorage)
     res.json({ emails: emails })
   })
 
-  router.post('/pm-users', requireAdmin, function(req, res) {
+  router.post('/pm-users', requireAdmin, requireScope('release-planning:write'), function(req, res) {
     const email = req.body && req.body.email
     if (!email || typeof email !== 'string' || !email.trim()) {
       return res.status(400).json({ error: 'email is required' })
@@ -678,7 +679,7 @@ module.exports = function registerRoutes(router, context) {
     res.json({ emails: emails })
   })
 
-  router.delete('/pm-users/:email', requireAdmin, function(req, res) {
+  router.delete('/pm-users/:email', requireAdmin, requireScope('release-planning:write'), function(req, res) {
     let email
     try {
       email = decodeURIComponent(req.params.email)
@@ -696,7 +697,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── Google Doc Import ───
 
-  router.post('/releases/:version/import/doc/preview', requirePM, async function(req, res) {
+  router.post('/releases/:version/import/doc/preview', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -732,7 +733,7 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
-  router.post('/releases/:version/import/doc', requirePM, async function(req, res) {
+  router.post('/releases/:version/import/doc', requirePM, requireScope('release-planning:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -779,7 +780,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── SmartSheet Release Discovery ───
 
-  router.get('/smartsheet/releases', requireAuth, async function(req, res) {
+  router.get('/smartsheet/releases', requireAuth, requireScope('release-planning:read'), async function(req, res) {
     try {
       if (!smartsheetClient.isConfigured()) {
         return res.status(503).json({
@@ -814,7 +815,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── Admin Seed / Bootstrap ───
 
-  router.post('/admin/seed', requireAdmin, async function(req, res) {
+  router.post('/admin/seed', requireAdmin, requireScope('release-planning:write'), async function(req, res) {
     const config = req.body
     if (!config || typeof config !== 'object' || !config.releases) {
       return res.status(400).json({ error: 'Request body must include a "releases" object' })
@@ -891,7 +892,7 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
-  router.get('/admin/seed/fixture', requireAdmin, function(req, res) {
+  router.get('/admin/seed/fixture', requireAdmin, requireScope('release-planning:write'), function(req, res) {
     const fixture = loadFixture('config.json')
     if (!fixture) {
       return res.status(404).json({ error: 'No fixture data found' })
@@ -901,7 +902,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── Audit Log ───
 
-  router.get('/audit-log', requireAuth, function(req, res) {
+  router.get('/audit-log', requireAuth, requireScope('release-planning:read'), function(req, res) {
     const version = req.query.version || null
     const action = req.query.action || null
     const limit = Math.min(Math.max(parseInt(req.query.limit) || 50, 1), 500)

--- a/modules/team-tracker/__tests__/server/derive-roster-merge.test.js
+++ b/modules/team-tracker/__tests__/server/derive-roster-merge.test.js
@@ -118,7 +118,8 @@ function createTestServer(storageData) {
   registerRoutes(router, {
     storage,
     requireAdmin: (_req, _res, next) => next(),
-    requireTeamAdmin: (_req, _res, next) => next()
+    requireTeamAdmin: (_req, _res, next) => next(),
+    requireScope: () => (_req, _res, next) => next()
   })
   app.use(router)
   return app

--- a/modules/team-tracker/__tests__/server/field-completeness-provider.test.js
+++ b/modules/team-tracker/__tests__/server/field-completeness-provider.test.js
@@ -40,6 +40,7 @@ function setupAndGetProvider(storageData) {
     storage,
     requireAdmin: (req, res, next) => next(),
     requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
     roleStore: mockRoleStore,
     registerMessageProvider(id, fn) {
       capturedProvider = { id, fn }

--- a/modules/team-tracker/__tests__/server/manager-dashboard-endpoint.test.js
+++ b/modules/team-tracker/__tests__/server/manager-dashboard-endpoint.test.js
@@ -45,6 +45,7 @@ function setupRoutes(storageData) {
     storage,
     requireAdmin: (req, res, next) => next(),
     requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
     roleStore: mockRoleStore
   }
 

--- a/modules/team-tracker/__tests__/server/org-teams.test.js
+++ b/modules/team-tracker/__tests__/server/org-teams.test.js
@@ -71,7 +71,8 @@ function setupRoutes(storage) {
 
   const context = {
     storage,
-    requireAdmin: (req, res, next) => next()
+    requireAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next()
   }
 
   // Clear config cache before registering

--- a/modules/team-tracker/__tests__/server/roster-sync-config.test.js
+++ b/modules/team-tracker/__tests__/server/roster-sync-config.test.js
@@ -70,6 +70,7 @@ function createTestApp() {
     storage: { readFromStorage, writeToStorage },
     requireAdmin: (req, res, next) => next(), // Pass-through for tests
     requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
     registerDiagnostics: vi.fn()
   }
 

--- a/modules/team-tracker/__tests__/server/sheets-discover.test.js
+++ b/modules/team-tracker/__tests__/server/sheets-discover.test.js
@@ -53,6 +53,7 @@ function createTestApp() {
     storage: { readFromStorage, writeToStorage },
     requireAdmin: (req, res, next) => next(),
     requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
     registerDiagnostics: vi.fn()
   }
   registerRoutes(router, context)

--- a/modules/team-tracker/__tests__/server/unified-sync.test.js
+++ b/modules/team-tracker/__tests__/server/unified-sync.test.js
@@ -103,7 +103,8 @@ function createApp() {
   registerRoutes(router, {
     storage: storageMock,
     requireAdmin: (req, res, next) => next(),
-    requireTeamAdmin: (req, res, next) => next()
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next()
   })
 
   app.use('/api/modules/team-tracker', router)
@@ -161,7 +162,8 @@ describe('Unified Sync Endpoint', () => {
       registerRoutes2(router2, {
         storage: storageMock,
         requireAdmin: (req, res, next) => next(),
-    requireTeamAdmin: (req, res, next) => next()
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next()
       })
       app2.use('/api/modules/team-tracker', router2)
 

--- a/modules/team-tracker/server/allocation/routes.js
+++ b/modules/team-tracker/server/allocation/routes.js
@@ -12,7 +12,7 @@ function isValidSprintId(id) { return /^(\d+|kanban-\d+)$/.test(id); }
 const REFRESH_COOLDOWN_MS = 60_000;
 
 module.exports = function registerAllocationRoutes(router, context) {
-  const { storage, requireAdmin } = context;
+  const { storage, requireAdmin, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
 
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
@@ -66,7 +66,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       200:
    *         description: Refresh status
    */
-  router.post('/allocation/refresh', requireAdmin, async function(req, res) {
+  router.post('/allocation/refresh', requireAdmin, requireScope('metrics:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' });
     }
@@ -161,7 +161,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       200:
    *         description: Current refresh state
    */
-  router.get('/allocation/refresh/status', function(_req, res) {
+  router.get('/allocation/refresh/status', requireScope('metrics:read'), function(_req, res) {
     const sanitized = { ...refreshState };
     if (sanitized.lastResult) {
       sanitized.lastResult = {
@@ -192,7 +192,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       200:
    *         description: Team allocation summary
    */
-  router.get('/allocation/team/:teamId/summary', function(req, res) {
+  router.get('/allocation/team/:teamId/summary', requireScope('metrics:read'), function(req, res) {
     try {
       const { teamId } = req.params;
       const data = allocRead(`summaries/team-${teamId}.json`);
@@ -222,7 +222,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       200:
    *         description: Org allocation summary
    */
-  router.get('/allocation/org/:orgKey/summary', function(req, res) {
+  router.get('/allocation/org/:orgKey/summary', requireScope('metrics:read'), function(req, res) {
     try {
       const orgParam = req.params.orgKey;
       // Try direct lookup first (orgParam is already an orgKey)
@@ -255,7 +255,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       200:
    *         description: Global allocation summary
    */
-  router.get('/allocation/global/summary', function(_req, res) {
+  router.get('/allocation/global/summary', requireScope('metrics:read'), function(_req, res) {
     try {
       const data = allocRead('summaries/global.json');
       if (!data) {
@@ -291,7 +291,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       200:
    *         description: Board sprint index
    */
-  router.get('/allocation/board/:boardId/sprints', function(req, res) {
+  router.get('/allocation/board/:boardId/sprints', requireScope('metrics:read'), function(req, res) {
     try {
       const { boardId } = req.params;
       if (!isValidBoardId(boardId)) {
@@ -335,7 +335,7 @@ module.exports = function registerAllocationRoutes(router, context) {
    *       404:
    *         description: Sprint data not found
    */
-  router.get('/allocation/sprints/:sprintId/issues', function(req, res) {
+  router.get('/allocation/sprints/:sprintId/issues', requireScope('metrics:read'), function(req, res) {
     try {
       const { sprintId } = req.params;
       if (!isValidSprintId(sprintId)) {

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -1,5 +1,5 @@
 module.exports = function registerRoutes(router, context) {
-  const { storage, requireAdmin, requireTeamAdmin, roleStore } = context;
+  const { storage, requireAdmin, requireTeamAdmin, requireScope, roleStore } = context;
   const { readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory } = storage;
 
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
@@ -510,7 +510,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Permission info
    */
-  router.get('/permissions/me', function(req, res) {
+  router.get('/permissions/me', requireScope('roster:read'), function(req, res) {
     const managed = req.userUid
       ? [...permissions.getManagedUids(req.userUid, managerMap)]
       : [];
@@ -539,7 +539,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: User is not a manager
    */
-  router.get('/manager/dashboard', function(req, res) {
+  router.get('/manager/dashboard', requireScope('roster:read'), function(req, res) {
     // Handle null userUid (e.g. local dev where email isn't in registry)
     if (!req.userUid) {
       return res.json({
@@ -752,7 +752,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: List of teams
    */
-  router.get('/structure/teams', function(req, res) {
+  router.get('/structure/teams', requireScope('team-tracker:read'), function(req, res) {
     const data = teamStore.readTeams(storage);
     let teams = Object.values(data.teams);
     if (req.query.orgKey) {
@@ -771,7 +771,7 @@ module.exports = function registerRoutes(router, context) {
    *       201:
    *         description: Created team
    */
-  router.post('/structure/teams', requireTeamAdmin, function(req, res) {
+  router.post('/structure/teams', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { name, orgKey } = req.body;
@@ -799,7 +799,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated team
    */
-  router.patch('/structure/teams/:teamId', requireTeamAdmin, function(req, res) {
+  router.patch('/structure/teams/:teamId', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { name } = req.body;
@@ -827,7 +827,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Deletion result
    */
-  router.delete('/structure/teams/:teamId', requireTeamAdmin, function(req, res) {
+  router.delete('/structure/teams/:teamId', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const result = teamStore.deleteTeam(storage, req.params.teamId, req.auditActor);
@@ -857,6 +857,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.post('/structure/teams/:teamId/members',
     requireManagerOrAdmin(req => req.body.uid),
+    requireScope('team-tracker:write'),
     function(req, res) {
       const guard = demoWriteGuard(res);
       if (guard) return;
@@ -886,7 +887,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Bulk assignment result
    */
-  router.post('/structure/teams/:teamId/members/bulk', function(req, res) {
+  router.post('/structure/teams/:teamId/members/bulk', requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { uids } = req.body;
@@ -933,6 +934,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.delete('/structure/teams/:teamId/members/:uid',
     requireManagerOrAdmin(req => req.params.uid),
+    requireScope('team-tracker:write'),
     function(req, res) {
       const guard = demoWriteGuard(res);
       if (guard) return;
@@ -962,7 +964,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: List of unassigned people
    */
-  router.get('/structure/unassigned', function(req, res) {
+  router.get('/structure/unassigned', requireScope('team-tracker:read'), function(req, res) {
     const VALID_SCOPES = ['all', 'direct', 'org'];
     const scope = req.query.scope || 'all';
     if (!VALID_SCOPES.includes(scope)) {
@@ -985,7 +987,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Person and team field definitions
    */
-  router.get('/structure/field-definitions', function(req, res) {
+  router.get('/structure/field-definitions', requireScope('team-tracker:read'), function(req, res) {
     const defs = fieldStore.readFieldDefinitions(storage);
     // Filter out soft-deleted fields for non-admin/team-admin users
     if (!req.isAdmin && !req.isTeamAdmin) {
@@ -1019,7 +1021,7 @@ module.exports = function registerRoutes(router, context) {
    *       201:
    *         description: Created field definition
    */
-  router.post('/structure/field-definitions/person', requireTeamAdmin, function(req, res) {
+  router.post('/structure/field-definitions/person', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { label, type, required, visible, primaryDisplay, allowedValues, multiValue, optionsRef } = req.body;
@@ -1053,7 +1055,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated field definition
    */
-  router.patch('/structure/field-definitions/person/:fieldId', requireTeamAdmin, function(req, res) {
+  router.patch('/structure/field-definitions/person/:fieldId', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     try {
@@ -1082,7 +1084,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Deleted field definition
    */
-  router.delete('/structure/field-definitions/person/:fieldId', requireTeamAdmin, function(req, res) {
+  router.delete('/structure/field-definitions/person/:fieldId', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const result = fieldStore.softDeleteField(storage, 'person', req.params.fieldId, req.auditActor);
@@ -1100,7 +1102,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Reorder confirmation
    */
-  router.post('/structure/field-definitions/person/reorder', requireTeamAdmin, function(req, res) {
+  router.post('/structure/field-definitions/person/reorder', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { orderedIds } = req.body;
@@ -1121,7 +1123,7 @@ module.exports = function registerRoutes(router, context) {
    *       201:
    *         description: Created field definition
    */
-  router.post('/structure/field-definitions/team', requireTeamAdmin, function(req, res) {
+  router.post('/structure/field-definitions/team', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { label, type, required, visible, primaryDisplay, allowedValues, multiValue, optionsRef } = req.body;
@@ -1155,7 +1157,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated field definition
    */
-  router.patch('/structure/field-definitions/team/:fieldId', requireTeamAdmin, function(req, res) {
+  router.patch('/structure/field-definitions/team/:fieldId', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     try {
@@ -1184,7 +1186,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Deleted field definition
    */
-  router.delete('/structure/field-definitions/team/:fieldId', requireTeamAdmin, function(req, res) {
+  router.delete('/structure/field-definitions/team/:fieldId', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const result = fieldStore.softDeleteField(storage, 'team', req.params.fieldId, req.auditActor);
@@ -1202,7 +1204,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Reorder confirmation
    */
-  router.post('/structure/field-definitions/team/reorder', requireTeamAdmin, function(req, res) {
+  router.post('/structure/field-definitions/team/reorder', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { orderedIds } = req.body;
@@ -1242,7 +1244,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: List of field option sets
    */
-  router.get('/field-options', function(req, res) {
+  router.get('/field-options', requireScope('team-tracker:read'), function(req, res) {
     try {
       const options = fieldOptionsStore.listFieldOptions(storage);
       res.json({ options });
@@ -1268,7 +1270,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Field option set with values
    */
-  router.get('/field-options/:name', function(req, res) {
+  router.get('/field-options/:name', requireScope('team-tracker:read'), function(req, res) {
     const safeName = sanitizeOptionsName(req.params.name);
     if (!safeName) return res.status(400).json({ error: 'Invalid option set name' });
     try {
@@ -1297,7 +1299,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated field option set
    */
-  router.put('/field-options/:name', requireAdmin, function(req, res) {
+  router.put('/field-options/:name', requireAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const safeName = sanitizeOptionsName(req.params.name);
@@ -1332,7 +1334,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated field option set
    */
-  router.post('/field-options/:name/values', requireTeamAdmin, function(req, res) {
+  router.post('/field-options/:name/values', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const safeName = sanitizeOptionsName(req.params.name);
@@ -1372,7 +1374,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated field option set
    */
-  router.delete('/field-options/:name/values', requireAdmin, function(req, res) {
+  router.delete('/field-options/:name/values', requireAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const safeName = sanitizeOptionsName(req.params.name);
@@ -1418,7 +1420,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Rename result with count of updated records
    */
-  router.patch('/field-options/:name/values/rename', requireTeamAdmin, function(req, res) {
+  router.patch('/field-options/:name/values/rename', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const safeName = sanitizeOptionsName(req.params.name);
@@ -1459,6 +1461,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.patch('/structure/person/:uid/fields',
     requireManagerOrAdmin(req => req.params.uid),
+    requireScope('team-tracker:write'),
     function(req, res) {
       const guard = demoWriteGuard(res);
       if (guard) return;
@@ -1500,7 +1503,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated team metadata
    */
-  router.patch('/structure/teams/:teamId/fields', requireTeamPurview, function(req, res) {
+  router.patch('/structure/teams/:teamId/fields', requireTeamPurview, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     if (typeof req.body !== 'object' || Array.isArray(req.body) || !req.body) {
@@ -1542,7 +1545,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Updated boards list
    */
-  router.patch('/structure/teams/:teamId/boards', requireTeamPurview, function(req, res) {
+  router.patch('/structure/teams/:teamId/boards', requireTeamPurview, requireScope('team-tracker:write'), function(req, res) {
     const guard = demoWriteGuard(res);
     if (guard) return;
     const { boards } = req.body;
@@ -1626,7 +1629,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Audit log entries
    */
-  router.get('/structure/audit-log', function(req, res) {
+  router.get('/structure/audit-log', requireScope('team-tracker:read'), function(req, res) {
     // Only admin and managers can view audit log
     if (req.permissionTier === 'user') {
       return res.status(403).json({ error: 'Manager or admin access required' });
@@ -1674,7 +1677,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Migration preview data
    */
-  router.get('/structure/migrate/preview', requireAdmin, async function(req, res) {
+  router.get('/structure/migrate/preview', requireAdmin, requireScope('team-tracker:write'), async function(req, res) {
     try {
       const config = rosterSyncConfig.loadConfig(storage);
       if (!config) return res.status(400).json({ error: 'No config found' });
@@ -1696,7 +1699,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Migration result
    */
-  router.post('/structure/migrate', requireAdmin, async function(req, res) {
+  router.post('/structure/migrate', requireAdmin, requireScope('team-tracker:write'), async function(req, res) {
     try {
       const guard = demoWriteGuard(res);
       if (guard) return;
@@ -1737,7 +1740,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Migration preview with extracted values
    */
-  router.get('/structure/migrate/field-to-options/preview', requireTeamAdmin, function(req, res) {
+  router.get('/structure/migrate/field-to-options/preview', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     try {
       const { fieldId } = req.query;
       if (!fieldId || typeof fieldId !== 'string') {
@@ -1762,7 +1765,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Migration result
    */
-  router.post('/structure/migrate/field-to-options', requireTeamAdmin, function(req, res) {
+  router.post('/structure/migrate/field-to-options', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     try {
       const guard = demoWriteGuard(res);
       if (guard) return;
@@ -1798,7 +1801,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.get('/refresh/status', requireAdmin, function(req, res) {
+  router.get('/refresh/status', requireAdmin, requireScope('metrics:read'), function(req, res) {
     res.json(refreshState);
   });
 
@@ -1828,7 +1831,7 @@ module.exports = function registerRoutes(router, context) {
    *       500:
    *         description: Server error
    */
-  router.post('/refresh', async function(req, res) {
+  router.post('/refresh', requireScope('metrics:write'), async function(req, res) {
     const { scope, name, teamKey, orgKey } = req.body || {};
     const force = req.body?.force === true;
     const sources = req.body?.sources || { jira: true, github: true, gitlab: true };
@@ -2125,7 +2128,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of configured sprint boards
    */
-  router.get('/boards', function(req, res) {
+  router.get('/boards', requireScope('metrics:read'), function(req, res) {
     try {
       const teamsData = readFromStorage('teams.json');
       if (!teamsData || !teamsData.teams) {
@@ -2167,7 +2170,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: List of sprints for the board
    */
-  router.get('/boards/:boardId/sprints', function(req, res) {
+  router.get('/boards/:boardId/sprints', requireScope('metrics:read'), function(req, res) {
     try {
       const { boardId } = req.params;
       const data = readFromStorage(`sprints/team-${boardId}.json`)
@@ -2199,7 +2202,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Sprint trend data for the board
    */
-  router.get('/boards/:boardId/trend', function(req, res) {
+  router.get('/boards/:boardId/trend', requireScope('metrics:read'), function(req, res) {
     try {
       const { boardId } = req.params;
       const sprintIndex = readFromStorage(`sprints/team-${boardId}.json`)
@@ -2261,7 +2264,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Sprint detail data
    */
-  router.get('/sprints/:sprintId', function(req, res) {
+  router.get('/sprints/:sprintId', requireScope('metrics:read'), function(req, res) {
     try {
       const { sprintId } = req.params;
       const data = readFromStorage(`sprints/${sprintId}.json`);
@@ -2287,7 +2290,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Sprint board team configuration
    */
-  router.get('/teams', function(req, res) {
+  router.get('/teams', requireScope('roster:read'), function(req, res) {
     try {
       const data = readFromStorage('teams.json');
       if (!data) {
@@ -2318,7 +2321,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.post('/teams', requireAdmin, function(req, res) {
+  router.post('/teams', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const { teams } = req.body;
       if (!teams || !Array.isArray(teams)) {
@@ -2342,7 +2345,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Dashboard summary data
    */
-  router.get('/dashboard-summary', function(req, res) {
+  router.get('/dashboard-summary', requireScope('metrics:read'), function(req, res) {
     try {
       const data = readFromStorage('dashboard-summary.json');
       if (data) {
@@ -2431,7 +2434,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Aggregated trend data
    */
-  router.get('/trend', function(req, res) {
+  router.get('/trend', requireScope('metrics:read'), function(req, res) {
     try {
       const boardIds = (req.query.boardIds || '').split(',').filter(Boolean);
       if (boardIds.length === 0) {
@@ -2494,7 +2497,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Last refresh timestamp and config info
    */
-  router.get('/last-refreshed', function(req, res) {
+  router.get('/last-refreshed', requireScope('metrics:read'), function(req, res) {
     const data = readFromStorage('last-refreshed.json');
     const jiraConfig = jiraSyncConfig.loadConfig(storage);
     res.json({
@@ -2517,7 +2520,7 @@ module.exports = function registerRoutes(router, context) {
    *             schema:
    *               $ref: '#/components/schemas/RosterResponse'
    */
-  router.get('/roster', function(req, res) {
+  router.get('/roster', requireScope('roster:read'), function(req, res) {
     try {
       const full = readRosterFull();
       if (!full) {
@@ -2555,7 +2558,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Metrics for all people
    */
-  router.get('/people/metrics', function(req, res) {
+  router.get('/people/metrics', requireScope('metrics:read'), function(req, res) {
     try {
       const files = listStorageFiles('people');
       if (files.length === 0) return res.json({});
@@ -2605,7 +2608,7 @@ module.exports = function registerRoutes(router, context) {
    *             schema:
    *               $ref: '#/components/schemas/PersonMetrics'
    */
-  router.get('/person/:jiraDisplayName/metrics', async function(req, res) {
+  router.get('/person/:jiraDisplayName/metrics', requireScope('metrics:read'), async function(req, res) {
     try {
       const name = decodeURIComponent(req.params.jiraDisplayName);
       const key = sanitizeFilename(name);
@@ -2647,7 +2650,7 @@ module.exports = function registerRoutes(router, context) {
    *             schema:
    *               $ref: '#/components/schemas/TeamMetrics'
    */
-  router.get('/team/:teamKey/metrics', function(req, res) {
+  router.get('/team/:teamKey/metrics', requireScope('metrics:read'), function(req, res) {
     try {
       const teamKey = decodeURIComponent(req.params.teamKey);
       const roster = deriveRoster();
@@ -2758,7 +2761,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.delete('/jira-name-cache', requireAdmin, function(req, res) {
+  router.delete('/jira-name-cache', requireAdmin, requireScope('metrics:write'), function(req, res) {
     jiraNameCache = {};
     writeToStorage('jira-name-map.json', {});
     res.json({ success: true });
@@ -2780,7 +2783,7 @@ module.exports = function registerRoutes(router, context) {
    *             schema:
    *               $ref: '#/components/schemas/GitHubContributions'
    */
-  router.get('/github/contributions', function(req, res) {
+  router.get('/github/contributions', requireScope('github:read'), function(req, res) {
     try {
       const cache = readGithubCache();
       res.json(cache);
@@ -2807,7 +2810,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: GitHub contribution data for the user
    */
-  router.get('/github/contributions/:username', function(req, res) {
+  router.get('/github/contributions/:username', requireScope('github:read'), function(req, res) {
     try {
       const username = decodeURIComponent(req.params.username);
       const cache = readGithubCache();
@@ -2835,7 +2838,7 @@ module.exports = function registerRoutes(router, context) {
    *             schema:
    *               $ref: '#/components/schemas/GitLabContributions'
    */
-  router.get('/gitlab/contributions', function(req, res) {
+  router.get('/gitlab/contributions', requireScope('gitlab:read'), function(req, res) {
     try {
       const cache = readGitlabCache();
       res.json(cache);
@@ -2862,7 +2865,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: GitLab contribution data for the user
    */
-  router.get('/gitlab/contributions/:username', function(req, res) {
+  router.get('/gitlab/contributions/:username', requireScope('gitlab:read'), function(req, res) {
     try {
       const username = decodeURIComponent(req.params.username);
       const cache = readGitlabCache();
@@ -2886,7 +2889,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Combined trend data from all sources
    */
-  router.get('/trends', function(req, res) {
+  router.get('/trends', requireScope('metrics:read'), function(req, res) {
     try {
       const jira = buildJiraTrends();
       const github = readGithubHistoryCache();
@@ -2917,7 +2920,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Annotations for the sprint
    */
-  router.get('/sprints/:sprintId/annotations', function(req, res) {
+  router.get('/sprints/:sprintId/annotations', requireScope('metrics:read'), function(req, res) {
     try {
       const { sprintId } = req.params;
       const data = readFromStorage(`annotations/${sprintId}.json`);
@@ -2959,7 +2962,7 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Missing assignee or text
    */
-  router.put('/sprints/:sprintId/annotations', function(req, res) {
+  router.put('/sprints/:sprintId/annotations', requireScope('metrics:write'), function(req, res) {
     try {
       const { sprintId } = req.params;
       const { assignee, text } = req.body;
@@ -3021,7 +3024,7 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Annotation not found
    */
-  router.delete('/sprints/:sprintId/annotations/:assignee/:annotationId', requireAdmin, function(req, res) {
+  router.delete('/sprints/:sprintId/annotations/:assignee/:annotationId', requireAdmin, requireScope('metrics:write'), function(req, res) {
     try {
       const { sprintId, assignee, annotationId } = req.params;
       const data = readFromStorage(`annotations/${sprintId}.json`);
@@ -3060,7 +3063,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Configuration status
    */
-  router.get('/roster-sync/configured', function(req, res) {
+  router.get('/roster-sync/configured', requireScope('roster:read'), function(req, res) {
     try {
       const config = rosterSyncConfig.loadConfig(storage);
       res.json({ configured: !!config });
@@ -3090,7 +3093,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.get('/sheets/discover', requireAdmin, async function(req, res) {
+  router.get('/sheets/discover', requireAdmin, requireScope('team-tracker:read'), async function(req, res) {
     try {
       const { spreadsheetId } = req.query;
 
@@ -3124,7 +3127,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.get('/admin/roster-sync/field-definitions', requireAdmin, function(req, res) {
+  router.get('/admin/roster-sync/field-definitions', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const config = rosterSyncConfig.loadConfig(storage);
       res.json({ customFields: (config && config.customFields) || [] });
@@ -3146,7 +3149,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.get('/admin/roster-sync/config', requireAdmin, function(req, res) {
+  router.get('/admin/roster-sync/config', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const config = rosterSyncConfig.loadConfig(storage);
       if (!config) {
@@ -3180,7 +3183,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.post('/admin/roster-sync/config', requireAdmin, function(req, res) {
+  router.post('/admin/roster-sync/config', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const { orgRoots, googleSheetId, sheetNames, githubOrgs, gitlabGroups, gitlabInstances, teamStructure, excludedTitles, teamDataSource } = req.body;
 
@@ -3379,7 +3382,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.post('/admin/roster-sync/custom-fields', requireAdmin, function(req, res) {
+  router.post('/admin/roster-sync/custom-fields', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const { customFields } = req.body;
 
@@ -3456,7 +3459,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.post('/admin/roster-sync/trigger', requireAdmin, function(req, res) {
+  router.post('/admin/roster-sync/trigger', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       if (consolidatedSync.isSyncInProgress()) {
         return res.json({ status: 'already_running' });
@@ -3492,7 +3495,7 @@ module.exports = function registerRoutes(router, context) {
    *         description: Forbidden — admin access required
    */
   // Status handler — uses unifiedSyncState which is set after org-teams routes register
-  router.get('/admin/roster-sync/status', requireAdmin, function(req, res) {
+  router.get('/admin/roster-sync/status', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const config = rosterSyncConfig.loadConfig(storage);
       const metadataSyncStatus = readFromStorage('org-roster/sync-status.json');
@@ -3549,7 +3552,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.get('/admin/jira-sync/config', requireAdmin, function(req, res) {
+  router.get('/admin/jira-sync/config', requireAdmin, requireScope('metrics:write'), function(req, res) {
     try {
       const config = jiraSyncConfig.loadConfig(storage);
       res.json({ projectKeys: [], ...config });
@@ -3579,7 +3582,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.post('/admin/jira-sync/config', requireAdmin, function(req, res) {
+  router.post('/admin/jira-sync/config', requireAdmin, requireScope('metrics:write'), function(req, res) {
     try {
       const { projectKeys } = req.body;
 
@@ -3674,7 +3677,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of team snapshots
    */
-  router.get('/snapshots/:teamKey', function(req, res) {
+  router.get('/snapshots/:teamKey', requireScope('team-tracker:read'), function(req, res) {
     try {
       const teamKey = decodeURIComponent(req.params.teamKey);
       const data = getOrGenerateTeamSnapshots(teamKey);
@@ -3708,7 +3711,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of person snapshots
    */
-  router.get('/snapshots/:teamKey/:personName', function(req, res) {
+  router.get('/snapshots/:teamKey/:personName', requireScope('team-tracker:read'), function(req, res) {
     try {
       const teamKey = decodeURIComponent(req.params.teamKey);
       const personName = decodeURIComponent(req.params.personName);
@@ -3739,7 +3742,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.post('/snapshots/generate', requireAdmin, function(req, res) {
+  router.post('/snapshots/generate', requireAdmin, requireScope('team-tracker:write'), function(req, res) {
     try {
       const roster = deriveRoster();
       const completedPeriods = snapshots.getCompletedPeriods();
@@ -3791,7 +3794,7 @@ module.exports = function registerRoutes(router, context) {
    *       403:
    *         description: Forbidden — admin access required
    */
-  router.delete('/snapshots', requireAdmin, function(req, res) {
+  router.delete('/snapshots', requireAdmin, requireScope('team-tracker:write'), function(req, res) {
     try {
       const result = deleteStorageDirectory('snapshots');
       res.json({ success: true, deleted: result.deleted });
@@ -4080,7 +4083,7 @@ module.exports = function registerRoutes(router, context) {
    *       409:
    *         description: Sync already in progress
    */
-  router.post('/admin/roster-sync/unified', requireAdmin, function(req, res) {
+  router.post('/admin/roster-sync/unified', requireAdmin, requireScope('roster:write'), function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Sync disabled in demo mode' });
     }

--- a/modules/team-tracker/server/routes/ipa-registry.js
+++ b/modules/team-tracker/server/routes/ipa-registry.js
@@ -30,6 +30,7 @@ function registerIpaRegistryRoutes(router, context) {
   var storage = context.storage;
   var requireAdmin = context.requireAdmin;
   var requireTeamAdmin = context.requireTeamAdmin;
+  var requireScope = context.requireScope;
   var DEMO_MODE = process.env.DEMO_MODE === 'true';
 
   // Rate limiting state for LDAP search (per user, 5 req / 10s)
@@ -59,7 +60,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Config and IPA status
    */
-  router.get('/ipa/config', requireAdmin, function(req, res) {
+  router.get('/ipa/config', requireAdmin, requireScope('roster:write'), function(req, res) {
     res.json({ config: loadConfig(storage), ipa: ipaClient.getIpaStatus() });
   });
 
@@ -73,7 +74,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Saved config
    */
-  router.post('/ipa/config', requireAdmin, function(req, res) {
+  router.post('/ipa/config', requireAdmin, requireScope('roster:write'), function(req, res) {
     var config = loadConfig(storage) || {};
     var body = req.body;
     if (body.orgRoots !== undefined) config.orgRoots = body.orgRoots;
@@ -95,7 +96,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Connection test result
    */
-  router.post('/ipa/test', requireAdmin, function(req, res) {
+  router.post('/ipa/test', requireAdmin, requireScope('roster:write'), function(req, res) {
     ipaClient.testConnection().then(function(result) {
       res.json(result);
     }).catch(function(err) {
@@ -115,7 +116,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Sync result
    */
-  router.post('/ipa/sync', requireAdmin, function(req, res) {
+  router.post('/ipa/sync', requireAdmin, requireScope('roster:write'), function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Sync disabled in demo mode' });
     }
@@ -136,7 +137,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Sync status
    */
-  router.get('/ipa/sync/status', function(req, res) {
+  router.get('/ipa/sync/status', requireScope('roster:read'), function(req, res) {
     var log = loadSyncLog(storage);
     res.json({ running: isConsolidatedSyncInProgress(), startedAt: null, lastResult: log });
   });
@@ -153,7 +154,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Filtered list of people
    */
-  router.get('/registry/people', function(req, res) {
+  router.get('/registry/people', requireScope('roster:read'), function(req, res) {
     var people = getPeopleMap();
     var result = [];
     var uids = Object.keys(people);
@@ -218,7 +219,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.get('/registry/people/:uid', function(req, res) {
+  router.get('/registry/people/:uid', requireScope('roster:read'), function(req, res) {
     var people = getPeopleMap();
     var person = Object.prototype.hasOwnProperty.call(people, req.params.uid) ? people[req.params.uid] : undefined;
     // Fallback: if not found by UID key, try matching by name
@@ -282,7 +283,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.put('/registry/people/:uid/github', requireAdmin, function(req, res) {
+  router.put('/registry/people/:uid/github', requireAdmin, requireScope('roster:write'), function(req, res) {
     var username = req.body.username;
     if (!username || typeof username !== 'string' || !username.trim()) return res.status(400).json({ error: 'Username is required' });
     if (!VALID_USERNAME.test(username.trim())) return res.status(400).json({ error: 'Invalid username format (1-39 chars, alphanumeric/dash/underscore/dot)' });
@@ -310,7 +311,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.put('/registry/people/:uid/gitlab', requireAdmin, function(req, res) {
+  router.put('/registry/people/:uid/gitlab', requireAdmin, requireScope('roster:write'), function(req, res) {
     var username = req.body.username;
     if (!username || typeof username !== 'string' || !username.trim()) return res.status(400).json({ error: 'Username is required' });
     if (!VALID_USERNAME.test(username.trim())) return res.status(400).json({ error: 'Invalid username format (1-39 chars, alphanumeric/dash/underscore/dot)' });
@@ -338,7 +339,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.delete('/registry/people/:uid/github', requireAdmin, function(req, res) {
+  router.delete('/registry/people/:uid/github', requireAdmin, requireScope('roster:write'), function(req, res) {
     var updated = writePeopleUpdate(req.params.uid, function(p) { p.github = null; });
     if (!updated) return res.status(404).json({ error: 'Person not found' });
     res.json({ status: 'removed' });
@@ -363,7 +364,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.delete('/registry/people/:uid/gitlab', requireAdmin, function(req, res) {
+  router.delete('/registry/people/:uid/gitlab', requireAdmin, requireScope('roster:write'), function(req, res) {
     var updated = writePeopleUpdate(req.params.uid, function(p) { p.gitlab = null; });
     if (!updated) return res.status(404).json({ error: 'Person not found' });
     res.json({ status: 'removed' });
@@ -390,7 +391,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.post('/registry/people/:uid/reactivate', requireAdmin, function(req, res) {
+  router.post('/registry/people/:uid/reactivate', requireAdmin, requireScope('roster:write'), function(req, res) {
     var updated = writePeopleUpdate(req.params.uid, function(p) { p.status = 'active'; p.inactiveSince = null; });
     if (!updated) return res.status(404).json({ error: 'Person not found' });
     res.json({ status: 'reactivated', person: updated });
@@ -415,7 +416,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       404:
    *         description: Person not found
    */
-  router.delete('/registry/people/:uid', requireAdmin, function(req, res) {
+  router.delete('/registry/people/:uid', requireAdmin, requireScope('roster:write'), function(req, res) {
     var reg = loadRegistry(storage);
     if (!reg.people || !Object.prototype.hasOwnProperty.call(reg.people, req.params.uid)) return res.status(404).json({ error: 'Person not found' });
     delete reg.people[req.params.uid];
@@ -435,7 +436,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Org tree hierarchy
    */
-  router.get('/registry/orgs', function(req, res) {
+  router.get('/registry/orgs', requireScope('roster:read'), function(req, res) {
     var reg = loadRegistry(storage);
     var people = reg.people || {};
     var meta = reg.meta || {};
@@ -474,7 +475,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       200:
    *         description: Registry stats including counts, coverage, and breakdowns
    */
-  router.get('/registry/stats', function(req, res) {
+  router.get('/registry/stats', requireScope('roster:read'), function(req, res) {
     var people = getPeopleMap();
     var uids = Object.keys(people);
     var active = 0, inactive = 0, auxiliaryCount = 0, byOrg = {}, byGeo = {};
@@ -572,7 +573,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       503:
    *         description: LDAP not available
    */
-  router.get('/registry/people/search/ldap', function(req, res) {
+  router.get('/registry/people/search/ldap', requireScope('team-tracker:read'), function(req, res) {
     if (DEMO_MODE) {
       return res.status(503).json({ error: 'LDAP not available in demo mode', code: 'LDAP_UNAVAILABLE' });
     }
@@ -664,7 +665,7 @@ function registerIpaRegistryRoutes(router, context) {
    *       503:
    *         description: LDAP not available
    */
-  router.post('/registry/people/ldap-import', requireTeamAdmin, function(req, res) {
+  router.post('/registry/people/ldap-import', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
     if (DEMO_MODE) {
       return res.status(503).json({ error: 'LDAP not available in demo mode', code: 'LDAP_UNAVAILABLE' });
     }

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -22,7 +22,7 @@ function isOrgSyncInProgress() {
 }
 
 module.exports = function registerOrgTeamsRoutes(router, context) {
-  const { storage, requireAdmin } = context;
+  const { storage, requireAdmin, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
 
@@ -228,7 +228,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: List of enriched teams with unassigned people
    */
-  router.get('/org-teams', function(req, res) {
+  router.get('/org-teams', requireScope('roster:read'), function(req, res) {
     try {
       const { teams, unassigned, totalPeople, fetchedAt } = buildEnrichedTeams(req.query.org);
       const rfeData = readFromStorage('org-roster/rfe-backlog.json');
@@ -265,7 +265,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       404:
    *         description: Team not found
    */
-  router.get('/org-teams/:teamKey', function(req, res) {
+  router.get('/org-teams/:teamKey', requireScope('roster:read'), function(req, res) {
     try {
       const teamKey = decodeURIComponent(req.params.teamKey);
       const sepIdx = teamKey.indexOf('::');
@@ -305,7 +305,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: List of team members
    */
-  router.get('/org-teams/:teamKey/members', function(req, res) {
+  router.get('/org-teams/:teamKey/members', requireScope('roster:read'), function(req, res) {
     try {
       const teamKey = decodeURIComponent(req.params.teamKey);
       const sepIdx = teamKey.indexOf('::');
@@ -340,7 +340,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: List of orgs
    */
-  router.get('/org-list', function(req, res) {
+  router.get('/org-list', requireScope('roster:read'), function(req, res) {
     try {
       // Derive orgs and team counts from people data (source of truth)
       const allPeople = getAllPeople(storage);
@@ -394,7 +394,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       404:
    *         description: No data for this org
    */
-  router.get('/org-summary/:orgName', function(req, res) {
+  router.get('/org-summary/:orgName', requireScope('roster:read'), function(req, res) {
     try {
       const orgName = decodeURIComponent(req.params.orgName);
       const isAll = orgName === '_all';
@@ -460,7 +460,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *         description: Component map
    *     deprecated: true
    */
-  router.get('/components', function(req, res) {
+  router.get('/components', requireScope('team-tracker:read'), function(req, res) {
     try {
       const { teams } = buildEnrichedTeams();
       const components = {};
@@ -495,7 +495,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: RFE backlog grouped by component and team
    */
-  router.get('/rfe-backlog', function(req, res) {
+  router.get('/rfe-backlog', requireScope('roster:read'), function(req, res) {
     try {
       const data = readFromStorage('org-roster/rfe-backlog.json');
       if (!data) return res.json({ byComponent: {}, byTeam: {} });
@@ -527,7 +527,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: RFE configuration
    */
-  router.get('/rfe-config', function(req, res) {
+  router.get('/rfe-config', requireScope('roster:read'), function(req, res) {
     try {
       const config = getOrgConfig();
       res.json({
@@ -555,7 +555,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       403:
    *         description: Admin access required
    */
-  router.get('/org-config', requireAdmin, function(req, res) {
+  router.get('/org-config', requireAdmin, requireScope('roster:write'), function(req, res) {
     try { res.json(getOrgConfig()); }
     catch { res.status(500).json({ error: 'Failed to load configuration' }); }
   });
@@ -572,7 +572,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       403:
    *         description: Admin access required
    */
-  router.post('/org-config', requireAdmin, function(req, res) {
+  router.post('/org-config', requireAdmin, requireScope('roster:write'), function(req, res) {
     try {
       const body = req.body;
       if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -609,7 +609,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       403:
    *         description: Admin access required
    */
-  router.get('/sheet-orgs', requireAdmin, async function(req, res) {
+  router.get('/sheet-orgs', requireAdmin, requireScope('roster:write'), async function(req, res) {
     try {
       const config = getOrgConfig();
       const tabName = config.teamBoardsTab;
@@ -644,7 +644,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: List of configured org names
    */
-  router.get('/configured-orgs', function(req, res) {
+  router.get('/configured-orgs', requireScope('roster:read'), function(req, res) {
     try {
       const displayNames = buildOrgKeyToDisplayName();
       const orgs = Object.values(displayNames).sort();
@@ -667,7 +667,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       200:
    *         description: Sync status with last sync time and current state
    */
-  router.get('/org-sync/status', function(req, res) {
+  router.get('/org-sync/status', requireScope('roster:read'), function(req, res) {
     try {
       const data = readFromStorage('org-roster/sync-status.json');
       res.json(data || { lastSyncAt: null, status: 'never', syncing: orgSyncInProgress });
@@ -724,7 +724,7 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
    *       409:
    *         description: Sync already in progress
    */
-  router.post('/org-sync/trigger', requireAdmin, async function(req, res) {
+  router.post('/org-sync/trigger', requireAdmin, requireScope('roster:write'), async function(req, res) {
     if (orgSyncInProgress) return res.status(409).json({ error: 'Sync already in progress' });
 
     res.json({ status: 'started' });

--- a/modules/upstream-pulse/__tests__/server/index.test.js
+++ b/modules/upstream-pulse/__tests__/server/index.test.js
@@ -15,7 +15,7 @@ describe('upstream-pulse server module', () => {
       get: vi.fn((...args) => registered.push({ method: 'get', path: args[0] })),
       post: vi.fn(),
     }
-    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn(), storage: { readFromStorage: vi.fn() } }
+    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } }
 
     registerRoutes(router, context)
 
@@ -38,26 +38,26 @@ describe('upstream-pulse server module', () => {
       post: vi.fn((...args) => postCalls.push({ path: args[0] })),
     }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin, storage: { readFromStorage: vi.fn() } })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } })
 
     expect(postCalls).toHaveLength(2)
     expect(postCalls.map(c => c.path)).toContain('/projects')
     expect(postCalls.map(c => c.path)).toContain('/roster-push')
-    expect(router.post).toHaveBeenCalledWith('/projects', requireAdmin, expect.any(Function))
-    expect(router.post).toHaveBeenCalledWith('/roster-push', requireAdmin, expect.any(Function))
+    expect(router.post).toHaveBeenCalledWith('/projects', requireAdmin, expect.any(Function), expect.any(Function))
+    expect(router.post).toHaveBeenCalledWith('/roster-push', requireAdmin, expect.any(Function), expect.any(Function))
   })
 
   it('gates repo-info behind requireAdmin', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin, storage: { readFromStorage: vi.fn() } })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } })
 
-    expect(router.get).toHaveBeenCalledWith('/repo-info', requireAdmin, expect.any(Function))
+    expect(router.get).toHaveBeenCalledWith('/repo-info', requireAdmin, expect.any(Function), expect.any(Function))
   })
 
   it('registers diagnostics hook when available', () => {
     const router = { get: vi.fn(), post: vi.fn() }
-    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn(), storage: { readFromStorage: vi.fn() } }
+    const context = { registerDiagnostics: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } }
 
     registerRoutes(router, context)
     expect(context.registerDiagnostics).toHaveBeenCalledWith(expect.any(Function))
@@ -65,7 +65,7 @@ describe('upstream-pulse server module', () => {
 
   it('does not fail when registerDiagnostics is absent', () => {
     const router = { get: vi.fn(), post: vi.fn() }
-    const context = { requireAdmin: vi.fn(), storage: { readFromStorage: vi.fn() } }
+    const context = { requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } }
 
     expect(() => registerRoutes(router, context)).not.toThrow()
   })

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -221,6 +221,7 @@ function startPeriodicRosterPush(storage) {
 }
 
 module.exports = function registerRoutes(router, context) {
+  const { requireScope } = context;
 
   function handleProxyError(res, err) {
     const status = err.upstreamStatus || 502;
@@ -231,7 +232,7 @@ module.exports = function registerRoutes(router, context) {
     });
   }
 
-  router.get('/config', async function(req, res) {
+  router.get('/config', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const connection = await checkConnection();
       res.json({
@@ -244,7 +245,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.get('/dashboard', async function(req, res) {
+  router.get('/dashboard', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const data = await proxyRequest('/api/metrics/dashboard', {
         days: req.query.days,
@@ -257,7 +258,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.get('/contributors', async function(req, res) {
+  router.get('/contributors', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const data = await proxyRequest('/api/metrics/contributors', {
         days: req.query.days,
@@ -271,7 +272,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.get('/leadership', async function(req, res) {
+  router.get('/leadership', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const data = await proxyRequest('/api/metrics/leadership', {
         githubOrg: req.query.githubOrg,
@@ -283,7 +284,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.get('/projects', async function(req, res) {
+  router.get('/projects', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const data = await proxyRequest('/api/projects', {
         githubOrg: req.query.githubOrg
@@ -294,7 +295,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.get('/orgs', async function(req, res) {
+  router.get('/orgs', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const data = await proxyRequest('/api/orgs', {
         days: req.query.days
@@ -305,7 +306,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.get('/project-jobs', async function(req, res) {
+  router.get('/project-jobs', requireScope('upstream-pulse:read'), async function(req, res) {
     try {
       const projectId = req.query.projectId;
       if (!projectId) {
@@ -334,7 +335,7 @@ module.exports = function registerRoutes(router, context) {
 
   const { requireAdmin } = context;
 
-  router.get('/repo-info', requireAdmin, async function(req, res) {
+  router.get('/repo-info', requireAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       const data = await proxyAdminGet('/api/github/repo-info', {
         org: req.query.org,
@@ -346,7 +347,7 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
-  router.post('/projects', requireAdmin, async function(req, res) {
+  router.post('/projects', requireAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       const data = await proxyMutatingRequest('/api/projects', req.body, req);
       for (const key of responseCache.keys()) {
@@ -367,7 +368,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ── Roster push (sync org-pulse team data to upstream-pulse) ──
 
-  router.post('/roster-push', requireAdmin, async function(req, res) {
+  router.post('/roster-push', requireAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       const result = await pushRosterToUpstream(context.storage);
       if (!result.skipped) {

--- a/server/__tests__/api-tokens.test.js
+++ b/server/__tests__/api-tokens.test.js
@@ -209,6 +209,194 @@ describe('api-tokens', () => {
     })
   })
 
+  describe('createToken with scopes', () => {
+    it('creates a token with valid scopes', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Scoped', null, ['roster:read', 'metrics:read'])
+      expect(result.scopes).toEqual(['roster:read', 'metrics:read'])
+    })
+
+    it('creates a full-access token with null scopes', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Full', null, null)
+      expect(result.scopes).toBeNull()
+    })
+
+    it('creates a full-access token when scopes omitted', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Default', null)
+      expect(result.scopes).toBeNull()
+    })
+
+    it('accepts wildcard ["*"] scopes', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Wild', null, ['*'])
+      expect(result.scopes).toEqual(['*'])
+    })
+
+    it('accepts empty array [] scopes', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Empty', null, [])
+      expect(result.scopes).toEqual([])
+    })
+
+    it('rejects invalid scopes', async () => {
+      await expect(apiTokens.createToken('user@test.com', 'Bad', null, ['invalid:scope']))
+        .rejects.toThrow('Invalid scopes')
+    })
+
+    it('rejects non-array scopes', async () => {
+      await expect(apiTokens.createToken('user@test.com', 'Bad', null, 'roster:read'))
+        .rejects.toThrow('scopes must be an array or null')
+    })
+
+    it('deduplicates scopes', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Dupes', null, ['roster:read', 'roster:read'])
+      expect(result.scopes).toEqual(['roster:read'])
+    })
+
+    it('stores scopes on the record', async () => {
+      await apiTokens.createToken('user@test.com', 'Scoped', null, ['roster:read'])
+      const data = storage._store['api-tokens.json']
+      expect(data.tokens[0].scopes).toEqual(['roster:read'])
+    })
+
+    it('return value includes scopes field', async () => {
+      const result = await apiTokens.createToken('user@test.com', 'Test', null, ['metrics:read'])
+      expect(result).toHaveProperty('scopes')
+      expect(result.scopes).toEqual(['metrics:read'])
+    })
+  })
+
+  describe('updateTokenScopes', () => {
+    it('updates scopes on own token', async () => {
+      const { id } = await apiTokens.createToken('user@test.com', 'Test', null, ['roster:read'])
+      const updated = await apiTokens.updateTokenScopes(id, 'user@test.com', ['metrics:read', 'github:read'])
+      expect(updated.scopes).toEqual(['metrics:read', 'github:read'])
+    })
+
+    it('returns null when token not owned by user', async () => {
+      const { id } = await apiTokens.createToken('user1@test.com', 'Test', null)
+      const result = await apiTokens.updateTokenScopes(id, 'user2@test.com', ['roster:read'])
+      expect(result).toBeNull()
+    })
+
+    it('admin can update any token (ownerEmail null)', async () => {
+      const { id } = await apiTokens.createToken('user@test.com', 'Test', null)
+      const updated = await apiTokens.updateTokenScopes(id, null, ['roster:read'])
+      expect(updated.scopes).toEqual(['roster:read'])
+    })
+
+    it('validates scope values', async () => {
+      const { id } = await apiTokens.createToken('user@test.com', 'Test', null)
+      await expect(apiTokens.updateTokenScopes(id, 'user@test.com', ['bad:scope']))
+        .rejects.toThrow('Invalid scopes')
+    })
+
+    it('returns null for non-existent token', async () => {
+      const result = await apiTokens.updateTokenScopes('nonexistent', 'user@test.com', ['roster:read'])
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('sanitizeToken with scopes', () => {
+    it('includes scopes field', async () => {
+      await apiTokens.createToken('user@test.com', 'Test', null, ['roster:read'])
+      const list = apiTokens.listUserTokens('user@test.com')
+      expect(list[0]).toHaveProperty('scopes')
+      expect(list[0].scopes).toEqual(['roster:read'])
+    })
+
+    it('normalizes undefined scopes to null', () => {
+      // Simulate a legacy token record without scopes
+      storage.writeToStorage('api-tokens.json', {
+        tokens: [{
+          id: 'legacy-1',
+          name: 'Legacy',
+          tokenHash: 'abc',
+          tokenPrefix: 'tt_legacy00',
+          ownerEmail: 'user@test.com',
+          createdAt: '2026-01-01T00:00:00Z',
+          expiresAt: null,
+          lastUsedAt: null
+          // No scopes field
+        }]
+      })
+      apiTokens._resetForTest()
+      const list = apiTokens.listUserTokens('user@test.com')
+      expect(list[0].scopes).toBeNull()
+    })
+  })
+
+  describe('legacy tokens', () => {
+    it('legacy tokens without scopes field still validate correctly', async () => {
+      const { token } = await apiTokens.createToken('user@test.com', 'Test', null)
+      // Manually remove scopes from the stored record
+      const data = storage._store['api-tokens.json']
+      delete data.tokens[0].scopes
+      apiTokens._resetForTest()
+      const record = apiTokens.validateToken(token)
+      expect(record).toBeTruthy()
+      expect(record.ownerEmail).toBe('user@test.com')
+    })
+  })
+
+  describe('validateScopes', () => {
+    it('returns null for null input', () => {
+      expect(apiTokens.validateScopes(null)).toBeNull()
+    })
+
+    it('returns null for undefined input', () => {
+      expect(apiTokens.validateScopes(undefined)).toBeNull()
+    })
+
+    it('accepts valid scopes', () => {
+      expect(apiTokens.validateScopes(['roster:read', 'metrics:write'])).toEqual(['roster:read', 'metrics:write'])
+    })
+
+    it('rejects invalid scopes', () => {
+      expect(() => apiTokens.validateScopes(['bad'])).toThrow('Invalid scopes: bad')
+    })
+
+    it('accepts wildcard', () => {
+      expect(apiTokens.validateScopes(['*'])).toEqual(['*'])
+    })
+
+    it('rejects non-array', () => {
+      expect(() => apiTokens.validateScopes('roster:read')).toThrow('scopes must be an array or null')
+    })
+  })
+
+  describe('enforceTokenScopeCeiling', () => {
+    it('returns null for full-access requesting token (null)', () => {
+      expect(apiTokens.enforceTokenScopeCeiling(null, ['roster:read'])).toBeNull()
+    })
+
+    it('returns null for wildcard requesting token', () => {
+      expect(apiTokens.enforceTokenScopeCeiling(['*'], ['roster:read'])).toBeNull()
+    })
+
+    it('returns null when requested is subset', () => {
+      expect(apiTokens.enforceTokenScopeCeiling(['roster:read', 'metrics:read'], ['roster:read'])).toBeNull()
+    })
+
+    it('returns error when requested exceeds requesting', () => {
+      const result = apiTokens.enforceTokenScopeCeiling(['roster:read'], ['roster:read', 'metrics:read'])
+      expect(result).toContain('Cannot grant scopes beyond')
+      expect(result).toContain('metrics:read')
+    })
+
+    it('blocks wildcard from scoped token', () => {
+      const result = apiTokens.enforceTokenScopeCeiling(['roster:read'], ['*'])
+      expect(result).toContain('Cannot grant wildcard')
+    })
+
+    it('rejects empty requested scopes from a scoped token', () => {
+      const result = apiTokens.enforceTokenScopeCeiling(['roster:read'], [])
+      expect(result).toContain('Cannot grant full access')
+    })
+
+    it('rejects null requested scopes from a scoped token', () => {
+      const result = apiTokens.enforceTokenScopeCeiling(['roster:read'], null)
+      expect(result).toContain('Cannot grant full access')
+    })
+  })
+
   describe('write lock serialization', () => {
     it('handles concurrent creates without data loss', async () => {
       const promises = []

--- a/server/api-tokens.js
+++ b/server/api-tokens.js
@@ -20,6 +20,57 @@ const EXPIRATION_OPTIONS = {
   '1y': 365 * 24 * 60 * 60 * 1000
 };
 
+const VALID_SCOPES = [
+  'roster:read', 'roster:write',
+  'metrics:read', 'metrics:write',
+  'github:read', 'github:write',
+  'gitlab:read', 'gitlab:write',
+  'team-tracker:read', 'team-tracker:write',
+  'feature-traffic:read', 'feature-traffic:write',
+  'ai-impact:read', 'ai-impact:write',
+  'release-analysis:read', 'release-analysis:write',
+  'release-planning:read', 'release-planning:write',
+  'upstream-pulse:read', 'upstream-pulse:write',
+  'health-metrics:read', 'health-metrics:write',
+  'admin:manage',
+  'tokens:manage',
+];
+
+/**
+ * Validate a scopes value. Returns normalized scopes or throws on invalid input.
+ */
+function validateScopes(scopes) {
+  if (scopes === null || scopes === undefined) return null; // full access
+  if (!Array.isArray(scopes)) throw new Error('scopes must be an array or null');
+  if (scopes.length === 1 && scopes[0] === '*') return ['*'];
+  const invalid = scopes.filter(s => !VALID_SCOPES.includes(s));
+  if (invalid.length > 0) throw new Error(`Invalid scopes: ${invalid.join(', ')}`);
+  return [...new Set(scopes)]; // deduplicate
+}
+
+/**
+ * Enforce scope escalation prevention for token-authenticated requests.
+ * Returns null if OK, or an error message string if escalation detected.
+ */
+function enforceTokenScopeCeiling(requestingScopes, requestedScopes) {
+  // No ceiling for full-access tokens or browser auth
+  if (!requestingScopes || (requestingScopes.length === 1 && requestingScopes[0] === '*')) {
+    return null; // no restriction
+  }
+  // If the requesting token is scoped, null/empty = full access = escalation
+  if (!requestedScopes || requestedScopes.length === 0) {
+    return 'Cannot grant full access from a scoped token';
+  }
+  if (requestedScopes.length === 1 && requestedScopes[0] === '*') {
+    return 'Cannot grant wildcard access from a scoped token';
+  }
+  const excess = requestedScopes.filter(s => !requestingScopes.includes(s));
+  if (excess.length > 0) {
+    return `Cannot grant scopes beyond your token's current access: ${excess.join(', ')}`;
+  }
+  return null; // OK
+}
+
 // In-memory state
 let _hashIndex = null; // Map<tokenHash, tokenRecord>
 let _lastUsedWriteTimes = new Map(); // Map<tokenId, timestamp>
@@ -88,10 +139,11 @@ function generateToken() {
 
 /**
  * Create a new API token for a user.
- * Returns { token, id, name, expiresAt } on success, or throws on validation error.
+ * Returns { token, id, name, scopes, expiresAt } on success, or throws on validation error.
  */
-function createToken(ownerEmail, name, expiresIn) {
+function createToken(ownerEmail, name, expiresIn, scopes) {
   return _withWriteLock(() => {
+    const validatedScopes = validateScopes(scopes);
     const tokens = _loadTokens();
 
     // Per-user limit
@@ -124,6 +176,7 @@ function createToken(ownerEmail, name, expiresIn) {
       tokenHash,
       tokenPrefix: rawToken.substring(0, 3 + 8), // "tt_" + 8 hex chars
       ownerEmail,
+      scopes: validatedScopes,
       createdAt: now,
       expiresAt,
       lastUsedAt: null
@@ -137,6 +190,7 @@ function createToken(ownerEmail, name, expiresIn) {
       token: rawToken,
       id,
       name,
+      scopes: record.scopes,
       expiresAt
     };
   });
@@ -221,10 +275,36 @@ function sanitizeToken(t) {
     name: t.name,
     tokenPrefix: t.tokenPrefix,
     ownerEmail: t.ownerEmail,
+    scopes: t.scopes || null,   // normalize undefined → null for JSON consistency
     createdAt: t.createdAt,
     expiresAt: t.expiresAt,
     lastUsedAt: t.lastUsedAt
   };
+}
+
+/**
+ * Update scopes for an existing token.
+ * If ownerEmail is provided, only update if the token belongs to that user.
+ * If ownerEmail is null, update regardless of owner (admin use).
+ * Returns updated sanitized token or null if not found.
+ */
+function updateTokenScopes(tokenId, ownerEmail, scopes) {
+  return _withWriteLock(() => {
+    const validatedScopes = validateScopes(scopes);
+    const tokens = _loadTokens();
+    const token = tokens.find(t => {
+      if (t.id !== tokenId) return false;
+      if (ownerEmail && t.ownerEmail !== ownerEmail) return false;
+      return true;
+    });
+
+    if (!token) return null;
+
+    token.scopes = validatedScopes;
+    _saveTokens(tokens);
+    _invalidateIndex();
+    return sanitizeToken(token);
+  });
 }
 
 /**
@@ -266,12 +346,16 @@ module.exports = {
   touchLastUsed,
   listUserTokens,
   listAllTokens,
+  updateTokenScopes,
   revokeToken,
   adminRevokeToken,
+  validateScopes,
+  enforceTokenScopeCeiling,
   // Constants for testing
   TOKEN_PREFIX,
   MAX_TOKENS_PER_USER,
   EXPIRATION_OPTIONS,
+  VALID_SCOPES,
   // Internal for testing
   _hashToken,
   _resetForTest() {

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -62,7 +62,7 @@ app.use(express.json({ limit: '10mb' }));
 app.use(function(req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
   res.header("Access-Control-Allow-Headers", "*");
-  res.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+  res.header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
   next();
 });
 
@@ -91,6 +91,13 @@ if (DEMO_MODE) {
         message: 'Token creation disabled in demo mode'
       });
     }
+    // Demo mode: block token scope editing
+    if (req.method === 'PATCH' && req.path.match(/^\/api\/(admin\/)?tokens\/[^/]+\/scopes$/)) {
+      return res.status(403).json({
+        status: 'skipped',
+        message: 'Token scope editing disabled in demo mode'
+      });
+    }
     next();
   });
 }
@@ -98,7 +105,7 @@ if (DEMO_MODE) {
 // ─── Auth (from shared package) ───
 
 const roleStore = createRoleStore(readFromStorage, writeToStorage);
-const { authMiddleware, requireAdmin, requireTeamAdmin, seedRoles } = createAuthMiddleware(readFromStorage, writeToStorage, {
+const { authMiddleware, requireAdmin, requireTeamAdmin, requireScope, seedRoles } = createAuthMiddleware(readFromStorage, writeToStorage, {
   tokenValidator: apiTokens,
   roleStore
 });
@@ -290,7 +297,7 @@ app.get('/api/site-config', function(req, res) {
  *       200:
  *         description: Updated site configuration
  */
-app.post('/api/site-config', requireAdmin, function(req, res) {
+app.post('/api/site-config', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Configuration changes disabled in demo mode' });
@@ -333,7 +340,7 @@ app.get('/api/messages', async function(req, res) {
   }
 });
 
-app.post('/api/admin/messages', requireAdmin, function(req, res) {
+app.post('/api/admin/messages', requireAdmin, requireScope('admin:manage'), function(req, res) {
   const { type, text, link } = req.body || {};
 
   // Validate required fields
@@ -373,7 +380,7 @@ app.post('/api/admin/messages', requireAdmin, function(req, res) {
   res.status(201).json(message);
 });
 
-app.delete('/api/admin/messages/:id', requireAdmin, function(req, res) {
+app.delete('/api/admin/messages/:id', requireAdmin, requireScope('admin:manage'), function(req, res) {
   const stored = readFromStorage('messages.json') || [];
   const index = stored.findIndex(m => m.id === req.params.id);
 
@@ -405,7 +412,7 @@ let backupRunning = false;
  *       409:
  *         description: Backup already in progress
  */
-app.post('/api/admin/backup', requireAdmin, async function(req, res) {
+app.post('/api/admin/backup', requireAdmin, requireScope('admin:manage'), async function(req, res) {
   if (backupRunning) {
     return res.status(409).json({ error: 'Backup already in progress' });
   }
@@ -432,7 +439,7 @@ app.post('/api/admin/backup', requireAdmin, async function(req, res) {
  *       200:
  *         description: List of backups
  */
-app.get('/api/admin/backup', requireAdmin, async function(req, res) {
+app.get('/api/admin/backup', requireAdmin, requireScope('admin:manage'), async function(req, res) {
   try {
     const backups = await backup.listBackups();
     res.json({ backups });
@@ -464,7 +471,7 @@ app.get('/api/admin/backup', requireAdmin, async function(req, res) {
  *       400:
  *         description: Invalid or missing key
  */
-app.post('/api/admin/backup/restore', requireAdmin, blockDuringImpersonation, async function(req, res) {
+app.post('/api/admin/backup/restore', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, async function(req, res) {
   const { key } = req.body || {};
   if (!key || typeof key !== 'string') {
     return res.status(400).json({ error: 'key is required' });
@@ -479,6 +486,100 @@ app.post('/api/admin/backup/restore', requireAdmin, blockDuringImpersonation, as
     console.error('[backup] Restore failed:', error);
     res.status(500).json({ error: error.message });
   }
+});
+
+// ─── Routes: Token Scopes Catalog ───
+
+/**
+ * @openapi
+ * /api/token-scopes:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Get available token scope catalog
+ *     description: Returns available scopes and presets for the UI. Requires authentication but no specific scope.
+ *     responses:
+ *       200:
+ *         description: Scope catalog with presets
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 scopes:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       key:
+ *                         type: string
+ *                       label:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ *                       category:
+ *                         type: string
+ *                 presets:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       key:
+ *                         type: string
+ *                       label:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ *                       scopes:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ */
+app.get('/api/token-scopes', function(req, res) {
+  res.json({
+    scopes: [
+      { key: 'roster:read', label: 'Roster (Read)', description: 'Read roster and org data', category: 'Roster' },
+      { key: 'roster:write', label: 'Roster (Write)', description: 'Trigger roster sync and refresh', category: 'Roster' },
+      { key: 'metrics:read', label: 'Metrics (Read)', description: 'Read person/team metrics and trends', category: 'Metrics' },
+      { key: 'metrics:write', label: 'Metrics (Write)', description: 'Refresh metrics', category: 'Metrics' },
+      { key: 'github:read', label: 'GitHub (Read)', description: 'Read GitHub contribution data', category: 'GitHub' },
+      { key: 'github:write', label: 'GitHub (Write)', description: 'Refresh GitHub data', category: 'GitHub' },
+      { key: 'gitlab:read', label: 'GitLab (Read)', description: 'Read GitLab contribution data', category: 'GitLab' },
+      { key: 'gitlab:write', label: 'GitLab (Write)', description: 'Refresh GitLab data', category: 'GitLab' },
+      { key: 'team-tracker:read', label: 'Team Tracker (Read)', description: 'Read team structure, fields, snapshots', category: 'Team Tracker' },
+      { key: 'team-tracker:write', label: 'Team Tracker (Write)', description: 'Mutate team structure, fields, snapshots', category: 'Team Tracker' },
+      { key: 'feature-traffic:read', label: 'Feature Traffic (Read)', description: 'Read feature traffic data', category: 'Feature Traffic' },
+      { key: 'feature-traffic:write', label: 'Feature Traffic (Write)', description: 'Refresh/configure feature traffic', category: 'Feature Traffic' },
+      { key: 'ai-impact:read', label: 'AI Impact (Read)', description: 'Read AI impact data', category: 'AI Impact' },
+      { key: 'ai-impact:write', label: 'AI Impact (Write)', description: 'Push/clear AI impact data', category: 'AI Impact' },
+      { key: 'release-analysis:read', label: 'Release Analysis (Read)', description: 'Read release analysis data', category: 'Release Analysis' },
+      { key: 'release-analysis:write', label: 'Release Analysis (Write)', description: 'Mutate release analysis data', category: 'Release Analysis' },
+      { key: 'release-planning:read', label: 'Release Planning (Read)', description: 'Read release planning / health data', category: 'Release Planning' },
+      { key: 'release-planning:write', label: 'Release Planning (Write)', description: 'Mutate release planning data', category: 'Release Planning' },
+      { key: 'upstream-pulse:read', label: 'Upstream Pulse (Read)', description: 'Read upstream pulse data', category: 'Upstream Pulse' },
+      { key: 'upstream-pulse:write', label: 'Upstream Pulse (Write)', description: 'Mutate upstream pulse data', category: 'Upstream Pulse' },
+      { key: 'health-metrics:read', label: 'Health Metrics (Read)', description: 'Read health metrics data', category: 'Health Metrics' },
+      { key: 'health-metrics:write', label: 'Health Metrics (Write)', description: 'Mutate health metrics data', category: 'Health Metrics' },
+      { key: 'admin:manage', label: 'Admin', description: 'Admin-only shell operations', category: 'Admin' },
+      { key: 'tokens:manage', label: 'Tokens', description: 'Manage own tokens (always implicitly granted)', category: 'Admin' }
+    ],
+    presets: [
+      {
+        key: 'read-only',
+        label: 'Read Only',
+        description: 'Read access to all data, no mutations',
+        scopes: ['roster:read', 'metrics:read', 'github:read', 'gitlab:read',
+                 'team-tracker:read', 'feature-traffic:read', 'ai-impact:read',
+                 'release-analysis:read', 'release-planning:read',
+                 'upstream-pulse:read', 'health-metrics:read']
+      },
+      {
+        key: 'full-access',
+        label: 'Full Access',
+        description: 'All scopes (same as no restrictions)',
+        scopes: ['*']
+      }
+    ]
+  });
 });
 
 // ─── Routes: API Tokens ───
@@ -502,7 +603,7 @@ app.post('/api/admin/backup/restore', requireAdmin, blockDuringImpersonation, as
  *                   items:
  *                     $ref: '#/components/schemas/ApiToken'
  */
-app.get('/api/tokens', blockDuringImpersonation, function(req, res) {
+app.get('/api/tokens', blockDuringImpersonation, requireScope('tokens:manage'), function(req, res) {
   try {
     const tokens = apiTokens.listUserTokens(req.userEmail);
     res.json({ tokens });
@@ -533,6 +634,12 @@ app.get('/api/tokens', blockDuringImpersonation, function(req, res) {
  *                 type: string
  *                 enum: [30d, 90d, 1y]
  *                 nullable: true
+ *               scopes:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 nullable: true
+ *                 description: Scope restrictions. Null or omitted for full access.
  *     responses:
  *       201:
  *         description: Token created (raw token shown only once)
@@ -547,6 +654,11 @@ app.get('/api/tokens', blockDuringImpersonation, function(req, res) {
  *                   type: string
  *                 name:
  *                   type: string
+ *                 scopes:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   nullable: true
  *                 expiresAt:
  *                   type: string
  *                   nullable: true
@@ -556,10 +668,16 @@ app.get('/api/tokens', blockDuringImpersonation, function(req, res) {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Scope escalation attempt
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  */
-app.post('/api/tokens', blockDuringImpersonation, async function(req, res) {
+app.post('/api/tokens', blockDuringImpersonation, requireScope('tokens:manage'), async function(req, res) {
   try {
-    const { name, expiresIn } = req.body;
+    const { name, expiresIn, scopes } = req.body;
 
     // Validate name
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -574,7 +692,16 @@ app.post('/api/tokens', blockDuringImpersonation, async function(req, res) {
       return res.status(400).json({ error: 'expiresIn must be one of: 30d, 90d, 1y, or null' });
     }
 
-    const result = await apiTokens.createToken(req.userEmail, name.trim(), expiresIn || null);
+    // Scope escalation guard for token-authenticated requests
+    if (req.authMethod === 'token') {
+      const validated = scopes != null ? apiTokens.validateScopes(scopes) : null;
+      const escalation = apiTokens.enforceTokenScopeCeiling(req.tokenScopes, validated);
+      if (escalation) {
+        return res.status(403).json({ error: escalation });
+      }
+    }
+
+    const result = await apiTokens.createToken(req.userEmail, name.trim(), expiresIn || null, scopes !== undefined ? scopes : null);
     res.status(201).json(result);
   } catch (error) {
     if (error.statusCode) {
@@ -603,7 +730,7 @@ app.post('/api/tokens', blockDuringImpersonation, async function(req, res) {
  *       404:
  *         $ref: '#/components/responses/NotFound'
  */
-app.delete('/api/tokens/:id', blockDuringImpersonation, async function(req, res) {
+app.delete('/api/tokens/:id', blockDuringImpersonation, requireScope('tokens:manage'), async function(req, res) {
   try {
     const revoked = await apiTokens.revokeToken(req.params.id, req.userEmail);
     if (!revoked) {
@@ -612,6 +739,68 @@ app.delete('/api/tokens/:id', blockDuringImpersonation, async function(req, res)
     res.json({ success: true });
   } catch (error) {
     console.error('Revoke token error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * @openapi
+ * /api/tokens/{id}/scopes:
+ *   patch:
+ *     tags: [Auth]
+ *     summary: Update scopes on own API token
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [scopes]
+ *             properties:
+ *               scopes:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 nullable: true
+ *     responses:
+ *       200:
+ *         description: Updated token record
+ *       400:
+ *         description: Invalid scopes
+ *       403:
+ *         description: Scope escalation or impersonation blocked
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ */
+app.patch('/api/tokens/:id/scopes', blockDuringImpersonation, requireScope('tokens:manage'), async function(req, res) {
+  try {
+    const { scopes } = req.body;
+
+    // Scope escalation guard for token-authenticated requests
+    if (req.authMethod === 'token') {
+      const validated = scopes != null ? apiTokens.validateScopes(scopes) : null;
+      const escalation = apiTokens.enforceTokenScopeCeiling(req.tokenScopes, validated);
+      if (escalation) {
+        return res.status(403).json({ error: escalation });
+      }
+    }
+
+    const updated = await apiTokens.updateTokenScopes(req.params.id, req.userEmail, scopes);
+    if (!updated) {
+      return res.status(404).json({ error: 'Token not found' });
+    }
+    res.json(updated);
+  } catch (error) {
+    if (error.message && (error.message.includes('Invalid scopes') || error.message.includes('scopes must be'))) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Update token scopes error:', error);
     res.status(500).json({ error: error.message });
   }
 });
@@ -637,7 +826,7 @@ app.delete('/api/tokens/:id', blockDuringImpersonation, async function(req, res)
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  */
-app.get('/api/admin/tokens', requireAdmin, function(req, res) {
+app.get('/api/admin/tokens', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     const tokens = apiTokens.listAllTokens();
     res.json({ tokens });
@@ -667,7 +856,7 @@ app.get('/api/admin/tokens', requireAdmin, function(req, res) {
  *       404:
  *         $ref: '#/components/responses/NotFound'
  */
-app.delete('/api/admin/tokens/:id', requireAdmin, blockDuringImpersonation, async function(req, res) {
+app.delete('/api/admin/tokens/:id', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, async function(req, res) {
   try {
     const revoked = await apiTokens.adminRevokeToken(req.params.id);
     if (!revoked) {
@@ -676,6 +865,68 @@ app.delete('/api/admin/tokens/:id', requireAdmin, blockDuringImpersonation, asyn
     res.json({ success: true });
   } catch (error) {
     console.error('Admin revoke token error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * @openapi
+ * /api/admin/tokens/{id}/scopes:
+ *   patch:
+ *     tags: [Auth]
+ *     summary: Update scopes on any API token (admin)
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [scopes]
+ *             properties:
+ *               scopes:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 nullable: true
+ *     responses:
+ *       200:
+ *         description: Updated token record
+ *       400:
+ *         description: Invalid scopes
+ *       403:
+ *         description: Admin access required or scope escalation
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ */
+app.patch('/api/admin/tokens/:id/scopes', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, async function(req, res) {
+  try {
+    const { scopes } = req.body;
+
+    // Scope escalation guard for token-authenticated requests
+    if (req.authMethod === 'token') {
+      const validated = scopes != null ? apiTokens.validateScopes(scopes) : null;
+      const escalation = apiTokens.enforceTokenScopeCeiling(req.tokenScopes, validated);
+      if (escalation) {
+        return res.status(403).json({ error: escalation });
+      }
+    }
+
+    const updated = await apiTokens.updateTokenScopes(req.params.id, null, scopes);
+    if (!updated) {
+      return res.status(404).json({ error: 'Token not found' });
+    }
+    res.json(updated);
+  } catch (error) {
+    if (error.message && (error.message.includes('Invalid scopes') || error.message.includes('scopes must be'))) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Admin update token scopes error:', error);
     res.status(500).json({ error: error.message });
   }
 });
@@ -700,7 +951,7 @@ app.delete('/api/admin/tokens/:id', requireAdmin, blockDuringImpersonation, asyn
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.get('/api/allowlist', requireAdmin, function(req, res) {
+app.get('/api/allowlist', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     res.json({ emails: roleStore.getAdminEmails() });
   } catch (error) {
@@ -750,7 +1001,7 @@ app.get('/api/allowlist', requireAdmin, function(req, res) {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.post('/api/allowlist', requireAdmin, blockDuringImpersonation, function(req, res) {
+app.post('/api/allowlist', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, function(req, res) {
   try {
     const { email } = req.body;
     if (!email || typeof email !== 'string') {
@@ -808,7 +1059,7 @@ app.post('/api/allowlist', requireAdmin, blockDuringImpersonation, function(req,
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.delete('/api/allowlist/:email', requireAdmin, blockDuringImpersonation, function(req, res) {
+app.delete('/api/allowlist/:email', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, function(req, res) {
   try {
     const email = decodeURIComponent(req.params.email).toLowerCase();
 
@@ -834,7 +1085,7 @@ app.get('/api/roles/me', function(req, res) {
   res.json({ roles: roleStore.getRoles(req.userEmail) });
 });
 
-app.get('/api/roles', requireAdmin, function(req, res) {
+app.get('/api/roles', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     res.json({ assignments: roleStore.listAssignments() });
   } catch (error) {
@@ -843,7 +1094,7 @@ app.get('/api/roles', requireAdmin, function(req, res) {
   }
 });
 
-app.post('/api/roles/assign', requireAdmin, blockDuringImpersonation, function(req, res) {
+app.post('/api/roles/assign', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, function(req, res) {
   try {
     const { email, role } = req.body;
     if (!email || typeof email !== 'string') {
@@ -861,7 +1112,7 @@ app.post('/api/roles/assign', requireAdmin, blockDuringImpersonation, function(r
   }
 });
 
-app.post('/api/roles/revoke', requireAdmin, blockDuringImpersonation, function(req, res) {
+app.post('/api/roles/revoke', requireAdmin, requireScope('admin:manage'), blockDuringImpersonation, function(req, res) {
   try {
     const { email, role } = req.body;
     if (!email || typeof email !== 'string') {
@@ -956,7 +1207,7 @@ messageRegistry.registerProvider('backup-staleness', async function(userContext)
     return [];
   }
 });
-const moduleContext = { storage: storageModule, requireAuth: authMiddleware, requireAdmin, requireTeamAdmin, roleStore, registerDiagnostics: null };
+const moduleContext = { storage: storageModule, requireAuth: authMiddleware, requireAdmin, requireTeamAdmin, requireScope, roleStore, registerDiagnostics: null };
 
 const persistedState = loadModuleState(storageModule);
 // Persist defaults for any newly discovered modules at startup (not in GET handlers).
@@ -1079,7 +1330,7 @@ app.get('/api/modules/:slug', function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: list modules (with git fields, masked tokens)
-app.get('/api/admin/modules', requireAdmin, function(req, res) {
+app.get('/api/admin/modules', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     const config = modulesConfig.loadModulesConfig(storageModule) || { modules: [] };
     res.json({ modules: config.modules.map(modulesConfig.sanitizeForAdmin) });
@@ -1120,7 +1371,7 @@ app.get('/api/admin/modules', requireAdmin, function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: register new module
-app.post('/api/admin/modules', requireAdmin, function(req, res) {
+app.post('/api/admin/modules', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     const result = modulesConfig.addModule(storageModule, req.body);
     if (result.error) {
@@ -1173,7 +1424,7 @@ app.post('/api/admin/modules', requireAdmin, function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: update module
-app.put('/api/admin/modules/:slug', requireAdmin, function(req, res) {
+app.put('/api/admin/modules/:slug', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     const result = modulesConfig.updateModule(storageModule, req.params.slug, req.body);
     if (result.error) {
@@ -1218,7 +1469,7 @@ app.put('/api/admin/modules/:slug', requireAdmin, function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: remove module
-app.delete('/api/admin/modules/:slug', requireAdmin, function(req, res) {
+app.delete('/api/admin/modules/:slug', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     const result = modulesConfig.removeModule(storageModule, req.params.slug);
     if (result.error) {
@@ -1272,7 +1523,7 @@ app.delete('/api/admin/modules/:slug', requireAdmin, function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: sync one module
-app.post('/api/admin/modules/:slug/sync', requireAdmin, async function(req, res) {
+app.post('/api/admin/modules/:slug/sync', requireAdmin, requireScope('admin:manage'), async function(req, res) {
   try {
     const mod = modulesConfig.getModule(storageModule, req.params.slug);
     if (!mod) {
@@ -1318,7 +1569,7 @@ app.post('/api/admin/modules/:slug/sync', requireAdmin, async function(req, res)
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: sync all git-static modules
-app.post('/api/admin/modules/sync', requireAdmin, async function(req, res) {
+app.post('/api/admin/modules/sync', requireAdmin, requireScope('admin:manage'), async function(req, res) {
   try {
     // Start sync in background
     gitSync.syncAllModules(storageModule).then(function(result) {
@@ -1355,7 +1606,7 @@ app.post('/api/admin/modules/sync', requireAdmin, async function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: get sync status
-app.get('/api/admin/modules/sync/status', requireAdmin, function(req, res) {
+app.get('/api/admin/modules/sync/status', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     res.json(gitSync.getSyncStatus(storageModule));
   } catch (error) {
@@ -1383,7 +1634,7 @@ const { handleExport } = require('./export');
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.get('/api/export/test-data', requireAdmin, function(req, res) {
+app.get('/api/export/test-data', requireAdmin, requireScope('admin:manage'), function(req, res) {
   handleExport(req, res, storageModule, builtInModules);
 });
 
@@ -1417,7 +1668,7 @@ const mustGather = require('./must-gather');
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.get('/api/must-gather', requireAdmin, async function(req, res) {
+app.get('/api/must-gather', requireAdmin, requireScope('admin:manage'), async function(req, res) {
   try {
     const redact = req.query.redact === 'aggressive' ? 'aggressive' : 'minimal';
     const bundle = await mustGather.collect({
@@ -1476,7 +1727,7 @@ app.get('/api/must-gather', requireAdmin, async function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: get all built-in modules with state
-app.get('/api/admin/modules/state', requireAdmin, function(req, res) {
+app.get('/api/admin/modules/state', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     const discovered = builtInModules;
     const currentState = loadModuleState(storageModule);
@@ -1542,7 +1793,7 @@ app.get('/api/admin/modules/state', requireAdmin, function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: enable a built-in module
-app.post('/api/admin/modules/:slug/enable', requireAdmin, function(req, res) {
+app.post('/api/admin/modules/:slug/enable', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Module state changes disabled in demo mode' });
@@ -1622,7 +1873,7 @@ app.post('/api/admin/modules/:slug/enable', requireAdmin, function(req, res) {
  *         $ref: '#/components/responses/ServerError'
  */
 // Admin: disable a built-in module
-app.post('/api/admin/modules/:slug/disable', requireAdmin, function(req, res) {
+app.post('/api/admin/modules/:slug/disable', requireAdmin, requireScope('admin:manage'), function(req, res) {
   try {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Module state changes disabled in demo mode' });

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -707,6 +707,9 @@ app.post('/api/tokens', blockDuringImpersonation, requireScope('tokens:manage'),
     if (error.statusCode) {
       return res.status(error.statusCode).json({ error: error.message });
     }
+    if (error.message && (error.message.includes('Invalid scopes') || error.message.includes('scopes must be'))) {
+      return res.status(400).json({ error: error.message });
+    }
     console.error('Create token error:', error);
     res.status(500).json({ error: error.message });
   }

--- a/server/health-metrics/routes.js
+++ b/server/health-metrics/routes.js
@@ -3,7 +3,7 @@ const { createEventStore } = require('./event-store');
 const { aggregateEvents, mergeDailyBreakdown } = require('./aggregator');
 
 function createHealthMetricsRouter(context) {
-  const { storage, requireAdmin, roleStore } = context;
+  const { storage, requireAdmin, requireScope, roleStore } = context;
   const { readFromStorage, writeToStorage } = storage;
   const { DATA_DIR } = require('../../shared/server/storage');
 
@@ -248,7 +248,7 @@ function createHealthMetricsRouter(context) {
   const PAGE_ID_PATTERN = /^[a-zA-Z0-9:_/-]+$/;
   const PAGE_ID_MAX_LENGTH = 200;
 
-  router.post('/track', (req, res) => {
+  router.post('/track', requireScope('health-metrics:write'), (req, res) => {
     if (DEMO_MODE) return res.json({ ok: true });
 
     const { page } = req.body;
@@ -293,12 +293,12 @@ function createHealthMetricsRouter(context) {
     res.json({ ok: true });
   });
 
-  router.get('/tracking/status', (req, res) => {
+  router.get('/tracking/status', requireScope('health-metrics:read'), (req, res) => {
     const optedOut = loadOptedOut();
     res.json({ optedOut: optedOut.emails.includes(req.userEmail) });
   });
 
-  router.post('/tracking/opt-out', (req, res) => {
+  router.post('/tracking/opt-out', requireScope('health-metrics:write'), (req, res) => {
     const optedOut = loadOptedOut();
     if (!optedOut.emails.includes(req.userEmail)) {
       optedOut.emails.push(req.userEmail);
@@ -307,7 +307,7 @@ function createHealthMetricsRouter(context) {
     res.json({ ok: true, optedOut: true });
   });
 
-  router.delete('/tracking/opt-out', (req, res) => {
+  router.delete('/tracking/opt-out', requireScope('health-metrics:write'), (req, res) => {
     const optedOut = loadOptedOut();
     const idx = optedOut.emails.indexOf(req.userEmail);
     if (idx !== -1) {
@@ -319,7 +319,7 @@ function createHealthMetricsRouter(context) {
 
   // ─── Routes: Dashboard (admin or viewer) ───
 
-  router.get('/dashboard', requireMetricsViewer, (req, res) => {
+  router.get('/dashboard', requireMetricsViewer, requireScope('health-metrics:read'), (req, res) => {
     const to = req.query.to || new Date().toISOString().slice(0, 10);
     const fromDate = new Date(req.query.from || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10));
     const toDate = new Date(to);
@@ -389,7 +389,7 @@ function createHealthMetricsRouter(context) {
     });
   });
 
-  router.get('/pages', requireMetricsViewer, (req, res) => {
+  router.get('/pages', requireMetricsViewer, requireScope('health-metrics:read'), (req, res) => {
     const to = req.query.to || new Date().toISOString().slice(0, 10);
     const fromDate = new Date(req.query.from || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10));
     const toDate = new Date(to);
@@ -423,7 +423,7 @@ function createHealthMetricsRouter(context) {
     res.json({ pages });
   });
 
-  router.get('/pages/:pageId', requireMetricsViewer, (req, res) => {
+  router.get('/pages/:pageId', requireMetricsViewer, requireScope('health-metrics:read'), (req, res) => {
     const pageId = req.params.pageId;
     const to = req.query.to || new Date().toISOString().slice(0, 10);
     const fromDate = new Date(req.query.from || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10));
@@ -456,7 +456,7 @@ function createHealthMetricsRouter(context) {
     res.json({ pageId, ...merged, daily });
   });
 
-  router.get('/user-types', requireMetricsViewer, (req, res) => {
+  router.get('/user-types', requireMetricsViewer, requireScope('health-metrics:read'), (req, res) => {
     const to = req.query.to || new Date().toISOString().slice(0, 10);
     const fromDate = new Date(req.query.from || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10));
     const toDate = new Date(to);
@@ -477,11 +477,11 @@ function createHealthMetricsRouter(context) {
 
   // ─── Routes: Admin config ───
 
-  router.get('/config', requireAdmin, (req, res) => {
+  router.get('/config', requireAdmin, requireScope('health-metrics:read'), (req, res) => {
     res.json(loadConfig());
   });
 
-  router.post('/config', requireAdmin, (req, res) => {
+  router.post('/config', requireAdmin, requireScope('health-metrics:write'), (req, res) => {
     const config = loadConfig();
     if (req.body.userTypeFieldId !== undefined) {
       config.userTypeFieldId = req.body.userTypeFieldId;
@@ -498,7 +498,7 @@ function createHealthMetricsRouter(context) {
     res.json(config);
   });
 
-  router.post('/aggregate', requireAdmin, (req, res) => {
+  router.post('/aggregate', requireAdmin, requireScope('health-metrics:write'), (req, res) => {
     const monthFiles = eventStore.listMonthFiles();
     let generated = 0;
     for (const monthKey of monthFiles) {
@@ -512,7 +512,7 @@ function createHealthMetricsRouter(context) {
     res.json({ ok: true, generated });
   });
 
-  router.delete('/events', requireAdmin, (req, res) => {
+  router.delete('/events', requireAdmin, requireScope('health-metrics:write'), (req, res) => {
     eventStore.deleteAllEvents();
     invalidateCurrentMonthCache();
     res.json({ ok: true });
@@ -520,7 +520,7 @@ function createHealthMetricsRouter(context) {
 
   // ─── Routes: Field definitions (for settings UI) ───
 
-  router.get('/field-definitions', requireAdmin, (req, res) => {
+  router.get('/field-definitions', requireAdmin, requireScope('health-metrics:read'), (req, res) => {
     const fieldDefs = readFromStorage('team-data/field-definitions.json');
     if (!fieldDefs) return res.json({ person: [], team: [] });
     // Return only person-level fields for user-type selection
@@ -530,7 +530,7 @@ function createHealthMetricsRouter(context) {
 
   // ─── Routes: Viewer management ───
 
-  router.get('/viewers', requireAdmin, (req, res) => {
+  router.get('/viewers', requireAdmin, requireScope('health-metrics:read'), (req, res) => {
     const assignments = roleStore.listAssignments();
     const viewers = Object.entries(assignments)
       .filter(([, entry]) => Array.isArray(entry.roles) && entry.roles.includes('usage-metrics-viewer'))
@@ -538,14 +538,14 @@ function createHealthMetricsRouter(context) {
     res.json({ viewers });
   });
 
-  router.post('/viewers', requireAdmin, (req, res) => {
+  router.post('/viewers', requireAdmin, requireScope('health-metrics:write'), (req, res) => {
     const { email } = req.body;
     if (!email) return res.status(400).json({ error: 'email is required.' });
     roleStore.assignRole(email, 'usage-metrics-viewer', req.userEmail);
     res.json({ ok: true });
   });
 
-  router.delete('/viewers/:email', requireAdmin, (req, res) => {
+  router.delete('/viewers/:email', requireAdmin, requireScope('health-metrics:write'), (req, res) => {
     roleStore.revokeRole(req.params.email, 'usage-metrics-viewer');
     res.json({ ok: true });
   });

--- a/shared/API.md
+++ b/shared/API.md
@@ -63,7 +63,7 @@ Core team owns `shared/` via CODEOWNERS. Changes require core team review.
 |--------|-------------|
 | `storage` | `{ readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory }` — filesystem-backed JSON storage |
 | `demoStorage` | `{ readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory }` — fixture-backed read-only storage for demo mode |
-| `createAuthMiddleware(readFromStorage, writeToStorage, options)` | Factory returning `{ authMiddleware, requireAdmin, requireTeamAdmin, isAdmin, seedRoles }`. Options: `{ tokenValidator, roleStore }` |
+| `createAuthMiddleware(readFromStorage, writeToStorage, options)` | Factory returning `{ authMiddleware, requireAdmin, requireTeamAdmin, requireScope, isAdmin, seedRoles }`. `requireScope(scopeName)` returns Express middleware that enforces the given scope for token-authenticated requests (browser/proxy auth is unrestricted). Options: `{ tokenValidator, roleStore }` |
 | `createRoleStore(readFromStorage, writeToStorage)` | Factory returning role CRUD: `{ getRoles, hasRole, assignRole, revokeRole, listAssignments, getAdminEmails, migrateFromAllowlist }` |
 | `blockDuringImpersonation` | Express middleware that returns 403 during impersonation. Exported from auth.js. |
 | `googleSheets` | `{ getAuth, discoverSheetNames, fetchRawSheet }` — Google Sheets auth and raw data fetching |

--- a/shared/server/__tests__/auth-tokens.test.js
+++ b/shared/server/__tests__/auth-tokens.test.js
@@ -152,6 +152,94 @@ describe('authMiddleware with Bearer tokens', () => {
   })
 })
 
+describe('requireScope', () => {
+  let requireScope
+
+  beforeEach(() => {
+    const storage = createMockStorage()
+    const result = createAuthMiddleware(
+      storage.readFromStorage.bind(storage),
+      storage.writeToStorage.bind(storage),
+      { tokenValidator: { validateToken() { return null }, touchLastUsed() {} } }
+    )
+    requireScope = result.requireScope
+  })
+
+  it('passes when token has correct scope', () => {
+    const req = createMockReq()
+    req.authMethod = 'token'
+    req.tokenScopes = ['roster:read', 'metrics:read']
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('roster:read')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(true)
+  })
+
+  it('returns 403 with requiredScope when token lacks scope', () => {
+    const req = createMockReq()
+    req.authMethod = 'token'
+    req.tokenScopes = ['roster:read']
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('metrics:read')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(false)
+    expect(res.statusCode).toBe(403)
+    expect(res.body.requiredScope).toBe('metrics:read')
+    // Must NOT include grantedScopes
+    expect(res.body.grantedScopes).toBeUndefined()
+  })
+
+  it('passes for token with null scopes (legacy full access)', () => {
+    const req = createMockReq()
+    req.authMethod = 'token'
+    req.tokenScopes = null
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('roster:read')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(true)
+  })
+
+  it('passes for token with undefined scopes (legacy full access)', () => {
+    const req = createMockReq()
+    req.authMethod = 'token'
+    req.tokenScopes = undefined
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('roster:read')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(true)
+  })
+
+  it('passes for token with ["*"] wildcard scopes', () => {
+    const req = createMockReq()
+    req.authMethod = 'token'
+    req.tokenScopes = ['*']
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('roster:read')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(true)
+  })
+
+  it('bypasses scope checks for browser auth (authMethod !== token)', () => {
+    const req = createMockReq()
+    // authMethod is not set (proxy/local-dev)
+    req.tokenScopes = undefined
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('admin:manage')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(true)
+  })
+
+  it('tokens:manage scope is always implicitly granted', () => {
+    const req = createMockReq()
+    req.authMethod = 'token'
+    req.tokenScopes = ['roster:read'] // does NOT include tokens:manage
+    const res = createMockRes()
+    let nextCalled = false
+    requireScope('tokens:manage')(req, res, () => { nextCalled = true })
+    expect(nextCalled).toBe(true)
+  })
+})
+
 describe('proxySecretGuard with Bearer tokens', () => {
   let originalEnv, tokenValidator
 

--- a/shared/server/auth.js
+++ b/shared/server/auth.js
@@ -162,6 +162,7 @@ function createAuthMiddleware(readFromStorage, writeToStorage, options = {}) {
         req.userEmail = tokenRecord.ownerEmail;
         req.isAdmin = isAdmin(tokenRecord.ownerEmail);
         req.authMethod = 'token';
+        req.tokenScopes = tokenRecord.scopes; // array, ['*'], null, or undefined
         // Update lastUsedAt (fire-and-forget, throttled)
         tokenValidator.touchLastUsed(tokenRecord.id);
         resolveUserUid(req);
@@ -217,7 +218,30 @@ function createAuthMiddleware(readFromStorage, writeToStorage, options = {}) {
     next()
   }
 
-  return { authMiddleware, requireAdmin, requireTeamAdmin, isAdmin, seedRoles }
+  function requireScope(scope) {
+    return function(req, res, next) {
+      // Only enforce scopes for token auth
+      if (req.authMethod !== 'token') return next();
+
+      const scopes = req.tokenScopes;
+
+      // null/undefined or ['*'] means full access (legacy / wildcard)
+      if (!scopes || (scopes.length === 1 && scopes[0] === '*')) return next();
+
+      // tokens:manage is always implicitly granted
+      if (scope === 'tokens:manage') return next();
+
+      if (!scopes.includes(scope)) {
+        return res.status(403).json({
+          error: 'Token scope insufficient',
+          requiredScope: scope
+        });
+      }
+      next();
+    };
+  }
+
+  return { authMiddleware, requireAdmin, requireTeamAdmin, requireScope, isAdmin, seedRoles }
 }
 
 let _emptySecretWarned = false;

--- a/src/__tests__/ApiTokensView.test.js
+++ b/src/__tests__/ApiTokensView.test.js
@@ -5,11 +5,15 @@ import { ref } from 'vue'
 // Mock the composable
 const mockTokens = ref([])
 const mockAllTokens = ref([])
+const mockAvailableScopes = ref(null)
 const mockLoading = ref(false)
 const mockError = ref(null)
 const mockLoadTokens = vi.fn().mockResolvedValue()
 const mockLoadAllTokens = vi.fn().mockResolvedValue()
+const mockLoadAvailableScopes = vi.fn().mockResolvedValue()
 const mockCreateToken = vi.fn()
+const mockUpdateTokenScopes = vi.fn()
+const mockAdminUpdateTokenScopes = vi.fn()
 const mockRevokeToken = vi.fn()
 const mockAdminRevokeToken = vi.fn()
 
@@ -17,11 +21,15 @@ vi.mock('../composables/useApiTokens', () => ({
   useApiTokens: () => ({
     tokens: mockTokens,
     allTokens: mockAllTokens,
+    availableScopes: mockAvailableScopes,
     loading: mockLoading,
     error: mockError,
     loadTokens: mockLoadTokens,
     loadAllTokens: mockLoadAllTokens,
+    loadAvailableScopes: mockLoadAvailableScopes,
     createToken: mockCreateToken,
+    updateTokenScopes: mockUpdateTokenScopes,
+    adminUpdateTokenScopes: mockAdminUpdateTokenScopes,
     revokeToken: mockRevokeToken,
     adminRevokeToken: mockAdminRevokeToken
   })
@@ -35,10 +43,12 @@ describe('ApiTokensView', () => {
     vi.clearAllMocks()
     mockTokens.value = []
     mockAllTokens.value = []
+    mockAvailableScopes.value = null
     mockLoading.value = false
     mockError.value = null
     mockLoadTokens.mockResolvedValue()
     mockLoadAllTokens.mockResolvedValue()
+    mockLoadAvailableScopes.mockResolvedValue()
 
     const mod = await import('../components/ApiTokensView.vue')
     ApiTokensView = mod.default
@@ -144,6 +154,92 @@ describe('ApiTokensView', () => {
     })
     await flushPromises()
     expect(mockLoadAllTokens).toHaveBeenCalled()
+  })
+
+  it('shows scope badge in token table', async () => {
+    mockTokens.value = [
+      {
+        id: '1',
+        name: 'Scoped Token',
+        tokenPrefix: 'tt_abc12345',
+        scopes: ['roster:read', 'metrics:read'],
+        createdAt: '2026-04-01T00:00:00Z',
+        expiresAt: null,
+        lastUsedAt: null
+      }
+    ]
+
+    const wrapper = mount(ApiTokensView, {
+      props: { isAdmin: false }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('2 scopes')
+  })
+
+  it('shows full access badge for null scopes', async () => {
+    mockTokens.value = [
+      {
+        id: '1',
+        name: 'Full Token',
+        tokenPrefix: 'tt_abc12345',
+        scopes: null,
+        createdAt: '2026-04-01T00:00:00Z',
+        expiresAt: null,
+        lastUsedAt: null
+      }
+    ]
+
+    const wrapper = mount(ApiTokensView, {
+      props: { isAdmin: false }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Full access')
+  })
+
+  it('shows Permissions field in create modal', async () => {
+    const wrapper = mount(ApiTokensView, {
+      props: { isAdmin: false }
+    })
+    await flushPromises()
+
+    const createBtn = wrapper.findAll('button').find(b => b.text().includes('Create Token'))
+    await createBtn.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Permissions')
+    expect(wrapper.text()).toContain('Full Access')
+  })
+
+  it('calls loadAvailableScopes on mount', async () => {
+    mount(ApiTokensView, {
+      props: { isAdmin: false }
+    })
+    await flushPromises()
+    expect(mockLoadAvailableScopes).toHaveBeenCalled()
+  })
+
+  it('shows Scopes button for each token', async () => {
+    mockTokens.value = [
+      {
+        id: '1',
+        name: 'Test Token',
+        tokenPrefix: 'tt_abc12345',
+        scopes: ['roster:read'],
+        createdAt: '2026-04-01T00:00:00Z',
+        expiresAt: null,
+        lastUsedAt: null
+      }
+    ]
+
+    const wrapper = mount(ApiTokensView, {
+      props: { isAdmin: false }
+    })
+    await flushPromises()
+
+    const scopesBtns = wrapper.findAll('button').filter(b => b.text() === 'Scopes')
+    expect(scopesBtns.length).toBeGreaterThan(0)
   })
 
   it('has collapsible help panel', async () => {

--- a/src/__tests__/useApiTokens.test.js
+++ b/src/__tests__/useApiTokens.test.js
@@ -45,18 +45,35 @@ describe('useApiTokens', () => {
     expect(allTokens.value).toEqual(mockTokens)
   })
 
-  it('createToken sends POST and reloads tokens', async () => {
-    const created = { token: 'tt_newtoken', id: '1', name: 'New', expiresAt: null }
+  it('createToken sends POST with scopes and reloads tokens', async () => {
+    const created = { token: 'tt_newtoken', id: '1', name: 'New', scopes: ['roster:read'], expiresAt: null }
     // First call: POST, second call: GET (reload)
     global.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, status: 201, json: () => Promise.resolve(created) })
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ tokens: [{ id: '1', name: 'New' }] }) })
 
     const { createToken } = useApiTokens()
-    const result = await createToken('New Token', '90d')
+    const result = await createToken('New Token', '90d', ['roster:read'])
 
     expect(result.token).toBe('tt_newtoken')
+    expect(result.scopes).toEqual(['roster:read'])
     expect(global.fetch).toHaveBeenCalledTimes(2)
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body.scopes).toEqual(['roster:read'])
+  })
+
+  it('createToken sends null scopes for full access', async () => {
+    const created = { token: 'tt_newtoken', id: '1', name: 'New', scopes: null, expiresAt: null }
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 201, json: () => Promise.resolve(created) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ tokens: [] }) })
+
+    const { createToken } = useApiTokens()
+    const result = await createToken('Full', '90d', null)
+
+    expect(result.scopes).toBeNull()
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body.scopes).toBeNull()
   })
 
   it('revokeToken sends DELETE and reloads tokens', async () => {
@@ -71,6 +88,44 @@ describe('useApiTokens', () => {
     const firstCall = global.fetch.mock.calls[0]
     expect(firstCall[0]).toContain('/tokens/tok-1')
     expect(firstCall[1].method).toBe('DELETE')
+  })
+
+  it('loadAvailableScopes fetches scope catalog', async () => {
+    const scopeData = { scopes: [{ key: 'roster:read', label: 'Roster (Read)', category: 'Roster' }], presets: [] }
+    mockFetch(scopeData)
+
+    const { availableScopes, loadAvailableScopes } = useApiTokens()
+    await loadAvailableScopes()
+
+    expect(availableScopes.value).toEqual(scopeData)
+  })
+
+  it('updateTokenScopes sends PATCH and reloads tokens', async () => {
+    const updated = { id: '1', name: 'Test', scopes: ['roster:read'] }
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(updated) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ tokens: [updated] }) })
+
+    const { updateTokenScopes } = useApiTokens()
+    const result = await updateTokenScopes('tok-1', ['roster:read'])
+
+    expect(result.scopes).toEqual(['roster:read'])
+    expect(global.fetch.mock.calls[0][0]).toContain('/tokens/tok-1/scopes')
+    expect(global.fetch.mock.calls[0][1].method).toBe('PATCH')
+  })
+
+  it('adminUpdateTokenScopes sends PATCH to admin endpoint', async () => {
+    const updated = { id: '1', name: 'Test', scopes: ['roster:read'] }
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(updated) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ tokens: [updated] }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ tokens: [updated] }) })
+
+    const { adminUpdateTokenScopes } = useApiTokens()
+    const result = await adminUpdateTokenScopes('tok-1', ['roster:read'])
+
+    expect(result.scopes).toEqual(['roster:read'])
+    expect(global.fetch.mock.calls[0][0]).toContain('/admin/tokens/tok-1/scopes')
   })
 
   it('sets error on load failure', async () => {

--- a/src/components/ApiTokensView.vue
+++ b/src/components/ApiTokensView.vue
@@ -6,7 +6,7 @@
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Create and manage personal API tokens for programmatic access.</p>
       </div>
       <button
-        @click="showCreateModal = true"
+        @click="openCreateModal"
         class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors"
       >
         <Plus :size="16" />
@@ -36,8 +36,9 @@
           <code class="block bg-blue-100 dark:bg-blue-900/40 px-3 py-2 rounded-lg text-xs font-mono break-all">curl -H "Authorization: Bearer tt_..." {{ apiBaseUrl }}/api/roster</code>
         </div>
         <ul class="list-disc list-inside space-y-1 text-xs">
-          <li>Tokens are shown <strong>once</strong> at creation — copy immediately.</li>
+          <li>Tokens are shown <strong>once</strong> at creation -- copy immediately.</li>
           <li>Tokens can have an optional expiration (30 days, 90 days, or 1 year).</li>
+          <li>Scopes control which API endpoints a token can access.</li>
           <li>Revoke tokens at any time from this page.</li>
           <li>In production, use the dedicated API route hostname for token-authenticated requests.</li>
         </ul>
@@ -85,9 +86,10 @@
           <tr class="text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
             <th class="px-4 py-2">Name</th>
             <th class="px-4 py-2">Prefix</th>
-            <th class="px-4 py-2 hidden sm:table-cell">Created</th>
+            <th class="px-4 py-2 hidden sm:table-cell">Scopes</th>
+            <th class="px-4 py-2 hidden md:table-cell">Created</th>
             <th class="px-4 py-2">Expires</th>
-            <th class="px-4 py-2 hidden md:table-cell">Last Used</th>
+            <th class="px-4 py-2 hidden lg:table-cell">Last Used</th>
             <th class="px-4 py-2"></th>
           </tr>
         </thead>
@@ -95,14 +97,21 @@
           <tr v-for="token in tokens" :key="token.id" class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
             <td class="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{{ token.name }}</td>
             <td class="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">{{ token.tokenPrefix }}...</td>
-            <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden sm:table-cell">{{ formatDate(token.createdAt) }}</td>
+            <td class="px-4 py-3 hidden sm:table-cell">
+              <ScopeBadge :scopes="token.scopes" />
+            </td>
+            <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden md:table-cell">{{ formatDate(token.createdAt) }}</td>
             <td class="px-4 py-3">
               <span v-if="!token.expiresAt" class="text-gray-400 dark:text-gray-500">Never</span>
               <span v-else-if="isExpired(token.expiresAt)" class="text-red-600 dark:text-red-400 font-medium">Expired</span>
               <span v-else class="text-gray-500 dark:text-gray-400">{{ formatDate(token.expiresAt) }}</span>
             </td>
-            <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden md:table-cell">{{ token.lastUsedAt ? formatDate(token.lastUsedAt) : 'Never' }}</td>
-            <td class="px-4 py-3 text-right">
+            <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden lg:table-cell">{{ token.lastUsedAt ? formatDate(token.lastUsedAt) : 'Never' }}</td>
+            <td class="px-4 py-3 text-right space-x-2">
+              <button
+                @click="openEditScopesModal(token)"
+                class="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 text-xs font-medium"
+              >Scopes</button>
               <button
                 @click="handleRevoke(token.id)"
                 class="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-xs font-medium"
@@ -135,9 +144,10 @@
               <th class="px-4 py-2">Owner</th>
               <th class="px-4 py-2">Name</th>
               <th class="px-4 py-2 hidden sm:table-cell">Prefix</th>
-              <th class="px-4 py-2 hidden md:table-cell">Created</th>
+              <th class="px-4 py-2 hidden md:table-cell">Scopes</th>
+              <th class="px-4 py-2 hidden lg:table-cell">Created</th>
               <th class="px-4 py-2">Expires</th>
-              <th class="px-4 py-2 hidden lg:table-cell">Last Used</th>
+              <th class="px-4 py-2 hidden xl:table-cell">Last Used</th>
               <th class="px-4 py-2"></th>
             </tr>
           </thead>
@@ -146,14 +156,21 @@
               <td class="px-4 py-3 text-gray-600 dark:text-gray-300">{{ token.ownerEmail }}</td>
               <td class="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{{ token.name }}</td>
               <td class="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400 hidden sm:table-cell">{{ token.tokenPrefix }}...</td>
-              <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden md:table-cell">{{ formatDate(token.createdAt) }}</td>
+              <td class="px-4 py-3 hidden md:table-cell">
+                <ScopeBadge :scopes="token.scopes" />
+              </td>
+              <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden lg:table-cell">{{ formatDate(token.createdAt) }}</td>
               <td class="px-4 py-3">
                 <span v-if="!token.expiresAt" class="text-gray-400 dark:text-gray-500">Never</span>
                 <span v-else-if="isExpired(token.expiresAt)" class="text-red-600 dark:text-red-400 font-medium">Expired</span>
                 <span v-else class="text-gray-500 dark:text-gray-400">{{ formatDate(token.expiresAt) }}</span>
               </td>
-              <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden lg:table-cell">{{ token.lastUsedAt ? formatDate(token.lastUsedAt) : 'Never' }}</td>
-              <td class="px-4 py-3 text-right">
+              <td class="px-4 py-3 text-gray-500 dark:text-gray-400 hidden xl:table-cell">{{ token.lastUsedAt ? formatDate(token.lastUsedAt) : 'Never' }}</td>
+              <td class="px-4 py-3 text-right space-x-2">
+                <button
+                  @click="openEditScopesModal(token, true)"
+                  class="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 text-xs font-medium"
+                >Scopes</button>
                 <button
                   @click="handleAdminRevoke(token.id)"
                   class="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-xs font-medium"
@@ -168,7 +185,7 @@
     <!-- Create Token Modal -->
     <div v-if="showCreateModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/30 dark:bg-black/50 backdrop-blur-sm" @click="showCreateModal = false" />
-      <div class="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+      <div class="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto">
         <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Create API Token</h3>
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Token Name</label>
@@ -193,6 +210,49 @@
             <option :value="null">No expiration</option>
           </select>
         </div>
+
+        <!-- Scope Selection -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Permissions</label>
+          <select
+            v-model="scopePreset"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent mb-2"
+            @change="applyScopePreset"
+          >
+            <option value="full">Full Access (all permissions)</option>
+            <option value="read-only">Read Only (all read scopes)</option>
+            <option value="custom">Custom (select individually)</option>
+          </select>
+
+          <div v-if="scopePreset === 'custom' && scopeCatalog" class="border border-gray-200 dark:border-gray-600 rounded-lg p-3 max-h-60 overflow-y-auto space-y-3">
+            <div v-for="(scopes, category) in groupedScopes" :key="category">
+              <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1">{{ category }}</p>
+              <label
+                v-for="scope in scopes"
+                :key="scope.key"
+                class="flex items-start gap-2 py-0.5 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded px-1"
+              >
+                <input
+                  type="checkbox"
+                  :value="scope.key"
+                  v-model="selectedScopes"
+                  class="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+                />
+                <span class="text-sm">
+                  <span class="text-gray-900 dark:text-gray-100">{{ scope.label }}</span>
+                  <span class="text-gray-400 dark:text-gray-500 ml-1 text-xs">{{ scope.key }}</span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Empty scopes warning -->
+          <div v-if="scopePreset === 'custom' && selectedScopes.length === 0" class="mt-2 flex items-start gap-2 text-amber-600 dark:text-amber-400 text-xs">
+            <AlertTriangle :size="14" class="mt-0.5 flex-shrink-0" />
+            <span>No scopes selected. This token will not be able to access any API endpoints (except token management).</span>
+          </div>
+        </div>
+
         <div v-if="createError" class="text-sm text-red-600 dark:text-red-400">{{ createError }}</div>
         <div class="flex justify-end gap-3 pt-2">
           <button
@@ -207,13 +267,86 @@
         </div>
       </div>
     </div>
+
+    <!-- Edit Scopes Modal -->
+    <div v-if="showEditScopesModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/30 dark:bg-black/50 backdrop-blur-sm" @click="showEditScopesModal = false" />
+      <div class="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Edit Token Scopes</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Token: <span class="font-medium text-gray-900 dark:text-gray-100">{{ editingToken?.name }}</span>
+        </p>
+
+        <div>
+          <select
+            v-model="editScopePreset"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent mb-2"
+            @change="applyEditScopePreset"
+          >
+            <option value="full">Full Access (all permissions)</option>
+            <option value="read-only">Read Only (all read scopes)</option>
+            <option value="custom">Custom (select individually)</option>
+          </select>
+
+          <div v-if="editScopePreset === 'custom' && scopeCatalog" class="border border-gray-200 dark:border-gray-600 rounded-lg p-3 max-h-60 overflow-y-auto space-y-3">
+            <div v-for="(scopes, category) in groupedScopes" :key="category">
+              <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1">{{ category }}</p>
+              <label
+                v-for="scope in scopes"
+                :key="scope.key"
+                class="flex items-start gap-2 py-0.5 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded px-1"
+              >
+                <input
+                  type="checkbox"
+                  :value="scope.key"
+                  v-model="editSelectedScopes"
+                  class="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+                />
+                <span class="text-sm">
+                  <span class="text-gray-900 dark:text-gray-100">{{ scope.label }}</span>
+                  <span class="text-gray-400 dark:text-gray-500 ml-1 text-xs">{{ scope.key }}</span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div v-if="editScopePreset === 'custom' && editSelectedScopes.length === 0" class="mt-2 flex items-start gap-2 text-amber-600 dark:text-amber-400 text-xs">
+            <AlertTriangle :size="14" class="mt-0.5 flex-shrink-0" />
+            <span>No scopes selected. This token will not be able to access any API endpoints (except token management).</span>
+          </div>
+        </div>
+
+        <div v-if="editScopesError" class="text-sm text-red-600 dark:text-red-400">{{ editScopesError }}</div>
+        <div class="flex justify-end gap-3 pt-2">
+          <button
+            @click="showEditScopesModal = false"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+          >Cancel</button>
+          <button
+            @click="handleUpdateScopes"
+            :disabled="savingScopes"
+            class="px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-100 dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >{{ savingScopes ? 'Saving...' : 'Save Scopes' }}</button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
-import { Plus, Info, ChevronUp, ChevronDown, Copy, X, CheckCircle, Shield } from 'lucide-vue-next'
+import { ref, computed, onMounted } from 'vue'
+import { Plus, Info, ChevronUp, ChevronDown, Copy, X, CheckCircle, Shield, AlertTriangle } from 'lucide-vue-next'
 import { useApiTokens } from '../composables/useApiTokens'
+
+const ScopeBadge = {
+  props: { scopes: { default: null } },
+  template: `
+    <span v-if="scopes === null" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">Full access</span>
+    <span v-else-if="scopes.length === 1 && scopes[0] === '*'" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">Full access</span>
+    <span v-else-if="scopes.length === 0" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">No scopes</span>
+    <span v-else class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">{{ scopes.length }} scope{{ scopes.length === 1 ? '' : 's' }}</span>
+  `
+}
 
 const props = defineProps({
   isAdmin: Boolean
@@ -224,10 +357,14 @@ const emit = defineEmits(['toast'])
 const {
   tokens,
   allTokens,
+  availableScopes,
   loading,
   loadTokens,
   loadAllTokens,
+  loadAvailableScopes,
   createToken,
+  updateTokenScopes,
+  adminUpdateTokenScopes,
   revokeToken,
   adminRevokeToken
 } = useApiTokens()
@@ -242,31 +379,144 @@ const copied = ref(false)
 const copyFailed = ref(false)
 const creating = ref(false)
 const createError = ref(null)
+const scopePreset = ref('full')
+const selectedScopes = ref([])
+
+// Edit scopes modal state
+const showEditScopesModal = ref(false)
+const editingToken = ref(null)
+const editingTokenIsAdmin = ref(false)
+const editScopePreset = ref('custom')
+const editSelectedScopes = ref([])
+const editScopesError = ref(null)
+const savingScopes = ref(false)
 
 const apiBaseUrl = window.location.origin
 
+const scopeCatalog = computed(() => {
+  if (!availableScopes.value) return null
+  return availableScopes.value.scopes || []
+})
+
+const groupedScopes = computed(() => {
+  if (!scopeCatalog.value) return {}
+  const groups = {}
+  for (const scope of scopeCatalog.value) {
+    const cat = scope.category || 'Other'
+    if (!groups[cat]) groups[cat] = []
+    groups[cat].push(scope)
+  }
+  return groups
+})
+
+const readOnlyScopes = computed(() => {
+  if (!scopeCatalog.value) return []
+  return scopeCatalog.value
+    .filter(s => s.key.endsWith(':read'))
+    .map(s => s.key)
+})
+
 onMounted(async () => {
   await loadTokens()
+  await loadAvailableScopes()
   if (props.isAdmin) {
     await loadAllTokens()
   }
 })
+
+function openCreateModal() {
+  newTokenName.value = ''
+  newTokenExpiry.value = '90d'
+  scopePreset.value = 'full'
+  selectedScopes.value = []
+  createError.value = null
+  showCreateModal.value = true
+}
+
+function applyScopePreset() {
+  if (scopePreset.value === 'read-only') {
+    selectedScopes.value = [...readOnlyScopes.value]
+  } else if (scopePreset.value === 'full') {
+    selectedScopes.value = []
+  }
+}
+
+function applyEditScopePreset() {
+  if (editScopePreset.value === 'read-only') {
+    editSelectedScopes.value = [...readOnlyScopes.value]
+  } else if (editScopePreset.value === 'full') {
+    editSelectedScopes.value = []
+  }
+}
+
+function computeScopesForSubmit(preset, selected) {
+  if (preset === 'full') return null
+  if (preset === 'read-only') return [...readOnlyScopes.value]
+  return [...selected]
+}
 
 async function handleCreate() {
   if (!newTokenName.value.trim() || creating.value) return
   creating.value = true
   createError.value = null
   try {
-    const result = await createToken(newTokenName.value.trim(), newTokenExpiry.value)
+    const scopes = computeScopesForSubmit(scopePreset.value, selectedScopes.value)
+    const result = await createToken(newTokenName.value.trim(), newTokenExpiry.value, scopes)
     newlyCreatedToken.value = result.token
     showCreateModal.value = false
     newTokenName.value = ''
     newTokenExpiry.value = '90d'
+    scopePreset.value = 'full'
+    selectedScopes.value = []
     if (props.isAdmin) await loadAllTokens()
   } catch (err) {
     createError.value = err.message
   } finally {
     creating.value = false
+  }
+}
+
+function openEditScopesModal(token, isAdmin = false) {
+  editingToken.value = token
+  editingTokenIsAdmin.value = isAdmin
+  editScopesError.value = null
+  savingScopes.value = false
+
+  if (token.scopes === null || (Array.isArray(token.scopes) && token.scopes.length === 1 && token.scopes[0] === '*')) {
+    editScopePreset.value = 'full'
+    editSelectedScopes.value = []
+  } else if (Array.isArray(token.scopes)) {
+    const isReadOnly = token.scopes.length > 0 &&
+      token.scopes.every(s => s.endsWith(':read')) &&
+      readOnlyScopes.value.length === token.scopes.length &&
+      readOnlyScopes.value.every(s => token.scopes.includes(s))
+    editScopePreset.value = isReadOnly ? 'read-only' : 'custom'
+    editSelectedScopes.value = [...token.scopes]
+  } else {
+    editScopePreset.value = 'full'
+    editSelectedScopes.value = []
+  }
+
+  showEditScopesModal.value = true
+}
+
+async function handleUpdateScopes() {
+  if (savingScopes.value) return
+  savingScopes.value = true
+  editScopesError.value = null
+  try {
+    const scopes = computeScopesForSubmit(editScopePreset.value, editSelectedScopes.value)
+    if (editingTokenIsAdmin.value) {
+      await adminUpdateTokenScopes(editingToken.value.id, scopes)
+    } else {
+      await updateTokenScopes(editingToken.value.id, scopes)
+    }
+    showEditScopesModal.value = false
+    emit('toast', { message: 'Token scopes updated', type: 'success' })
+  } catch (err) {
+    editScopesError.value = err.message
+  } finally {
+    savingScopes.value = false
   }
 }
 

--- a/src/composables/useApiTokens.js
+++ b/src/composables/useApiTokens.js
@@ -5,6 +5,7 @@ import { apiRequest } from '@shared/client/services/api'
 // share the same token cache (same approach as useAllowlist)
 const tokens = ref([])
 const allTokens = ref([])
+const availableScopes = ref(null)
 const loading = ref(false)
 const error = ref(null)
 
@@ -32,12 +33,42 @@ export function useApiTokens() {
     }
   }
 
-  async function createToken(name, expiresIn) {
+  async function loadAvailableScopes() {
+    try {
+      const data = await apiRequest('/token-scopes')
+      availableScopes.value = data
+    } catch (err) {
+      console.error('Failed to load available scopes:', err)
+    }
+  }
+
+  async function createToken(name, expiresIn, scopes = null) {
     const data = await apiRequest('/tokens', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, expiresIn })
+      body: JSON.stringify({ name, expiresIn, scopes })
     })
+    await loadTokens()
+    return data
+  }
+
+  async function updateTokenScopes(id, scopes) {
+    const data = await apiRequest(`/tokens/${id}/scopes`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scopes })
+    })
+    await loadTokens()
+    return data
+  }
+
+  async function adminUpdateTokenScopes(id, scopes) {
+    const data = await apiRequest(`/admin/tokens/${id}/scopes`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scopes })
+    })
+    await loadAllTokens()
     await loadTokens()
     return data
   }
@@ -56,11 +87,15 @@ export function useApiTokens() {
   return {
     tokens,
     allTokens,
+    availableScopes,
     loading,
     error,
     loadTokens,
     loadAllTokens,
+    loadAvailableScopes,
     createToken,
+    updateTokenScopes,
+    adminUpdateTokenScopes,
     revokeToken,
     adminRevokeToken
   }


### PR DESCRIPTION
## Summary

- Adds **24 module-aware scopes** (e.g., `roster:read`, `team-tracker:write`, `admin:manage`) that can be assigned to API tokens to restrict which endpoints they can access
- Existing tokens default to **full access** for backward compatibility — no migration needed
- **Scope escalation prevention**: scoped tokens cannot widen their own access or create broader child tokens
- **Frontend UI**: preset dropdown (Full Access / Read Only / Custom) with grouped checkboxes, edit scopes modal, scope badges in token tables

### New API endpoints
- `GET /api/token-scopes` — scope catalog and presets
- `PATCH /api/tokens/:id/scopes` — edit own token scopes
- `PATCH /api/admin/tokens/:id/scopes` — edit any token scopes (admin)

### Security
- `requireScope()` middleware enforces scopes on all routes across all 7 modules + health-metrics
- 403 responses include `requiredScope` but never leak `grantedScopes`
- `blockDuringImpersonation` on all token mutation endpoints
- Demo mode guards extended for new PATCH endpoints
- CORS updated to allow PATCH method

### Files changed
41 files across backend core, auth middleware, all module route handlers, frontend components/composables, tests, and documentation.

## Test plan

- [x] All 2673 unit tests pass
- [x] Lint clean
- [x] Live curl test: full-access token accesses everything (5/5)
- [x] Live curl test: scoped token blocked on out-of-scope endpoints (4/4)
- [x] Live curl test: implicit `tokens:manage` allows self-management
- [x] Live curl test: unscoped endpoints (whoami, site-config, token-scopes) accessible
- [x] Live curl test: multi-scope token correctly allows/denies per-scope
- [x] Live curl test: 403 response has `requiredScope`, no `grantedScopes` leak
- [x] Live curl test: scope escalation blocked (null, wildcard, broader scopes)
- [x] Live curl test: subset child token creation allowed
- [x] Live curl test: PATCH scope editing works
- [x] Frontend: preset dropdown, grouped checkboxes, edit modal, scope badges all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)