### PR TITLE
fix(ai-impact): remove 12-month lookback on RFE data fetch

### DIFF
--- a/modules/ai-impact/__tests__/server/config.test.js
+++ b/modules/ai-impact/__tests__/server/config.test.js
@@ -41,9 +41,9 @@ describe('saveConfig', () => {
 
   it('rejects non-integer lookbackMonths', () => {
     const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { lookbackMonths: 1.5 })).toThrow('integer between 1 and 120');
-    expect(() => saveConfig(writeToStorage, { lookbackMonths: 0 })).toThrow('integer between 1 and 120');
-    expect(() => saveConfig(writeToStorage, { lookbackMonths: 121 })).toThrow('integer between 1 and 120');
+    expect(() => saveConfig(writeToStorage, { lookbackMonths: 1.5 })).toThrow('integer between 0 and 120');
+    expect(() => saveConfig(writeToStorage, { lookbackMonths: -1 })).toThrow('integer between 0 and 120');
+    expect(() => saveConfig(writeToStorage, { lookbackMonths: 121 })).toThrow('integer between 0 and 120');
   });
 
   it('rejects non-array excludedStatuses', () => {

--- a/modules/ai-impact/server/config.js
+++ b/modules/ai-impact/server/config.js
@@ -6,7 +6,7 @@ const DEFAULT_CONFIG = {
   testExclusionLabel: 'rfe-creator-skill-testing',
   linkTypeName: 'Cloners',
   excludedStatuses: ['Closed'],
-  lookbackMonths: 12,
+  lookbackMonths: 0,
   trendThresholdPp: 2,
   autofixProjects: ['AIPCC', 'RHOAIENG'],
   autofixCreatedAfter: null,
@@ -99,11 +99,11 @@ function saveConfig(writeToStorage, config) {
     merged.docRequiredStatuses = config.docRequiredStatuses;
   }
 
-  // lookbackMonths — must be a positive integer
+  // lookbackMonths — must be a non-negative integer (0 = no lookback limit)
   if (config.lookbackMonths !== undefined) {
     const val = Number(config.lookbackMonths);
-    if (!Number.isInteger(val) || val < 1 || val > 120) {
-      throw new Error('lookbackMonths must be an integer between 1 and 120');
+    if (!Number.isInteger(val) || val < 0 || val > 120) {
+      throw new Error('lookbackMonths must be an integer between 0 and 120');
     }
     merged.lookbackMonths = val;
   }


### PR DESCRIPTION
## Summary
- Removes the default 12-month lookback constraint on RFE data fetching, which was excluding 141 non-Closed RFEs from the review page
- Sets `lookbackMonths` default to `0` (fetch all), while keeping it configurable via admin settings
- Updates validation to accept `0` as a valid value (previously required >= 1)

## Test plan
- [x] Unit tests updated and passing (config validation, rfe-fetcher)
- [ ] Verify RFE Review page loads with the larger dataset after deploy
- [ ] Verify `lookbackMonths` can still be set to a positive value via Settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)