### PR TITLE
feat(ai-impact): add GitLab links to test plans

### DIFF
--- a/fixtures/ai-impact/test-plans.json
+++ b/fixtures/ai-impact/test-plans.json
@@ -32,7 +32,8 @@
         "humanReviewStatus": "approved",
         "approvedBy": "Alice Nguyen",
         "approvedAt": "2026-05-10T14:30:00Z",
-        "reviewedAt": "2026-05-10T12:00:00Z"
+        "reviewedAt": "2026-05-10T12:00:00Z",
+        "gitlabPath": "RHAISTRAT/20260510-120000-RHAISTRAT-1168/gpu_observability_dashboard"
       },
       "history": [
         {

--- a/modules/ai-impact/__tests__/server/test-plan-validation.test.js
+++ b/modules/ai-impact/__tests__/server/test-plan-validation.test.js
@@ -215,6 +215,34 @@ describe('validateTestPlan', () => {
     expect(result.valid).toBe(true);
     expect(result.data.humanReviewStatus).toBe('needs-review');
   });
+
+  describe('gitlabPath', () => {
+    it('accepts valid gitlabPath string', () => {
+      const result = validateTestPlan(makeValid({
+        gitlabPath: 'RHAISTRAT/20260510-120000-RHAISTRAT-1168/gpu_observability_dashboard'
+      }));
+      expect(result.valid).toBe(true);
+      expect(result.data.gitlabPath).toBe('RHAISTRAT/20260510-120000-RHAISTRAT-1168/gpu_observability_dashboard');
+    });
+
+    it('accepts omitted gitlabPath (optional field)', () => {
+      const result = validateTestPlan(makeValid());
+      expect(result.valid).toBe(true);
+      expect(result.data.gitlabPath).toBeUndefined();
+    });
+
+    it('rejects non-string gitlabPath', () => {
+      const result = validateTestPlan(makeValid({ gitlabPath: 123 }));
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('gitlabPath must be a string'))).toBe(true);
+    });
+
+    it('accepts null gitlabPath', () => {
+      const result = validateTestPlan(makeValid({ gitlabPath: null }));
+      expect(result.valid).toBe(true);
+      expect(result.data.gitlabPath).toBeUndefined();
+    });
+  });
 });
 
 describe('deriveHumanReviewStatus', () => {

--- a/modules/ai-impact/client/components/PipelineTimeline.vue
+++ b/modules/ai-impact/client/components/PipelineTimeline.vue
@@ -244,6 +244,18 @@ function getFeaturePhaseSignal(phaseId) {
                 >
                   {{ getPhaseSignal(phase.id).detail }}
                 </button>
+                <a
+                  v-if="testPlan.gitlabPath"
+                  :href="`https://gitlab.com/redhat/rhel-ai/agentic-ci/test-plans-data/-/tree/main/${testPlan.gitlabPath}`"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="ml-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+                  title="View test plan in GitLab"
+                >
+                  <svg class="inline h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51A.42.42 0 0 1 18.6 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51L23 13.45a.84.84 0 0 1-.35.94z"/>
+                  </svg>
+                </a>
               </template>
               <template v-else-if="phase.status === 'coming-soon' && phase.id !== 'feature-review' && phase.id !== 'build-release'">
                 <span class="text-gray-300 dark:text-gray-600">No signals yet</span>

--- a/modules/ai-impact/client/components/TestPlanDetailPanel.vue
+++ b/modules/ai-impact/client/components/TestPlanDetailPanel.vue
@@ -358,6 +358,21 @@ const allHistoryEntries = computed(() => {
                   </svg>
                   View in Jira
                 </a>
+
+                <!-- GitLab link (test plan artifacts) -->
+                <a
+                  v-if="currentPlan.gitlabPath"
+                  :href="`https://gitlab.com/redhat/rhel-ai/agentic-ci/test-plans-data/-/tree/main/${currentPlan.gitlabPath}`"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
+                  title="View test plan artifacts in GitLab"
+                >
+                  <svg class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51A.42.42 0 0 1 18.6 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51L23 13.45a.84.84 0 0 1-.35.94z"/>
+                  </svg>
+                  View in GitLab
+                </a>
               </div>
             </div>
 

--- a/modules/ai-impact/server/test-plans/validation.js
+++ b/modules/ai-impact/server/test-plans/validation.js
@@ -202,6 +202,11 @@ function validateTestPlan(body) {
     }
   }
 
+  // gitlabPath: optional string (path to test plan in GitLab repo)
+  if (b.gitlabPath !== undefined && b.gitlabPath !== null && typeof b.gitlabPath !== 'string') {
+    errors.push('gitlabPath must be a string');
+  }
+
   if (errors.length > 0) {
     return { valid: false, errors };
   }
@@ -241,7 +246,8 @@ function validateTestPlan(body) {
       humanReviewStatus: resolvedHumanReviewStatus || undefined,
       approvedBy: b.approvedBy || undefined,
       approvedAt: b.approvedAt || undefined,
-      reviewedAt: b.reviewedAt
+      reviewedAt: b.reviewedAt,
+      gitlabPath: b.gitlabPath || undefined
     }
   };
 }


### PR DESCRIPTION
Adds optional gitlabPath field to test plan schema. When populated, GitLab icons appear in pipeline timeline and test plan detail panel, linking to test plan artifacts in the GitLab repository.

<img width="753" height="493" alt="Screenshot 2026-05-19 at 17 05 07" src="https://github.com/user-attachments/assets/ba882fcb-1cd5-48b6-93cc-758d0532d87d" />
