### PR TITLE
fix: resolve role mapping domain mismatch between LDAP and OAuth proxy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,6 +38,7 @@ npm run dev:full       # Starts Vite (5173) + Express (3001)
 | `PRODUCT_PAGES_CLIENT_SECRET` | OAuth client secret for Product Pages (production). Used with `PRODUCT_PAGES_CLIENT_ID`. |
 | `PRODUCT_PAGES_TOKEN` | Personal bearer token for Product Pages (local dev fallback). Used when OAuth env vars are not set. |
 | `FEATURE_TRAFFIC_GITLAB_TOKEN` | GitLab PAT with `read_api` scope for feature-traffic pipeline. Overrides `GITLAB_TOKEN` for CI artifact fetching. |
+| `AUTH_EMAIL_DOMAIN` | Override email domain for role matching (e.g. `cluster.local`). When set, role assignments normalize emails to this domain. Env var takes precedence over `authEmailDomain` in site-config.json. |
 | `DEMO_MODE` / `VITE_DEMO_MODE` | Set both to `true` for fixture data (no credentials needed). |
 
 ## Key Concepts
@@ -49,7 +50,7 @@ npm run dev:full       # Starts Vite (5173) + Express (3001)
 - **GitLab contributions**: `data/gitlab-contributions.json` + `data/gitlab-history.json`. Multi-instance support via `gitlabInstances` config.
 - **Snapshots**: `data/snapshots/{sanitized-teamKey}/{YYYY-MM-DD}.json` (teamKey sanitized: `::` → `--`).
 - **Trends**: Built dynamically from person metric files by bucketing resolved issues by month.
-- **Site config**: `data/site-config.json` — platform-level settings (title prefix).
+- **Site config**: `data/site-config.json` — platform-level settings (title prefix, auth email domain).
 - **Composite keys**: Teams = `orgKey::teamName` (e.g., `shgriffi::Model Serving`).
 - **Field options**: `data/team-data/field-options/<name>.json` — named allowed-value sets, referenced by `optionsRef`.
 - **Messages**: `data/messages.json` — admin announcements, merged with computed provider messages.

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ GITHUB_TOKEN=your-github-pat
 # Admin emails (comma-separated, used to seed the allowlist)
 ADMIN_EMAILS=you@redhat.com
 
+# Auth email domain override (optional)
+# If your OAuth proxy rewrites user emails to a different domain (e.g. cluster.local),
+# set this so role assignments match the authenticated email domain.
+# AUTH_EMAIL_DOMAIN=
+
 # API Endpoint (optional — defaults to /api, which Vite proxies to the dev server on port 3001)
 # Use a full URL only if the UI and API are on different origins. Include /api if you point at the
 # server root, or set only the origin (e.g. http://localhost:3001) — /api is appended automatically.

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
 - behavior: merge
   literals:
   - API_PUBLIC_URL=https://api-team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com
+  - AUTH_EMAIL_DOMAIN=cluster.local
   name: team-tracker-config
 
 patches:

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -140,13 +140,15 @@ Platform-level configuration for the site. Created when an admin saves settings 
 
 ```json
 {
-  "titlePrefix": "AI Engineering"
+  "titlePrefix": "AI Engineering",
+  "authEmailDomain": "cluster.local"
 }
 ```
 
 **Notes:**
 - `titlePrefix` is a string (max 100 characters). When non-empty, it's shown as a subtitle in the sidebar and prepended to the page title.
-- If this file doesn't exist, `titlePrefix` defaults to `""` (empty string).
+- `authEmailDomain` is a string (max 253 characters, valid RFC 1123 domain). When set, role assignments normalize emails to this domain so that LDAP-provided emails (e.g. `user@redhat.com`) match OAuth proxy emails (e.g. `user@cluster.local`). Can also be set via the `AUTH_EMAIL_DOMAIN` env var, which takes precedence.
+- If this file doesn't exist, both fields default to `""` (empty string).
 
 ## Messages — `data/messages.json`
 

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -24,6 +24,7 @@ const storageModule = DEMO_MODE ? require('../shared/server/demo-storage') : req
 const { readFromStorage, writeToStorage } = storageModule;
 const { createAuthMiddleware, proxySecretGuard, blockDuringImpersonation } = require('../shared/server/auth');
 const { createRoleStore } = require('../shared/server/role-store');
