### PR TITLE
feat: implement releases audit log view

### DIFF
--- a/modules/releases/client/plan/composables/useAuditLog.js
+++ b/modules/releases/client/plan/composables/useAuditLog.js
@@ -1,7 +1,7 @@
 import { ref } from 'vue'
 import { apiRequest } from '@shared/client/services/api'
 
-const API_BASE = '/modules/releases/planning'
+const API_BASE = '/modules/releases'
 
 export function useAuditLog() {
   const entries = ref([])
@@ -16,6 +16,7 @@ export function useAuditLog() {
     const params = new URLSearchParams()
     if (options && options.version) params.set('version', options.version)
     if (options && options.action) params.set('action', options.action)
+    if (options && options.domain) params.set('domain', options.domain)
     if (options && options.limit) params.set('limit', String(options.limit))
     if (options && options.offset) params.set('offset', String(options.offset))
 

--- a/modules/releases/client/views/AuditView.vue
+++ b/modules/releases/client/views/AuditView.vue
@@ -1,22 +1,201 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useAuditLog } from '../plan/composables/useAuditLog'
+
+const { entries, total, loading, error, loadAuditLog } = useAuditLog()
+
+const filters = ref({
+  domain: '',
+  version: '',
+  action: '',
+  limit: 50,
+  offset: 0
+})
+
+let debounceTimer = null
+
+onMounted(function() { loadAuditLog(filters.value) })
+onUnmounted(function() { clearTimeout(debounceTimer) })
+
+function applyFilters() {
+  filters.value.offset = 0
+  loadAuditLog(filters.value)
+}
+
+function debouncedApply() {
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(applyFilters, 300)
+}
+
+function nextPage() {
+  filters.value.offset += filters.value.limit
+  loadAuditLog(filters.value)
+}
+
+function prevPage() {
+  filters.value.offset = Math.max(0, filters.value.offset - filters.value.limit)
+  loadAuditLog(filters.value)
+}
+
+const ACTION_LABELS = {
+  create_rock: 'Big Rock Created',
+  update_rock: 'Big Rock Updated',
+  delete_rock: 'Big Rock Deleted',
+  reorder_rocks: 'Big Rocks Reordered',
+  create_release: 'Release Created',
+  clone_release: 'Release Cloned',
+  delete_release: 'Release Deleted',
+  import_doc: 'Doc Imported',
+  add_pm: 'PM Added',
+  remove_pm: 'PM Removed',
+  seed: 'Data Seeded',
+  registry_create: 'Registry Created',
+  registry_update: 'Registry Updated',
+  manual_refresh: 'Manual Refresh',
+  config_save: 'Config Saved',
+  config_update: 'Config Updated',
+  set_override: 'Override Set',
+  remove_override: 'Override Removed',
+  commit_snapshot: 'Snapshot Committed',
+  health_refresh: 'Health Refreshed',
+  delivery_refresh: 'Delivery Refreshed',
+  upload_releases: 'Releases Uploaded',
+  conforma_bulk: 'Conforma Updated'
+}
+
+const DOMAIN_LABELS = {
+  planning: 'Planning',
+  execution: 'Execution',
+  delivery: 'Delivery',
+  registry: 'Registry'
+}
+
+const DOMAIN_COLORS = {
+  planning: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
+  execution: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300',
+  delivery: 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300',
+  registry: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300'
+}
+
+function formatDate(ts) {
+  return new Date(ts).toLocaleString()
+}
+
+function shortUser(email) {
+  if (!email) return 'System'
+  const at = email.indexOf('@')
+  return at > 0 ? email.substring(0, at) : email
+}
+</script>
+
 <template>
-  <div class="p-6">
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
-      <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-700 mb-4">
-        <svg class="w-6 h-6 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
+  <div class="max-w-6xl mx-auto py-6 px-4">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Audit Log</h1>
+
+    <!-- Filters -->
+    <div class="flex items-end gap-4 flex-wrap mb-6">
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1.5">Domain</label>
+        <select
+          v-model="filters.domain"
+          class="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100 h-[38px] px-3 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          @change="applyFilters"
+        >
+          <option value="">All Domains</option>
+          <option v-for="(label, key) in DOMAIN_LABELS" :key="key" :value="key">{{ label }}</option>
+        </select>
       </div>
-      <p class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">Audit Log</p>
-      <p class="text-sm max-w-md mx-auto">
-        The unified audit log will show actions across planning, execution, and delivery
-        domains. It will be available after audit integration in Phase 5.
-      </p>
+      <div class="w-48">
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1.5">Version</label>
+        <div class="relative">
+          <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            v-model="filters.version"
+            type="text"
+            placeholder="e.g. 2.18"
+            class="block w-full pl-10 pr-4 h-[38px] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            @input="debouncedApply"
+          >
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1.5">Action</label>
+        <select
+          v-model="filters.action"
+          class="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100 h-[38px] px-3 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          @change="applyFilters"
+        >
+          <option value="">All Actions</option>
+          <option v-for="(label, key) in ACTION_LABELS" :key="key" :value="key">{{ label }}</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400 py-4">Loading...</div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="text-sm text-red-600 dark:text-red-400 py-4">{{ error }}</div>
+
+    <!-- Results -->
+    <div v-else>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Time</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Domain</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Action</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">User</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Version</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Summary</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            <tr v-for="entry in entries" :key="entry.id" class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ formatDate(entry.timestamp) }}</td>
+              <td class="px-4 py-3 text-sm whitespace-nowrap">
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                  :class="DOMAIN_COLORS[entry.domain] || 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'"
+                >{{ DOMAIN_LABELS[entry.domain] || entry.domain }}</span>
+              </td>
+              <td class="px-4 py-3 text-sm">
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                  {{ ACTION_LABELS[entry.action] || entry.action }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{{ shortUser(entry.user) }}</td>
+              <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{{ entry.version || '--' }}</td>
+              <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-200">{{ entry.summary }}</td>
+            </tr>
+            <tr v-if="entries.length === 0">
+              <td colspan="6" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400 text-sm">No audit log entries</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="total > filters.limit" class="flex items-center justify-between mt-3">
+        <span class="text-sm text-gray-600 dark:text-gray-400">
+          Showing {{ filters.offset + 1 }}-{{ Math.min(filters.offset + filters.limit, total) }} of {{ total }}
+        </span>
+        <div class="flex gap-2">
+          <button
+            class="px-3 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 disabled:opacity-50"
+            :disabled="filters.offset === 0"
+            @click="prevPage"
+          >Prev</button>
+          <button
+            class="px-3 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 disabled:opacity-50"
+            :disabled="filters.offset + filters.limit >= total"
+            @click="nextPage"
+          >Next</button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
-
-<script setup>
-// Audit view placeholder.
-// Will display cross-domain audit entries from releases/audit-log.json
-// with filtering by domain, version, action, and date range.
-</script>

--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -13,7 +13,7 @@
       { "id": "execute", "label": "Execute", "icon": "GitBranch" },
       { "id": "deliver", "label": "Deliver", "icon": "Rocket" },
       { "id": "reports", "label": "Reports", "icon": "BarChart3" },
-      { "id": "audit", "label": "Audit", "icon": "History" }
+      { "id": "audit", "label": "Audit", "icon": "History", "requireRole": "release-manager" }
     ],
     "settingsComponent": "./client/components/ReleasesSettings.vue",
     "hiddenRoutes": {


### PR DESCRIPTION
## Summary

- Replace the placeholder "Phase 5" AuditView with a working audit log UI showing cross-domain entries (planning, execution, delivery, registry)
- Fix `useAuditLog` composable to use the unified `/modules/releases/audit-log` endpoint instead of the old planning-only path, and add `domain` filter support
- Restrict audit nav item to `release-manager` role in `module.json`

## Details

**Backend was already complete** — all 4 domains log audit entries via `GET /api/modules/releases/audit-log`. This PR builds the frontend.

**AuditView.vue** — table-based UI with:
- Filters: domain dropdown, version search (debounced auto-update), action dropdown
- Table columns: Time, Domain (colored badges), Action, User, Version, Summary
- Pagination (50 per page)
- Loading, error, and empty states
- Dark mode support
- Styling matches existing table patterns (TeamMembersTable, AuditLogView)

**useAuditLog.js** — endpoint changed from `/modules/releases/planning` → `/modules/releases`, added `domain` query param support. RecentActivity widget on plan detail pages continues to work (same response shape).

## Test plan

- [ ] Navigate to Releases > Audit — verify table renders with entries
- [ ] Filter by domain dropdown — verify results update
- [ ] Type in version search — verify results auto-update (no Enter needed)
- [ ] Filter by action dropdown — verify results update
- [ ] Verify pagination works when > 50 entries
- [ ] Verify non-release-managers cannot see the Audit nav item
- [ ] Verify RecentActivity widget on plan detail page still works
- [ ] `npm test` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)