### PR TITLE
feat(ai-impact): add guide modal to Documentation view

### DIFF
--- a/modules/ai-impact/client/components/AIImpactGuide.vue
+++ b/modules/ai-impact/client/components/AIImpactGuide.vue
@@ -2,6 +2,10 @@
 import { ref, onMounted } from 'vue'
 import AssessmentGuideModal from './AssessmentGuideModal.vue'
 
+const props = defineProps({
+  defaultTab: { type: String, default: null }
+})
+
 const DISMISS_KEY = 'ai-impact-guide-dismissed'
 
 const showGuideModal = ref(false)
@@ -9,6 +13,7 @@ const initialTab = ref(null)
 
 onMounted(() => {
   if (localStorage.getItem(DISMISS_KEY) !== 'true') {
+    initialTab.value = props.defaultTab
     showGuideModal.value = true
   }
 })

--- a/modules/ai-impact/client/views/DocumentationView.vue
+++ b/modules/ai-impact/client/views/DocumentationView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { useDocumentation } from '../composables/useDocumentation.js'
 import DocumentationContent from '../components/DocumentationContent.vue'
+import AIImpactGuide from '../components/AIImpactGuide.vue'
 
 const { docData, loading, error, load } = useDocumentation()
 </script>
@@ -13,5 +14,6 @@ const { docData, loading, error, load } = useDocumentation()
       :docData="docData"
       @retry="load"
     />
+    <AIImpactGuide defaultTab="enablement" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Add `AIImpactGuide` component to the Documentation view so the modal dialog with "don't show again" appears like on other AI Impact pages (RFE, STRAT, Quality, Build)
- Add `defaultTab` prop to `AIImpactGuide` so the modal can open pre-positioned on a specific tab
- Documentation view uses `defaultTab="enablement"` to open on the Enablement tab by default

## Test plan
- [x] Navigate to Documentation page — guide modal should appear on the Enablement tab
- [x] Dismiss with "don't show again" — modal should not reappear on revisit
- [x] Floating help button should still allow manual re-opening
- [x] Verify other views (RFE, STRAT, etc.) are unaffected (no defaultTab, so behavior unchanged)

## Test proofs:

<img width="1292" height="928" alt="image" src="https://github.com/user-attachments/assets/3c535f4b-15f5-43ad-b693-e1479aadb098" />
