### PR TITLE
fix: rename ai1st-doc-create label to ai1st-doc-start

### DIFF
--- a/docs/AI-First-doc-prompt-design-plan-execution.md
+++ b/docs/AI-First-doc-prompt-design-plan-execution.md
@@ -24,7 +24,7 @@ semantic: check how many of the RHAISTRAT which are Dev-Complete and requing doc
 Row graph C.
 Y: Number of RHAISTRAT and RHOAIENG with `ai1st-doc-invoked` label or ``ai1st-doc-contributed` label which have been modified in the last 30days
 X: last rolling 30days
-semantic: check trend of the tool usage (the `ai1st-doc-create` label is substituted by `ai1st-doc-invoked` and then with `ai1st-doc-contributed` comes from the Merge Requests)
+semantic: check trend of the tool usage (the `ai1st-doc-start` label is substituted by `ai1st-doc-invoked` and then with `ai1st-doc-contributed` comes from the Merge Requests)
 note: modified in the last 30days to get the moving average and over the last rolling 30days to get the trend (2nd derivative)
 
 Table 
@@ -260,7 +260,7 @@ Layout (top to bottom):
    - Graph B: Coverage Rate (0–100%)
    - Graph C: Tool Activity (7-day rolling average, two series: invoked + contributed)
 
-4. **Features Ready for Documentation Table**: instruction banner for `ai1st-doc-create` label, then sortable/filterable table with Key, Summary, Status, AI-First Doc Contributed (Yes/Not yet), CCS Epic, MR Link(s) columns. Default sort: "Not yet" first. MR links displayed as `!1234` (GitLab) or `#123` (GitHub).
+4. **Features Ready for Documentation Table**: instruction banner for `ai1st-doc-start` label, then sortable/filterable table with Key, Summary, Status, AI-First Doc Contributed (Yes/Not yet), CCS Epic, MR Link(s) columns. Default sort: "Not yet" first. MR links displayed as `!1234` (GitLab) or `#123` (GitHub).
 
 5. **Completed with Documentation Table**: Resolved/Closed RHAISTRAT issues with `ai1st-doc-contributed` updated in last 30 days. Shows empty-state row when no matches.
 

--- a/modules/ai-impact/client/components/DocumentationContent.vue
+++ b/modules/ai-impact/client/components/DocumentationContent.vue
@@ -380,7 +380,7 @@ function mrLabel(url) {
               </div>
             </div>
             <div class="px-5 py-2.5 border-b border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-500/10 text-xs text-gray-600 dark:text-gray-400">
-              To trigger AI-First documentation, add the label <code class="px-1.5 py-0.5 rounded-md bg-gray-200/80 dark:bg-gray-700/80 text-gray-800 dark:text-gray-200 font-mono text-[11px] border border-gray-300/60 dark:border-gray-600/60">ai1st-doc-create</code> to the Jira issue (preferably RHAISTRAT, but not required).
+              To trigger AI-First documentation, add the label <code class="px-1.5 py-0.5 rounded-md bg-gray-200/80 dark:bg-gray-700/80 text-gray-800 dark:text-gray-200 font-mono text-[11px] border border-gray-300/60 dark:border-gray-600/60">ai1st-doc-start</code> to the Jira issue (preferably RHAISTRAT, but not required).
             </div>
             <div class="overflow-x-auto">
               <table class="w-full text-sm">

--- a/modules/ai-impact/client/views/AIFactoryGuideView.vue
+++ b/modules/ai-impact/client/views/AIFactoryGuideView.vue
@@ -774,7 +774,7 @@ function labelColorClasses(color) {
               </div>
               <div>
                 <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">Trigger</div>
-                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Add the <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-teal-600 dark:text-teal-400 text-xs rounded font-mono">ai1st-doc-create</code> label to the Jira issue needing documentation (preferably RHAISTRAT)</div>
+                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Add the <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-teal-600 dark:text-teal-400 text-xs rounded font-mono">ai1st-doc-start</code> label to the Jira issue needing documentation (preferably RHAISTRAT)</div>
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">This at the moment for AI-First is the signal that dev work is completed and documentation can begin</div>
               </div>
             </div>
@@ -813,7 +813,7 @@ function labelColorClasses(color) {
           <h3 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Jira Labels Reference</h3>
           <div class="space-y-2">
             <div class="flex items-center gap-3 p-2.5 bg-gray-50 dark:bg-gray-700/30 rounded-lg">
-              <code class="text-xs px-2 py-0.5 rounded whitespace-nowrap font-mono bg-green-500/15 text-green-600 dark:text-green-400">ai1st-doc-create</code>
+              <code class="text-xs px-2 py-0.5 rounded whitespace-nowrap font-mono bg-green-500/15 text-green-600 dark:text-green-400">ai1st-doc-start</code>
               <span class="text-xs text-gray-500 dark:text-gray-400">Add this label to trigger AI documentation generation</span>
             </div>
             <div class="flex items-center gap-3 p-2.5 bg-gray-50 dark:bg-gray-700/30 rounded-lg">
@@ -833,7 +833,7 @@ function labelColorClasses(color) {
           <ul class="space-y-3">
             <li class="flex items-start gap-3">
               <Pencil :size="20" class="text-teal-600 dark:text-teal-400 flex-shrink-0 mt-0.5" />
-              <span class="text-sm text-gray-700 dark:text-gray-300">Add the <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-teal-700 dark:text-teal-400 text-xs rounded font-mono">ai1st-doc-create</code> label to (preferably) RHAISTRAT issues that need documentation</span>
+              <span class="text-sm text-gray-700 dark:text-gray-300">Add the <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-teal-700 dark:text-teal-400 text-xs rounded font-mono">ai1st-doc-start</code> label to (preferably) RHAISTRAT issues that need documentation</span>
             </li>
             <li class="flex items-start gap-3">
               <Eye :size="20" class="text-teal-600 dark:text-teal-400 flex-shrink-0 mt-0.5" />


### PR DESCRIPTION
## Summary
- Renamed all occurrences of `ai1st-doc-create` to `ai1st-doc-start` — the correct Jira label name
- Fixed in docs, DocumentationContent.vue, and AIFactoryGuideView.vue (6 occurrences total)

## Test plan
- [x] Verify the label displays correctly in the AI Factory Guide view
- [x] Verify the label displays correctly in the Documentation Content table banner

## Test proofs:

<img width="1017" height="444" alt="image" src="https://github.com/user-attachments/assets/f25539ae-b0c0-4300-9028-602437a8b989" />

<img width="1048" height="1079" alt="image" src="https://github.com/user-attachments/assets/5a583def-d0b3-4b22-914e-945b3e7f3f31" />
