### PR TITLE
fix(ci): skip Claude review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,8 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft != true &&
-       github.actor != 'github-actions[bot]') ||
+       github.actor != 'github-actions[bot]' &&
+       github.actor != 'dependabot[bot]') ||
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name != github.repository &&
        github.event.pull_request.draft != true &&
@@ -180,7 +181,9 @@ jobs:
       # --- Shared: GCP auth ---
 
       - name: Authenticate to Google Cloud
-        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true' && env.HAS_GCP_KEY == 'true'
+        env:
+          HAS_GCP_KEY: ${{ secrets.GCP_SA_KEY != '' }}
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Summary

- Excludes `dependabot[bot]` from the Claude Review job condition so Dependabot PRs skip AI review entirely (automated version bumps don't benefit from it)
- Adds a defensive `secrets.GCP_SA_KEY != ''` guard on the GCP auth step so missing secrets fail gracefully instead of crashing the workflow

## Context

PR #730 (Dependabot bump of `actions/checkout`) fails on the "Claude Review" required check. Dependabot PRs come from branches inside the repo (not forks), so they pass the same-repo check — but GitHub withholds secrets from Dependabot-triggered `pull_request` events, causing the GCP auth step to crash.

GitHub treats skipped required checks as passing, so excluding Dependabot at the job level won't block merging.

## Test plan

- [ ] Verify this PR's own "Claude Review" check passes (it will run since this is not a Dependabot PR)
- [ ] After merge, verify PR #730's "Claude Review" shows as skipped (not failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)