### PR TITLE
feat: add team metadata query and group-by API endpoints

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -245,6 +245,8 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/manager/dashboard` — manager dashboard data
 - `/api/modules/team-tracker/admin/field-completeness` — all people/teams with field data for data quality auditing (team-admin/admin)
 - `/api/modules/team-tracker/structure/teams` — list teams
+- `/api/modules/team-tracker/structure/teams/query` — query teams by metadata field values with AND/OR, pagination
+- `/api/modules/team-tracker/structure/group-by` — group teams by metadata field value (inverted index)
 - `/api/modules/team-tracker/structure/unassigned` — unassigned people
 - `/api/modules/team-tracker/structure/field-definitions` — field definitions
 - `/api/modules/team-tracker/structure/audit-log` — audit log

--- a/modules/team-tracker/__tests__/server/team-query.test.js
+++ b/modules/team-tracker/__tests__/server/team-query.test.js
@@ -1,0 +1,521 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }))
+
+function makeStorage(initial = {}) {
+  const data = { ...initial }
+  return {
+    readFromStorage(key) { return data[key] ? JSON.parse(JSON.stringify(data[key])) : null },
+    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    listStorageFiles(dir) {
+      return Object.keys(data)
+        .filter(k => k.startsWith(dir + '/') && k.endsWith('.json'))
+        .map(k => k.split('/').pop())
+    },
+    deleteStorageDirectory: vi.fn(),
+    _data: data
+  }
+}
+
+function setupRoutes(storageData) {
+  const handlers = {}
+  const mockRouter = {
+    get(path, ...args) { handlers[`GET ${path}`] = args[args.length - 1] },
+    post(path, ...args) { handlers[`POST ${path}`] = args[args.length - 1] },
+    put(path, ...args) { handlers[`PUT ${path}`] = args[args.length - 1] },
+    patch(path, ...args) { handlers[`PATCH ${path}`] = args[args.length - 1] },
+    delete(path, ...args) { handlers[`DELETE ${path}`] = args[args.length - 1] }
+  }
+
+  const storage = makeStorage(storageData)
+  const context = {
+    storage,
+    requireAdmin: (req, res, next) => next(),
+    requireTeamAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next(),
+    roleStore: {
+      getRoles: vi.fn(() => []),
+      isAdmin: vi.fn(() => false),
+      isTeamAdmin: vi.fn(() => false)
+    }
+  }
+
+  const registerRoutes = require('../../server/index.js')
+  registerRoutes(mockRouter, context)
+
+  return { handlers, storage }
+}
+
+function mockRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) { res._status = code; return res },
+    json(body) { res._body = body; return res }
+  }
+  return res
+}
+
+function baseStorageData() {
+  return {
+    'team-data/field-definitions.json': {
+      personFields: [],
+      teamFields: [
+        {
+          id: 'field_comp', label: 'Component', type: 'constrained', multiValue: true,
+          required: false, visible: true, primaryDisplay: false, allowedValues: [],
+          deleted: false, order: 0, createdAt: '2026-01-01', createdBy: 'admin@test.com',
+          optionsRef: 'component'
+        },
+        {
+          id: 'field_status', label: 'Status', type: 'constrained', multiValue: false,
+          required: false, visible: true, primaryDisplay: false, allowedValues: ['Active', 'Sunset'],
+          deleted: false, order: 1, createdAt: '2026-01-01', createdBy: 'admin@test.com'
+        },
+        {
+          id: 'field_deleted', label: 'OldField', type: 'free-text', multiValue: false,
+          required: false, visible: true, primaryDisplay: false, allowedValues: [],
+          deleted: true, order: 2, createdAt: '2026-01-01', createdBy: 'admin@test.com'
+        }
+      ]
+    },
+    'team-data/teams.json': {
+      teams: {
+        team_a: {
+          id: 'team_a', name: 'Pipelines', orgKey: 'org1',
+          createdAt: '2026-01-01', createdBy: 'admin@test.com',
+          metadata: { field_comp: ['AI Pipelines', 'MLflow'], field_status: 'Active' },
+          boards: []
+        },
+        team_b: {
+          id: 'team_b', name: 'Serving', orgKey: 'org1',
+          createdAt: '2026-01-01', createdBy: 'admin@test.com',
+          metadata: { field_comp: ['Model Serving'], field_status: 'Active' },
+          boards: []
+        },
+        team_c: {
+          id: 'team_c', name: 'Legacy', orgKey: 'org2',
+          createdAt: '2026-01-01', createdBy: 'admin@test.com',
+          metadata: { field_comp: ['AI Pipelines'], field_status: 'Sunset' },
+          boards: []
+        },
+        team_d: {
+          id: 'team_d', name: 'Empty', orgKey: 'org1',
+          createdAt: '2026-01-01', createdBy: 'admin@test.com',
+          metadata: {},
+          boards: []
+        }
+      }
+    },
+    'team-data/registry.json': {
+      meta: { generatedAt: '2026-01-01', provider: 'test', orgRoots: ['org1'] },
+      people: {}
+    },
+    'audit-log.json': { entries: [] }
+  }
+}
+
+function callHandler(handler, query = {}) {
+  const req = { query, auditActor: 'test@test.com' }
+  const res = mockRes()
+  handler(req, res)
+  return res
+}
+
+describe('GET /structure/teams/query', () => {
+  let handlers
+
+  beforeAll(() => {
+    const setup = setupRoutes(baseStorageData())
+    handlers = setup.handlers
+  })
+
+  function query(params = {}) {
+    return callHandler(handlers['GET /structure/teams/query'], params)
+  }
+
+  describe('no filters', () => {
+    it('returns all teams when no filter is provided', () => {
+      const res = query()
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(4)
+      expect(res._body.teams).toHaveLength(4)
+    })
+  })
+
+  describe('filter by field ID', () => {
+    it('matches teams with array metadata containing the value', () => {
+      const res = query({ filter: 'field_comp:AI Pipelines' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(2)
+      const names = res._body.teams.map(t => t.name).sort()
+      expect(names).toEqual(['Legacy', 'Pipelines'])
+    })
+
+    it('matches teams with scalar metadata', () => {
+      const res = query({ filter: 'field_status:Active' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(2)
+      const names = res._body.teams.map(t => t.name).sort()
+      expect(names).toEqual(['Pipelines', 'Serving'])
+    })
+
+    it('returns empty when no teams match', () => {
+      const res = query({ filter: 'field_comp:Nonexistent' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(0)
+      expect(res._body.teams).toEqual([])
+    })
+  })
+
+  describe('filter by label', () => {
+    it('resolves field by label with label: prefix', () => {
+      const res = query({ filter: 'label:Component:Model Serving' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(1)
+      expect(res._body.teams[0].name).toBe('Serving')
+    })
+
+    it('is case-insensitive on label', () => {
+      const res = query({ filter: 'label:component:Model Serving' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(1)
+    })
+
+    it('rejects unknown label', () => {
+      const res = query({ filter: 'label:Bogus:value' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/No team field found/)
+    })
+
+    it('rejects label missing value after colon', () => {
+      const res = query({ filter: 'label:Component' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/missing value/)
+    })
+  })
+
+  describe('case-insensitive value matching', () => {
+    it('matches regardless of case', () => {
+      const res = query({ filter: 'field_comp:ai pipelines' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(2)
+    })
+
+    it('matches scalar values case-insensitively', () => {
+      const res = query({ filter: 'field_status:active' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(2)
+    })
+  })
+
+  describe('multiple filters', () => {
+    it('ANDs filters by default (match=all)', () => {
+      const res = query({ filter: ['field_comp:AI Pipelines', 'field_status:Active'] })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(1)
+      expect(res._body.teams[0].name).toBe('Pipelines')
+    })
+
+    it('ORs filters with match=any', () => {
+      const res = query({ filter: ['field_comp:Model Serving', 'field_status:Sunset'], match: 'any' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(2)
+      const names = res._body.teams.map(t => t.name).sort()
+      expect(names).toEqual(['Legacy', 'Serving'])
+    })
+
+    it('same-field multi-filter with match=all requires team to have ALL values', () => {
+      const res = query({ filter: ['field_comp:AI Pipelines', 'field_comp:MLflow'], match: 'all' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(1)
+      expect(res._body.teams[0].name).toBe('Pipelines')
+    })
+
+    it('same-field multi-filter with match=any matches teams with either value', () => {
+      const res = query({ filter: ['field_comp:AI Pipelines', 'field_comp:Model Serving'], match: 'any' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(3)
+    })
+  })
+
+  describe('pagination', () => {
+    it('respects limit', () => {
+      const res = query({ limit: '2' })
+      expect(res._status).toBe(200)
+      expect(res._body.teams).toHaveLength(2)
+      expect(res._body.total).toBe(4)
+      expect(res._body.limit).toBe(2)
+    })
+
+    it('respects offset', () => {
+      const res = query({ limit: '2', offset: '2' })
+      expect(res._status).toBe(200)
+      expect(res._body.teams).toHaveLength(2)
+      expect(res._body.total).toBe(4)
+      expect(res._body.offset).toBe(2)
+    })
+
+    it('clamps limit to max 1000', () => {
+      const res = query({ limit: '9999' })
+      expect(res._body.limit).toBe(1000)
+    })
+
+    it('defaults limit to 200 and offset to 0', () => {
+      const res = query()
+      expect(res._body.limit).toBe(200)
+      expect(res._body.offset).toBe(0)
+    })
+  })
+
+  describe('first-colon splitting', () => {
+    it('handles values containing colons (split on first colon only)', () => {
+      // Set up a team with a URL-like value
+      const data = baseStorageData()
+      data['team-data/teams.json'].teams.team_a.metadata.field_status = 'https://example.com'
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/teams/query'], { filter: 'field_status:https://example.com' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(1)
+      expect(res._body.teams[0].name).toBe('Pipelines')
+    })
+
+    it('handles label filter values containing colons', () => {
+      const data = baseStorageData()
+      data['team-data/teams.json'].teams.team_a.metadata.field_status = 'val:with:colons'
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/teams/query'], { filter: 'label:Status:val:with:colons' })
+      expect(res._status).toBe(200)
+      expect(res._body.total).toBe(1)
+    })
+  })
+
+  describe('error handling', () => {
+    it('rejects unknown field ID', () => {
+      const res = query({ filter: 'field_unknown:value' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Unknown team field ID/)
+    })
+
+    it('rejects filter without colon separator', () => {
+      const res = query({ filter: 'novalue' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/expected fieldId:value/)
+    })
+
+    it('rejects invalid match mode', () => {
+      const res = query({ filter: 'field_status:Active', match: 'invalid' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/match must be/)
+    })
+
+    it('ignores deleted field definitions', () => {
+      const res = query({ filter: 'field_deleted:anything' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Unknown team field ID/)
+    })
+
+    it('ignores deleted fields in label lookup', () => {
+      const res = query({ filter: 'label:OldField:anything' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/No team field found/)
+    })
+  })
+
+  describe('teams with no metadata', () => {
+    it('skips teams with empty metadata', () => {
+      const res = query({ filter: 'field_comp:AI Pipelines' })
+      const names = res._body.teams.map(t => t.name)
+      expect(names).not.toContain('Empty')
+    })
+  })
+
+  describe('ambiguous labels', () => {
+    it('returns 400 when multiple fields share the same label', () => {
+      const data = baseStorageData()
+      data['team-data/field-definitions.json'].teamFields.push({
+        id: 'field_comp2', label: 'Component', type: 'constrained', multiValue: false,
+        required: false, visible: true, primaryDisplay: false, allowedValues: [],
+        deleted: false, order: 3, createdAt: '2026-01-01', createdBy: 'admin@test.com'
+      })
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/teams/query'], { filter: 'label:Component:value' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Ambiguous label/)
+      expect(res._body.error).toMatch(/field_comp/)
+      expect(res._body.error).toMatch(/field_comp2/)
+    })
+  })
+})
+
+describe('GET /structure/group-by', () => {
+  let handlers
+
+  beforeAll(() => {
+    const setup = setupRoutes(baseStorageData())
+    handlers = setup.handlers
+  })
+
+  function groupBy(params = {}) {
+    return callHandler(handlers['GET /structure/group-by'], params)
+  }
+
+  describe('by field ID', () => {
+    it('returns an inverted index of value → teams', () => {
+      const res = groupBy({ field: 'field_comp' })
+      expect(res._status).toBe(200)
+      expect(res._body.fieldId).toBe('field_comp')
+      expect(res._body.label).toBe('Component')
+      expect(res._body.type).toBe('constrained')
+      expect(res._body.index['AI Pipelines']).toHaveLength(2)
+      expect(res._body.index['MLflow']).toHaveLength(1)
+      expect(res._body.index['Model Serving']).toHaveLength(1)
+    })
+
+    it('includes full metadata on each team', () => {
+      const res = groupBy({ field: 'field_comp' })
+      const team = res._body.index['AI Pipelines'].find(t => t.name === 'Pipelines')
+      expect(team.metadata).toBeDefined()
+      expect(team.metadata.field_status).toBe('Active')
+      expect(team.metadata.field_comp).toEqual(['AI Pipelines', 'MLflow'])
+    })
+
+    it('includes team id, name, orgKey', () => {
+      const res = groupBy({ field: 'field_comp' })
+      const team = res._body.index['Model Serving'][0]
+      expect(team.id).toBe('team_b')
+      expect(team.name).toBe('Serving')
+      expect(team.orgKey).toBe('org1')
+    })
+
+    it('does not include boards', () => {
+      const res = groupBy({ field: 'field_comp' })
+      const team = res._body.index['Model Serving'][0]
+      expect(team.boards).toBeUndefined()
+    })
+
+    it('works with scalar fields', () => {
+      const res = groupBy({ field: 'field_status' })
+      expect(res._body.index['Active']).toHaveLength(2)
+      expect(res._body.index['Sunset']).toHaveLength(1)
+    })
+  })
+
+  describe('by label', () => {
+    it('resolves field by label', () => {
+      const res = groupBy({ label: 'Component' })
+      expect(res._status).toBe(200)
+      expect(res._body.fieldId).toBe('field_comp')
+      expect(Object.keys(res._body.index).length).toBeGreaterThan(0)
+    })
+
+    it('is case-insensitive on label', () => {
+      const res = groupBy({ label: 'component' })
+      expect(res._status).toBe(200)
+      expect(res._body.fieldId).toBe('field_comp')
+    })
+
+    it('rejects unknown label', () => {
+      const res = groupBy({ label: 'Bogus' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/No team field found/)
+    })
+
+    it('rejects ambiguous labels', () => {
+      const data = baseStorageData()
+      data['team-data/field-definitions.json'].teamFields.push({
+        id: 'field_comp2', label: 'Component', type: 'constrained', multiValue: false,
+        required: false, visible: true, primaryDisplay: false, allowedValues: [],
+        deleted: false, order: 3, createdAt: '2026-01-01', createdBy: 'admin@test.com'
+      })
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/group-by'], { label: 'Component' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Ambiguous label/)
+    })
+  })
+
+  describe('counts', () => {
+    it('returns correct valueCount and teamCount', () => {
+      const res = groupBy({ field: 'field_comp' })
+      // Values: AI Pipelines, MLflow, Model Serving = 3
+      expect(res._body.valueCount).toBe(3)
+      // Teams with at least one value: team_a, team_b, team_c = 3 (team_d has no components)
+      expect(res._body.teamCount).toBe(3)
+    })
+
+    it('teamCount counts distinct teams even when they appear under multiple values', () => {
+      const res = groupBy({ field: 'field_comp' })
+      // team_a has AI Pipelines + MLflow, appears in 2 buckets but teamCount should not double-count
+      const totalInBuckets = Object.values(res._body.index).flat().length
+      expect(totalInBuckets).toBeGreaterThan(res._body.teamCount)
+    })
+  })
+
+  describe('empty/null handling', () => {
+    it('omits teams with no value for the field', () => {
+      const res = groupBy({ field: 'field_comp' })
+      // team_d has empty metadata, should not appear anywhere
+      const allTeamIds = Object.values(res._body.index).flat().map(t => t.id)
+      expect(allTeamIds).not.toContain('team_d')
+    })
+
+    it('omits empty string values', () => {
+      const data = baseStorageData()
+      data['team-data/teams.json'].teams.team_d.metadata.field_status = ''
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/group-by'], { field: 'field_status' })
+      expect(res._body.index['']).toBeUndefined()
+    })
+
+    it('omits null values', () => {
+      const data = baseStorageData()
+      data['team-data/teams.json'].teams.team_d.metadata.field_status = null
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/group-by'], { field: 'field_status' })
+      const allTeamIds = Object.values(res._body.index).flat().map(t => t.id)
+      expect(allTeamIds).not.toContain('team_d')
+    })
+
+    it('skips empty strings within arrays', () => {
+      const data = baseStorageData()
+      data['team-data/teams.json'].teams.team_d.metadata.field_comp = ['Valid', '']
+      const { handlers: h } = setupRoutes(data)
+      const res = callHandler(h['GET /structure/group-by'], { field: 'field_comp' })
+      expect(res._body.index['']).toBeUndefined()
+      expect(res._body.index['Valid']).toHaveLength(1)
+    })
+  })
+
+  describe('error handling', () => {
+    it('rejects when neither field nor label is provided', () => {
+      const res = groupBy({})
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Provide a/)
+    })
+
+    it('rejects when both field and label are provided', () => {
+      const res = groupBy({ field: 'field_comp', label: 'Component' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/not both/)
+    })
+
+    it('rejects unknown field ID', () => {
+      const res = groupBy({ field: 'field_nope' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Unknown team field ID/)
+    })
+
+    it('ignores deleted fields', () => {
+      const res = groupBy({ field: 'field_deleted' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/Unknown team field ID/)
+    })
+
+    it('ignores deleted fields in label lookup', () => {
+      const res = groupBy({ label: 'OldField' })
+      expect(res._status).toBe(400)
+      expect(res._body.error).toMatch(/No team field found/)
+    })
+  })
+})

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -804,6 +804,231 @@ module.exports = function registerRoutes(router, context) {
 
   /**
    * @openapi
+   * /api/modules/team-tracker/structure/teams/query:
+   *   get:
+   *     tags: ['TT: Structure']
+   *     summary: Query teams by metadata field values
+   *     description: >
+   *       Filter teams by metadata field values. Each filter is a `fieldId:value` pair
+   *       (split on the first colon). To filter by field label instead of ID, prefix with
+   *       `label:` (e.g. `label:Components:Pipelines`). Value matching is case-insensitive.
+   *       For array metadata fields, a team matches if any element matches. Multiple filters
+   *       on the same field with `match=all` means the team must have ALL specified values.
+   *       With no filters, returns all teams.
+   *     parameters:
+   *       - in: query
+   *         name: filter
+   *         schema:
+   *           type: array
+   *           items:
+   *             type: string
+   *         style: form
+   *         explode: true
+   *         description: 'Field filter: `fieldId:value` or `label:FieldLabel:value`'
+   *       - in: query
+   *         name: match
+   *         schema:
+   *           type: string
+   *           enum: [all, any]
+   *           default: all
+   *         description: How multiple filters combine (AND vs OR)
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           default: 200
+   *         description: Maximum number of teams to return
+   *       - in: query
+   *         name: offset
+   *         schema:
+   *           type: integer
+   *           default: 0
+   *         description: Number of teams to skip
+   *     responses:
+   *       200:
+   *         description: Matching teams
+   *       400:
+   *         description: Invalid filter syntax, unknown field, or ambiguous label
+   */
+  router.get('/structure/teams/query', requireScope('team-tracker:read'), function(req, res) {
+    const matchMode = req.query.match || 'all';
+    if (matchMode !== 'all' && matchMode !== 'any') {
+      return res.status(400).json({ error: 'match must be "all" or "any"' });
+    }
+
+    const limit = Math.max(1, Math.min(1000, parseInt(req.query.limit, 10) || 200));
+    const offset = Math.max(0, parseInt(req.query.offset, 10) || 0);
+
+    // Normalize filter to array
+    const rawFilters = req.query.filter
+      ? (Array.isArray(req.query.filter) ? req.query.filter : [req.query.filter])
+      : [];
+
+    // Resolve field definitions for label lookup
+    const fieldDefs = fieldStore.readFieldDefinitions(storage);
+    const teamFields = (fieldDefs.teamFields || []).filter(f => !f.deleted);
+
+    // Parse and resolve filters
+    const parsed = [];
+    for (const raw of rawFilters) {
+      let fieldKey, value;
+
+      if (raw.startsWith('label:')) {
+        // label:FieldLabel:value — split off prefix, then first colon
+        const afterPrefix = raw.substring(6);
+        const colonIdx = afterPrefix.indexOf(':');
+        if (colonIdx === -1) {
+          return res.status(400).json({ error: `Invalid label filter (missing value): ${raw}` });
+        }
+        const label = afterPrefix.substring(0, colonIdx);
+        value = afterPrefix.substring(colonIdx + 1);
+
+        const matches = teamFields.filter(f => f.label.toLowerCase() === label.toLowerCase());
+        if (matches.length === 0) {
+          return res.status(400).json({ error: `No team field found with label "${label}"` });
+        }
+        if (matches.length > 1) {
+          return res.status(400).json({
+            error: `Ambiguous label "${label}" matches ${matches.length} fields. Use field ID instead: ${matches.map(f => f.id).join(', ')}`
+          });
+        }
+        fieldKey = matches[0].id;
+      } else {
+        // fieldId:value — split on first colon
+        const colonIdx = raw.indexOf(':');
+        if (colonIdx === -1) {
+          return res.status(400).json({ error: `Invalid filter (expected fieldId:value): ${raw}` });
+        }
+        fieldKey = raw.substring(0, colonIdx);
+        value = raw.substring(colonIdx + 1);
+
+        if (!teamFields.some(f => f.id === fieldKey)) {
+          return res.status(400).json({ error: `Unknown team field ID "${fieldKey}"` });
+        }
+      }
+
+      parsed.push({ fieldId: fieldKey, value });
+    }
+
+    // Load teams and filter
+    const data = teamStore.readTeams(storage);
+    let teams = Object.values(data.teams);
+
+    if (parsed.length > 0) {
+      teams = teams.filter(team => {
+        const meta = team.metadata || {};
+        const results = parsed.map(({ fieldId, value }) => {
+          const stored = meta[fieldId];
+          if (stored == null) return false;
+          const needle = value.toLowerCase();
+          if (Array.isArray(stored)) {
+            return stored.some(v => String(v).toLowerCase() === needle);
+          }
+          return String(stored).toLowerCase() === needle;
+        });
+        return matchMode === 'all' ? results.every(Boolean) : results.some(Boolean);
+      });
+    }
+
+    const total = teams.length;
+    const paged = teams.slice(offset, offset + limit);
+
+    res.json({ teams: paged, total, limit, offset });
+  });
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/structure/group-by:
+   *   get:
+   *     tags: ['TT: Structure']
+   *     summary: Group teams by a metadata field value
+   *     description: >
+   *       Returns an inverted index mapping each distinct value of a team metadata field
+   *       to the teams that have it. Useful for lookups like "which teams own each component?"
+   *       Specify the field by ID (`field` param) or by label (`label` param, case-insensitive).
+   *       Teams with null, empty string, or empty array values for the field are omitted.
+   *       For multi-value (array) fields, a team appears under every value it has.
+   *     parameters:
+   *       - in: query
+   *         name: field
+   *         schema:
+   *           type: string
+   *         description: Field ID to group by (mutually exclusive with `label`)
+   *       - in: query
+   *         name: label
+   *         schema:
+   *           type: string
+   *         description: Field label to group by, case-insensitive (mutually exclusive with `field`)
+   *     responses:
+   *       200:
+   *         description: Grouped teams by field value
+   *       400:
+   *         description: Missing/invalid field, ambiguous label, or both field and label provided
+   */
+  router.get('/structure/group-by', requireScope('team-tracker:read'), function(req, res) {
+    const { field: fieldParam, label: labelParam } = req.query;
+
+    if (fieldParam && labelParam) {
+      return res.status(400).json({ error: 'Provide either "field" or "label", not both' });
+    }
+    if (!fieldParam && !labelParam) {
+      return res.status(400).json({ error: 'Provide a "field" (field ID) or "label" (field label) query parameter' });
+    }
+
+    const fieldDefs = fieldStore.readFieldDefinitions(storage);
+    const teamFields = (fieldDefs.teamFields || []).filter(f => !f.deleted);
+
+    let resolvedField;
+    if (fieldParam) {
+      resolvedField = teamFields.find(f => f.id === fieldParam);
+      if (!resolvedField) {
+        return res.status(400).json({ error: `Unknown team field ID "${fieldParam}"` });
+      }
+    } else {
+      const matches = teamFields.filter(f => f.label.toLowerCase() === labelParam.toLowerCase());
+      if (matches.length === 0) {
+        return res.status(400).json({ error: `No team field found with label "${labelParam}"` });
+      }
+      if (matches.length > 1) {
+        return res.status(400).json({
+          error: `Ambiguous label "${labelParam}" matches ${matches.length} fields. Use "field" parameter instead: ${matches.map(f => f.id).join(', ')}`
+        });
+      }
+      resolvedField = matches[0];
+    }
+
+    const data = teamStore.readTeams(storage);
+    const index = Object.create(null);
+    const seenTeamIds = new Set();
+
+    for (const team of Object.values(data.teams)) {
+      const raw = (team.metadata || {})[resolvedField.id];
+      if (raw == null) continue;
+
+      const values = Array.isArray(raw) ? raw : [raw];
+      const teamObj = { id: team.id, name: team.name, orgKey: team.orgKey, metadata: team.metadata || {} };
+
+      for (const v of values) {
+        const str = String(v);
+        if (str === '') continue;
+        if (!index[str]) index[str] = [];
+        index[str].push(teamObj);
+        seenTeamIds.add(team.id);
+      }
+    }
+
+    res.json({
+      fieldId: resolvedField.id,
+      label: resolvedField.label,
+      type: resolvedField.type,
+      index,
+      valueCount: Object.keys(index).length,
+      teamCount: seenTeamIds.size
+    });
+  });
+
+  /**
+   * @openapi
    * /api/modules/team-tracker/structure/teams:
    *   post:
    *     tags: ['TT: Structure']


### PR DESCRIPTION
## Summary

- Adds `GET /api/modules/team-tracker/structure/teams/query` — filter teams by metadata field values with AND/OR combining, pagination, case-insensitive matching, and field ID or `label:` prefix resolution
- Adds `GET /api/modules/team-tracker/structure/group-by` — inverted index mapping each distinct value of a metadata field to the teams that have it (e.g. component → teams), with full team metadata for transitive lookups (component → team → eng lead)
- These are general-purpose replacements for the deprecated `GET /components` endpoint, working with any team metadata field

## Design decisions

- `/query` splits filter values on first colon only (safe for URL-like values)
- Label-based field resolution requires explicit `label:` prefix (stable contract — bare key is always a field ID)
- Value matching is case-insensitive; deleted fields are excluded from resolution
- `/group-by` uses query params (`?field=` or `?label=`) instead of path params to avoid route collisions with `/structure/teams/:teamId` and colon-in-path issues
- Both endpoints went through adversarial design review before implementation

## Test plan

- [x] 47 unit tests covering both endpoints (field ID/label resolution, AND/OR, pagination, colon splitting, empty/null handling, ambiguous labels, deleted fields, error cases)
- [x] Manual verification against live data — queried component→team mappings (59 components, 64 teams)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)