### PR TITLE
chore: transfer releases module code ownership to saprabhu05

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /modules/team-tracker/          @accorvin
 /modules/ai-impact/             @accorvin
 /modules/org-roster/            @accorvin
-/modules/releases/              @accorvin
+/modules/releases/              @saprabhu05
 # /modules/search/              @search-team-lead
 # /modules/dashboards/          @dashboards-team-lead
 


### PR DESCRIPTION
## Summary
- Updates `.github/CODEOWNERS` to assign `@saprabhu05` as the code owner for `modules/releases/` (previously `@accorvin`)

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm future PRs touching `modules/releases/` request review from `@saprabhu05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)