### PR TITLE
deploy: configure PRODUCT_BUILDS_API_URL for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@ ADMIN_EMAILS=you@redhat.com
 # Defaults to in-cluster service URL. Set for local dev when port-forwarding.
 # UPSTREAM_PULSE_API_URL=http://localhost:4321
 
+# Product Builds API URL (optional - for the product-builds module)
+# Base URL of the AIPCC Dashboard API server. Can also be configured via Settings UI (admin).
+# PRODUCT_BUILDS_API_URL=
+
 # Product Pages OAuth (production — service account)
 # PRODUCT_PAGES_CLIENT_ID=
 # PRODUCT_PAGES_CLIENT_SECRET=

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -12,6 +12,7 @@ configMapGenerator:
   literals:
   - API_PUBLIC_URL=https://api-team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com
   - AUTH_EMAIL_DOMAIN=cluster.local
+  - PRODUCT_BUILDS_API_URL=https://aipcc-dashboard-api.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com
   name: team-tracker-config
 
 patches:


### PR DESCRIPTION
Add the AIPCC Dashboard API URL to the prod ConfigMap so the product-builds module can proxy requests to the upstream API. Also document the env var in .env.example.