### PR TITLE
feat(ai-impact): include Release Pending in doc demand

### DIFF
--- a/fixtures/ai-impact/doc-data.json
+++ b/fixtures/ai-impact/doc-data.json
@@ -32,7 +32,7 @@
     {
       "key": "RHAISTRAT-2003",
       "summary": "Model registry federation across clusters",
-      "status": "Review",
+      "status": "Release Pending",
       "labels": ["Require Product Documentation", "ai1st-doc-invoked"],
       "created": "2026-04-22T12:00:00Z",
       "updated": "2026-05-11T10:00:00Z",
@@ -74,7 +74,7 @@
     {
       "key": "RHAISTRAT-2006",
       "summary": "Custom serving runtime with vLLM",
-      "status": "Review",
+      "status": "Release Pending",
       "labels": ["Require Product Documentation", "ai1st-doc-contributed"],
       "created": "2026-04-20T10:00:00Z",
       "updated": "2026-05-03T11:00:00Z",
@@ -116,7 +116,7 @@
     {
       "key": "RHAISTRAT-2009",
       "summary": "RBAC for model serving endpoints",
-      "status": "Review",
+      "status": "Release Pending",
       "labels": ["Require Product Documentation"],
       "created": "2026-05-06T08:00:00Z",
       "updated": "2026-05-06T08:00:00Z",

--- a/modules/ai-impact/client/components/DocumentationContent.vue
+++ b/modules/ai-impact/client/components/DocumentationContent.vue
@@ -300,13 +300,13 @@ function mrLabel(url) {
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   <div class="absolute left-0 top-6 z-10 hidden group-hover:block w-64 p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
-                    RHAISTRAT issues in Review with "Product Documentation Required" = Yes. This demand signal is independent of the AI-First tool. Use trend to inspect rising/stable/decreasing for doc demand.
+                    RHAISTRAT issues in Review or Release Pending with "Product Documentation Required" = Yes. This demand signal is independent of the AI-First tool. Use trend to inspect rising/stable/decreasing for doc demand.
                   </div>
                 </div>
               </div>
               <span class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ metrics?.demandCount || 0 }}</span>
             </div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mb-3">issues requiring docs</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mb-3">demand for docs</div>
             <div class="h-[160px]">
               <Line :data="demandChartData" :options="demandChartOptions" />
             </div>
@@ -328,7 +328,7 @@ function mrLabel(url) {
               </div>
               <span class="text-lg font-bold" :class="(metrics?.coverageRate || 0) > 0 ? 'text-green-600 dark:text-green-400' : 'text-gray-900 dark:text-gray-100'">{{ metrics?.coverageRate || 0 }}%</span>
             </div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mb-3">{{ metrics?.coverageCount || 0 }} of {{ metrics?.demandCount || 0 }} with doc MR</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mb-3">{{ metrics?.coverageCount || 0 }} of {{ metrics?.demandCount || 0 }} features with AI-First doc MR</div>
             <div class="h-[160px]">
               <Line :data="coverageChartData" :options="coverageChartOptions" />
             </div>

--- a/modules/ai-impact/server/config.js
+++ b/modules/ai-impact/server/config.js
@@ -11,7 +11,7 @@ const DEFAULT_CONFIG = {
   autofixProjects: ['AIPCC', 'RHOAIENG'],
   autofixCreatedAfter: null,
   docProject: 'RHAISTRAT',
-  docRequiredStatus: 'Review',
+  docRequiredStatuses: ['Review', 'Release Pending'],
   docRequiredFieldId: 'customfield_10665',
   docContributedLabel: 'ai1st-doc-contributed',
   docInvokedLabel: 'ai1st-doc-invoked',
@@ -54,7 +54,7 @@ function saveConfig(writeToStorage, config) {
   // String fields — validate type and JQL safety
   const stringFields = ['jiraProject', 'linkedProject', 'createdLabel',
     'revisedLabel', 'testExclusionLabel', 'linkTypeName',
-    'docProject', 'docRequiredStatus', 'docContributedLabel',
+    'docProject', 'docContributedLabel',
     'docInvokedLabel', 'docRequiredFieldId', 'docMrFieldId'];
   for (const key of stringFields) {
     if (config[key] !== undefined) {
@@ -82,6 +82,20 @@ function saveConfig(writeToStorage, config) {
       validateJqlSafeString(s, 'excludedStatuses entry');
     }
     merged.excludedStatuses = config.excludedStatuses;
+  }
+
+  // docRequiredStatuses — must be array of JQL-safe strings
+  if (config.docRequiredStatuses !== undefined) {
+    if (!Array.isArray(config.docRequiredStatuses)) {
+      throw new Error('docRequiredStatuses must be an array');
+    }
+    if (config.docRequiredStatuses.length === 0) {
+      throw new Error('docRequiredStatuses must not be empty');
+    }
+    for (const s of config.docRequiredStatuses) {
+      validateJqlSafeString(s, 'docRequiredStatuses entry');
+    }
+    merged.docRequiredStatuses = config.docRequiredStatuses;
   }
 
   // lookbackMonths — must be a positive integer

--- a/modules/ai-impact/server/jira/doc-fetcher.js
+++ b/modules/ai-impact/server/jira/doc-fetcher.js
@@ -257,15 +257,18 @@ async function resolveMRLinks(jiraRequest, issues, config) {
 async function fetchDocData(jiraRequest, config) {
   const {
     docProject,
-    docRequiredStatus,
+    docRequiredStatuses,
     docContributedLabel,
     docInvokedLabel
   } = config;
 
   validateJqlSafeString(docProject, 'docProject');
-  validateJqlSafeString(docRequiredStatus, 'docRequiredStatus');
+  for (const s of docRequiredStatuses) {
+    validateJqlSafeString(s, 'docRequiredStatuses entry');
+  }
 
-  const jql = `project = "${docProject}" AND status = "${docRequiredStatus}" AND "Product Documentation Required" = "Yes" ORDER BY created DESC`;
+  const statusClause = docRequiredStatuses.map(s => `"${s}"`).join(', ');
+  const jql = `project = "${docProject}" AND status IN (${statusClause}) AND "Product Documentation Required" = "Yes" ORDER BY created DESC`;
   const fields = 'summary,status,created,updated,labels';
 
   const rawIssues = await fetchAllJqlResults(jiraRequest, jql, fields, { expand: 'changelog' });


### PR DESCRIPTION
## Summary
- Broadens the RHAISTRAT documentation demand filter to include issues in **Release Pending** status, in addition to **Review**
- Renames config field from `docRequiredStatus` (string) to `docRequiredStatuses` (array) with proper validation, so additional statuses can be added without code changes
- Updates demo fixtures with sample "Release Pending" issues for coverage across different doc states
- Updates frontend tooltip and subtitles to reflect the wider filter

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — all 2716 tests pass
- [x] Verified live data refresh fetches 83 doc issues (includes both statuses)
- [x] Verify Documentation view renders both Review and Release Pending issues with correct status badges

## Test proofs

<img width="2032" height="1192" alt="Screenshot 2026-05-15 at 10 13 55" src="https://github.com/user-attachments/assets/9b9bbe14-09ca-48f2-a589-a62a86bc3abf" />

<img width="2032" height="1192" alt="Screenshot 2026-05-15 at 10 14 11" src="https://github.com/user-attachments/assets/72efef07-cc00-456a-8e2e-14fc49fb569b" />
