### PR TITLE
feat: add MR/PR status icons to Documentation AI-First view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ ADMIN_EMAILS=you@redhat.com
 # GITLAB_BASE_URL=        # Optional legacy setting, defaults to https://gitlab.com (prefer Settings UI)
 # GITLAB_TOKEN_INTERNAL=  # Example: token for an additional internal GitLab instance
 
+# AI-First, Documentation
+# GITLAB_CEE_REDHAT_DOCS_TOKEN=  # token with `read_api` for https://gitlab.cee.redhat.com/documentation-red-hat-openshift-data-science-documentation in the internal instance
+
 # Feature Traffic GitLab token (optional - overrides GITLAB_TOKEN for CI artifact fetching)
 # Only needed if the feature-traffic pipeline project requires a different token
 # Use a PAT with read_api scope

--- a/deploy/openshift/base/backend-deployment.yaml
+++ b/deploy/openshift/base/backend-deployment.yaml
@@ -69,6 +69,12 @@ spec:
                   name: team-tracker-secrets
                   key: FEATURE_TRAFFIC_GITLAB_TOKEN
                   optional: true
+            - name: GITLAB_CEE_REDHAT_DOCS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: team-tracker-secrets
+                  key: GITLAB_CEE_REDHAT_DOCS_TOKEN
+                  optional: true
             - name: PROXY_AUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/fixtures/ai-impact/doc-data.json
+++ b/fixtures/ai-impact/doc-data.json
@@ -15,7 +15,8 @@
       "docSkippedDate": null,
       "docInvokedDate": "2026-05-02T09:00:00Z",
       "ccsEpic": { "key": "RHOAIENG-70001", "summary": "[CCS] Model serving autoscaling docs", "status": "In Progress" },
