### PR TITLE
feat: add shareable deep links to AI Factory Guide sections

### DIFF
--- a/modules/ai-impact/client/views/AIFactoryGuideView.vue
+++ b/modules/ai-impact/client/views/AIFactoryGuideView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, inject } from 'vue'
+import { ref, watch, nextTick, inject } from 'vue'
 import { PHASES } from '../constants.js'
 import { ArrowLeft, ChevronRight, Sparkles, User, Pencil, Eye, RefreshCw, AlertTriangle, Play, FileText, StickyNote, Code, MessageSquare, HelpCircle, BookOpen, ChevronDown, Search, Zap, ChevronsRight, Archive, Globe, Lightbulb } from 'lucide-vue-next'
 
@@ -8,6 +8,23 @@ const moduleNav = inject('moduleNav')
 const selectedPhase = ref(null)
 const labelsExpanded = ref(false)
 const featureLabelsExpanded = ref(false)
+
+let updatingFromUrl = false
+
+const initialSection = moduleNav.params.value?.section
+if (initialSection) {
+  const match = PHASES.find(p => p.id === initialSection)
+  if (match) selectedPhase.value = match
+}
+
+watch(() => moduleNav.params.value?.section, (section) => {
+  const target = section ? PHASES.find(p => p.id === section) : null
+  if ((target?.id || null) !== (selectedPhase.value?.id || null)) {
+    updatingFromUrl = true
+    selectedPhase.value = target || null
+    nextTick(() => { updatingFromUrl = false })
+  }
+})
 
 // Phase metadata for the rich overview cards
 const phaseInfo = {
@@ -59,10 +76,16 @@ function getPhaseColors(phaseId) {
 
 function selectPhase(phase) {
   selectedPhase.value = phase
+  if (!updatingFromUrl) {
+    moduleNav.updateParams({ section: phase?.id })
+  }
 }
 
 function closeDetail() {
   selectedPhase.value = null
+  if (!updatingFromUrl) {
+    moduleNav.updateParams({ section: undefined })
+  }
 }
 
 function goToPage(phaseId) {


### PR DESCRIPTION
## Summary
- Adds a `?section=<phase-id>` query parameter to the AI Factory Guide view so each detail section (rfe-review, feature-review, documentation) gets a unique, shareable URL
- Back-button navigation works correctly between sections and the landing page
- Uses the same `updateParams`/`watch` pattern already established for `?tab=` in FeatureDetailView and TeamRosterView

## Test plan
- [x] Open `#/ai-impact/ai-factory-guide` — landing page loads normally

<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/929ba2b2-0e9e-4146-b33e-6882c7684d03" />

- [x] Click a phase (e.g. RFE Review) — URL updates to `?section=rfe-review`, detail view shows

<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/beaabf3e-8341-4246-ab17-9fe0ca57bab3" />

- [x] Click "Back to Pipeline Overview" — `?section=` is removed, landing page shows

<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/6a9578fc-fd9a-439b-9016-e4a24f9771a0" />


- [x] Paste `#/ai-impact/ai-factory-guide?section=documentation` directly — Documentation detail loads

<img width="845" height="218" alt="image" src="https://github.com/user-attachments/assets/0834188e-6982-4e23-b58c-5c55cebc211a" />

<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/a9dfcaea-a150-4e4d-b2f2-67e41752e1e5" />

- [x] Use browser back/forward buttons — sections switch correctly

<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/f923a05c-a93b-475a-a504-c7ceeecb9b31" />

- [x] "What's next" links within detail views update the URL

> confirmed working where enabled

- [x] Invalid `?section=` values are ignored (landing page shown)

<img width="703" height="165" alt="image" src="https://github.com/user-attachments/assets/54165e7b-b039-4d9a-8ac6-a594238a9e19" />


<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/bde94e0a-d919-4c07-bc02-06049a0cc168" />
