### PR TITLE
refactor(ci): unify Claude review into single job with shared verdict

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,13 +23,16 @@ permissions:
   id-token: write
 
 jobs:
-  # Full review with autofix — runs for same-repo PRs only (trusted code)
   claude-review:
     name: Claude Review
     timeout-minutes: 20
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.draft != true &&
+       github.actor != 'github-actions[bot]') ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.full_name != github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]') ||
       (github.event_name == 'issue_comment' &&
@@ -41,15 +44,27 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
+      - name: Determine review context
+        id: context
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${{ github.event.pull_request.number || github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for reviewable changes
         id: check-paths
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          PR_NUM="${{ steps.context.outputs.pr_number }}"
+          if [ -z "$PR_NUM" ]; then
             echo "needs_review=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${PR_NUM}/files \
             --paginate --jq '.[].filename')
 
           needs_review=false
@@ -88,28 +103,81 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # --- Same-repo setup (full checkout, Node.js, git identity) ---
+
       - name: Checkout code
-        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
 
       - name: Install dependencies
-        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
         run: npm ci
 
       - name: Configure git identity
-        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
         run: |
           git config user.name "claude-code-review[bot]"
           git config user.email "claude-code-review[bot]@users.noreply.github.com"
+
+      # --- Fork setup (base-branch checkout, temp branch for action) ---
+
+      - name: Checkout base branch
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork == 'true' && github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup fork PR branch for action
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork == 'true' && github.event_name == 'pull_request_target'
+        id: fork-setup
+        run: |
+          echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
+
+          # Check if PR modifies workflow files
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${PR_NUM}/files \
+            --paginate --jq '.[].filename')
+
+          MODIFIES_WORKFLOWS=false
+          while IFS= read -r file; do
+            if [[ "$file" == .github/workflows/* ]]; then
+              MODIFIES_WORKFLOWS=true
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          if [ "$MODIFIES_WORKFLOWS" = "true" ]; then
+            echo "::warning::PR modifies workflow files - skipping temp branch push due to GitHub security restrictions"
+            echo "::notice::Review will proceed using gh pr diff only (some Read/Grep/Glob tools may not work on PR code)"
+            echo "modifies_workflows=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The claude-code-action runs `git fetch origin <branchName>` internally,
+          # which fails for fork PRs because the branch only exists on the fork.
+          # Workaround: push the PR head commit to origin under a namespaced ref
+          # so the action's fetch succeeds. Clean up after the review completes.
+          SAFE_BRANCH="claude-review/fork-pr-${PR_NUM}"
+
+          git fetch origin "refs/pull/${PR_NUM}/head"
+          git push origin "FETCH_HEAD:refs/heads/${SAFE_BRANCH}"
+
+          echo "fork_branch=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Pushed fork PR head to origin/${SAFE_BRANCH}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
+      # --- Shared: GCP auth ---
 
       - name: Authenticate to Google Cloud
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
@@ -117,8 +185,10 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
+      # --- Claude review (one step per mode, shared verdict check) ---
+
       - name: Claude Code Review
-        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
@@ -129,7 +199,7 @@ jobs:
           claude_args: '--model claude-opus-4-6 --json-schema ''{"type":"object","properties":{"verdict":{"enum":["PASS","FAIL"]},"unfixed_blocking_issues":{"type":"array","items":{"type":"object","properties":{"category":{"type":"string"},"description":{"type":"string"}},"required":["category","description"]}}},"required":["verdict","unfixed_blocking_issues"]}'' --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git diff:*),Bash(git status:*),Bash(npm test:*),Bash(npm run lint:*),Read,Glob,Grep,Edit,Write"'
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            PR NUMBER: ${{ steps.context.outputs.pr_number }}
 
             You are reviewing a pull request. Your job is to:
 
@@ -191,10 +261,62 @@ jobs:
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_PROMPT_CACHING: "1"
 
+      - name: Claude Code Review (Read-Only)
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork == 'true' && github.event_name == 'pull_request_target'
+        id: claude-review-fork
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_vertex: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: true
+          display_report: "true"
+          allowed_bots: "claude"
+          claude_args: '--model claude-opus-4-6 --json-schema ''{"type":"object","properties":{"verdict":{"enum":["PASS","FAIL"]},"unfixed_blocking_issues":{"type":"array","items":{"type":"object","properties":{"category":{"type":"string"},"description":{"type":"string"}},"required":["category","description"]}}},"required":["verdict","unfixed_blocking_issues"]}'' --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.context.outputs.pr_number }}
+
+            You are reviewing a **fork pull request**. This is a READ-ONLY review.
+            You must NEVER execute any code from the PR (no npm test, npm run, node,
+            or any other command that runs PR code). You do NOT have tools to edit
+            files, commit, or push — only read and comment.
+
+            1. Run `gh pr diff ${{ steps.context.outputs.pr_number }}` to get the
+               full diff of the PR.
+
+            2. **Review** the diff. Read `AGENTS.md` (hard constraints and
+               conventions) and `.github/instructions/review.instructions.md`
+               (review checklist and verdict rules). Apply all criteria from both.
+
+            3. **Report** your findings:
+               - Use inline comments for specific issues in the diff
+               - Post a top-level PR comment summarizing:
+                 - Issues found (with brief descriptions and suggestions)
+                 - If no issues were found, say so briefly
+               - Note that this was a read-only review (fork PR) and no autofixes
+                 were applied
+
+            4. **Set review verdict**: Follow the "Verdict rules" section in
+               `.github/instructions/review.instructions.md` to populate the
+               structured output. This is your very last action.
+
+            **Important rules:**
+            - This is a FORK PR. Do NOT run any commands that execute PR code.
+            - Do NOT attempt to check out the PR branch.
+            - Use `gh pr diff` and `Read` to understand the changes.
+            - Be concise. Focus on actionable feedback.
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
+          CLOUD_ML_REGION: "us-east5"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
+
+      # --- Shared: verdict check and cleanup ---
+
       - name: Check review result
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
         env:
-          STRUCTURED_OUTPUT: ${{ steps.claude-review.outputs.structured_output }}
+          STRUCTURED_OUTPUT: ${{ steps.claude-review.outputs.structured_output || steps.claude-review-fork.outputs.structured_output }}
         run: |
           if [ -z "$STRUCTURED_OUTPUT" ] || [ "$STRUCTURED_OUTPUT" = "null" ]; then
             echo "::error::No structured output from Claude review"
@@ -211,140 +333,6 @@ jobs:
           fi
 
           echo "Claude review passed"
-
-  # Read-only review for fork PRs — never executes fork code
-  claude-review-fork:
-    name: Claude Review
-    timeout-minutes: 20
-    if: |
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.event.pull_request.draft != true &&
-      github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for reviewable changes
-        id: check-paths
-        run: |
-          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
-            --paginate --jq '.[].filename')
-
-          needs_review=false
-          while IFS= read -r file; do
-            case "$file" in
-              deploy/openshift/overlays/*/kustomization.yaml)
-                ;; # matches ignore pattern
-              *)
-                needs_review=true
-                break
-                ;;
-            esac
-          done <<< "$CHANGED_FILES"
-
-          echo "needs_review=$needs_review" >> "$GITHUB_OUTPUT"
-          if [ "$needs_review" = "false" ]; then
-            echo "All changed files match ignore patterns — skipping review"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout base branch
-        if: steps.check-paths.outputs.needs_review == 'true'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-
-      - name: Setup fork PR branch for action
-        if: steps.check-paths.outputs.needs_review == 'true'
-        id: fork-setup
-        run: |
-          echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
-
-          # Check if PR modifies workflow files
-          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${PR_NUM}/files \
-            --paginate --jq '.[].filename')
-
-          MODIFIES_WORKFLOWS=false
-          while IFS= read -r file; do
-            if [[ "$file" == .github/workflows/* ]]; then
-              MODIFIES_WORKFLOWS=true
-              break
-            fi
-          done <<< "$CHANGED_FILES"
-
-          if [ "$MODIFIES_WORKFLOWS" = "true" ]; then
-            echo "::warning::PR modifies workflow files - skipping temp branch push due to GitHub security restrictions"
-            echo "::notice::Review will proceed using gh pr diff only (some Read/Grep/Glob tools may not work on PR code)"
-            echo "modifies_workflows=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # The claude-code-action runs `git fetch origin <branchName>` internally,
-          # which fails for fork PRs because the branch only exists on the fork.
-          # Workaround: push the PR head commit to origin under a namespaced ref
-          # so the action's fetch succeeds. Clean up after the review completes.
-          SAFE_BRANCH="claude-review/fork-pr-${PR_NUM}"
-
-          git fetch origin "refs/pull/${PR_NUM}/head"
-          git push origin "FETCH_HEAD:refs/heads/${SAFE_BRANCH}"
-
-          echo "fork_branch=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "Pushed fork PR head to origin/${SAFE_BRANCH}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-
-      - name: Authenticate to Google Cloud
-        if: steps.check-paths.outputs.needs_review == 'true'
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Claude Code Review (Read-Only)
-        if: steps.check-paths.outputs.needs_review == 'true'
-        uses: anthropics/claude-code-action@v1
-        continue-on-error: true
-        with:
-          use_vertex: "true"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          track_progress: true
-          display_report: "true"
-          allowed_bots: "claude"
-          claude_args: '--model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"'
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            You are reviewing a **fork pull request**. This is a READ-ONLY review.
-            You must NEVER execute any code from the PR (no npm test, npm run, node,
-            or any other command that runs PR code). You do NOT have tools to edit
-            files, commit, or push — only read and comment.
-
-            1. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the
-               full diff of the PR.
-
-            2. **Review** the diff. Read `.github/instructions/review.instructions.md`
-               for the full review checklist. Apply all criteria from that file.
-
-            3. **Report** your findings:
-               - Use inline comments for specific issues in the diff
-               - Post a top-level PR comment summarizing:
-                 - Issues found (with brief descriptions and suggestions)
-                 - If no issues were found, say so briefly
-               - Note that this was a read-only review (fork PR) and no autofixes
-                 were applied
-
-            **Important rules:**
-            - This is a FORK PR. Do NOT run any commands that execute PR code.
-            - Do NOT attempt to check out the PR branch.
-            - Use `gh pr diff` and `Read` to understand the changes.
-            - Be concise. Focus on actionable feedback.
-        env:
-          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
-          CLOUD_ML_REGION: "us-east5"
-          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
-          DISABLE_PROMPT_CACHING: "1"
 
       - name: Cleanup fork PR branch
         if: always() && steps.fork-setup.outputs.fork_branch && steps.fork-setup.outputs.modifies_workflows != 'true'


### PR DESCRIPTION
## Summary

- Merges `claude-review` and `claude-review-fork` into a single job with conditional steps
- Fork reviews now enforce the same structured verdict gate as same-repo reviews
- Removes `continue-on-error: true` from fork reviews (auth is fixed via #715)
- Eliminates duplicated path-checking, GCP auth, and env var blocks

## What changed

**Before:** Two separate jobs (`claude-review` for same-repo, `claude-review-fork` for forks) with duplicated path-checking, GCP auth, env vars, and different behavior — the fork job lacked `--json-schema` and the "Check review result" verdict gate, and silently swallowed failures via `continue-on-error: true`.

**After:** One job with a "Determine review context" step that sets `is_fork`. Conditional steps branch for checkout/setup (full checkout + Node.js for same-repo, base-branch checkout + temp branch for forks). Two Claude action steps (one per mode, with different tools and prompts), but both produce structured verdict output. A single shared "Check review result" step gates both paths using `${{ steps.claude-review.outputs.structured_output || steps.claude-review-fork.outputs.structured_output }}`.

Also fixes:
- Fork prompt now references `AGENTS.md` (was missing)
- Fork prompt includes verdict instructions (step 4)
- PR number references use `steps.context.outputs.pr_number` consistently instead of raw event expressions
- Status check name ambiguity resolved (was two jobs both named "Claude Review")

## Test plan

- [ ] Verify same-repo PR review works (this PR itself will test it)
- [ ] Verify fork PR review works with verdict enforcement (ask a fork contributor to push)
- [ ] Verify `issue_comment` with `@claude` still works on same-repo PRs
- [ ] Verify `issue_comment` on fork PRs still gets the rejection message

🤖 Generated with [Claude Code](https://claude.com/claude-code)