### PR TITLE
feat: Migrate frontend smoke tests to use Playwright + add browser-based smoke tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -146,6 +146,34 @@ Overlays: `dev/` (team-tracker ns), `preprod/` (ambient-code--team-tracker ns), 
 
 **Daily CronJob** (`deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml`): Runs at 6:00 AM UTC, triggers roster sync then full metrics refresh via the backend API.
 
+### Testing
+
+**Unit tests** use Vitest with jsdom and @vue/test-utils. Run via `npm test`.
+
+**Smoke tests** use Playwright to verify the production container images. Located in `tests/smoke/app-loads.spec.js`. These run automatically in CI after images are built and can also be run locally:
+
+```bash
+make build-frontend-image  # Build frontend container
+make build-backend-image   # Build backend container
+make smoke-test            # Run Playwright smoke tests (uses demo mode)
+```
+
+Smoke tests verify:
+- Application loads without JavaScript errors (console errors, unhandled exceptions)
+- Core UI structure renders (sidebar, main content, page title)
+- Data/API integration works (no stuck loading spinners, no error states)
+- Client-side routing functions (hash-based navigation)
+- Basic accessibility (semantic landmarks present)
+
+Playwright runs in a container (`mcr.microsoft.com/playwright:v1.60.0`), so no local browser installation needed. Works on any OS (RHEL/Podman, macOS/Docker, Ubuntu). The Makefile auto-detects the container runtime (prefers Podman on RHEL).
+
+**IMPORTANT:** The Playwright version must match between `package.json` (`@playwright/test`) and `Makefile` (`PLAYWRIGHT_IMAGE`). When updating Playwright, change both files to the same version to prevent browser binary mismatches.
+
+CI workflow (`build-images.yml`):
+1. Builds frontend and backend images via `make build-frontend-image` and `make build-backend-image`
+2. Runs `make smoke-test FRONTEND_IMAGE=<image>:<sha> BACKEND_IMAGE=<image>:<sha>` against the built images
+3. Uploads images to Quay if tests pass
+
 ### Building images on ARM Macs
 Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. See `deploy/OPENSHIFT.md` step 3 for details. This works because the backend has no native Node addons (all pure JS).
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,6 +25,9 @@ on:
       # Shared
       - 'modules/*/module.json'
       - 'package*.json'
+      # Smoke tests
+      - 'tests/smoke/**'
+      - 'playwright.config.js'
 
 concurrency:
   group: build-images-${{ github.ref_name }}
@@ -62,7 +65,7 @@ jobs:
           fi
 
           # Check frontend paths
-          if echo "$CHANGED" | grep -qE '^(src/|public/|modules/[^/]+/client/|modules/[^/]+/module\.json|shared/client/|index\.html|vite\.config|tailwind\.config|postcss\.config|deploy/frontend\.Dockerfile|deploy/nginx\.conf|deploy/nginx-entrypoint\.sh|package)'; then
+          if echo "$CHANGED" | grep -qE '^(src/|public/|modules/[^/]+/client/|modules/[^/]+/module\.json|shared/client/|index\.html|vite\.config|tailwind\.config|postcss\.config|deploy/frontend\.Dockerfile|deploy/nginx\.conf|deploy/nginx-entrypoint\.sh|tests/smoke/|playwright\.config|package)'; then
             FRONTEND=true
           fi
 
@@ -152,38 +155,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build image
-        run: |
-          docker build \
-            -f deploy/frontend.Dockerfile \
-            -t ${{ env.FRONTEND_IMAGE }}:${{ github.sha }} \
-            .
+      - name: Build frontend image
+        run: make build-frontend-image FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
 
