### PR TITLE
fix(releases): use registry versions for hygiene feature status view

### DIFF
--- a/modules/releases/client/execute/views/HygieneView.vue
+++ b/modules/releases/client/execute/views/HygieneView.vue
@@ -9,6 +9,7 @@ const nav = inject('moduleNav')
 // ── Version / product state ──
 
 const allVersions = ref([])
+const registryReleases = ref([])
 const selectedProduct = ref(null)
 const selectedVersion = ref('')
 const loading = ref(false)
@@ -57,8 +58,10 @@ const fetchedAt = ref(null)
 
 async function loadVersions() {
   try {
-    const data = await apiRequest('/modules/releases/execution/versions')
-    allVersions.value = data.versions || []
+    const data = await apiRequest('/modules/releases/registry')
+    const releases = (data.releases || []).filter(r => r.state !== 'archived')
+    registryReleases.value = releases
+    allVersions.value = releases.map(r => r.displayName).sort()
 
     // Restore filters from URL params (e.g. returning from feature detail)
     const params = nav.params.value || {}
@@ -81,10 +84,16 @@ async function loadData(version) {
   error.value = null
 
   try {
+    // Look up registry fixVersions for execution feature query
+    const rel = registryReleases.value.find(r => r.displayName === version)
+    const execVersion = (rel && rel.fixVersions && rel.fixVersions.length > 0)
+      ? rel.fixVersions[0]
+      : version
+
     const [hygieneData, summaryData, execData] = await Promise.all([
       apiRequest(`/modules/releases/hygiene/features?version=${encodeURIComponent(version)}`),
       apiRequest(`/modules/releases/hygiene/summary?version=${encodeURIComponent(version)}`),
-      apiRequest(`/modules/releases/execution/features?version=${encodeURIComponent(version)}`)
+      apiRequest(`/modules/releases/execution/features?version=${encodeURIComponent(execVersion)}`)
     ])
 
     hygieneFeatures.value = hygieneData.features || {}


### PR DESCRIPTION
## Summary

- The HygieneView was loading its version dropdown from the execution endpoint (`/execution/versions`), which returns Jira `fixVersion` strings (e.g. `rhoai-3.6.EA1`). But hygiene data is stored by registry `displayName` (e.g. `rhoai-3.6.z.EA1`), so queries always returned empty results — the feature status kanban board never showed data.
- Switched `loadVersions()` to fetch from the registry, using `displayName` for the version dropdown (matches hygiene storage keys).
- Maps `displayName` → `fixVersions[0]` for the execution features cross-reference query.

## Test plan

- [x] All 3391 unit tests pass
- [x] Lint clean
- [ ] Verify in production: Feature Status tab shows hygiene data after deploy
- [ ] Verify version selector shows registry displayNames (e.g. `rhoai-3.5.z.EA1` not `rhoai-3.5.EA1`)
- [ ] Verify clicking a feature navigates to detail view correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)