### PR TITLE
feat(team-tracker): add snapshot generation button and nightly refresh

### DIFF
--- a/deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml
+++ b/deploy/openshift/overlays/prod/cronjob-sync-refresh.yaml
@@ -183,6 +183,12 @@ spec:
                     echo "WARNING: Feature Jira sync timed out (non-fatal, continuing)"
                   fi
 
+                  # Step 4c: Generate metric snapshots (refresh current month)
+                  echo "=== Generating metric snapshots ==="
+                  curl -sf -X POST "$BACKEND/api/modules/team-tracker/snapshots/generate" \
+                    -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" -H "Content-Type: application/json" \
+                    -d '{"refreshCurrent":true}' || echo "WARNING: Snapshot generation failed (non-fatal)"
+
                   # Step 5: Sync Release Registry with Product Pages
                   echo "=== Syncing Release Registry with Product Pages ==="
                   curl -sf -X POST "$BACKEND/api/modules/releases/registry/discover" \

--- a/modules/team-tracker/client/components/SnapshotSettings.vue
+++ b/modules/team-tracker/client/components/SnapshotSettings.vue
@@ -3,11 +3,18 @@
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
       <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Snapshot Data</h3>
       <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Monthly metric snapshots are generated automatically for each team. Use this to delete all stored snapshots
-        so they can be regenerated with the latest data.
+        Monthly metric snapshots capture a point-in-time record of team and individual delivery metrics.
+        Snapshots for completed months are immutable; the current month's snapshot is refreshed with the latest data.
       </p>
 
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-3 flex-wrap">
+        <button
+          @click="handleGenerate"
+          :disabled="generating"
+          class="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {{ generating ? 'Generating...' : 'Generate Snapshots' }}
+        </button>
         <button
           @click="handleDelete"
           :disabled="deleting"
@@ -25,11 +32,37 @@
 
 <script setup>
 import { ref } from 'vue'
-import { deleteAllSnapshots } from '@shared/client/services/api'
+import { generateSnapshots, deleteAllSnapshots } from '@shared/client/services/api'
 
+const generating = ref(false)
 const deleting = ref(false)
 const message = ref(null)
 const isError = ref(false)
+
+function clearMessage() {
+  setTimeout(() => { message.value = null }, 5000)
+}
+
+async function handleGenerate() {
+  generating.value = true
+  message.value = null
+  isError.value = false
+
+  try {
+    const result = await generateSnapshots({ refreshCurrent: true })
+    const parts = []
+    if (result.generated > 0) parts.push(`${result.generated} generated`)
+    if (result.refreshed > 0) parts.push(`${result.refreshed} refreshed`)
+    if (result.skipped > 0) parts.push(`${result.skipped} skipped`)
+    message.value = parts.length > 0 ? `Snapshots: ${parts.join(', ')}.` : 'No snapshot periods available.'
+    clearMessage()
+  } catch (err) {
+    message.value = err.message
+    isError.value = true
+  } finally {
+    generating.value = false
+  }
+}
 
 async function handleDelete() {
   if (!confirm('Are you sure you want to delete all snapshots? They will be regenerated on the next view or scheduled sync.')) {
@@ -43,7 +76,7 @@ async function handleDelete() {
   try {
     const result = await deleteAllSnapshots()
     message.value = `Deleted ${result.deleted} snapshot file${result.deleted === 1 ? '' : 's'}.`
-    setTimeout(() => { message.value = null }, 5000)
+    clearMessage()
   } catch (err) {
     message.value = err.message
     isError.value = true

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -3799,6 +3799,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.post('/snapshots/generate', requireAdmin, requireScope('team-tracker:write'), function(req, res) {
     try {
+      const refreshCurrent = req.body?.refreshCurrent === true;
       const roster = deriveRoster();
       const completedPeriods = snapshots.getCompletedPeriods();
       const currentPeriod = snapshots.getCurrentPeriod();
@@ -3813,6 +3814,7 @@ module.exports = function registerRoutes(router, context) {
 
       let generated = 0;
       let skipped = 0;
+      let refreshed = 0;
 
       for (const org of roster.orgs) {
         for (const [teamName, team] of Object.entries(org.teams)) {
@@ -3820,7 +3822,13 @@ module.exports = function registerRoutes(router, context) {
           for (const period of periodsToSnapshot) {
             const path = snapshots.snapshotPath(teamKey, period.end);
             const existing = readFromStorage(path);
-            if (existing) {
+
+            // Regenerate current period snapshot when refreshCurrent is set
+            if (existing && refreshCurrent && currentPeriod && period.monthKey === currentPeriod.monthKey) {
+              const snapshot = snapshots.generateSnapshot(storage, teamKey, team, period);
+              writeToStorage(path, snapshot);
+              refreshed++;
+            } else if (existing) {
               skipped++;
             } else {
               snapshots.generateAndStoreSnapshot(storage, teamKey, team, period);
@@ -3830,7 +3838,7 @@ module.exports = function registerRoutes(router, context) {
         }
       }
 
-      res.json({ status: 'complete', generated, skipped });
+      res.json({ status: 'complete', generated, skipped, refreshed });
     } catch (error) {
       console.error('Generate snapshots error:', error);
       res.status(500).json({ error: error.message });

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -3791,6 +3791,14 @@ module.exports = function registerRoutes(router, context) {
    *   post:
    *     tags: ['TT: Snapshots']
    *     summary: Generate snapshots for all teams
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               refreshCurrent:
+   *                 type: boolean
    *     responses:
    *       200:
    *         description: Snapshot generation result

--- a/shared/client/services/api.js
+++ b/shared/client/services/api.js
@@ -326,10 +326,11 @@ export async function getPersonSnapshots(teamKey, personName) {
   return apiRequest(`/modules/team-tracker/snapshots/${encodeURIComponent(teamKey)}/${encodeURIComponent(personName)}`)
 }
 
-export async function generateSnapshots() {
+export async function generateSnapshots(options = {}) {
   return apiRequest('/modules/team-tracker/snapshots/generate', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' }
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(options)
   })
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Generate Snapshots** button to the admin Snapshot Settings UI, calling the existing `POST /snapshots/generate` endpoint
- Adds a `refreshCurrent` body parameter to the generate endpoint — when true, regenerates the current month's snapshot with latest metrics (completed months are never overwritten)
- Adds snapshot generation as a step in the nightly cronjob, after metrics refresh completes

## Test plan

- [ ] Verify "Generate Snapshots" button appears in Settings > Snapshots
- [ ] Click the button and confirm it reports generated/refreshed/skipped counts
- [ ] Confirm completed-month snapshots are not overwritten on subsequent runs
- [ ] Confirm current-month snapshot is refreshed when `refreshCurrent: true`
- [ ] Review cronjob YAML — snapshot step runs after allocation refresh, before registry sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)