### PR TITLE
fix: re-fetch all data when backend recovers from outage

### DIFF
--- a/shared/client/composables/useBackendHealth.js
+++ b/shared/client/composables/useBackendHealth.js
@@ -1,6 +1,6 @@
 import { ref, onUnmounted } from 'vue'
+import { getApiBase } from '../services/api'
 
-const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT || '/api'
 const CHECK_INTERVAL = 5000
 const FAILURE_THRESHOLD = 2
 const EXTENDED_OUTAGE_MS = 2 * 60 * 1000
@@ -13,15 +13,25 @@ let _outageStartedAt = null
 let pollTimer = null
 let extendedTimer = null
 let started = false
+const _recoveryCallbacks = new Set()
+
+function onRecovery(cb) {
+  _recoveryCallbacks.add(cb)
+}
+
+function offRecovery(cb) {
+  _recoveryCallbacks.delete(cb)
+}
 
 async function checkHealth() {
   try {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 3000)
-    const res = await fetch(`${API_ENDPOINT}/healthz`, { signal: controller.signal })
+    const res = await fetch(`${getApiBase()}/healthz`, { signal: controller.signal })
     clearTimeout(timeout)
 
     if (res.ok) {
+      const wasDown = isBackendDown.value
       consecutiveFailures = 0
       isBackendDown.value = false
       isExtendedOutage.value = false
@@ -29,6 +39,11 @@ async function checkHealth() {
       if (extendedTimer) {
         clearTimeout(extendedTimer)
         extendedTimer = null
+      }
+      if (wasDown) {
+        for (const cb of _recoveryCallbacks) {
+          try { cb() } catch (e) { console.error('Recovery callback error:', e) }
+        }
       }
     } else {
       handleFailure()
@@ -73,6 +88,7 @@ export function useBackendHealth() {
 
 // Exported for testing
 export { checkHealth, handleFailure, CHECK_INTERVAL, FAILURE_THRESHOLD, EXTENDED_OUTAGE_MS }
+export { onRecovery, offRecovery }
 
 export function _resetForTesting() {
   consecutiveFailures = 0
@@ -80,6 +96,7 @@ export function _resetForTesting() {
   isBackendDown.value = false
   isExtendedOutage.value = false
   started = false
+  _recoveryCallbacks.clear()
   if (pollTimer) { clearInterval(pollTimer); pollTimer = null }
   if (extendedTimer) { clearTimeout(extendedTimer); extendedTimer = null }
 }

--- a/shared/client/composables/useGithubStats.js
+++ b/shared/client/composables/useGithubStats.js
@@ -36,10 +36,16 @@ export function useGithubStats() {
     githubData.value.users[username] = data
   }
 
+  async function reloadGithubStats() {
+    githubData.value = null
+    return loadGithubStats()
+  }
+
   return {
     contributionsMap,
     getContributions,
     loadGithubStats,
+    reloadGithubStats,
     setUserContributions,
     loading
   }

--- a/shared/client/composables/useGitlabStats.js
+++ b/shared/client/composables/useGitlabStats.js
@@ -74,12 +74,18 @@ export function useGitlabStats() {
     }))
   }
 
+  async function reloadGitlabStats() {
+    gitlabData.value = null
+    return loadGitlabStats()
+  }
+
   return {
     contributionsMap,
     getContributions,
     getInstanceContributions,
     knownInstances,
     loadGitlabStats,
+    reloadGitlabStats,
     setUserContributions,
     getProfileUrls,
     loading

--- a/src/__tests__/useBackendHealth.test.js
+++ b/src/__tests__/useBackendHealth.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-let useBackendHealth, _resetForTesting
+let useBackendHealth, _resetForTesting, onRecovery, offRecovery
 
 describe('useBackendHealth', () => {
   beforeEach(async () => {
@@ -10,6 +10,8 @@ describe('useBackendHealth', () => {
     const mod = await import('@shared/client/composables/useBackendHealth')
     useBackendHealth = mod.useBackendHealth
     _resetForTesting = mod._resetForTesting
+    onRecovery = mod.onRecovery
+    offRecovery = mod.offRecovery
     _resetForTesting()
   })
 
@@ -90,5 +92,47 @@ describe('useBackendHealth', () => {
     await vi.advanceTimersByTimeAsync(0)
     await vi.advanceTimersByTimeAsync(5000)
     expect(isBackendDown.value).toBe(true)
+  })
+
+  it('calls recovery callbacks when backend recovers', async () => {
+    const cb = vi.fn()
+    onRecovery(cb)
+
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'))
+    useBackendHealth()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(5000)
+
+    global.fetch = vi.fn().mockResolvedValue({ ok: true })
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call recovery callbacks on normal healthy checks', async () => {
+    const cb = vi.fn()
+    onRecovery(cb)
+
+    global.fetch = vi.fn().mockResolvedValue({ ok: true })
+    useBackendHealth()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('stops calling removed recovery callbacks', async () => {
+    const cb = vi.fn()
+    onRecovery(cb)
+
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'))
+    useBackendHealth()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(5000)
+
+    offRecovery(cb)
+
+    global.fetch = vi.fn().mockResolvedValue({ ok: true })
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(cb).not.toHaveBeenCalled()
   })
 })

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -207,6 +207,7 @@ import AppMessages from '@shared/client/components/AppMessages.vue'
 import { computed, ref, readonly, provide, onUnmounted, watch } from 'vue'
 import { useAuth } from '@shared/client/composables/useAuth'
 import { useImpersonation } from '@shared/client/composables/useImpersonation'
+import { onRecovery, offRecovery } from '@shared/client/composables/useBackendHealth'
 import { useMessages } from '@shared/client/composables/useMessages'
 import { usePermissions } from '@shared/client/composables/usePermissions'
 import { useRoster } from '@shared/client/composables/useRoster'
@@ -243,10 +244,10 @@ export default {
     const { user: authUser, isAdmin: authIsAdmin, isTeamAdmin: authIsTeamAdmin, refresh: refreshAuth } = useAuth()
     const { isImpersonating, impersonatingUid: impersonatingUidRef, impersonatingName: impersonatingNameRef, stopImpersonating } = useImpersonation()
     const { isManager: authIsManager, refresh: refreshPermissions } = usePermissions()
-    const { loadRoster, teams, selectedOrgKey, selectOrg, rosterData } = useRoster()
-    const { loadGithubStats } = useGithubStats()
-    const { loadGitlabStats } = useGitlabStats()
-    const { modulesData, loadModules, enabledBuiltInSlugs, loadEnabledBuiltInSlugs } = useModules()
+    const { loadRoster, reloadRoster, teams, selectedOrgKey, selectOrg, rosterData } = useRoster()
+    const { loadGithubStats, reloadGithubStats } = useGithubStats()
+    const { loadGitlabStats, reloadGitlabStats } = useGitlabStats()
+    const { modulesData, loadModules, reloadModules, enabledBuiltInSlugs, loadEnabledBuiltInSlugs } = useModules()
     const { mode: themeMode, cycle: cycleTheme } = useTheme()
     const { messages: appMessages, fetchMessages, dismiss: dismissMessage } = useMessages()
     const titlePrefix = ref('')
@@ -254,6 +255,20 @@ export default {
     watch(titlePrefix, (prefix) => {
       document.title = prefix ? `${prefix} Org Pulse` : 'Org Pulse'
     })
+
+    function handleBackendRecovery() {
+      reloadRoster()
+      reloadGithubStats()
+      reloadGitlabStats()
+      reloadModules()
+      refreshAuth()
+      refreshPermissions()
+      fetchMessages()
+      fetchLastRefreshed()
+      fetchSiteConfig()
+    }
+    onRecovery(handleBackendRecovery)
+    onUnmounted(() => offRecovery(handleBackendRecovery))
 
     const lastRefreshedAt = ref(null)
     const tick = ref(0)


### PR DESCRIPTION
When the backend goes down and comes back up, the health check dismissed the connectivity modal but no data was re-fetched. Composables had "already loaded" guards that prevented re-fetching, leaving pages empty until a hard refresh.

- Add recovery callback system to useBackendHealth (onRecovery/offRecovery)
- Add reloadGithubStats/reloadGitlabStats to bypass load guards
- Register recovery handler in App.vue to re-fetch all critical data
- Use getApiBase() in health check for consistency with API service

Fixes #609

Generated with [Claude Code](https://claude.ai/code)