### PR TITLE
fix: validate Jira name resolution against roster name

### DIFF
--- a/modules/team-tracker/server/jira/__tests__/person-metrics.test.js
+++ b/modules/team-tracker/server/jira/__tests__/person-metrics.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildProjectFilter, projectKeysFingerprint, computeCycleTimeDays, findWorkStartDate, fetchPersonMetrics, mergeResolvedIssues, needsFullRefresh, FIELDS_VERSION } from '../person-metrics'
+import { buildProjectFilter, projectKeysFingerprint, computeCycleTimeDays, findWorkStartDate, fetchPersonMetrics, resolveJiraDisplayName, namesMatch, mergeResolvedIssues, needsFullRefresh, FIELDS_VERSION } from '../person-metrics'
 
 function makeIssue({ created, resolutiondate, histories }) {
   return {
@@ -330,6 +330,141 @@ describe('fetchPersonMetrics', () => {
       accountId: 'acc-mprahl-123',
       displayName: 'Matthew Prahl'
     })
+  })
+})
+
+describe('namesMatch', () => {
+  it('matches when first initial and last name agree', () => {
+    expect(namesMatch('Matt Prahl', 'Matthew Prahl')).toBe(true)
+  })
+
+  it('rejects when first initials differ', () => {
+    expect(namesMatch('Adam Drew', 'Rob Drew')).toBe(false)
+  })
+
+  it('rejects when last names differ', () => {
+    expect(namesMatch('Chris Prahl', 'Christopher Smith')).toBe(false)
+  })
+
+  it('handles multi-word names using last word as last name', () => {
+    expect(namesMatch('David Cohn Lifshitz', 'David Lifshitz')).toBe(true)
+  })
+
+  it('rejects multi-word names with different first initial', () => {
+    expect(namesMatch('David Cohn Lifshitz', 'Artom Lifshitz')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(namesMatch('john smith', 'JOHN SMITH')).toBe(true)
+  })
+
+  it('returns false for empty displayName', () => {
+    expect(namesMatch('Test User', '')).toBe(false)
+  })
+
+  it('returns false for null displayName', () => {
+    expect(namesMatch('Test User', null)).toBe(false)
+  })
+})
+
+describe('resolveJiraDisplayName — name validation', () => {
+  function createMockJiraRequest(handlers = {}) {
+    return vi.fn(async (url) => {
+      if (url.includes('/rest/api/2/user/search')) {
+        if (handlers.userSearch) return handlers.userSearch(url)
+        return []
+      }
+      return []
+    })
+  }
+
+  it('rejects single user-search result when first name does not match', async () => {
+    const nameCache = {}
+    const mockJiraRequest = createMockJiraRequest({
+      userSearch: () => [{ displayName: 'Rob Drew', accountId: 'acc-rob' }]
+    })
+
+    const result = await resolveJiraDisplayName(mockJiraRequest, 'Adam Drew', nameCache)
+
+    expect(result.accountId).toBeNull()
+    expect(nameCache['Adam Drew']).toBeUndefined()
+  })
+
+  it('picks correct person when multiple results share a last name', async () => {
+    const nameCache = {}
+    const mockJiraRequest = createMockJiraRequest({
+      userSearch: () => [
+        { displayName: 'Artom Lifshitz', accountId: 'acc-artom' },
+        { displayName: 'David Cohn Lifshitz', accountId: 'acc-david' }
+      ]
+    })
+
+    const result = await resolveJiraDisplayName(mockJiraRequest, 'David Cohn Lifshitz', nameCache)
+
+    expect(result.accountId).toBe('acc-david')
+    expect(result.displayName).toBe('David Cohn Lifshitz')
+  })
+
+  it('rejects all results when no first initial matches', async () => {
+    const nameCache = {}
+    const mockJiraRequest = createMockJiraRequest({
+      userSearch: () => [
+        { displayName: 'Rob Drew', accountId: 'acc-rob' },
+        { displayName: 'Jane Drew', accountId: 'acc-jane' }
+      ]
+    })
+
+    const result = await resolveJiraDisplayName(mockJiraRequest, 'Adam Drew', nameCache)
+
+    expect(result.accountId).toBeNull()
+  })
+
+  it('rejects email-search single result when name does not match', async () => {
+    const nameCache = {}
+    const mockJiraRequest = createMockJiraRequest({
+      userSearch: (url) => {
+        if (url.includes('adam%40example.com') || url.includes('adam@example.com')) {
+          return [{ displayName: 'Rob Drew', accountId: 'acc-rob' }]
+        }
+        return []
+      }
+    })
+
+    const result = await resolveJiraDisplayName(mockJiraRequest, 'Adam Drew', nameCache, 'adam@example.com')
+
+    expect(result.accountId).toBeNull()
+  })
+
+  it('accepts email-search single result when name matches', async () => {
+    const nameCache = {}
+    const mockJiraRequest = createMockJiraRequest({
+      userSearch: (url) => {
+        if (url.includes('adam%40example.com') || url.includes('adam@example.com')) {
+          return [{ displayName: 'Adam Drew', accountId: 'acc-adam' }]
+        }
+        return []
+      }
+    })
+
+    const result = await resolveJiraDisplayName(mockJiraRequest, 'Adam Drew', nameCache, 'adam@example.com')
+
+    expect(result.accountId).toBe('acc-adam')
+  })
+
+  it('still accepts exact email match regardless of displayName', async () => {
+    const nameCache = {}
+    const mockJiraRequest = createMockJiraRequest({
+      userSearch: (url) => {
+        if (url.includes('adam%40example.com') || url.includes('adam@example.com')) {
+          return [{ displayName: 'A. Drew (Contractor)', accountId: 'acc-adam', emailAddress: 'adam@example.com' }]
+        }
+        return []
+      }
+    })
+
+    const result = await resolveJiraDisplayName(mockJiraRequest, 'Adam Drew', nameCache, 'adam@example.com')
+
+    expect(result.accountId).toBe('acc-adam')
   })
 })
 

--- a/modules/team-tracker/server/jira/person-metrics.js
+++ b/modules/team-tracker/server/jira/person-metrics.js
@@ -119,7 +119,7 @@ async function resolveJiraDisplayName(jiraRequest, rosterName, nameCache, email)
 
   // Try email search first (most reliable)
   if (email) {
-    const resolved = await tryEmailSearch(jiraRequest, email);
+    const resolved = await tryEmailSearch(jiraRequest, email, rosterName);
     if (resolved) {
       resolved.resolvedViaEmail = email;
       nameCache[rosterName] = resolved;
@@ -160,9 +160,26 @@ async function resolveJiraDisplayName(jiraRequest, rosterName, nameCache, email)
 }
 
 /**
+ * Check whether a Jira displayName plausibly belongs to the same person
+ * as the roster name by comparing first initial and last name.
+ */
+function namesMatch(rosterName, jiraDisplayName) {
+  const rosterParts = rosterName.trim().split(/\s+/);
+  const jiraParts = (jiraDisplayName || '').trim().split(/\s+/);
+  if (rosterParts.length === 0 || jiraParts.length === 0) return false;
+
+  const rosterFirstInitial = rosterParts[0][0]?.toLowerCase();
+  const rosterLast = rosterParts[rosterParts.length - 1].toLowerCase();
+  const jiraFirstInitial = jiraParts[0][0]?.toLowerCase();
+  const jiraLast = jiraParts[jiraParts.length - 1].toLowerCase();
+
+  return rosterLast === jiraLast && rosterFirstInitial === jiraFirstInitial;
+}
+
+/**
  * Search for a Jira user by email address. Returns exactly one match or null.
  */
-async function tryEmailSearch(jiraRequest, email) {
+async function tryEmailSearch(jiraRequest, email, rosterName) {
   try {
     const users = await jiraRequest(`/rest/api/2/user/search?query=${encodeURIComponent(email)}`);
     if (!Array.isArray(users) || users.length === 0) return null;
@@ -171,8 +188,8 @@ async function tryEmailSearch(jiraRequest, email) {
     const match = users.find(u => u.emailAddress?.toLowerCase() === email.toLowerCase());
     if (match) return { accountId: match.accountId, displayName: match.displayName };
 
-    // If only one result, trust it
-    if (users.length === 1) {
+    // If only one result, validate against roster name before trusting
+    if (users.length === 1 && namesMatch(rosterName, users[0].displayName)) {
       return { accountId: users[0].accountId, displayName: users[0].displayName };
     }
 
@@ -187,17 +204,14 @@ async function tryUserSearch(jiraRequest, query, rosterName) {
     const users = await jiraRequest(`/rest/api/2/user/search?query=${encodeURIComponent(query)}`);
     if (!Array.isArray(users) || users.length === 0) return null;
 
-    // Extract last name from roster name for matching
-    const parts = rosterName.trim().split(/\s+/);
-    const lastName = parts[parts.length - 1];
-
     if (users.length === 1) {
-      return { accountId: users[0].accountId, displayName: users[0].displayName };
+      if (namesMatch(rosterName, users[0].displayName)) {
+        return { accountId: users[0].accountId, displayName: users[0].displayName };
+      }
+      return null;
     }
-    // Multiple results — match on last name
-    const match = users.find(u =>
-      u.displayName?.toLowerCase().endsWith(lastName.toLowerCase())
-    );
+    // Multiple results — match on first initial + last name
+    const match = users.find(u => namesMatch(rosterName, u.displayName));
     if (match) return { accountId: match.accountId, displayName: match.displayName };
     return null;
   } catch {
@@ -486,6 +500,7 @@ module.exports = {
   computeCycleTimeDays,
   findWorkStartDate,
   resolveJiraDisplayName,
+  namesMatch,
   mergeResolvedIssues,
   needsFullRefresh,
   FIELDS_VERSION


### PR DESCRIPTION
The `resolveJiraDisplayName()` flow could silently resolve to the wrong person when names shared a last name but had different first names (e.g. "Adam Drew" → "Rob Drew").

Adds a `namesMatch()` helper that requires both first initial and last name to agree before accepting a Jira user match. Applied to both `tryUserSearch()` and `tryEmailSearch()`.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)