### PR TITLE
feat: add `feature-traffic` integration tests and refactor test helpers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -193,13 +193,14 @@ Tests run in same Playwright container as smoke tests. Uses tag-based filtering 
 CI workflow (`integration-tests.yml`):
 - Triggers on changes to `modules/**` or `tests/integration/**`
 - Uses `dorny/paths-filter` to detect which modules changed
+- Uses matrix strategy: changed modules are automatically added to test matrix via `steps.filter.outputs.changes`
 - Runs tests only for changed modules via generic `test-module` Makefile target
 - Reusable composite action at `.github/actions/test-org-pulse-module/`
 
 To add integration tests for a new module:
 1. Create `tests/integration/<module>.spec.js` with `@<module-name>` tag
-2. Add filter in `integration-tests.yml` `detect-changes` job
-3. Add job output and test job (copy pattern from `test-ai-impact`)
+2. Add filter definition in `integration-tests.yml` `detect-changes` job filters section
+3. That's it! The matrix automatically picks up the new module when it changes
 
 ### Building images on ARM Macs
 Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. See `deploy/OPENSHIFT.md` step 3 for details. This works because the backend has no native Node addons (all pure JS).

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      ai-impact: ${{ steps.filter.outputs.ai-impact }}
+      # This captures the dynamic JSON array of modules to test
+      enabled-modules: ${{ steps.build-matrix.outputs.modules }}
 
     steps:
       - uses: actions/checkout@v4
@@ -27,23 +28,52 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # This determines which keys get added to the 'changes' output array
+          # Adding a new module here automatically adds it to the test matrix
           filters: |
+            shared-test-files:
+              - 'tests/integration/constants.js'
+              - 'tests/integration/helpers.js'
             ai-impact:
               - 'modules/ai-impact/**'
               - 'tests/integration/ai-impact.spec.js'
-              - 'tests/integration/constants.js'
-              - 'tests/integration/helpers.js'
+            feature-traffic:
+              - 'modules/feature-traffic/**'
+              - 'tests/integration/feature-traffic.spec.js'
 
-  test-ai-impact:
-    name: Test AI Impact Module
+      - name: Build module matrix
+        id: build-matrix
+        run: |
+          # If shared test files changed, then test all modules
+          if [ "${{ steps.filter.outputs.shared-test-files }}" == "true" ]; then
+            MODULES='["ai-impact", "feature-traffic"]'
+          else
+            # Otherwise, use the modules that have direct changes
+            MODULES='${{ steps.filter.outputs.changes }}'
+            # Remove 'shared-test-files' from the array if it's present
+            MODULES=$(echo "$MODULES" | jq 'map(select(. != "shared-test-files"))')
+          fi
+
+          echo "modules=$MODULES" >> $GITHUB_OUTPUT
+          echo "Testing modules: $MODULES"
+
+  run-tests:
+    name: Test ${{ matrix.module }}
     needs: detect-changes
