### PR TITLE
fix(ci): force docker runtime in frontend build to match push step

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -156,13 +156,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build frontend image
-        run: make build-frontend-image FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
+        run: make build-frontend-image CONTAINER_RUNTIME=docker FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
 
       - name: Build backend image (needed for frontend smoke tests to work)
-        run: make build-backend-image BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+        run: make build-backend-image CONTAINER_RUNTIME=docker BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}:${{ github.sha }}
 
       - name: Run frontend smoke tests with Playwright
-        run: make smoke-test FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}:${{ github.sha }} BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+        run: make smoke-test CONTAINER_RUNTIME=docker FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}:${{ github.sha }} BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}:${{ github.sha }}
 
       - name: Login to Quay.io
         uses: docker/login-action@v3


### PR DESCRIPTION
## Problem

The `Build & Push Frontend` job fails with:

```
Error response from daemon: No such image: quay.io/org-pulse/team-tracker-frontend:2988ca20...
```

**Root cause:** PR #612 switched the frontend build to use the Makefile (`make build-frontend-image`), which auto-detects the container runtime. On GitHub Actions Ubuntu runners, `podman` is found first, so the image gets built into podman's image store. But `docker/login-action` and the push step use `docker`, which has a separate image store — so Docker can't find the image podman built.

## Fix

Pass `CONTAINER_RUNTIME=docker` to all Makefile targets in CI, ensuring the build, smoke test, and push steps all use the same runtime.

Local dev is unaffected — the Makefile still auto-detects podman when available.

## Verify

The `Build & Push Backend` job (which uses `docker build` directly) succeeded on the same run, confirming the issue is isolated to the Makefile's runtime detection.