### PR TITLE
fix: render scope badges on API tokens page

### DIFF
--- a/modules/ai-impact/__tests__/client/AutofixContent.test.js
+++ b/modules/ai-impact/__tests__/client/AutofixContent.test.js
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AutofixContent from '../../client/components/AutofixContent.vue'
 
+// Use relative dates so time-window filtering never ages out of the 30-day window
+const daysAgo = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString()
+
 const MOCK_DATA = {
-  fetchedAt: '2026-04-18T12:00:00Z',
+  fetchedAt: daysAgo(0),
   jiraHost: 'https://redhat.atlassian.net',
   metrics: {
     triageTotal: 10,
@@ -15,8 +18,8 @@ const MOCK_DATA = {
     totalIssues: 10
   },
   trendData: [
-    { date: '2026-04-11', triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0 },
-    { date: '2026-04-18', triaged: 7, autofixed: 4, merged: 1, total: 7, review: 1, ciFailing: 1, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 1 }
+    { date: daysAgo(7).slice(0, 10), triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0 },
+    { date: daysAgo(0).slice(0, 10), triaged: 7, autofixed: 4, merged: 1, total: 7, review: 1, ciFailing: 1, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 1 }
   ],
   componentBreakdown: [
     { component: 'Model Server', triaged: 5, autofixed: 3, done: 1 },
@@ -28,8 +31,8 @@ const MOCK_DATA = {
       summary: 'Fix null pointer',
       status: 'In Progress',
       priority: 'Major',
-      created: '2026-04-16T10:00:00Z',
-      updated: '2026-04-17T10:00:00Z',
+      created: daysAgo(2),
+      updated: daysAgo(1),
       labels: ['jira-autofix-review'],
       components: ['Model Server'],
       assignee: 'Jane Doe',
@@ -40,8 +43,8 @@ const MOCK_DATA = {
       summary: 'Handle timeout',
       status: 'New',
       priority: 'Normal',
-      created: '2026-04-15T10:00:00Z',
-      updated: '2026-04-15T10:00:00Z',
+      created: daysAgo(3),
+      updated: daysAgo(3),
       labels: ['jira-triage-not-fixable'],
       components: ['Notebooks'],
       assignee: null,

--- a/src/components/ApiTokensView.vue
+++ b/src/components/ApiTokensView.vue
@@ -334,18 +334,26 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, h } from 'vue'
 import { Plus, Info, ChevronUp, ChevronDown, Copy, X, CheckCircle, Shield, AlertTriangle } from 'lucide-vue-next'
 import { useApiTokens } from '../composables/useApiTokens'
 
+const badgeClass = 'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium'
 const ScopeBadge = {
   props: { scopes: { default: null } },
-  template: `
-    <span v-if="scopes === null" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">Full access</span>
-    <span v-else-if="scopes.length === 1 && scopes[0] === '*'" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">Full access</span>
-    <span v-else-if="scopes.length === 0" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">No scopes</span>
-    <span v-else class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">{{ scopes.length }} scope{{ scopes.length === 1 ? '' : 's' }}</span>
-  `
+  setup(props) {
+    return () => {
+      const s = props.scopes
+      if (s === null || (Array.isArray(s) && s.length === 1 && s[0] === '*')) {
+        return h('span', { class: `${badgeClass} bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300` }, 'Full access')
+      }
+      if (Array.isArray(s) && s.length === 0) {
+        return h('span', { class: `${badgeClass} bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300` }, 'No scopes')
+      }
+      const count = Array.isArray(s) ? s.length : 0
+      return h('span', { class: `${badgeClass} bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300` }, `${count} scope${count === 1 ? '' : 's'}`)
+    }
+  }
 }
 
 const props = defineProps({


### PR DESCRIPTION
## Summary
- ScopeBadge was defined as an inline component with a `template:` string, but Vite ships Vue's runtime-only build which lacks the template compiler
- The template was never compiled so the scopes column rendered nothing in the tokens table
- Converted to a render function using `h()` which works with the runtime-only build

## Test plan
- [ ] Create an API token with full access → verify "Full access" badge appears
- [ ] Create a token with custom scopes → verify "N scopes" badge appears
- [ ] Create a token with no scopes → verify "No scopes" badge appears
- [ ] Check admin "All Tokens" table shows badges correctly too

🤖 Generated with [Claude Code](https://claude.com/claude-code)