### PR TITLE
fix(ai-impact): rename doc labels to AI Generated

### DIFF
--- a/fixtures/ai-impact/doc-data.json
+++ b/fixtures/ai-impact/doc-data.json
@@ -1,5 +1,12 @@
 {
   "fetchedAt": "2026-05-13T10:00:00Z",
+  "cumulativeStats": {
+    "stratsContributed": 3,
+    "allContributed": 3,
+    "allInvoked": 4,
+    "allResolvedContributed": 0,
+    "stratsResolvedContributed": 0
+  },
   "issues": [
     {
       "key": "RHAISTRAT-2001",

--- a/modules/ai-impact/client/components/DocumentationContent.vue
+++ b/modules/ai-impact/client/components/DocumentationContent.vue
@@ -124,7 +124,7 @@ const coverageChartData = computed(() => ({
       stack: 'coverage'
     },
     {
-      label: 'Contributed',
+      label: 'AI Generated',
       data: trendData.value.map(p => p.contributedCount || 0),
       backgroundColor: 'rgba(16, 185, 129, 0.7)',
       borderColor: '#10b981',
@@ -297,11 +297,11 @@ function mrLabel(url) {
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
             <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
               <a :href="jiraJqlUrl(cumulativeJqls.stratsContributed)" target="_blank" rel="noopener" class="text-2xl font-bold text-indigo-600 dark:text-indigo-400 hover:underline">{{ cumulativeStats.stratsContributed }}</a>
-              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">RHAISTRATs with AI-First doc contributed</div>
+              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">RHAISTRATs with AI Generated docs</div>
             </div>
             <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
               <a :href="jiraJqlUrl(cumulativeJqls.allContributed)" target="_blank" rel="noopener" class="text-2xl font-bold text-indigo-600 dark:text-indigo-400 hover:underline">{{ cumulativeStats.allContributed }}</a>
-              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">Total Jiras with AI-First doc contributed</div>
+              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">Total Jiras with AI Generated docs</div>
             </div>
             <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
               <a :href="jiraJqlUrl(cumulativeJqls.allInvoked)" target="_blank" rel="noopener" class="text-2xl font-bold text-blue-600 dark:text-blue-400 hover:underline">{{ cumulativeStats.allInvoked }}</a>
@@ -309,11 +309,11 @@ function mrLabel(url) {
             </div>
             <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
               <a :href="jiraJqlUrl(cumulativeJqls.allResolvedContributed)" target="_blank" rel="noopener" class="text-2xl font-bold text-green-600 dark:text-green-400 hover:underline">{{ cumulativeStats.allResolvedContributed }}</a>
-              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">Resolved/Closed with AI-First doc contributed</div>
+              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">Resolved/Closed with AI Generated docs</div>
             </div>
             <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
               <a :href="jiraJqlUrl(cumulativeJqls.stratsResolvedContributed)" target="_blank" rel="noopener" class="text-2xl font-bold text-green-600 dark:text-green-400 hover:underline">{{ cumulativeStats.stratsResolvedContributed }}</a>
-              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">RHAISTRATs Resolved/Closed with AI-First doc contributed</div>
+              <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-1">RHAISTRATs Resolved/Closed with AI Generated docs</div>
             </div>
           </div>
         </div>
@@ -411,7 +411,7 @@ function mrLabel(url) {
               </div>
             </div>
             <div class="px-5 py-2.5 border-b border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-500/10 text-xs text-gray-600 dark:text-gray-400">
-              To trigger AI-First documentation, add the label <code class="px-1.5 py-0.5 rounded-md bg-gray-200/80 dark:bg-gray-700/80 text-gray-800 dark:text-gray-200 font-mono text-[11px] border border-gray-300/60 dark:border-gray-600/60">ai1st-doc-start</code> to the Jira issue (preferably RHAISTRAT, but not required).
+              To trigger AI-First documentation, add the label <code class="px-1.5 py-0.5 rounded-md bg-gray-200/80 dark:bg-gray-700/80 text-gray-800 dark:text-gray-200 font-mono text-[11px] border border-gray-300/60 dark:border-gray-600/60">ai1st-doc-start</code> to the Jira issue (preferably RHAISTRAT, but not required). <a href="#/ai-impact/ai-factory-guide?section=documentation" class="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">See AI Factory Guide for more info</a>.
             </div>
             <div class="overflow-x-auto">
               <table class="w-full text-sm">
@@ -420,7 +420,7 @@ function mrLabel(url) {
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Key</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Summary</th>
                     <th class="px-3 py-2 text-center text-gray-500 dark:text-gray-400 font-medium w-20">Status</th>
-                    <th class="px-2 py-2 text-center text-gray-500 dark:text-gray-400 font-medium whitespace-nowrap">AI-First Doc Contributed</th>
+                    <th class="px-2 py-2 text-center text-gray-500 dark:text-gray-400 font-medium whitespace-nowrap">AI Generated</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">CCS Epic</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">MR Link(s)</th>
                   </tr>

--- a/modules/ai-impact/client/views/AIFactoryGuideView.vue
+++ b/modules/ai-impact/client/views/AIFactoryGuideView.vue
@@ -1062,7 +1062,7 @@ function labelColorClasses(color) {
                 <Sparkles :size="16" class="text-teal-600 dark:text-teal-400" />
               </div>
               <div>
-                <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">AI Documentation Generation</div>
+                <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">AI Generation of Documentation</div>
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Pipeline generates documentation and raises an MR against the docs repo. Issue is labeled <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-teal-600 dark:text-teal-400 text-xs rounded font-mono">ai1st-doc-invoked</code></div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Rename "AI-First doc contributed" / "Contributed" labels to "AI Generated" across KPIs, chart legend, and table header in the Documentation view
- Add link to AI Factory Guide (`?section=documentation`) in the table info banner
- Add missing `cumulativeStats` to demo fixture so the KPI row renders in demo mode

## Test plan
- [x] Verify KPI row renders in demo mode (`DEMO_MODE=true`)
- [x] Verify KPI labels say "AI Generated docs" instead of "AI-First doc contributed"
- [x] Verify Graph B green stack legend says "AI Generated"
- [x] Verify table header says "AI Generated"
- [x] Verify "See AI Factory Guide for more info" link navigates correctly

## Test proofs:

<img width="2032" height="1192" alt="Screenshot 2026-05-20 at 07 30 28" src="https://github.com/user-attachments/assets/c6598fc8-9bdb-404e-968d-5ee9d994b8a2" />
<img width="2032" height="1192" alt="Screenshot 2026-05-20 at 07 27 42" src="https://github.com/user-attachments/assets/9501a82e-e2ef-470d-867e-a25829ba6a5c" />