-      - name: Smoke test
-        run: |
-          # Start a dummy backend on the host so nginx can resolve the
-          # "backend" upstream at startup (it crashes without it)
-          python3 -m http.server 3001 &
-          BACKEND_PID=$!
-          docker run -d --network host --add-host=backend:127.0.0.1 \
-            --name frontend-smoke \
-            ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
-          echo "Waiting for nginx to be ready..."
-          for i in $(seq 1 10); do
-            if curl -sf --max-time 2 http://localhost:8080/healthz > /dev/null 2>&1; then
-              echo "✅ Smoke test passed — nginx responded on /healthz (attempt $i)"
-              docker stop frontend-smoke
-              kill $BACKEND_PID 2>/dev/null
-              exit 0
-            fi
-            echo "  Attempt $i/10 — not ready yet, retrying in 3s..."
-            sleep 3
-          done
-          echo "❌ Smoke test failed — nginx never responded"
-          docker logs frontend-smoke
-          docker stop frontend-smoke
-          kill $BACKEND_PID 2>/dev/null
-          exit 1
+      - name: Build backend image (needed for frontend smoke tests to work)
+        run: make build-backend-image BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+
+      - name: Run frontend smoke tests with Playwright
+        run: make smoke-test FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}:${{ github.sha }} BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}:${{ github.sha }}
 
       - name: Login to Quay.io
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     name: Test & Build
     runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.changes.outputs.app }}
 
     steps:
       - name: Checkout code
@@ -19,7 +21,7 @@ jobs:
         id: changes
         run: |
           CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD)
-          if echo "$CHANGED" | grep -qE '^(src/|server/|modules/|shared/|scripts/validate|package|vite\.config|tailwind\.config|postcss\.config|vitest\.config|index\.html|public/)'; then
+          if echo "$CHANGED" | grep -qE '^(src/|server/|modules/|shared/|scripts/validate|package|vite\.config|tailwind\.config|postcss\.config|vitest\.config|index\.html|public/|tests/smoke/|playwright\.config|Makefile)'; then
             echo "app=true" >> "$GITHUB_OUTPUT"
           fi
           if echo "$CHANGED" | grep -q '^deploy/'; then
@@ -71,3 +73,24 @@ jobs:
             echo "=== Validating overlay: $name ==="
             kustomize build "$overlay" > /dev/null
           done
+
+  smoke-test:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    needs: test
+    if: needs.test.outputs.app == 'true'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build backend image
+        run: make build-backend-image
+
+      - name: Build frontend image
+        run: make build-frontend-image
+
+      - name: Run smoke tests
+        run: make smoke-test

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ node_modules/
 # Build output
 dist/
 
+# Playwright
+playwright-report/
+test-results/
+.playwright/
+
 # Environment variables
 .env
 .env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,17 +138,35 @@ hard constraints. Key points:
 - No cross-module imports (use `@shared` or API calls)
 - Extract reusable logic into composables (`shared/client/composables/`)
 
-### Writing tests
+### Testing
 
-Tests use **Vitest** with **jsdom** and **@vue/test-utils**.
+#### Unit tests
+
+Unit tests use **Vitest** with **jsdom** and **@vue/test-utils**:
 
 ```bash
+npm test            # Run all tests
+npm run test:watch  # Watch mode
+
 # Run a specific test file
 npx vitest run server/jira/__tests__/sprint-report.test.js
-
-# Run in watch mode
-npm run test:watch
 ```
+
+#### Smoke tests
+
+Smoke tests use **Playwright** to verify the production container images work correctly. These run in CI and can also be run locally on any OS (RHEL, macOS, Ubuntu), but do NOT require secrets/credentials to run.
+
+**Note:** First-time image pulls can take a while (~5-10 minutes)
+
+```bash
+make build-backend-image   # Builds an image with the backend sources (required for frontend tests)
+make build-frontend-image  # Builds an image with the frontend sources
+make smoke-test            # Run smoke tests against both containers (uses demo mode)
+```
+
+Smoke tests run Playwright in a container, so no local browser installation is needed. The backend runs in demo mode (using fixture data) so no credentials are required.
+
+**macOS note:** The Playwright container bind-mounts your workspace and runs `npm ci`, which installs Linux-native packages into your local `node_modules/`. After running `make smoke-test`, you may need to run `npm ci` again to restore macOS-native packages before running local commands like `npm test` or `npm run dev`.
 
 ## Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,113 @@
