### PR TITLE
feat(releases): add Jira version resolution to release registry

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -260,6 +260,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/structure/migrate/preview` — migration preview (admin)
 - `/api/modules/team-tracker/structure/migrate/field-to-options/preview` — field-to-options migration preview (team-admin)
 - `/api/modules/releases/registry` — list releases
+- `/api/modules/releases/registry/config` — registry config (Jira projects for version resolution) (release-manager)
 - `/api/modules/releases/registry/:id` — single release
 - `/api/modules/releases/audit-log` — unified audit log across all release domains
 - `/api/modules/releases/planning/releases` — planning releases
@@ -378,7 +379,10 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/team-tracker/field-exceptions` — create field exception (team-admin/admin)
 - `/api/modules/team-tracker/registry/people/ldap-import` — LDAP import (team-admin/admin)
 - `/api/modules/releases/registry` — create release (release-manager)
+- `/api/modules/releases/registry/config` — save registry config (release-manager)
 - `/api/modules/releases/registry/discover` — auto-discover from Product Pages (release-manager)
+- `/api/modules/releases/registry/resolve-jira-versions` — preview Jira version resolution (release-manager)
+- `/api/modules/releases/registry/resolve-jira-versions/apply` — apply resolved Jira versions to registry (release-manager)
 - `/api/modules/releases/admin/migrate-storage` — clean up old storage paths after migration (admin)
 - `/api/modules/releases/planning/releases` — create planning release (release-manager)
 - `/api/modules/releases/planning/releases/:version/big-rocks` — create big rock (release-manager)

--- a/fixtures/releases/registry-config.json
+++ b/fixtures/releases/registry-config.json
@@ -1,0 +1,3 @@
+{
+  "jiraProjects": ["RHAISTRAT", "RHOAIENG"]
+}

--- a/modules/releases/__tests__/server/hygiene/jira-fetch.test.js
+++ b/modules/releases/__tests__/server/hygiene/jira-fetch.test.js
@@ -468,6 +468,16 @@ describe('fetchHygieneFeatures jqlVersions option', function () {
     expect(mock.capturedJqls[0]).not.toContain('ver"sion')
   })
 
+  it('sanitizes backslashes before quotes to prevent escape bypass', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'test', {}, null, {
+      jqlVersions: ['ver\\"sion']
+    })
+    // Input: ver\"sion → after backslash escape: ver\\"sion → after quote escape: ver\\\\"sion
+    // The backslash must be escaped first so \" doesn't become \\" (breaking out of the string)
+    expect(mock.capturedJqls[0]).not.toContain('ver\\"sion')
+  })
+
   it('falls back to version when jqlVersions is empty array', async function () {
     var mock = createMockJira()
     await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {

--- a/modules/releases/__tests__/server/hygiene/jira-fetch.test.js
+++ b/modules/releases/__tests__/server/hygiene/jira-fetch.test.js
@@ -406,3 +406,89 @@ describe('transformIssue', function () {
     expect(result.violations).toEqual([])
   })
 })
+
+// ─── fetchHygieneFeatures — jqlVersions parameter ──────────────────
+
+const { fetchHygieneFeatures } = require('../../../server/hygiene/jira-fetch')
+
+describe('fetchHygieneFeatures jqlVersions option', function () {
+  // Capture JQL queries without hitting Jira
+  function createMockJira() {
+    var capturedJqls = []
+    function mockJiraRequest() { return Promise.resolve({}) }
+    function mockFetchAll(_jiraReq, jql) {
+      capturedJqls.push(jql)
+      return Promise.resolve([])
+    }
+    return { mockJiraRequest, mockFetchAll, capturedJqls }
+  }
+
+  it('uses version string in JQL when jqlVersions not provided', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {})
+    expect(mock.capturedJqls[0]).toContain('"Target Version" = "rhoai-3.5.z"')
+  })
+
+  it('uses single jqlVersion with = syntax', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {
+      jqlVersions: ['rhoai-3.5']
+    })
+    expect(mock.capturedJqls[0]).toContain('"Target Version" = "rhoai-3.5"')
+    expect(mock.capturedJqls[0]).not.toContain('rhoai-3.5.z')
+  })
+
+  it('uses multiple jqlVersions with IN syntax', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {
+      jqlVersions: ['rhoai-3.5', 'RHOAI-3.5']
+    })
+    expect(mock.capturedJqls[0]).toContain('"Target Version" IN ("rhoai-3.5", "RHOAI-3.5")')
+  })
+
+  it('uses jqlVersions for fixVersion filter too', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {
+      jqlVersions: ['rhoai-3.5']
+    })
+    // The supplementary queries (pass 1 missing TV and bugs) also use the version
+    var fixVersionJqls = mock.capturedJqls.filter(function (q) { return q.includes('fixVersion') })
+    for (var i = 0; i < fixVersionJqls.length; i++) {
+      expect(fixVersionJqls[i]).toContain('fixVersion = "rhoai-3.5"')
+      expect(fixVersionJqls[i]).not.toContain('rhoai-3.5.z')
+    }
+  })
+
+  it('sanitizes double quotes in version strings', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'test', {}, null, {
+      jqlVersions: ['ver"sion']
+    })
+    expect(mock.capturedJqls[0]).toContain('ver\\"sion')
+    expect(mock.capturedJqls[0]).not.toContain('ver"sion')
+  })
+
+  it('falls back to version when jqlVersions is empty array', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {
+      jqlVersions: []
+    })
+    expect(mock.capturedJqls[0]).toContain('"Target Version" = "rhoai-3.5.z"')
+  })
+
+  it('falls back to version when jqlVersions is null', async function () {
+    var mock = createMockJira()
+    await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {
+      jqlVersions: null
+    })
+    expect(mock.capturedJqls[0]).toContain('"Target Version" = "rhoai-3.5.z"')
+  })
+
+  it('preserves version in result for storage key', async function () {
+    var mock = createMockJira()
+    var result = await fetchHygieneFeatures(mock.mockJiraRequest, mock.mockFetchAll, 'rhoai-3.5.z', {}, null, {
+      jqlVersions: ['rhoai-3.5']
+    })
+    expect(result.version).toBe('rhoai-3.5.z')
+  })
+})