+const auditLog = require('../shared/server/audit-log');
 const apiTokens = require('./api-tokens');
 
 const modulesConfig = require('./modules/config');
@@ -104,7 +105,17 @@ if (DEMO_MODE) {
 
 // ─── Auth (from shared package) ───
 
-const roleStore = createRoleStore(readFromStorage, writeToStorage);
+const roleStore = createRoleStore(readFromStorage, writeToStorage, {
+  getAuthDomain: () => {
+    // Env var takes precedence (solves bootstrap: can be set in ConfigMap
+    // before first deployment, so migration runs on first startup)
+    if (process.env.AUTH_EMAIL_DOMAIN) {
+      return process.env.AUTH_EMAIL_DOMAIN.trim().toLowerCase();
+    }
+    const config = readFromStorage('site-config.json');
+    return config?.authEmailDomain || null;
+  }
+});
 const { authMiddleware, requireAdmin, requireTeamAdmin, requireScope, seedRoles } = createAuthMiddleware(readFromStorage, writeToStorage, {
   tokenValidator: apiTokens,
   roleStore
@@ -248,6 +259,20 @@ app.get('/api/whoami', function(req, res) {
   res.json(response);
 });
 
+// ─── Helpers ───
+
+/** Validate a domain name per RFC 1123: labels separated by dots, each 1-63 chars, alphanumeric + hyphen. */
+function isValidDomain(domain) {
+  if (!domain || typeof domain !== 'string') return false;
+  if (domain.length > 253) return false;
+  if (domain.includes('@') || /\s/.test(domain)) return false;
+  const labels = domain.split('.');
+  if (labels.length < 1) return false;
+  return labels.every(label =>
+    label.length >= 1 && label.length <= 63 && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(label)
+  );
+}
+
 // ─── Routes: Site Config ───
 
 /**
@@ -266,11 +291,17 @@ app.get('/api/whoami', function(req, res) {
  *               properties:
  *                 titlePrefix:
  *                   type: string
+ *                 authEmailDomain:
+ *                   type: string
+ *                   description: Auth email domain for role matching (e.g. cluster.local)
  */
 app.get('/api/site-config', function(req, res) {
   try {
-    const config = readFromStorage('site-config.json') || { titlePrefix: '' };
-    res.json({ titlePrefix: config.titlePrefix || '' });
+    const config = readFromStorage('site-config.json') || {};
+    res.json({
+      titlePrefix: config.titlePrefix || '',
+      authEmailDomain: config.authEmailDomain || ''
+    });
   } catch (error) {
     console.error('Get site-config error:', error);
     res.status(500).json({ error: error.message });
@@ -293,6 +324,10 @@ app.get('/api/site-config', function(req, res) {
  *               titlePrefix:
  *                 type: string
  *                 maxLength: 100
+ *               authEmailDomain:
+ *                 type: string
+ *                 maxLength: 253
+ *                 description: Auth email domain for role matching (e.g. cluster.local)
  *     responses:
  *       200:
  *         description: Updated site configuration
@@ -302,12 +337,49 @@ app.post('/api/site-config', requireAdmin, requireScope('admin:manage'), functio
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Configuration changes disabled in demo mode' });
     }
-    const { titlePrefix } = req.body;
-    if (typeof titlePrefix !== 'string' || titlePrefix.length > 100) {
-      return res.status(400).json({ error: 'titlePrefix must be a string of 100 characters or fewer' });
+    const existing = readFromStorage('site-config.json') || {};
+    const updates = {};
+
+    // titlePrefix
+    if (req.body.titlePrefix !== undefined) {
+      if (typeof req.body.titlePrefix !== 'string' || req.body.titlePrefix.length > 100) {
+        return res.status(400).json({ error: 'titlePrefix must be a string of 100 characters or fewer' });
+      }
+      updates.titlePrefix = req.body.titlePrefix;
     }
-    const config = { titlePrefix };
+
+    // authEmailDomain
+    if (req.body.authEmailDomain !== undefined) {
+      const domain = req.body.authEmailDomain.trim().toLowerCase();
+      if (domain && !isValidDomain(domain)) {
+        return res.status(400).json({ error: 'authEmailDomain must be a valid domain name (no @ or whitespace, max 253 chars)' });
+      }
+      updates.authEmailDomain = domain;
+    }
+
+    const config = { ...existing, ...updates };
     writeToStorage('site-config.json', config);
+
+    // Trigger role migration when authEmailDomain changes
+    if (updates.authEmailDomain !== undefined && updates.authEmailDomain !== existing.authEmailDomain) {
+      auditLog.appendAuditEntry({ readFromStorage, writeToStorage }, {
+        action: 'config.authEmailDomain.change',
+        actor: req.userEmail || 'unknown',
+        entityType: 'config',
+        entityId: 'site-config',
+        field: 'authEmailDomain',
+        oldValue: existing.authEmailDomain || '',
+        newValue: updates.authEmailDomain,
+        detail: `Auth email domain changed from "${existing.authEmailDomain || ''}" to "${updates.authEmailDomain}"`
+      });
+
+      roleStore.invalidateCache();
+      const count = roleStore.migrateEmailDomains();
+      if (count > 0) {
+        console.log(`site-config: authEmailDomain changed, migrated ${count} role(s)`);
+      }
+    }
+
     res.json(config);
   } catch (error) {
     console.error('Save site-config error:', error);
@@ -1984,7 +2056,16 @@ app.options('/api/{*path}', function(req, res) { res.status(200).end(); });
 
 // ─── Start ───
 
+// Warn if AUTH_EMAIL_DOMAIN is set but invalid
+if (process.env.AUTH_EMAIL_DOMAIN) {
+  const envDomain = process.env.AUTH_EMAIL_DOMAIN.trim().toLowerCase();
+  if (!isValidDomain(envDomain)) {
+    console.warn(`WARNING: AUTH_EMAIL_DOMAIN="${process.env.AUTH_EMAIL_DOMAIN}" is not a valid domain name. Role email normalization may not work correctly.`);
+  }
+}
+
 seedRoles();
+roleStore.migrateEmailDomains();
 modulesConfig.seedIfMissing(storageModule);
 
 // Start daily module sync

--- a/shared/API.md
+++ b/shared/API.md
@@ -43,7 +43,7 @@ Core team owns `shared/` via CODEOWNERS. Changes require core team review.
 | `apiRequest(url, options)` | Fetch wrapper with error handling |
 | `cachedRequest(key, fetcher, onData)` | Stale-while-revalidate caching via localStorage |
 | `clearApiCache()` | Clear all cached API data |
-| `getSiteConfig()` | Fetch site configuration (`{ titlePrefix }`) — no cache |
+| `getSiteConfig()` | Fetch site configuration (`{ titlePrefix, authEmailDomain }`) — no cache |
 | `saveSiteConfig(config)` | Save site configuration (admin only) |
 
 ### Components
@@ -64,7 +64,8 @@ Core team owns `shared/` via CODEOWNERS. Changes require core team review.
 | `storage` | `{ readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory }` — filesystem-backed JSON storage |
 | `demoStorage` | `{ readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory }` — fixture-backed read-only storage for demo mode |
 | `createAuthMiddleware(readFromStorage, writeToStorage, options)` | Factory returning `{ authMiddleware, requireAdmin, requireTeamAdmin, requireScope, isAdmin, seedRoles }`. `requireScope(scopeName)` returns Express middleware that enforces the given scope for token-authenticated requests (browser/proxy auth is unrestricted). Options: `{ tokenValidator, roleStore }` |
-| `createRoleStore(readFromStorage, writeToStorage)` | Factory returning role CRUD: `{ getRoles, hasRole, assignRole, revokeRole, listAssignments, getAdminEmails, migrateFromAllowlist }` |
+| `createRoleStore(readFromStorage, writeToStorage, options?)` | Factory returning role CRUD: `{ getRoles, hasRole, assignRole, revokeRole, listAssignments, getAdminEmails, migrateFromAllowlist, migrateEmailDomains, invalidateCache }`. Options: `{ getAuthDomain }` — function returning the auth email domain string (or null). When set, all email arguments are normalized to this domain before storage/lookup. |
+| `normalizeEmail(email, authDomain)` | Normalize an email's domain to the given auth domain. Returns the email with its domain replaced, or the original if no authDomain. Exported for testing. |
 | `blockDuringImpersonation` | Express middleware that returns 403 during impersonation. Exported from auth.js. |
 | `googleSheets` | `{ getAuth, discoverSheetNames, fetchRawSheet }` — Google Sheets auth and raw data fetching |
 | `roster` | `{ readRosterFull, getAllPeople, getPeopleByOrg, getOrgKeys, getTeamRollup, getOrgDisplayNames }` — shared roster data access |

--- a/shared/server/__tests__/role-store.test.js
+++ b/shared/server/__tests__/role-store.test.js
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { createRoleStore, normalizeEmail } = require('../role-store');
+
+// Suppress console.log output in tests
+vi.spyOn(console, 'log').mockImplementation(() => {});
+
+function createMockStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    read(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    write(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    raw: store
+  };
+}
+
+function makeStore(opts = {}) {
+  const { authDomain = null, rolesData = null, allowlistData = null } = opts;
+  const initial = {};
+  if (rolesData) initial['roles.json'] = rolesData;
+  if (allowlistData) initial['allowlist.json'] = allowlistData;
+
+  const storage = createMockStorage(initial);
+  const roleStore = createRoleStore(
+    (key) => storage.read(key),
+    (key, data) => storage.write(key, data),
+    { getAuthDomain: () => authDomain }
+  );
+  return { roleStore, storage };
+}
+
+// ── normalizeEmail ──
+
+describe('normalizeEmail', () => {
+  it('returns null/undefined for falsy email', () => {
+    expect(normalizeEmail(null, 'cluster.local')).toBeNull();
+    expect(normalizeEmail(undefined, 'cluster.local')).toBeUndefined();
+    expect(normalizeEmail('', 'cluster.local')).toBe('');
+  });
+
+  it('lowercases and trims when no authDomain', () => {
+    expect(normalizeEmail('  User@RedHat.COM  ', null)).toBe('user@redhat.com');
+    expect(normalizeEmail('  User@RedHat.COM  ', '')).toBe('user@redhat.com');
+  });
+
+  it('replaces domain when authDomain is set', () => {
+    expect(normalizeEmail('user@redhat.com', 'cluster.local')).toBe('user@cluster.local');
+  });
+
+  it('handles email without @ sign', () => {
+    expect(normalizeEmail('admin', 'cluster.local')).toBe('admin');
+  });
+});
+
+// ── assignRole normalization ──
+
+describe('assignRole normalization', () => {
+  it('normalizes email when authDomain is set', () => {
+    const { roleStore, storage } = makeStore({ authDomain: 'cluster.local' });
+    roleStore.assignRole('user@redhat.com', 'admin', 'test');
+    const data = storage.read('roles.json');
+    expect(data.assignments['user@cluster.local']).toBeDefined();
+    expect(data.assignments['user@redhat.com']).toBeUndefined();
+  });
+
+  it('preserves email when no authDomain', () => {
+    const { roleStore, storage } = makeStore({ authDomain: null });
+    roleStore.assignRole('user@redhat.com', 'admin', 'test');
+    const data = storage.read('roles.json');
+    expect(data.assignments['user@redhat.com']).toBeDefined();
+  });
+});
+
+// ── revokeRole normalization ──
+
+describe('revokeRole normalization', () => {
+  it('normalizes email for revocation', () => {
+    const { roleStore } = makeStore({ authDomain: 'cluster.local' });
+    // Assign a second admin so we can revoke the first
+    roleStore.assignRole('user@redhat.com', 'admin', 'test');
+    roleStore.assignRole('other@redhat.com', 'admin', 'test');
+    // Revoke using the original (non-auth) domain
+    const result = roleStore.revokeRole('user@redhat.com', 'admin', 'test');
+    expect(result.email).toBe('user@cluster.local');
+  });
+});
+
+// ── getRoles normalization ──
+
+describe('getRoles normalization', () => {
+  it('normalizes email before lookup', () => {
+    const { roleStore } = makeStore({
+      authDomain: 'cluster.local',
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@cluster.local': { roles: ['admin'], assignedBy: 'test', assignedAt: '2024-01-01' }
+        }
+      }
+    });
+    const roles = roleStore.getRoles('user@redhat.com');
+    expect(roles).toEqual(['admin']);
+  });
+});
+
+// ── hasRole normalization ──
+
+describe('hasRole normalization', () => {
+  it('normalizes email via getRoles delegation', () => {
+    const { roleStore } = makeStore({
+      authDomain: 'cluster.local',
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@cluster.local': { roles: ['admin'], assignedBy: 'test', assignedAt: '2024-01-01' }
+        }
+      }
+    });
+    expect(roleStore.hasRole('user@redhat.com', 'admin')).toBe(true);
+  });
+});
+
+// ── Last-admin guard with normalization ──
+
+describe('last-admin guard', () => {
+  it('works with normalized emails', () => {
+    const { roleStore } = makeStore({ authDomain: 'cluster.local' });
+    roleStore.assignRole('solo@redhat.com', 'admin', 'test');
+    expect(() => roleStore.revokeRole('solo@redhat.com', 'admin', 'test'))
+      .toThrow('Cannot remove the last admin');
+  });
+});
+
+// ── migrateEmailDomains ──
+
+describe('migrateEmailDomains', () => {
+  it('rewrites existing keys to auth domain', () => {
+    const { roleStore, storage } = makeStore({
+      authDomain: 'cluster.local',
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@redhat.com': { roles: ['admin'], assignedBy: 'test', assignedAt: '2024-01-01' }
+        }
+      }
+    });
+    const count = roleStore.migrateEmailDomains();
+    expect(count).toBe(1);
+    const data = storage.read('roles.json');
+    expect(data.assignments['user@cluster.local']).toBeDefined();
+    expect(data.assignments['user@redhat.com']).toBeUndefined();
+  });
+
+  it('is idempotent — running twice produces same result', () => {
+    const { roleStore, storage } = makeStore({
+      authDomain: 'cluster.local',
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@redhat.com': { roles: ['admin'], assignedBy: 'test', assignedAt: '2024-01-01' }
+        }
+      }
+    });
+    roleStore.migrateEmailDomains();
+    const count2 = roleStore.migrateEmailDomains();
+    expect(count2).toBe(0);
+    const data = storage.read('roles.json');
+    expect(data.assignments['user@cluster.local']).toBeDefined();
+  });
+
+  it('no-ops when authDomain is empty', () => {
+    const { roleStore } = makeStore({
+      authDomain: null,
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@redhat.com': { roles: ['admin'], assignedBy: 'test', assignedAt: '2024-01-01' }
+        }
+      }
+    });
+    const count = roleStore.migrateEmailDomains();
+    expect(count).toBe(0);
+  });
+
+  it('merges roles when both domain variants exist', () => {
+    const { roleStore, storage } = makeStore({
+      authDomain: 'cluster.local',
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@redhat.com': { roles: ['admin'], assignedBy: 'ldap', assignedAt: '2024-01-01' },
+          'user@cluster.local': { roles: ['team-admin'], assignedBy: 'seed', assignedAt: '2024-01-02' }
+        }
+      }
+    });
+    const count = roleStore.migrateEmailDomains();
+    expect(count).toBe(1);
+    const data = storage.read('roles.json');
+    expect(data.assignments['user@cluster.local'].roles).toEqual(
+      expect.arrayContaining(['admin', 'team-admin'])
+    );
+    expect(data.assignments['user@redhat.com']).toBeUndefined();
+  });
+
+  it('creates backup before rewriting', () => {
+    const { roleStore, storage } = makeStore({
+      authDomain: 'cluster.local',
+      rolesData: {
+        version: 1,
+        assignments: {
+          'user@redhat.com': { roles: ['admin'], assignedBy: 'test', assignedAt: '2024-01-01' }
+        }
+      }
+    });
+    roleStore.migrateEmailDomains();
+    const backupKeys = Object.keys(storage.raw).filter(k => k.startsWith('roles-backup-'));
+    expect(backupKeys.length).toBe(1);
+    const backup = storage.read(backupKeys[0]);
+    expect(backup.assignments['user@redhat.com']).toBeDefined();
+  });
+});
+
+// ── migrateFromAllowlist ──
+
+describe('migrateFromAllowlist', () => {
+  it('normalizes emails via assignRole', () => {
+    const { roleStore, storage } = makeStore({
+      authDomain: 'cluster.local',
+      allowlistData: { emails: ['admin@redhat.com'] }
+    });
+    roleStore.migrateFromAllowlist();
+    const data = storage.read('roles.json');
+    expect(data.assignments['admin@cluster.local']).toBeDefined();
+    expect(data.assignments['admin@cluster.local'].roles).toContain('admin');
+    expect(data.assignments['admin@redhat.com']).toBeUndefined();
+  });
+});
+
+// ── seedRoles interaction ──
+
+describe('seedRoles interaction', () => {
+  it('assignRole normalizes ADMIN_EMAILS entries', () => {
+    const { roleStore } = makeStore({ authDomain: 'cluster.local' });
+    // Simulates what seedRoles does: calls assignRole for each ADMIN_EMAILS entry
+    roleStore.assignRole('user@redhat.com', 'admin', 'system-seed');
+    const roles = roleStore.getRoles('user@cluster.local');
+    expect(roles).toContain('admin');
+  });
+});
+
+// ── Cache invalidation ──
+
+describe('invalidateCache', () => {
+  it('causes fresh authDomain lookup after invalidation', () => {
+    let currentDomain = 'old.local';
+    const storage = createMockStorage({});
+    const roleStore = createRoleStore(
+      (key) => storage.read(key),
+      (key, data) => storage.write(key, data),
+      { getAuthDomain: () => currentDomain }
+    );
+
+    roleStore.assignRole('user@redhat.com', 'admin', 'test');
+    let data = storage.read('roles.json');
+    expect(data.assignments['user@old.local']).toBeDefined();
+
+    // Change domain and invalidate cache
+    currentDomain = 'new.local';
+    roleStore.invalidateCache();
+
+    roleStore.assignRole('user2@redhat.com', 'admin', 'test');
+    data = storage.read('roles.json');
+    expect(data.assignments['user2@new.local']).toBeDefined();
+  });
+});

