### PR TITLE
fix: add rate limiting to export and must-gather endpoints

### DIFF
--- a/modules/ai-impact/__tests__/client/AutofixContent.test.js
+++ b/modules/ai-impact/__tests__/client/AutofixContent.test.js
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AutofixContent from '../../client/components/AutofixContent.vue'
 
+// Use relative dates so time-window filtering never ages out of the 30-day window
+const daysAgo = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString()
+
 const MOCK_DATA = {
-  fetchedAt: '2026-04-18T12:00:00Z',
+  fetchedAt: daysAgo(0),
   jiraHost: 'https://redhat.atlassian.net',
   metrics: {
     triageTotal: 10,
@@ -15,8 +18,8 @@ const MOCK_DATA = {
     totalIssues: 10
   },
   trendData: [
-    { date: '2026-04-11', triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0 },
-    { date: '2026-04-18', triaged: 7, autofixed: 4, merged: 1, total: 7, review: 1, ciFailing: 1, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 1 }
+    { date: daysAgo(7).slice(0, 10), triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0 },
+    { date: daysAgo(0).slice(0, 10), triaged: 7, autofixed: 4, merged: 1, total: 7, review: 1, ciFailing: 1, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 1 }
   ],
   componentBreakdown: [
     { component: 'Model Server', triaged: 5, autofixed: 3, done: 1 },
@@ -28,8 +31,8 @@ const MOCK_DATA = {
       summary: 'Fix null pointer',
       status: 'In Progress',
       priority: 'Major',
-      created: '2026-04-16T10:00:00Z',
-      updated: '2026-04-17T10:00:00Z',
+      created: daysAgo(2),
+      updated: daysAgo(1),
       labels: ['jira-autofix-review'],
       components: ['Model Server'],
       assignee: 'Jane Doe',
@@ -40,8 +43,8 @@ const MOCK_DATA = {
       summary: 'Handle timeout',
       status: 'New',
       priority: 'Normal',
-      created: '2026-04-15T10:00:00Z',
-      updated: '2026-04-15T10:00:00Z',
+      created: daysAgo(3),
+      updated: daysAgo(3),
       labels: ['jira-triage-not-fixable'],
       components: ['Notebooks'],
       assignee: null,

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -1620,6 +1620,26 @@ app.get('/api/admin/modules/sync/status', requireAdmin, requireScope('admin:mana
 
 const { handleExport } = require('./export');
 
+// Rate limiter for expensive export endpoints (per-user, 5 requests per 10 minutes)
+const EXPORT_RATE_MAX = 5;
+const EXPORT_RATE_WINDOW_MS = 10 * 60_000;
+const exportRateCounts = new Map();
+
+function exportRateLimit(req, res, next) {
+  const email = req.userEmail;
+  const now = Date.now();
+  const entry = exportRateCounts.get(email);
+  if (!entry || now - entry.windowStart >= EXPORT_RATE_WINDOW_MS) {
+    exportRateCounts.set(email, { windowStart: now, count: 1 });
+    return next();
+  }
+  entry.count++;
+  if (entry.count > EXPORT_RATE_MAX) {
+    return res.status(429).json({ error: 'Rate limit exceeded. Try again later.' });
+  }
+  return next();
+}
+
 /**
  * @openapi
  * /api/export/test-data:
@@ -1634,10 +1654,12 @@ const { handleExport } = require('./export');
  *             schema:
  *               type: string
  *               format: binary
+ *       429:
+ *         description: Rate limit exceeded
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.get('/api/export/test-data', requireAdmin, requireScope('admin:manage'), function(req, res) {
+app.get('/api/export/test-data', requireAdmin, requireScope('admin:manage'), exportRateLimit, function(req, res) {
   handleExport(req, res, storageModule, builtInModules);
 });
 
@@ -1668,10 +1690,12 @@ const mustGather = require('./must-gather');
  *               type: object
  *       403:
  *         $ref: '#/components/responses/Forbidden'
+ *       429:
+ *         description: Rate limit exceeded
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-app.get('/api/must-gather', requireAdmin, requireScope('admin:manage'), async function(req, res) {
+app.get('/api/must-gather', requireAdmin, requireScope('admin:manage'), exportRateLimit, async function(req, res) {
   try {
     const redact = req.query.redact === 'aggressive' ? 'aggressive' : 'minimal';
     const bundle = await mustGather.collect({


### PR DESCRIPTION
## Summary

- Adds per-user rate limiting (5 requests / 10 minutes) to `/api/export/test-data` and `/api/must-gather`
- These admin-only endpoints perform filesystem-heavy operations without rate limiting, flagged by CodeQL in #606
- Uses the same in-memory sliding window pattern as the existing `/api/health-metrics/track` rate limiter
- Updates OpenAPI annotations to document 429 responses

## Test plan

- [x] Lint passes
- [x] No test regressions (pre-existing `FeatureDetailPanel` failures on main)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)