--- a/modules/releases/__tests__/server/registry-version-resolution.test.js
+++ b/modules/releases/__tests__/server/registry-version-resolution.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+
+const { normalizeVersionName, matchVersionsToReleases } = require('../../server/registry');
+const { loadRegistryConfig, saveRegistryConfig, STORAGE_KEY } = require('../../server/registry-config');
+
+function createMockStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    _store: store
+  };
+}
+
+describe('normalizeVersionName', () => {
+  it('lowercases', () => {
+    expect(normalizeVersionName('RHOAI-2.14')).toBe('rhoai 2 14');
+  });
+
+  it('strips terminal .z suffix', () => {
+    expect(normalizeVersionName('rhoai-3.5.z')).toBe('rhoai 3 5');
+  });
+
+  it('strips .z before EA suffix', () => {
+    expect(normalizeVersionName('rhoai-3.5.z.EA1')).toBe('rhoai 3 5 ea1');
+  });
+
+  it('normalizes dots and hyphens to spaces', () => {
+    expect(normalizeVersionName('RHOAI-2.14')).toBe('rhoai 2 14');
+    expect(normalizeVersionName('RHOAI 2.14')).toBe('rhoai 2 14');
+    expect(normalizeVersionName('rhoai.2.14')).toBe('rhoai 2 14');
+  });
+
+  it('normalizes EA variants to same form', () => {
+    // "RHAII-3.5.EA1" and "RHAII-3.5 EA1" should normalize identically
+    expect(normalizeVersionName('RHAII-3.5.EA1')).toBe('rhaii 3 5 ea1');
+    expect(normalizeVersionName('RHAII-3.5 EA1')).toBe('rhaii 3 5 ea1');
+    expect(normalizeVersionName('RHAII 3.5 EA1')).toBe('rhaii 3 5 ea1');
+  });
+
+  it('handles underscores', () => {
+    expect(normalizeVersionName('rhoai_3_5')).toBe('rhoai 3 5');
+  });
+
+  it('collapses multiple spaces', () => {
+    expect(normalizeVersionName('rhoai  3.5')).toBe('rhoai 3 5');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeVersionName('  rhoai-3.5  ')).toBe('rhoai 3 5');
+  });
+});
+
+describe('matchVersionsToReleases', () => {
+  const baseReleases = [
+    { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: [], state: 'active' },
+    { id: 'rhoai-3.5.z.ea1', displayName: 'rhoai-3.5.z.EA1', fixVersions: [], state: 'active' },
+    { id: 'rhaii-3.5.ea1', displayName: 'RHAII-3.5.EA1', fixVersions: [], state: 'active' },
+    { id: 'rhaii-3.6', displayName: 'RHAII-3.6', fixVersions: [], state: 'active' },
+    { id: 'rhoai-3.4.z', displayName: 'rhoai-3.4.z', fixVersions: [], state: 'archived' }
+  ];
+
+  it('matches rhoai-3.5 to rhoai-3.5.z (strips .z)', () => {
+    const jiraVersions = [{ name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, baseReleases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].releaseId).toBe('rhoai-3.5.z');
+    expect(result.matches[0].proposedFixVersions).toEqual(['rhoai-3.5']);
+    expect(result.unmatched).toHaveLength(0);
+  });
+
+  it('matches rhoai-3.5.EA1 to rhoai-3.5.z.EA1 (strips .z)', () => {
+    const jiraVersions = [{ name: 'rhoai-3.5.EA1', id: '2', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, baseReleases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].releaseId).toBe('rhoai-3.5.z.ea1');
+    expect(result.matches[0].proposedFixVersions).toEqual(['rhoai-3.5.EA1']);
+  });
+
+  it('matches RHAII-3.5 EA1 to RHAII-3.5.EA1 (dot vs space)', () => {
+    const jiraVersions = [{ name: 'RHAII-3.5 EA1', id: '3', project: 'RHAISTRAT' }];
+    const result = matchVersionsToReleases(jiraVersions, baseReleases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].releaseId).toBe('rhaii-3.5.ea1');
+  });
+
+  it('matches exact version strings', () => {
+    const jiraVersions = [{ name: 'RHAII-3.6', id: '4', project: 'RHAISTRAT' }];
+    const result = matchVersionsToReleases(jiraVersions, baseReleases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].releaseId).toBe('rhaii-3.6');
+  });
+
+  it('reports unmatched Jira versions', () => {
+    const jiraVersions = [{ name: 'UNKNOWN-1.0', id: '5', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, baseReleases);
+    expect(result.matches).toHaveLength(0);
+    expect(result.unmatched).toHaveLength(1);
+    expect(result.unmatched[0].name).toBe('UNKNOWN-1.0');
+  });
+
+  it('skips archived releases', () => {
+    const jiraVersions = [{ name: 'rhoai-3.4', id: '6', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, baseReleases);
+    expect(result.matches).toHaveLength(0);
+    expect(result.unmatched).toHaveLength(1);
+  });
+
+  it('does not duplicate existing fixVersions in proposed', () => {
+    const releases = [
+      { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['rhoai-3.5'], state: 'active' }
+    ];
+    const jiraVersions = [{ name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].proposedFixVersions).toEqual(['rhoai-3.5']);
+  });
+
+  it('adds new Jira versions to existing fixVersions', () => {
+    const releases = [
+      { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['existing-v'], state: 'active' }
+    ];
+    const jiraVersions = [{ name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches[0].proposedFixVersions).toEqual(['existing-v', 'rhoai-3.5']);
+  });
+
+  it('matches via existing fixVersions on the release', () => {
+    const releases = [
+      { id: 'custom-release', displayName: 'Custom Release', fixVersions: ['rhoai-3.5'], state: 'active' }
+    ];
+    const jiraVersions = [{ name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].releaseId).toBe('custom-release');
+  });
+
+  it('groups multiple Jira versions matching the same release', () => {
+    const releases = [
+      { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: [], state: 'active' }
+    ];
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: 'rhoai-3.5', id: '2', project: 'RHAISTRAT' }
+    ];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].jiraMatches).toHaveLength(2);
+    // Proposed should deduplicate by name
+    expect(result.matches[0].proposedFixVersions).toEqual(['rhoai-3.5']);
+  });
+
+  it('does not produce false positives between similar versions', () => {
+    const releases = [
+      { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: [], state: 'active' },
+      { id: 'rhoai-3.6.z', displayName: 'rhoai-3.6.z', fixVersions: [], state: 'active' }
+    ];
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: 'rhoai-3.6', id: '2', project: 'RHOAIENG' }
+    ];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches).toHaveLength(2);
+
+    const match35 = result.matches.find(m => m.releaseId === 'rhoai-3.5.z');
+    const match36 = result.matches.find(m => m.releaseId === 'rhoai-3.6.z');
+    expect(match35.proposedFixVersions).toEqual(['rhoai-3.5']);
+    expect(match36.proposedFixVersions).toEqual(['rhoai-3.6']);
+  });
+});
+
+describe('registry-config', () => {
+  it('returns defaults when no config exists', () => {
+    const storage = createMockStorage();
+    const config = loadRegistryConfig(storage);
+    expect(config.jiraProjects).toEqual(['RHAISTRAT', 'RHOAIENG']);
+  });
+
+  it('loads stored config', () => {
+    const storage = createMockStorage({
+      [STORAGE_KEY]: { jiraProjects: ['PROJ1', 'PROJ2'] }
+    });
+    const config = loadRegistryConfig(storage);
+    expect(config.jiraProjects).toEqual(['PROJ1', 'PROJ2']);
+  });
+
+  it('falls back to defaults for malformed data', () => {
+    const storage = createMockStorage({ [STORAGE_KEY]: 'not-object' });
+    const config = loadRegistryConfig(storage);
+    expect(config.jiraProjects).toEqual(['RHAISTRAT', 'RHOAIENG']);
+  });
+
+  it('saves config to storage', () => {
+    const storage = createMockStorage();
+    saveRegistryConfig(storage, { jiraProjects: ['A', 'B'] });
+    expect(storage._store[STORAGE_KEY].jiraProjects).toEqual(['A', 'B']);
+  });
+
+  it('filters out non-string and empty project values', () => {
+    const storage = createMockStorage();
+    saveRegistryConfig(storage, { jiraProjects: ['A', '', null, 42, 'B'] });
+    expect(storage._store[STORAGE_KEY].jiraProjects).toEqual(['A', 'B']);
+  });
+
+  it('throws on non-object config', () => {
+    const storage = createMockStorage();
+    expect(() => saveRegistryConfig(storage, null)).toThrow('Config must be an object');
+  });
+});