-      "mrLinks": ["https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1001"]
+      "mrLinks": ["https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1001"],
+      "mrStatuses": { "https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1001": "merged" }
     },
     {
       "key": "RHAISTRAT-2002",
@@ -31,7 +32,8 @@
       "docSkippedDate": null,
       "docInvokedDate": "2026-05-04T14:00:00Z",
       "ccsEpic": { "key": "RHOAIENG-70002", "summary": "[DOCS RHAISTRAT-2002] Pipeline SDK v2 docs", "status": "Done" },
-      "mrLinks": ["https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1002"]
+      "mrLinks": ["https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1002"],
+      "mrStatuses": { "https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1002": "merged" }
     },
     {
       "key": "RHAISTRAT-2003",
@@ -95,7 +97,8 @@
       "docSkippedDate": null,
       "docInvokedDate": null,
       "ccsEpic": { "key": "RHOAIENG-70006", "summary": "[DOCS RHAISTRAT-2006] vLLM serving runtime", "status": "In Progress" },
-      "mrLinks": ["https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1006"]
+      "mrLinks": ["https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1006"],
+      "mrStatuses": { "https://gitlab.example.com/docs/openshift-ai/-/merge_requests/1006": "opened" }
     },
     {
       "key": "RHAISTRAT-2007",

--- a/modules/ai-impact/__tests__/server/mr-status.test.js
+++ b/modules/ai-impact/__tests__/server/mr-status.test.js
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+const { parseMrUrl, resolveGitlabToken, enrichMRStatuses, _setFetch } = require('../../server/mr-status')
+
+describe('parseMrUrl', () => {
+  it('parses GitLab MR URL with /-/ separator', () => {
+    const result = parseMrUrl('https://gitlab.cee.redhat.com/docs/openshift-ai/-/merge_requests/1001')
+    expect(result).toEqual({
+      type: 'gitlab',
+      host: 'https://gitlab.cee.redhat.com',
+      projectPath: 'docs/openshift-ai',
+      iid: '1001'
+    })
+  })
+
+  it('parses GitLab MR URL with nested groups', () => {
+    const result = parseMrUrl('https://gitlab.com/group/subgroup/project/-/merge_requests/42')
+    expect(result).toEqual({
+      type: 'gitlab',
+      host: 'https://gitlab.com',
+      projectPath: 'group/subgroup/project',
+      iid: '42'
+    })
+  })
+
+  it('parses legacy GitLab MR URL without /-/', () => {
+    const result = parseMrUrl('https://gitlab.com/mygroup/myproject/merge_requests/99')
+    expect(result).toEqual({
+      type: 'gitlab',
+      host: 'https://gitlab.com',
+      projectPath: 'mygroup/myproject',
+      iid: '99'
+    })
+  })
+
+  it('parses GitHub PR URL', () => {
+    const result = parseMrUrl('https://github.com/openshift/docs/pull/123')
+    expect(result).toEqual({
+      type: 'github',
+      owner: 'openshift',
+      repo: 'docs',
+      number: '123'
+    })
+  })
+
+  it('returns null for unrecognized URL', () => {
+    expect(parseMrUrl('https://example.com/something')).toBeNull()
+  })
+
+  it('returns null for null/undefined', () => {
+    expect(parseMrUrl(null)).toBeNull()
+    expect(parseMrUrl(undefined)).toBeNull()
+  })
+})
+
+describe('resolveGitlabToken', () => {
+  afterEach(() => {
+    delete process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN
+    delete process.env.GITLAB_TOKEN
+  })
+
+  it('returns GITLAB_CEE_REDHAT_DOCS_TOKEN for gitlab.cee.redhat.com', () => {
+    process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN = 'cee-token'
+    expect(resolveGitlabToken('https://gitlab.cee.redhat.com')).toBe('cee-token')
+  })
+
+  it('returns GITLAB_TOKEN for gitlab.com', () => {
+    process.env.GITLAB_TOKEN = 'gl-token'
+    expect(resolveGitlabToken('https://gitlab.com')).toBe('gl-token')
+  })
+
+  it('returns GITLAB_TOKEN for other GitLab hosts', () => {
+    process.env.GITLAB_TOKEN = 'gl-token'
+    expect(resolveGitlabToken('https://gitlab.example.com')).toBe('gl-token')
+  })
+
+  it('returns null when no token is set', () => {
+    expect(resolveGitlabToken('https://gitlab.com')).toBeNull()
+  })
+})
+
+describe('enrichMRStatuses', () => {
+  let mockFetch
+
+  beforeEach(() => {
+    mockFetch = () => Promise.resolve({ ok: false, status: 404 })
+    _setFetch((...args) => mockFetch(...args))
+    delete process.env.GITLAB_TOKEN
+    delete process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN
+    delete process.env.GITHUB_TOKEN
+  })
+
+  afterEach(() => {
+    _setFetch(require('node-fetch'))
+    delete process.env.GITLAB_TOKEN
+    delete process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN
+    delete process.env.GITHUB_TOKEN
+  })
+
+  it('does nothing for empty issues', async () => {
+    await enrichMRStatuses([])
+  })
+
+  it('does nothing for issues with no mrLinks', async () => {
+    const issues = [{ key: 'TEST-1', mrLinks: [] }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({})
+  })
+
+  it('skips URLs when no token is available', async () => {
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://gitlab.com/org/repo/-/merge_requests/1']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({})
+  })
+
+  it('fetches GitLab MR state and attaches to issue', async () => {
+    process.env.GITLAB_TOKEN = 'test-token'
+    mockFetch = (url, opts) => {
+      expect(url).toContain('/api/v4/projects/')
+      expect(opts.headers.Authorization).toBe('Bearer test-token')
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: 'merged' })
+      })
+    }
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://gitlab.com/org/repo/-/merge_requests/42']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({
+      'https://gitlab.com/org/repo/-/merge_requests/42': 'merged'
+    })
+  })
+
+  it('uses GITLAB_CEE_REDHAT_DOCS_TOKEN for gitlab.cee.redhat.com', async () => {
+    process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN = 'cee-token'
+    mockFetch = (url, opts) => {
+      expect(opts.headers.Authorization).toBe('Bearer cee-token')
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: 'opened' })
+      })
+    }
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://gitlab.cee.redhat.com/docs/project/-/merge_requests/5']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({
+      'https://gitlab.cee.redhat.com/docs/project/-/merge_requests/5': 'opened'
+    })
+  })
+
+  it('fetches GitHub PR state — merged', async () => {
+    process.env.GITHUB_TOKEN = 'gh-token'
+    mockFetch = (url, opts) => {
+      expect(url).toContain('/repos/openshift/docs/pulls/10')
+      expect(opts.headers.Authorization).toBe('Bearer gh-token')
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: 'closed', merged: true })
+      })
+    }
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://github.com/openshift/docs/pull/10']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({
+      'https://github.com/openshift/docs/pull/10': 'merged'
+    })
+  })
+
+  it('fetches GitHub PR state — open', async () => {
+    process.env.GITHUB_TOKEN = 'gh-token'
+    mockFetch = () => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ state: 'open', merged: false })
+    })
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://github.com/openshift/docs/pull/10']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({
+      'https://github.com/openshift/docs/pull/10': 'opened'
+    })
+  })
+
+  it('handles API errors gracefully', async () => {
+    process.env.GITLAB_TOKEN = 'test-token'
+    mockFetch = () => Promise.resolve({ ok: false, status: 404 })
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://gitlab.com/org/repo/-/merge_requests/999']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({})
+  })
+
+  it('handles network errors gracefully', async () => {
+    process.env.GITLAB_TOKEN = 'test-token'
+    mockFetch = () => Promise.reject(new Error('ECONNREFUSED'))
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: ['https://gitlab.com/org/repo/-/merge_requests/1']
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({})
+  })
+
+  it('deduplicates URLs across multiple issues', async () => {
+    process.env.GITLAB_TOKEN = 'test-token'
+    let callCount = 0
+    mockFetch = () => {
+      callCount++
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: 'merged' })
+      })
+    }
+
+    const url = 'https://gitlab.com/org/repo/-/merge_requests/1'
+    const issues = [
+      { key: 'TEST-1', mrLinks: [url] },
+      { key: 'TEST-2', mrLinks: [url] }
+    ]
+    await enrichMRStatuses(issues)
+    expect(callCount).toBe(1)
+    expect(issues[0].mrStatuses).toEqual({ [url]: 'merged' })
+    expect(issues[1].mrStatuses).toEqual({ [url]: 'merged' })
+  })
+
+  it('handles mixed GitLab and GitHub URLs', async () => {
+    process.env.GITLAB_TOKEN = 'gl-token'
+    process.env.GITHUB_TOKEN = 'gh-token'
+    mockFetch = (url) => {
+      if (url.includes('api.github.com')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ state: 'open', merged: false })
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: 'merged' })
+      })
+    }
+
+    const issues = [{
+      key: 'TEST-1',
+      mrLinks: [
+        'https://gitlab.com/org/repo/-/merge_requests/1',
+        'https://github.com/org/repo/pull/2'
+      ]
+    }]
+    await enrichMRStatuses(issues)
+    expect(issues[0].mrStatuses).toEqual({
+      'https://gitlab.com/org/repo/-/merge_requests/1': 'merged',
+      'https://github.com/org/repo/pull/2': 'opened'
+    })
+  })
+})

