### PR TITLE
fix(ai-impact): use shared storage abstraction for atomic writes

### DIFF
--- a/modules/ai-impact/__tests__/server/assessment-routes.test.js
+++ b/modules/ai-impact/__tests__/server/assessment-routes.test.js
@@ -26,7 +26,8 @@ function makeValidBody() {
 function makeContext(storageData = null) {
   return {
     storage: {
-      readFromStorage: vi.fn().mockReturnValue(storageData)
+      readFromStorage: vi.fn().mockReturnValue(storageData),
+      writeToStorageAtomic: vi.fn()
     },
     requireAdmin: (req, res, next) => next(),
     requireScope: () => (req, res, next) => next()

--- a/modules/ai-impact/__tests__/server/feature-routes.test.js
+++ b/modules/ai-impact/__tests__/server/feature-routes.test.js
@@ -30,7 +30,8 @@ function makeValidBody() {
 function makeContext(storageData = null) {
   return {
     storage: {
-      readFromStorage: vi.fn().mockReturnValue(storageData)
+      readFromStorage: vi.fn().mockReturnValue(storageData),
+      writeToStorageAtomic: vi.fn()
     },
     requireAdmin: (req, res, next) => next(),
     requireScope: () => (req, res, next) => next()

--- a/modules/ai-impact/__tests__/server/test-plan-routes.test.js
+++ b/modules/ai-impact/__tests__/server/test-plan-routes.test.js
@@ -29,7 +29,8 @@ function makeValidBody() {
 function makeContext(storageData = null) {
   return {
     storage: {
-      readFromStorage: vi.fn().mockReturnValue(storageData)
+      readFromStorage: vi.fn().mockReturnValue(storageData),
+      writeToStorageAtomic: vi.fn()
     },
     requireAdmin: (req, res, next) => next(),
     requireScope: () => (req, res, next) => next()

--- a/modules/ai-impact/server/assessments/routes.js
+++ b/modules/ai-impact/server/assessments/routes.js
@@ -28,7 +28,7 @@ const BULK_CAP = 5000;
  */
 module.exports = function registerAssessmentRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage } = storage;
+  const { readFromStorage, writeToStorageAtomic } = storage;
 
   // ─── 1. Static routes FIRST ───
 
@@ -79,7 +79,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
     data.lastSyncedAt = new Date().toISOString();
     data.totalAssessed = Object.keys(data.assessments).length;
 
-    writeAssessmentsAtomic(data);
+    writeAssessmentsAtomic(writeToStorageAtomic, data);
 
     res.json({
       created: counts.created,
@@ -95,7 +95,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }
 
-    writeAssessmentsAtomic({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
+    writeAssessmentsAtomic(writeToStorageAtomic, { lastSyncedAt: null, totalAssessed: 0, assessments: {} });
     res.json({ status: 'cleared' });
   });
 
@@ -137,7 +137,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
     data.lastSyncedAt = new Date().toISOString();
     data.totalAssessed = Object.keys(data.assessments).length;
 
-    writeAssessmentsAtomic(data);
+    writeAssessmentsAtomic(writeToStorageAtomic, data);
     res.json({ status });
   });
 };

--- a/modules/ai-impact/server/assessments/storage.js
+++ b/modules/ai-impact/server/assessments/storage.js
@@ -1,11 +1,5 @@
-const fs = require('fs');
-const path = require('path');
-
 const STORAGE_KEY = 'ai-impact/assessments.json';
 const MAX_HISTORY = 20;
-
-// Resolve DATA_DIR the same way shared/server/storage.js does
-const DATA_DIR = path.join(__dirname, '..', '..', '..', '..', 'data');
 
 /**
  * Read assessments from storage with null/malformed data guard.
@@ -21,19 +15,12 @@ function readAssessments(readFromStorage) {
 }
 
 /**
- * Atomic write: write to temp file then rename.
- * Bypasses writeToStorage to avoid non-atomic writeFileSync.
+ * Atomic write via the shared storage abstraction.
+ * @param {Function} writeToStorageAtomic - The storage atomic write function
  * @param {object} data - The assessments data object to write
  */
-function writeAssessmentsAtomic(data) {
-  const filePath = path.resolve(DATA_DIR, STORAGE_KEY);
-  const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  const tmpPath = filePath + '.tmp.' + process.pid;
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-  fs.renameSync(tmpPath, filePath);
+function writeAssessmentsAtomic(writeToStorageAtomic, data) {
+  writeToStorageAtomic(STORAGE_KEY, data);
 }
 
 /**

--- a/modules/ai-impact/server/component-onboarding/routes.js
+++ b/modules/ai-impact/server/component-onboarding/routes.js
@@ -18,7 +18,7 @@ const BULK_CAP = 5000;
  */
 module.exports = function registerComponentOnboardingRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage } = storage;
+  const { readFromStorage, writeToStorageAtomic } = storage;
 
   // ─── Static routes first ───
 
@@ -89,7 +89,7 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
     data.fetchedAt = new Date().toISOString();
     data.totalComponents = Object.keys(data.components).length;
 
-    writeComponentOnboardingAtomic(data);
+    writeComponentOnboardingAtomic(writeToStorageAtomic, data);
 
     res.json({
       created: counts.created,
@@ -114,7 +114,7 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Component onboarding ingest disabled in demo mode' });
     }
-    writeComponentOnboardingAtomic({ fetchedAt: null, totalComponents: 0, components: {} });
+    writeComponentOnboardingAtomic(writeToStorageAtomic, { fetchedAt: null, totalComponents: 0, components: {} });
     res.json({ status: 'cleared' });
   });
 

--- a/modules/ai-impact/server/component-onboarding/storage.js
+++ b/modules/ai-impact/server/component-onboarding/storage.js
@@ -1,10 +1,5 @@
-const fs = require('fs');
-const path = require('path');
-
 const STORAGE_KEY = 'ai-impact/component-onboarding-data.json';
 const MAX_HISTORY = 20;
-
-const DATA_DIR = path.join(__dirname, '..', '..', '..', '..', 'data');
 
 function readComponentOnboarding(readFromStorage) {
   const data = readFromStorage(STORAGE_KEY);
@@ -14,15 +9,8 @@ function readComponentOnboarding(readFromStorage) {
   return data;
 }
 
-function writeComponentOnboardingAtomic(data) {
-  const filePath = path.resolve(DATA_DIR, STORAGE_KEY);
-  const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  const tmpPath = filePath + '.tmp.' + process.pid;
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-  fs.renameSync(tmpPath, filePath);
+function writeComponentOnboardingAtomic(writeToStorageAtomic, data) {
+  writeToStorageAtomic(STORAGE_KEY, data);
 }
 
 function trimForHistory(component) {

--- a/modules/ai-impact/server/features/jira-sync.js
+++ b/modules/ai-impact/server/features/jira-sync.js
@@ -31,11 +31,11 @@ function releaseLock() {
  * @param {Function} readFromStorage
  * @returns {Promise<{synced: number, updated: number, statusChanged: number, notFound: number, errors: string[]}>}
  */
-async function syncFeaturesFromJira(readFromStorage) {
+async function syncFeaturesFromJira(readFromStorage, writeToStorageAtomic) {
   const data = readFeatures(readFromStorage);
   const result = await syncFeatureData(data);
   data.lastJiraSyncAt = new Date().toISOString();
-  writeFeaturesAtomic(data);
+  writeFeaturesAtomic(writeToStorageAtomic, data);
   return result;
 }
 

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -27,7 +27,7 @@ const syncState = {
  * Run the Jira sync in the background. Updates syncState.
  * @param {Function} readFromStorage
  */
-async function runSync(readFromStorage) {
+async function runSync(readFromStorage, writeToStorageAtomic) {
   if (syncState.running) return;
   if (!acquireLock()) {
     console.warn('[ai-impact] Feature sync skipped: write lock held');
@@ -38,7 +38,7 @@ async function runSync(readFromStorage) {
   syncState.startedAt = new Date().toISOString();
 
   try {
-    const result = await syncFeaturesFromJira(readFromStorage);
+    const result = await syncFeaturesFromJira(readFromStorage, writeToStorageAtomic);
     syncState.lastResult = {
       status: result.errors.length > 0 ? 'partial' : 'success',
       message: `Synced ${result.synced} features: ${result.updated} updated (${result.statusChanged} review status changes), ${result.notFound} not found in Jira`,
@@ -67,7 +67,7 @@ async function runSync(readFromStorage) {
  */
 module.exports = function registerFeatureRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage } = storage;
+  const { readFromStorage, writeToStorageAtomic } = storage;
 
   // ─── 1. Static routes FIRST ───
 
@@ -97,7 +97,7 @@ module.exports = function registerFeatureRoutes(router, context) {
     }
 
     res.json({ status: 'started' });
-    runSync(readFromStorage);
+    runSync(readFromStorage, writeToStorageAtomic);
   });
 
   // POST /features/bulk (Admin) — bulk upsert features
@@ -137,7 +137,7 @@ module.exports = function registerFeatureRoutes(router, context) {
     data.lastSyncedAt = new Date().toISOString();
     data.totalFeatures = Object.keys(data.features).length;
 
-    writeFeaturesAtomic(data);
+    writeFeaturesAtomic(writeToStorageAtomic, data);
 
     res.json({
       created: counts.created,
@@ -151,7 +151,7 @@ module.exports = function registerFeatureRoutes(router, context) {
     if (counts.created > 0 || counts.updated > 0) {
       setTimeout(() => {
         console.log('[ai-impact] Triggering post-ingest Jira sync');
-        runSync(readFromStorage);
+        runSync(readFromStorage, writeToStorageAtomic);
       }, 10000);
     }
   });
@@ -162,7 +162,7 @@ module.exports = function registerFeatureRoutes(router, context) {
       return res.json({ status: 'skipped', message: 'Feature ingest disabled in demo mode' });
     }
 
-    writeFeaturesAtomic({ lastSyncedAt: null, totalFeatures: 0, features: {} });
+    writeFeaturesAtomic(writeToStorageAtomic, { lastSyncedAt: null, totalFeatures: 0, features: {} });
     res.json({ status: 'cleared' });
   });
 
@@ -204,7 +204,7 @@ module.exports = function registerFeatureRoutes(router, context) {
     data.lastSyncedAt = new Date().toISOString();
     data.totalFeatures = Object.keys(data.features).length;
 
-    writeFeaturesAtomic(data);
+    writeFeaturesAtomic(writeToStorageAtomic, data);
     res.json({ status });
   });
 };

--- a/modules/ai-impact/server/features/storage.js
+++ b/modules/ai-impact/server/features/storage.js
@@ -1,11 +1,5 @@
-const fs = require('fs');
-const path = require('path');
-
 const STORAGE_KEY = 'ai-impact/features.json';
 const MAX_HISTORY = 20;
-
-// Resolve DATA_DIR the same way shared/server/storage.js does
-const DATA_DIR = path.join(__dirname, '..', '..', '..', '..', 'data');
 
 /**
  * Read features from storage with null/malformed data guard.
@@ -21,18 +15,12 @@ function readFeatures(readFromStorage) {
 }
 
 /**
- * Atomic write: write to temp file then rename.
+ * Atomic write via the shared storage abstraction.
+ * @param {Function} writeToStorageAtomic - The storage atomic write function
  * @param {object} data - The features data object to write
  */
-function writeFeaturesAtomic(data) {
-  const filePath = path.resolve(DATA_DIR, STORAGE_KEY);
-  const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  const tmpPath = filePath + '.tmp.' + process.pid;
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-  fs.renameSync(tmpPath, filePath);
+function writeFeaturesAtomic(writeToStorageAtomic, data) {
+  writeToStorageAtomic(STORAGE_KEY, data);
 }
 
 /**

--- a/modules/ai-impact/server/test-plans/jira-sync.js
+++ b/modules/ai-impact/server/test-plans/jira-sync.js
@@ -31,11 +31,11 @@ function releaseLock() {
  * @param {Function} readFromStorage
  * @returns {Promise<{synced: number, updated: number, statusChanged: number, notFound: number, errors: string[]}>}
  */
-async function syncTestPlansFromJira(readFromStorage) {
+async function syncTestPlansFromJira(readFromStorage, writeToStorageAtomic) {
   const data = readTestPlans(readFromStorage);
   const result = await syncTestPlanData(data);
   data.lastJiraSyncAt = new Date().toISOString();
-  writeTestPlansAtomic(data);
+  writeTestPlansAtomic(writeToStorageAtomic, data);
   return result;
 }
 

--- a/modules/ai-impact/server/test-plans/routes.js
+++ b/modules/ai-impact/server/test-plans/routes.js
@@ -26,7 +26,7 @@ const syncState = {
  * Run the Jira sync in the background. Updates syncState.
  * @param {Function} readFromStorage
  */
-async function runSync(readFromStorage) {
+async function runSync(readFromStorage, writeToStorageAtomic) {
   if (syncState.running) return;
   if (!acquireLock()) {
     console.warn('[ai-impact] Test plan sync skipped: write lock held');
@@ -37,7 +37,7 @@ async function runSync(readFromStorage) {
   syncState.startedAt = new Date().toISOString();
 
   try {
-    const result = await syncTestPlansFromJira(readFromStorage);
+    const result = await syncTestPlansFromJira(readFromStorage, writeToStorageAtomic);
     syncState.lastResult = {
       status: result.errors.length > 0 ? 'partial' : 'success',
       message: `Synced ${result.synced} test plans: ${result.updated} updated (${result.statusChanged} review status changes), ${result.notFound} not found in Jira`,
@@ -59,7 +59,7 @@ async function runSync(readFromStorage) {
 
 module.exports = function registerTestPlanRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage } = storage;
+  const { readFromStorage, writeToStorageAtomic } = storage;
 
   // ─── 1. Static routes FIRST ───
 
@@ -118,7 +118,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     }
 
     res.json({ status: 'started' });
-    runSync(readFromStorage);
+    runSync(readFromStorage, writeToStorageAtomic);
   });
 
   /**
@@ -178,7 +178,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     if (counts.created > 0 || counts.updated > 0) {
       data.lastSyncedAt = new Date().toISOString();
       data.totalTestPlans = Object.keys(data.testPlans).length;
-      writeTestPlansAtomic(data);
+      writeTestPlansAtomic(writeToStorageAtomic, data);
     }
 
     res.json({
@@ -193,7 +193,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     if (counts.created > 0 || counts.updated > 0) {
       setTimeout(() => {
         console.log('[ai-impact] Triggering post-ingest test plan Jira sync');
-        runSync(readFromStorage);
+        runSync(readFromStorage, writeToStorageAtomic);
       }, 10000);
     }
   });
@@ -214,7 +214,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
       return res.json({ status: 'skipped', message: 'Test plan ingest disabled in demo mode' });
     }
 
-    writeTestPlansAtomic({ lastSyncedAt: null, totalTestPlans: 0, testPlans: {} });
+    writeTestPlansAtomic(writeToStorageAtomic, { lastSyncedAt: null, totalTestPlans: 0, testPlans: {} });
     res.json({ status: 'cleared' });
   });
 
@@ -306,7 +306,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     data.lastSyncedAt = new Date().toISOString();
     data.totalTestPlans = Object.keys(data.testPlans).length;
 
-    writeTestPlansAtomic(data);
+    writeTestPlansAtomic(writeToStorageAtomic, data);
     res.json({ status });
   });
 };

--- a/modules/ai-impact/server/test-plans/storage.js
+++ b/modules/ai-impact/server/test-plans/storage.js
@@ -1,10 +1,5 @@
-const fs = require('fs');
-const path = require('path');
-
 const STORAGE_KEY = 'ai-impact/test-plans.json';
 const MAX_HISTORY = 20;
-
-const DATA_DIR = path.join(__dirname, '..', '..', '..', '..', 'data');
 
 function readTestPlans(readFromStorage) {
   const data = readFromStorage(STORAGE_KEY);
@@ -14,15 +9,8 @@ function readTestPlans(readFromStorage) {
   return data;
 }
 
-function writeTestPlansAtomic(data) {
-  const filePath = path.resolve(DATA_DIR, STORAGE_KEY);
-  const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  const tmpPath = filePath + '.tmp.' + process.pid;
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-  fs.renameSync(tmpPath, filePath);
+function writeTestPlansAtomic(writeToStorageAtomic, data) {
+  writeToStorageAtomic(STORAGE_KEY, data);
 }
 
 function trimForHistory(testPlan) {

--- a/shared/API.md
+++ b/shared/API.md
@@ -61,8 +61,8 @@ Core team owns `shared/` via CODEOWNERS. Changes require core team review.
 
 | Export | Description |
 |--------|-------------|
-| `storage` | `{ readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory }` — filesystem-backed JSON storage |
-| `demoStorage` | `{ readFromStorage, writeToStorage, listStorageFiles, deleteStorageDirectory }` — fixture-backed read-only storage for demo mode |
+| `storage` | `{ readFromStorage, writeToStorage, writeToStorageAtomic, listStorageFiles, deleteStorageDirectory }` — filesystem-backed JSON storage |
+| `demoStorage` | `{ readFromStorage, writeToStorage, writeToStorageAtomic, listStorageFiles, deleteStorageDirectory }` — fixture-backed read-only storage for demo mode |
 | `createAuthMiddleware(readFromStorage, writeToStorage, options)` | Factory returning `{ authMiddleware, requireAdmin, requireTeamAdmin, requireScope, isAdmin, seedRoles }`. `requireScope(scopeName)` returns Express middleware that enforces the given scope for token-authenticated requests (browser/proxy auth is unrestricted). Options: `{ tokenValidator, roleStore }` |
 | `createRoleStore(readFromStorage, writeToStorage, options?)` | Factory returning role CRUD: `{ getRoles, hasRole, assignRole, revokeRole, listAssignments, getAdminEmails, migrateFromAllowlist, migrateEmailDomains, invalidateCache }`. Options: `{ getAuthDomain }` — function returning the auth email domain string (or null). When set, all email arguments are normalized to this domain before storage/lookup. |
 | `normalizeEmail(email, authDomain)` | Normalize an email's domain to the given auth domain. Returns the email with its domain replaced, or the original if no authDomain. Exported for testing. |

--- a/shared/server/demo-storage.js
+++ b/shared/server/demo-storage.js
@@ -45,6 +45,15 @@ function writeToStorage(key, _data) {
 }
 
 /**
+ * No-op atomic write for demo mode (fixtures are read-only)
+ * @param {string} key - Would-be path
+ * @param {object} _data - Data that would be written
+ */
+function writeToStorageAtomic(key, _data) {
+  console.log(`[Demo Mode] Write ignored: ${key}`);
+}
+
+/**
  * List JSON files in a subdirectory of fixtures
  * @param {string} dir - Subdirectory name (e.g., 'people')
  * @returns {string[]} Array of filenames (without path)
@@ -86,6 +95,7 @@ function deleteFromStorage(key) {
 module.exports = {
   readFromStorage,
   writeToStorage,
+  writeToStorageAtomic,
   listStorageFiles,
   deleteStorageDirectory,
   deleteFromStorage,

--- a/shared/server/storage.js
+++ b/shared/server/storage.js
@@ -67,6 +67,24 @@ function writeToStorage(key, data) {
 }
 
 /**
+ * Atomic write: write to a temp file then rename.
+ * Prevents partial reads if the process crashes mid-write.
+ * @param {string} key - S3-style key
+ * @param {object} data - Data to write
+ */
+function writeToStorageAtomic(key, data) {
+  const filePath = path.resolve(DATA_DIR, key);
+  if (!isPathSafe(filePath)) {
+    console.error(`[storage] Blocked path traversal attempt: ${key}`);
+    return;
+  }
+  ensureDir(filePath);
+  const tmpPath = filePath + '.tmp.' + process.pid;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+/**
  * List JSON files in a subdirectory of storage
  * @param {string} dir - Subdirectory name (e.g., 'people')
  * @returns {string[]} Array of filenames (without path)
@@ -145,6 +163,7 @@ function deleteFromStorage(key) {
 module.exports = {
   readFromStorage,
   writeToStorage,
+  writeToStorageAtomic,
   listStorageFiles,
   deleteStorageDirectory,
   deleteFromStorage,


### PR DESCRIPTION
## Summary

- Adds `writeToStorageAtomic(key, data)` to `shared/server/storage.js` (temp-file + rename with path-traversal safety) and as a no-op in `demo-storage.js`
- Migrates all four ai-impact storage modules (assessments, features, test-plans, component-onboarding) from raw `fs`/`path` to the new shared abstraction
- Removes direct `fs` and `path` dependencies from all ai-impact storage files
- Updates route handlers and jira-sync modules to pass `writeToStorageAtomic` from context
- Updates `shared/API.md` to document the new export

Fixes the hard constraint #2 violation ("always use storage abstractions") introduced in #528 and pre-existing in the other three ai-impact domains. The raw `fs` writes bypassed path-traversal safety checks and broke demo mode compatibility.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — all previously-passing tests pass (20 failures are pre-existing untracked test files)
- [ ] Smoke test in demo mode (writeToStorageAtomic is a no-op, bulk endpoints return skipped)
- [ ] Verify bulk ingest still works in non-demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)