### PR TITLE
feat(team-tracker): add Rover People profile link to person detail

### DIFF
--- a/modules/team-tracker/client/views/PersonProfileView.vue
+++ b/modules/team-tracker/client/views/PersonProfileView.vue
@@ -250,6 +250,9 @@ onBeforeUnmount(() => {
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2 flex-wrap">
                   <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">{{ person.name }}</h2>
+                  <a v-if="person.uid" :href="'https://rover.redhat.com/people/profile/' + person.uid" target="_blank" rel="noopener" title="View Rover People profile" class="inline-flex items-center hover:opacity-80 transition-opacity">
+                    <img src="/redhat-logo.svg" alt="Red Hat" class="h-5 w-auto" />
+                  </a>
                   <span v-if="person.status === 'inactive'" class="text-xs font-normal px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400">Inactive</span>
                 </div>
                 <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ person.title }}</p>


### PR DESCRIPTION
## Summary

- Adds a Red Hat logo link next to the person's name on the Person Profile page
- Links to the person's Rover People profile (`https://rover.redhat.com/people/profile/{uid}`)
- Opens in a new tab with "View Rover People profile" tooltip on hover

## Test plan

- [ ] Navigate to any person's profile page
- [ ] Verify the Red Hat logo appears next to the person's name
- [ ] Hover over the logo and confirm the tooltip reads "View Rover People profile"
- [ ] Click the logo and confirm it opens the correct Rover People URL in a new tab
- [ ] Verify the logo does not appear for persons without a `uid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)