--- a/shared/server/index.js
+++ b/shared/server/index.js
@@ -6,7 +6,7 @@ const roster = require('./roster')
 const rosterSync = require('./roster-sync')
 const jira = require('./jira')
 const permissions = require('./permissions')
-const { createRoleStore } = require('./role-store')
+const { createRoleStore, normalizeEmail } = require('./role-store')
 
 module.exports = {
   storage,
@@ -14,6 +14,7 @@ module.exports = {
   createAuthMiddleware,
   proxySecretGuard,
   createRoleStore,
+  normalizeEmail,
   googleSheets,
   roster,
   rosterSync,

--- a/shared/server/role-store.js
+++ b/shared/server/role-store.js
@@ -15,7 +15,43 @@ function isSafeKey(key) {
   return typeof key === 'string' && !['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
-function createRoleStore(readFromStorage, writeToStorage) {
+/**
+ * Normalize an email to the configured auth domain.
+ * If authDomain is set, replaces the domain portion of the email.
+ * Exported for testing.
+ */
+function normalizeEmail(email, authDomain) {
+  if (!email || !authDomain) return email ? email.trim().toLowerCase() : email;
+  const normalized = email.trim().toLowerCase();
+  const atIdx = normalized.indexOf('@');
+  if (atIdx < 0) return normalized;
+  return normalized.substring(0, atIdx + 1) + authDomain;
+}
+
+function createRoleStore(readFromStorage, writeToStorage, options = {}) {
+  const getAuthDomain = typeof options.getAuthDomain === 'function'
+    ? options.getAuthDomain
+    : () => null;
+
+  // Cache for getAuthDomain result (30s TTL)
+  let _cachedDomain = undefined;
+  let _cachedAt = 0;
+  const CACHE_TTL_MS = 30_000;
+
+  function getCachedAuthDomain() {
+    const now = Date.now();
+    if (_cachedDomain === undefined || now - _cachedAt > CACHE_TTL_MS) {
+      _cachedDomain = getAuthDomain() || null;
+      _cachedAt = now;
+    }
+    return _cachedDomain;
+  }
+
+  function invalidateCache() {
+    _cachedDomain = undefined;
+    _cachedAt = 0;
+  }
+
   function readRoles() {
     return readFromStorage(ROLES_FILE) || { version: 1, assignments: {} };
   }
@@ -26,7 +62,8 @@ function createRoleStore(readFromStorage, writeToStorage) {
 
   function getRoles(email) {
     if (!email) return [];
-    const key = email.toLowerCase();
+    const authDomain = getCachedAuthDomain();
+    const key = normalizeEmail(email, authDomain);
     if (!isSafeKey(key)) return [];
     const data = readRoles();
     const entry = data.assignments[key];
@@ -45,7 +82,8 @@ function createRoleStore(readFromStorage, writeToStorage) {
       return { demo: true, message: 'Demo mode -- changes are not saved' };
     }
 
-    const normalized = email.trim().toLowerCase();
+    const authDomain = getCachedAuthDomain();
+    const normalized = normalizeEmail(email, authDomain);
     if (!isSafeKey(normalized)) throw new Error('Invalid email');
     const data = readRoles();
 
@@ -85,7 +123,8 @@ function createRoleStore(readFromStorage, writeToStorage) {
       return { demo: true, message: 'Demo mode -- changes are not saved' };
     }
 
-    const normalized = email.trim().toLowerCase();
+    const authDomain = getCachedAuthDomain();
+    const normalized = normalizeEmail(email, authDomain);
     if (!isSafeKey(normalized)) throw new Error('Invalid email');
     const data = readRoles();
     const entry = data.assignments[normalized];
@@ -146,20 +185,12 @@ function createRoleStore(readFromStorage, writeToStorage) {
       return false; // Nothing to migrate
     }
 
-    const now = new Date().toISOString();
     for (const email of allowlist.emails) {
-      const normalized = email.trim().toLowerCase();
-      if (!isSafeKey(normalized)) continue;
-      rolesData.assignments[normalized] = {
-        roles: ['admin'],
-        assignedBy: 'migration',
-        assignedAt: now
-      };
+      assignRole(email, 'admin', 'migration');
     }
 
-    writeRoles(rolesData);
-
     // Mark allowlist as migrated
+    const now = new Date().toISOString();
     writeToStorage(ALLOWLIST_FILE, {
       _migrated: 'roles.json',
       _migratedAt: now,
@@ -170,6 +201,55 @@ function createRoleStore(readFromStorage, writeToStorage) {
     return true;
   }
 
+  function migrateEmailDomains() {
+    const authDomain = getAuthDomain();
+    if (!authDomain) return 0;
+
+    const data = readRoles();
+    const oldKeys = Object.keys(data.assignments);
+    const needsMigration = oldKeys.some(email => normalizeEmail(email, authDomain) !== email);
+
+    if (!needsMigration) return 0;
+
+    // Backup before migration
+    const backupKey = `roles-backup-${Date.now()}.json`;
+    writeToStorage(backupKey, JSON.parse(JSON.stringify(data)));
+    console.log(`Roles: backup saved to ${backupKey}`);
+
+    let migrated = 0;
+
+    for (const oldEmail of oldKeys) {
+      const newEmail = normalizeEmail(oldEmail, authDomain);
+      if (newEmail === oldEmail) continue;
+
+      const oldEntry = data.assignments[oldEmail];
+      const existingEntry = data.assignments[newEmail];
+
+      if (existingEntry) {
+        // Merge roles from both entries
+        const mergedRoles = [...new Set([...existingEntry.roles, ...oldEntry.roles])];
+        existingEntry.roles = mergedRoles;
+        // Keep the newer assignedAt
+        if (oldEntry.assignedAt > existingEntry.assignedAt) {
+          existingEntry.assignedBy = oldEntry.assignedBy;
+          existingEntry.assignedAt = oldEntry.assignedAt;
+        }
+      } else {
+        data.assignments[newEmail] = oldEntry;
+      }
+
+      delete data.assignments[oldEmail];
+      migrated++;
+    }
+
+    if (migrated > 0) {
+      writeRoles(data);
+      console.log(`Roles: migrated ${migrated} email(s) to @${authDomain} (backup: ${backupKey})`);
+    }
+
+    return migrated;
+  }
+
   return {
     getRoles,
     hasRole,
@@ -177,8 +257,10 @@ function createRoleStore(readFromStorage, writeToStorage) {
     revokeRole,
     listAssignments,
     getAdminEmails,
-    migrateFromAllowlist
+    migrateFromAllowlist,
+    migrateEmailDomains,
+    invalidateCache
   };
 }
 
-module.exports = { createRoleStore, VALID_ROLES };
+module.exports = { createRoleStore, normalizeEmail, VALID_ROLES };

--- a/src/__tests__/SiteSettings.test.js
+++ b/src/__tests__/SiteSettings.test.js
@@ -43,7 +43,7 @@ describe('SiteSettings', () => {
     await wrapper.find('button').trigger('click')
     await flushPromises()
 
-    expect(mockSaveSiteConfig).toHaveBeenCalledWith({ titlePrefix: 'New Prefix' })
+    expect(mockSaveSiteConfig).toHaveBeenCalledWith({ titlePrefix: 'New Prefix', authEmailDomain: '' })
     expect(wrapper.emitted('toast')).toBeTruthy()
     expect(wrapper.emitted('toast')[0][0]).toEqual({
       message: 'Site configuration saved',

--- a/src/components/SiteSettings.vue
+++ b/src/components/SiteSettings.vue
@@ -19,6 +19,25 @@
             class="w-full max-w-md px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           />
         </div>
+        <div>
+          <label for="authEmailDomain" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Auth Email Domain
+          </label>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            If your OAuth proxy rewrites user emails to a different domain
+            (e.g. cluster.local), set that domain here so role assignments
+            match correctly. Can also be set via AUTH_EMAIL_DOMAIN env var
+            (env var takes precedence).
+          </p>
+          <input
+            id="authEmailDomain"
+            v-model="authEmailDomain"
+            type="text"
+            maxlength="253"
+            placeholder="e.g. cluster.local"
+            class="w-full max-w-md px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
         <button
           @click="save"
           :disabled="saving"
@@ -38,12 +57,14 @@ import { getSiteConfig, saveSiteConfig } from '@shared/client/services/api'
 const emit = defineEmits(['toast', 'config-updated'])
 
 const titlePrefix = ref('')
+const authEmailDomain = ref('')
 const saving = ref(false)
 
 onMounted(async () => {
   try {
     const config = await getSiteConfig()
     titlePrefix.value = config.titlePrefix || ''
+    authEmailDomain.value = config.authEmailDomain || ''
   } catch {
     // ignore — defaults to empty
   }
@@ -52,7 +73,10 @@ onMounted(async () => {
 async function save() {
   saving.value = true
   try {
-    await saveSiteConfig({ titlePrefix: titlePrefix.value })
+    await saveSiteConfig({
+      titlePrefix: titlePrefix.value,
+      authEmailDomain: authEmailDomain.value
+    })
     emit('config-updated', { titlePrefix: titlePrefix.value })
     emit('toast', { message: 'Site configuration saved', type: 'success' })
   } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #603

- Role assignments via the admin UI stored emails with the LDAP domain (`@redhat.com`), but the OAuth proxy authenticates users as `@cluster.local`. The role store did exact email matching, so assigned roles never applied in production.
- Adds configurable `AUTH_EMAIL_DOMAIN` env var (primary) and `authEmailDomain` site-config setting (secondary) to normalize emails at assignment time
- All role-store public methods (`getRoles`, `assignRole`, `revokeRole`) normalize consistently — lookups remain O(1)
- Existing `roles.json` entries are migrated on startup with backup and conflict merging (handles cases where both `@redhat.com` and `@cluster.local` entries exist)
- Site-config GET/POST endpoints fixed to use read-merge-write pattern (prevents field loss)
- Settings UI includes "Auth Email Domain" input with helper text
- Prod overlay ConfigMap includes `AUTH_EMAIL_DOMAIN: cluster.local` for immediate bootstrap (no chicken-and-egg problem)

## Files Changed (11 files, +504/-31)

| File | Change |
|------|--------|
| `shared/server/role-store.js` | `normalizeEmail` helper, domain-aware normalization in all public methods, safe migration with merge + backup, cache with invalidation |
| `server/dev-server.js` | `getAuthDomain` wiring, site-config read-merge-write, `isValidDomain`, startup migration, audit logging, env var validation |
| `src/components/SiteSettings.vue` | Auth Email Domain input field |
| `shared/server/__tests__/role-store.test.js` | 18 new tests |
| `src/__tests__/SiteSettings.test.js` | Updated assertion for new payload |
| `.claude/CLAUDE.md` | Document `AUTH_EMAIL_DOMAIN` env var |
| `.env.example` | Add `AUTH_EMAIL_DOMAIN` |
| `deploy/openshift/overlays/prod/kustomization.yaml` | Add `AUTH_EMAIL_DOMAIN: cluster.local` |
| `docs/DATA-FORMATS.md` | Add `authEmailDomain` to site-config format |
| `shared/API.md` | Document `normalizeEmail` export, update `getSiteConfig` response |
| `shared/server/index.js` | Re-export `normalizeEmail` |

## Test plan

- [x] 18 new unit tests for role-store normalization, migration, merge, backup, cache
- [x] 4 SiteSettings component tests pass (updated for new payload)
- [x] Lint clean
- [ ] Deploy to dev/preprod: set `AUTH_EMAIL_DOMAIN=cluster.local`, verify admin can log in
- [ ] Verify role assignment via LDAP lookup stores `@cluster.local` key
- [ ] Verify existing `@redhat.com` roles are migrated on startup
- [ ] Verify Settings > General shows Auth Email Domain field

🤖 Generated with [Claude Code](https://claude.ai/code)