--- a/modules/releases/client/views/RegistryView.vue
+++ b/modules/releases/client/views/RegistryView.vue
@@ -41,12 +41,116 @@
           class="w-64 pl-4 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
         />
         <button
+          @click="handleResolveJiraVersions"
+          :disabled="resolving"
+          class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+        >
+          {{ resolving ? 'Resolving...' : 'Resolve Jira Versions' }}
+        </button>
+        <button
           @click="handleDiscover"
           :disabled="discovering"
           class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
         >
           {{ discovering ? 'Discovering...' : 'Discover' }}
         </button>
+      </div>
+    </div>
+
+    <!-- Resolve Jira Versions modal -->
+    <div v-if="showResolveModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="showResolveModal = false">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-3xl max-h-[80vh] flex flex-col mx-4">
+        <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Resolve Jira Versions</h2>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Matched {{ resolveResult?.jiraVersionCount || 0 }} Jira versions from {{ (resolveResult?.projects || []).join(', ') }}.
+            Select which mappings to apply.
+          </p>
+        </div>
+        <div class="flex-1 overflow-y-auto px-6 py-4">
+          <!-- No matches -->
+          <div v-if="!resolveResult?.matches?.length && !resolveResult?.unmatched?.length" class="text-center py-8 text-gray-500 dark:text-gray-400">
+            No Jira versions found.
+          </div>
+
+          <!-- Matches -->
+          <div v-if="resolveResult?.matches?.length">
+            <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Matched releases ({{ resolveResult.matches.length }})</h3>
+            <div class="space-y-3">
+              <label
+                v-for="match in resolveResult.matches"
+                :key="match.releaseId"
+                class="flex items-start gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-750 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  :checked="selectedResolves[match.releaseId]"
+                  @change="selectedResolves[match.releaseId] = $event.target.checked"
+                  class="mt-1 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+                />
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ match.releaseName }}</p>
+                  <div class="flex flex-wrap gap-1.5 mt-1">
+                    <span
+                      v-for="jv in match.jiraMatches"
+                      :key="jv.id"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800"
+                    >
+                      {{ jv.name }}
+                      <span class="ml-1 text-blue-400 dark:text-blue-500">({{ jv.project }})</span>
+                    </span>
+                  </div>
+                  <p v-if="match.currentFixVersions?.length" class="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                    Current: {{ match.currentFixVersions.join(', ') }}
+                  </p>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          <!-- Unmatched -->
+          <details v-if="resolveResult?.unmatched?.length" class="mt-4">
+            <summary class="text-sm font-medium text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
+              Unmatched Jira versions ({{ resolveResult.unmatched.length }})
+            </summary>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <span
+                v-for="uv in resolveResult.unmatched"
+                :key="uv.id"
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400"
+              >
+                {{ uv.name }} ({{ uv.project }})
+              </span>
+            </div>
+          </details>
+        </div>
+        <div class="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <p v-if="resolveApplyMessage" class="text-sm" :class="resolveApplyError ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">
+            {{ resolveApplyMessage }}
+          </p>
+          <span v-else></span>
+          <div class="flex items-center gap-3">
+            <button
+              @click="handleSelectAllResolves"
+              class="px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+            >
+              {{ allResolvesSelected ? 'Deselect All' : 'Select All' }}
+            </button>
+            <button
+              @click="showResolveModal = false"
+              class="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+            >
+              Close
+            </button>
+            <button
+              @click="handleApplyResolves"
+              :disabled="applyingResolves || selectedResolveCount === 0"
+              class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+            >
+              {{ applyingResolves ? 'Applying...' : `Apply (${selectedResolveCount})` }}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -484,6 +588,13 @@ const saving = ref(false)
 const editingId = ref(null)
 const createIdError = ref('')
 const cardRefs = ref({})
