### PR TITLE
feat(team-tracker): add field exceptions system

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -250,6 +250,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/registry/people/search/ldap` — LDAP search (rate-limited)
 - `/api/modules/team-tracker/field-options` — list field option sets
 - `/api/modules/team-tracker/field-options/:name` — single option set
+- `/api/modules/team-tracker/field-exceptions` — list field exceptions with optional filters (roster:read)
 - `/api/modules/team-tracker/snapshots/:teamKey` — team snapshots
 - `/api/modules/team-tracker/snapshots/:teamKey/:personName` — person snapshots
 - `/api/modules/team-tracker/components` — component list (deprecated alias)
@@ -353,6 +354,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/structure/migrate` — Sheets-to-in-app migration (admin)
 - `/api/modules/team-tracker/structure/migrate/field-to-options` — field-to-options migration (team-admin)
 - `/api/modules/team-tracker/field-options/:name/values` — add option values (team-admin)
+- `/api/modules/team-tracker/field-exceptions` — create field exception (team-admin/admin)
 - `/api/modules/team-tracker/registry/people/ldap-import` — LDAP import (team-admin/admin)
 - `/api/modules/releases/registry` — create release (release-manager)
 - `/api/modules/releases/registry/discover` — auto-discover from Product Pages (release-manager)
@@ -417,6 +419,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/structure/field-definitions/person/:fieldId` — soft-delete field (admin/team-admin)
 - `/api/modules/team-tracker/structure/field-definitions/team/:fieldId` — soft-delete field (admin/team-admin)
 - `/api/modules/team-tracker/field-options/:name/values` — remove option values (admin)
+- `/api/modules/team-tracker/field-exceptions/:id` — remove field exception (team-admin/admin)
 - `/api/health-metrics/tracking/opt-out` — opt back in (authenticated)
 - `/api/health-metrics/events` — purge raw events (admin)
 - `/api/health-metrics/viewers/:email` — remove viewer (admin)

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -498,6 +498,45 @@ Each field option set is a separate JSON file, identified by name. Used by field
 - `updatedAt` and `updatedBy` track the last modification.
 - `migrationDone`, `migratedAt`, `migratedBy` are set by the component model migration to prevent re-running. Only present on the "components" option set after migration.
 
+## Field Exceptions — `data/team-data/field-exceptions.json`
+
+Per-field exceptions that exclude specific fields from completeness checks for individual people or teams. Centrally managed — expected volume is low (tens to hundreds).
+
+```json
+{
+  "version": 1,
+  "exceptions": [
+    {
+      "id": "fex_a1b2c3d4",
+      "entityType": "person",
+      "entityId": "jsmith",
+      "fieldId": "field_dept_id",
+      "reason": "Contractor — department not applicable",
+      "createdAt": "2026-05-20T14:00:00.000Z",
+      "createdBy": "admin@example.com"
+    },
+    {
+      "id": "fex_i9j0k1l2",
+      "entityType": "team",
+      "entityId": "team_def456",
+      "fieldId": "__boards__",
+      "reason": "Infrastructure team — no Jira boards",
+      "createdAt": "2026-05-20T16:00:00.000Z",
+      "createdBy": "admin@example.com"
+    }
+  ]
+}
+```
+
+**Notes:**
+- `id` format: `fex_` prefix + 8 hex chars.
+- `entityType` is `"person"` or `"team"`.
+- `entityId` is a person UID (registry key) or team ID.
+- `fieldId` references a field from `field-definitions.json`, or the reserved sentinel `__boards__` (valid only with `entityType: "team"`) for teams that intentionally have no Jira boards.
+- Uniqueness: one exception per `(entityType, entityId, fieldId)` tuple. Duplicate creates update the reason (upsert).
+- If the file does not exist, the system treats it as zero exceptions.
+- Excepted fields are excluded from completeness counts in the message provider and Data Quality/Manager Dashboard UIs, but remain visible with an "Exception" badge.
+
 ## Audit Log — `data/audit-log.json`
 
 Append-only log of team structure management actions. Entries are added by team, field, and migration operations.
@@ -525,8 +564,8 @@ Append-only log of team structure management actions. Entries are added by team,
 
 **Notes:**
 - `entries` is ordered newest-first (prepended). Capped at `maxEntries` (10,000) — oldest entries are trimmed.
-- `action` values include: `team.create`, `team.rename`, `team.delete`, `team.boards.update`, `person.team.assign`, `person.team.unassign`, `person.fields.update`, `team.fields.update`, `field.create`, `field.update`, `field.delete`, `field.reorder`, `migration.sheets_to_inapp`, `field-options.add`, `field-options.replace`, `field-options.remove`, `migration.field-to-options`.
-- `entityType` is one of: `"team"`, `"person"`, `"field"`, `"system"`, `"field-options"`, `"migration"`.
+- `action` values include: `team.create`, `team.rename`, `team.delete`, `team.boards.update`, `person.team.assign`, `person.team.unassign`, `person.fields.update`, `team.fields.update`, `field.create`, `field.update`, `field.delete`, `field.reorder`, `migration.sheets_to_inapp`, `field-options.add`, `field-options.replace`, `field-options.remove`, `migration.field-to-options`, `field-exception.create`, `field-exception.update`, `field-exception.remove`.
+- `entityType` is one of: `"team"`, `"person"`, `"field"`, `"system"`, `"field-options"`, `"field-exception"`, `"migration"`.
 - `field`, `oldValue`, `newValue` are used for change-tracking (e.g., rename, field value updates). `null` when not applicable.
 - `detail` is a human-readable summary of the action.
 

--- a/fixtures/team-data/field-exceptions.json
+++ b/fixtures/team-data/field-exceptions.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "exceptions": [
+    {
+      "id": "fex_a1b2c3d4",
+      "entityType": "person",
+      "entityId": "bsmith",
+      "fieldId": "field_x1y2z3",
+      "reason": "Contractor — focus area not applicable",
+      "createdAt": "2026-01-10T14:00:00.000Z",
+      "createdBy": "admin@example.com"
+    },
+    {
+      "id": "fex_e5f6g7h8",
+      "entityType": "team",
+      "entityId": "team_d4e5f6",
+      "fieldId": "field_g7h8i9",
+      "reason": "New team, product manager TBD after reorg",
+      "createdAt": "2026-01-10T15:00:00.000Z",
+      "createdBy": "admin@example.com"
+    },
+    {
+      "id": "fex_i9j0k1l2",
+      "entityType": "team",
+      "entityId": "team_d4e5f6",
+      "fieldId": "__boards__",
+      "reason": "Infrastructure team — no Jira boards",
+      "createdAt": "2026-01-10T16:00:00.000Z",
+      "createdBy": "admin@example.com"
+    }
+  ]
+}

--- a/modules/team-tracker/__tests__/client/DataQualityTab.test.js
+++ b/modules/team-tracker/__tests__/client/DataQualityTab.test.js
@@ -12,6 +12,7 @@ const mockAllPeople = ref([])
 const mockReferencedPeople = ref({})
 const mockFieldDefinitions = ref({ person: [], team: [] })
 const mockOrgKeys = ref([])
+const mockFieldExceptions = ref([])
 const mockLoading = ref(false)
 const mockError = ref(null)
 
@@ -23,6 +24,7 @@ vi.mock('../../client/composables/useFieldCompleteness', () => ({
     referencedPeople: mockReferencedPeople,
     fieldDefinitions: mockFieldDefinitions,
     orgKeys: mockOrgKeys,
+    fieldExceptions: mockFieldExceptions,
     loading: mockLoading,
     error: mockError,
     load: mockLoad,
@@ -84,6 +86,7 @@ beforeEach(() => {
   mockReferencedPeople.value = {}
   mockFieldDefinitions.value = { person: [], team: [] }
   mockOrgKeys.value = []
+  mockFieldExceptions.value = []
   mockLoading.value = false
   mockError.value = null
   mockLoad.mockClear()

--- a/modules/team-tracker/__tests__/client/FieldExceptionsTab.test.js
+++ b/modules/team-tracker/__tests__/client/FieldExceptionsTab.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import FieldExceptionsTab from '../../client/components/FieldExceptionsTab.vue'
+
+// Mock the composable
+const mockLoad = vi.fn()
+const mockPeople = ref([])
+const mockTeams = ref([])
+const mockFieldDefinitions = ref({ person: [], team: [] })
+
+vi.mock('../../client/composables/useFieldCompleteness', () => ({
+  useFieldCompleteness: () => ({
+    people: mockPeople,
+    teams: mockTeams,
+    allPeople: ref([]),
+    referencedPeople: ref({}),
+    fieldDefinitions: mockFieldDefinitions,
+    orgKeys: ref([]),
+    loading: ref(false),
+    error: ref(null),
+    load: mockLoad,
+    refresh: mockLoad
+  })
+}))
+
+const mockApiRequest = vi.fn()
+vi.mock('@shared/client/services/api', () => ({
+  apiRequest: (...args) => mockApiRequest(...args)
+}))
+
+function mountTab() {
+  return mount(FieldExceptionsTab, {
+    global: {
+      stubs: {
+        AddExceptionModal: { template: '<div class="add-modal" />', props: ['people', 'teams', 'fieldDefinitions'] }
+      }
+    }
+  })
+}
+
+const sampleExceptions = [
+  { id: 'fex_1', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'Contractor', createdAt: '2026-01-10T14:00:00.000Z', createdBy: 'admin@test.com' },
+  { id: 'fex_2', entityType: 'team', entityId: 'team_a', fieldId: '__boards__', reason: 'No boards needed', createdAt: '2026-01-10T15:00:00.000Z', createdBy: 'admin@test.com' }
+]
+
+beforeEach(() => {
+  mockPeople.value = [
+    { uid: 'alice', name: 'Alice Chen' },
+    { uid: 'bob', name: 'Bob Smith' }
+  ]
+  mockTeams.value = [
+    { id: 'team_a', name: 'Platform', orgKey: 'org1' }
+  ]
+  mockFieldDefinitions.value = {
+    person: [{ id: 'field_f1', label: 'Focus Area', visible: true, deleted: false }],
+    team: [{ id: 'field_t1', label: 'Sprint', visible: true, deleted: false }]
+  }
+  mockLoad.mockClear()
+  mockApiRequest.mockReset()
+  mockApiRequest.mockResolvedValue({ exceptions: sampleExceptions })
+})
+
+describe('FieldExceptionsTab', () => {
+  it('loads exceptions on mount', async () => {
+    mountTab()
+    await flushPromises()
+    expect(mockApiRequest).toHaveBeenCalledWith('/modules/team-tracker/field-exceptions')
+  })
+
+  it('renders exception rows', async () => {
+    const wrapper = mountTab()
+    await flushPromises()
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(2)
+  })
+
+  it('resolves person name', async () => {
+    const wrapper = mountTab()
+    await flushPromises()
+    expect(wrapper.text()).toContain('Alice Chen')
+  })
+
+  it('resolves team name', async () => {
+    const wrapper = mountTab()
+    await flushPromises()
+    expect(wrapper.text()).toContain('Platform')
+  })
+
+  it('resolves field labels including Boards sentinel', async () => {
+    const wrapper = mountTab()
+    await flushPromises()
+    expect(wrapper.text()).toContain('Focus Area')
+    expect(wrapper.text()).toContain('Boards')
+  })
+
+  it('filters by entity type', async () => {
+    const wrapper = mountTab()
+    await flushPromises()
+    const select = wrapper.find('select')
+    await select.setValue('team')
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(1)
+    expect(wrapper.text()).toContain('Platform')
+  })
+
+  it('shows empty state when no exceptions', async () => {
+    mockApiRequest.mockResolvedValue({ exceptions: [] })
+    const wrapper = mountTab()
+    await flushPromises()
+    expect(wrapper.text()).toContain('No exceptions')
+  })
+
+  it('opens add modal when button clicked', async () => {
+    const wrapper = mountTab()
+    await flushPromises()
+    expect(wrapper.find('.add-modal').exists()).toBe(false)
+    await wrapper.find('button').trigger('click')
+    // The "Add Exception" button is the one that opens modal
+    const addBtn = wrapper.findAll('button').find(b => b.text().includes('Add Exception'))
+    if (addBtn) await addBtn.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.add-modal').exists()).toBe(true)
+  })
+
+  it('calls delete API when remove is confirmed', async () => {
+    // Mock window.confirm
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockApiRequest
+      .mockResolvedValueOnce({ exceptions: sampleExceptions }) // initial load
+      .mockResolvedValueOnce({}) // delete call
+
+    const wrapper = mountTab()
+    await flushPromises()
+
+    const removeBtn = wrapper.findAll('button').find(b => b.text() === 'Remove')
+    await removeBtn.trigger('click')
+    await flushPromises()
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/modules/team-tracker/field-exceptions/fex_1',
+      { method: 'DELETE' }
+    )
+
+    window.confirm.mockRestore()
+  })
+})

--- a/modules/team-tracker/__tests__/client/ManagerDashboardView.test.js
+++ b/modules/team-tracker/__tests__/client/ManagerDashboardView.test.js
@@ -14,6 +14,7 @@ const mockAllOrgTeams = ref([])
 const mockAllPeople = ref([])
 const mockReferencedPeople = ref({})
 const mockFieldDefinitions = ref({ person: [], team: [] })
+const mockFieldExceptions = ref([])
 const mockLoading = ref(false)
 const mockError = ref(null)
 const mockReason = ref(null)
@@ -29,6 +30,7 @@ vi.mock('../../client/composables/useManagerDashboard', () => ({
     allPeople: mockAllPeople,
     referencedPeople: mockReferencedPeople,
     fieldDefinitions: mockFieldDefinitions,
+    fieldExceptions: mockFieldExceptions,
     loading: mockLoading,
     error: mockError,
     reason: mockReason,
@@ -99,6 +101,7 @@ beforeEach(() => {
   mockAllPeople.value = []
   mockReferencedPeople.value = {}
   mockFieldDefinitions.value = { person: [], team: [] }
+  mockFieldExceptions.value = []
   mockLoading.value = false
   mockError.value = null
   mockReason.value = null

--- a/modules/team-tracker/__tests__/server/field-completeness-with-exceptions.test.js
+++ b/modules/team-tracker/__tests__/server/field-completeness-with-exceptions.test.js
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock node-fetch (required by transitive imports)
+vi.mock('node-fetch', () => ({ default: vi.fn() }))
+
+function makeStorage(initial = {}) {
+  const data = { ...initial }
+  return {
+    readFromStorage(key) { return data[key] ? JSON.parse(JSON.stringify(data[key])) : null },
+    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    listStorageFiles(dir) {
+      return Object.keys(data)
+        .filter(k => k.startsWith(dir + '/') && k.endsWith('.json'))
+        .map(k => k.split('/').pop())
+    },
+    deleteStorageDirectory: vi.fn(),
+    _data: data
+  }
+}
+
+// ─── Message Provider Tests ───
+
+function setupAndGetProvider(storageData) {
+  let capturedProvider = null
+
+  const mockRouter = {
+    get() {},
+    post() {},
+    put() {},
+    patch() {},
+    delete() {}
+  }
+
+  const storage = makeStorage(storageData)
+  const mockRoleStore = {
+    getRoles: vi.fn(() => []),
+    isAdmin: vi.fn(() => false),
+    isTeamAdmin: vi.fn(() => false)
+  }
+
+  const context = {
+    storage,
+    requireAdmin: (req, res, next) => next(),
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
+    roleStore: mockRoleStore,
+    registerMessageProvider(id, fn) {
+      capturedProvider = { id, fn }
+    }
+  }
+
+  const registerRoutes = require('../../server/index.js')
+  registerRoutes(mockRouter, context)
+
+  return { provider: capturedProvider, storage }
+}
+
+function baseStorageData() {
+  return {
+    'team-data/registry.json': {
+      meta: { generatedAt: '2026-01-01', provider: 'test', orgRoots: ['org1'] },
+      people: {
+        mgr1: {
+          uid: 'mgr1', name: 'Manager One', email: 'mgr1@example.com',
+          title: 'Engineering Manager', status: 'active', managerUid: null,
+          orgRoot: 'org1', teamIds: ['team_a'],
+          _appFields: { field_f1: 'backend' }
+        },
+        alice: {
+          uid: 'alice', name: 'Alice', email: 'alice@example.com',
+          title: 'Software Engineer', status: 'active', managerUid: 'mgr1',
+          orgRoot: 'org1', teamIds: ['team_a'],
+          _appFields: { field_f1: 'frontend' }
+        },
+        bob: {
+          uid: 'bob', name: 'Bob', email: 'bob@example.com',
+          title: 'SRE', status: 'active', managerUid: 'mgr1',
+          orgRoot: 'org1', teamIds: ['team_a'],
+          _appFields: {} // missing field_f1
+        }
+      }
+    },
+    'team-data/teams.json': {
+      teams: {
+        team_a: { id: 'team_a', name: 'Alpha', orgKey: 'org1', metadata: { field_t1: 'Sprint 1' }, boards: [{ url: 'https://board.example.com/a' }] },
+        team_b: { id: 'team_b', name: 'Beta', orgKey: 'org1', metadata: {}, boards: [] }
+      }
+    },
+    'team-data/field-definitions.json': {
+      personFields: [
+        { id: 'field_f1', label: 'Focus Area', type: 'free-text', visible: true, deleted: false }
+      ],
+      teamFields: [
+        { id: 'field_t1', label: 'Sprint', type: 'free-text', visible: true, deleted: false }
+      ]
+    },
+    'team-data/config.json': {
+      orgRoots: [{ uid: 'org1', displayName: 'Org One' }],
+      teamDataSource: 'in-app'
+    },
+    'audit-log.json': { entries: [] }
+  }
+}
+
+describe('field-completeness with exceptions — message provider', () => {
+  it('counts person as incomplete when no exception exists', async () => {
+    const data = baseStorageData()
+    // Fill team data so only person incompleteness triggers
+    data['team-data/teams.json'].teams.team_b.metadata = { field_t1: 'Sprint 2' }
+    data['team-data/teams.json'].teams.team_b.boards = [{ url: 'https://board.example.com/b' }]
+
+    const { provider } = setupAndGetProvider(data)
+    const result = await provider.fn({ uid: 'mgr1', permissionTier: 'manager' })
+    expect(result).toHaveLength(1)
+    expect(result[0].text).toContain('1 person')
+  })
+
+  it('excludes excepted person field from incompleteness count', async () => {
+    const data = baseStorageData()
+    // Fill team data
+    data['team-data/teams.json'].teams.team_b.metadata = { field_t1: 'Sprint 2' }
+    data['team-data/teams.json'].teams.team_b.boards = [{ url: 'https://board.example.com/b' }]
+    // Add exception for bob's missing field_f1
+    data['team-data/field-exceptions.json'] = {
+      version: 1,
+      exceptions: [
+        { id: 'fex_1', entityType: 'person', entityId: 'bob', fieldId: 'field_f1', reason: 'Contractor', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      ]
+    }
+
+    const { provider } = setupAndGetProvider(data)
+    const result = await provider.fn({ uid: 'mgr1', permissionTier: 'manager' })
+    // bob's missing field is excepted, so no warnings
+    expect(result).toEqual([])
+  })
+
+  it('excludes excepted team boards (__boards__ sentinel)', async () => {
+    const data = baseStorageData()
+    // All person fields filled
+    data['team-data/registry.json'].people.bob._appFields = { field_f1: 'devops' }
+    // Put bob on team_b so it's in mgr1's purview
+    data['team-data/registry.json'].people.bob.teamIds = ['team_a', 'team_b']
+    // team_b has no boards and no field_t1 — add exception for boards only
+    data['team-data/field-exceptions.json'] = {
+      version: 1,
+      exceptions: [
+        { id: 'fex_2', entityType: 'team', entityId: 'team_b', fieldId: '__boards__', reason: 'No boards needed', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      ]
+    }
+
+    const { provider } = setupAndGetProvider(data)
+    const result = await provider.fn({ uid: 'mgr1', permissionTier: 'manager' })
+    // team_b still has missing field_t1, so warning remains
+    expect(result).toHaveLength(1)
+    expect(result[0].text).toContain('1 team')
+    expect(result[0].text).not.toContain('people')
+  })
+
+  it('excludes excepted team field from incompleteness count', async () => {
+    const data = baseStorageData()
+    // All person fields filled
+    data['team-data/registry.json'].people.bob._appFields = { field_f1: 'devops' }
+    // Put bob on team_b so it's in mgr1's purview
+    data['team-data/registry.json'].people.bob.teamIds = ['team_a', 'team_b']
+    // Exception for team_b boards AND field_t1
+    data['team-data/field-exceptions.json'] = {
+      version: 1,
+      exceptions: [
+        { id: 'fex_2', entityType: 'team', entityId: 'team_b', fieldId: '__boards__', reason: 'No boards', createdAt: '2026-01-01', createdBy: 'admin@test.com' },
+        { id: 'fex_3', entityType: 'team', entityId: 'team_b', fieldId: 'field_t1', reason: 'Not applicable', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      ]
+    }
+
+    const { provider } = setupAndGetProvider(data)
+    const result = await provider.fn({ uid: 'mgr1', permissionTier: 'manager' })
+    // All empty fields are excepted — no warnings
+    expect(result).toEqual([])
+  })
+})
+
+// ─── Field Completeness Endpoint Tests ───
+
+function setupRoutes(storageData) {
+  const handlers = {}
+  const mockRouter = {
+    get(path, ...args) { handlers[`GET ${path}`] = args[args.length - 1] },
+    post(path, ...args) { handlers[`POST ${path}`] = args[args.length - 1] },
+    put(path, ...args) { handlers[`PUT ${path}`] = args[args.length - 1] },
+    patch(path, ...args) { handlers[`PATCH ${path}`] = args[args.length - 1] },
+    delete(path, ...args) { handlers[`DELETE ${path}`] = args[args.length - 1] }
+  }
+
+  const storage = makeStorage(storageData)
+  const mockRoleStore = {
+    getRoles: vi.fn(() => []),
+    isAdmin: vi.fn(() => false),
+    isTeamAdmin: vi.fn(() => false)
+  }
+
+  const context = {
+    storage,
+    requireAdmin: (req, res, next) => next(),
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
+    roleStore: mockRoleStore
+  }
+
+  const registerRoutes = require('../../server/index.js')
+  registerRoutes(mockRouter, context)
+
+  return { handlers, storage }
+}
+
+function mockRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) { res._status = code; return res },
+    json(body) { res._body = body; return res }
+  }
+  return res
+}
+
+describe('field-completeness endpoint — includes fieldExceptions', () => {
+  it('includes fieldExceptions array in response', () => {
+    const data = baseStorageData()
+    data['team-data/field-exceptions.json'] = {
+      version: 1,
+      exceptions: [
+        { id: 'fex_1', entityType: 'person', entityId: 'bob', fieldId: 'field_f1', reason: 'Contractor', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      ]
+    }
+    const { handlers } = setupRoutes(data)
+    const req = { permissionTier: 'admin', query: {} }
+    const res = mockRes()
+    handlers['GET /admin/field-completeness'](req, res)
+    expect(res._body.fieldExceptions).toBeDefined()
+    expect(res._body.fieldExceptions).toHaveLength(1)
+    expect(res._body.fieldExceptions[0].id).toBe('fex_1')
+  })
+
+  it('returns empty fieldExceptions when no file exists', () => {
+    const data = baseStorageData()
+    const { handlers } = setupRoutes(data)
+    const req = { permissionTier: 'admin', query: {} }
+    const res = mockRes()
+    handlers['GET /admin/field-completeness'](req, res)
+    expect(res._body.fieldExceptions).toBeDefined()
+    expect(res._body.fieldExceptions).toEqual([])
+  })
+})
+
+describe('manager dashboard — includes fieldExceptions', () => {
+  it('includes fieldExceptions filtered to manager purview', () => {
+    const data = baseStorageData()
+    data['team-data/field-exceptions.json'] = {
+      version: 1,
+      exceptions: [
+        { id: 'fex_1', entityType: 'person', entityId: 'bob', fieldId: 'field_f1', reason: 'Contractor', createdAt: '2026-01-01', createdBy: 'admin@test.com' },
+        { id: 'fex_2', entityType: 'person', entityId: 'unrelated', fieldId: 'field_f1', reason: 'Other', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      ]
+    }
+    const { handlers } = setupRoutes(data)
+    const req = {
+      userUid: 'mgr1',
+      userEmail: 'mgr1@example.com',
+      isAdmin: false,
+      isTeamAdmin: false,
+      permissionTier: 'manager',
+      query: {}
+    }
+    const res = mockRes()
+    handlers['GET /manager/dashboard'](req, res)
+    // Only bob's exception should be included (alice and bob are mgr1's reports)
+    expect(res._body.fieldExceptions).toBeDefined()
+    const personExceptions = res._body.fieldExceptions.filter(e => e.entityType === 'person')
+    expect(personExceptions.every(e => ['alice', 'bob'].includes(e.entityId))).toBe(true)
+    // The 'unrelated' exception should not be included
+    expect(res._body.fieldExceptions.find(e => e.entityId === 'unrelated')).toBeUndefined()
+  })
+})

--- a/modules/team-tracker/__tests__/server/field-exceptions-routes.test.js
+++ b/modules/team-tracker/__tests__/server/field-exceptions-routes.test.js
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock node-fetch (required by transitive imports)
+vi.mock('node-fetch', () => ({ default: vi.fn() }))
+
+function makeStorage(initial = {}) {
+  const data = { ...initial }
+  return {
+    readFromStorage(key) { return data[key] ? JSON.parse(JSON.stringify(data[key])) : null },
+    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    listStorageFiles(dir) {
+      return Object.keys(data)
+        .filter(k => k.startsWith(dir + '/') && k.endsWith('.json'))
+        .map(k => k.split('/').pop())
+    },
+    deleteStorageDirectory: vi.fn(),
+    _data: data
+  }
+}
+
+function setupRoutes(storageData) {
+  const handlers = {}
+  const mockRouter = {
+    get(path, ...args) { handlers[`GET ${path}`] = args[args.length - 1] },
+    post(path, ...args) { handlers[`POST ${path}`] = args[args.length - 1] },
+    put(path, ...args) { handlers[`PUT ${path}`] = args[args.length - 1] },
+    patch(path, ...args) { handlers[`PATCH ${path}`] = args[args.length - 1] },
+    delete(path, ...args) { handlers[`DELETE ${path}`] = args[args.length - 1] }
+  }
+
+  const storage = makeStorage(storageData)
+  const mockRoleStore = {
+    getRoles: vi.fn(() => []),
+    isAdmin: vi.fn(() => false),
+    isTeamAdmin: vi.fn(() => false)
+  }
+
+  const context = {
+    storage,
+    requireAdmin: (req, res, next) => next(),
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
+    roleStore: mockRoleStore
+  }
+
+  const registerRoutes = require('../../server/index.js')
+  registerRoutes(mockRouter, context)
+
+  return { handlers, storage }
+}
+
+function mockRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) { res._status = code; return res },
+    json(body) { res._body = body; return res }
+  }
+  return res
+}
+
+function baseStorageData() {
+  return {
+    'team-data/registry.json': {
+      meta: { generatedAt: '2026-01-01', provider: 'test', orgRoots: ['org1'] },
+      people: {
+        alice: {
+          uid: 'alice', name: 'Alice', email: 'alice@example.com',
+          title: 'Software Engineer', status: 'active', managerUid: 'mgr1',
+          orgRoot: 'org1', teamIds: ['team_a'],
+          _appFields: { field_f1: 'backend' }
+        },
+        bob: {
+          uid: 'bob', name: 'Bob', email: 'bob@example.com',
+          title: 'SRE', status: 'active', managerUid: 'mgr1',
+          orgRoot: 'org1', teamIds: ['team_a'],
+          _appFields: {}
+        }
+      }
+    },
+    'team-data/teams.json': {
+      teams: {
+        team_a: { id: 'team_a', name: 'Alpha', orgKey: 'org1', metadata: { field_t1: 'val' }, boards: [{ url: 'https://board.example.com', name: 'Board' }] },
+        team_b: { id: 'team_b', name: 'Beta', orgKey: 'org1', metadata: {}, boards: [] }
+      }
+    },
+    'team-data/field-definitions.json': {
+      personFields: [
+        { id: 'field_f1', label: 'Focus Area', type: 'free-text', multiValue: false, required: false, visible: true, deleted: false, order: 0 }
+      ],
+      teamFields: [
+        { id: 'field_t1', label: 'Sprint', type: 'free-text', multiValue: false, required: false, visible: true, deleted: false, order: 0 }
+      ]
+    },
+    'team-data/field-exceptions.json': {
+      version: 1,
+      exceptions: [
+        { id: 'fex_existing1', entityType: 'person', entityId: 'bob', fieldId: 'field_f1', reason: 'Contractor', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      ]
+    },
+    'audit-log.json': { entries: [] }
+  }
+}
+
+describe('field-exceptions routes', () => {
+  describe('GET /field-exceptions', () => {
+    it('returns all exceptions for admin', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = { query: {}, isAdmin: true, isTeamAdmin: false, permissionTier: 'admin' }
+      const res = mockRes()
+      handlers['GET /field-exceptions'](req, res)
+      expect(res._body.exceptions).toHaveLength(1)
+      expect(res._body.exceptions[0].id).toBe('fex_existing1')
+    })
+
+    it('filters by entityType', () => {
+      const data = baseStorageData()
+      data['team-data/field-exceptions.json'].exceptions.push(
+        { id: 'fex_team1', entityType: 'team', entityId: 'team_b', fieldId: '__boards__', reason: 'no boards', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+      )
+      const { handlers } = setupRoutes(data)
+      const req = { query: { entityType: 'team' }, isAdmin: true, isTeamAdmin: false, permissionTier: 'admin' }
+      const res = mockRes()
+      handlers['GET /field-exceptions'](req, res)
+      expect(res._body.exceptions).toHaveLength(1)
+      expect(res._body.exceptions[0].entityType).toBe('team')
+    })
+
+    it('returns empty list for user tier', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = { query: {}, isAdmin: false, isTeamAdmin: false, permissionTier: 'user' }
+      const res = mockRes()
+      handlers['GET /field-exceptions'](req, res)
+      expect(res._body.exceptions).toHaveLength(0)
+    })
+  })
+
+  describe('POST /field-exceptions', () => {
+    it('creates a new person exception', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'Test reason' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(201)
+      expect(res._body.exception.entityId).toBe('alice')
+      expect(res._body.exception.reason).toBe('Test reason')
+    })
+
+    it('creates a team exception', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'team', entityId: 'team_a', fieldId: 'field_t1', reason: 'Not applicable' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(201)
+      expect(res._body.exception.entityType).toBe('team')
+    })
+
+    it('creates a __boards__ exception for team', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'team', entityId: 'team_b', fieldId: '__boards__', reason: 'No boards needed' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(201)
+      expect(res._body.exception.fieldId).toBe('__boards__')
+    })
+
+    it('upserts on duplicate tuple', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'bob', fieldId: 'field_f1', reason: 'Updated reason' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(200)
+      expect(res._body.exception.id).toBe('fex_existing1')
+      expect(res._body.exception.reason).toBe('Updated reason')
+    })
+
+    it('rejects invalid entityType', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'invalid', entityId: 'alice', fieldId: 'field_f1', reason: 'test' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('entityType')
+    })
+
+    it('rejects missing reason', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: '' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('reason')
+    })
+
+    it('rejects reason over 500 chars', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'x'.repeat(501) },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('500')
+    })
+
+    it('rejects non-existent person', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'nonexistent', fieldId: 'field_f1', reason: 'test' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('not found')
+    })
+
+    it('rejects non-existent team', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'team', entityId: 'team_nonexistent', fieldId: 'field_t1', reason: 'test' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('not found')
+    })
+
+    it('rejects deleted field', () => {
+      const data = baseStorageData()
+      data['team-data/field-definitions.json'].personFields[0].deleted = true
+      const { handlers } = setupRoutes(data)
+      const req = {
+        body: { entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('deleted')
+    })
+
+    it('rejects __boards__ with person entityType', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'alice', fieldId: '__boards__', reason: 'test' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('__boards__')
+    })
+
+    it('rejects non-existent fieldId', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = {
+        body: { entityType: 'person', entityId: 'alice', fieldId: 'field_nonexistent', reason: 'test' },
+        userEmail: 'admin@test.com'
+      }
+      const res = mockRes()
+      handlers['POST /field-exceptions'](req, res)
+      expect(res._status).toBe(400)
+      expect(res._body.error).toContain('not found')
+    })
+  })
+
+  describe('DELETE /field-exceptions/:id', () => {
+    it('removes an existing exception', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = { params: { id: 'fex_existing1' }, userEmail: 'admin@test.com' }
+      const res = mockRes()
+      handlers['DELETE /field-exceptions/:id'](req, res)
+      expect(res._body.removed).toBe(true)
+    })
+
+    it('returns 404 for non-existent exception', () => {
+      const { handlers } = setupRoutes(baseStorageData())
+      const req = { params: { id: 'fex_nonexistent' }, userEmail: 'admin@test.com' }
+      const res = mockRes()
+      handlers['DELETE /field-exceptions/:id'](req, res)
+      expect(res._status).toBe(404)
+    })
+  })
+})

--- a/modules/team-tracker/__tests__/server/field-exceptions-store.test.js
+++ b/modules/team-tracker/__tests__/server/field-exceptions-store.test.js
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const fieldExceptionsStore = require('../../server/field-exceptions-store')
+
+function makeStorage(initial = {}) {
+  const data = { ...initial }
+  return {
+    readFromStorage(key) { return data[key] ? JSON.parse(JSON.stringify(data[key])) : null },
+    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    _data: data
+  }
+}
+
+function storageWithAuditLog(initial = {}) {
+  return makeStorage({ 'audit-log.json': { entries: [] }, ...initial })
+}
+
+describe('field-exceptions-store', () => {
+  describe('readExceptions', () => {
+    it('returns empty exceptions when file does not exist', () => {
+      const storage = makeStorage({})
+      const result = fieldExceptionsStore.readExceptions(storage)
+      expect(result).toEqual({ version: 1, exceptions: [] })
+    })
+
+    it('returns stored data when file exists', () => {
+      const stored = {
+        version: 1,
+        exceptions: [{ id: 'fex_00000001', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test', createdAt: '2026-01-01', createdBy: 'admin@test.com' }]
+      }
+      const storage = makeStorage({ 'team-data/field-exceptions.json': stored })
+      const result = fieldExceptionsStore.readExceptions(storage)
+      expect(result.exceptions).toHaveLength(1)
+      expect(result.exceptions[0].id).toBe('fex_00000001')
+    })
+  })
+
+  describe('listExceptions', () => {
+    const exceptions = [
+      { id: 'fex_1', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'r1', createdAt: '2026-01-01', createdBy: 'admin@test.com' },
+      { id: 'fex_2', entityType: 'person', entityId: 'bob', fieldId: 'field_f1', reason: 'r2', createdAt: '2026-01-01', createdBy: 'admin@test.com' },
+      { id: 'fex_3', entityType: 'team', entityId: 'team_a', fieldId: 'field_g1', reason: 'r3', createdAt: '2026-01-01', createdBy: 'admin@test.com' },
+      { id: 'fex_4', entityType: 'team', entityId: 'team_a', fieldId: '__boards__', reason: 'r4', createdAt: '2026-01-01', createdBy: 'admin@test.com' }
+    ]
+
+    it('returns all exceptions when no filters', () => {
+      const storage = makeStorage({ 'team-data/field-exceptions.json': { version: 1, exceptions } })
+      expect(fieldExceptionsStore.listExceptions(storage)).toHaveLength(4)
+    })
+
+    it('filters by entityType', () => {
+      const storage = makeStorage({ 'team-data/field-exceptions.json': { version: 1, exceptions } })
+      const result = fieldExceptionsStore.listExceptions(storage, { entityType: 'team' })
+      expect(result).toHaveLength(2)
+      expect(result.every(e => e.entityType === 'team')).toBe(true)
+    })
+
+    it('filters by entityId', () => {
+      const storage = makeStorage({ 'team-data/field-exceptions.json': { version: 1, exceptions } })
+      const result = fieldExceptionsStore.listExceptions(storage, { entityId: 'alice' })
+      expect(result).toHaveLength(1)
+      expect(result[0].entityId).toBe('alice')
+    })
+
+    it('filters by fieldId', () => {
+      const storage = makeStorage({ 'team-data/field-exceptions.json': { version: 1, exceptions } })
+      const result = fieldExceptionsStore.listExceptions(storage, { fieldId: '__boards__' })
+      expect(result).toHaveLength(1)
+      expect(result[0].fieldId).toBe('__boards__')
+    })
+
+    it('combines multiple filters', () => {
+      const storage = makeStorage({ 'team-data/field-exceptions.json': { version: 1, exceptions } })
+      const result = fieldExceptionsStore.listExceptions(storage, { entityType: 'person', fieldId: 'field_f1' })
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('getException', () => {
+    it('returns exception by ID', () => {
+      const storage = makeStorage({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [{ id: 'fex_abc', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test', createdAt: '2026-01-01', createdBy: 'a@t.com' }]
+        }
+      })
+      expect(fieldExceptionsStore.getException(storage, 'fex_abc')).toBeTruthy()
+      expect(fieldExceptionsStore.getException(storage, 'fex_abc').entityId).toBe('alice')
+    })
+
+    it('returns null for non-existent ID', () => {
+      const storage = makeStorage({ 'team-data/field-exceptions.json': { version: 1, exceptions: [] } })
+      expect(fieldExceptionsStore.getException(storage, 'fex_nonexistent')).toBeNull()
+    })
+  })
+
+  describe('findException', () => {
+    it('finds by natural key tuple', () => {
+      const storage = makeStorage({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [{ id: 'fex_abc', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test', createdAt: '2026-01-01', createdBy: 'a@t.com' }]
+        }
+      })
+      expect(fieldExceptionsStore.findException(storage, 'person', 'alice', 'field_f1')).toBeTruthy()
+      expect(fieldExceptionsStore.findException(storage, 'person', 'alice', 'field_f2')).toBeNull()
+    })
+  })
+
+  describe('createException', () => {
+    it('creates a new exception with generated ID', () => {
+      const storage = storageWithAuditLog()
+      const { exception, created } = fieldExceptionsStore.createException(
+        storage,
+        { entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test reason' },
+        'admin@test.com'
+      )
+      expect(created).toBe(true)
+      expect(exception.id).toMatch(/^fex_[0-9a-f]{8}$/)
+      expect(exception.entityType).toBe('person')
+      expect(exception.entityId).toBe('alice')
+      expect(exception.fieldId).toBe('field_f1')
+      expect(exception.reason).toBe('test reason')
+      expect(exception.createdBy).toBe('admin@test.com')
+      expect(exception.createdAt).toBeTruthy()
+
+      // Verify persisted
+      const saved = storage._data['team-data/field-exceptions.json']
+      expect(saved.exceptions).toHaveLength(1)
+    })
+
+    it('upserts on duplicate tuple', () => {
+      const storage = storageWithAuditLog({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [{ id: 'fex_existing', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'old reason', createdAt: '2026-01-01', createdBy: 'old@test.com' }]
+        }
+      })
+
+      const { exception, created } = fieldExceptionsStore.createException(
+        storage,
+        { entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'new reason' },
+        'admin@test.com'
+      )
+      expect(created).toBe(false)
+      expect(exception.id).toBe('fex_existing') // Same ID
+      expect(exception.reason).toBe('new reason')
+      expect(exception.createdBy).toBe('admin@test.com')
+
+      // Only one exception
+      const saved = storage._data['team-data/field-exceptions.json']
+      expect(saved.exceptions).toHaveLength(1)
+    })
+
+    it('logs audit entry on create', () => {
+      const storage = storageWithAuditLog()
+      fieldExceptionsStore.createException(
+        storage,
+        { entityType: 'team', entityId: 'team_a', fieldId: '__boards__', reason: 'no boards' },
+        'admin@test.com'
+      )
+      const log = storage._data['audit-log.json']
+      expect(log.entries).toHaveLength(1)
+      expect(log.entries[0].action).toBe('field-exception.create')
+    })
+
+    it('logs audit entry on upsert', () => {
+      const storage = storageWithAuditLog({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [{ id: 'fex_existing', entityType: 'team', entityId: 'team_a', fieldId: '__boards__', reason: 'old', createdAt: '2026-01-01', createdBy: 'old@t.com' }]
+        }
+      })
+      fieldExceptionsStore.createException(
+        storage,
+        { entityType: 'team', entityId: 'team_a', fieldId: '__boards__', reason: 'new' },
+        'admin@test.com'
+      )
+      const log = storage._data['audit-log.json']
+      expect(log.entries).toHaveLength(1)
+      expect(log.entries[0].action).toBe('field-exception.update')
+    })
+  })
+
+  describe('removeException', () => {
+    it('removes an existing exception', () => {
+      const storage = storageWithAuditLog({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [{ id: 'fex_abc', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test', createdAt: '2026-01-01', createdBy: 'a@t.com' }]
+        }
+      })
+      const removed = fieldExceptionsStore.removeException(storage, 'fex_abc', 'admin@test.com')
+      expect(removed).toBeTruthy()
+      expect(removed.id).toBe('fex_abc')
+
+      const saved = storage._data['team-data/field-exceptions.json']
+      expect(saved.exceptions).toHaveLength(0)
+    })
+
+    it('returns null for non-existent ID', () => {
+      const storage = storageWithAuditLog({ 'team-data/field-exceptions.json': { version: 1, exceptions: [] } })
+      const removed = fieldExceptionsStore.removeException(storage, 'fex_nope', 'admin@test.com')
+      expect(removed).toBeNull()
+    })
+
+    it('logs audit entry on remove', () => {
+      const storage = storageWithAuditLog({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [{ id: 'fex_abc', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'test', createdAt: '2026-01-01', createdBy: 'a@t.com' }]
+        }
+      })
+      fieldExceptionsStore.removeException(storage, 'fex_abc', 'admin@test.com')
+      const log = storage._data['audit-log.json']
+      expect(log.entries).toHaveLength(1)
+      expect(log.entries[0].action).toBe('field-exception.remove')
+    })
+  })
+
+  describe('getExceptionMap', () => {
+    it('builds map keyed by entityType:entityId:fieldId', () => {
+      const storage = makeStorage({
+        'team-data/field-exceptions.json': {
+          version: 1,
+          exceptions: [
+            { id: 'fex_1', entityType: 'person', entityId: 'alice', fieldId: 'field_f1', reason: 'r1', createdAt: '2026-01-01', createdBy: 'a@t.com' },
+            { id: 'fex_2', entityType: 'team', entityId: 'team_a', fieldId: '__boards__', reason: 'r2', createdAt: '2026-01-01', createdBy: 'a@t.com' }
+          ]
+        }
+      })
+      const map = fieldExceptionsStore.getExceptionMap(storage)
+      expect(map.size).toBe(2)
+      expect(map.has('person:alice:field_f1')).toBe(true)
+      expect(map.has('team:team_a:__boards__')).toBe(true)
+      expect(map.has('person:bob:field_f1')).toBe(false)
+    })
+
+    it('returns empty map when no exceptions', () => {
+      const storage = makeStorage({})
+      const map = fieldExceptionsStore.getExceptionMap(storage)
+      expect(map.size).toBe(0)
+    })
+  })
+})

--- a/modules/team-tracker/client/components/AddExceptionModal.vue
+++ b/modules/team-tracker/client/components/AddExceptionModal.vue
@@ -1,0 +1,234 @@
+<template>
+  <div
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+    @click.self="$emit('close')"
+  >
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4">
+      <!-- Header -->
+      <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Add Field Exception</h2>
+        <button @click="$emit('close')" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="px-6 py-5 space-y-4">
+        <div v-if="error" class="p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-700 dark:text-red-400 text-sm">
+          {{ error }}
+        </div>
+
+        <!-- Entity Type -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+          <select
+            v-model="entityType"
+            :disabled="isPrefilled"
+            class="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm disabled:opacity-60"
+          >
+            <option value="person">Person</option>
+            <option value="team">Team</option>
+          </select>
+        </div>
+
+        <!-- Entity Selector -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {{ entityType === 'person' ? 'Person' : 'Team' }}
+          </label>
+          <template v-if="isPrefilled && selectedEntity">
+            <div class="flex items-center gap-2">
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300">
+                {{ selectedEntity.label }}
+              </span>
+            </div>
+          </template>
+          <template v-else>
+            <div class="relative">
+              <input
+                v-model="entitySearch"
+                type="text"
+                :placeholder="entityType === 'person' ? 'Search by name or UID...' : 'Search by team name...'"
+                class="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
+              />
+            </div>
+            <ul v-if="entitySearch && filteredEntities.length > 0" class="mt-1 max-h-36 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded-md divide-y divide-gray-100 dark:divide-gray-700">
+              <li
+                v-for="entity in filteredEntities"
+                :key="entity.id"
+                @click="selectEntity(entity)"
+                class="px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                <span class="font-medium text-gray-900 dark:text-gray-100">{{ entity.label }}</span>
+                <span v-if="entity.sub" class="ml-2 text-xs text-gray-500 dark:text-gray-400">{{ entity.sub }}</span>
+              </li>
+            </ul>
+            <div v-if="selectedEntity" class="mt-1 flex items-center gap-2">
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300">
+                {{ selectedEntity.label }}
+              </span>
+              <button @click="clearEntity" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+                <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </template>
+        </div>
+
+        <!-- Field Selector -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Field</label>
+          <select
+            v-model="selectedFieldId"
+            :disabled="isPrefilled"
+            class="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm disabled:opacity-60"
+          >
+            <option value="">Select a field...</option>
+            <option v-for="field in availableFields" :key="field.id" :value="field.id">{{ field.label }}</option>
+          </select>
+        </div>
+
+        <!-- Reason -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Reason</label>
+          <textarea
+            v-model="reason"
+            rows="3"
+            maxlength="500"
+            placeholder="Why is this field intentionally unset?"
+            class="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
+          />
+          <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">{{ reason.length }}/500</p>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-3">
+        <button
+          @click="$emit('close')"
+          class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600"
+        >
+          Cancel
+        </button>
+        <button
+          @click="handleCreate"
+          :disabled="!canSubmit || saving"
+          class="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700 disabled:opacity-50"
+        >
+          {{ saving ? 'Creating...' : 'Create Exception' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const props = defineProps({
+  people: { type: Array, default: () => [] },
+  teams: { type: Array, default: () => [] },
+  fieldDefinitions: { type: Object, default: () => ({ person: [], team: [] }) },
+  prefillEntityType: { type: String, default: null },
+  prefillEntityId: { type: String, default: null },
+  prefillEntityLabel: { type: String, default: null },
+  prefillFieldId: { type: String, default: null }
+})
+
+const emit = defineEmits(['close', 'created'])
+
+const entityType = ref(props.prefillEntityType || 'person')
+const entitySearch = ref('')
+const selectedEntity = ref(
+  props.prefillEntityId
+    ? { id: props.prefillEntityId, label: props.prefillEntityLabel || props.prefillEntityId }
+    : null
+)
+const selectedFieldId = ref(props.prefillFieldId || '')
+const reason = ref('')
+const saving = ref(false)
+const error = ref(null)
+
+const isPrefilled = computed(() => !!props.prefillEntityId)
+
+// Clear selection when type changes (skip if pre-filled on mount)
+watch(entityType, (newVal, oldVal) => {
+  if (oldVal === null) return
+  selectedEntity.value = null
+  entitySearch.value = ''
+  selectedFieldId.value = ''
+})
+
+const filteredEntities = computed(() => {
+  const q = entitySearch.value.trim().toLowerCase()
+  if (!q) return []
+
+  if (entityType.value === 'person') {
+    return props.people
+      .filter(p => p.name?.toLowerCase().includes(q) || p.uid?.toLowerCase().includes(q))
+      .slice(0, 20)
+      .map(p => ({ id: p.uid, label: p.name, sub: p.uid }))
+  } else {
+    return props.teams
+      .filter(t => t.name?.toLowerCase().includes(q))
+      .slice(0, 20)
+      .map(t => ({ id: t.id, label: t.name, sub: t.orgKey }))
+  }
+})
+
+const availableFields = computed(() => {
+  const scope = entityType.value === 'person' ? 'person' : 'team'
+  const fields = (props.fieldDefinitions[scope] || [])
+    .filter(f => !f.deleted && f.visible)
+    .map(f => ({ id: f.id, label: f.label }))
+
+  if (entityType.value === 'team') {
+    fields.push({ id: '__boards__', label: 'Boards' })
+  }
+
+  return fields
+})
+
+const canSubmit = computed(() =>
+  selectedEntity.value && selectedFieldId.value && reason.value.trim()
+)
+
+function selectEntity(entity) {
+  selectedEntity.value = entity
+  entitySearch.value = ''
+}
+
+function clearEntity() {
+  selectedEntity.value = null
+  entitySearch.value = ''
+}
+
+async function handleCreate() {
+  if (!canSubmit.value) return
+  saving.value = true
+  error.value = null
+
+  try {
+    await apiRequest('/modules/team-tracker/field-exceptions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        entityType: entityType.value,
+        entityId: selectedEntity.value.id,
+        fieldId: selectedFieldId.value,
+        reason: reason.value.trim()
+      })
+    })
+    emit('created')
+    emit('close')
+  } catch (err) {
+    error.value = err.message || 'Failed to create exception'
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/modules/team-tracker/client/components/DataQualityTab.vue
+++ b/modules/team-tracker/client/components/DataQualityTab.vue
@@ -238,15 +238,28 @@
                         @add-person="addToEditPersonValue($event)"
                         @remove-person="removeFromEditPersonValue($event)"
                       />
+                      <button
+                        v-if="isFieldEmpty(person.customFields?.[field.id], field)"
+                        class="mt-1 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 rounded hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                        @click="openExceptionModal('person', person.uid, person.name, field.id)"
+                      >Add Exception</button>
                     </div>
-                    <div v-else class="cursor-pointer" @click="startCellEdit(person, field)">
-                      <FieldDisplayCell
-                        :value="person.customFields?.[field.id]"
-                        :field="field"
-                        :referenced-people="referencedPeople"
-                        :highlight="isFieldEmpty(person.customFields?.[field.id], field)"
-                        @person-click="navigateToPersonDetail($event)"
+                    <div v-else>
+                      <ExceptionPopover
+                        v-if="isFieldEmpty(person.customFields?.[field.id], field) && hasExceptionFor('person', person.uid, field.id)"
+                        :exception="getExceptionObj('person', person.uid, field.id)"
+                        @remove="handleRemoveException"
+                        @view-all="navigateToExceptionsTab"
                       />
+                      <div v-else class="cursor-pointer" @click="startCellEdit(person, field)">
+                        <FieldDisplayCell
+                          :value="person.customFields?.[field.id]"
+                          :field="field"
+                          :referenced-people="referencedPeople"
+                          :highlight="isFieldEmpty(person.customFields?.[field.id], field)"
+                          @person-click="navigateToPersonDetail($event)"
+                        />
+                      </div>
                     </div>
                   </td>
                 </tr>
@@ -383,22 +396,35 @@
                         @add-person="addToEditTeamFieldValue($event)"
                         @remove-person="editTeamFieldValue = editTeamFieldValue.filter(u => u !== $event)"
                       />
+                      <button
+                        v-if="isFieldEmpty(team.metadata?.[field.id], field)"
+                        class="mt-1 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 rounded hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                        @click="openExceptionModal('team', team.id, team.name, field.id)"
+                      >Add Exception</button>
                     </div>
-                    <div v-else class="cursor-pointer" @click="startTeamFieldEdit(team, field)">
-                      <FieldDisplayCell
-                        :value="team.metadata?.[field.id]"
-                        :field="field"
-                        :referenced-people="referencedPeople"
-                        :highlight="isFieldEmpty(team.metadata?.[field.id], field)"
-                        @person-click="navigateToPersonDetail($event)"
+                    <div v-else>
+                      <ExceptionPopover
+                        v-if="isFieldEmpty(team.metadata?.[field.id], field) && hasExceptionFor('team', team.id, field.id)"
+                        :exception="getExceptionObj('team', team.id, field.id)"
+                        @remove="handleRemoveException"
+                        @view-all="navigateToExceptionsTab"
                       />
+                      <div v-else class="cursor-pointer" @click="startTeamFieldEdit(team, field)">
+                        <FieldDisplayCell
+                          :value="team.metadata?.[field.id]"
+                          :field="field"
+                          :referenced-people="referencedPeople"
+                          :highlight="isFieldEmpty(team.metadata?.[field.id], field)"
+                          @person-click="navigateToPersonDetail($event)"
+                        />
+                      </div>
                     </div>
                   </td>
                   <!-- Boards column -->
                   <td class="px-4 py-3 text-sm" :class="teamBulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''">
                     <div
                       class="group flex items-center gap-1.5 cursor-pointer"
-                      :class="{ 'bg-red-100 dark:bg-red-700/50 rounded px-1': !team.boards || team.boards.length === 0 }"
+                      :class="{ 'bg-red-100 dark:bg-red-700/50 rounded px-1': (!team.boards || team.boards.length === 0) && !hasExceptionFor('team', team.id, '__boards__') }"
                       @click="boardsDrawerTeam = team"
                     >
                       <div v-if="team.boards && team.boards.length > 0" class="flex flex-wrap gap-1.5">
@@ -415,6 +441,12 @@
                           <ExternalLink class="w-3 h-3" />
                         </a>
                       </div>
+                      <ExceptionPopover
+                        v-else-if="hasExceptionFor('team', team.id, '__boards__')"
+                        :exception="getExceptionObj('team', team.id, '__boards__')"
+                        @remove="handleRemoveException"
+                        @view-all="navigateToExceptionsTab"
+                      />
                       <span v-else class="text-gray-400 dark:text-gray-500">—</span>
                       <svg class="h-3 w-3 text-gray-400 dark:text-gray-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
@@ -436,6 +468,20 @@
       @close="boardsDrawerTeam = null"
       @saved="refresh()"
     />
+
+    <!-- Exception modal (inline creation from edit mode) -->
+    <AddExceptionModal
+      v-if="showExceptionModal"
+      :people="allPeople.map(p => ({ uid: p.uid, name: p.name }))"
+      :teams="teams.map(t => ({ id: t.id, name: t.name, orgKey: t.orgKey }))"
+      :field-definitions="fieldDefinitions"
+      :prefill-entity-type="exceptionPrefill.entityType"
+      :prefill-entity-id="exceptionPrefill.entityId"
+      :prefill-entity-label="exceptionPrefill.entityLabel"
+      :prefill-field-id="exceptionPrefill.fieldId"
+      @close="showExceptionModal = false"
+      @created="handleExceptionCreated"
+    />
   </div>
 </template>
 
@@ -447,14 +493,17 @@ import { useFieldDefinitions } from '@shared/client/composables/useFieldDefiniti
 import { useTeams } from '@shared/client/composables/useTeams'
 import { useRoster } from '@shared/client/composables/useRoster'
 import { apiRequest } from '@shared/client/services/api'
+import { isFieldEmpty as _isFieldEmpty, buildExceptionSet, hasException as _hasException, getException as _getException } from '../utils/field-helpers'
 import ConstrainedAutocomplete from './ConstrainedAutocomplete.vue'
 import FieldDisplayCell from './FieldDisplayCell.vue'
 import FieldEditCell from './FieldEditCell.vue'
 import TeamBoardsDrawer from './TeamBoardsDrawer.vue'
+import AddExceptionModal from './AddExceptionModal.vue'
+import ExceptionPopover from './ExceptionPopover.vue'
 
 const nav = inject('moduleNav', null)
 
-const { people, teams, allPeople, referencedPeople, fieldDefinitions, orgKeys, loading, error, load, refresh } = useFieldCompleteness()
+const { people, teams, allPeople, referencedPeople, fieldDefinitions, orgKeys, fieldExceptions, loading, error, load, refresh } = useFieldCompleteness()
 const { updatePersonFields } = useFieldDefinitions()
 const { updateTeamFields } = useTeams()
 const { reloadRoster } = useRoster()
@@ -495,6 +544,36 @@ const boardsDrawerTeam = ref(null)
 // --- Teams: bulk editing ---
 const teamBulkEditing = ref(false)
 const teamBulkChanges = reactive({})
+
+// --- Exception modal (inline creation from edit mode) ---
+const showExceptionModal = ref(false)
+const exceptionPrefill = ref({ entityType: null, entityId: null, entityLabel: null, fieldId: null })
+
+function openExceptionModal(entityType, entityId, entityLabel, fieldId) {
+  exceptionPrefill.value = { entityType, entityId, entityLabel, fieldId }
+  // Close whichever edit mode is open
+  editingCell.value = { uid: null, fieldId: null }
+  editingTeamCell.value = { teamId: null, fieldId: null }
+  showExceptionModal.value = true
+}
+
+async function handleExceptionCreated() {
+  showExceptionModal.value = false
+  await refresh()
+}
+
+async function handleRemoveException(exceptionId) {
+  try {
+    await apiRequest(`/modules/team-tracker/field-exceptions/${exceptionId}`, { method: 'DELETE' })
+    await refresh()
+  } catch (err) {
+    console.error('Failed to remove exception:', err)
+  }
+}
+
+function navigateToExceptionsTab() {
+  nav?.navigateTo('manage', { tab: 'exceptions' })
+}
 
 // --- Computed: field definitions ---
 const visiblePersonFields = computed(() =>
@@ -580,16 +659,24 @@ const filteredPeopleBeforeSearch = computed(() => {
 
 // Step 2: incompleteness computation (on filtered set)
 function isFieldEmpty(value, field) {
-  if (value === null || value === undefined || value === '') return true
-  if (Array.isArray(value) && value.length === 0) return true
-  if (field.multiValue && Array.isArray(value) && value.every(v => !v)) return true
-  return false
+  return _isFieldEmpty(value, field)
+}
+
+const exceptionSet = computed(() => buildExceptionSet(fieldExceptions.value))
+
+function hasExceptionFor(entityType, entityId, fieldId) {
+  return _hasException(exceptionSet.value, entityType, entityId, fieldId)
+}
+
+function getExceptionObj(entityType, entityId, fieldId) {
+  return _getException(fieldExceptions.value, entityType, entityId, fieldId)
 }
 
 const incompletePeople = computed(() =>
   filteredPeopleBeforeSearch.value.filter(person =>
     visiblePersonFields.value.some(field =>
-      isFieldEmpty(person.customFields?.[field.id], field)
+      isFieldEmpty(person.customFields?.[field.id], field) &&
+      !hasExceptionFor('person', person.uid, field.id)
     )
   )
 )
@@ -647,9 +734,12 @@ const filteredTeamsBeforeSearch = computed(() => {
 
 const incompleteTeams = computed(() =>
   filteredTeamsBeforeSearch.value.filter(team => {
-    if (!team.boards || team.boards.length === 0) return true
+    const hasEmptyBoards = (!team.boards || team.boards.length === 0)
+      && !hasExceptionFor('team', team.id, '__boards__')
+    if (hasEmptyBoards) return true
     return visibleTeamFields.value.some(field =>
-      isFieldEmpty(team.metadata?.[field.id], field)
+      isFieldEmpty(team.metadata?.[field.id], field) &&
+      !hasExceptionFor('team', team.id, field.id)
     )
   })
 )

--- a/modules/team-tracker/client/components/ExceptionPopover.vue
+++ b/modules/team-tracker/client/components/ExceptionPopover.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="relative inline-block" ref="anchorEl">
+    <button
+      @click.stop="toggle"
+      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
+    >Exception</button>
+
+    <Teleport to="body">
+      <div
+        v-if="open"
+        ref="popoverEl"
+        class="fixed z-50 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-sm"
+        :style="popoverStyle"
+      >
+        <div class="px-3 py-2 border-b border-gray-100 dark:border-gray-700">
+          <p class="font-medium text-gray-900 dark:text-gray-100 mb-1">Exception</p>
+          <p class="text-gray-600 dark:text-gray-400 text-xs">{{ exception.reason }}</p>
+        </div>
+        <div class="px-3 py-1.5 text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+          Created by {{ exception.createdBy }}<br>
+          {{ formatDate(exception.createdAt) }}
+        </div>
+        <div class="px-3 py-2 flex items-center justify-between">
+          <button
+            @click.stop="$emit('view-all')"
+            class="text-xs text-primary-600 dark:text-primary-400 hover:underline"
+          >View all exceptions</button>
+          <button
+            @click.stop="handleRemove"
+            :disabled="removing"
+            class="text-xs text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 disabled:opacity-50"
+          >{{ removing ? 'Removing...' : 'Remove' }}</button>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+
+const props = defineProps({
+  exception: { type: Object, required: true }
+})
+
+const emit = defineEmits(['remove', 'view-all'])
+
+const open = ref(false)
+const removing = ref(false)
+const popoverEl = ref(null)
+const anchorEl = ref(null)
+const popoverStyle = ref({})
+
+function updatePosition() {
+  if (!anchorEl.value) return
+  const rect = anchorEl.value.getBoundingClientRect()
+  const popoverWidth = 256
+  let left = rect.left
+  if (left + popoverWidth > window.innerWidth - 8) {
+    left = window.innerWidth - popoverWidth - 8
+  }
+  popoverStyle.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${left}px`
+  }
+}
+
+function toggle() {
+  open.value = !open.value
+  if (open.value) {
+    nextTick(updatePosition)
+  }
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString()
+}
+
+async function handleRemove() {
+  if (!confirm('Remove this exception? The field will be tracked as incomplete again.')) return
+  removing.value = true
+  emit('remove', props.exception.id)
+}
+
+function onClickOutside(e) {
+  if (!open.value) return
+  if (popoverEl.value && popoverEl.value.contains(e.target)) return
+  if (anchorEl.value && anchorEl.value.contains(e.target)) return
+  open.value = false
+}
+
+// Close when the anchor scrolls out of the visible area
+function onScroll() {
+  if (!open.value || !anchorEl.value) return
+  const rect = anchorEl.value.getBoundingClientRect()
+  if (rect.bottom < 0 || rect.top > window.innerHeight) {
+    open.value = false
+  } else {
+    updatePosition()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', onClickOutside)
+  window.addEventListener('scroll', onScroll, true)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onClickOutside)
+  window.removeEventListener('scroll', onScroll, true)
+})
+
+watch(open, (val) => {
+  if (!val) removing.value = false
+})
+</script>