--- a/modules/ai-impact/client/components/DocumentationContent.vue
+++ b/modules/ai-impact/client/components/DocumentationContent.vue
@@ -215,6 +215,24 @@ const cumulativeJqls = computed(() => ({
   stratsResolvedContributed: 'project = "RHAISTRAT" AND status IN ("Resolved", "Closed") AND labels = "ai1st-doc-contributed"'
 }))
 
+const MR_STATUS_ICONS = {
+  merged: {
+    title: 'Merged',
+    color: 'text-purple-600 dark:text-purple-400',
+    path: 'M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z'
+  },
+  opened: {
+    title: 'Open',
+    color: 'text-green-600 dark:text-green-400',
+    path: 'M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z'
+  },
+  closed: {
+    title: 'Closed',
+    color: 'text-red-500 dark:text-red-400',
+    path: 'M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 3.25 1Zm9.5 5.5a.75.75 0 0 1 .75.75v3.378a2.251 2.251 0 1 1-1.5 0V7.25a.75.75 0 0 1 .75-.75Zm-2.03-5.273a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1-1.06 1.06L12 3.56l-.72.72a.75.75 0 1 1-1.06-1.06l2-2ZM3.25 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z'
+  }
+}
+
 function mrLabel(url) {
   if (!url) return ''
   const match = url.match(/merge_requests\/(\d+)/)
@@ -459,9 +477,12 @@ function mrLabel(url) {
                             :href="mr"
                             target="_blank"
                             rel="noopener"
-                            class="text-primary-600 dark:text-blue-400 text-xs hover:underline"
+                            class="text-primary-600 dark:text-blue-400 text-xs hover:underline inline-flex items-center gap-0.5"
                             :title="mr"
-                          >{{ mrLabel(mr) }}</a><span v-if="idx < issue.mrLinks.length - 1" class="text-gray-300 dark:text-gray-600 mx-1">·</span>
+                          >
+                            <svg v-if="MR_STATUS_ICONS[issue.mrStatuses?.[mr]]" :class="['w-3 h-3 shrink-0', MR_STATUS_ICONS[issue.mrStatuses[mr]].color]" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><title>{{ MR_STATUS_ICONS[issue.mrStatuses[mr]].title }}</title><path :d="MR_STATUS_ICONS[issue.mrStatuses[mr]].path" /></svg>
+                            {{ mrLabel(mr) }}
+                          </a><span v-if="idx < issue.mrLinks.length - 1" class="text-gray-300 dark:text-gray-600 mx-1">·</span>
                         </span>
                       </template>
                       <span v-else class="text-gray-400 dark:text-gray-500">&mdash;</span>
@@ -539,9 +560,12 @@ function mrLabel(url) {
                             :href="mr"
                             target="_blank"
                             rel="noopener"
-                            class="text-primary-600 dark:text-blue-400 text-xs hover:underline"
+                            class="text-primary-600 dark:text-blue-400 text-xs hover:underline inline-flex items-center gap-0.5"
                             :title="mr"
-                          >{{ mrLabel(mr) }}</a><span v-if="idx < issue.mrLinks.length - 1" class="text-gray-300 dark:text-gray-600 mx-1">·</span>
+                          >
+                            <svg v-if="MR_STATUS_ICONS[issue.mrStatuses?.[mr]]" :class="['w-3 h-3 shrink-0', MR_STATUS_ICONS[issue.mrStatuses[mr]].color]" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><title>{{ MR_STATUS_ICONS[issue.mrStatuses[mr]].title }}</title><path :d="MR_STATUS_ICONS[issue.mrStatuses[mr]].path" /></svg>
+                            {{ mrLabel(mr) }}
+                          </a><span v-if="idx < issue.mrLinks.length - 1" class="text-gray-300 dark:text-gray-600 mx-1">·</span>
                         </span>
                       </template>
                       <span v-else class="text-gray-400 dark:text-gray-500">&mdash;</span>

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -13,6 +13,7 @@ module.exports = function registerRoutes(router, context) {
   const { computeAllMetrics } = require('./metrics');
   const { fetchAutofixData, computeAutofixMetrics, buildTrendData: buildAutofixTrend } = require('./jira/autofix-fetcher');
   const { fetchDocData, fetchDocActivityEvents, fetchDocCumulativeStats, fetchDocCompletedData, computeDocMetrics, buildDocTrendData } = require('./jira/doc-fetcher');
+  const { enrichMRStatuses } = require('./mr-status');
 
   // Assessment routes (Phase 1: Storage + Ingest API)
   const registerAssessmentRoutes = require('./assessments/routes');
@@ -238,6 +239,12 @@ module.exports = function registerRoutes(router, context) {
           cumulativeStats = await fetchDocCumulativeStats(jiraRequest, config);
         } catch (statsErr) {
           console.error('[ai-impact] Documentation cumulative stats fetch failed:', statsErr.message);
+        }
+        try {
+          await enrichMRStatuses(docResult.issues);
+          await enrichMRStatuses(completedIssues);
+        } catch (mrErr) {
+          console.error('[ai-impact] MR status enrichment failed:', mrErr.message);
         }
         writeToStorage('ai-impact/doc-data.json', {
           fetchedAt: new Date().toISOString(),

--- a/modules/ai-impact/server/mr-status.js
+++ b/modules/ai-impact/server/mr-status.js
@@ -1,0 +1,159 @@
+const fetch = require('node-fetch');
+
+let _fetch = fetch;
+
+const GITLAB_MR_RE = /^(https?:\/\/[^/]+)\/(.+?)\/-\/merge_requests\/(\d+)/;
+const GITLAB_MR_LEGACY_RE = /^(https?:\/\/[^/]+)\/(.+?)\/merge_requests\/(\d+)/;
+const GITHUB_PR_RE = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
+
+function parseMrUrl(url) {
+  if (!url) return null;
+
+  const ghMatch = url.match(GITHUB_PR_RE);
+  if (ghMatch) {
+    return { type: 'github', owner: ghMatch[1], repo: ghMatch[2], number: ghMatch[3] };
+  }
+
+  const glMatch = url.match(GITLAB_MR_RE) || url.match(GITLAB_MR_LEGACY_RE);
+  if (glMatch) {
+    return { type: 'gitlab', host: glMatch[1], projectPath: glMatch[2], iid: glMatch[3] };
+  }
+
+  return null;
+}
+
+function resolveGitlabToken(host) {
+  try {
+    const hostname = new URL(host).hostname;
+    if (hostname === 'gitlab.cee.redhat.com') {
+      return process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN || null;
+    }
+  } catch { /* invalid host URL */ }
+  return process.env.GITLAB_TOKEN || null;
+}
+
+async function fetchGitlabMrState(host, projectPath, iid, token) {
+  const encodedPath = encodeURIComponent(projectPath);
+  const url = `${host}/api/v4/projects/${encodedPath}/merge_requests/${iid}`;
+
+  try {
+    const res = await _fetch(url, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+
+    if (!res.ok) {
+      if (res.status === 401 || res.status === 403) {
+        console.warn(`[ai-impact/mr-status] Auth failed for ${host} MR !${iid} (${res.status})`);
+      }
+      return null;
+    }
+
+    const data = await res.json();
+    return data.state || null;
+  } catch (err) {
+    console.warn(`[ai-impact/mr-status] GitLab fetch failed for ${host} MR !${iid}: ${err.message}`);
+    return null;
+  }
+}
+
+async function fetchGithubPrState(owner, repo, number, token) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
+
+  try {
+    const headers = { 'User-Agent': 'rhai-org-pulse' };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const res = await _fetch(url, { headers });
+
+    if (!res.ok) {
+      if (res.status === 401 || res.status === 403) {
+        console.warn(`[ai-impact/mr-status] Auth failed for GitHub PR #${number} (${res.status})`);
+      }
+      return null;
+    }
+
+    const data = await res.json();
+    if (data.merged) return 'merged';
+    if (data.state === 'open') return 'opened';
+    if (data.state === 'closed') return 'closed';
+    return null;
+  } catch (err) {
+    console.warn(`[ai-impact/mr-status] GitHub fetch failed for PR #${number}: ${err.message}`);
+    return null;
+  }
+}
+
+async function enrichMRStatuses(issues) {
+  if (!issues || issues.length === 0) return;
+
+  const allUrls = new Set();
+  for (const issue of issues) {
+    if (issue.mrLinks) {
+      for (const url of issue.mrLinks) allUrls.add(url);
+    }
+  }
+
+  if (allUrls.size === 0) {
+    for (const issue of issues) { issue.mrStatuses = {}; }
+    return;
+  }
+
+  const statusMap = {};
+  const parsed = [];
+  for (const url of allUrls) {
+    const info = parseMrUrl(url);
+    if (info) parsed.push({ url, info });
+  }
+
+  if (parsed.length === 0) return;
+
+  const BATCH_SIZE = 10;
+  for (let i = 0; i < parsed.length; i += BATCH_SIZE) {
+    const batch = parsed.slice(i, i + BATCH_SIZE);
+
+    const results = await Promise.allSettled(batch.map(({ url, info }) => {
+      if (info.type === 'gitlab') {
+        const token = resolveGitlabToken(info.host);
+        if (!token) return Promise.resolve({ url, state: null });
+        return fetchGitlabMrState(info.host, info.projectPath, info.iid, token)
+          .then(state => ({ url, state }));
+      }
+      if (info.type === 'github') {
+        const token = process.env.GITHUB_TOKEN || null;
+        return fetchGithubPrState(info.owner, info.repo, info.number, token)
+          .then(state => ({ url, state }));
+      }
+      return Promise.resolve({ url, state: null });
+    }));
+
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value.state) {
+        statusMap[result.value.url] = result.value.state;
+      }
+    }
+
+    if (i + BATCH_SIZE < parsed.length) {
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+  }
+
+  for (const issue of issues) {
+    issue.mrStatuses = {};
+    if (issue.mrLinks) {
+      for (const url of issue.mrLinks) {
+        if (statusMap[url]) {
+          issue.mrStatuses[url] = statusMap[url];
+        }
+      }
+    }
+  }
+}
+
+module.exports = {
+  enrichMRStatuses,
+  parseMrUrl,
+  resolveGitlabToken,
+  _setFetch(fn) { _fetch = fn; }
+};


### PR DESCRIPTION
## Summary
- Show open/merged/closed status icons next to each MR/PR link in the Documentation AI-First tables
- Status is fetched from GitLab/GitHub REST APIs during data refresh, using a dedicated `GITLAB_CEE_REDHAT_DOCS_TOKEN` for `gitlab.cee.redhat.com` and existing `GITLAB_TOKEN`/`GITHUB_TOKEN` for other hosts
- Violet merge icon for merged, green for open, red for closed; no icon when status is unknown (graceful degradation)
- SVG icon paths defined once in a lookup object, reused across both tables
- Added `GITLAB_CEE_REDHAT_DOCS_TOKEN` to OpenShift deployment YAML

## Test plan
- [x] 21 new unit tests for URL parsing, token resolution, API response mapping, error handling, deduplication
- [x] Full test suite passes (2799 tests)
- [x] Lint passes
- [x] Verified locally: refreshed AI Impact data with `GITLAB_CEE_REDHAT_DOCS_TOKEN` set, MR statuses populated correctly (merged/opened)

<img width="3680" height="2394" alt="image" src="https://github.com/user-attachments/assets/e613bfea-c554-4fb5-ae54-ff3c12f176f3" />

- [x] Verify icons render in demo mode (`DEMO_MODE=true`)

demo mode:

<img width="1840" height="1197" alt="image" src="https://github.com/user-attachments/assets/69e38927-ff04-4e2e-8a02-407460d144cc" />


- [x] Verify graceful degradation without tokens

renamed the .env token, results in: 

<img width="458" height="187" alt="image" src="https://github.com/user-attachments/assets/895b91fa-ead5-4078-af52-5a104f2d8095" />
