### PR TITLE
fix: derive hygiene refresh-all versions from registry instead of files

### DIFF
--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -329,13 +329,19 @@ module.exports = function registerHygieneRoutes(router, context) {
       return res.json({ status: 'already_running' });
     }
 
-    // Build version list from previously-refreshed hygiene data files
-    // (these use the correct Jira Target Version strings, unlike registry IDs)
-    var hygieneFiles = storage.listStorageFiles ? storage.listStorageFiles('releases/hygiene') : [];
+    // Build version list from active registry releases.
+    // Use displayName (not id) — displayName is the Jira "Target Version" string
+    // used in JQL queries and as the storage key (e.g. "RHOAI 2.14").
+    var registry = readRegistry(storage.readFromStorage);
+    var registryReleases = registry.releases || [];
+    var seen = {};
     var activeVersions = [];
-    for (var hfi = 0; hfi < hygieneFiles.length; hfi++) {
-      var match = hygieneFiles[hfi].match(/^features-(.+)\.json$/);
-      if (match) activeVersions.push(match[1]);
+    for (var rri = 0; rri < registryReleases.length; rri++) {
+      var rel = registryReleases[rri];
+      if (rel.state === 'archived' || !rel.displayName) continue;
+      if (seen[rel.displayName]) continue;
+      seen[rel.displayName] = true;
+      activeVersions.push(rel.displayName);
     }
     activeVersions.sort();
 


### PR DESCRIPTION
## Summary

- The `refresh-all` hygiene endpoint was building its version list by scanning existing hygiene data files, causing a chicken-and-egg problem: no data could be seeded because the endpoint required pre-existing files
- New releases added to the registry were also never picked up for hygiene refresh
- Now derives versions from active (non-archived) registry releases using `displayName` as the version key, deduplicating to prevent double-refresh

## Test plan

- [ ] Verify `POST /api/modules/releases/hygiene/refresh-all` works with no pre-existing hygiene data files
- [ ] Verify newly added registry releases are included in the refresh
- [ ] Verify archived releases are excluded
- [ ] Verify duplicate `displayName` entries don't cause double-refresh
- [ ] Run `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)