--- a/modules/team-tracker/client/components/FieldExceptionsTab.vue
+++ b/modules/team-tracker/client/components/FieldExceptionsTab.vue
@@ -1,0 +1,225 @@
+<template>
+  <div>
+    <!-- Loading state -->
+    <div v-if="loading" class="text-center py-12 text-gray-500 dark:text-gray-400">
+      Loading exceptions...
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="error" class="text-center py-12 text-red-600 dark:text-red-400">
+      {{ error }}
+    </div>
+
+    <template v-else>
+      <!-- Header with filters + add button -->
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <div class="flex flex-wrap items-center gap-3">
+          <select
+            v-model="filterType"
+            class="h-8 text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+          >
+            <option value="">All types</option>
+            <option value="person">People</option>
+            <option value="team">Teams</option>
+          </select>
+
+          <div class="relative">
+            <svg class="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search..."
+              class="pl-8 pr-3 h-8 text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-48"
+            />
+          </div>
+        </div>
+
+        <button
+          @click="showAddModal = true"
+          class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-md hover:bg-primary-700"
+        >
+          Add Exception
+        </button>
+      </div>
+
+      <!-- Empty state -->
+      <div v-if="filteredExceptions.length === 0" class="text-center py-12 text-gray-500 dark:text-gray-400">
+        <p class="text-lg font-medium mb-1">No exceptions</p>
+        <p class="text-sm">{{ exceptions.length > 0 ? 'No exceptions match your filters.' : 'Create an exception to exclude a field from completeness checks.' }}</p>
+      </div>
+
+      <!-- Exceptions table -->
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Field</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Reason</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created By</th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            <tr
+              v-for="ex in filteredExceptions"
+              :key="ex.id"
+              class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+            >
+              <td class="px-4 py-3 text-sm whitespace-nowrap">
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                  :class="ex.entityType === 'person'
+                    ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+                    : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'"
+                >
+                  {{ ex.entityType === 'person' ? 'Person' : 'Team' }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                {{ resolveEntityName(ex) }}
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                {{ resolveFieldLabel(ex) }}
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 max-w-xs truncate" :title="ex.reason">
+                {{ ex.reason }}
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                {{ ex.createdBy }}
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                {{ formatDate(ex.createdAt) }}
+              </td>
+              <td class="px-4 py-3 text-right">
+                <button
+                  @click="confirmDelete(ex)"
+                  class="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 text-sm"
+                  :disabled="deleting === ex.id"
+                >
+                  {{ deleting === ex.id ? 'Removing...' : 'Remove' }}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+
+    <!-- Add Exception Modal -->
+    <AddExceptionModal
+      v-if="showAddModal"
+      :people="allPeople"
+      :teams="allTeams"
+      :field-definitions="fieldDefinitions"
+      @close="showAddModal = false"
+      @created="handleCreated"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+import { useFieldCompleteness } from '../composables/useFieldCompleteness'
+import AddExceptionModal from './AddExceptionModal.vue'
+
+const { people, teams, fieldDefinitions, load: loadCompleteness } = useFieldCompleteness()
+
+const exceptions = ref([])
+const loading = ref(false)
+const error = ref(null)
+const showAddModal = ref(false)
+const deleting = ref(null)
+
+const filterType = ref('')
+const searchQuery = ref('')
+
+// Expose people and teams for the modal
+const allPeople = computed(() =>
+  people.value.map(p => ({ uid: p.uid, name: p.name }))
+)
+const allTeams = computed(() =>
+  teams.value.map(t => ({ id: t.id, name: t.name, orgKey: t.orgKey }))
+)
+
+// Resolve entity name from loaded completeness data
+function resolveEntityName(ex) {
+  if (ex.entityType === 'person') {
+    const person = people.value.find(p => p.uid === ex.entityId)
+    return person?.name || ex.entityId
+  } else {
+    const team = teams.value.find(t => t.id === ex.entityId)
+    return team?.name || ex.entityId
+  }
+}
+
+// Resolve field label from field definitions
+function resolveFieldLabel(ex) {
+  if (ex.fieldId === '__boards__') return 'Boards'
+  const scope = ex.entityType === 'person' ? 'person' : 'team'
+  const field = (fieldDefinitions.value[scope] || []).find(f => f.id === ex.fieldId)
+  return field?.label || ex.fieldId
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString()
+}
+
+const filteredExceptions = computed(() => {
+  let result = exceptions.value
+  if (filterType.value) {
+    result = result.filter(e => e.entityType === filterType.value)
+  }
+  const q = searchQuery.value.trim().toLowerCase()
+  if (q) {
+    result = result.filter(e => {
+      const name = resolveEntityName(e).toLowerCase()
+      const field = resolveFieldLabel(e).toLowerCase()
+      return name.includes(q) || field.includes(q) || e.reason?.toLowerCase().includes(q)
+    })
+  }
+  return result
+})
+
+async function loadExceptions() {
+  loading.value = true
+  error.value = null
+  try {
+    await loadCompleteness()
+    const data = await apiRequest('/modules/team-tracker/field-exceptions')
+    exceptions.value = data.exceptions || []
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleCreated() {
+  await loadExceptions()
+}
+
+async function confirmDelete(ex) {
+  const name = resolveEntityName(ex)
+  const field = resolveFieldLabel(ex)
+  if (!confirm(`Remove exception for ${ex.entityType} "${name}" on field "${field}"?`)) return
+
+  deleting.value = ex.id
+  try {
+    await apiRequest(`/modules/team-tracker/field-exceptions/${ex.id}`, { method: 'DELETE' })
+    exceptions.value = exceptions.value.filter(e => e.id !== ex.id)
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    deleting.value = null
+  }
+}
+
+onMounted(loadExceptions)
+</script>

--- a/modules/team-tracker/client/composables/useFieldCompleteness.js
+++ b/modules/team-tracker/client/composables/useFieldCompleteness.js
@@ -7,6 +7,7 @@ const allPeople = ref([])
 const referencedPeople = ref({})
 const fieldDefinitions = ref({ person: [], team: [] })
 const orgKeys = ref([])
+const fieldExceptions = ref([])
 const loading = ref(false)
 const error = ref(null)
 
@@ -22,6 +23,7 @@ export function useFieldCompleteness() {
       referencedPeople.value = data.referencedPeople || {}
       fieldDefinitions.value = data.fieldDefinitions || { person: [], team: [] }
       orgKeys.value = data.orgKeys || []
+      fieldExceptions.value = data.fieldExceptions || []
     } catch (err) {
       error.value = err.message
     } finally {
@@ -40,6 +42,7 @@ export function useFieldCompleteness() {
     referencedPeople,
     fieldDefinitions,
     orgKeys,
+    fieldExceptions,
     loading,
     error,
     load,

--- a/modules/team-tracker/client/composables/useManagerDashboard.js
+++ b/modules/team-tracker/client/composables/useManagerDashboard.js
@@ -9,6 +9,7 @@ const allOrgTeams = ref([])
 const allPeople = ref([])
 const referencedPeople = ref({})
 const fieldDefinitions = ref({ person: [], team: [] })
+const fieldExceptions = ref([])
 const loading = ref(false)
 const error = ref(null)
 const reason = ref(null)
@@ -30,6 +31,7 @@ export function useManagerDashboard() {
       allPeople.value = data.allPeople || []
       referencedPeople.value = data.referencedPeople || {}
       fieldDefinitions.value = data.fieldDefinitions || { person: [], team: [] }
+      fieldExceptions.value = data.fieldExceptions || []
       reason.value = data.reason || null
     } catch (err) {
       error.value = err.message
@@ -51,6 +53,7 @@ export function useManagerDashboard() {
     allPeople,
     referencedPeople,
     fieldDefinitions,
+    fieldExceptions,
     loading,
     error,
     reason,

--- a/modules/team-tracker/client/utils/field-helpers.js
+++ b/modules/team-tracker/client/utils/field-helpers.js
@@ -1,0 +1,54 @@
+/**
+ * Shared field completeness helpers for team-tracker.
+ * Used by DataQualityTab and ManagerDashboardView.
+ */
+
+/**
+ * Check if a field value is empty (not set).
+ */
+export function isFieldEmpty(value, field) {
+  if (value === null || value === undefined || value === '') return true
+  if (Array.isArray(value) && value.length === 0) return true
+  if (field.multiValue && Array.isArray(value) && value.every(v => !v)) return true
+  return false
+}
+
+/**
+ * Build a Set of exception keys for O(1) lookup.
+ * Key format: "entityType:entityId:fieldId"
+ * @param {Array} exceptions - Array of exception objects
+ * @returns {Set<string>}
+ */
+export function buildExceptionSet(exceptions) {
+  const set = new Set()
+  for (const ex of exceptions) {
+    set.add(`${ex.entityType}:${ex.entityId}:${ex.fieldId}`)
+  }
+  return set
+}
+
+/**
+ * Check if a field is incomplete, accounting for exceptions.
+ * Returns true if the field is empty AND not excepted.
+ */
+export function isFieldIncomplete(value, field, exceptionSet, entityType, entityId) {
+  if (!isFieldEmpty(value, field)) return false
+  if (exceptionSet && exceptionSet.has(`${entityType}:${entityId}:${field.id}`)) return false
+  return true
+}
+
+/**
+ * Check if a field has an active exception.
+ */
+export function hasException(exceptionSet, entityType, entityId, fieldId) {
+  return exceptionSet && exceptionSet.has(`${entityType}:${entityId}:${fieldId}`)
+}
+
+/**
+ * Get the exception object for a specific field.
+ */
+export function getException(exceptions, entityType, entityId, fieldId) {
+  return exceptions.find(
+    ex => ex.entityType === entityType && ex.entityId === entityId && ex.fieldId === fieldId
+  ) || null
+}

--- a/modules/team-tracker/client/views/ManageView.vue
+++ b/modules/team-tracker/client/views/ManageView.vue
@@ -25,6 +25,7 @@
       <FieldDefinitionManager v-if="activeTab === 'fields'" />
       <FieldOptionsManager v-if="activeTab === 'field-options'" />
       <DataQualityTab v-if="activeTab === 'data-quality'" />
+      <FieldExceptionsTab v-if="activeTab === 'exceptions'" />
     </template>
   </div>
 </template>
@@ -36,6 +37,7 @@ import TeamManagement from '../components/TeamManagement.vue'
 import FieldDefinitionManager from '../components/FieldDefinitionManager.vue'
 import FieldOptionsManager from '../components/FieldOptionsManager.vue'
 import DataQualityTab from '../components/DataQualityTab.vue'
+import FieldExceptionsTab from '../components/FieldExceptionsTab.vue'
 
 const { isAdmin, isTeamAdmin, loading } = usePermissions()
 const moduleNav = inject('moduleNav')
@@ -44,7 +46,8 @@ const tabs = [
   { id: 'teams', label: 'Teams' },
   { id: 'fields', label: 'Fields' },
   { id: 'field-options', label: 'Field Options' },
-  { id: 'data-quality', label: 'Data Quality' }
+  { id: 'data-quality', label: 'Data Quality' },
+  { id: 'exceptions', label: 'Exceptions' }
 ]
 
 // Support deep-linking via ?tab=data-quality
@@ -60,6 +63,15 @@ watch(activeTab, (tab) => {
     moduleNav?.updateParams({ tab }, { push: false })
   }
 })
+
+// React to param changes (e.g. navigateTo('manage', { tab: 'exceptions' }) from a child)
+if (moduleNav?.params) {
+  watch(() => moduleNav.params.value?.tab, (newTab) => {
+    if (newTab && tabIds.includes(newTab)) {
+      activeTab.value = newTab
+    }
+  })
+}
 
 const hasAccess = computed(() => isAdmin.value || isTeamAdmin.value)
 

--- a/modules/team-tracker/client/views/ManagerDashboardView.vue
+++ b/modules/team-tracker/client/views/ManagerDashboardView.vue
@@ -269,7 +269,13 @@
                     class="cursor-pointer"
                     @click="startCellEdit(report, field)"
                   >
+                    <span
+                      v-if="isFieldEmpty(report.customFields?.[field.id], field) && hasExceptionFor('person', report.uid, field.id)"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                      :title="getExceptionReason('person', report.uid, field.id)"
+                    >Exception</span>
                     <FieldDisplayCell
+                      v-else
                       :value="report.customFields?.[field.id]"
                       :field="field"
                       :referenced-people="referencedPeople"
@@ -429,7 +435,13 @@
                       class="cursor-pointer"
                       @click="startTeamFieldEdit(team, field)"
                     >
+                      <span
+                        v-if="isFieldEmpty(team.metadata?.[field.id], field) && hasExceptionFor('team', team.id, field.id)"
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                        :title="getExceptionReason('team', team.id, field.id)"
+                      >Exception</span>
                       <FieldDisplayCell
+                        v-else
                         :value="team.metadata?.[field.id]"
                         :field="field"
                         :referenced-people="referencedPeople"
@@ -442,7 +454,7 @@
                   <td class="px-4 py-3 text-sm" :class="teamBulkEditing ? 'bg-blue-50 dark:bg-blue-900/20' : ''">
                     <div
                       class="group flex items-center gap-1.5 cursor-pointer"
-                      :class="{ 'bg-red-100 dark:bg-red-700/50 rounded px-1': !team.boards || team.boards.length === 0 }"
+                      :class="{ 'bg-red-100 dark:bg-red-700/50 rounded px-1': (!team.boards || team.boards.length === 0) && !hasExceptionFor('team', team.id, '__boards__') }"
                       @click="boardsDrawerTeam = team"
                     >
                       <div v-if="team.boards && team.boards.length > 0" class="flex flex-wrap gap-1.5">
@@ -459,6 +471,11 @@
                           <ExternalLink class="w-3 h-3" />
                         </a>
                       </div>
+                      <span
+                        v-else-if="hasExceptionFor('team', team.id, '__boards__')"
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                        :title="getExceptionReason('team', team.id, '__boards__')"
+                      >Exception</span>
                       <span v-else class="text-gray-400 dark:text-gray-500">—</span>
                       <svg class="h-3 w-3 text-gray-400 dark:text-gray-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
@@ -492,6 +509,7 @@ import { useFieldDefinitions } from '@shared/client/composables/useFieldDefiniti
 import { useTeams } from '@shared/client/composables/useTeams'
 import { useRoster } from '@shared/client/composables/useRoster'
 import { apiRequest } from '@shared/client/services/api'
+import { isFieldEmpty as _isFieldEmpty, buildExceptionSet, hasException as _hasException, getException as _getException } from '../utils/field-helpers'
 import ConstrainedAutocomplete from '../components/ConstrainedAutocomplete.vue'
 import FieldDisplayCell from '../components/FieldDisplayCell.vue'
 import FieldEditCell from '../components/FieldEditCell.vue'
@@ -500,7 +518,7 @@ import { useManagerTutorial } from '../composables/useManagerTutorial'
 
 const nav = inject('moduleNav', null)
 
-const { directReports, indirectReports, teams, allOrgTeams, allPeople, referencedPeople, fieldDefinitions, loading, error, reason, includeIndirect, load, refresh } = useManagerDashboard()
+const { directReports, indirectReports, teams, allOrgTeams, allPeople, referencedPeople, fieldDefinitions, fieldExceptions, loading, error, reason, includeIndirect, load, refresh } = useManagerDashboard()
 const { updatePersonFields } = useFieldDefinitions()
 const { updateTeamFields } = useTeams()
 const { reloadRoster } = useRoster()
@@ -550,16 +568,25 @@ const visibleReports = computed(() =>
 // --- Field completeness ---
 
 function isFieldEmpty(value, field) {
-  if (value === null || value === undefined || value === '') return true
-  if (Array.isArray(value) && value.length === 0) return true
-  if (field.multiValue && Array.isArray(value) && value.every(v => !v)) return true
-  return false
+  return _isFieldEmpty(value, field)
+}
+
+const exceptionSet = computed(() => buildExceptionSet(fieldExceptions.value))
+
+function hasExceptionFor(entityType, entityId, fieldId) {
+  return _hasException(exceptionSet.value, entityType, entityId, fieldId)
+}
+
+function getExceptionReason(entityType, entityId, fieldId) {
+  const ex = _getException(fieldExceptions.value, entityType, entityId, fieldId)
+  return ex ? `Exception: ${ex.reason}\nCreated by ${ex.createdBy}` : ''
 }
 
 const incompleteReports = computed(() => {
   return visibleReports.value.filter(report => {
     return visiblePersonFields.value.some(field =>
-      isFieldEmpty(report.customFields?.[field.id], field)
+      isFieldEmpty(report.customFields?.[field.id], field) &&
+      !hasExceptionFor('person', report.uid, field.id)
     )
   })
 })
@@ -568,9 +595,12 @@ const incompleteReportUids = computed(() => new Set(incompleteReports.value.map(
 
 const incompleteTeams = computed(() => {
   return teams.value.filter(team => {
-    if (!team.boards || team.boards.length === 0) return true
+    const hasEmptyBoards = (!team.boards || team.boards.length === 0)
+      && !hasExceptionFor('team', team.id, '__boards__')
+    if (hasEmptyBoards) return true
     return visibleTeamFields.value.some(field =>
-      isFieldEmpty(team.metadata?.[field.id], field)
+      isFieldEmpty(team.metadata?.[field.id], field) &&
+      !hasExceptionFor('team', team.id, field.id)
     )
   })
 })

--- a/modules/team-tracker/server/field-exceptions-store.js
+++ b/modules/team-tracker/server/field-exceptions-store.js
@@ -1,0 +1,161 @@
+/**
+ * Field exceptions store for team-tracker.
+ * Manages per-field exceptions that exclude specific fields from completeness
+ * checks for individual people or teams.
+ * Single file at data/team-data/field-exceptions.json.
+ */
+
+const crypto = require('crypto');
+const { appendAuditEntry } = require('../../../shared/server/audit-log');
+
+const STORAGE_KEY = 'team-data/field-exceptions.json';
+
+function generateId() {
+  return 'fex_' + crypto.randomBytes(4).toString('hex');
+}
+
+function readExceptions(storage) {
+  return storage.readFromStorage(STORAGE_KEY) || { version: 1, exceptions: [] };
+}
+
+function writeExceptions(storage, data) {
+  storage.writeToStorage(STORAGE_KEY, data);
+}
+
+/**
+ * List exceptions with optional filters.
+ */
+function listExceptions(storage, filters = {}) {
+  const data = readExceptions(storage);
+  let results = data.exceptions;
+
+  if (filters.entityType) {
+    results = results.filter(e => e.entityType === filters.entityType);
+  }
+  if (filters.entityId) {
+    results = results.filter(e => e.entityId === filters.entityId);
+  }
+  if (filters.fieldId) {
+    results = results.filter(e => e.fieldId === filters.fieldId);
+  }
+
+  return results;
+}
+
+/**
+ * Get a single exception by ID.
+ */
+function getException(storage, id) {
+  const data = readExceptions(storage);
+  return data.exceptions.find(e => e.id === id) || null;
+}
+
+/**
+ * Find an exception by its natural key tuple.
+ */
+function findException(storage, entityType, entityId, fieldId) {
+  const data = readExceptions(storage);
+  return data.exceptions.find(
+    e => e.entityType === entityType && e.entityId === entityId && e.fieldId === fieldId
+  ) || null;
+}
+
+/**
+ * Create or upsert an exception.
+ * Returns { exception, created } where created is true for new, false for upsert.
+ */
+function createException(storage, { entityType, entityId, fieldId, reason }, actorEmail) {
+  const data = readExceptions(storage);
+  const existing = data.exceptions.find(
+    e => e.entityType === entityType && e.entityId === entityId && e.fieldId === fieldId
+  );
+
+  if (existing) {
+    // Upsert: update reason
+    existing.reason = reason;
+    existing.createdAt = new Date().toISOString();
+    existing.createdBy = actorEmail;
+    writeExceptions(storage, data);
+
+    appendAuditEntry(storage, {
+      action: 'field-exception.update',
+      actor: actorEmail,
+      entityType: 'field-exception',
+      entityId: existing.id,
+      detail: `Updated exception reason for ${entityType} "${entityId}" on field "${fieldId}"`
+    });
+
+    return { exception: existing, created: false };
+  }
+
+  const exception = {
+    id: generateId(),
+    entityType,
+    entityId,
+    fieldId,
+    reason,
+    createdAt: new Date().toISOString(),
+    createdBy: actorEmail
+  };
+
+  data.exceptions.push(exception);
+  writeExceptions(storage, data);
+
+  appendAuditEntry(storage, {
+    action: 'field-exception.create',
+    actor: actorEmail,
+    entityType: 'field-exception',
+    entityId: exception.id,
+    detail: `Created exception for ${entityType} "${entityId}" on field "${fieldId}": ${reason}`
+  });
+
+  return { exception, created: true };
+}
+
+/**
+ * Remove an exception by ID.
+ * Returns the removed exception, or null if not found.
+ */
+function removeException(storage, id, actorEmail) {
+  const data = readExceptions(storage);
+  const idx = data.exceptions.findIndex(e => e.id === id);
+  if (idx === -1) return null;
+
+  const [removed] = data.exceptions.splice(idx, 1);
+  writeExceptions(storage, data);
+
+  appendAuditEntry(storage, {
+    action: 'field-exception.remove',
+    actor: actorEmail,
+    entityType: 'field-exception',
+    entityId: id,
+    detail: `Removed exception for ${removed.entityType} "${removed.entityId}" on field "${removed.fieldId}"`
+  });
+
+  return removed;
+}
+
+/**
+ * Build an exception map for O(1) lookups during completeness checks.
+ * Key format: "entityType:entityId:fieldId"
+ */
+function getExceptionMap(storage) {
+  const data = readExceptions(storage);
+  const map = new Map();
+  for (const ex of data.exceptions) {
+    map.set(`${ex.entityType}:${ex.entityId}:${ex.fieldId}`, ex);
+  }
+  return map;
+}
+
+module.exports = {
+  readExceptions,
+  writeExceptions,
+  listExceptions,
+  getException,
+  findException,
+  createException,
+  removeException,
+  getExceptionMap,
+  STORAGE_KEY
+};

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -636,6 +636,17 @@ module.exports = function registerRoutes(router, context) {
       team.orgDisplayName = orgDisplayNames[team.orgKey] || team.orgKey;
     }
 
+    // Load field exceptions filtered to manager's purview
+    const fieldExceptionsStoreForDashboard = require('./field-exceptions-store');
+    const allExceptions = fieldExceptionsStoreForDashboard.listExceptions(storage);
+    const directReportUidSet = new Set(purview.directReportUids);
+    const purviewTeamIds = new Set(purview.teams.map(t => t.id));
+    const filteredExceptions = allExceptions.filter(ex => {
+      if (ex.entityType === 'person') return directReportUidSet.has(ex.entityId);
+      if (ex.entityType === 'team') return purviewTeamIds.has(ex.entityId);
+      return false;
+    });
+
     const response = {
       manager: managerPerson ? {
         uid: req.userUid,
@@ -650,7 +661,8 @@ module.exports = function registerRoutes(router, context) {
       fieldDefinitions: {
         person: personFieldDefs,
         team: teamFieldDefs
-      }
+      },
+      fieldExceptions: filteredExceptions
     };
     if (includeIndirect) response.indirectReports = indirectReports || [];
     res.json(response);
@@ -727,6 +739,9 @@ module.exports = function registerRoutes(router, context) {
       displayName: orgDisplayNames[key] || key
     }));
 
+    const fieldExceptionsStoreLocal = require('./field-exceptions-store');
+    const exceptionsData = fieldExceptionsStoreLocal.readExceptions(storage);
+
     res.json({
       people,
       teams,
@@ -736,7 +751,8 @@ module.exports = function registerRoutes(router, context) {
         person: personFieldDefs,
         team: teamFieldDefs
       },
-      orgKeys
+      orgKeys,
+      fieldExceptions: exceptionsData.exceptions
     });
   });
 
@@ -4076,11 +4092,15 @@ module.exports = function registerRoutes(router, context) {
 
       const fieldStore = require('../../../shared/server/field-store');
       const teamStore = require('../../../shared/server/team-store');
+      const fieldExceptionsStore = require('./field-exceptions-store');
       const fieldDefs = fieldStore.readFieldDefinitions(storage);
       if (!fieldDefs) return [];
 
       const personFields = fieldDefs.personFields.filter(f => !f.deleted && f.visible);
       const teamFields = fieldDefs.teamFields.filter(f => !f.deleted && f.visible);
+
+      // Load exception map for O(1) lookups
+      const exceptionMap = fieldExceptionsStore.getExceptionMap(storage);
 
       // If no visible person fields and no team fields, still check boards
       // (boards are always a completeness concern for teams)
@@ -4090,7 +4110,10 @@ module.exports = function registerRoutes(router, context) {
       for (const uid of directReportSet) {
         const person = registry.people[uid];
         if (!person || person.status !== 'active') continue;
-        const hasEmpty = personFields.some(f => isFieldEmpty(person._appFields?.[f.id], f));
+        const hasEmpty = personFields.some(f =>
+          isFieldEmpty(person._appFields?.[f.id], f) &&
+          !exceptionMap.has(`person:${uid}:${f.id}`)
+        );
         if (hasEmpty) incompletePersonCount++;
       }
 
@@ -4099,8 +4122,12 @@ module.exports = function registerRoutes(router, context) {
       const purview = getManagerPurview(user.uid, registry, teamsData, { includeIndirect: false });
       let incompleteTeamCount = 0;
       for (const team of purview.teams) {
-        const hasEmptyBoards = !team.boards || team.boards.length === 0;
-        const hasEmptyField = teamFields.some(f => isFieldEmpty(team.metadata?.[f.id], f));
+        const hasEmptyBoards = (!team.boards || team.boards.length === 0)
+          && !exceptionMap.has(`team:${team.id}:__boards__`);
+        const hasEmptyField = teamFields.some(f =>
+          isFieldEmpty(team.metadata?.[f.id], f) &&
+          !exceptionMap.has(`team:${team.id}:${f.id}`)
+        );
         if (hasEmptyBoards || hasEmptyField) incompleteTeamCount++;
       }
 
@@ -4142,9 +4169,11 @@ module.exports = function registerRoutes(router, context) {
   const registerIpaRegistryRoutes = require('./routes/ipa-registry');
   const registerOrgTeamsRoutes = require('./routes/org-teams');
   const { isOrgSyncInProgress, getTriggerOrgSync } = require('./routes/org-teams');
+  const registerFieldExceptionRoutes = require('./routes/field-exceptions');
 
   registerIpaRegistryRoutes(router, context);
   registerOrgTeamsRoutes(router, context);
+  registerFieldExceptionRoutes(router, context);
 
   // ─── Unified Sync ───
 

--- a/modules/team-tracker/server/routes/field-exceptions.js
+++ b/modules/team-tracker/server/routes/field-exceptions.js
@@ -1,0 +1,229 @@
+/**
+ * Field exception routes for team-tracker.
+ * CRUD for per-field exceptions that exclude specific fields from completeness checks.
+ */
+
+const fieldExceptionsStore = require('../field-exceptions-store');
+
+module.exports = function registerFieldExceptionRoutes(router, context) {
+  const { storage, requireTeamAdmin, requireScope } = context;
+  const { readFromStorage } = storage;
+
+  const DEMO_MODE = process.env.DEMO_MODE === 'true';
+
+  function demoWriteGuard(res) {
+    if (DEMO_MODE) {
+      return res.json({ demo: true, message: 'Demo mode — changes are not saved' });
+    }
+    return null;
+  }
+
+  // ─── Permission-based filtering ───
+
+  function filterExceptionsForUser(exceptions, req) {
+    if (req.isAdmin || req.isTeamAdmin) return exceptions;
+    if (req.permissionTier === 'user') return [];
+
+    // Manager: filter to managed people and purview teams
+    const permissions = require('../../../../shared/server/permissions');
+    const { getManagerPurview } = require('../manager-purview');
+
+    const registry = readFromStorage('team-data/registry.json');
+    if (!registry) return [];
+
+    const teamStore = require('../../../../shared/server/team-store');
+    const teamsData = teamStore.readTeams(storage);
+
+    const managedUids = permissions.getManagedUids(req.userUid, permissions.buildManagerMap(registry));
+    const purview = getManagerPurview(req.userUid, registry, teamsData, { includeIndirect: false });
+    const purviewTeamIds = new Set(purview.teams.map(t => t.id));
+
+    return exceptions.filter(ex => {
+      if (ex.entityType === 'person') return managedUids.has(ex.entityId);
+      if (ex.entityType === 'team') return purviewTeamIds.has(ex.entityId);
+      return false;
+    });
+  }
+
+  // ─── GET /field-exceptions ───
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/field-exceptions:
+   *   get:
+   *     tags: ['TT: Field Exceptions']
+   *     summary: List field exceptions with optional filters
+   *     parameters:
+   *       - name: entityType
+   *         in: query
+   *         schema:
+   *           type: string
+   *           enum: [person, team]
+   *       - name: entityId
+   *         in: query
+   *         schema:
+   *           type: string
+   *       - name: fieldId
+   *         in: query
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Filtered exceptions list
+   */
+  router.get('/field-exceptions', requireScope('roster:read'), function(req, res) {
+    const filters = {};
+    if (req.query.entityType) filters.entityType = req.query.entityType;
+    if (req.query.entityId) filters.entityId = req.query.entityId;
+    if (req.query.fieldId) filters.fieldId = req.query.fieldId;
+
+    let exceptions = fieldExceptionsStore.listExceptions(storage, filters);
+    exceptions = filterExceptionsForUser(exceptions, req);
+
+    res.json({ exceptions });
+  });
+
+  // ─── POST /field-exceptions ───
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/field-exceptions:
+   *   post:
+   *     tags: ['TT: Field Exceptions']
+   *     summary: Create a field exception
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [entityType, entityId, fieldId, reason]
+   *             properties:
+   *               entityType:
+   *                 type: string
+   *                 enum: [person, team]
+   *               entityId:
+   *                 type: string
+   *               fieldId:
+   *                 type: string
+   *               reason:
+   *                 type: string
+   *                 maxLength: 500
+   *     responses:
+   *       201:
+   *         description: Exception created
+   *       200:
+   *         description: Exception updated (duplicate tuple)
+   *       400:
+   *         description: Validation error
+   *       403:
+   *         description: Not team-admin or admin
+   */
+  router.post('/field-exceptions', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
+    const guarded = demoWriteGuard(res);
+    if (guarded) return;
+
+    const { entityType, entityId, fieldId, reason } = req.body;
+
+    // Validate entityType
+    if (!entityType || !['person', 'team'].includes(entityType)) {
+      return res.status(400).json({ error: 'entityType must be "person" or "team"' });
+    }
+
+    // Validate entityId
+    if (!entityId || typeof entityId !== 'string') {
+      return res.status(400).json({ error: 'entityId is required' });
+    }
+
+    // Validate reason
+    if (!reason || typeof reason !== 'string' || !reason.trim()) {
+      return res.status(400).json({ error: 'reason is required' });
+    }
+    if (reason.length > 500) {
+      return res.status(400).json({ error: 'reason must be 500 characters or fewer' });
+    }
+
+    // Validate fieldId
+    if (!fieldId || typeof fieldId !== 'string') {
+      return res.status(400).json({ error: 'fieldId is required' });
+    }
+
+    // Validate __boards__ sentinel
+    if (fieldId === '__boards__' && entityType !== 'team') {
+      return res.status(400).json({ error: '__boards__ is only valid with entityType "team"' });
+    }
+
+    // Validate entity exists
+    if (entityType === 'person') {
+      const registry = readFromStorage('team-data/registry.json');
+      if (!registry || !registry.people || !registry.people[entityId]) {
+        return res.status(400).json({ error: `Person "${entityId}" not found in registry` });
+      }
+    } else {
+      const teamStore = require('../../../../shared/server/team-store');
+      const teamsData = teamStore.readTeams(storage);
+      if (!teamsData || !teamsData.teams || !teamsData.teams[entityId]) {
+        return res.status(400).json({ error: `Team "${entityId}" not found` });
+      }
+    }
+
+    // Validate fieldId exists and is not deleted (skip for __boards__ sentinel)
+    if (fieldId !== '__boards__') {
+      const fieldStore = require('../../../../shared/server/field-store');
+      const fieldDefs = fieldStore.readFieldDefinitions(storage);
+      const scope = entityType === 'person' ? 'personFields' : 'teamFields';
+      const field = (fieldDefs[scope] || []).find(f => f.id === fieldId);
+      if (!field) {
+        return res.status(400).json({ error: `Field "${fieldId}" not found in ${entityType} field definitions` });
+      }
+      if (field.deleted) {
+        return res.status(400).json({ error: `Field "${fieldId}" is deleted` });
+      }
+    }
+
+    const actorEmail = req.userEmail || 'unknown';
+    const { exception, created } = fieldExceptionsStore.createException(
+      storage,
+      { entityType, entityId, fieldId, reason: reason.trim() },
+      actorEmail
+    );
+
+    res.status(created ? 201 : 200).json({ exception });
+  });
+
+  // ─── DELETE /field-exceptions/:id ───
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/field-exceptions/{id}:
+   *   delete:
+   *     tags: ['TT: Field Exceptions']
+   *     summary: Remove a field exception
+   *     parameters:
+   *       - name: id
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Exception removed
+   *       404:
+   *         description: Exception not found
+   *       403:
+   *         description: Not team-admin or admin
+   */
+  router.delete('/field-exceptions/:id', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
+    const guarded = demoWriteGuard(res);
+    if (guarded) return;
+
+    const actorEmail = req.userEmail || 'unknown';
+    const removed = fieldExceptionsStore.removeException(storage, req.params.id, actorEmail);
+
+    if (!removed) {
+      return res.status(404).json({ error: 'Exception not found' });
+    }
+
+    res.json({ removed: true });
+  });
+};


### PR DESCRIPTION
## Summary

- Adds a centralized, auditable **field exceptions system** allowing team admins to mark specific fields as intentionally unset for people or teams
- Excepted fields are excluded from completeness counts and notifications
- Team admins manage exceptions via a new **Exceptions tab** on the Manage view (CRUD with search/filters)
- Managers can see, create, and remove exceptions inline from the **Data Quality tab** via popovers and edit-mode buttons
- Manager dashboard updated to surface exception indicators

## What's included

**Backend:**
- `field-exceptions-store.js` — CRUD store with `fex_` prefixed IDs, audit logging
- `routes/field-exceptions.js` — GET (roster:read, permission-filtered), POST/DELETE (team-admin)
- Completeness calculations updated to exclude excepted fields
- OpenAPI annotations on all new routes

**Frontend:**
- `FieldExceptionsTab.vue` — full management UI with type filter, search, add modal
- `AddExceptionModal.vue` — entity search, field selector, reason textarea, prefill support
- `ExceptionPopover.vue` — teleported popover showing exception details, remove action, link to Exceptions tab
- `DataQualityTab.vue` — inline "Add Exception" button in edit mode, exception popovers replacing static badges
- `ManageView.vue` — reactive tab switching via moduleNav params
- `field-helpers.js` — shared helpers for field emptiness and exception checking

**Tests:**
- Store unit tests, route unit tests, completeness integration tests
- Frontend component tests for FieldExceptionsTab and DataQualityTab

**Docs:**
- Updated `.claude/CLAUDE.md` API routes
- Updated `docs/DATA-FORMATS.md` with field-exceptions schema
- Demo fixture at `fixtures/team-data/field-exceptions.json`

## Test plan

- [ ] Create an exception from the Exceptions tab via "Add Exception" modal
- [ ] Verify excepted fields no longer count as incomplete on Data Quality tab
- [ ] Click an Exception badge on Data Quality tab → popover shows reason, created by, date
- [ ] Remove an exception from the popover → field becomes incomplete again
- [ ] Click "View all exceptions" in popover → navigates to Exceptions tab
- [ ] In edit mode on Data Quality tab, click "Add Exception" on an empty field → modal opens prefilled
- [ ] Verify managers can see (but not create/remove) exceptions for their reports
- [ ] Run `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)