### PR TITLE
Revert "fix(ci): use pull_request_target for Claude review on fork PRs"

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,11 +1,13 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     # NOTE: No paths-ignore here. "Claude Review" is a required status check,
     # so the workflow must always run to report a result. Path filtering is
     # handled inside the job via the "Check for reviewable changes" step.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -26,7 +28,7 @@ jobs:
     name: Claude Review
     timeout-minutes: 20
     if: |
-      (github.event_name == 'pull_request_target' &&
+      (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]') ||
@@ -42,7 +44,7 @@ jobs:
       - name: Check for reviewable changes
         id: check-paths
         run: |
-          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "needs_review=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -250,7 +252,48 @@ jobs:
         if: steps.check-paths.outputs.needs_review == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup fork PR branch for action
+        if: steps.check-paths.outputs.needs_review == 'true'
+        id: fork-setup
+        run: |
+          echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
+
+          # Check if PR modifies workflow files
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${PR_NUM}/files \
+            --paginate --jq '.[].filename')
+
+          MODIFIES_WORKFLOWS=false
+          while IFS= read -r file; do
+            if [[ "$file" == .github/workflows/* ]]; then
+              MODIFIES_WORKFLOWS=true
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          if [ "$MODIFIES_WORKFLOWS" = "true" ]; then
+            echo "::warning::PR modifies workflow files - skipping temp branch push due to GitHub security restrictions"
+            echo "::notice::Review will proceed using gh pr diff only (some Read/Grep/Glob tools may not work on PR code)"
+            echo "modifies_workflows=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The claude-code-action runs `git fetch origin <branchName>` internally,
+          # which fails for fork PRs because the branch only exists on the fork.
+          # Workaround: push the PR head commit to origin under a namespaced ref
+          # so the action's fetch succeeds. Clean up after the review completes.
+          SAFE_BRANCH="claude-review/fork-pr-${PR_NUM}"
+
+          git fetch origin "refs/pull/${PR_NUM}/head"
+          git push origin "FETCH_HEAD:refs/heads/${SAFE_BRANCH}"
+
+          echo "fork_branch=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Pushed fork PR head to origin/${SAFE_BRANCH}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
 
       - name: Authenticate to Google Cloud
         if: steps.check-paths.outputs.needs_review == 'true'
@@ -261,6 +304,7 @@ jobs:
       - name: Claude Code Review (Read-Only)
         if: steps.check-paths.outputs.needs_review == 'true'
         uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           use_vertex: "true"
           track_progress: true
@@ -300,3 +344,11 @@ jobs:
           CLOUD_ML_REGION: "us-east5"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_PROMPT_CACHING: "1"
+
+      - name: Cleanup fork PR branch
+        if: always() && steps.fork-setup.outputs.fork_branch && steps.fork-setup.outputs.modifies_workflows != 'true'
+        run: |
+          echo "Cleaning up temporary branch: ${{ steps.fork-setup.outputs.fork_branch }}"
+          git push origin --delete "${{ steps.fork-setup.outputs.fork_branch }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Reverts #698. Switching from `pull_request` to `pull_request_target` as the sole trigger broke the Claude Code Action's OIDC authentication — see the comment on #698 for details.

This restores the previous dual-trigger (`pull_request` + `pull_request_target`) workflow so Claude reviews work again for same-repo PRs.

## Test plan

- Verify Claude review runs successfully on a same-repo PR after merge