+const resolving = ref(false)
+const showResolveModal = ref(false)
+const resolveResult = ref(null)
+const selectedResolves = ref({})
+const applyingResolves = ref(false)
+const resolveApplyMessage = ref('')
+const resolveApplyError = ref(false)
 
 onBeforeUpdate(() => { cardRefs.value = {} })
 
@@ -701,6 +812,76 @@ async function handleRestore(id) {
     await fetchReleases()
   } catch (e) {
     console.error('Failed to restore release:', e)
+  }
+}
+
+// ── Resolve Jira Versions ──
+
+const selectedResolveCount = computed(() => {
+  return Object.values(selectedResolves.value).filter(Boolean).length
+})
+
+const allResolvesSelected = computed(() => {
+  const matches = resolveResult.value?.matches || []
+  if (matches.length === 0) return false
+  return matches.every(m => selectedResolves.value[m.releaseId])
+})
+
+function handleSelectAllResolves() {
+  const matches = resolveResult.value?.matches || []
+  const allSelected = allResolvesSelected.value
+  for (const match of matches) {
+    selectedResolves.value[match.releaseId] = !allSelected
+  }
+}
+
+async function handleResolveJiraVersions() {
+  resolving.value = true
+  resolveApplyMessage.value = ''
+  resolveApplyError.value = false
+  try {
+    const result = await apiRequest('/modules/releases/registry/resolve-jira-versions', { method: 'POST' })
+    resolveResult.value = result
+    // Pre-select matches that have new versions to add
+    const sel = {}
+    for (const match of result.matches || []) {
+      sel[match.releaseId] = match.proposedFixVersions.length > match.currentFixVersions.length
+    }
+    selectedResolves.value = sel
+    showResolveModal.value = true
+  } catch (e) {
+    resolveApplyError.value = true
+    resolveApplyMessage.value = e.message || 'Resolution failed.'
+    showResolveModal.value = true
+    resolveResult.value = { matches: [], unmatched: [], jiraVersionCount: 0, projects: [] }
+  } finally {
+    resolving.value = false
+  }
+}
+
+async function handleApplyResolves() {
+  applyingResolves.value = true
+  resolveApplyMessage.value = ''
+  resolveApplyError.value = false
+  try {
+    const mappings = []
+    for (const match of resolveResult.value?.matches || []) {
+      if (selectedResolves.value[match.releaseId]) {
+        mappings.push({ releaseId: match.releaseId, fixVersions: match.proposedFixVersions })
+      }
+    }
+    const result = await apiRequest('/modules/releases/registry/resolve-jira-versions/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mappings })
+    })
+    resolveApplyMessage.value = `Updated ${(result.updated || []).length} release(s).`
+    await fetchReleases()
+  } catch (e) {
+    resolveApplyError.value = true
+    resolveApplyMessage.value = e.message || 'Apply failed.'
+  } finally {
+    applyingResolves.value = false
   }
 }
 