+.PHONY: build-frontend-image build-backend-image smoke-test _start-frontend clean-smoke-test help
+
+FRONTEND_IMAGE ?= frontend-smoke-local
+BACKEND_IMAGE ?= backend-smoke-local
+FRONTEND_CONTAINER := frontend-smoke-local
+BACKEND_CONTAINER := backend-smoke-local
+PLAYWRIGHT_IMAGE := mcr.microsoft.com/playwright:v1.60.0
+BACKEND_PORT := 3001
+FRONTEND_PORT := 8080
+WORKSPACE := /workspace
+
+# Used for configuring container-based commands
+CONTAINER_RUNTIME := $(shell basename $$(command -v podman 2>/dev/null) || echo "docker")
+OS := $(shell uname -s)
+
+# Environment variables for Playwright container
+# PLAYWRIGHT_BROWSERS_PATH: Use pre-installed browsers in the container
+# instead of downloading them at runtime (saves time, ensures consistency)
+COMMON_ENV := \
+	-e HOME=/tmp \
+	-e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+	-e XDG_CACHE_HOME=/tmp/.cache \
+	-e npm_config_cache=/tmp/.npm \
+	-e BASE_URL=http://localhost:$(FRONTEND_PORT)
+
+CONTAINER_FLAGS := --rm -t \
+	--network host \
+	-v $(CURDIR):$(WORKSPACE):z \
+	-w $(WORKSPACE)
+
+# Smoke tests setup command: install dependencies in container
+# Note: npm ci inherently replaces node_modules with Linux packages via bind mount
+SETUP_CMD := mkdir -p /tmp/.cache /tmp/.npm && npm ci --silent
+
+# Helper function to start a frontend or backend container for smoke testing,
+# then wait for the health check to pass
+define start-container
+	@echo "Starting $(1) container..."
+	@if [ "$(CONTAINER_RUNTIME)" = "podman" ] && [ "$(OS)" = "Darwin" ]; then \
+		$(CONTAINER_RUNTIME) run -d \
+			-p $(3):$(3) \
+			$(5) \
+			--name $(1) \
+			$(2) > /dev/null; \
+	else \
+		$(CONTAINER_RUNTIME) run -d \
+			--network host \
+			$(5) \
+			--name $(1) \
+			$(2) > /dev/null; \
+	fi
+	@echo "Waiting for $(1) to be ready..."
+	@for i in 1 2 3 4 5 6 7 8 9 10; do \
+		if curl -sf http://localhost:$(3)$(4) > /dev/null 2>&1; then \
+			echo "$(1) is ready (attempt $$i)"; \
+			break; \
+		fi; \
+		if [ $$i -eq 10 ]; then \
+			echo "$(1) failed to start after 10 attempts"; \
+			$(MAKE) clean-smoke-test; \
+			exit 1; \
+		fi; \
+		sleep 2; \
+	done
+endef
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2}'
+
+build-frontend-image:
+	@echo "Building frontend container image..."
+	@$(CONTAINER_RUNTIME) build -f deploy/frontend.Dockerfile -t $(FRONTEND_IMAGE) .
+
+build-backend-image:
+	@echo "Building backend container image..."
+	@$(CONTAINER_RUNTIME) build -f deploy/backend.Dockerfile -t $(BACKEND_IMAGE) .
+
+# Run smoke tests against container images
+smoke-test:
+	# Start backend container in demo mode (uses fixture data, no credentials needed)
+	$(call start-container,$(BACKEND_CONTAINER),$(BACKEND_IMAGE),$(BACKEND_PORT),/api/healthz,-e DEMO_MODE=true)
+	# Start frontend (macOS/Podman uses gateway IP, others use localhost)
+	@if [ "$(CONTAINER_RUNTIME)" = "podman" ] && [ "$(OS)" = "Darwin" ]; then \
+		BACKEND_HOST=$$($(CONTAINER_RUNTIME) run --rm alpine ip route | awk '/default/ {print $$3}'); \
+		$(MAKE) -s _start-frontend BACKEND_HOST=$$BACKEND_HOST; \
+	else \
+		$(MAKE) -s _start-frontend BACKEND_HOST=127.0.0.1; \
+	fi
+	# Run Playwright tests in container (no local browser installation needed)
+	@echo "Running Playwright smoke tests in container..."
+	$(CONTAINER_RUNTIME) run $(CONTAINER_FLAGS) $(COMMON_ENV) \
+		$(PLAYWRIGHT_IMAGE) \
+		bash -c "$(SETUP_CMD) && npm run test:smoke" || \
+		(EXIT_CODE=$$?; $(MAKE) clean-smoke-test; exit $$EXIT_CODE)
+	@echo "All smoke tests passed!"
+	@$(MAKE) clean-smoke-test
+
+# Helper target to start frontend with dynamic BACKEND_HOST
+# Note: This is a target (not a function) because calling $(call start-container,...)
+# on a backslash-continued line causes Makefile escaping issues with @ and $$ symbols
+_start-frontend:
+	$(call start-container,$(FRONTEND_CONTAINER),$(FRONTEND_IMAGE),$(FRONTEND_PORT),/healthz,--add-host=backend:$(BACKEND_HOST))
+
+clean-smoke-test:
+	@echo "Cleaning up..."
+	@$(CONTAINER_RUNTIME) stop $(FRONTEND_CONTAINER) > /dev/null 2>&1 || true
+	@$(CONTAINER_RUNTIME) rm $(FRONTEND_CONTAINER) > /dev/null 2>&1 || true
+	@$(CONTAINER_RUNTIME) stop $(BACKEND_CONTAINER) > /dev/null 2>&1 || true
+	@$(CONTAINER_RUNTIME) rm $(BACKEND_CONTAINER) > /dev/null 2>&1 || true
+	@echo "Cleanup complete"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "1.60.0",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.20",
@@ -115,6 +116,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1165,6 +1167,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1188,6 +1191,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2094,6 +2098,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -3501,6 +3521,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3986,6 +4007,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4177,6 +4199,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -4730,7 +4753,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5063,6 +5087,7 @@
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5364,6 +5389,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6423,6 +6449,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6484,6 +6511,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -7627,6 +7655,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -7646,6 +7721,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9120,6 +9196,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9417,6 +9494,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10023,6 +10101,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10569,6 +10648,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10628,6 +10708,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:smoke": "playwright test",
     "lint": "eslint .",
     "validate:modules": "node scripts/validate-modules.js",
     "validate:openapi": "node scripts/validate-openapi.js",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "1.60.0",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.20",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,51 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Playwright configuration optimized for CI smoke tests.
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+  testDir: './tests/smoke',
+
+  // Each test can run for a max of 30 seconds
+  timeout: 30 * 1000,
+
+  // Run tests in parallel
+  fullyParallel: true,
+
+  // Fail the build on CI if tests were accidentally left in exclusive mode
+  forbidOnly: !!process.env.CI,
+
+  // No retries - smoke tests should be stable, failures indicate real problems
+  retries: 0,
+
+  // Single worker in CI to avoid resource contention
+  workers: process.env.CI ? 1 : undefined,
+
+  // Reporter config
+  reporter: process.env.CI
+    ? [['list'], ['github']]  // CI: console + GitHub annotations
+    : [['list']],             // Local: console only
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:5173',
+    actionTimeout: 10 * 1000,
+  },
+
+  // Web server configuration - wait for the container/server to be ready
+  webServer: process.env.CI ? undefined : {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+
+  // Test projects - Chromium only for fast CI smoke tests
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/smoke/app-loads.spec.js
+++ b/tests/smoke/app-loads.spec.js
@@ -1,0 +1,165 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Comprehensive smoke tests for Org Pulse frontend
+ *
+ * These tests verify critical functionality:
+ * - Application loads without JavaScript errors
+ * - Core UI structure renders correctly
+ * - Data/API integration works (no stuck loading states)
+ * - Client-side routing functions properly
+ */
+
+test.describe('Frontend Smoke Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Keep track of test errors
+    page.errors = [];
+
+    // Listen for unhandled JavaScript exceptions
+    page.on('pageerror', error => {
+      page.errors.push({
+        type: 'pageerror',
+        message: error.message,
+        stack: error.stack
+      });
+    });
+
+    // Listen for console errors
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        page.errors.push({
+          type: 'console.error',
+          message: msg.text()
+        });
+      }
+    });
+  });
+
+  test('should load without JavaScript errors', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Fail test if any unhandled errors occurred
+    if (page.errors.length > 0) {
+      console.error('JavaScript errors detected:');
+      page.errors.forEach((err, idx) => {
+        console.error(`  ${idx + 1}. [${err.type}] ${err.message}`);
+        if (err.stack) console.error(`     ${err.stack}`);
+      });
+    }
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should render core layout structure', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle(/Org Pulse/);
+
+    // appContainer rendering
+    const appContainer = page.locator('#app').first();
+    await expect(appContainer).toBeVisible();
+
+    // sidebar rendering
+    const sidebar = page.locator('aside, nav, [role="navigation"]').first();
+    await expect(sidebar).toBeVisible({ timeout: 10000 });
+
+    // mainContent rendering
+    const mainContent = page.locator('main, [role="main"], .min-h-screen').first();
+    await expect(mainContent).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should load data successfully (no stuck loading states)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Add buffer in case the page needs time to load
+    await page.waitForTimeout(2000);
+
+    // Check that no permanent loading spinners remain
+    // (temporary spinners during initial load are OK, but they should auto-resolve!)
+    const loadingSpinners = page.locator('[role="status"], [aria-busy="true"], .loading');
+    const spinnerCount = await loadingSpinners.count();
+
+    // If spinners exist, verify they're not stuck
+    if (spinnerCount > 0) {
+      await page.waitForTimeout(3000);
+      const stillLoading = await loadingSpinners.count();
+      expect(stillLoading).toBe(0);
+    }
+
+    // Confirm we didn't encounter API errors
+    const errorMessages = page.locator('text=/error|failed|unavailable/i').filter({
+      hasNot: page.locator('[style*="display: none"]')
+    });
+    const errorCount = await errorMessages.count();
+
+    if (errorCount > 0) {
+      const errorText = await errorMessages.first().textContent();
+      throw new Error(`API error state detected: ${errorText}`);
+    }
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should navigate between pages (client-side routing)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Capture initial URL (hash-based routing)
+    const initialUrl = page.url();
+
+    // Find and click a navigation link (settings, or any secondary nav item)
+    // Using multiple selectors to be resilient to UI changes
+    const navLink = page.locator('a[href*="settings"], a:has-text("Settings"), nav a').first();
+
+    if (await navLink.count() > 0) {
+      await navLink.click();
+
+      // Add buffer in case the page needs time to load
+      await page.waitForTimeout(1000);
+
+      // Verify URL changed (hash routing)
+      const newUrl = page.url();
+      expect(newUrl).not.toBe(initialUrl);
+
+      // Verify page still renders without errors
+      const appContainer = page.locator('#app');
+      await expect(appContainer).toBeVisible();
+    } else {
+      // If no settings link found, try any navigation link
+      const anyNavLink = page.locator('nav a, aside a').nth(1); // Second nav item
+
+      if (await anyNavLink.count() > 0) {
+        await anyNavLink.click();
+        await page.waitForTimeout(1000);
+
+        const newUrl = page.url();
+        expect(newUrl).not.toBe(initialUrl);
+      } else {
+        console.warn('No navigation links found to test routing');
+      }
+    }
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should render without critical accessibility violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // 1. Page should have a main landmark
+    const mainLandmark = page.locator('main, [role="main"]');
+    const hasMain = await mainLandmark.count() > 0;
+
+    // 2. Navigation should be identifiable
+    const navLandmark = page.locator('nav, [role="navigation"]');
+    const hasNav = await navLandmark.count() > 0;
+
+    // At least one of these should exist for basic user accessibility
+    expect(hasMain || hasNav).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
@@ -17,6 +17,11 @@ export default defineConfig({
       ['server/**', 'node'],
       ['modules/*/server/**', 'node'],
       ['modules/*/__tests__/server/**', 'node'],
+    ],
+    exclude: [
+      ...configDefaults.exclude,
+      '**/tests/smoke/**',       // Exclude Playwright smoke tests
+      'playwright-report/**',    // Exclude any Playwright output folders
     ],
   },
 })


### PR DESCRIPTION
## Purpose
The current smoke tests sanity check if the frontend can start, but they don't validate the UI itself in any way. These changes  simulate what it's like for a user to click around the UI so that we ensure everything works as expected. So think of this as a meaningful extension to the existing smoke tests.

The other benefit of these changes is that they can serve as the foundation for true E2E tests for gating (such as before pushing the backend + frontend to production).

## Summary of Changes
This change replaces basic `curl` smoke testing with comprehensive Playwright tests that verify:
- Application loads without JavaScript errors
- Core UI structure renders correctly
- Data/API integration works (no stuck loading states)
- Client-side routing functions properly
- Basic accessibility (semantic landmarks)

This change also includes a `Makefile` that can be used in the CI or run locally to execute the smoke tests. Instructions for doing so are provided in `CONTRIBUTING.md`

Finally, many users probably don't want to provide secrets, etc. just to run the smoke tests locally, so the smoke tests are currently setup to execute against the backend in "demo" mode, which does not require credentials/secrets.