### PR TITLE
fix: correct metrics lookback label from 90 to 365 days

### DIFF
--- a/modules/team-tracker/client/views/PersonProfileView.vue
+++ b/modules/team-tracker/client/views/PersonProfileView.vue
@@ -356,12 +356,12 @@ onBeforeUnmount(() => {
                 <div>
                   <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ jiraMetrics.resolved?.issues?.length || 0 }}</div>
                   <div class="text-xs text-gray-500 dark:text-gray-400">Resolved Issues</div>
-                  <div class="text-[10px] text-gray-400 dark:text-gray-500">90 days</div>
+                  <div class="text-[10px] text-gray-400 dark:text-gray-500">365 days</div>
                 </div>
                 <div>
                   <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ jiraMetrics.resolved?.storyPoints || 0 }}</div>
                   <div class="text-xs text-gray-500 dark:text-gray-400">Story Points</div>
-                  <div class="text-[10px] text-gray-400 dark:text-gray-500">90 days</div>
+                  <div class="text-[10px] text-gray-400 dark:text-gray-500">365 days</div>
                 </div>
                 <div>
                   <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ jiraMetrics.cycleTime?.avgDays != null ? jiraMetrics.cycleTime.avgDays + 'd' : '—' }}</div>


### PR DESCRIPTION
## Summary
- The person profile metrics cards ("Resolved Issues" and "Story Points") displayed "90 days" as the lookback period, but the actual Jira query uses a 365-day window (`lookbackDays` defaults to 365 in `person-metrics.js`)
- Updated both labels to "365 days" to match the actual data

## Test plan
- [ ] Navigate to any person's profile page and verify the metrics cards show "365 days" instead of "90 days"

🤖 Generated with [Claude Code](https://claude.com/claude-code)