### PR TITLE
ci: add dependency security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,25 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Setup Socket Security
+        if: steps.changes.outputs.app == 'true'
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
         if: steps.changes.outputs.app == 'true'
-        run: npm ci
+        run: |
+          if command -v sfw &> /dev/null; then
+            sfw npm ci
+          else
+            echo "::warning::Socket firewall not available, falling back to plain npm ci"
+            npm ci
+          fi
+
+      - name: Security audit
+        if: steps.changes.outputs.app == 'true'
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Validate module manifests
         if: steps.changes.outputs.app == 'true'

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "team-tracker",
   "private": true,
   "version": "0.0.0",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "dev:server": "node -r dotenv/config server/dev-server.js",


### PR DESCRIPTION
## Summary
- Add Socket.dev free firewall to CI — wraps `npm ci` to block malicious/suspicious packages before install
- Add `npm audit --audit-level=high` CI step to gate PRs on known high/critical CVEs
- Add Dependabot config for weekly automated dependency update PRs (npm + GitHub Actions)
- Add `.npmrc` with `engine-strict=true` and `engines` field in `package.json` (`node >=20`) to enforce Node version compatibility

## Test plan
- [ ] Open this PR and verify the CI workflow runs with the new Socket and audit steps
- [ ] Confirm `npm audit --audit-level=high` passes (or shows expected failures for existing vulns)
- [ ] After merge, verify Dependabot starts opening PRs within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)