--- a/modules/releases/server/hygiene/jira-fetch.js
+++ b/modules/releases/server/hygiene/jira-fetch.js
@@ -341,10 +341,10 @@ async function fetchHygieneFeatures(jiraRequestFn, fetchAllJqlResultsFn, version
     ? options.jqlVersions
     : [version]
 
-  // Sanitize: escape double quotes to prevent JQL injection
+  // Sanitize: escape backslashes then double quotes to prevent JQL injection
   const sanitized = []
   for (var si = 0; si < jqlVersions.length; si++) {
-    sanitized.push(jqlVersions[si].replace(/"/g, '\\"'))
+    sanitized.push(jqlVersions[si].replace(/\\/g, '\\\\').replace(/"/g, '\\"'))
   }
 
   // ── Pass 1: Fetch all features (lightweight) ──

--- a/modules/releases/server/hygiene/jira-fetch.js
+++ b/modules/releases/server/hygiene/jira-fetch.js
@@ -322,22 +322,39 @@ async function fetchRfeMap(jiraRequestFn, fetchAllJqlResultsFn, rfeKeys) {
  *
  * @param {Function} jiraRequestFn - The shared jiraRequest function
  * @param {Function} fetchAllJqlResultsFn - The shared fetchAllJqlResults function
- * @param {string} version - Target version string (e.g., "RHOAI 2.18")
+ * @param {string} version - Display version string used for storage key and result metadata
  * @param {object} config - { projects: string[], issueTypes: string[] }
  * @param {Function} [onProgress] - Optional callback: (stage, detail) => void
+ * @param {object} [options] - Optional settings
+ * @param {string[]} [options.jqlVersions] - Jira version strings to use in JQL queries.
+ *   When provided, uses these instead of `version` for Target Version and fixVersion filters.
+ *   Supports multiple values via IN (...) syntax.
  * @returns {Promise<{ features: object, fetchedAt: string, version: string }>}
  */
-async function fetchHygieneFeatures(jiraRequestFn, fetchAllJqlResultsFn, version, config, onProgress) {
+async function fetchHygieneFeatures(jiraRequestFn, fetchAllJqlResultsFn, version, config, onProgress, options) {
   const projects = config.projects || ['RHAISTRAT', 'RHOAIENG']
   const issueTypes = config.issueTypes || ['Feature', 'Initiative']
   const notify = typeof onProgress === 'function' ? onProgress : function () {}
+
+  // Determine JQL version strings — use options.jqlVersions if provided, else fall back to version
+  const jqlVersions = (options && Array.isArray(options.jqlVersions) && options.jqlVersions.length > 0)
+    ? options.jqlVersions
+    : [version]
+
+  // Sanitize: escape double quotes to prevent JQL injection
+  const sanitized = []
+  for (var si = 0; si < jqlVersions.length; si++) {
+    sanitized.push(jqlVersions[si].replace(/"/g, '\\"'))
+  }
 
   // ── Pass 1: Fetch all features (lightweight) ──
   notify('pass1', { message: 'Fetching features for ' + version })
 
   const projectFilter = 'project IN (' + projects.join(', ') + ')'
   const issueTypeFilter = 'issuetype IN (' + issueTypes.join(', ') + ')'
-  const versionFilter = '"Target Version" = "' + version + '"'
+  const versionFilter = sanitized.length === 1
+    ? '"Target Version" = "' + sanitized[0] + '"'
+    : '"Target Version" IN (' + sanitized.map(function (v) { return '"' + v + '"' }).join(', ') + ')'
 
   const jql = projectFilter + ' AND ' + issueTypeFilter + ' AND ' + versionFilter
 
@@ -350,8 +367,12 @@ async function fetchHygieneFeatures(jiraRequestFn, fetchAllJqlResultsFn, version
   // ── Supplementary: Issues with fixVersion but no Target Version ──
   notify('supplementary', { message: 'Checking for issues with fixVersion but no Target Version' })
 
+  const fixVersionFilter = sanitized.length === 1
+    ? 'fixVersion = "' + sanitized[0] + '"'
+    : 'fixVersion IN (' + sanitized.map(function (v) { return '"' + v + '"' }).join(', ') + ')'
+
   const missingTvJql = projectFilter + ' AND ' + issueTypeFilter +
-    ' AND fixVersion = "' + version + '" AND "Target Version" IS EMPTY'
+    ' AND ' + fixVersionFilter + ' AND "Target Version" IS EMPTY'
 
   try {
     const missingTvIssues = await fetchAllJqlResultsFn(jiraRequestFn, missingTvJql, PASS1_FIELDS, {
@@ -373,7 +394,7 @@ async function fetchHygieneFeatures(jiraRequestFn, fetchAllJqlResultsFn, version
   // ── Supplementary: Post-release bugs missing Affected Version ──
   notify('supplementary', { message: 'Checking for post-release bugs' })
 
-  const bugJql = projectFilter + ' AND issuetype = Bug AND fixVersion = "' + version + '"'
+  const bugJql = projectFilter + ' AND issuetype = Bug AND ' + fixVersionFilter
 
   try {
     const bugIssues = await fetchAllJqlResultsFn(jiraRequestFn, bugJql, PASS1_FIELDS, {

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -242,14 +242,27 @@ module.exports = function registerHygieneRoutes(router, context) {
       var jiraRequest = jira.jiraRequest;
       var fetchAllJqlResults = jira.fetchAllJqlResults;
 
+      // Look up fixVersions from registry for JQL queries
+      var registry = readRegistry(storage.readFromStorage);
+      var registryReleases = registry.releases || [];
+      var jqlVersions = null;
+      for (var rli = 0; rli < registryReleases.length; rli++) {
+        var rl = registryReleases[rli];
+        if (rl.displayName === version || rl.id === version) {
+          if (rl.fixVersions && rl.fixVersions.length > 0) {
+            jqlVersions = rl.fixVersions;
+          }
+          break;
+        }
+      }
+
       function onProgress(stage, detail) {
         refreshState.progress = { stage: stage, message: detail.message || stage };
       }
 
-      fetchHygieneFeatures(jiraRequest, fetchAllJqlResults, version, config, onProgress)
+      fetchHygieneFeatures(jiraRequest, fetchAllJqlResults, version, config, onProgress, { jqlVersions: jqlVersions })
         .then(function(result) {
           // Enrich with version-released status from registry
-          var registry = readRegistry(storage.readFromStorage);
           var registryReleases = registry.releases || [];
           var versionReleased = false;
           var versionGaDate = null;
@@ -397,6 +410,19 @@ module.exports = function registerHygieneRoutes(router, context) {
           message: 'Refreshing ' + version + ' (' + (versionIndex + 1) + '/' + activeVersions.length + ')'
         };
 
+        // Look up registry release for fixVersions and version-released enrichment
+        var rel = null;
+        for (var rri = 0; rri < registryReleases.length; rri++) {
+          var rr = registryReleases[rri];
+          if (rr.id === version || rr.displayName === version) {
+            rel = rr;
+            break;
+          }
+        }
+        var jqlVersions = (rel && rel.fixVersions && rel.fixVersions.length > 0)
+          ? rel.fixVersions
+          : null;
+
         function onProgress(stage, detail) {
           refreshState.progress = {
             stage: stage,
@@ -404,17 +430,8 @@ module.exports = function registerHygieneRoutes(router, context) {
           };
         }
 
-        fetchHygieneFeatures(jiraRequest, fetchAllJqlResults, version, config, onProgress)
+        fetchHygieneFeatures(jiraRequest, fetchAllJqlResults, version, config, onProgress, { jqlVersions: jqlVersions })
           .then(function(result) {
-            // Look up registry release for version-released enrichment
-            var rel = null;
-            for (var rri = 0; rri < registryReleases.length; rri++) {
-              var rr = registryReleases[rri];
-              if (rr.id === version || rr.displayName === version) {
-                rel = rr;
-                break;
-              }
-            }
             var gaDate = rel && rel.milestones && (rel.milestones.gaDate || rel.milestones.ga);
             var versionReleased = false;
             var versionGaDate = null;

--- a/modules/releases/server/registry-config.js
+++ b/modules/releases/server/registry-config.js
@@ -1,0 +1,62 @@
+/**
+ * Registry-level configuration for Jira version resolution.
+ *
+ * Stores settings that control how the registry discovers and maps
+ * Jira project versions to registry releases.
+ *
+ * Storage: releases/registry-config.json
+ */
+
+const STORAGE_KEY = 'releases/registry-config.json'
+
+const DEFAULT_JIRA_PROJECTS = ['RHAISTRAT', 'RHOAIENG']
+
+function getDefaults() {
+  return {
+    jiraProjects: DEFAULT_JIRA_PROJECTS.slice()
+  }
+}
+
+/**
+ * Load registry config from storage, merging with defaults.
+ * @param {{ readFromStorage: function }} storage
+ * @returns {{ jiraProjects: string[] }}
+ */
+function loadRegistryConfig(storage) {
+  var defaults = getDefaults()
+  var stored = storage.readFromStorage(STORAGE_KEY)
+
+  if (!stored || typeof stored !== 'object') {
+    return defaults
+  }
+
+  return {
+    jiraProjects: Array.isArray(stored.jiraProjects) ? stored.jiraProjects : defaults.jiraProjects
+  }
+}
+
+/**
+ * Save registry config to storage.
+ * @param {{ writeToStorage: function }} storage
+ * @param {{ jiraProjects?: string[] }} config
+ */
+function saveRegistryConfig(storage, config) {
+  if (!config || typeof config !== 'object') {
+    throw new Error('Config must be an object')
+  }
+
+  var toSave = {
+    jiraProjects: Array.isArray(config.jiraProjects)
+      ? config.jiraProjects.filter(function(p) { return typeof p === 'string' && p.trim().length > 0 })
+      : DEFAULT_JIRA_PROJECTS.slice()
+  }
+
+  storage.writeToStorage(STORAGE_KEY, toSave)
+}
+
+module.exports = {
+  loadRegistryConfig,
+  saveRegistryConfig,
+  getDefaults,
+  STORAGE_KEY
+}

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -624,8 +624,7 @@ function registerRegistryRoutes(router, context) {
         });
       }
 
-      var { fetchProjectVersions } = require('../../../shared/server/jira');
-      var { jiraRequest: jiraRequestFn } = require('../../../shared/server/jira');
+      var { fetchProjectVersions, jiraRequest: jiraRequestFn } = require('../../../shared/server/jira');
 
       var jiraVersions = await fetchProjectVersions(jiraRequestFn, projects);
       var registry = readRegistry(readFromStorage);
@@ -692,6 +691,9 @@ function registerRegistryRoutes(router, context) {
       var mapping = mappings[i];
       if (!mapping.releaseId || !Array.isArray(mapping.fixVersions)) continue;
 
+      // Filter to string values only
+      var cleanVersions = mapping.fixVersions.filter(function(v) { return typeof v === 'string' && v.trim().length > 0; });
+
       var release = null;
       for (var ri = 0; ri < registry.releases.length; ri++) {
         if (registry.releases[ri].id === mapping.releaseId) {
@@ -702,7 +704,7 @@ function registerRegistryRoutes(router, context) {
 
       if (!release) continue;
 
-      release.fixVersions = mapping.fixVersions;
+      release.fixVersions = cleanVersions;
       release.updatedAt = new Date().toISOString();
       updated.push({ releaseId: release.id, fixVersions: release.fixVersions });
     }

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -8,6 +8,7 @@
  */
 
 const { logAudit } = require('./planning/audit-log');
+const { loadRegistryConfig, saveRegistryConfig } = require('./registry-config');
 
 const REGISTRY_FILE = 'releases/registry.json';
 const SCHEMA_VERSION = 1;
@@ -76,6 +77,107 @@ function normalizeRelease(input) {
 }
 
 /**
+ * Normalize a version name for fuzzy matching.
+ * Lowercases, strips ".z" suffixes (Product Pages z-stream convention),
+ * collapses separators (hyphens, dots) to spaces, and trims.
+ * @param {string} name
+ * @returns {string}
+ */
+function normalizeVersionName(name) {
+  var s = String(name).toLowerCase();
+  // Strip ".z" suffix (but not ".z." — only terminal .z)
+  s = s.replace(/\.z(?=$|\.)/g, '');
+  // Collapse hyphens and dots to spaces
+  s = s.replace(/[-._]+/g, ' ');
+  // Collapse multiple spaces
+  s = s.replace(/\s+/g, ' ');
+  return s.trim();
+}
+
+/**
+ * Match Jira project versions against registry releases.
+ * @param {Array<{ name: string, id: string, project: string }>} jiraVersions
+ * @param {Array<{ id: string, displayName: string, fixVersions: string[], state: string }>} registryReleases
+ * @returns {{ matches: Array<{ releaseId: string, releaseName: string, currentFixVersions: string[], proposedFixVersions: string[], jiraMatches: Array<{ name: string, id: string, project: string }> }>, unmatched: Array<{ name: string, id: string, project: string }> }}
+ */
+function matchVersionsToReleases(jiraVersions, registryReleases) {
+  // Build normalized lookup for active releases
+  var releasesByNormalized = {};
+  for (var ri = 0; ri < registryReleases.length; ri++) {
+    var rel = registryReleases[ri];
+    if (rel.state === 'archived') continue;
+
+    // Normalize displayName and all existing fixVersions as candidate keys
+    var keys = [normalizeVersionName(rel.displayName)];
+    var fvs = rel.fixVersions || [];
+    for (var fi = 0; fi < fvs.length; fi++) {
+      var nfv = normalizeVersionName(fvs[fi]);
+      if (keys.indexOf(nfv) === -1) keys.push(nfv);
+    }
+
+    for (var ki = 0; ki < keys.length; ki++) {
+      if (!releasesByNormalized[keys[ki]]) {
+        releasesByNormalized[keys[ki]] = rel;
+      }
+    }
+  }
+
+  // Match each Jira version
+  var matchMap = {}; // releaseId -> { release, jiraMatches[], proposedVersionNames Set }
+  var unmatched = [];
+
+  for (var ji = 0; ji < jiraVersions.length; ji++) {
+    var jv = jiraVersions[ji];
+    var normalized = normalizeVersionName(jv.name);
+    var release = releasesByNormalized[normalized];
+
+    if (release) {
+      if (!matchMap[release.id]) {
+        matchMap[release.id] = {
+          release: release,
+          jiraMatches: [],
+          proposedNames: {}
+        };
+      }
+      matchMap[release.id].jiraMatches.push({
+        name: jv.name,
+        id: jv.id,
+        project: jv.project
+      });
+      matchMap[release.id].proposedNames[jv.name] = true;
+    } else {
+      unmatched.push({ name: jv.name, id: jv.id, project: jv.project });
+    }
+  }
+
+  // Build matches array
+  var matches = [];
+  var matchIds = Object.keys(matchMap);
+  for (var mi = 0; mi < matchIds.length; mi++) {
+    var entry = matchMap[matchIds[mi]];
+    var currentFvs = entry.release.fixVersions || [];
+    // Proposed = current + any new Jira version names not already present
+    var proposed = currentFvs.slice();
+    var proposedNames = Object.keys(entry.proposedNames);
+    for (var pi = 0; pi < proposedNames.length; pi++) {
+      if (proposed.indexOf(proposedNames[pi]) === -1) {
+        proposed.push(proposedNames[pi]);
+      }
+    }
+
+    matches.push({
+      releaseId: entry.release.id,
+      releaseName: entry.release.displayName,
+      currentFixVersions: currentFvs,
+      proposedFixVersions: proposed,
+      jiraMatches: entry.jiraMatches
+    });
+  }
+
+  return { matches: matches, unmatched: unmatched };
+}
+
+/**
  * Register release registry routes on the provided router.
  */
 function registerRegistryRoutes(router, context) {
@@ -106,6 +208,53 @@ function registerRegistryRoutes(router, context) {
   router.get('/registry', requireAuth, requireScope('releases:read'), function(req, res) {
     const registry = readRegistry(readFromStorage);
     res.json(registry);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/releases/registry/config:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get registry configuration (Jira projects for version resolution)
+   *     responses:
+   *       200:
+   *         description: Registry config
+   */
+  router.get('/registry/config', requireReleaseManager, requireScope('releases:read'), function(req, res) {
+    var config = loadRegistryConfig(storage);
+    res.json(config);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/releases/registry/config:
+   *   post:
+   *     tags: [Releases]
+   *     summary: Save registry configuration
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               jiraProjects:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *     responses:
+   *       200:
+   *         description: Config saved
+   *       400:
+   *         description: Validation error
+   */
+  router.post('/registry/config', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+    try {
+      saveRegistryConfig(storage, req.body);
+      res.json({ status: 'saved' });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
   });
 
   /**
@@ -445,6 +594,135 @@ function registerRegistryRoutes(router, context) {
       res.status(500).json({ error: 'Auto-discover failed: ' + err.message });
     }
   });
+
+  /**
+   * @openapi
+   * /api/modules/releases/registry/resolve-jira-versions:
+   *   post:
+   *     tags: [Releases]
+   *     summary: Preview Jira version resolution against registry releases
+   *     description: >
+   *       Fetches all versions from configured Jira projects and matches them
+   *       against registry releases using normalized string comparison.
+   *       Returns proposed fixVersions mappings without writing.
+   *     responses:
+   *       200:
+   *         description: Proposed version mappings
+   *       400:
+   *         description: No Jira projects configured
+   *       500:
+   *         description: Jira API error
+   */
+  router.post('/registry/resolve-jira-versions', requireReleaseManager, requireScope('releases:write'), async function(req, res) {
+    try {
+      var config = loadRegistryConfig(storage);
+      var projects = config.jiraProjects || [];
+
+      if (projects.length === 0) {
+        return res.status(400).json({
+          error: 'No Jira projects configured. Set jiraProjects in registry config first.'
+        });
+      }
+
+      var { fetchProjectVersions } = require('../../../shared/server/jira');
+      var { jiraRequest: jiraRequestFn } = require('../../../shared/server/jira');
+
+      var jiraVersions = await fetchProjectVersions(jiraRequestFn, projects);
+      var registry = readRegistry(readFromStorage);
+      var result = matchVersionsToReleases(jiraVersions, registry.releases);
+
+      res.json({
+        status: 'ok',
+        jiraVersionCount: jiraVersions.length,
+        projects: projects,
+        matches: result.matches,
+        unmatched: result.unmatched
+      });
+    } catch (err) {
+      console.error('[releases/registry] Jira version resolution failed:', err.message);
+      res.status(500).json({ error: 'Jira version resolution failed: ' + err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /api/modules/releases/registry/resolve-jira-versions/apply:
+   *   post:
+   *     tags: [Releases]
+   *     summary: Apply resolved Jira versions to registry releases
+   *     description: >
+   *       Accepts a list of release-to-fixVersions mappings and writes them
+   *       to the registry. Only updates releases included in the request.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [mappings]
+   *             properties:
+   *               mappings:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   required: [releaseId, fixVersions]
+   *                   properties:
+   *                     releaseId:
+   *                       type: string
+   *                     fixVersions:
+   *                       type: array
+   *                       items:
+   *                         type: string
+   *     responses:
+   *       200:
+   *         description: Versions applied
+   *       400:
+   *         description: Invalid request
+   */
+  router.post('/registry/resolve-jira-versions/apply', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+    var mappings = req.body && req.body.mappings;
+    if (!Array.isArray(mappings) || mappings.length === 0) {
+      return res.status(400).json({ error: 'mappings array is required and must not be empty' });
+    }
+
+    var registry = readRegistry(readFromStorage);
+    var updated = [];
+
+    for (var i = 0; i < mappings.length; i++) {
+      var mapping = mappings[i];
+      if (!mapping.releaseId || !Array.isArray(mapping.fixVersions)) continue;
+
+      var release = null;
+      for (var ri = 0; ri < registry.releases.length; ri++) {
+        if (registry.releases[ri].id === mapping.releaseId) {
+          release = registry.releases[ri];
+          break;
+        }
+      }
+
+      if (!release) continue;
+
+      release.fixVersions = mapping.fixVersions;
+      release.updatedAt = new Date().toISOString();
+      updated.push({ releaseId: release.id, fixVersions: release.fixVersions });
+    }
+
+    if (updated.length > 0) {
+      writeRegistry(writeToStorage, registry);
+      logAudit(readFromStorage, writeToStorage, {
+        domain: 'registry',
+        action: 'registry_resolve_jira_versions',
+        user: req.userEmail || 'unknown',
+        summary: 'Applied Jira version mappings to ' + updated.length + ' releases',
+        details: { updated: updated }
+      });
+    }
+
+    res.json({ status: 'ok', updated: updated });
+  });
 }
 
-module.exports = { registerRegistryRoutes, readRegistry, writeRegistry, validateRelease, normalizeRelease, REGISTRY_FILE };
+module.exports = {
+  registerRegistryRoutes, readRegistry, writeRegistry, validateRelease, normalizeRelease,
+  normalizeVersionName, matchVersionsToReleases, REGISTRY_FILE
+};

--- a/shared/API.md
+++ b/shared/API.md
@@ -70,7 +70,7 @@ Core team owns `shared/` via CODEOWNERS. Changes require core team review.
 | `googleSheets` | `{ getAuth, discoverSheetNames, fetchRawSheet }` — Google Sheets auth and raw data fetching |
 | `roster` | `{ readRosterFull, getAllPeople, getPeopleByOrg, getOrgKeys, getTeamRollup, getOrgDisplayNames }` — shared roster data access |
 | `rosterSync` | `{ runSync, isSyncInProgress }` — barrel re-export of the consolidated sync pipeline (LDAP + Google Sheets + lifecycle tracking). `runSync` is an alias for `runConsolidatedSync` from `roster-sync/consolidated-sync`. Sub-modules: `roster-sync/consolidated-sync` (runConsolidatedSync, isSyncInProgress), `roster-sync/config` (loadConfig, saveConfig, isConfigured, getOrgDisplayNames, updateSyncStatus), `roster-sync/constants`, `roster-sync/ldap`, `roster-sync/sheets`, `roster-sync/merge`, `roster-sync/username-inference`, `roster-sync/lifecycle` (mergePerson) |
-| `jira` | `{ JIRA_HOST, getJiraAuth, jiraRequest, fetchAllJqlResults }` — Jira Cloud API helpers: auth (Basic via `JIRA_TOKEN`/`JIRA_EMAIL` env vars), request wrapper with 429 retry, cursor-based JQL pagination via `/rest/api/3/search/jql` |
+| `jira` | `{ JIRA_HOST, getJiraAuth, jiraRequest, fetchAllJqlResults, fetchProjectVersions }` — Jira Cloud API helpers: auth (Basic via `JIRA_TOKEN`/`JIRA_EMAIL` env vars), request wrapper with 429 retry, cursor-based JQL pagination via `/rest/api/3/search/jql`, project version catalog via `/rest/api/3/project/{key}/versions` |
 | `permissions` | `{ LDAP_FIELDS, buildManagerMap, getManagedUids, getDirectReports, isManager, getPermissionTier, canEditPerson }` — RBAC logic: manager subtree computation, direct reports, permission tier detection, authorization checks |
 
 ## Cross-Module Data Access

--- a/shared/server/jira.js
+++ b/shared/server/jira.js
@@ -89,4 +89,42 @@ async function fetchAllJqlResults(jiraRequest, jql, fields, { maxResults = 100, 
   return issues;
 }
 
-module.exports = { JIRA_HOST, getJiraAuth, jiraRequest, fetchAllJqlResults };
+/**
+ * Fetch all versions from the given Jira projects.
+ * Uses the unpaginated /versions endpoint (returns flat array).
+ * @param {Function} jiraRequestFn - The jiraRequest function
+ * @param {string[]} projects - Jira project keys (e.g., ['RHAISTRAT', 'RHOAIENG'])
+ * @returns {Promise<Array<{ name: string, id: string, project: string, released: boolean, archived: boolean, releaseDate: string|null }>>}
+ */
+async function fetchProjectVersions(jiraRequestFn, projects) {
+  const versions = [];
+
+  for (const project of projects) {
+    try {
+      const data = await jiraRequestFn(
+        `/rest/api/3/project/${encodeURIComponent(project)}/versions`
+      );
+      const arr = Array.isArray(data) ? data : [];
+
+      for (let i = 0; i < arr.length; i++) {
+        const v = arr[i];
+        const name = String(v.name || '').trim();
+        if (!name) continue;
+        versions.push({
+          name,
+          id: String(v.id || ''),
+          project,
+          released: v.released === true,
+          archived: v.archived === true,
+          releaseDate: v.releaseDate || null
+        });
+      }
+    } catch (err) {
+      console.warn(`[jira] Failed to fetch versions for project ${project}: ${err.message}`);
+    }
+  }
+
+  return versions;
+}
+
+module.exports = { JIRA_HOST, getJiraAuth, jiraRequest, fetchAllJqlResults, fetchProjectVersions };


### PR DESCRIPTION
## Summary

- Fixes hygiene feature returning empty results in production — registry `displayName` values from Product Pages don't match Jira's "Target Version" field values (e.g., `rhoai-3.5.z` vs `rhoai-3.5`)
- Adds a Jira version resolution capability to the release registry with preview/apply flow so admins can review matches before committing
- Decouples hygiene JQL queries from storage keys — `fixVersions` from the registry are used for Jira queries while `displayName` remains the storage key

### What's new

**Backend:**
- `fetchProjectVersions` shared utility in `shared/server/jira.js`
- Registry config (`jiraProjects` array) at `releases/registry-config.json`
- Version normalization algorithm (`.z` stripping, case folding, separator collapse)
- `POST /registry/resolve-jira-versions` — preview endpoint
- `POST /registry/resolve-jira-versions/apply` — apply confirmed mappings
- `GET/POST /registry/config` — registry config endpoints
- `fetchHygieneFeatures` now accepts `jqlVersions` array with `IN (...)` JQL syntax and quote sanitization
- Both `refresh` and `refresh-all` look up `fixVersions` from registry

**Frontend:**
- "Resolve Jira Versions" button on the Manage → Releases page
- Modal showing matched/unmatched versions with checkboxes for selective apply

**Tests:** 33 new tests covering normalization, matching, config load/save, and JQL construction

## Test plan

- [ ] Run `npm test` — all 3390 tests pass
- [ ] Verify lint clean (`npm run lint`)
- [ ] Deploy to dev and run "Resolve Jira Versions" from the Manage page
- [ ] Confirm the preview shows correct mappings (e.g., `rhoai-3.5.z` → `rhoai-3.5`)
- [ ] Apply mappings and verify `fixVersions` appear on release cards
- [ ] Trigger hygiene refresh and confirm features are now returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)