### PR TITLE
fix(releases): correct post-release defects bug counts and chart truncation

### DIFF
--- a/modules/releases/__tests__/server/delivery/quality-calculations.test.js
+++ b/modules/releases/__tests__/server/delivery/quality-calculations.test.js
@@ -200,4 +200,39 @@ describe('computeCumulativeBugData', () => {
     // Cumulative count stays at 1 for days 1-4, then increments to 2 on day 5
     expect(result.datasets[0].data).toEqual([0, 1, 1, 1, 1, 2])
   })
+
+  it('truncates data at actual elapsed days per version', () => {
+    const bugs = [
+      {
+        key: 'BUG-1',
+        affectedVersions: ['v-old', 'v-new'],
+        created: '2026-01-19T10:00:00.000Z'
+      },
+      {
+        key: 'BUG-2',
+        affectedVersions: ['v-old'],
+        created: '2026-01-20T10:00:00.000Z'
+      }
+    ]
+    const versions = ['v-old', 'v-new']
+    const versionReleaseMap = new Map([
+      ['v-old', '2026-01-15'],
+      ['v-new', '2026-01-18']
+    ])
+
+    // Jan 21 = 6 days after v-old release, 3 days after v-new release
+    const now = new Date('2026-01-21T00:00:00.000Z').getTime()
+    const result = computeCumulativeBugData(bugs, versions, versionReleaseMap, { now })
+
+    const vOld = result.datasets.find(d => d.label === 'v-old')
+    const vNew = result.datasets.find(d => d.label === 'v-new')
+
+    // v-old: released Jan 15, elapsed=6, maxDays=5 → cap=5, all points filled
+    // BUG-1 at day 4 (Jan 19 - Jan 15), BUG-2 at day 5 (Jan 20 - Jan 15)
+    expect(vOld.data).toEqual([0, 0, 0, 0, 1, 2])
+
+    // v-new: released Jan 18, elapsed=3, maxDays=5 → cap=3
+    // BUG-1 at day 1 (Jan 19 - Jan 18), days 4-5 should be null
+    expect(vNew.data).toEqual([0, 1, 1, 1, null, null])
+  })
 })

--- a/modules/releases/__tests__/server/delivery/quality-data-fetcher.test.js
+++ b/modules/releases/__tests__/server/delivery/quality-data-fetcher.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { fetchVersions, fetchBugs } from '../../../server/delivery/quality/data-fetcher.js'
+import { fetchVersions, fetchBugs, fetchBugCounts } from '../../../server/delivery/quality/data-fetcher.js'
 
 describe('fetchVersions', () => {
   it('fetches and deduplicates versions from multiple projects', async () => {
@@ -96,9 +96,9 @@ describe('fetchBugs', () => {
     const [, jql, fields] = mockFetchAll.mock.calls[0]
 
     expect(jql).toContain('project = RHOAIENG')
-    expect(jql).toContain('priority in (Blocker, Critical, Major)')
     expect(jql).toContain('issuetype = Bug')
     expect(jql).toContain('affectedVersion is not EMPTY')
+    expect(jql).not.toContain('priority in')
 
     expect(fields).toContain('versions')
     expect(fields).toContain('components')
@@ -276,5 +276,72 @@ describe('fetchBugs', () => {
     expect(result).toHaveLength(1)
     expect(result[0].key).toBe('AIPCC-123')
     expect(result[0].releaseDate).toBe('2026-01-15')
+  })
+})
+
+describe('fetchBugCounts', () => {
+  const mockVersions = [
+    { name: 'rhoai-3.3', releaseDate: '2026-01-15', project: 'RHOAIENG' },
+    { name: 'rhoai-3.4', releaseDate: '2026-03-20', project: 'RHOAIENG' }
+  ]
+
+  it('queries Jira per project and counts bugs by affected version', async () => {
+    const mockFetchAll = vi.fn()
+      .mockResolvedValueOnce([
+        { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-3.3' }] } },
+        { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }, { name: 'rhoai-3.4' }] } },
+        { key: 'RHOAIENG-3', fields: { versions: [{ name: 'rhoai-3.4' }] } }
+      ])
+      .mockResolvedValueOnce([
+        { key: 'AIPCC-1', fields: { versions: [{ name: 'rhoai-3.3' }] } }
+      ])
+
+    const counts = await fetchBugCounts(['RHOAIENG', 'AIPCC'], mockVersions, { jiraFetchAll: mockFetchAll })
+
+    expect(mockFetchAll).toHaveBeenCalledTimes(2)
+
+    const [, jql1] = mockFetchAll.mock.calls[0]
+    expect(jql1).toContain('project = RHOAIENG')
+    expect(jql1).toContain('issuetype = Bug')
+    expect(jql1).toContain('affectedVersion is not EMPTY')
+
+    expect(counts.get('rhoai-3.3')).toBe(3)
+    expect(counts.get('rhoai-3.4')).toBe(2)
+  })
+
+  it('returns 0 for projects that fail to fetch', async () => {
+    const mockFetchAll = vi.fn()
+      .mockRejectedValueOnce(new Error('Jira timeout'))
+      .mockResolvedValueOnce([
+        { key: 'AIPCC-1', fields: { versions: [{ name: 'rhoai-3.3' }] } }
+      ])
+
+    const counts = await fetchBugCounts(['RHOAIENG', 'AIPCC'], mockVersions, { jiraFetchAll: mockFetchAll })
+
+    expect(counts.get('rhoai-3.3')).toBe(1)
+    expect(counts.get('rhoai-3.4')).toBe(0)
+  })
+
+  it('ignores affected versions not in the versions list', async () => {
+    const mockFetchAll = vi.fn().mockResolvedValue([
+      { key: 'RHOAIENG-1', fields: { versions: [{ name: 'rhoai-99.0' }] } },
+      { key: 'RHOAIENG-2', fields: { versions: [{ name: 'rhoai-3.3' }] } }
+    ])
+
+    const counts = await fetchBugCounts(['RHOAIENG'], mockVersions, { jiraFetchAll: mockFetchAll })
+
+    expect(counts.get('rhoai-3.3')).toBe(1)
+    expect(counts.get('rhoai-3.4')).toBe(0)
+    expect(counts.has('rhoai-99.0')).toBe(false)
+  })
+
+  it('returns all zeros for empty projects list', async () => {
+    const mockFetchAll = vi.fn()
+
+    const counts = await fetchBugCounts([], mockVersions, { jiraFetchAll: mockFetchAll })
+
+    expect(mockFetchAll).not.toHaveBeenCalled()
+    expect(counts.get('rhoai-3.3')).toBe(0)
+    expect(counts.get('rhoai-3.4')).toBe(0)
   })
 })

--- a/modules/releases/client/deliver/quality-components/CumulativeBugChart.vue
+++ b/modules/releases/client/deliver/quality-components/CumulativeBugChart.vue
@@ -36,7 +36,8 @@ const chartData = computed(() => ({
     backgroundColor: (COLORS[i % COLORS.length]) + '20',
     borderWidth: 2,
     pointRadius: 2,
-    tension: 0.3
+    tension: 0.3,
+    spanGaps: false
   }))
 }));
 

