### PR TITLE
feat(team-tracker): add Data Quality tab for org-wide field completeness

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -242,6 +242,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/org-teams/:teamKey/members` — team members
 - `/api/modules/team-tracker/permissions/me` — permission tier + managed UIDs
 - `/api/modules/team-tracker/manager/dashboard` — manager dashboard data
+- `/api/modules/team-tracker/admin/field-completeness` — all people/teams with field data for data quality auditing (team-admin/admin)
 - `/api/modules/team-tracker/structure/teams` — list teams
 - `/api/modules/team-tracker/structure/unassigned` — unassigned people
 - `/api/modules/team-tracker/structure/field-definitions` — field definitions

--- a/modules/team-tracker/__tests__/client/DataQualityTab.test.js
+++ b/modules/team-tracker/__tests__/client/DataQualityTab.test.js
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import DataQualityTab from '../../client/components/DataQualityTab.vue'
+
+// Mock the composable
+const mockLoad = vi.fn()
+const mockRefresh = vi.fn()
+const mockPeople = ref([])
+const mockTeams = ref([])
+const mockAllPeople = ref([])
+const mockReferencedPeople = ref({})
+const mockFieldDefinitions = ref({ person: [], team: [] })
+const mockOrgKeys = ref([])
+const mockLoading = ref(false)
+const mockError = ref(null)
+
+vi.mock('../../client/composables/useFieldCompleteness', () => ({
+  useFieldCompleteness: () => ({
+    people: mockPeople,
+    teams: mockTeams,
+    allPeople: mockAllPeople,
+    referencedPeople: mockReferencedPeople,
+    fieldDefinitions: mockFieldDefinitions,
+    orgKeys: mockOrgKeys,
+    loading: mockLoading,
+    error: mockError,
+    load: mockLoad,
+    refresh: mockRefresh
+  })
+}))
+
+vi.mock('@shared/client/composables/useFieldDefinitions', () => ({
+  useFieldDefinitions: () => ({
+    updatePersonFields: vi.fn().mockResolvedValue({})
+  })
+}))
+
+vi.mock('@shared/client/composables/useTeams', () => ({
+  useTeams: () => ({
+    updateTeamFields: vi.fn().mockResolvedValue({})
+  })
+}))
+
+vi.mock('@shared/client/composables/useRoster', () => ({
+  useRoster: () => ({
+    reloadRoster: vi.fn()
+  })
+}))
+
+vi.mock('@shared/client/services/api', () => ({
+  apiRequest: vi.fn().mockResolvedValue({})
+}))
+
+function mountTab() {
+  return mount(DataQualityTab, {
+    global: {
+      provide: {
+        moduleNav: {
+          navigateTo: vi.fn(),
+          goBack: vi.fn(),
+          params: ref({})
+        }
+      },
+      stubs: {
+        AlertTriangle: { template: '<span class="alert-triangle-icon" />' },
+        Search: { template: '<span />' },
+        X: { template: '<span />' },
+        Pencil: { template: '<span />' },
+        ExternalLink: { template: '<span />' },
+        ConstrainedAutocomplete: { template: '<div />', props: ['modelValue', 'options', 'multiValue'] },
+        PersonAutocomplete: { template: '<div />', props: ['modelValue', 'people'] },
+        FieldEditCell: { template: '<div class="field-edit-cell" />', props: ['field', 'modelValue', 'allPeople', 'referencedPeople', 'showButtons', 'disabled'] },
+        TeamBoardsDrawer: { template: '<div />', props: ['team', 'isOpen'] }
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  mockPeople.value = []
+  mockTeams.value = []
+  mockAllPeople.value = []
+  mockReferencedPeople.value = {}
+  mockFieldDefinitions.value = { person: [], team: [] }
+  mockOrgKeys.value = []
+  mockLoading.value = false
+  mockError.value = null
+  mockLoad.mockClear()
+  mockRefresh.mockClear()
+})
+
+describe('DataQualityTab', () => {
+  it('calls load on mount', async () => {
+    mountTab()
+    await flushPromises()
+    expect(mockLoad).toHaveBeenCalled()
+  })
+
+  it('shows loading state', async () => {
+    mockLoading.value = true
+    const w = mountTab()
+    await flushPromises()
+    expect(w.text()).toContain('Loading')
+  })
+
+  it('shows error state', async () => {
+    mockError.value = 'Something went wrong'
+    const w = mountTab()
+    await flushPromises()
+    expect(w.text()).toContain('Something went wrong')
+  })
+
+  it('renders people tab by default', async () => {
+    mockPeople.value = [
+      { uid: 'alice', name: 'Alice', email: 'alice@example.com', title: 'Engineer', teamIds: [], customFields: {} }
+    ]
+    const w = mountTab()
+    await flushPromises()
+    expect(w.text()).toContain('People')
+    expect(w.text()).toContain('Alice')
+  })
+
+  it('renders field column headers from field definitions', async () => {
+    mockPeople.value = [
+      { uid: 'alice', name: 'Alice', email: 'alice@example.com', title: 'Engineer', teamIds: [], customFields: { f1: 'val' } }
+    ]
+    mockFieldDefinitions.value = {
+      person: [{ id: 'f1', label: 'Focus', type: 'free-text', visible: true, deleted: false }],
+      team: []
+    }
+    const w = mountTab()
+    await flushPromises()
+    expect(w.text()).toContain('Focus')
+  })
+
+  it('switches to teams tab', async () => {
+    mockTeams.value = [
+      { id: 'team_a', name: 'Alpha', orgKey: 'org1', orgDisplayName: 'Org One', metadata: {}, boards: [] }
+    ]
+    const w = mountTab()
+    await flushPromises()
+
+    const teamsTab = w.findAll('button').find(b => b.text().includes('Teams'))
+    await teamsTab.trigger('click')
+    await nextTick()
+
+    expect(w.text()).toContain('Alpha')
+  })
+
+  // --- Filtering ---
+
+  describe('org filter', () => {
+    it('filters people by org when org is selected', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice', email: 'a@x.com', title: 'Eng', teamIds: ['t1'], customFields: {} },
+        { uid: 'bob', name: 'Bob', email: 'b@x.com', title: 'SRE', teamIds: ['t2'], customFields: {} }
+      ]
+      mockTeams.value = [
+        { id: 't1', name: 'Team A', orgKey: 'org1', orgDisplayName: 'Org One', metadata: {}, boards: [] },
+        { id: 't2', name: 'Team B', orgKey: 'org2', orgDisplayName: 'Org Two', metadata: {}, boards: [] }
+      ]
+      mockOrgKeys.value = [
+        { key: 'org1', displayName: 'Org One' },
+        { key: 'org2', displayName: 'Org Two' }
+      ]
+      const w = mountTab()
+      await flushPromises()
+
+      // Select org1 filter
+      const orgSelect = w.find('select[data-testid="org-filter"]')
+      await orgSelect.setValue('org1')
+      await nextTick()
+
+      // Only Alice (on team in org1) should be visible
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).not.toContain('Bob')
+    })
+  })
+
+  describe('team filter', () => {
+    it('filters people by team when team is selected', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice', email: 'a@x.com', title: 'Eng', teamIds: ['t1'], customFields: {} },
+        { uid: 'bob', name: 'Bob', email: 'b@x.com', title: 'SRE', teamIds: ['t2'], customFields: {} }
+      ]
+      mockTeams.value = [
+        { id: 't1', name: 'Team A', orgKey: 'org1', orgDisplayName: 'Org One', metadata: {}, boards: [] },
+        { id: 't2', name: 'Team B', orgKey: 'org1', orgDisplayName: 'Org One', metadata: {}, boards: [] }
+      ]
+      const w = mountTab()
+      await flushPromises()
+
+      const teamSelect = w.find('select[data-testid="team-filter"]')
+      await teamSelect.setValue('t1')
+      await nextTick()
+
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).not.toContain('Bob')
+    })
+  })
+
+  describe('field filter', () => {
+    it('filters to only people missing the selected field', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice', email: 'a@x.com', title: 'Eng', teamIds: [], customFields: { f1: '', f2: 'val' } },
+        { uid: 'bob', name: 'Bob', email: 'b@x.com', title: 'SRE', teamIds: [], customFields: { f1: 'backend', f2: 'val' } }
+      ]
+      mockFieldDefinitions.value = {
+        person: [
+          { id: 'f1', label: 'Focus', type: 'free-text', visible: true, deleted: false },
+          { id: 'f2', label: 'Role', type: 'free-text', visible: true, deleted: false }
+        ],
+        team: []
+      }
+      const w = mountTab()
+      await flushPromises()
+
+      const fieldSelect = w.find('select[data-testid="field-filter"]')
+      await fieldSelect.setValue('f1')
+      await nextTick()
+
+      // Only Alice (missing f1) should be visible
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).not.toContain('Bob')
+    })
+  })
+
+  // --- Completeness banner ---
+
+  describe('completeness banner', () => {
+    it('shows banner when people have incomplete fields', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice', email: 'a@x.com', title: 'Eng', teamIds: [], customFields: { f1: '' } },
+        { uid: 'bob', name: 'Bob', email: 'b@x.com', title: 'SRE', teamIds: [], customFields: { f1: 'val' } }
+      ]
+      mockFieldDefinitions.value = {
+        person: [{ id: 'f1', label: 'Focus', type: 'free-text', visible: true, deleted: false }],
+        team: []
+      }
+      const w = mountTab()
+      await flushPromises()
+
+      expect(w.text()).toContain('1 of 2')
+      expect(w.text()).toContain('incomplete fields')
+    })
+
+    it('does not show banner when all complete', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice', email: 'a@x.com', title: 'Eng', teamIds: [], customFields: { f1: 'val' } }
+      ]
+      mockFieldDefinitions.value = {
+        person: [{ id: 'f1', label: 'Focus', type: 'free-text', visible: true, deleted: false }],
+        team: []
+      }
+      const w = mountTab()
+      await flushPromises()
+
+      expect(w.text()).not.toContain('incomplete fields')
+    })
+
+    it('show incomplete only filter works', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice', email: 'a@x.com', title: 'Eng', teamIds: [], customFields: { f1: '' } },
+        { uid: 'bob', name: 'Bob', email: 'b@x.com', title: 'SRE', teamIds: [], customFields: { f1: 'val' } }
+      ]
+      mockFieldDefinitions.value = {
+        person: [{ id: 'f1', label: 'Focus', type: 'free-text', visible: true, deleted: false }],
+        team: []
+      }
+      const w = mountTab()
+      await flushPromises()
+
+      const filterBtn = w.findAll('button').find(b => b.text().includes('Show incomplete only'))
+      await filterBtn.trigger('click')
+      await nextTick()
+
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).not.toContain('Bob')
+    })
+
+    it('shows team banner when teams have incomplete fields', async () => {
+      mockTeams.value = [
+        { id: 't1', name: 'Alpha', orgKey: 'org1', orgDisplayName: 'Org One', metadata: { f1: '' }, boards: [{ url: 'http://x', name: 'B' }] },
+        { id: 't2', name: 'Beta', orgKey: 'org1', orgDisplayName: 'Org One', metadata: { f1: 'val' }, boards: [{ url: 'http://x', name: 'B' }] }
+      ]
+      mockFieldDefinitions.value = {
+        person: [],
+        team: [{ id: 'f1', label: 'Sprint', type: 'free-text', visible: true, deleted: false }]
+      }
+      const w = mountTab()
+      await flushPromises()
+
+      const teamsTab = w.findAll('button').find(b => b.text().includes('Teams'))
+      await teamsTab.trigger('click')
+      await nextTick()
+
+      expect(w.text()).toContain('1 of 2')
+      expect(w.text()).toContain('incomplete fields')
+    })
+  })
+
+  // --- Search ---
+
+  describe('search', () => {
+    it('filters people by search query', async () => {
+      mockPeople.value = [
+        { uid: 'alice', name: 'Alice Smith', email: 'a@x.com', title: 'Engineer', teamIds: [], customFields: {} },
+        { uid: 'bob', name: 'Bob Jones', email: 'b@x.com', title: 'SRE', teamIds: [], customFields: {} }
+      ]
+      const w = mountTab()
+      await flushPromises()
+
+      const input = w.find('input[type="text"]')
+      await input.setValue('alice')
+      await nextTick()
+
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).not.toContain('Bob')
+    })
+  })
+
+  // --- Empty states ---
+
+  it('shows empty state when no people', async () => {
+    mockPeople.value = []
+    const w = mountTab()
+    await flushPromises()
+    expect(w.text()).toContain('No people')
+  })
+
+  it('shows empty state when no teams', async () => {
+    mockTeams.value = []
+    const w = mountTab()
+    await flushPromises()
+
+    const teamsTab = w.findAll('button').find(b => b.text().includes('Teams'))
+    await teamsTab.trigger('click')
+    await nextTick()
+
+    expect(w.text()).toContain('No teams')
+  })
+})

--- a/modules/team-tracker/__tests__/client/FieldDisplayCell.test.js
+++ b/modules/team-tracker/__tests__/client/FieldDisplayCell.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FieldDisplayCell from '../../client/components/FieldDisplayCell.vue'
+
+function mountCell(props = {}) {
+  return mount(FieldDisplayCell, {
+    props: {
+      value: null,
+      field: { id: 'f1', label: 'Test', type: 'free-text', visible: true, deleted: false },
+      referencedPeople: {},
+      ...props
+    }
+  })
+}
+
+describe('FieldDisplayCell', () => {
+  describe('isFieldEmpty logic', () => {
+    it('treats null as empty', () => {
+      const w = mountCell({ value: null })
+      expect(w.text()).toBe('—')
+    })
+
+    it('treats undefined as empty', () => {
+      const w = mountCell({ value: undefined })
+      expect(w.text()).toBe('—')
+    })
+
+    it('treats empty string as empty', () => {
+      const w = mountCell({ value: '' })
+      expect(w.text()).toBe('—')
+    })
+
+    it('treats empty array as empty', () => {
+      const w = mountCell({
+        value: [],
+        field: { id: 'f1', label: 'Test', type: 'constrained', visible: true, deleted: false, multiValue: true, allowedValues: ['a'] }
+      })
+      expect(w.text()).toBe('—')
+    })
+
+    it('treats multi-value array with all falsy elements as empty', () => {
+      const w = mountCell({
+        value: ['', ''],
+        field: { id: 'f1', label: 'Test', type: 'constrained', visible: true, deleted: false, multiValue: true, allowedValues: ['a'] }
+      })
+      expect(w.text()).toBe('—')
+    })
+
+    it('treats non-empty string as populated', () => {
+      const w = mountCell({ value: 'backend' })
+      expect(w.text()).toContain('backend')
+      expect(w.text()).not.toBe('—')
+    })
+  })
+
+  describe('highlight prop', () => {
+    it('applies red highlight class when highlight is true', () => {
+      const w = mountCell({ value: '', highlight: true })
+      expect(w.find('.bg-red-100').exists()).toBe(true)
+    })
+
+    it('does not apply highlight when highlight is false', () => {
+      const w = mountCell({ value: '' })
+      expect(w.find('.bg-red-100').exists()).toBe(false)
+    })
+  })
+
+  describe('free-text field type', () => {
+    it('renders plain text value', () => {
+      const w = mountCell({ value: 'hello world' })
+      expect(w.text()).toContain('hello world')
+    })
+
+    it('renders dash for empty', () => {
+      const w = mountCell({ value: null })
+      expect(w.text()).toBe('—')
+    })
+
+    it('unwraps single-element array', () => {
+      const w = mountCell({ value: ['hello'] })
+      expect(w.text()).toContain('hello')
+    })
+  })
+
+  describe('constrained single-value field', () => {
+    const field = { id: 'f1', label: 'Status', type: 'constrained', visible: true, deleted: false, allowedValues: ['active', 'inactive'] }
+
+    it('renders the value as text', () => {
+      const w = mountCell({ value: 'active', field })
+      expect(w.text()).toContain('active')
+    })
+  })
+
+  describe('constrained multi-value field', () => {
+    const field = { id: 'f1', label: 'Tags', type: 'constrained', visible: true, deleted: false, multiValue: true, allowedValues: ['a', 'b', 'c'] }
+
+    it('renders values as pills', () => {
+      const w = mountCell({ value: ['a', 'b'], field })
+      const pills = w.findAll('span').filter(s => s.classes().some(c => c.includes('rounded')))
+      expect(pills.length).toBeGreaterThanOrEqual(2)
+      expect(w.text()).toContain('a')
+      expect(w.text()).toContain('b')
+    })
+
+    it('renders dash for empty array', () => {
+      const w = mountCell({ value: [], field })
+      expect(w.text()).toBe('—')
+    })
+  })
+
+  describe('person-reference-linked field', () => {
+    const field = { id: 'f1', label: 'PM', type: 'person-reference-linked', visible: true, deleted: false }
+
+    it('renders resolved person name', () => {
+      const w = mountCell({
+        value: 'uid1',
+        field,
+        referencedPeople: { uid1: 'Alice Smith' }
+      })
+      expect(w.text()).toContain('Alice Smith')
+    })
+
+    it('renders uid as fallback when name not found', () => {
+      const w = mountCell({
+        value: 'uid1',
+        field,
+        referencedPeople: {}
+      })
+      expect(w.text()).toContain('uid1')
+    })
+
+    it('renders multiple person names from array', () => {
+      const w = mountCell({
+        value: ['uid1', 'uid2'],
+        field,
+        referencedPeople: { uid1: 'Alice', uid2: 'Bob' }
+      })
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).toContain('Bob')
+    })
+
+    it('emits person-click when a person name is clicked', async () => {
+      const w = mountCell({
+        value: 'uid1',
+        field,
+        referencedPeople: { uid1: 'Alice' }
+      })
+      const btn = w.find('button')
+      await btn.trigger('click')
+      expect(w.emitted('person-click')).toBeTruthy()
+      expect(w.emitted('person-click')[0]).toEqual(['uid1'])
+    })
+
+    it('renders dash for null value', () => {
+      const w = mountCell({ value: null, field, referencedPeople: {} })
+      expect(w.text()).toBe('—')
+    })
+  })
+
+  describe('pencil icon', () => {
+    it('shows pencil icon by default', () => {
+      const w = mountCell({ value: 'test' })
+      expect(w.find('svg').exists()).toBe(true)
+    })
+
+    it('hides pencil icon when showPencil is false', () => {
+      const w = mountCell({ value: 'test', showPencil: false })
+      expect(w.find('svg').exists()).toBe(false)
+    })
+  })
+})

--- a/modules/team-tracker/__tests__/client/FieldEditCell.test.js
+++ b/modules/team-tracker/__tests__/client/FieldEditCell.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FieldEditCell from '../../client/components/FieldEditCell.vue'
+
+// Stub sub-components
+const ConstrainedAutocompleteStub = {
+  name: 'ConstrainedAutocomplete',
+  template: '<div class="constrained-autocomplete" :data-multi="multiValue" />',
+  props: ['modelValue', 'options', 'multiValue', 'placeholder'],
+  emits: ['update:modelValue', 'save', 'cancel']
+}
+
+const PersonAutocompleteStub = {
+  name: 'PersonAutocomplete',
+  template: '<div class="person-autocomplete" />',
+  props: ['modelValue', 'people', 'placeholder'],
+  emits: ['update:modelValue', 'save', 'cancel']
+}
+
+function mountCell(props = {}, stubs = {}) {
+  return mount(FieldEditCell, {
+    props: {
+      field: { id: 'f1', label: 'Test', type: 'free-text', visible: true, deleted: false },
+      modelValue: '',
+      allPeople: [],
+      ...props
+    },
+    global: {
+      stubs: {
+        ConstrainedAutocomplete: ConstrainedAutocompleteStub,
+        PersonAutocomplete: PersonAutocompleteStub,
+        ...stubs
+      }
+    }
+  })
+}
+
+describe('FieldEditCell', () => {
+  describe('field type rendering', () => {
+    it('renders plain input for free-text field', () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'Test', type: 'free-text', visible: true, deleted: false },
+        modelValue: 'hello'
+      })
+      const input = w.find('input')
+      expect(input.exists()).toBe(true)
+      expect(input.element.value).toBe('hello')
+    })
+
+    it('renders ConstrainedAutocomplete for constrained field', () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'Test', type: 'constrained', visible: true, deleted: false, allowedValues: ['a', 'b'] },
+        modelValue: 'a'
+      })
+      expect(w.find('.constrained-autocomplete').exists()).toBe(true)
+    })
+
+    it('renders ConstrainedAutocomplete with multiValue for multi-value constrained', () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'Test', type: 'constrained', visible: true, deleted: false, multiValue: true, allowedValues: ['a', 'b'] },
+        modelValue: ['a']
+      })
+      const autocomplete = w.find('.constrained-autocomplete')
+      expect(autocomplete.exists()).toBe(true)
+      expect(autocomplete.attributes('data-multi')).toBe('true')
+    })
+
+    it('renders PersonAutocomplete for person-reference-linked single-value', () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'PM', type: 'person-reference-linked', visible: true, deleted: false },
+        modelValue: 'uid1',
+        allPeople: [{ uid: 'uid1', name: 'Alice' }]
+      })
+      expect(w.find('.person-autocomplete').exists()).toBe(true)
+    })
+
+    it('renders multi-value person-reference with pills and add input', () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'PM', type: 'person-reference-linked', visible: true, deleted: false, multiValue: true },
+        modelValue: ['uid1', 'uid2'],
+        allPeople: [{ uid: 'uid1', name: 'Alice' }, { uid: 'uid2', name: 'Bob' }, { uid: 'uid3', name: 'Carol' }],
+        referencedPeople: { uid1: 'Alice', uid2: 'Bob' }
+      })
+      // Should show pills for existing values
+      expect(w.text()).toContain('Alice')
+      expect(w.text()).toContain('Bob')
+      // Should show person autocomplete for adding
+      expect(w.find('.person-autocomplete').exists()).toBe(true)
+    })
+  })
+
+  describe('events', () => {
+    it('emits update:modelValue on input change for free-text', async () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'Test', type: 'free-text', visible: true, deleted: false },
+        modelValue: 'hello'
+      })
+      const input = w.find('input')
+      await input.setValue('world')
+      expect(w.emitted('update:modelValue')).toBeTruthy()
+      expect(w.emitted('update:modelValue')[0]).toEqual(['world'])
+    })
+
+    it('emits save on Enter key for free-text', async () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'Test', type: 'free-text', visible: true, deleted: false },
+        modelValue: 'hello'
+      })
+      const input = w.find('input')
+      await input.trigger('keyup.enter')
+      expect(w.emitted('save')).toBeTruthy()
+    })
+
+    it('emits cancel on Escape key for free-text', async () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'Test', type: 'free-text', visible: true, deleted: false },
+        modelValue: 'hello'
+      })
+      const input = w.find('input')
+      await input.trigger('keyup.escape')
+      expect(w.emitted('cancel')).toBeTruthy()
+    })
+
+    it('emits remove-person when pill remove button clicked (multi-value person-ref)', async () => {
+      const w = mountCell({
+        field: { id: 'f1', label: 'PM', type: 'person-reference-linked', visible: true, deleted: false, multiValue: true },
+        modelValue: ['uid1'],
+        allPeople: [{ uid: 'uid1', name: 'Alice' }],
+        referencedPeople: { uid1: 'Alice' }
+      })
+      const removeBtn = w.find('button')
+      await removeBtn.trigger('click')
+      expect(w.emitted('remove-person')).toBeTruthy()
+      expect(w.emitted('remove-person')[0]).toEqual(['uid1'])
+    })
+  })
+
+  describe('showButtons prop', () => {
+    it('shows save/cancel buttons by default', () => {
+      const w = mountCell()
+      expect(w.text()).toContain('Save')
+      expect(w.text()).toContain('Cancel')
+    })
+
+    it('hides save/cancel buttons when showButtons is false', () => {
+      const w = mountCell({ showButtons: false })
+      expect(w.text()).not.toContain('Save')
+      expect(w.text()).not.toContain('Cancel')
+    })
+  })
+
+  describe('disabled prop', () => {
+    it('disables save button when disabled is true', () => {
+      const w = mountCell({ disabled: true })
+      const saveBtn = w.findAll('button').find(b => b.text() === 'Save')
+      expect(saveBtn.attributes('disabled')).toBeDefined()
+    })
+  })
+})

--- a/modules/team-tracker/__tests__/client/ManagerDashboardView.test.js
+++ b/modules/team-tracker/__tests__/client/ManagerDashboardView.test.js
@@ -11,6 +11,7 @@ const mockDirectReports = ref([])
 const mockIndirectReports = ref([])
 const mockTeams = ref([])
 const mockAllOrgTeams = ref([])
+const mockAllPeople = ref([])
 const mockReferencedPeople = ref({})
 const mockFieldDefinitions = ref({ person: [], team: [] })
 const mockLoading = ref(false)
@@ -25,6 +26,7 @@ vi.mock('../../client/composables/useManagerDashboard', () => ({
     indirectReports: mockIndirectReports,
     teams: mockTeams,
     allOrgTeams: mockAllOrgTeams,
+    allPeople: mockAllPeople,
     referencedPeople: mockReferencedPeople,
     fieldDefinitions: mockFieldDefinitions,
     loading: mockLoading,
@@ -81,7 +83,8 @@ function mountView() {
         AlertTriangle: { template: '<span class="alert-triangle-icon" />' },
         CircleQuestionMark: { template: '<span />' },
         ConstrainedAutocomplete: { template: '<div />', props: ['modelValue', 'options', 'multiValue'] },
-        PersonAutocomplete: { template: '<div />', props: ['modelValue', 'people'] }
+        PersonAutocomplete: { template: '<div />', props: ['modelValue', 'people'] },
+        FieldEditCell: { template: '<div class="field-edit-cell" />', props: ['field', 'modelValue', 'allPeople', 'referencedPeople', 'showButtons', 'disabled'] }
       }
     }
   })
@@ -93,6 +96,7 @@ beforeEach(() => {
   mockIndirectReports.value = []
   mockTeams.value = []
   mockAllOrgTeams.value = []
+  mockAllPeople.value = []
   mockReferencedPeople.value = {}
   mockFieldDefinitions.value = { person: [], team: [] }
   mockLoading.value = false

--- a/modules/team-tracker/__tests__/server/field-completeness-endpoint.test.js
+++ b/modules/team-tracker/__tests__/server/field-completeness-endpoint.test.js
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock node-fetch (required by transitive imports)
+vi.mock('node-fetch', () => ({ default: vi.fn() }))
+
+function makeStorage(initial = {}) {
+  const data = { ...initial }
+  return {
+    readFromStorage(key) { return data[key] ? JSON.parse(JSON.stringify(data[key])) : null },
+    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    listStorageFiles(dir) {
+      return Object.keys(data)
+        .filter(k => k.startsWith(dir + '/') && k.endsWith('.json'))
+        .map(k => k.split('/').pop())
+    },
+    deleteStorageDirectory: vi.fn(),
+    _data: data
+  }
+}
+
+function setupRoutes(storageData) {
+  const handlers = {}
+  const mockRouter = {
+    get(path, ...args) { handlers[`GET ${path}`] = args[args.length - 1] },
+    post(path, ...args) { handlers[`POST ${path}`] = args[args.length - 1] },
+    put(path, ...args) { handlers[`PUT ${path}`] = args[args.length - 1] },
+    patch(path, ...args) { handlers[`PATCH ${path}`] = args[args.length - 1] },
+    delete(path, ...args) { handlers[`DELETE ${path}`] = args[args.length - 1] }
+  }
+
+  const storage = makeStorage(storageData)
+  const mockRoleStore = {
+    getRoles: vi.fn(() => []),
+    isAdmin: vi.fn(() => false),
+    isTeamAdmin: vi.fn(() => false)
+  }
+
+  const context = {
+    storage,
+    requireAdmin: (req, res, next) => next(),
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
+    roleStore: mockRoleStore
+  }
+
+  const registerRoutes = require('../../server/index.js')
+  registerRoutes(mockRouter, context)
+
+  return { handlers, storage }
+}
+
+function mockRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) { res._status = code; return res },
+    json(body) { res._body = body; return res }
+  }
+  return res
+}
+
+function baseStorageData() {
+  return {
+    'team-data/registry.json': {
+      meta: { generatedAt: '2026-01-01', provider: 'test', orgRoots: ['org1'] },
+      people: {
+        alice: {
+          uid: 'alice', name: 'Alice', email: 'alice@example.com',
+          title: 'Software Engineer', status: 'active', managerUid: 'mgr1',
+          orgRoot: 'org1', orgType: 'engineering', teamIds: ['team_a'],
+          _appFields: { field_f1: 'backend' }
+        },
+        bob: {
+          uid: 'bob', name: 'Bob', email: 'bob@example.com',
+          title: 'SRE', status: 'active', managerUid: 'mgr1',
+          orgRoot: 'org1', orgType: 'engineering', teamIds: ['team_a'],
+          _appFields: { field_f1: '' }
+        },
+        inactive: {
+          uid: 'inactive', name: 'Gone', email: 'gone@example.com',
+          title: 'Former', status: 'inactive', managerUid: null,
+          orgRoot: 'org1', teamIds: [],
+          _appFields: {}
+        },
+        pmcarol: {
+          uid: 'pmcarol', name: 'Carol', email: 'carol@example.com',
+          title: 'Product Manager', status: 'active', managerUid: null,
+          orgRoot: 'org1', orgType: 'auxiliary', teamIds: [],
+          _appFields: {}
+        }
+      }
+    },
+    'team-data/teams.json': {
+      teams: {
+        team_a: { id: 'team_a', name: 'Alpha', orgKey: 'org1', metadata: { field_t1: 'sprint-42' }, boards: [{ url: 'https://board.example.com', name: 'Board' }] },
+        team_b: { id: 'team_b', name: 'Beta', orgKey: 'org2', metadata: {}, boards: [] }
+      }
+    },
+    'team-data/field-definitions.json': {
+      personFields: [
+        { id: 'field_f1', label: 'Focus Area', type: 'free-text', visible: true, deleted: false }
+      ],
+      teamFields: [
+        { id: 'field_t1', label: 'Sprint', type: 'free-text', visible: true, deleted: false }
+      ]
+    },
+    'team-data/config.json': {
+      orgRoots: [{ uid: 'org1', displayName: 'Org One' }],
+      teamDataSource: 'in-app'
+    },
+    'audit-log.json': { entries: [] }
+  }
+}
+
+describe('GET /admin/field-completeness', () => {
+  it('returns 403 for regular users', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: false,
+      isTeamAdmin: false,
+      permissionTier: 'user'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+    expect(res._status).toBe(403)
+  })
+
+  it('returns 403 for managers who are not team-admins', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'mgr1',
+      userEmail: 'mgr1@example.com',
+      isAdmin: false,
+      isTeamAdmin: false,
+      permissionTier: 'manager'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+    expect(res._status).toBe(403)
+  })
+
+  it('returns all active people for team-admins', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: false,
+      isTeamAdmin: true,
+      permissionTier: 'team-admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    expect(res._status).toBe(200)
+    // Should include alice and bob (active), not inactive
+    expect(res._body.people).toHaveLength(2)
+    expect(res._body.people.map(p => p.uid).sort()).toEqual(['alice', 'bob'])
+  })
+
+  it('returns all teams for admins', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    expect(res._status).toBe(200)
+    expect(res._body.teams).toHaveLength(2)
+    expect(res._body.teams.map(t => t.name).sort()).toEqual(['Alpha', 'Beta'])
+  })
+
+  it('populates customFields from _appFields', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    const alice = res._body.people.find(p => p.uid === 'alice')
+    expect(alice.customFields).toEqual({ field_f1: 'backend' })
+
+    const bob = res._body.people.find(p => p.uid === 'bob')
+    // Empty string in _appFields becomes null via enrichPerson's `|| null` fallback
+    expect(bob.customFields).toEqual({ field_f1: null })
+  })
+
+  it('returns field definitions', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    expect(res._body.fieldDefinitions.person).toHaveLength(1)
+    expect(res._body.fieldDefinitions.person[0].id).toBe('field_f1')
+    expect(res._body.fieldDefinitions.team).toHaveLength(1)
+  })
+
+  it('returns org keys from teams', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    expect(res._body.orgKeys).toHaveLength(2)
+    expect(res._body.orgKeys.map(o => o.key).sort()).toEqual(['org1', 'org2'])
+  })
+
+  it('returns allPeople list for autocomplete', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    // allPeople includes all active people (including auxiliary) for autocomplete
+    expect(res._body.allPeople).toHaveLength(3)
+    expect(res._body.allPeople.every(p => p.uid && p.name)).toBe(true)
+  })
+
+  it('excludes auxiliary people from the people list', () => {
+    const { handlers } = setupRoutes(baseStorageData())
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    const uids = res._body.people.map(p => p.uid)
+    expect(uids).toContain('alice')
+    expect(uids).toContain('bob')
+    expect(uids).not.toContain('pmcarol')
+  })
+
+  it('returns empty data when registry is missing', () => {
+    const data = baseStorageData()
+    delete data['team-data/registry.json']
+    const { handlers } = setupRoutes(data)
+    const res = mockRes()
+    const req = {
+      userUid: 'alice',
+      userEmail: 'alice@example.com',
+      isAdmin: true,
+      isTeamAdmin: false,
+      permissionTier: 'admin'
+    }
+
+    handlers['GET /admin/field-completeness'](req, res)
+
+    expect(res._status).toBe(200)
+    expect(res._body.people).toEqual([])
+    expect(res._body.teams).toEqual([])
+  })
+})

--- a/modules/team-tracker/__tests__/server/field-payload.test.js
+++ b/modules/team-tracker/__tests__/server/field-payload.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+const { enrichPerson, resolveFieldDefinitions, buildReferencedPeopleMap, buildAllPeopleList } = require('../../server/field-payload');
+
+describe('field-payload utility', () => {
+  describe('enrichPerson', () => {
+    const fieldDefs = [
+      { id: 'f1', label: 'Focus', type: 'free-text' },
+      { id: 'f2', label: 'Component', type: 'constrained', multiValue: true }
+    ];
+
+    it('populates customFields from _appFields', () => {
+      const person = {
+        uid: 'alice',
+        name: 'Alice',
+        email: 'alice@example.com',
+        title: 'Engineer',
+        teamIds: ['team_a'],
+        _appFields: { f1: 'backend', f2: ['ui', 'api'] }
+      };
+      const result = enrichPerson(person, fieldDefs);
+      expect(result.customFields).toEqual({ f1: 'backend', f2: ['ui', 'api'] });
+      expect(result.uid).toBe('alice');
+      expect(result.name).toBe('Alice');
+    });
+
+    it('returns null for missing _appFields values', () => {
+      const person = { uid: 'bob', name: 'Bob', email: 'bob@x.com', title: 'PM', teamIds: [] };
+      const result = enrichPerson(person, fieldDefs);
+      expect(result.customFields).toEqual({ f1: null, f2: null });
+    });
+
+    it('returns null for null person', () => {
+      expect(enrichPerson(null, fieldDefs)).toBeNull();
+    });
+
+    it('includes managerUid when option is set', () => {
+      const person = { uid: 'alice', name: 'Alice', managerUid: 'mgr1' };
+      const result = enrichPerson(person, fieldDefs, { includeManagerUid: true });
+      expect(result.managerUid).toBe('mgr1');
+    });
+
+    it('omits managerUid by default', () => {
+      const person = { uid: 'alice', name: 'Alice', managerUid: 'mgr1' };
+      const result = enrichPerson(person, fieldDefs);
+      expect(result.managerUid).toBeUndefined();
+    });
+  });
+
+  describe('resolveFieldDefinitions', () => {
+    it('resolves optionsRef to allowedValues', () => {
+      const storage = {};
+      const mockFieldStore = require('../../../../shared/server/field-store');
+      vi.spyOn(mockFieldStore, 'readFieldDefinitions').mockReturnValue({
+        personFields: [
+          { id: 'f1', label: 'Component', type: 'constrained', optionsRef: 'component', deleted: false }
+        ],
+        teamFields: [
+          { id: 'f2', label: 'Status', type: 'free-text', deleted: false }
+        ]
+      });
+
+      const resolver = (ref) => ref === 'component' ? ['a', 'b', 'c'] : null;
+      const { personFieldDefs, teamFieldDefs } = resolveFieldDefinitions(storage, resolver);
+
+      expect(personFieldDefs[0].allowedValues).toEqual(['a', 'b', 'c']);
+      expect(personFieldDefs[0]._resolvedFromOptions).toBe(true);
+      expect(teamFieldDefs).toHaveLength(1);
+
+      mockFieldStore.readFieldDefinitions.mockRestore();
+    });
+
+    it('filters out deleted fields', () => {
+      const storage = {};
+      const mockFieldStore = require('../../../../shared/server/field-store');
+      vi.spyOn(mockFieldStore, 'readFieldDefinitions').mockReturnValue({
+        personFields: [
+          { id: 'f1', label: 'Active', deleted: false },
+          { id: 'f2', label: 'Deleted', deleted: true }
+        ],
+        teamFields: []
+      });
+
+      const { personFieldDefs } = resolveFieldDefinitions(storage, () => null);
+      expect(personFieldDefs).toHaveLength(1);
+      expect(personFieldDefs[0].id).toBe('f1');
+
+      mockFieldStore.readFieldDefinitions.mockRestore();
+    });
+  });
+
+  describe('buildReferencedPeopleMap', () => {
+    const teamFieldDefs = [
+      { id: 'f1', type: 'person-reference-linked', label: 'PM' },
+      { id: 'f2', type: 'free-text', label: 'Notes' }
+    ];
+
+    it('builds uid->name map from team metadata person-ref fields', () => {
+      const teams = [
+        { id: 't1', metadata: { f1: ['uid1', 'uid2'], f2: 'notes' } }
+      ];
+      const people = {
+        uid1: { name: 'Alice' },
+        uid2: { name: 'Bob' }
+      };
+      const result = buildReferencedPeopleMap(teams, teamFieldDefs, people);
+      expect(result).toEqual({ uid1: 'Alice', uid2: 'Bob' });
+    });
+
+    it('falls back to uid when person not in registry', () => {
+      const teams = [{ id: 't1', metadata: { f1: 'unknown_uid' } }];
+      const result = buildReferencedPeopleMap(teams, teamFieldDefs, {});
+      expect(result).toEqual({ unknown_uid: 'unknown_uid' });
+    });
+
+    it('returns empty map when no person-ref fields', () => {
+      const teams = [{ id: 't1', metadata: { f2: 'notes' } }];
+      const nonRefDefs = [{ id: 'f2', type: 'free-text', label: 'Notes' }];
+      const result = buildReferencedPeopleMap(teams, nonRefDefs, {});
+      expect(result).toEqual({});
+    });
+
+    it('handles null metadata gracefully', () => {
+      const teams = [{ id: 't1', metadata: null }];
+      const result = buildReferencedPeopleMap(teams, teamFieldDefs, {});
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('buildAllPeopleList', () => {
+    it('includes only active people', () => {
+      const people = {
+        alice: { uid: 'alice', name: 'Alice', title: 'Eng', status: 'active' },
+        bob: { uid: 'bob', name: 'Bob', title: 'PM', status: 'inactive' }
+      };
+      const result = buildAllPeopleList(people);
+      expect(result).toHaveLength(1);
+      expect(result[0].uid).toBe('alice');
+    });
+
+    it('uses uid as fallback name', () => {
+      const people = {
+        alice: { uid: 'alice', status: 'active' }
+      };
+      const result = buildAllPeopleList(people);
+      expect(result[0].name).toBe('alice');
+    });
+  });
+});

--- a/modules/team-tracker/client/components/DataQualityTab.vue
+++ b/modules/team-tracker/client/components/DataQualityTab.vue
@@ -1,20 +1,8 @@
 <template>
-  <div class="max-w-7xl mx-auto px-4 py-6">
-    <div data-tour="dashboard-header" class="flex items-center justify-between mb-6">
-      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">My Teams</h2>
-      <button
-        v-if="!loading && !error && reason !== 'no-registry-identity'"
-        @click="handleLaunchTutorial"
-        class="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-        title="Dashboard tour"
-      >
-        <CircleQuestionMark class="w-5 h-5" />
-      </button>
-    </div>
-
+  <div>
     <!-- Loading state -->
     <div v-if="loading" class="text-center py-12 text-gray-500 dark:text-gray-400">
-      Loading dashboard...
+      Loading data quality...
     </div>
 
     <!-- Error state -->
@@ -22,44 +10,49 @@
       {{ error }}
     </div>
 
-    <!-- Empty state: no registry identity -->
-    <div v-else-if="reason === 'no-registry-identity'" class="text-center py-12 text-gray-500 dark:text-gray-400">
-      <p class="text-lg font-medium mb-2">No Registry Identity</p>
-      <p>Your account is not linked to the people registry. In local dev, this typically means your email address does not match any person in the registry.</p>
-    </div>
-
-    <!-- Empty state: no direct reports -->
-    <div v-else-if="reason === 'no-direct-reports'" class="text-center py-12 text-gray-500 dark:text-gray-400">
-      <p class="text-lg font-medium mb-2">No Direct Reports</p>
-      <p>You have no direct reports in the system.</p>
-    </div>
-
-    <!-- Dashboard content -->
     <template v-else>
-      <!-- Include indirect reports toggle -->
-      <label data-tour="indirect-toggle" class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-4 cursor-pointer select-none">
-        <button
-          role="switch"
-          :aria-checked="includeIndirect"
-          @click="toggleIndirectReports"
-          class="relative inline-flex h-5 w-9 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-          :class="includeIndirect ? 'bg-primary-600' : 'bg-gray-200 dark:bg-gray-600'"
+      <!-- Filters -->
+      <div class="flex flex-wrap items-center gap-3 mb-4">
+        <select
+          v-if="orgKeys.length > 1"
+          v-model="selectedOrg"
+          data-testid="org-filter"
+          class="text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
         >
-          <span
-            class="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-            :class="includeIndirect ? 'translate-x-4' : 'translate-x-0'"
-          />
-        </button>
-        Include indirect reports
-      </label>
+          <option value="">All orgs</option>
+          <option v-for="org in orgKeys" :key="org.key" :value="org.key">{{ org.displayName }}</option>
+        </select>
 
-      <!-- Tabs -->
-      <div class="flex space-x-4 border-b border-gray-200 dark:border-gray-700 mb-6">
+        <select
+          v-model="selectedTeam"
+          data-testid="team-filter"
+          class="text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        >
+          <option value="">All teams</option>
+          <option v-for="team in filteredTeamOptions" :key="team.id" :value="team.id">{{ team.name }}</option>
+        </select>
+
+        <select
+          v-if="activeTab === 'people' ? visiblePersonFields.length > 0 : visibleTeamFields.length > 0"
+          v-model="selectedField"
+          data-testid="field-filter"
+          class="text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        >
+          <option value="">All fields</option>
+          <option
+            v-for="field in (activeTab === 'people' ? visiblePersonFields : visibleTeamFields)"
+            :key="field.id"
+            :value="field.id"
+          >Missing: {{ field.label }}</option>
+        </select>
+      </div>
+
+      <!-- Sub-tabs: People / Teams -->
+      <div class="flex space-x-4 border-b border-gray-200 dark:border-gray-700 mb-4">
         <button
           v-for="tab in tabs"
           :key="tab.id"
-          @click="activeTab = tab.id"
-          :data-tour="tab.id === 'teams' ? 'tab-teams' : undefined"
+          @click="switchTab(tab.id)"
           class="pb-2 px-1 text-sm font-medium border-b-2 transition-colors"
           :class="activeTab === tab.id
             ? 'border-primary-600 text-primary-600'
@@ -70,13 +63,13 @@
         </button>
       </div>
 
-      <!-- My Reports tab -->
-      <div v-if="activeTab === 'reports'">
-        <div v-if="directReports.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
-          No direct reports found.
+      <!-- ═══ People tab ═══ -->
+      <div v-if="activeTab === 'people'">
+        <div v-if="filteredPeopleForDisplay.length === 0 && !searchQuery" class="text-center py-8 text-gray-500 dark:text-gray-400">
+          No people found{{ selectedOrg || selectedTeam ? ' matching the selected filters' : '' }}.
         </div>
         <div v-else>
-          <!-- Edit mode controls -->
+          <!-- Edit controls -->
           <div class="flex items-center justify-end gap-3 mb-3">
             <template v-if="bulkEditing">
               <span v-if="pendingChangeCount > 0" class="text-xs text-amber-600 dark:text-amber-400">{{ pendingChangeCount }} unsaved change{{ pendingChangeCount !== 1 ? 's' : '' }}</span>
@@ -84,20 +77,15 @@
                 class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 disabled:opacity-50 transition-colors"
                 :disabled="saving || pendingChangeCount === 0"
                 @click="saveAllChanges"
-              >
-                {{ saving ? 'Saving...' : `Save All (${pendingChangeCount})` }}
-              </button>
+              >{{ saving ? 'Saving...' : `Save All (${pendingChangeCount})` }}</button>
               <button
                 class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 transition-colors"
                 :disabled="saving"
                 @click="cancelBulkEdit"
-              >
-                Cancel
-              </button>
+              >Cancel</button>
             </template>
             <button
               v-else
-              data-tour="edit-all-btn"
               class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 transition-colors flex items-center gap-1.5"
               @click="enterBulkEdit"
             >
@@ -107,7 +95,7 @@
           </div>
 
           <!-- Search -->
-          <div data-tour="search-reports" class="relative mb-3">
+          <div class="relative mb-3">
             <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none" />
             <input
               v-model="searchQuery"
@@ -124,13 +112,13 @@
             </button>
           </div>
 
-          <!-- Field completeness banner -->
+          <!-- Completeness banner -->
           <div
-            v-if="!bannerDismissed && incompleteReports.length > 0"
+            v-if="!bannerDismissed && incompletePeople.length > 0"
             class="flex items-center gap-3 px-4 py-3 mb-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 text-sm"
           >
             <AlertTriangle class="w-4 h-4 flex-shrink-0" />
-            <span>{{ incompleteReports.length }} of {{ visibleReports.length }} {{ visibleReports.length === 1 ? 'person has' : 'people have' }} incomplete fields</span>
+            <span>{{ incompletePeople.length }} of {{ filteredPeopleBeforeSearch.length }} {{ filteredPeopleBeforeSearch.length === 1 ? 'person has' : 'people have' }} incomplete fields</span>
             <button
               @click="showIncompleteOnly = !showIncompleteOnly"
               class="ml-auto text-xs font-medium text-amber-700 dark:text-amber-300 hover:underline"
@@ -140,157 +128,141 @@
             </button>
           </div>
 
-          <div v-if="searchQuery && filteredReports.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
-            No reports match "{{ searchQuery }}"
+          <div v-if="searchQuery && filteredPeopleForDisplay.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
+            No people match "{{ searchQuery }}"
           </div>
 
-          <table v-else class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead class="bg-gray-50 dark:bg-gray-800">
-              <tr>
-                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider" :class="bulkEditing ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'">Name</th>
-                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider" :class="bulkEditing ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'">Title</th>
-                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider" :class="bulkEditing ? 'text-primary-700 dark:text-primary-300 bg-blue-50 dark:bg-blue-900/30' : 'text-gray-500 dark:text-gray-400'">Team(s)</th>
-                <th
-                  v-for="(field, idx) in visiblePersonFields"
-                  :key="field.id"
-                  :data-tour="idx === 0 ? 'field-cell' : undefined"
-                  class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider"
-                  :class="bulkEditing ? 'text-primary-700 dark:text-primary-300 bg-blue-50 dark:bg-blue-900/30' : 'text-gray-500 dark:text-gray-400'"
-                >{{ field.label }}</th>
-              </tr>
-            </thead>
-            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-              <tr
-                v-for="report in filteredReports"
-                :key="report.uid"
-                class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
-              >
-                <td class="px-4 py-3 text-sm whitespace-nowrap" :class="bulkEditing ? 'opacity-50' : ''">
-                  <div class="flex items-center gap-1.5">
-                    <button
-                      @click="navigateToPersonDetail(report.uid)"
-                      class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
-                    >
-                      {{ report.name }}
-                    </button>
-                    <span
-                      v-if="includeIndirect && !directReportUidSet.has(report.uid)"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
-                      title="Indirect report"
-                    >indirect</span>
-                  </div>
-                </td>
-                <td class="px-4 py-3 text-sm whitespace-nowrap" :class="bulkEditing ? 'opacity-50 text-gray-400 dark:text-gray-500' : 'text-gray-600 dark:text-gray-400'">
-                  {{ report.title || '—' }}
-                </td>
-                <td class="px-4 py-3 text-sm" :class="bulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''">
-                  <!-- BULK EDIT MODE -->
-                  <div v-if="bulkEditing" class="min-w-[140px]">
-                    <ConstrainedAutocomplete
-                      :model-value="getBulkTeamValue(report.uid)"
-                      :options="allOrgTeamNames"
-                      :multi-value="true"
-                      @update:model-value="setBulkTeamValue(report.uid, $event)"
-                    />
-                  </div>
-
-                  <!-- SINGLE-CELL EDIT MODE -->
-                  <div v-else-if="editingTeamUid === report.uid" class="relative min-w-[160px]">
-                    <ConstrainedAutocomplete
-                      :model-value="editTeamValue"
-                      :options="allOrgTeamNames"
-                      :multi-value="true"
-                      @update:model-value="editTeamValue = $event"
-                    />
-                    <div class="flex gap-1.5 mt-1">
-                      <button class="px-2 py-0.5 text-xs font-medium text-white bg-primary-600 rounded hover:bg-primary-700 disabled:opacity-50" :disabled="saving" @click="saveTeamEdit(report.uid)">Save</button>
-                      <button class="px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200 dark:hover:bg-gray-600" @click="cancelTeamEdit">Cancel</button>
-                    </div>
-                  </div>
-
-                  <!-- DISPLAY MODE -->
-                  <div v-else class="group flex items-center gap-1.5 cursor-pointer" @click="startTeamEdit(report)">
-                    <div v-if="report.teamIds.length > 0">
-                      <template v-for="(id, idx) in report.teamIds" :key="id">
-                        <span v-if="idx > 0" class="text-gray-400 dark:text-gray-500">, </span>
-                        <button
-                          v-if="teamById[id]"
-                          @click.stop="navigateToTeamDetail(teamById[id])"
-                          class="text-primary-600 dark:text-primary-400 hover:underline"
-                        >{{ teamById[id].name }}</button>
-                        <span v-else class="text-gray-600 dark:text-gray-400">{{ id }}</span>
-                      </template>
-                    </div>
-                    <span v-else class="text-amber-500 dark:text-amber-400">Unassigned</span>
-                    <svg class="h-3 w-3 text-gray-400 dark:text-gray-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                    </svg>
-                  </div>
-                </td>
-                <!-- Field cells -->
-                <td
-                  v-for="field in visiblePersonFields"
-                  :key="field.id"
-                  class="px-4 py-3 text-sm"
-                  :class="bulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''"
+          <div v-else class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead class="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider" :class="bulkEditing ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'">Name</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider" :class="bulkEditing ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'">Title</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider" :class="bulkEditing ? 'text-primary-700 dark:text-primary-300 bg-blue-50 dark:bg-blue-900/30' : 'text-gray-500 dark:text-gray-400'">Team(s)</th>
+                  <th
+                    v-for="field in visiblePersonFields"
+                    :key="field.id"
+                    class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider"
+                    :class="bulkEditing ? 'text-primary-700 dark:text-primary-300 bg-blue-50 dark:bg-blue-900/30' : 'text-gray-500 dark:text-gray-400'"
+                  >{{ field.label }}</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                <tr
+                  v-for="person in filteredPeopleForDisplay"
+                  :key="person.uid"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
                 >
-                  <!-- BULK EDIT MODE -->
-                  <FieldEditCell
-                    v-if="bulkEditing"
-                    :field="field"
-                    :model-value="getBulkValue(report.uid, field)"
-                    :all-people="allPeopleForEditor"
-                    :referenced-people="referencedPeople"
-                    :show-buttons="false"
-                    @update:model-value="setBulkValue(report.uid, field.id, $event)"
-                    @add-person="addToBulkPersonValue(report.uid, field.id, $event)"
-                    @remove-person="removeFromBulkPersonValue(report.uid, field.id, $event)"
-                  />
-
-                  <!-- SINGLE-CELL EDIT MODE -->
-                  <div v-else-if="editingCell.uid === report.uid && editingCell.fieldId === field.id" class="editing-cell relative min-w-[160px]">
+                  <!-- Name -->
+                  <td class="px-4 py-3 text-sm whitespace-nowrap" :class="bulkEditing ? 'opacity-50' : ''">
+                    <button
+                      @click="navigateToPersonDetail(person.uid)"
+                      class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
+                    >{{ person.name }}</button>
+                  </td>
+                  <!-- Title -->
+                  <td class="px-4 py-3 text-sm whitespace-nowrap" :class="bulkEditing ? 'opacity-50 text-gray-400 dark:text-gray-500' : 'text-gray-600 dark:text-gray-400'">
+                    {{ person.title || '—' }}
+                  </td>
+                  <!-- Team(s) -->
+                  <td class="px-4 py-3 text-sm" :class="bulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''">
+                    <!-- BULK EDIT -->
+                    <div v-if="bulkEditing" class="min-w-[140px]">
+                      <ConstrainedAutocomplete
+                        :model-value="getBulkTeamValue(person.uid)"
+                        :options="allTeamNames"
+                        :multi-value="true"
+                        @update:model-value="setBulkTeamValue(person.uid, $event)"
+                      />
+                    </div>
+                    <!-- SINGLE-CELL EDIT -->
+                    <div v-else-if="editingTeamUid === person.uid" class="relative min-w-[160px]">
+                      <ConstrainedAutocomplete
+                        :model-value="editTeamValue"
+                        :options="allTeamNames"
+                        :multi-value="true"
+                        @update:model-value="editTeamValue = $event"
+                      />
+                      <div class="flex gap-1.5 mt-1">
+                        <button class="px-2 py-0.5 text-xs font-medium text-white bg-primary-600 rounded hover:bg-primary-700 disabled:opacity-50" :disabled="saving" @click="saveTeamEdit(person.uid)">Save</button>
+                        <button class="px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200 dark:hover:bg-gray-600" @click="editingTeamUid = null">Cancel</button>
+                      </div>
+                    </div>
+                    <!-- DISPLAY -->
+                    <div v-else class="group flex items-center gap-1.5 cursor-pointer" @click="startTeamEdit(person)">
+                      <div v-if="person.teamIds.length > 0">
+                        <template v-for="(id, idx) in person.teamIds" :key="id">
+                          <span v-if="idx > 0" class="text-gray-400 dark:text-gray-500">, </span>
+                          <button
+                            v-if="teamById[id]"
+                            @click.stop="navigateToTeamDetail(teamById[id])"
+                            class="text-primary-600 dark:text-primary-400 hover:underline"
+                          >{{ teamById[id].name }}</button>
+                          <span v-else class="text-gray-600 dark:text-gray-400">{{ id }}</span>
+                        </template>
+                      </div>
+                      <span v-else class="text-amber-500 dark:text-amber-400">Unassigned</span>
+                      <svg class="h-3 w-3 text-gray-400 dark:text-gray-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                      </svg>
+                    </div>
+                  </td>
+                  <!-- Field cells -->
+                  <td
+                    v-for="field in visiblePersonFields"
+                    :key="field.id"
+                    class="px-4 py-3 text-sm"
+                    :class="bulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''"
+                  >
                     <FieldEditCell
+                      v-if="bulkEditing"
                       :field="field"
-                      :model-value="editValue"
+                      :model-value="getBulkValue(person.uid, field)"
                       :all-people="allPeopleForEditor"
                       :referenced-people="referencedPeople"
-                      :disabled="saving"
-                      @update:model-value="editValue = $event"
-                      @save="saveCell(report.uid, field.id)"
-                      @cancel="cancelEdit"
-                      @add-person="addToEditPersonValue($event)"
-                      @remove-person="removeFromEditPersonValue($event)"
+                      :show-buttons="false"
+                      @update:model-value="setBulkValue(person.uid, field.id, $event)"
+                      @add-person="addToBulkPersonValue(person.uid, field.id, $event)"
+                      @remove-person="removeFromBulkPersonValue(person.uid, field.id, $event)"
                     />
-                  </div>
-
-                  <!-- DISPLAY MODE -->
-                  <div
-                    v-else
-                    class="cursor-pointer"
-                    @click="startCellEdit(report, field)"
-                  >
-                    <FieldDisplayCell
-                      :value="report.customFields?.[field.id]"
-                      :field="field"
-                      :referenced-people="referencedPeople"
-                      :highlight="isFieldEmpty(report.customFields?.[field.id], field)"
-                      @person-click="navigateToPersonDetail($event)"
-                    />
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                    <div v-else-if="editingCell.uid === person.uid && editingCell.fieldId === field.id" class="editing-cell relative min-w-[160px]">
+                      <FieldEditCell
+                        :field="field"
+                        :model-value="editValue"
+                        :all-people="allPeopleForEditor"
+                        :referenced-people="referencedPeople"
+                        :disabled="saving"
+                        @update:model-value="editValue = $event"
+                        @save="saveCell(person.uid, field.id)"
+                        @cancel="cancelEdit"
+                        @add-person="addToEditPersonValue($event)"
+                        @remove-person="removeFromEditPersonValue($event)"
+                      />
+                    </div>
+                    <div v-else class="cursor-pointer" @click="startCellEdit(person, field)">
+                      <FieldDisplayCell
+                        :value="person.customFields?.[field.id]"
+                        :field="field"
+                        :referenced-people="referencedPeople"
+                        :highlight="isFieldEmpty(person.customFields?.[field.id], field)"
+                        @person-click="navigateToPersonDetail($event)"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
 
-      <!-- My Teams tab -->
+      <!-- ═══ Teams tab ═══ -->
       <div v-if="activeTab === 'teams'">
-        <div v-if="teams.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
-          None of your direct reports are assigned to a team.
+        <div v-if="filteredTeamsForDisplay.length === 0 && !teamSearchQuery" class="text-center py-8 text-gray-500 dark:text-gray-400">
+          No teams found{{ selectedOrg ? ' matching the selected filters' : '' }}.
         </div>
         <div v-else>
-          <!-- Edit mode controls -->
+          <!-- Edit controls -->
           <div class="flex items-center justify-end gap-3 mb-3">
             <template v-if="teamBulkEditing">
               <span v-if="teamPendingChangeCount > 0" class="text-xs text-amber-600 dark:text-amber-400">{{ teamPendingChangeCount }} unsaved change{{ teamPendingChangeCount !== 1 ? 's' : '' }}</span>
@@ -298,16 +270,12 @@
                 class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 disabled:opacity-50 transition-colors"
                 :disabled="saving || teamPendingChangeCount === 0"
                 @click="saveAllTeamChanges"
-              >
-                {{ saving ? 'Saving...' : `Save All (${teamPendingChangeCount})` }}
-              </button>
+              >{{ saving ? 'Saving...' : `Save All (${teamPendingChangeCount})` }}</button>
               <button
                 class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 transition-colors"
                 :disabled="saving"
                 @click="cancelTeamBulkEdit"
-              >
-                Cancel
-              </button>
+              >Cancel</button>
             </template>
             <button
               v-else
@@ -337,13 +305,13 @@
             </button>
           </div>
 
-          <!-- Field completeness banner -->
+          <!-- Team completeness banner -->
           <div
             v-if="!teamBannerDismissed && incompleteTeams.length > 0"
             class="flex items-center gap-3 px-4 py-3 mb-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 text-sm"
           >
             <AlertTriangle class="w-4 h-4 flex-shrink-0" />
-            <span>{{ incompleteTeams.length }} of {{ teams.length }} {{ teams.length === 1 ? 'team has' : 'teams have' }} incomplete fields</span>
+            <span>{{ incompleteTeams.length }} of {{ filteredTeamsBeforeSearch.length }} {{ filteredTeamsBeforeSearch.length === 1 ? 'team has' : 'teams have' }} incomplete fields</span>
             <button
               @click="showIncompleteTeamsOnly = !showIncompleteTeamsOnly"
               class="ml-auto text-xs font-medium text-amber-700 dark:text-amber-300 hover:underline"
@@ -353,11 +321,11 @@
             </button>
           </div>
 
-          <div v-if="teamSearchQuery && filteredTeams.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
+          <div v-if="teamSearchQuery && filteredTeamsForDisplay.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
             No teams match "{{ teamSearchQuery }}"
           </div>
 
-          <div v-else data-tour="team-fields-table" class="overflow-x-auto">
+          <div v-else class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
               <thead class="bg-gray-50 dark:bg-gray-800">
                 <tr>
@@ -373,15 +341,12 @@
               </thead>
               <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 <tr
-                  v-for="(team, idx) in filteredTeams"
+                  v-for="team in filteredTeamsForDisplay"
                   :key="team.id"
                   class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
                 >
-                  <!-- Team name -->
                   <td class="px-4 py-3 text-sm whitespace-nowrap" :class="teamBulkEditing ? 'opacity-50' : ''">
                     <button
-                      :data-tour="idx === 0 ? 'first-team-link' : undefined"
-                      :data-tour-team-key="idx === 0 ? `${team.orgKey}::${team.name}` : undefined"
                       @click="navigateToTeamDetail(team)"
                       class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
                     >{{ team.name }}</button>
@@ -394,7 +359,6 @@
                     class="px-4 py-3 text-sm text-left"
                     :class="teamBulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''"
                   >
-                    <!-- BULK EDIT MODE -->
                     <FieldEditCell
                       v-if="teamBulkEditing"
                       :field="field"
@@ -406,8 +370,6 @@
                       @add-person="addToTeamBulkPersonValue(team.id, field.id, $event)"
                       @remove-person="removeFromTeamBulkPersonValue(team.id, field.id, $event)"
                     />
-
-                    <!-- SINGLE-CELL EDIT MODE -->
                     <div v-else-if="editingTeamCell.teamId === team.id && editingTeamCell.fieldId === field.id" class="editing-cell relative min-w-[160px]">
                       <FieldEditCell
                         :field="field"
@@ -422,13 +384,7 @@
                         @remove-person="editTeamFieldValue = editTeamFieldValue.filter(u => u !== $event)"
                       />
                     </div>
-
-                    <!-- DISPLAY MODE -->
-                    <div
-                      v-else
-                      class="cursor-pointer"
-                      @click="startTeamFieldEdit(team, field)"
-                    >
+                    <div v-else class="cursor-pointer" @click="startTeamFieldEdit(team, field)">
                       <FieldDisplayCell
                         :value="team.metadata?.[field.id]"
                         :field="field"
@@ -473,82 +429,156 @@
       </div>
     </template>
 
-    <!-- Boards edit drawer -->
+    <!-- Boards drawer -->
     <TeamBoardsDrawer
       :team="boardsDrawerTeam"
       :is-open="!!boardsDrawerTeam"
       @close="boardsDrawerTeam = null"
       @saved="refresh()"
     />
-
   </div>
 </template>
 
 <script setup>
-import { ref, computed, reactive, onMounted, onBeforeUnmount, inject, watch } from 'vue'
-import { ExternalLink, Pencil, Search, X, AlertTriangle, CircleQuestionMark } from 'lucide-vue-next'
-import { useManagerDashboard } from '../composables/useManagerDashboard'
+import { ref, computed, reactive, onMounted, inject, watch } from 'vue'
+import { ExternalLink, Pencil, Search, X, AlertTriangle } from 'lucide-vue-next'
+import { useFieldCompleteness } from '../composables/useFieldCompleteness'
 import { useFieldDefinitions } from '@shared/client/composables/useFieldDefinitions'
 import { useTeams } from '@shared/client/composables/useTeams'
 import { useRoster } from '@shared/client/composables/useRoster'
 import { apiRequest } from '@shared/client/services/api'
-import ConstrainedAutocomplete from '../components/ConstrainedAutocomplete.vue'
-import FieldDisplayCell from '../components/FieldDisplayCell.vue'
-import FieldEditCell from '../components/FieldEditCell.vue'
-import TeamBoardsDrawer from '../components/TeamBoardsDrawer.vue'
-import { useManagerTutorial } from '../composables/useManagerTutorial'
+import ConstrainedAutocomplete from './ConstrainedAutocomplete.vue'
+import FieldDisplayCell from './FieldDisplayCell.vue'
+import FieldEditCell from './FieldEditCell.vue'
+import TeamBoardsDrawer from './TeamBoardsDrawer.vue'
 
 const nav = inject('moduleNav', null)
 
-const { directReports, indirectReports, teams, allOrgTeams, allPeople, referencedPeople, fieldDefinitions, loading, error, reason, includeIndirect, load, refresh } = useManagerDashboard()
+const { people, teams, allPeople, referencedPeople, fieldDefinitions, orgKeys, loading, error, load, refresh } = useFieldCompleteness()
 const { updatePersonFields } = useFieldDefinitions()
 const { updateTeamFields } = useTeams()
 const { reloadRoster } = useRoster()
-const { launchTutorial, destroyTour, checkFirstVisit } = useManagerTutorial()
 
-const activeTab = ref('reports')
+// --- Tab state ---
+const activeTab = ref('people')
+
+// --- Filter state ---
+const selectedOrg = ref('')
+const selectedTeam = ref('')
+const selectedField = ref('')
 const searchQuery = ref('')
 const teamSearchQuery = ref('')
 
-// Field completeness filter & banner state
+// --- Completeness filter ---
 const showIncompleteOnly = ref(false)
 const showIncompleteTeamsOnly = ref(false)
 const bannerDismissed = ref(false)
 const teamBannerDismissed = ref(false)
 
-// Single-cell editing state
+// --- People: single-cell editing ---
 const editingCell = ref({ uid: null, fieldId: null })
 const editValue = ref(null)
 const editingTeamUid = ref(null)
 const editTeamValue = ref([])
 const saving = ref(false)
 
-// Bulk editing state
+// --- People: bulk editing ---
 const bulkEditing = ref(false)
-// Stores pending changes: { "uid:fieldId": newValue }
 const bulkChanges = reactive({})
-// Stores pending team changes: { "uid": ["teamName1", "teamName2"] }
 const bulkTeamChanges = reactive({})
 
-// Team tab: single-cell editing state
+// --- Teams: single-cell editing ---
 const editingTeamCell = ref({ teamId: null, fieldId: null })
 const editTeamFieldValue = ref(null)
-
-// Team tab: boards drawer state
 const boardsDrawerTeam = ref(null)
 
-// Team tab: bulk editing state
+// --- Teams: bulk editing ---
 const teamBulkEditing = ref(false)
 const teamBulkChanges = reactive({})
 
-const visibleReports = computed(() =>
-  includeIndirect.value
-    ? [...directReports.value, ...indirectReports.value]
-    : directReports.value
+// --- Computed: field definitions ---
+const visiblePersonFields = computed(() =>
+  (fieldDefinitions.value.person || []).filter(f => !f.deleted && f.visible)
 )
 
-// --- Field completeness ---
+const visibleTeamFields = computed(() =>
+  (fieldDefinitions.value.team || []).filter(f => !f.deleted && f.visible)
+)
 
+// --- Computed: team lookup ---
+const teamById = computed(() => {
+  const map = {}
+  for (const team of teams.value) {
+    map[team.id] = team
+  }
+  return map
+})
+
+const allTeamNames = computed(() =>
+  teams.value.map(t => t.name).sort()
+)
+
+const teamNameToId = computed(() => {
+  const map = {}
+  for (const t of teams.value) map[t.name] = t.id
+  return map
+})
+
+const allPeopleForEditor = computed(() => {
+  const seen = new Set()
+  const result = []
+  for (const p of allPeople.value) {
+    if (!seen.has(p.uid)) {
+      seen.add(p.uid)
+      result.push(p)
+    }
+  }
+  for (const [uid, name] of Object.entries(referencedPeople.value)) {
+    if (!seen.has(uid)) {
+      seen.add(uid)
+      result.push({ uid, name })
+    }
+  }
+  return result
+})
+
+// --- Computed: team filter options (cascade from org) ---
+const filteredTeamOptions = computed(() => {
+  let t = teams.value
+  if (selectedOrg.value) {
+    t = t.filter(team => team.orgKey === selectedOrg.value)
+  }
+  return t
+})
+
+// --- Computed: filtered people ---
+
+// Step 1: apply org/team/field filters (before search)
+const filteredPeopleBeforeSearch = computed(() => {
+  let result = people.value
+
+  if (selectedOrg.value) {
+    const orgTeamIds = new Set(
+      teams.value.filter(t => t.orgKey === selectedOrg.value).map(t => t.id)
+    )
+    result = result.filter(p => p.teamIds?.some(id => orgTeamIds.has(id)))
+  }
+
+  if (selectedTeam.value) {
+    result = result.filter(p => p.teamIds?.includes(selectedTeam.value))
+  }
+
+  if (selectedField.value) {
+    const fieldDef = visiblePersonFields.value.find(f => f.id === selectedField.value)
+    if (fieldDef) {
+      result = result.filter(p => isFieldEmpty(p.customFields?.[selectedField.value], fieldDef))
+    }
+  }
+
+  return result
+})
+
+// Step 2: incompleteness computation (on filtered set)
 function isFieldEmpty(value, field) {
   if (value === null || value === undefined || value === '') return true
   if (Array.isArray(value) && value.length === 0) return true
@@ -556,40 +586,25 @@ function isFieldEmpty(value, field) {
   return false
 }
 
-const incompleteReports = computed(() => {
-  return visibleReports.value.filter(report => {
-    return visiblePersonFields.value.some(field =>
-      isFieldEmpty(report.customFields?.[field.id], field)
+const incompletePeople = computed(() =>
+  filteredPeopleBeforeSearch.value.filter(person =>
+    visiblePersonFields.value.some(field =>
+      isFieldEmpty(person.customFields?.[field.id], field)
     )
-  })
-})
-
-const incompleteReportUids = computed(() => new Set(incompleteReports.value.map(r => r.uid)))
-
-const incompleteTeams = computed(() => {
-  return teams.value.filter(team => {
-    if (!team.boards || team.boards.length === 0) return true
-    return visibleTeamFields.value.some(field =>
-      isFieldEmpty(team.metadata?.[field.id], field)
-    )
-  })
-})
-
-const incompleteTeamIds = computed(() => new Set(incompleteTeams.value.map(t => t.id)))
-
-const directReportUidSet = computed(() =>
-  new Set(directReports.value.map(r => r.uid))
+  )
 )
 
-const filteredReports = computed(() => {
-  let result = visibleReports.value
+const incompletePeopleUids = computed(() => new Set(incompletePeople.value.map(p => p.uid)))
+
+// Step 3: search + incomplete filter
+const filteredPeopleForDisplay = computed(() => {
+  let result = filteredPeopleBeforeSearch.value
   const q = searchQuery.value.trim().toLowerCase()
   if (q) {
     result = result.filter(r => {
       if (r.name?.toLowerCase().includes(q)) return true
       if (r.title?.toLowerCase().includes(q)) return true
       if (r.teamIds?.some(id => teamById.value[id]?.name?.toLowerCase().includes(q))) return true
-      // Search custom field values
       for (const field of visiblePersonFields.value) {
         const val = r.customFields?.[field.id]
         if (!val) continue
@@ -606,19 +621,48 @@ const filteredReports = computed(() => {
     })
   }
   if (showIncompleteOnly.value) {
-    result = result.filter(r => incompleteReportUids.value.has(r.uid))
+    result = result.filter(r => incompletePeopleUids.value.has(r.uid))
   }
   return result
 })
 
-const filteredTeams = computed(() => {
+// --- Computed: filtered teams ---
+
+const filteredTeamsBeforeSearch = computed(() => {
   let result = teams.value
+  if (selectedOrg.value) {
+    result = result.filter(t => t.orgKey === selectedOrg.value)
+  }
+  if (selectedTeam.value) {
+    result = result.filter(t => t.id === selectedTeam.value)
+  }
+  if (selectedField.value && activeTab.value === 'teams') {
+    const fieldDef = visibleTeamFields.value.find(f => f.id === selectedField.value)
+    if (fieldDef) {
+      result = result.filter(t => isFieldEmpty(t.metadata?.[selectedField.value], fieldDef))
+    }
+  }
+  return result
+})
+
+const incompleteTeams = computed(() =>
+  filteredTeamsBeforeSearch.value.filter(team => {
+    if (!team.boards || team.boards.length === 0) return true
+    return visibleTeamFields.value.some(field =>
+      isFieldEmpty(team.metadata?.[field.id], field)
+    )
+  })
+)
+
+const incompleteTeamIds = computed(() => new Set(incompleteTeams.value.map(t => t.id)))
+
+const filteredTeamsForDisplay = computed(() => {
+  let result = filteredTeamsBeforeSearch.value
   const q = teamSearchQuery.value.trim().toLowerCase()
   if (q) {
     result = result.filter(t => {
       if (t.name?.toLowerCase().includes(q)) return true
       if (t.orgKey?.toLowerCase().includes(q)) return true
-      // Search team metadata field values
       for (const field of visibleTeamFields.value) {
         const val = t.metadata?.[field.id]
         if (!val) continue
@@ -641,84 +685,31 @@ const filteredTeams = computed(() => {
 })
 
 const teamsHaveMultipleOrgs = computed(() => {
-  const orgs = new Set(filteredTeams.value.map(t => t.orgKey))
+  const orgs = new Set(filteredTeamsForDisplay.value.map(t => t.orgKey))
   return orgs.size > 1
 })
 
+// --- Tabs ---
+
 const tabs = computed(() => [
-  { id: 'reports', label: 'My Reports', count: visibleReports.value.length },
-  { id: 'teams', label: 'My Teams', count: teams.value.length }
+  { id: 'people', label: 'People', count: filteredPeopleBeforeSearch.value.length },
+  { id: 'teams', label: 'Teams', count: filteredTeamsBeforeSearch.value.length }
 ])
 
-const personFieldDefs = computed(() =>
-  (fieldDefinitions.value.person || []).filter(f => !f.deleted)
-)
-
-const visiblePersonFields = computed(() =>
-  personFieldDefs.value.filter(f => f.visible)
-)
-
-const teamFieldDefs = computed(() =>
-  (fieldDefinitions.value.team || []).filter(f => !f.deleted)
-)
-
-const visibleTeamFields = computed(() =>
-  teamFieldDefs.value.filter(f => f.visible)
-)
-
-const teamById = computed(() => {
-  const map = {}
-  for (const team of teams.value) {
-    map[team.id] = team
-  }
-  return map
-})
-
-const allPeopleForEditor = computed(() => {
-  const seen = new Set()
-  const result = []
-  // Use the full registry people list so person-reference fields (e.g. Product Manager) can find anyone
-  for (const p of allPeople.value) {
-    if (!seen.has(p.uid)) {
-      seen.add(p.uid)
-      result.push(p)
-    }
-  }
-  // Include referenced people not already in registry (edge case: inactive person still referenced)
-  for (const [uid, name] of Object.entries(referencedPeople.value)) {
-    if (!seen.has(uid)) {
-      seen.add(uid)
-      result.push({ uid, name })
-    }
-  }
-  return result
-})
-
-async function toggleIndirectReports() {
-  includeIndirect.value = !includeIndirect.value
-  if (bulkEditing.value) cancelBulkEdit()
-  await load()
+function switchTab(tabId) {
+  activeTab.value = tabId
+  showIncompleteOnly.value = false
+  showIncompleteTeamsOnly.value = false
+  bannerDismissed.value = false
+  teamBannerDismissed.value = false
+  selectedField.value = ''
 }
 
-const allOrgTeamNames = computed(() =>
-  allOrgTeams.value.map(t => t.name).sort()
+// --- People: bulk editing ---
+
+const pendingChangeCount = computed(() =>
+  Object.keys(bulkChanges).length + Object.keys(bulkTeamChanges).length
 )
-
-const orgTeamNameToId = computed(() => {
-  const map = {}
-  for (const t of allOrgTeams.value) {
-    map[t.name] = t.id
-  }
-  return map
-})
-
-const pendingChangeCount = computed(() => {
-  const fieldChanges = Object.keys(bulkChanges).length
-  const teamChanges = Object.keys(bulkTeamChanges).length
-  return fieldChanges + teamChanges
-})
-
-// --- Bulk editing ---
 
 function enterBulkEdit() {
   bulkEditing.value = true
@@ -733,14 +724,13 @@ function cancelBulkEdit() {
 }
 
 function bulkKey(uid, fieldId) {
-  return `${uid}:${fieldId}`
+  return `${uid}\0${fieldId}`
 }
 
 function getBulkValue(uid, field) {
   const key = bulkKey(uid, field.id)
   if (key in bulkChanges) return bulkChanges[key]
-  // Return current value from data
-  const raw = visibleReports.value.find(r => r.uid === uid)?.customFields?.[field.id] ?? null
+  const raw = people.value.find(r => r.uid === uid)?.customFields?.[field.id] ?? null
   if (field.type === 'constrained' && field.multiValue) {
     return Array.isArray(raw) ? raw : (raw ? [raw] : [])
   }
@@ -752,9 +742,8 @@ function getBulkValue(uid, field) {
 
 function setBulkValue(uid, fieldId, value) {
   const key = bulkKey(uid, fieldId)
-  // Check if value differs from original
-  const report = visibleReports.value.find(r => r.uid === uid)
-  const original = report?.customFields?.[fieldId] ?? null
+  const person = people.value.find(r => r.uid === uid)
+  const original = person?.customFields?.[fieldId] ?? null
   const field = visiblePersonFields.value.find(f => f.id === fieldId)
 
   let originalNormalized
@@ -766,7 +755,6 @@ function setBulkValue(uid, fieldId, value) {
     originalNormalized = Array.isArray(original) ? (original[0] || '') : (original || '')
   }
 
-  // If value matches original, remove from pending changes
   if (JSON.stringify(value) === JSON.stringify(originalNormalized)) {
     delete bulkChanges[key]
   } else {
@@ -774,10 +762,10 @@ function setBulkValue(uid, fieldId, value) {
   }
 }
 
-// Person field bulk person-reference helpers
 function addToBulkPersonValue(uid, fieldId, personUid) {
   if (!personUid) return
-  const current = [...(Array.isArray(getBulkValue(uid, { id: fieldId, type: 'person-reference-linked', multiValue: true })) ? getBulkValue(uid, { id: fieldId, type: 'person-reference-linked', multiValue: true }) : [])]
+  const field = visiblePersonFields.value.find(f => f.id === fieldId)
+  const current = [...(Array.isArray(getBulkValue(uid, field)) ? getBulkValue(uid, field) : [])]
   if (!current.includes(personUid)) {
     current.push(personUid)
     setBulkValue(uid, fieldId, current)
@@ -790,22 +778,11 @@ function removeFromBulkPersonValue(uid, fieldId, personUid) {
   setBulkValue(uid, fieldId, current.filter(u => u !== personUid))
 }
 
-function addToEditPersonValue(personUid) {
-  if (personUid && Array.isArray(editValue.value) && !editValue.value.includes(personUid)) {
-    editValue.value = [...editValue.value, personUid]
-  }
-}
-
-function removeFromEditPersonValue(personUid) {
-  if (Array.isArray(editValue.value)) {
-    editValue.value = editValue.value.filter(u => u !== personUid)
-  }
-}
-
+// Team assignment helpers
 function teamNamesForUid(uid) {
-  const report = visibleReports.value.find(r => r.uid === uid)
-  if (!report || !report.teamIds) return []
-  return report.teamIds.map(id => teamById.value[id]?.name).filter(Boolean)
+  const person = people.value.find(r => r.uid === uid)
+  if (!person || !person.teamIds) return []
+  return person.teamIds.map(id => teamById.value[id]?.name).filter(Boolean)
 }
 
 function getBulkTeamValue(uid) {
@@ -822,10 +799,10 @@ function setBulkTeamValue(uid, names) {
   }
 }
 
-async function saveTeamChanges(uid, newNames) {
-  const report = directReports.value.find(r => r.uid === uid)
-  const oldIds = report?.teamIds || []
-  const newIds = newNames.map(n => orgTeamNameToId.value[n]).filter(Boolean)
+async function saveTeamMemberChanges(uid, newNames) {
+  const person = people.value.find(r => r.uid === uid)
+  const oldIds = person?.teamIds || []
+  const newIds = newNames.map(n => teamNameToId.value[n]).filter(Boolean)
   const toAdd = newIds.filter(id => !oldIds.includes(id))
   const toRemove = oldIds.filter(id => !newIds.includes(id))
   const ops = [
@@ -846,10 +823,9 @@ async function saveTeamChanges(uid, newNames) {
 async function saveAllChanges() {
   saving.value = true
   try {
-    // Group field changes by uid
     const changesByUid = {}
     for (const [key, value] of Object.entries(bulkChanges)) {
-      const [uid, fieldId] = key.split(':')
+      const [uid, fieldId] = key.split('\0')
       if (!changesByUid[uid]) changesByUid[uid] = {}
       const field = visiblePersonFields.value.find(f => f.id === fieldId)
       let valueToSave = value
@@ -858,13 +834,12 @@ async function saveAllChanges() {
       }
       changesByUid[uid][fieldId] = valueToSave
     }
-    // Save field changes and team changes in parallel
     await Promise.all([
       ...Object.entries(changesByUid).map(([uid, fields]) =>
         updatePersonFields(uid, fields)
       ),
       ...Object.entries(bulkTeamChanges).map(([uid, names]) =>
-        saveTeamChanges(uid, names)
+        saveTeamMemberChanges(uid, names)
       )
     ])
     bulkEditing.value = false
@@ -877,10 +852,10 @@ async function saveAllChanges() {
   }
 }
 
-// --- Single-cell editing ---
+// --- People: single-cell editing ---
 
-function startCellEdit(report, field) {
-  const raw = report.customFields?.[field.id] ?? null
+function startCellEdit(person, field) {
+  const raw = person.customFields?.[field.id] ?? null
   if (field.type === 'constrained' && field.multiValue) {
     editValue.value = Array.isArray(raw) ? [...raw] : (raw ? [raw] : [])
   } else if (field.type === 'person-reference-linked') {
@@ -888,7 +863,7 @@ function startCellEdit(report, field) {
   } else {
     editValue.value = Array.isArray(raw) ? (raw[0] || '') : (raw || '')
   }
-  editingCell.value = { uid: report.uid, fieldId: field.id }
+  editingCell.value = { uid: person.uid, fieldId: field.id }
 }
 
 async function saveCell(uid, fieldId) {
@@ -911,15 +886,27 @@ function cancelEdit() {
   editingCell.value = { uid: null, fieldId: null }
 }
 
-function startTeamEdit(report) {
-  editingTeamUid.value = report.uid
-  editTeamValue.value = [...teamNamesForUid(report.uid)]
+function addToEditPersonValue(personUid) {
+  if (personUid && Array.isArray(editValue.value) && !editValue.value.includes(personUid)) {
+    editValue.value = [...editValue.value, personUid]
+  }
+}
+
+function removeFromEditPersonValue(personUid) {
+  if (Array.isArray(editValue.value)) {
+    editValue.value = editValue.value.filter(u => u !== personUid)
+  }
+}
+
+function startTeamEdit(person) {
+  editingTeamUid.value = person.uid
+  editTeamValue.value = [...teamNamesForUid(person.uid)]
 }
 
 async function saveTeamEdit(uid) {
   saving.value = true
   try {
-    await saveTeamChanges(uid, editTeamValue.value)
+    await saveTeamMemberChanges(uid, editTeamValue.value)
     editingTeamUid.value = null
     reloadRoster()
     refresh()
@@ -928,19 +915,7 @@ async function saveTeamEdit(uid) {
   }
 }
 
-function cancelTeamEdit() {
-  editingTeamUid.value = null
-}
-
-function navigateToPersonDetail(uid) {
-  if (nav) nav.navigateTo('person-detail', { uid })
-}
-
-function navigateToTeamDetail(team) {
-  if (nav) nav.navigateTo('team-detail', { teamKey: `${team.orgKey}::${team.name}` })
-}
-
-// --- Team tab: single-cell editing ---
+// --- Teams: single-cell editing ---
 
 function isMultiValueField(field) {
   return (field.type === 'constrained' && field.multiValue) || field.type === 'person-reference-linked'
@@ -982,25 +957,9 @@ function addToEditTeamFieldValue(uid) {
   }
 }
 
-function addToTeamBulkPersonValue(teamId, fieldId, uid) {
-  if (!uid) return
-  const current = [...getTeamBulkValue(teamId, { id: fieldId, type: 'person-reference-linked' })]
-  if (!current.includes(uid)) {
-    current.push(uid)
-    setTeamBulkValue(teamId, fieldId, current)
-  }
-}
+// --- Teams: bulk editing ---
 
-function removeFromTeamBulkPersonValue(teamId, fieldId, uid) {
-  const current = [...getTeamBulkValue(teamId, { id: fieldId, type: 'person-reference-linked' })]
-  setTeamBulkValue(teamId, fieldId, current.filter(u => u !== uid))
-}
-
-// --- Team tab: bulk editing ---
-
-const teamPendingChangeCount = computed(() => {
-  return Object.keys(teamBulkChanges).length
-})
+const teamPendingChangeCount = computed(() => Object.keys(teamBulkChanges).length)
 
 function enterTeamBulkEdit() {
   teamBulkEditing.value = true
@@ -1013,7 +972,7 @@ function cancelTeamBulkEdit() {
 }
 
 function teamBulkKey(teamId, fieldId) {
-  return `${teamId}:${fieldId}`
+  return `${teamId}\0${fieldId}`
 }
 
 function getTeamBulkValue(teamId, field) {
@@ -1046,14 +1005,26 @@ function setTeamBulkValue(teamId, fieldId, value) {
   }
 }
 
+function addToTeamBulkPersonValue(teamId, fieldId, uid) {
+  if (!uid) return
+  const current = [...getTeamBulkValue(teamId, { id: fieldId, type: 'person-reference-linked' })]
+  if (!current.includes(uid)) {
+    current.push(uid)
+    setTeamBulkValue(teamId, fieldId, current)
+  }
+}
+
+function removeFromTeamBulkPersonValue(teamId, fieldId, uid) {
+  const current = [...getTeamBulkValue(teamId, { id: fieldId, type: 'person-reference-linked' })]
+  setTeamBulkValue(teamId, fieldId, current.filter(u => u !== uid))
+}
 
 async function saveAllTeamChanges() {
   saving.value = true
   try {
-    // Group field changes by teamId
     const changesByTeam = {}
     for (const [key, value] of Object.entries(teamBulkChanges)) {
-      const [teamId, fieldId] = key.split(':')
+      const [teamId, fieldId] = key.split('\0')
       if (!changesByTeam[teamId]) changesByTeam[teamId] = {}
       const field = visibleTeamFields.value.find(f => f.id === fieldId)
       let valueToSave = value
@@ -1077,44 +1048,23 @@ async function saveAllTeamChanges() {
   }
 }
 
-watch(activeTab, () => {
-  showIncompleteOnly.value = false
-  showIncompleteTeamsOnly.value = false
-  bannerDismissed.value = false
-  teamBannerDismissed.value = false
-})
+// --- Navigation ---
 
-watch(bulkEditing, () => {
-  // Cross-tab filter is irrelevant, clear it; same-tab filter is preserved
-  showIncompleteTeamsOnly.value = false
-})
-
-watch(teamBulkEditing, () => {
-  showIncompleteOnly.value = false
-})
-
-function handleLaunchTutorial() {
-  launchTutorial({ onTabClick: (tabId) => { activeTab.value = tabId }, nav })
+function navigateToPersonDetail(uid) {
+  if (nav) nav.navigateTo('person-detail', { uid })
 }
 
-let initialLoadHandled = false
-watch(loading, (isLoading, wasLoading) => {
-  if (!initialLoadHandled && wasLoading && !isLoading && !error.value && !reason.value) {
-    initialLoadHandled = true
-    const opts = { onTabClick: (tabId) => { activeTab.value = tabId }, nav }
-    if (nav?.params.value?.tutorial === '1') {
-      launchTutorial(opts)
-    } else {
-      checkFirstVisit(opts)
-    }
-  }
+function navigateToTeamDetail(team) {
+  if (nav) nav.navigateTo('team-detail', { teamKey: `${team.orgKey}::${team.name}` })
+}
+
+// --- Reset filters on org change ---
+watch(selectedOrg, () => {
+  selectedTeam.value = ''
 })
 
+// --- Lifecycle ---
 onMounted(() => {
   load()
-})
-
-onBeforeUnmount(() => {
-  destroyTour()
 })
 </script>

--- a/modules/team-tracker/client/components/FieldDisplayCell.vue
+++ b/modules/team-tracker/client/components/FieldDisplayCell.vue
@@ -1,0 +1,85 @@
+<template>
+  <div
+    class="group flex items-center gap-1.5"
+    :class="{ 'bg-red-100 dark:bg-red-700/50 rounded px-1': highlight && isEmpty }"
+  >
+    <!-- Person reference linked -->
+    <template v-if="field.type === 'person-reference-linked'">
+      <div class="flex-1 text-left">
+        <template v-for="(uid, i) in normalizedArray" :key="uid">
+          <button
+            class="inline text-left text-primary-600 dark:text-primary-400 hover:underline"
+            @click.stop="$emit('person-click', uid)"
+          >{{ referencedPeople[uid] || uid }}<template v-if="i < normalizedArray.length - 1">,</template></button>{{ ' ' }}
+        </template>
+        <span v-if="normalizedArray.length === 0" class="text-gray-400 dark:text-gray-500">—</span>
+      </div>
+    </template>
+
+    <!-- Constrained multi-value pills -->
+    <template v-else-if="field.type === 'constrained' && field.multiValue">
+      <div class="flex flex-wrap gap-1">
+        <span
+          v-for="v in normalizedArray"
+          :key="v"
+          class="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+        >{{ v }}</span>
+        <span v-if="normalizedArray.length === 0" class="text-gray-400 dark:text-gray-500">—</span>
+      </div>
+    </template>
+
+    <!-- Plain text (free-text, constrained single-value) -->
+    <template v-else>
+      <span class="text-gray-900 dark:text-gray-100">{{ displayValue }}</span>
+    </template>
+
+    <!-- Pencil icon -->
+    <svg
+      v-if="showPencil"
+      class="h-3 w-3 text-gray-400 dark:text-gray-500 flex-shrink-0"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+    </svg>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  value: { type: [String, Array, null, undefined], default: null },
+  field: { type: Object, required: true },
+  referencedPeople: { type: Object, default: () => ({}) },
+  highlight: { type: Boolean, default: false },
+  showPencil: { type: Boolean, default: true }
+})
+
+defineEmits(['person-click'])
+
+function isFieldEmpty(value, field) {
+  if (value === null || value === undefined || value === '') return true
+  if (Array.isArray(value) && value.length === 0) return true
+  if (field.multiValue && Array.isArray(value) && value.every(v => !v)) return true
+  return false
+}
+
+const isEmpty = computed(() => isFieldEmpty(props.value, props.field))
+
+const normalizedArray = computed(() => {
+  const val = props.value
+  if (Array.isArray(val)) return val.filter(v => v)
+  if (val) return [val]
+  return []
+})
+
+const displayValue = computed(() => {
+  const raw = props.value
+  const val = Array.isArray(raw) ? raw[0] : raw
+  return val || '—'
+})
+</script>

--- a/modules/team-tracker/client/components/FieldEditCell.vue
+++ b/modules/team-tracker/client/components/FieldEditCell.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="min-w-[140px]">
+    <!-- Constrained autocomplete -->
+    <ConstrainedAutocomplete
+      v-if="field.type === 'constrained' && field.allowedValues"
+      :model-value="modelValue"
+      :options="field.allowedValues"
+      :multi-value="!!field.multiValue"
+      @update:model-value="$emit('update:modelValue', $event)"
+      @save="$emit('save')"
+      @cancel="$emit('cancel')"
+    />
+
+    <!-- Person reference: multi-value (pill + add) -->
+    <div v-else-if="field.type === 'person-reference-linked' && field.multiValue" class="space-y-1">
+      <div class="flex flex-wrap gap-1">
+        <span
+          v-for="uid in normalizedPersonValues"
+          :key="uid"
+          class="inline-flex items-center px-2 py-0.5 rounded text-xs bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300"
+        >
+          {{ displayName(uid) }}
+          <button class="ml-1 text-primary-500 hover:text-primary-700" @click="$emit('remove-person', uid)">&times;</button>
+        </span>
+      </div>
+      <PersonAutocomplete
+        :model-value="''"
+        :people="filteredPeople"
+        placeholder="Add person..."
+        @update:model-value="$emit('add-person', $event)"
+      />
+    </div>
+
+    <!-- Person reference: single-value -->
+    <PersonAutocomplete
+      v-else-if="field.type === 'person-reference-linked'"
+      :model-value="modelValue"
+      :people="allPeople"
+      @update:model-value="$emit('update:modelValue', $event)"
+      @save="$emit('save')"
+      @cancel="$emit('cancel')"
+    />
+
+    <!-- Plain text input -->
+    <input
+      v-else
+      :value="modelValue"
+      class="w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
+      @input="$emit('update:modelValue', $event.target.value)"
+      @keyup.enter="$emit('save')"
+      @keyup.escape="$emit('cancel')"
+    >
+
+    <!-- Save / Cancel buttons -->
+    <div v-if="showButtons" class="flex gap-1.5 mt-1">
+      <button
+        class="px-2 py-0.5 text-xs font-medium text-white bg-primary-600 rounded hover:bg-primary-700 disabled:opacity-50"
+        :disabled="disabled"
+        @click="$emit('save')"
+      >Save</button>
+      <button
+        class="px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200 dark:hover:bg-gray-600"
+        @click="$emit('cancel')"
+      >Cancel</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import ConstrainedAutocomplete from './ConstrainedAutocomplete.vue'
+import PersonAutocomplete from './PersonAutocomplete.vue'
+
+const props = defineProps({
+  field: { type: Object, required: true },
+  modelValue: { type: [String, Array, null, undefined], default: null },
+  allPeople: { type: Array, default: () => [] },
+  referencedPeople: { type: Object, default: () => ({}) },
+  showButtons: { type: Boolean, default: true },
+  disabled: { type: Boolean, default: false }
+})
+
+defineEmits(['update:modelValue', 'save', 'cancel', 'remove-person', 'add-person'])
+
+const normalizedPersonValues = computed(() => {
+  const val = props.modelValue
+  if (Array.isArray(val)) return val.filter(v => v)
+  if (val) return [val]
+  return []
+})
+
+const filteredPeople = computed(() =>
+  props.allPeople.filter(p => !normalizedPersonValues.value.includes(p.uid))
+)
+
+function displayName(uid) {
+  return props.referencedPeople[uid] || props.allPeople.find(p => p.uid === uid)?.name || uid
+}
+</script>

--- a/modules/team-tracker/client/composables/useFieldCompleteness.js
+++ b/modules/team-tracker/client/composables/useFieldCompleteness.js
@@ -1,0 +1,48 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const people = ref([])
+const teams = ref([])
+const allPeople = ref([])
+const referencedPeople = ref({})
+const fieldDefinitions = ref({ person: [], team: [] })
+const orgKeys = ref([])
+const loading = ref(false)
+const error = ref(null)
+
+export function useFieldCompleteness() {
+  async function load() {
+    loading.value = true
+    error.value = null
+    try {
+      const data = await apiRequest('/modules/team-tracker/admin/field-completeness')
+      people.value = data.people || []
+      teams.value = data.teams || []
+      allPeople.value = data.allPeople || []
+      referencedPeople.value = data.referencedPeople || {}
+      fieldDefinitions.value = data.fieldDefinitions || { person: [], team: [] }
+      orgKeys.value = data.orgKeys || []
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refresh() {
+    return load()
+  }
+
+  return {
+    people,
+    teams,
+    allPeople,
+    referencedPeople,
+    fieldDefinitions,
+    orgKeys,
+    loading,
+    error,
+    load,
+    refresh
+  }
+}

--- a/modules/team-tracker/client/views/ManageView.vue
+++ b/modules/team-tracker/client/views/ManageView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-5xl mx-auto px-4 py-6">
+  <div class="max-w-7xl mx-auto px-4 py-6">
     <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Manage Teams & Fields</h2>
 
     <div v-if="!hasAccess" class="text-center py-12 text-gray-500 dark:text-gray-400">
@@ -24,6 +24,7 @@
       <TeamManagement v-if="activeTab === 'teams'" />
       <FieldDefinitionManager v-if="activeTab === 'fields'" />
       <FieldOptionsManager v-if="activeTab === 'field-options'" />
+      <DataQualityTab v-if="activeTab === 'data-quality'" />
     </template>
   </div>
 </template>
@@ -34,6 +35,7 @@ import { usePermissions } from '@shared/client/composables/usePermissions'
 import TeamManagement from '../components/TeamManagement.vue'
 import FieldDefinitionManager from '../components/FieldDefinitionManager.vue'
 import FieldOptionsManager from '../components/FieldOptionsManager.vue'
+import DataQualityTab from '../components/DataQualityTab.vue'
 
 const { isAdmin, isTeamAdmin, loading } = usePermissions()
 const moduleNav = inject('moduleNav')
@@ -41,10 +43,23 @@ const moduleNav = inject('moduleNav')
 const tabs = [
   { id: 'teams', label: 'Teams' },
   { id: 'fields', label: 'Fields' },
-  { id: 'field-options', label: 'Field Options' }
+  { id: 'field-options', label: 'Field Options' },
+  { id: 'data-quality', label: 'Data Quality' }
 ]
 
-const activeTab = ref('teams')
+// Support deep-linking via ?tab=data-quality
+const tabIds = tabs.map(t => t.id)
+const initialTab = moduleNav?.params?.value?.tab
+const activeTab = ref(tabIds.includes(initialTab) ? initialTab : 'teams')
+
+// Sync active tab to URL so deep links work both ways
+watch(activeTab, (tab) => {
+  if (tab === 'teams') {
+    moduleNav?.updateParams({ tab: null }, { push: false })
+  } else {
+    moduleNav?.updateParams({ tab }, { push: false })
+  }
+})
 
 const hasAccess = computed(() => isAdmin.value || isTeamAdmin.value)
 

--- a/modules/team-tracker/server/field-payload.js
+++ b/modules/team-tracker/server/field-payload.js
@@ -1,0 +1,106 @@
+/**
+ * Shared data assembly logic for building field completeness payloads.
+ * Used by both the manager dashboard and field-completeness endpoints.
+ */
+
+const fieldStore = require('../../../shared/server/field-store');
+
+/**
+ * Build an enriched person object with customFields populated from _appFields.
+ * @param {Object} person - Registry person object
+ * @param {Array} personFieldDefs - Non-deleted person field definitions
+ * @param {Object} [options] - Optional fields to include
+ * @param {boolean} [options.includeManagerUid] - Include managerUid in output
+ * @returns {Object|null}
+ */
+function enrichPerson(person, personFieldDefs, options = {}) {
+  if (!person) return null;
+  const customFields = {};
+  for (const fieldDef of personFieldDefs) {
+    customFields[fieldDef.id] = person._appFields?.[fieldDef.id] || null;
+  }
+  const result = {
+    uid: person.uid,
+    name: person.name || null,
+    email: person.email || null,
+    title: person.title || null,
+    teamIds: person.teamIds || [],
+    customFields
+  };
+  if (options.includeManagerUid) {
+    result.managerUid = person.managerUid || null;
+  }
+  return result;
+}
+
+/**
+ * Read and prepare field definitions with optionsRef resolution.
+ * @param {Object} storage - Storage abstraction
+ * @param {Function} optionsResolver - (refName) => values array
+ * @returns {{ personFieldDefs: Array, teamFieldDefs: Array }}
+ */
+function resolveFieldDefinitions(storage, optionsResolver) {
+  const fieldDefs = fieldStore.readFieldDefinitions(storage);
+  const personFieldDefs = fieldDefs ? fieldDefs.personFields.filter(f => !f.deleted) : [];
+  const teamFieldDefs = fieldDefs ? fieldDefs.teamFields.filter(f => !f.deleted) : [];
+
+  for (const field of [...personFieldDefs, ...teamFieldDefs]) {
+    if (field.optionsRef && !field.allowedValues) {
+      const values = optionsResolver(field.optionsRef);
+      if (values) {
+        field.allowedValues = values;
+        field._resolvedFromOptions = true;
+      }
+    }
+  }
+
+  return { personFieldDefs, teamFieldDefs };
+}
+
+/**
+ * Build a uid->name map for person-reference-linked field values in team metadata.
+ * @param {Array} teams - Array of team objects with metadata
+ * @param {Array} teamFieldDefs - Team field definitions
+ * @param {Object} registryPeople - Registry people map (uid -> person)
+ * @returns {Object} uid -> display name
+ */
+function buildReferencedPeopleMap(teams, teamFieldDefs, registryPeople) {
+  const referencedPeople = {};
+  const personRefFields = teamFieldDefs.filter(f => f.type === 'person-reference-linked');
+  if (personRefFields.length === 0) return referencedPeople;
+
+  for (const team of teams) {
+    for (const field of personRefFields) {
+      const val = team.metadata?.[field.id];
+      const uids = Array.isArray(val) ? val : (val ? [val] : []);
+      for (const uid of uids) {
+        if (uid && !referencedPeople[uid]) {
+          const person = registryPeople[uid];
+          referencedPeople[uid] = person?.name || uid;
+        }
+      }
+    }
+  }
+  return referencedPeople;
+}
+
+/**
+ * Build a slim people list from the full registry for person-reference autocomplete.
+ * @param {Object} registryPeople - Registry people map (uid -> person)
+ * @returns {Array<{uid, name, title}>}
+ */
+function buildAllPeopleList(registryPeople) {
+  const allPeople = [];
+  for (const [uid, person] of Object.entries(registryPeople)) {
+    if (person.status !== 'active') continue;
+    allPeople.push({ uid, name: person.name || uid, title: person.title || '' });
+  }
+  return allPeople;
+}
+
+module.exports = {
+  enrichPerson,
+  resolveFieldDefinitions,
+  buildReferencedPeopleMap,
+  buildAllPeopleList
+};

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -587,65 +587,26 @@ module.exports = function registerRoutes(router, context) {
     }
 
     const teamStore = require('../../../shared/server/team-store');
-    const fieldStore = require('../../../shared/server/field-store');
     const fieldOptionsStore = require('./field-options-store');
+    const { enrichPerson, resolveFieldDefinitions, buildReferencedPeopleMap, buildAllPeopleList } = require('./field-payload');
     const teamsData = teamStore.readTeams(storage);
-    const fieldDefs = fieldStore.readFieldDefinitions(storage);
-    const personFieldDefs = fieldDefs ? fieldDefs.personFields.filter(f => !f.deleted) : [];
-    const teamFieldDefs = fieldDefs ? fieldDefs.teamFields.filter(f => !f.deleted) : [];
-
-    // Resolve optionsRef fields (e.g. Component) so allowedValues are populated
-    for (const field of [...personFieldDefs, ...teamFieldDefs]) {
-      if (field.optionsRef && !field.allowedValues) {
-        const values = fieldOptionsStore.getValues(storage, field.optionsRef);
-        if (values) {
-          field.allowedValues = values;
-          field._resolvedFromOptions = true;
-        }
-      }
-    }
+    const optionsResolver = (ref) => fieldOptionsStore.getValues(storage, ref);
+    const { personFieldDefs, teamFieldDefs } = resolveFieldDefinitions(storage, optionsResolver);
 
     const includeIndirect = req.query?.includeIndirect === 'true';
     const purview = getManagerPurview(req.userUid, registry, teamsData, { includeIndirect });
 
     // Build enriched direct reports with customFields
-    const directReports = purview.directReportUids.map(uid => {
-      const person = registry.people[uid];
-      if (!person) return null;
-      const customFields = {};
-      for (const fieldDef of personFieldDefs) {
-        customFields[fieldDef.id] = person._appFields?.[fieldDef.id] || null;
-      }
-      return {
-        uid: person.uid,
-        name: person.name || null,
-        email: person.email || null,
-        title: person.title || null,
-        teamIds: person.teamIds || [],
-        customFields
-      };
-    }).filter(Boolean);
+    const directReports = purview.directReportUids
+      .map(uid => enrichPerson(registry.people[uid], personFieldDefs))
+      .filter(Boolean);
 
     // Build enriched indirect reports when requested
     let indirectReports;
     if (includeIndirect && purview.indirectReportUids) {
-      indirectReports = purview.indirectReportUids.map(uid => {
-        const person = registry.people[uid];
-        if (!person) return null;
-        const customFields = {};
-        for (const fieldDef of personFieldDefs) {
-          customFields[fieldDef.id] = person._appFields?.[fieldDef.id] || null;
-        }
-        return {
-          uid: person.uid,
-          name: person.name || null,
-          email: person.email || null,
-          title: person.title || null,
-          teamIds: person.teamIds || [],
-          managerUid: person.managerUid || null,
-          customFields
-        };
-      }).filter(Boolean);
+      indirectReports = purview.indirectReportUids
+        .map(uid => enrichPerson(registry.people[uid], personFieldDefs, { includeManagerUid: true }))
+        .filter(Boolean);
     }
 
     // Collect distinct orgRoot values from direct reports to determine available teams
@@ -666,30 +627,8 @@ module.exports = function registerRoutes(router, context) {
           .map(t => ({ id: t.id, name: t.name, orgKey: t.orgKey }))
       : [];
 
-    // Build a uid->name map for person-reference-linked values in team metadata
-    const referencedPeople = {};
-    const personRefTeamFields = teamFieldDefs.filter(f => f.type === 'person-reference-linked');
-    if (personRefTeamFields.length > 0) {
-      for (const team of purview.teams) {
-        for (const field of personRefTeamFields) {
-          const val = team.metadata[field.id];
-          const uids = Array.isArray(val) ? val : (val ? [val] : []);
-          for (const uid of uids) {
-            if (uid && !referencedPeople[uid]) {
-              const person = registry.people[uid];
-              referencedPeople[uid] = person?.name || uid;
-            }
-          }
-        }
-      }
-    }
-
-    // Build slim people list from full registry for person-reference autocomplete
-    const allPeople = [];
-    for (const [uid, person] of Object.entries(registry.people)) {
-      if (person.status !== 'active') continue;
-      allPeople.push({ uid, name: person.name || uid, title: person.title || '' });
-    }
+    const referencedPeople = buildReferencedPeopleMap(purview.teams, teamFieldDefs, registry.people);
+    const allPeople = buildAllPeopleList(registry.people);
 
     // Enrich teams with org display names
     const orgDisplayNames = getOrgDisplayNames();
@@ -715,6 +654,90 @@ module.exports = function registerRoutes(router, context) {
     };
     if (includeIndirect) response.indirectReports = indirectReports || [];
     res.json(response);
+  });
+
+  // ─── Admin: Field Completeness (Data Quality) ───
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/admin/field-completeness:
+   *   get:
+   *     tags: ['TT: Admin']
+   *     summary: Get all people and teams with field data for completeness auditing
+   *     responses:
+   *       200:
+   *         description: All people/teams with field definitions and values
+   *       403:
+   *         description: Not a team-admin or admin
+   */
+  router.get('/admin/field-completeness', requireScope('roster:read'), function(req, res) {
+    if (req.permissionTier !== 'admin' && req.permissionTier !== 'team-admin') {
+      return res.status(403).json({ error: 'Requires team-admin or admin role' });
+    }
+
+    const teamStoreLocal = require('../../../shared/server/team-store');
+    const fieldOptionsStoreLocal = require('./field-options-store');
+    const { enrichPerson, resolveFieldDefinitions: resolveFieldDefs, buildReferencedPeopleMap, buildAllPeopleList } = require('./field-payload');
+
+    const registry = readFromStorage('team-data/registry.json');
+    if (!registry || !registry.people) {
+      return res.json({
+        people: [],
+        teams: [],
+        allPeople: [],
+        referencedPeople: {},
+        fieldDefinitions: { person: [], team: [] },
+        orgKeys: []
+      });
+    }
+
+    const teamsData = teamStoreLocal.readTeams(storage);
+    const localOptionsResolver = (ref) => fieldOptionsStoreLocal.getValues(storage, ref);
+    const { personFieldDefs, teamFieldDefs } = resolveFieldDefs(storage, localOptionsResolver);
+
+    // Build enriched people list (active engineering people only — excludes auxiliary)
+    const people = Object.values(registry.people)
+      .filter(p => p.status === 'active' && p.orgType !== 'auxiliary')
+      .map(p => enrichPerson(p, personFieldDefs))
+      .filter(Boolean);
+
+    // Build teams list with metadata
+    const orgDisplayNames = getOrgDisplayNames();
+    const teams = teamsData && teamsData.teams
+      ? Object.values(teamsData.teams).map(t => ({
+          id: t.id,
+          name: t.name,
+          orgKey: t.orgKey,
+          orgDisplayName: orgDisplayNames[t.orgKey] || t.orgKey,
+          metadata: t.metadata || {},
+          boards: t.boards || []
+        }))
+      : [];
+
+    const referencedPeople = buildReferencedPeopleMap(teams, teamFieldDefs, registry.people);
+    const allPeople = buildAllPeopleList(registry.people);
+
+    // Build org keys list
+    const orgKeySet = new Set();
+    for (const team of teams) {
+      if (team.orgKey) orgKeySet.add(team.orgKey);
+    }
+    const orgKeys = [...orgKeySet].map(key => ({
+      key,
+      displayName: orgDisplayNames[key] || key
+    }));
+
+    res.json({
+      people,
+      teams,
+      allPeople,
+      referencedPeople,
+      fieldDefinitions: {
+        person: personFieldDefs,
+        team: teamFieldDefs
+      },
+      orgKeys
+    });
   });
 
   // ─── Routes: Team Structure Management ───
@@ -4080,13 +4103,19 @@ module.exports = function registerRoutes(router, context) {
       const subject = parts.join(' and ');
       const verb = (incompletePersonCount + incompleteTeamCount) === 1 ? 'has' : 'have';
 
+      // Link admins/team-admins to data quality tab; managers to their dashboard
+      const isAdminLike = user.permissionTier === 'admin' || user.permissionTier === 'team-admin';
+      const href = isAdminLike
+        ? '#/team-tracker/manage?tab=data-quality'
+        : '#/team-tracker/manager-dashboard';
+
       return [{
         id: 'team-tracker:field-completeness',
         type: 'warning',
         text: `${subject} ${verb} incomplete fields.`,
         link: {
           label: 'Review',
-          href: '#/team-tracker/manager-dashboard'
+          href
         }
       }];
     });


### PR DESCRIPTION
## Summary

- Adds a **Data Quality** tab on the Manage page (admin/team-admin) showing all people and teams with missing or incomplete fields
- Supports filtering by org, team, and specific missing field, with completeness banners and show-incomplete-only toggle
- Supports inline single-cell editing, bulk editing, and team assignment — same UX as the existing manager dashboard
- Extracts reusable `FieldDisplayCell` and `FieldEditCell` components, refactoring `ManagerDashboardView` to use them (removes ~100 lines of duplicated template code)
- Extracts shared `field-payload.js` server utilities used by both the manager dashboard and the new endpoint
- New backend endpoint: `GET /api/modules/team-tracker/admin/field-completeness` (requires team-admin or admin)
- Missing-fields message provider now deep-links admins/team-admins to the Data Quality tab

## New files

| File | Purpose |
|------|---------|
| `server/field-payload.js` | Shared enrichPerson, resolveFieldDefinitions, buildReferencedPeopleMap, buildAllPeopleList |
| `client/components/FieldDisplayCell.vue` | Reusable field value display (all field types, highlight, pencil icon) |
| `client/components/FieldEditCell.vue` | Reusable field editor (free-text, constrained, person-reference) |
| `client/components/DataQualityTab.vue` | Main Data Quality tab component |
| `client/composables/useFieldCompleteness.js` | Data fetching composable for field-completeness endpoint |

## Test plan

- [x] 71 new unit tests across 5 test files (all passing)
- [x] Existing ManagerDashboardView tests updated and passing (19 tests)
- [x] Full test suite passes (3020 tests)
- [x] Lint clean
- [ ] Manual: navigate to Manage → Data Quality tab as admin
- [ ] Manual: verify org/team/field filters work correctly
- [ ] Manual: verify inline editing and bulk editing
- [ ] Manual: verify completeness banner counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)