-    if: needs.detect-changes.outputs.ai-impact == 'true'
+    # Only run if one or more modules need testing
+    if: needs.detect-changes.outputs.enabled-modules != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false  # Allows other modules to finish even if one fails
+      matrix:
+        module: ${{ fromJson(needs.detect-changes.outputs.enabled-modules) }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/test-org-pulse-module
+      - name: Run Module Test
+        uses: ./.github/actions/test-org-pulse-module
         with:
-          module: ai-impact
+          module: ${{ matrix.module }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,10 +182,7 @@ MODULE_NAME=ai-impact                   # Choose a testable module
 make test-module MODULE=${MODULE_NAME}  # Runs the integration tests against an existing module
 ```
 
-Available, testable modules:
-- [ai-impact](./modules/ai-impact/)
-
-Integration tests for [other modules](./modules/) are coming soon.
+Available, testable modules can be found here by name: [tests/integration](./tests/integration/)
 
 ## Deployment
 

--- a/tests/integration/ai-impact.spec.js
+++ b/tests/integration/ai-impact.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const { DEFAULT_PAGE_WAIT_TIME } = require('./constants');
-const { setupErrorTracking, logCapturedErrors } = require('./helpers');
+const { setupErrorTracking, logCapturedErrors, pageHasContent, pageLoadComplete, mainContentIsVisible } = require('./helpers');
 
 /**
  * Integration tests for AI Impact module
@@ -153,29 +153,17 @@ test.describe('AI Impact Views @ai-impact', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // Before we verify content, we need to verify the overall view loads
-    const mainContent = page.locator('main, [role="main"], .min-h-screen').first();
-    await expect(mainContent).toBeVisible();
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
 
     // Verify the view has rendered some meaningful content by checking for
     // data-bearing elements (not just empty containers or placeholders)
-    const hasButtons = await page.locator('button').count() > 0;
-    const hasInputs = await page.locator('input, select, textarea').count() > 0;
-    const hasList = await page.locator('ul li, ol li').count() > 0;
-    const hasTable = await page.locator('table tbody tr').count() > 0; // Data rows, not just headers
-    const hasHeadings = await page.locator('h1, h2, h3').count() > 0;
-    const hasLinks = await page.locator('a[href]').count() > 0;
-    const hasDataElements = await page.locator('[data-testid], [data-key], [data-id]').count() > 0;
-    const hasSections = await page.locator('article, section').count() > 0;
-
-    // If this value is 'false', then it indicates we've loaded an empty page.
-    const hasContent = hasButtons || hasInputs || hasList || hasTable ||
-                       hasHeadings || hasLinks || hasDataElements || hasSections;
+    const hasContent = await pageHasContent(page);
     expect(hasContent).toBe(true);
 
     // Verify we're not stuck in an infinite loading state
-    // Use specific selectors to avoid matching legitimate status regions
-    const loadingSpinners = await page.locator('[aria-busy="true"], [role="progressbar"], .loading, .spinner, [aria-label*="loading" i]').count();
-    expect(loadingSpinners).toBe(0);
+    const pageHasFinishedLoading = await pageLoadComplete(page);
+    expect(pageHasFinishedLoading).toBe(true);
     if (page.errors.length > 0) {
       console.error(`${viewName} errors:`, page.errors);
     }

--- a/tests/integration/feature-traffic.spec.js
+++ b/tests/integration/feature-traffic.spec.js
@@ -1,0 +1,256 @@
+const { test, expect } = require('@playwright/test');
+const { DEFAULT_PAGE_WAIT_TIME } = require('./constants');
+const { setupErrorTracking, logCapturedErrors, pageHasContent, pageLoadComplete, mainContentIsVisible } = require('./helpers');
+
+/**
+ * Error message displayed when no feature key is provided to the feature detail view
+ */
+const NO_FEATURE_KEY_ERROR_MESSAGE = 'No feature key provided. Go back to the overview and select a feature.';
+
+/**
+ * Integration tests for Feature Traffic module
+ *
+ * These tests verify:
+ * - Module loads and renders correctly
+ * - Data fetching and display works
+ * - Navigation within the module functions
+ * - API integration is functional
+ *
+ * Tag: @feature-traffic
+ * Usage: npx playwright test --grep @feature-traffic
+ */
+
+test.describe('Feature Traffic Module @feature-traffic', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should fetch data from Feature Traffic API endpoints', async ({ page }) => {
+    // Monitor network requests
+    const apiRequests = [];
+    page.on('request', request => {
+      if (request.url().includes('/api/modules/feature-traffic')) {
+        apiRequests.push({
+          url: request.url(),
+          method: request.method()
+        });
+      }
+    });
+
+    // Navigate to Overview (default view that makes API calls)
+    await page.goto('/#/feature-traffic/overview');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Verify that API requests were made to the Feature Traffic endpoints
+    // In demo mode, these should still be called and return fixture data
+    expect(apiRequests.length).toBeGreaterThan(0);
+    console.log(`Feature Traffic API requests: ${apiRequests.length}`);
+    apiRequests.forEach(req => {
+      console.log(`  ${req.method} ${req.url}`);
+    });
+
+    // Verify specific expected endpoints were called
+    const endpointPatterns = [
+      /\/features($|\?)/,  // GET /features or /features?...
+      /\/status/,          // GET /status
+      /\/versions/         // GET /versions
+    ];
+
+    endpointPatterns.forEach(pattern => {
+      const matchingRequest = apiRequests.find(req => pattern.test(req.url));
+      if (matchingRequest) {
+        console.log(`  ✓ Expected endpoint called: ${matchingRequest.url}`);
+      }
+    });
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+});
+
+/**
+ * Active Views
+ *
+ * Verify each major view (aka menu item) in the Feature Traffic module loads with
+ * meaningful content
+ */
+test.describe('Feature Traffic Views @feature-traffic', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  // Helper to navigate and verify a view loads with content
+  async function testView(page, viewId, viewName) {
+    await page.goto(`/#/feature-traffic/${viewId}`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Before we verify content, we need to verify the overall view loads
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
+
+    // Verify the view has rendered some meaningful content by checking for
+    // data-bearing elements (not just empty containers or placeholders)
+    const hasContent = await pageHasContent(page);
+    expect(hasContent).toBe(true);
+
+    // Verify we're not stuck in an infinite loading state
+    const pageHasFinishedLoading = await pageLoadComplete(page);
+    expect(pageHasFinishedLoading).toBe(true);
+    if (page.errors.length > 0) {
+      console.error(`${viewName} errors:`, page.errors);
+    }
+
+    expect(page.errors).toHaveLength(0);
+  }
+
+  test('should load Overview view', async ({ page }) => {
+    await testView(page, 'overview', 'Overview');
+  });
+
+  test('should load Feature Detail view with a valid feature key', async ({ page }) => {
+    const testFeatureKey = 'TESTINT-001';
+
+    // Mock the feature-traffic API response
+    await page.route('**/api/modules/feature-traffic/features/TESTINT-001', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          key: 'TESTINT-001',
+          summary: 'Integration Test Feature 1',
+          status: 'In Progress',
+          statusCategory: 'In Progress',
+          priority: 'High',
+          assignee: 'Test User',
+          fixVersions: ['1.0.0'],
+          labels: ['integration-test'],
+          completionPct: 50,
+          epicCount: 2,
+          issueCount: 5,
+          blockerCount: 0,
+          health: 'GREEN',
+          epics: [],
+          issues: []
+        })
+      });
+    });
+
+    // Mock the ai-impact API response (returns null for non-existent feature)
+    await page.route('**/api/modules/ai-impact/features/TESTINT-001', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(null)
+      });
+    });
+
+    console.log(`Testing Feature Detail view with key: ${testFeatureKey}`);
+
+    // Navigate to feature detail view with the key as a query parameter
+    await page.goto(`/#/feature-traffic/feature-detail?key=${testFeatureKey}`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Verify the view loads
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
+
+    // Verify content renders
+    const hasContent = await pageHasContent(page);
+    expect(hasContent).toBe(true);
+
+    // Verify no stuck loading spinners
+    const pageHasFinishedLoading = await pageLoadComplete(page);
+    expect(pageHasFinishedLoading).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should display error message when no feature key is provided', async ({ page }) => {
+    // Navigate to feature detail view WITHOUT a key parameter
+    await page.goto('/#/feature-traffic/feature-detail');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Verify the view loads
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
+
+    // Verify that we get an error message about no feature key being provided
+    const errorMessage = page.getByText(NO_FEATURE_KEY_ERROR_MESSAGE);
+    await expect(errorMessage).toBeVisible();
+
+    // Verify no stuck loading spinners
+    const pageHasFinishedLoading = await pageLoadComplete(page);
+    expect(pageHasFinishedLoading).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should not display error message when a valid feature key is provided', async ({ page }) => {
+    const mockFeatureKey = 'TESTINT-001';
+
+    // Mock the feature-traffic API response
+    await page.route('**/api/modules/feature-traffic/features/TESTINT-001', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          key: 'TESTINT-001',
+          summary: 'Integration Test Feature 1',
+          status: 'In Progress',
+          statusCategory: 'In Progress',
+          priority: 'High',
+          assignee: 'Test User',
+          fixVersions: ['1.0.0'],
+          labels: ['integration-test'],
+          completionPct: 50,
+          epicCount: 2,
+          issueCount: 5,
+          blockerCount: 0,
+          health: 'GREEN',
+          epics: [],
+          issues: []
+        })
+      });
+    });
+
+    // Mock the ai-impact API response (returns null for non-existent feature)
+    await page.route('**/api/modules/ai-impact/features/TESTINT-001', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(null)
+      });
+    });
+
+    // Navigate to feature detail view WITH a feature key parameter
+    await page.goto(`/#/feature-traffic/feature-detail?key=${mockFeatureKey}`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Verify the view loads
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
+
+    // Verify that we don't get an error message
+    const errorMessage = page.getByText(NO_FEATURE_KEY_ERROR_MESSAGE);
+    await expect(errorMessage).not.toBeVisible();
+
+    // Verify no stuck loading spinners
+    const pageHasFinishedLoading = await pageLoadComplete(page);
+    expect(pageHasFinishedLoading).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
+});

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -26,7 +26,7 @@ function setupErrorTracking(page) {
 /**
  * Logs any errors to the console that were captured during the test so that users
  * can debug any failing integration test.
- * 
+ *
  * Use in test.afterEach hook
  * @param {import('@playwright/test').Page} page - Playwright page object
  * @param {import('@playwright/test').TestInfo} testInfo - Test metadata
@@ -44,7 +44,54 @@ function logCapturedErrors(page, testInfo) {
   }
 }
 
+/**
+ * Checks if a page has rendered meaningful content by looking for
+ * data-bearing elements (not just empty containers or placeholders)
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @returns {Promise<boolean>} - True if the page has content, false otherwise
+ */
+async function pageHasContent(page) {
+  const hasButtons = await page.locator('button').count() > 0;
+  const hasInputs = await page.locator('input, select, textarea').count() > 0;
+  const hasList = await page.locator('ul li, ol li').count() > 0;
+  const hasTable = await page.locator('table tbody tr').count() > 0; // Data rows, not just headers
+  const hasHeadings = await page.locator('h1, h2, h3').count() > 0;
+  const hasLinks = await page.locator('a[href]').count() > 0;
+  const hasDataElements = await page.locator('[data-testid], [data-key], [data-id]').count() > 0;
+  const hasSections = await page.locator('article, section').count() > 0;
+
+  // If this value is 'false', then it indicates we've loaded an empty page.
+  return hasButtons || hasInputs || hasList || hasTable ||
+         hasHeadings || hasLinks || hasDataElements || hasSections;
+}
+
+/**
+ * Checks if a page has finished loading by verifying no active loading spinners are present
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @returns {Promise<boolean>} - True if loading is complete, false if still loading
+ */
+async function pageLoadComplete(page) {
+  const loadingSpinners = await page.locator('[aria-busy="true"], [role="progressbar"], .loading, .spinner, [aria-label*="loading" i]').count();
+  return loadingSpinners === 0;
+}
+
+/**
+ * Checks if the main content container of the page is visible
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @returns {Promise<boolean>} - True if main content is visible, false otherwise
+ */
+async function mainContentIsVisible(page) {
+  const mainContent = page.locator('main, [role="main"], .min-h-screen').first();
+  return await mainContent.isVisible();
+}
+
 module.exports = {
   setupErrorTracking,
-  logCapturedErrors
+  logCapturedErrors,
+  pageHasContent,
+  pageLoadComplete,
+  mainContentIsVisible
 };


### PR DESCRIPTION
## Purpose

This PR is a follow up to #616 by adding `feature-traffic` integration tests. These tests are very similar to the `ai-helpers` integration tests, but they also validate that the **#/feature-traffic/feature-detail** page throws an error when users fail to select a feature in the UI. Basically, they validate this use case:

<img width="936" height="257" alt="Screenshot 2026-05-15 at 3 22 03 PM" src="https://github.com/user-attachments/assets/97545aed-6778-4596-a685-c5dee44b0493" />

The tests also mock a real feature to validate that we don't see `No feature key provided. Go back to the overview and select a feature.` when a feature is selected. Mocking this use case makes the testing maintainable and portable, while also giving us a good signal about the health of the "Feature Status" tab.

## Summary of Changes

- Added reusable test helpers (`pageHasContent`, `pageLoadComplete`, `mainContentIsVisible`) for common logic in the new tests
- Updated `integration-tests.yml` to use a GitHub matrix strategy. This prevents us from needing to copy-paste the same job over and over again with minimal tweaks.
- Updated `CLAUDE.md` + `CONTRIBUTING.md` to reflect the latest changes.