--- a/modules/releases/client/deliver/quality-services/api.js
+++ b/modules/releases/client/deliver/quality-services/api.js
@@ -2,9 +2,8 @@ import { apiRequest } from '@shared/client';
 
 const BASE = '/modules/releases/delivery/quality';
 
-export async function getVersions(component = null) {
-  const params = component ? `?component=${encodeURIComponent(component)}` : '';
-  return apiRequest(`${BASE}/versions${params}`);
+export async function getVersions() {
+  return apiRequest(`${BASE}/versions`);
 }
 
 export async function getBugData(versions, component = null) {

--- a/modules/releases/client/deliver/views/PostReleaseDefectsView.vue
+++ b/modules/releases/client/deliver/views/PostReleaseDefectsView.vue
@@ -60,8 +60,8 @@
           <tbody>
             <tr v-for="(dataset, i) in chartData.datasets" :key="i" class="border-b dark:border-gray-700">
               <td class="py-2">{{ dataset.label }}</td>
-              <td class="text-right">{{ dataset.data.length > 0 ? dataset.data[dataset.data.length - 1] : 0 }}</td>
-              <td class="text-right">{{ dataset.data.length > 0 ? dataset.data.length - 1 : 0 }}</td>
+              <td class="text-right">{{ lastValue(dataset.data) }}</td>
+              <td class="text-right">{{ lastIndex(dataset.data) }}</td>
             </tr>
           </tbody>
         </table>
@@ -113,24 +113,18 @@ onMounted(async () => {
   }
 });
 
-// Watch component filter - refetch versions when component changes
+// Watch component filter - refetch chart data when component changes
 watch(selectedComponent, async () => {
   try {
     error.value = null;
 
-    // Refetch versions filtered by component (or all if null)
-    versions.value = await getVersions(selectedComponent.value);
-
-    // Auto-select first 3 versions with bugs after component filter change
-    const versionsWithBugs = versions.value.filter(v => v.bugCount > 0);
-    if (versionsWithBugs.length > 0) {
-      selectedVersions.value = versionsWithBugs.slice(0, 3).map(v => v.name);
-    } else {
-      selectedVersions.value = [];
+    if (selectedVersions.value.length > 0) {
+      const response = await getBugData(selectedVersions.value, selectedComponent.value);
+      chartData.value = { labels: response.labels, datasets: response.datasets };
     }
   } catch (err) {
     console.error('[quality] Failed to filter by component:', err);
-    error.value = err.message || 'Failed to filter versions by component';
+    error.value = err.message || 'Failed to filter chart data by component';
   }
 });
 
@@ -150,6 +144,20 @@ watch(selectedVersions, async () => {
   }
 }, { deep: true });
 
+function lastValue(data) {
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (data[i] !== null) return data[i];
+  }
+  return 0;
+}
+
+function lastIndex(data) {
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (data[i] !== null) return i;
+  }
+  return 0;
+}
+
 async function handleRefresh() {
   try {
     error.value = null;
@@ -160,8 +168,8 @@ async function handleRefresh() {
     // Reload components with fresh bug counts
     allComponents.value = await getComponents();
 
-    // Reload versions filtered by current component (if any)
-    versions.value = await getVersions(selectedComponent.value);
+    // Reload versions with fresh bug counts
+    versions.value = await getVersions();
 
     // Refetch chart data if versions are selected
     if (selectedVersions.value.length > 0) {

--- a/modules/releases/server/delivery/quality/calculations.js
+++ b/modules/releases/server/delivery/quality/calculations.js
@@ -4,9 +4,11 @@
  * @param {Array} bugs - Filtered bug objects
  * @param {string[]} versions - Selected version names
  * @param {Map} versionReleaseMap - Map of version name to release date string
+ * @param {Object} [options]
+ * @param {number} [options.now] - Current timestamp in ms (defaults to Date.now())
  * @returns {Object} - { labels: [0, 1, 2, ...], datasets: [{ label, data }, ...] }
  */
-function computeCumulativeBugData(bugs, versions, versionReleaseMap) {
+function computeCumulativeBugData(bugs, versions, versionReleaseMap, options) {
 
   const versionBugs = new Map();
 
@@ -42,16 +44,24 @@ function computeCumulativeBugData(bugs, versions, versionReleaseMap) {
     };
   }
 
+  const now = options?.now ?? Date.now();
+
   const labels = Array.from({ length: maxDays + 1 }, (_, i) => i);
 
   const datasets = versions.map(version => {
     const entries = versionBugs.get(version) || [];
-    const data = new Array(maxDays + 1).fill(0);
+    const releaseDate = versionReleaseMap.get(version);
+    const elapsedDays = releaseDate
+      ? Math.floor((now - new Date(releaseDate).getTime()) / (24 * 60 * 60 * 1000))
+      : maxDays;
+
+    const data = new Array(maxDays + 1).fill(null);
 
     let cumulativeCount = 0;
     let bugIndex = 0;
 
-    for (let day = 0; day <= maxDays; day++) {
+    const cap = Math.min(elapsedDays, maxDays);
+    for (let day = 0; day <= cap; day++) {
       while (bugIndex < entries.length && entries[bugIndex].daysSinceRelease === day) {
         cumulativeCount++;
         bugIndex++;

--- a/modules/releases/server/delivery/quality/data-fetcher.js
+++ b/modules/releases/server/delivery/quality/data-fetcher.js
@@ -38,7 +38,7 @@ async function fetchVersions(projects, { jiraFetch } = {}) {
 }
 
 /**
- * Fetch Blocker/Critical/Major bugs with Affects Version
+ * Fetch all bugs with Affects Version (all priorities)
  * @param {string} project - Project key
  * @param {Array} versions - Version objects with release dates
  * @returns {Promise<Array>} - Bug objects
@@ -52,7 +52,6 @@ async function fetchBugs(project, versions, { jiraFetchAll } = {}) {
 
   const jql = `
     project = ${project}
-    AND priority in (Blocker, Critical, Major)
     AND issuetype = Bug
     AND affectedVersion is not EMPTY
     AND created >= -730d
@@ -105,5 +104,42 @@ async function fetchBugs(project, versions, { jiraFetchAll } = {}) {
   }
 }
 
-module.exports = { fetchVersions, fetchBugs };
+/**
+ * Fetch total bug count per version by querying all bugs across projects
+ * and counting locally. Equivalent to: issuetype = Bug AND affectedVersion = "x"
+ * @param {string[]} projects - Jira project keys
+ * @param {Array} versions - Version objects with name field
+ * @param {Object} [options]
+ * @param {Function} [options.jiraFetchAll] - Injectable fetchAllJqlResults for testing
+ * @returns {Promise<Map<string, number>>} - Map of version name to total bug count
+ */
+async function fetchBugCounts(projects, versions, { jiraFetchAll } = {}) {
+  const fetchAll = jiraFetchAll || jira.fetchAllJqlResults;
+  const counts = new Map();
+  for (const v of versions) {
+    counts.set(v.name, 0);
+  }
+
+  for (const project of projects) {
+    try {
+      const jql = `project = ${project} AND issuetype = Bug AND affectedVersion is not EMPTY AND created >= -730d`;
+      const issues = await fetchAll(jira.jiraRequest, jql, 'versions');
+
+      for (const issue of issues) {
+        const affectedVersions = (issue.fields.versions || []).map(v => v.name);
+        for (const vName of affectedVersions) {
+          if (counts.has(vName)) {
+            counts.set(vName, counts.get(vName) + 1);
+          }
+        }
+      }
+    } catch (error) {
+      console.warn(`[releases/quality] Failed to fetch bug counts for project ${project}:`, error.message);
+    }
+  }
+
+  return counts;
+}
+
+module.exports = { fetchVersions, fetchBugs, fetchBugCounts };
 

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -1255,7 +1255,7 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Quality (Post-Release Defects) routes ---
 
-  const { fetchVersions: fetchQualityVersions, fetchBugs } = require('./quality/data-fetcher.js')
+  const { fetchVersions: fetchQualityVersions, fetchBugs, fetchBugCounts } = require('./quality/data-fetcher.js')
   const { computeCumulativeBugData } = require('./quality/calculations.js')
 
   // In-memory cache for loadAllBugs() with 5-minute TTL
@@ -1292,38 +1292,18 @@ module.exports = function registerRoutes(router, context) {
    * /api/modules/releases/delivery/quality/versions:
    *   get:
    *     tags: ['Releases: Quality']
-   *     summary: List release versions with bug counts
-   *     parameters:
-   *       - in: query
-   *         name: component
-   *         schema: { type: string }
-   *         description: Filter bug counts by component
+   *     summary: List release versions with pre-computed bug counts
    *     responses:
    *       200:
    *         description: Versions sorted by bug count
    */
   router.get('/quality/versions', requireAuth, requireScope('releases:read'), function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
       const versions = readFromStorage('releases/delivery/quality/versions.json') || []
-      const componentFilter = req.query.component || null
 
-      const allBugs = loadAllBugs(config.projectKeys)
+      const sorted = [...versions].sort((a, b) => (b.bugCount || 0) - (a.bugCount || 0))
 
-      const filteredBugs = componentFilter
-        ? allBugs.filter(bug => bug.components.includes(componentFilter))
-        : allBugs
-
-      const versionsWithCounts = versions.map(version => {
-        const bugCount = filteredBugs.filter(bug =>
-          bug.affectedVersions.includes(version.name)
-        ).length
-        return { ...version, bugCount }
-      })
-
-      versionsWithCounts.sort((a, b) => b.bugCount - a.bugCount)
-
-      res.json(versionsWithCounts)
+      res.json(sorted)
     } catch (error) {
       console.error('[releases/quality] Read versions error:', error)
       res.status(500).json({ error: 'Internal server error' })
@@ -1436,7 +1416,13 @@ module.exports = function registerRoutes(router, context) {
     try {
       const config = getConfig(readFromStorage)
       const versions = await fetchQualityVersions(config.projectKeys)
-      writeToStorage('releases/delivery/quality/versions.json', versions)
+
+      const bugCounts = await fetchBugCounts(config.projectKeys, versions)
+      const versionsWithCounts = versions.map(v => ({
+        ...v,
+        bugCount: bugCounts.get(v.name) || 0
+      }))
+      writeToStorage('releases/delivery/quality/versions.json', versionsWithCounts)
 
       for (const project of config.projectKeys) {
         const bugs = await fetchBugs(project, versions)


### PR DESCRIPTION
## Summary
- **Bug count fix**: Version bug counts now use `issuetype = Bug AND affectedVersion = "x"` (all priorities) instead of the previous Blocker/Critical/Major-only filter, which caused many versions to incorrectly show 0 bugs
- **Chart data broadened**: Cumulative chart now includes bugs of all priorities (still scoped to last 2 years, post-release only)
- **Chart truncation**: Each version's trend line stops at its actual days since release instead of flat-lining across the full timeline
- **Component filter scoped**: Component filter now only affects the chart, not the version bug counts (counts always reflect the total)

## Test plan
- [x] All 17 `quality-data-fetcher` tests pass (including 4 new tests for `fetchBugCounts`)
- [x] All 8 `quality-calculations` tests pass
- [x] Full test suite passes (3440 tests)
- [x] Lint clean
- [ ] Verify version dropdown shows correct bug counts after "Refresh Data"
- [ ] Verify cumulative chart lines stop at actual elapsed days per version
- [ ] Verify Summary Statistics table shows correct Total Bugs and Days Tracked


Made with [Cursor](https://cursor.com)