### PR TITLE
fix(ci): provide github_token to fix Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -307,6 +307,7 @@ jobs:
         continue-on-error: true
         with:
           use_vertex: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           display_report: "true"
           allowed_bots: "claude"


### PR DESCRIPTION
## Summary

- Adds `github_token` input to the `claude-review-fork` job to bypass the claude-code-action's internal GitHub App OIDC token exchange, which rejects `pull_request_target` event subjects

## Background

The fork review job has silently failed since it was added — `continue-on-error: true` hid the `401 Invalid OIDC token` error. PR #698 tried to fix this by switching all triggers to `pull_request_target`, but that broke same-repo reviews too (reverted in #702).

The root cause: the action internally requests a GitHub OIDC token for its own App authentication. The OIDC subject claim includes the event name, and the token exchange endpoint rejects `pull_request_target` subjects. Providing `github_token` explicitly bypasses this OIDC path entirely, letting the existing Vertex + SA key auth (`google-github-actions/auth@v2` with `credentials_json`) handle AI provider authentication.

## What this does NOT change

- Same-repo reviews (`claude-review` job) — untouched
- `continue-on-error: true` — kept until we verify the fix works on a real fork PR
- The temp-branch workaround — kept (the action needs the branch accessible on origin)

## Test plan

- [ ] Verify same-repo PR reviews still work (this PR itself)
- [ ] Have a fork contributor open a PR and verify the fork review job succeeds
- [ ] If verified working, follow up to remove `continue-on-error: true`

## Fallback

If the OIDC failure turns out to be in the Vertex AI auth path (not the GitHub App path), we'll need to switch the fork job to use a direct `ANTHROPIC_API_KEY` instead of Vertex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)