### PR TITLE
feat: add pipeline operations module

### DIFF
--- a/deploy/openshift/overlays/prod/cronjob-pipeline-ops.yaml
+++ b/deploy/openshift/overlays/prod/cronjob-pipeline-ops.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pipeline-ops-collector
+  labels:
+    app: team-tracker
+    component: pipeline-ops
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: team-tracker
+            component: pipeline-ops
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: pipeline-ops-collector
+              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              env:
+                - name: PROXY_AUTH_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: proxy-auth-secret
+                      key: secret
+                      optional: true
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  BACKEND="http://backend:3001"
+                  AUTH_HEADER="X-Forwarded-Email: acorvin@redhat.com"
+                  PROXY_SECRET_HEADER="X-Proxy-Secret: ${PROXY_AUTH_SECRET}"
+
+                  echo "=== Triggering pipeline-ops data collection ==="
+                  RESP=$(curl -sf -X POST "$BACKEND/api/modules/pipeline-ops/refresh" \
+                    -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" --max-time 30)
+                  echo "Response: $RESP"
+
+                  STATUS=$(echo "$RESP" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+                  if [ "$STATUS" = "already_running" ]; then
+                    echo "Collection already in progress, exiting"
+                    exit 0
+                  fi
+
+                  # Poll until complete
+                  ATTEMPTS=0
+                  MAX_ATTEMPTS=20
+                  while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
+                    sleep 10
+                    ATTEMPTS=$((ATTEMPTS + 1))
+                    REFRESH_STATUS=$(curl -sf "$BACKEND/api/modules/pipeline-ops/refresh/status" \
+                      -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER")
+                    RUNNING=$(echo "$REFRESH_STATUS" | grep -oE '"running"\s*:\s*true' || true)
+                    if [ -z "$RUNNING" ]; then
+                      echo "Collection complete after $ATTEMPTS checks"
+                      echo "Result: $REFRESH_STATUS"
+                      break
+                    fi
+                    echo "Still collecting... (attempt $ATTEMPTS/$MAX_ATTEMPTS)"
+                  done
+
+                  if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
+                    echo "WARNING: Collection timed out"
+                    exit 1
+                  fi
+
+                  echo "=== Pipeline-ops collection completed ==="
+              resources:
+                requests:
+                  memory: "32Mi"
+                  cpu: "10m"
+                limits:
+                  memory: "64Mi"
+                  cpu: "50m"

--- a/fixtures/pipeline-ops/config.json
+++ b/fixtures/pipeline-ops/config.json
@@ -1,0 +1,206 @@
+{
+  "retentionDays": 30,
+  "pipelines": [
+    {
+      "slug": "rfe-autofixer",
+      "name": "RFE Review Pipeline",
+      "group": "Autofix",
+      "description": "Discovers RHAIRFE Jira issues, scores against rubric, auto-revises descriptions",
+      "owner": "jforrester",
+      "repo": {
+        "url": "https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-autofixer",
+        "platform": "gitlab"
+      },
+      "schedule": {
+        "cron": "0 */12 * * *",
+        "expectedIntervalMinutes": 720,
+        "timeoutMinutes": 240
+      },
+      "jobs": ["autofix-rfe"],
+      "jiraContract": {
+        "projects": ["RHAIRFE"],
+        "labelsApplied": [
+          "rfe-creator-autofix-rubric-pass",
+          "rfe-creator-autofix-rubric-fail",
+          "rfe-creator-feasibility-pass",
+          "rfe-creator-feasibility-fail"
+        ]
+      },
+      "images": [
+        {
+          "name": "CI runner base",
+          "ref": "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+        }
+      ],
+      "skillRepos": [
+        {
+          "repo": "https://github.com/opendatahub-io/rfe-creator",
+          "branch": "ci-prod",
+          "purpose": "RFE review, split, auto-fix skills"
+        }
+      ],
+      "sharedLibs": [
+        {
+          "repo": "https://gitlab.com/redhat/rhel-ai/agentic-ci/ai-agentic-lib",
+          "purpose": "Claude Code container runner, Jira CLI ops"
+        }
+      ],
+      "telemetry": {
+        "otelCollector": "local",
+        "otelEndpoint": "http://127.0.0.1:4318",
+        "summaryScript": "otel-summary.py",
+        "status": "active"
+      },
+      "artifacts": {
+        "resultsRepo": "https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-autofixer-results",
+        "status": "active"
+      },
+      "status": "production",
+      "addedAt": "2026-05-28T00:00:00Z"
+    },
+    {
+      "slug": "feature-review",
+      "name": "Feature Review Pipeline",
+      "group": "Autofix",
+      "description": "Reviews RHAI feature issues against completeness rubric",
+      "owner": "jforrester",
+      "repo": {
+        "url": "https://gitlab.com/redhat/rhel-ai/agentic-ci/feature-review",
+        "platform": "gitlab"
+      },
+      "schedule": {
+        "cron": "0 */8 * * *",
+        "expectedIntervalMinutes": 480,
+        "timeoutMinutes": 180
+      },
+      "jobs": ["review-features"],
+      "jiraContract": {
+        "projects": ["RHAI"],
+        "labelsApplied": [
+          "feature-review-pass",
+          "feature-review-fail"
+        ]
+      },
+      "images": [
+        {
+          "name": "CI runner base",
+          "ref": "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+        }
+      ],
+      "skillRepos": [
+        {
+          "repo": "https://github.com/opendatahub-io/rfe-creator",
+          "branch": "ci-prod",
+          "purpose": "Feature review skills"
+        }
+      ],
+      "sharedLibs": [
+        {
+          "repo": "https://gitlab.com/redhat/rhel-ai/agentic-ci/ai-agentic-lib",
+          "purpose": "Claude Code container runner, Jira CLI ops"
+        }
+      ],
+      "telemetry": {
+        "otelCollector": "local",
+        "otelEndpoint": "http://127.0.0.1:4318",
+        "status": "active"
+      },
+      "artifacts": {
+        "resultsRepo": "https://gitlab.com/redhat/rhel-ai/agentic-ci/feature-review-results",
+        "status": "active"
+      },
+      "status": "production",
+      "addedAt": "2026-05-28T00:00:00Z"
+    },
+    {
+      "slug": "test-plan-review",
+      "name": "Test Plan Review Pipeline",
+      "group": "Autofix",
+      "description": "Reviews test plan Jira issues for completeness and quality",
+      "owner": "jforrester",
+      "repo": {
+        "url": "https://gitlab.com/redhat/rhel-ai/agentic-ci/test-plan-review",
+        "platform": "gitlab"
+      },
+      "schedule": {
+        "cron": "0 */12 * * *",
+        "expectedIntervalMinutes": 720,
+        "timeoutMinutes": 180
+      },
+      "jobs": ["review-test-plans"],
+      "jiraContract": {
+        "projects": ["RHAI"],
+        "labelsApplied": [
+          "test-plan-review-pass",
+          "test-plan-review-fail"
+        ]
+      },
+      "images": [
+        {
+          "name": "CI runner base",
+          "ref": "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+        }
+      ],
+      "skillRepos": [
+        {
+          "repo": "https://github.com/opendatahub-io/rfe-creator",
+          "branch": "ci-prod",
+          "purpose": "Test plan review skills"
+        }
+      ],
+      "sharedLibs": [
+        {
+          "repo": "https://gitlab.com/redhat/rhel-ai/agentic-ci/ai-agentic-lib",
+          "purpose": "Claude Code container runner, Jira CLI ops"
+        }
+      ],
+      "telemetry": {
+        "otelCollector": "local",
+        "otelEndpoint": "http://127.0.0.1:4318",
+        "status": "active"
+      },
+      "artifacts": {
+        "resultsRepo": "https://gitlab.com/redhat/rhel-ai/agentic-ci/test-plan-review-results",
+        "status": "active"
+      },
+      "status": "production",
+      "addedAt": "2026-05-28T00:00:00Z"
+    },
+    {
+      "slug": "fips-compliance",
+      "name": "FIPS Compliance Pipeline",
+      "group": "Security",
+      "description": "Scans container images for FIPS 140-3 compliance violations",
+      "owner": "jtanner",
+      "repo": {
+        "url": "https://github.com/red-hat-data-services/fips-compliance",
+        "platform": "github"
+      },
+      "schedule": {
+        "cron": "0 6 * * *",
+        "expectedIntervalMinutes": 1440,
+        "timeoutMinutes": 120
+      },
+      "jobs": ["fips-scan"],
+      "jiraContract": null,
+      "images": [
+        {
+          "name": "Scanner image",
+          "ref": "registry.access.redhat.com/ubi9/ubi:latest"
+        }
+      ],
+      "skillRepos": [],
+      "sharedLibs": [],
+      "telemetry": {
+        "otelCollector": "none",
+        "status": "inactive"
+      },
+      "artifacts": {
+        "resultsRepo": "https://github.com/red-hat-data-services/fips-compliance",
+        "status": "active"
+      },
+      "status": "production",
+      "addedAt": "2026-05-28T00:00:00Z"
+    }
+  ]
+}

--- a/modules/pipeline-ops/__tests__/client/PipelineCard.test.js
+++ b/modules/pipeline-ops/__tests__/client/PipelineCard.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PipelineCard from '../../client/components/PipelineCard.vue'
+
+const PIPELINE = {
+  slug: 'rfe-autofixer',
+  name: 'RFE Review Pipeline',
+  owner: 'jforrester',
+  repo: { url: 'https://gitlab.com/example/repo', platform: 'gitlab' },
+  schedule: { expectedIntervalMinutes: 720 },
+  skillRepos: [{ repo: 'https://github.com/org/skill-repo', branch: 'main', purpose: 'Skills' }],
+  health: { healthStatus: 'grey', successRate: null }
+}
+
+describe('PipelineCard', () => {
+  it('renders pipeline name and owner', () => {
+    const wrapper = mount(PipelineCard, { props: { pipeline: PIPELINE } })
+    expect(wrapper.text()).toContain('RFE Review Pipeline')
+    expect(wrapper.text()).toContain('jforrester')
+  })
+
+  it('renders schedule label', () => {
+    const wrapper = mount(PipelineCard, { props: { pipeline: PIPELINE } })
+    expect(wrapper.text()).toContain('every 12h')
+  })
+
+  it('renders platform label', () => {
+    const wrapper = mount(PipelineCard, { props: { pipeline: PIPELINE } })
+    expect(wrapper.text()).toContain('GitLab')
+  })
+
+  it('shows grey status dot when no data', () => {
+    const wrapper = mount(PipelineCard, { props: { pipeline: PIPELINE } })
+    const dot = wrapper.find('span.rounded-full')
+    expect(dot.classes()).toContain('bg-gray-400')
+  })
+
+  it('shows green status dot when healthy', () => {
+    const p = { ...PIPELINE, health: { healthStatus: 'green', successRate: 95 } }
+    const wrapper = mount(PipelineCard, { props: { pipeline: p } })
+    const dot = wrapper.find('span.rounded-full')
+    expect(dot.classes()).toContain('bg-emerald-400')
+  })
+
+  it('emits click event', async () => {
+    const wrapper = mount(PipelineCard, { props: { pipeline: PIPELINE } })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('click')).toBeTruthy()
+    expect(wrapper.emitted('click')[0][0]).toEqual(PIPELINE)
+  })
+})

--- a/modules/pipeline-ops/__tests__/server/collector.test.js
+++ b/modules/pipeline-ops/__tests__/server/collector.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+const { mergeRuns, pruneRuns, resolveToken, extractRepoPath } = await import('../../server/collector.js')
+
+describe('extractRepoPath', () => {
+  it('extracts path from GitLab URL', () => {
+    expect(extractRepoPath('https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-autofixer'))
+      .toBe('redhat/rhel-ai/agentic-ci/rfe-autofixer')
+  })
+
+  it('extracts path from GitHub URL', () => {
+    expect(extractRepoPath('https://github.com/red-hat-data-services/fips-compliance'))
+      .toBe('red-hat-data-services/fips-compliance')
+  })
+
+  it('strips .git suffix', () => {
+    expect(extractRepoPath('https://gitlab.com/org/repo.git'))
+      .toBe('org/repo')
+  })
+
+  it('returns null for invalid URL', () => {
+    expect(extractRepoPath('not-a-url')).toBeNull()
+  })
+})
+
+describe('resolveToken', () => {
+  beforeEach(() => {
+    delete process.env.GITLAB_TOKEN
+    delete process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN
+    delete process.env.GITHUB_TOKEN
+  })
+
+  it('returns GITHUB_TOKEN for github pipelines', () => {
+    process.env.GITHUB_TOKEN = 'gh-token'
+    const token = resolveToken({ repo: { url: 'https://github.com/org/repo', platform: 'github' } })
+    expect(token).toBe('gh-token')
+  })
+
+  it('returns GITLAB_TOKEN for gitlab.com pipelines', () => {
+    process.env.GITLAB_TOKEN = 'gl-token'
+    const token = resolveToken({ repo: { url: 'https://gitlab.com/org/repo', platform: 'gitlab' } })
+    expect(token).toBe('gl-token')
+  })
+
+  it('returns GITLAB_CEE_REDHAT_DOCS_TOKEN for internal GitLab', () => {
+    process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN = 'cee-token'
+    const token = resolveToken({ repo: { url: 'https://gitlab.cee.redhat.com/org/repo', platform: 'gitlab' } })
+    expect(token).toBe('cee-token')
+  })
+
+  it('falls back to GITLAB_TOKEN for internal GitLab when CEE token missing', () => {
+    process.env.GITLAB_TOKEN = 'gl-token'
+    const token = resolveToken({ repo: { url: 'https://gitlab.cee.redhat.com/org/repo', platform: 'gitlab' } })
+    expect(token).toBe('gl-token')
+  })
+
+  it('returns null when no token set', () => {
+    const token = resolveToken({ repo: { url: 'https://gitlab.com/org/repo', platform: 'gitlab' } })
+    expect(token).toBeNull()
+  })
+})
+
+describe('mergeRuns', () => {
+  it('deduplicates by id, preferring fresh', () => {
+    const existing = [
+      { id: '1', status: 'running', startedAt: '2026-05-28T06:00:00Z' },
+      { id: '2', status: 'success', startedAt: '2026-05-27T06:00:00Z' },
+    ]
+    const fresh = [
+      { id: '1', status: 'success', startedAt: '2026-05-28T06:00:00Z' },
+      { id: '3', status: 'success', startedAt: '2026-05-28T12:00:00Z' },
+    ]
+    const merged = mergeRuns(existing, fresh)
+    expect(merged).toHaveLength(3)
+    expect(merged[0].id).toBe('3')
+    expect(merged.find(r => r.id === '1').status).toBe('success')
+  })
+
+  it('sorts newest first', () => {
+    const runs = mergeRuns(
+      [{ id: '1', startedAt: '2026-05-26T00:00:00Z' }],
+      [{ id: '2', startedAt: '2026-05-28T00:00:00Z' }]
+    )
+    expect(runs[0].id).toBe('2')
+    expect(runs[1].id).toBe('1')
+  })
+})
+
+describe('pruneRuns', () => {
+  it('removes runs older than retentionDays', () => {
+    const now = Date.now()
+    const runs = [
+      { id: '1', startedAt: new Date(now - 10 * 86400000).toISOString() },
+      { id: '2', startedAt: new Date(now - 40 * 86400000).toISOString() },
+    ]
+    const pruned = pruneRuns(runs, 30)
+    expect(pruned).toHaveLength(1)
+    expect(pruned[0].id).toBe('1')
+  })
+
+  it('keeps all runs within retention window', () => {
+    const now = Date.now()
+    const runs = [
+      { id: '1', startedAt: new Date(now - 1 * 86400000).toISOString() },
+      { id: '2', startedAt: new Date(now - 5 * 86400000).toISOString() },
+    ]
+    const pruned = pruneRuns(runs, 30)
+    expect(pruned).toHaveLength(2)
+  })
+})

--- a/modules/pipeline-ops/__tests__/server/health.test.js
+++ b/modules/pipeline-ops/__tests__/server/health.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+
+const { computeHealth } = await import('../../server/health.js')
+
+const PIPELINE = {
+  slug: 'test-pipeline',
+  schedule: { expectedIntervalMinutes: 720 }
+}
+
+function makeRun(overrides = {}) {
+  return {
+    id: '1',
+    startedAt: new Date().toISOString(),
+    finishedAt: new Date().toISOString(),
+    durationSeconds: 3600,
+    status: 'success',
+    ...overrides
+  }
+}
+
+describe('computeHealth', () => {
+  it('returns grey when no runs', () => {
+    const result = computeHealth(PIPELINE, [])
+    expect(result.healthStatus).toBe('grey')
+    expect(result.successRate).toBeNull()
+    expect(result.failureStreak).toBe(0)
+  })
+
+  it('returns grey when runs is null', () => {
+    const result = computeHealth(PIPELINE, null)
+    expect(result.healthStatus).toBe('grey')
+  })
+
+  it('returns green when recent run succeeded within interval', () => {
+    const runs = Array.from({ length: 10 }, (_, i) =>
+      makeRun({
+        id: String(i),
+        startedAt: new Date(Date.now() - i * 720 * 60 * 1000).toISOString(),
+        status: 'success'
+      })
+    )
+    const result = computeHealth(PIPELINE, runs)
+    expect(result.healthStatus).toBe('green')
+    expect(result.successRate).toBe(100)
+    expect(result.failureStreak).toBe(0)
+  })
+
+  it('returns red when failure streak >= 3', () => {
+    const runs = [
+      makeRun({ id: '1', startedAt: new Date(Date.now() - 1000).toISOString(), status: 'failed' }),
+      makeRun({ id: '2', startedAt: new Date(Date.now() - 100000).toISOString(), status: 'failed' }),
+      makeRun({ id: '3', startedAt: new Date(Date.now() - 200000).toISOString(), status: 'failed' }),
+      makeRun({ id: '4', startedAt: new Date(Date.now() - 300000).toISOString(), status: 'success' }),
+    ]
+    const result = computeHealth(PIPELINE, runs)
+    expect(result.healthStatus).toBe('red')
+    expect(result.failureStreak).toBe(3)
+  })
+
+  it('returns yellow when last run failed but previous succeeded', () => {
+    const runs = [
+      makeRun({ id: '1', startedAt: new Date(Date.now() - 1000).toISOString(), status: 'failed' }),
+      ...Array.from({ length: 9 }, (_, i) =>
+        makeRun({
+          id: String(i + 2),
+          startedAt: new Date(Date.now() - (i + 1) * 720 * 60 * 1000).toISOString(),
+          status: 'success'
+        })
+      )
+    ]
+    const result = computeHealth(PIPELINE, runs)
+    expect(result.healthStatus).toBe('yellow')
+  })
+
+  it('computes average duration', () => {
+    const runs = [
+      makeRun({ durationSeconds: 100 }),
+      makeRun({ durationSeconds: 200, startedAt: new Date(Date.now() - 10000).toISOString() }),
+    ]
+    const result = computeHealth(PIPELINE, runs)
+    expect(result.avgDurationSeconds).toBe(150)
+  })
+})

--- a/modules/pipeline-ops/__tests__/server/index.test.js
+++ b/modules/pipeline-ops/__tests__/server/index.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const { createTestContext } = await import('../../../../shared/server/module-context.js')
+const registerRoutes = (await import('../../server/index.js')).default
+
+describe('pipeline-ops server routes', () => {
+  it('registers expected routes', () => {
+    const router = { get: vi.fn(), post: vi.fn() }
+    const context = createTestContext()
+    registerRoutes(router, context)
+
+    const getPaths = router.get.mock.calls.map(c => c[0])
+    expect(getPaths).toContain('/pipelines')
+    expect(getPaths).toContain('/pipelines/:slug')
+    expect(getPaths).toContain('/config')
+    expect(getPaths).toContain('/refresh/status')
+
+    const postPaths = router.post.mock.calls.map(c => c[0])
+    expect(postPaths).toContain('/config')
+    expect(postPaths).toContain('/refresh')
+    expect(postPaths).toContain('/runs/bulk')
+  })
+
+  it('registers diagnostics', () => {
+    const router = { get: vi.fn(), post: vi.fn() }
+    const context = createTestContext({ registerDiagnostics: vi.fn() })
+    registerRoutes(router, context)
+    expect(context.registerDiagnostics).toHaveBeenCalled()
+  })
+})

--- a/modules/pipeline-ops/client/components/PipelineCard.vue
+++ b/modules/pipeline-ops/client/components/PipelineCard.vue
@@ -1,0 +1,140 @@
+<script setup>
+import { computed } from 'vue'
+import { ExternalLinkIcon, ClockIcon, UserIcon, GitBranchIcon } from 'lucide-vue-next'
+
+const props = defineProps({
+  pipeline: { type: Object, required: true }
+})
+
+defineEmits(['click'])
+
+const statusColor = computed(() => {
+  const s = props.pipeline.health?.healthStatus
+  if (s === 'green') return 'bg-emerald-400'
+  if (s === 'yellow') return 'bg-amber-400'
+  if (s === 'red') return 'bg-red-500'
+  return 'bg-gray-400'
+})
+
+const statusLabel = computed(() => {
+  const s = props.pipeline.health?.healthStatus
+  if (s === 'green') return 'Healthy'
+  if (s === 'yellow') return 'Warning'
+  if (s === 'red') return 'Critical'
+  return 'No data'
+})
+
+const scheduleLabel = computed(() => {
+  const mins = props.pipeline.schedule?.expectedIntervalMinutes
+  if (!mins) return 'Unknown'
+  if (mins < 60) return `every ${mins}m`
+  if (mins === 60) return 'every hour'
+  if (mins < 1440) return `every ${mins / 60}h`
+  if (mins === 1440) return 'daily'
+  return `every ${Math.round(mins / 1440)}d`
+})
+
+const platformLabel = computed(() => {
+  return props.pipeline.repo?.platform === 'github' ? 'GitHub' : 'GitLab'
+})
+
+const skillSummary = computed(() => {
+  const repos = props.pipeline.skillRepos || []
+  if (repos.length === 0) return null
+  return repos.map(r => {
+    const name = r.repo.split('/').pop()
+    return r.branch ? `${name} (${r.branch})` : name
+  }).join(', ')
+})
+
+const lastRunAgo = computed(() => {
+  const at = props.pipeline.health?.lastRunAt
+  if (!at) return null
+  const diff = Date.now() - new Date(at).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+})
+
+const lastRunStatus = computed(() => {
+  const h = props.pipeline.health
+  if (!h?.lastRunAt) return null
+  if (h.failureStreak > 0) return `${h.failureStreak} consecutive failures`
+  return 'last run succeeded'
+})
+</script>
+
+<template>
+  <button
+    class="w-full text-left bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all cursor-pointer"
+    @click="$emit('click', pipeline)"
+  >
+    <div class="flex items-start justify-between mb-3">
+      <div class="flex items-center gap-2.5">
+        <span :class="['w-2.5 h-2.5 rounded-full flex-shrink-0', statusColor]" :title="statusLabel" />
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 leading-tight">{{ pipeline.name }}</h3>
+      </div>
+      <a
+        v-if="pipeline.repo?.url"
+        :href="pipeline.repo.url"
+        target="_blank"
+        rel="noopener"
+        class="text-gray-400 hover:text-primary-500 flex-shrink-0"
+        @click.stop
+      >
+        <ExternalLinkIcon :size="14" />
+      </a>
+    </div>
+
+    <div class="space-y-1.5 text-xs text-gray-500 dark:text-gray-400">
+      <div class="flex items-center gap-1.5">
+        <ClockIcon :size="12" />
+        <span>{{ scheduleLabel }}</span>
+        <span class="text-gray-300 dark:text-gray-600 mx-0.5">|</span>
+        <span>{{ platformLabel }}</span>
+      </div>
+
+      <div v-if="pipeline.owner" class="flex items-center gap-1.5">
+        <UserIcon :size="12" />
+        <span>{{ pipeline.owner }}</span>
+      </div>
+
+      <div v-if="skillSummary" class="flex items-center gap-1.5">
+        <GitBranchIcon :size="12" />
+        <span class="truncate">{{ skillSummary }}</span>
+      </div>
+    </div>
+
+    <div v-if="pipeline.health?.lastRunAt" class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 space-y-1">
+      <div class="flex items-center justify-between text-xs">
+        <span class="text-gray-500 dark:text-gray-400">
+          Last run: <span class="font-medium text-gray-700 dark:text-gray-300">{{ lastRunAgo }}</span>
+          <span class="text-gray-400 dark:text-gray-500"> — {{ lastRunStatus }}</span>
+        </span>
+      </div>
+      <div v-if="pipeline.health?.successRate != null" class="flex items-center gap-2 text-xs">
+        <span class="text-gray-500 dark:text-gray-400">Success rate:</span>
+        <div class="flex-1 h-1.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+          <div
+            class="h-full rounded-full"
+            :class="pipeline.health.successRate >= 80 ? 'bg-emerald-400' : pipeline.health.successRate >= 50 ? 'bg-amber-400' : 'bg-red-400'"
+            :style="{ width: pipeline.health.successRate + '%' }"
+          />
+        </div>
+        <span class="font-medium text-gray-700 dark:text-gray-300 w-8 text-right">{{ pipeline.health.successRate }}%</span>
+      </div>
+      <div v-if="pipeline.health?.queue?.waiting > 0" class="flex items-center gap-1.5 text-xs mt-1">
+        <span class="w-2 h-2 rounded-full animate-pulse" :class="pipeline.health.queue.waiting >= 6 ? 'bg-red-500' : 'bg-amber-400'" />
+        <span :class="pipeline.health.queue.waiting >= 6 ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'">
+          {{ pipeline.health.queue.waiting }} queued
+        </span>
+        <span v-if="pipeline.health.queue.runnerTags?.length" class="text-gray-400 dark:text-gray-500 truncate">
+          ({{ pipeline.health.queue.runnerTags.join(', ') }})
+        </span>
+      </div>
+    </div>
+  </button>
+</template>

--- a/modules/pipeline-ops/client/components/QueuePanel.vue
+++ b/modules/pipeline-ops/client/components/QueuePanel.vue
@@ -1,0 +1,99 @@
+<script setup>
+import { computed } from 'vue'
+import { ClockIcon, AlertTriangleIcon, ServerIcon } from 'lucide-vue-next'
+
+const props = defineProps({
+  queue: { type: Object, default: null },
+  avgQueuedSeconds: { type: Number, default: null },
+  maxQueuedSeconds: { type: Number, default: null },
+  runs: { type: Array, default: () => [] }
+})
+
+function formatDuration(seconds) {
+  if (seconds == null) return '—'
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return remMins > 0 ? `${hours}h ${remMins}m` : `${hours}h`
+}
+
+const waitingSince = computed(() => {
+  if (!props.queue?.oldestWaitingSince) return null
+  const diff = Date.now() - new Date(props.queue.oldestWaitingSince).getTime()
+  return formatDuration(Math.round(diff / 1000))
+})
+
+const severityClass = computed(() => {
+  const w = props.queue?.waiting || 0
+  if (w >= 6) return 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20'
+  if (w >= 1) return 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20'
+  return 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800'
+})
+
+const dotClass = computed(() => {
+  const w = props.queue?.waiting || 0
+  if (w >= 6) return 'bg-red-500'
+  if (w >= 1) return 'bg-amber-400'
+  return 'bg-emerald-400'
+})
+
+const hasData = computed(() =>
+  (props.queue?.waiting > 0) || props.avgQueuedSeconds != null
+)
+</script>
+
+<template>
+  <div v-if="hasData" :class="['border rounded-xl p-5', severityClass]">
+    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2 mb-3">
+      <ServerIcon :size="14" />
+      Runner Queue
+    </h3>
+
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <!-- Waiting now -->
+      <div v-if="queue?.waiting > 0">
+        <div class="flex items-center gap-1.5 mb-1">
+          <span :class="['w-2 h-2 rounded-full animate-pulse', dotClass]" />
+          <span class="text-xs text-gray-500 dark:text-gray-400">Waiting now</span>
+        </div>
+        <div class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ queue.waiting }}</div>
+        <div v-if="queue.runnerTags?.length" class="mt-1 flex flex-wrap gap-1">
+          <span
+            v-for="tag in queue.runnerTags"
+            :key="tag"
+            class="text-[10px] px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-gray-600 dark:text-gray-400"
+          >{{ tag }}</span>
+        </div>
+      </div>
+
+      <!-- Longest wait -->
+      <div v-if="waitingSince">
+        <div class="flex items-center gap-1.5 mb-1">
+          <AlertTriangleIcon :size="12" class="text-amber-500" />
+          <span class="text-xs text-gray-500 dark:text-gray-400">Longest wait</span>
+        </div>
+        <div class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ waitingSince }}</div>
+      </div>
+
+      <!-- Avg queue time (completed jobs) -->
+      <div v-if="avgQueuedSeconds != null">
+        <div class="flex items-center gap-1.5 mb-1">
+          <ClockIcon :size="12" class="text-gray-400" />
+          <span class="text-xs text-gray-500 dark:text-gray-400">Avg wait</span>
+        </div>
+        <div class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ formatDuration(avgQueuedSeconds) }}</div>
+      </div>
+
+      <!-- Max queue time (completed jobs) -->
+      <div v-if="maxQueuedSeconds != null">
+        <div class="flex items-center gap-1.5 mb-1">
+          <ClockIcon :size="12" class="text-gray-400" />
+          <span class="text-xs text-gray-500 dark:text-gray-400">Max wait</span>
+        </div>
+        <div class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ formatDuration(maxQueuedSeconds) }}</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/modules/pipeline-ops/client/components/RunCharts.vue
+++ b/modules/pipeline-ops/client/components/RunCharts.vue
@@ -1,0 +1,133 @@
+<script setup>
+import { computed } from 'vue'
+import { Line, Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Tooltip,
+  Filler
+} from 'chart.js'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Tooltip, Filler)
+
+const props = defineProps({
+  runs: { type: Array, default: () => [] }
+})
+
+const sortedRuns = computed(() =>
+  [...props.runs].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
+)
+
+const durationChartData = computed(() => {
+  const runs = sortedRuns.value.filter(r => r.durationSeconds != null)
+  return {
+    labels: runs.map(r =>
+      new Date(r.startedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    ),
+    datasets: [{
+      label: 'Duration (min)',
+      data: runs.map(r => Math.round(r.durationSeconds / 60)),
+      borderColor: '#6366f1',
+      backgroundColor: 'rgba(99, 102, 241, 0.1)',
+      fill: true,
+      tension: 0.3,
+      pointRadius: 3,
+      pointBackgroundColor: runs.map(r =>
+        r.status === 'success' ? '#10b981' : '#ef4444'
+      )
+    }]
+  }
+})
+
+const durationChartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => {
+          const run = sortedRuns.value.filter(r => r.durationSeconds != null)[ctx.dataIndex]
+          return `${ctx.parsed.y}min — ${run?.status || '?'}`
+        }
+      }
+    }
+  },
+  scales: {
+    x: { ticks: { font: { size: 9 }, maxRotation: 45 } },
+    y: { min: 0, title: { display: true, text: 'minutes', font: { size: 9 } }, ticks: { font: { size: 9 } } }
+  }
+}
+
+const successChartData = computed(() => {
+  const runs = sortedRuns.value
+  const windowSize = 5
+  const labels = []
+  const rates = []
+
+  for (let i = windowSize - 1; i < runs.length; i++) {
+    const window = runs.slice(i - windowSize + 1, i + 1)
+    const successes = window.filter(r => r.status === 'success').length
+    const rate = Math.round((successes / windowSize) * 100)
+    labels.push(
+      new Date(runs[i].startedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    )
+    rates.push(rate)
+  }
+
+  return {
+    labels,
+    datasets: [{
+      label: 'Success Rate %',
+      data: rates,
+      backgroundColor: rates.map(r =>
+        r >= 80 ? 'rgba(16, 185, 129, 0.6)' : r >= 50 ? 'rgba(245, 158, 11, 0.6)' : 'rgba(239, 68, 68, 0.6)'
+      ),
+      borderRadius: 2,
+    }]
+  }
+})
+
+const successChartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => `${ctx.parsed.y}% success (rolling ${5}-run window)`
+      }
+    }
+  },
+  scales: {
+    x: { ticks: { font: { size: 9 }, maxRotation: 45 } },
+    y: { min: 0, max: 100, title: { display: true, text: '%', font: { size: 9 } }, ticks: { font: { size: 9 }, stepSize: 20 } }
+  }
+}
+
+const hasData = computed(() => sortedRuns.value.length >= 2)
+</script>
+
+<template>
+  <div v-if="hasData" class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+      <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Run Duration</h3>
+      <div class="h-48">
+        <Line :data="durationChartData" :options="durationChartOptions" />
+      </div>
+      <p class="text-[10px] text-gray-400 mt-2">Green dots = success, red = failed</p>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5">
+      <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Success Rate (rolling 5-run)</h3>
+      <div class="h-48">
+        <Bar :data="successChartData" :options="successChartOptions" />
+      </div>
+      <p class="text-[10px] text-gray-400 mt-2">Green >= 80%, amber >= 50%, red &lt; 50%</p>
+    </div>
+  </div>
+</template>

--- a/modules/pipeline-ops/client/components/RunHistoryTable.vue
+++ b/modules/pipeline-ops/client/components/RunHistoryTable.vue
@@ -1,0 +1,114 @@
+<script setup>
+import { computed } from 'vue'
+import { ExternalLinkIcon, CheckCircleIcon, XCircleIcon, MinusCircleIcon, ClockIcon, LoaderIcon } from 'lucide-vue-next'
+
+const props = defineProps({
+  runs: { type: Array, default: () => [] }
+})
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+    ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
+function formatDuration(seconds) {
+  if (seconds == null) return '—'
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return remMins > 0 ? `${hours}h ${remMins}m` : `${hours}h`
+}
+
+function queueWait(run) {
+  if (run.queuedSeconds) return run.queuedSeconds
+  if (run.status === 'waiting_for_resource' && run.createdAt) {
+    return Math.round((Date.now() - new Date(run.createdAt).getTime()) / 1000)
+  }
+  return null
+}
+
+function queueClass(seconds) {
+  if (seconds == null) return ''
+  if (seconds > 3600) return 'text-red-500'
+  if (seconds > 600) return 'text-amber-500'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+const statusIcon = {
+  success: CheckCircleIcon,
+  failed: XCircleIcon,
+  waiting_for_resource: ClockIcon,
+  running: LoaderIcon,
+}
+
+const statusColor = {
+  success: 'text-emerald-500',
+  failed: 'text-red-500',
+  waiting_for_resource: 'text-amber-500',
+  running: 'text-blue-500',
+}
+
+const displayRuns = computed(() => props.runs.slice(0, 50))
+const hasQueueData = computed(() => props.runs.some(r => r.queuedSeconds || r.status === 'waiting_for_resource'))
+</script>
+
+<template>
+  <div class="overflow-x-auto">
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="border-b border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400">
+          <th class="text-left py-2 pr-3 font-medium">Status</th>
+          <th class="text-left py-2 pr-3 font-medium">Job</th>
+          <th class="text-left py-2 pr-3 font-medium">Started</th>
+          <th class="text-right py-2 pr-3 font-medium">Duration</th>
+          <th v-if="hasQueueData" class="text-right py-2 pr-3 font-medium">Wait</th>
+          <th class="text-left py-2 pr-3 font-medium">Ref</th>
+          <th class="text-right py-2 font-medium">Link</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="run in displayRuns"
+          :key="run.id"
+          class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+        >
+          <td class="py-1.5 pr-3">
+            <component
+              :is="statusIcon[run.status] || MinusCircleIcon"
+              :size="14"
+              :class="[statusColor[run.status] || 'text-gray-400', run.status === 'running' ? 'animate-spin' : '']"
+            />
+          </td>
+          <td class="py-1.5 pr-3 text-gray-700 dark:text-gray-300 font-medium">{{ run.job }}</td>
+          <td class="py-1.5 pr-3 text-gray-500 dark:text-gray-400">
+            {{ run.status === 'waiting_for_resource' ? formatDate(run.createdAt) : formatDate(run.startedAt) }}
+            <span v-if="run.status === 'waiting_for_resource'" class="text-amber-500 ml-1">(queued)</span>
+          </td>
+          <td class="py-1.5 pr-3 text-right text-gray-700 dark:text-gray-300 tabular-nums">{{ formatDuration(run.durationSeconds) }}</td>
+          <td v-if="hasQueueData" class="py-1.5 pr-3 text-right tabular-nums" :class="queueClass(queueWait(run))">
+            {{ formatDuration(queueWait(run)) }}
+          </td>
+          <td class="py-1.5 pr-3 text-gray-400">
+            <code class="text-[10px]">{{ run.ref }}</code>
+          </td>
+          <td class="py-1.5 text-right">
+            <a
+              v-if="run.webUrl"
+              :href="run.webUrl"
+              target="_blank"
+              rel="noopener"
+              class="text-gray-400 hover:text-primary-500"
+            >
+              <ExternalLinkIcon :size="12" />
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-if="displayRuns.length === 0" class="text-center text-gray-400 dark:text-gray-500 py-4">No runs recorded yet.</p>
+  </div>
+</template>

--- a/modules/pipeline-ops/client/composables/usePipelines.js
+++ b/modules/pipeline-ops/client/composables/usePipelines.js
@@ -1,0 +1,43 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+export function usePipelines() {
+  const pipelines = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function load() {
+    loading.value = true
+    error.value = null
+    try {
+      const data = await apiRequest('/modules/pipeline-ops/pipelines')
+      pipelines.value = data.pipelines || []
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { pipelines, loading, error, load }
+}
+
+export function usePipelineDetail() {
+  const pipeline = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function load(slug) {
+    loading.value = true
+    error.value = null
+    try {
+      pipeline.value = await apiRequest(`/modules/pipeline-ops/pipelines/${encodeURIComponent(slug)}`)
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { pipeline, loading, error, load }
+}

--- a/modules/pipeline-ops/client/index.js
+++ b/modules/pipeline-ops/client/index.js
@@ -1,0 +1,6 @@
+import { defineAsyncComponent } from 'vue'
+
+export const routes = {
+  'status': defineAsyncComponent(() => import('./views/StatusBoard.vue')),
+  'detail': defineAsyncComponent(() => import('./views/PipelineDetail.vue')),
+}

--- a/modules/pipeline-ops/client/views/PipelineDetail.vue
+++ b/modules/pipeline-ops/client/views/PipelineDetail.vue
@@ -1,0 +1,133 @@
+<script setup>
+import { computed, onMounted, watch, inject } from 'vue'
+import {
+  ArrowLeftIcon, ExternalLinkIcon, ClockIcon, UserIcon,
+  AlertCircleIcon
+} from 'lucide-vue-next'
+import { usePipelineDetail } from '../composables/usePipelines.js'
+import RunCharts from '../components/RunCharts.vue'
+import RunHistoryTable from '../components/RunHistoryTable.vue'
+import QueuePanel from '../components/QueuePanel.vue'
+
+const moduleNav = inject('moduleNav')
+const slug = computed(() => moduleNav.params.value?.slug || '')
+const { pipeline, loading, error, load } = usePipelineDetail()
+
+function goBack() {
+  moduleNav.navigateTo('status')
+}
+
+const statusColor = computed(() => {
+  const s = pipeline.value?.health?.healthStatus
+  if (s === 'green') return 'bg-emerald-400'
+  if (s === 'yellow') return 'bg-amber-400'
+  if (s === 'red') return 'bg-red-500'
+  return 'bg-gray-400'
+})
+
+const statusLabel = computed(() => {
+  const s = pipeline.value?.health?.healthStatus
+  if (s === 'green') return 'Healthy'
+  if (s === 'yellow') return 'Warning'
+  if (s === 'red') return 'Critical'
+  return 'No data'
+})
+
+const scheduleLabel = computed(() => {
+  const mins = pipeline.value?.schedule?.expectedIntervalMinutes
+  if (!mins) return 'Unknown'
+  if (mins < 60) return `every ${mins}m`
+  if (mins === 60) return 'every hour'
+  if (mins < 1440) return `every ${mins / 60}h`
+  if (mins === 1440) return 'daily'
+  return `every ${Math.round(mins / 1440)}d`
+})
+
+onMounted(() => {
+  if (slug.value) load(slug.value)
+})
+
+watch(slug, (val) => {
+  if (val) load(val)
+})
+</script>
+
+<template>
+  <div>
+    <!-- Back nav -->
+    <button
+      class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600 mb-4"
+      @click="goBack"
+    >
+      <ArrowLeftIcon :size="14" />
+      Back to Status Board
+    </button>
+
+    <!-- Loading -->
+    <div v-if="loading && !pipeline" class="animate-pulse space-y-4">
+      <div class="h-8 bg-gray-200 dark:bg-gray-700 rounded w-64" />
+      <div class="h-4 bg-gray-100 dark:bg-gray-700 rounded w-96" />
+      <div class="h-48 bg-gray-100 dark:bg-gray-700 rounded-xl" />
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-6 text-center">
+      <AlertCircleIcon :size="24" class="text-red-500 mx-auto mb-2" />
+      <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Error loading pipeline</h3>
+      <p class="text-sm text-red-700 dark:text-red-400">{{ error }}</p>
+      <button class="mt-3 text-sm text-primary-600 hover:text-primary-700 font-medium" @click="load(slug)">Retry</button>
+    </div>
+
+    <!-- Content -->
+    <template v-else-if="pipeline">
+      <!-- Header -->
+      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-6">
+        <div class="flex items-start justify-between">
+          <div>
+            <div class="flex items-center gap-3 mb-2">
+              <span :class="['w-3 h-3 rounded-full', statusColor]" />
+              <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">{{ pipeline.name }}</h2>
+              <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                {{ statusLabel }}
+              </span>
+            </div>
+            <p v-if="pipeline.description" class="text-sm text-gray-500 dark:text-gray-400 mb-3">{{ pipeline.description }}</p>
+            <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+              <span class="flex items-center gap-1"><ClockIcon :size="12" /> {{ scheduleLabel }}</span>
+              <span v-if="pipeline.owner" class="flex items-center gap-1"><UserIcon :size="12" /> {{ pipeline.owner }}</span>
+              <span class="flex items-center gap-1">{{ pipeline.repo?.platform === 'github' ? 'GitHub' : 'GitLab' }}</span>
+            </div>
+          </div>
+          <a
+            v-if="pipeline.repo?.url"
+            :href="pipeline.repo.url"
+            target="_blank"
+            rel="noopener"
+            class="text-gray-400 hover:text-primary-500"
+          >
+            <ExternalLinkIcon :size="16" />
+          </a>
+        </div>
+      </div>
+
+      <!-- Runner queue -->
+      <QueuePanel
+        :queue="pipeline.health?.queue"
+        :avgQueuedSeconds="pipeline.health?.avgQueuedSeconds"
+        :maxQueuedSeconds="pipeline.health?.maxQueuedSeconds"
+        :runs="pipeline.runs || []"
+        class="mb-6"
+      />
+
+      <!-- Trend charts -->
+      <RunCharts v-if="pipeline.runs?.length" :runs="pipeline.runs" class="mb-6" />
+
+      <!-- Run history table -->
+      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 mb-6">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Recent Runs</h3>
+        <RunHistoryTable :runs="pipeline.runs || []" />
+      </div>
+
+    </template>
+  </div>
+</template>

--- a/modules/pipeline-ops/client/views/StatusBoard.vue
+++ b/modules/pipeline-ops/client/views/StatusBoard.vue
@@ -1,0 +1,231 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted, inject } from 'vue'
+import { AlertCircleIcon, FilterIcon, LayoutGridIcon, ListIcon, RefreshCwIcon, LoaderIcon, CheckCircleIcon } from 'lucide-vue-next'
+import { useAuth } from '@shared/client/composables/useAuth'
+import { apiRequest } from '@shared/client/services/api'
+import { usePipelines } from '../composables/usePipelines.js'
+import PipelineCard from '../components/PipelineCard.vue'
+
+const moduleNav = inject('moduleNav')
+const { isAdmin } = useAuth()
+const canRefresh = computed(() => isAdmin.value || import.meta.env.DEV)
+const { pipelines, loading, error, load } = usePipelines()
+
+const filterOwner = ref('')
+const filterPlatform = ref('')
+const grouped = ref(true)
+
+const refreshing = ref(false)
+const refreshResult = ref(null)
+let pollTimer = null
+
+async function triggerRefresh() {
+  refreshing.value = true
+  refreshResult.value = null
+  try {
+    await apiRequest('/modules/pipeline-ops/refresh', { method: 'POST' })
+    pollTimer = setInterval(pollRefreshStatus, 3000)
+  } catch (err) {
+    refreshing.value = false
+    refreshResult.value = { error: err.message }
+  }
+}
+
+async function pollRefreshStatus() {
+  try {
+    const status = await apiRequest('/modules/pipeline-ops/refresh/status')
+    if (!status.running) {
+      clearInterval(pollTimer)
+      pollTimer = null
+      refreshing.value = false
+      refreshResult.value = status.lastResult
+      load()
+      setTimeout(() => { refreshResult.value = null }, 15000)
+    }
+  } catch {
+    clearInterval(pollTimer)
+    pollTimer = null
+    refreshing.value = false
+  }
+}
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+})
+
+const owners = computed(() => {
+  const set = new Set(pipelines.value.map(p => p.owner).filter(Boolean))
+  return [...set].sort()
+})
+
+const platforms = computed(() => {
+  const set = new Set(pipelines.value.map(p => p.repo?.platform).filter(Boolean))
+  return [...set].sort()
+})
+
+const filtered = computed(() => {
+  let list = pipelines.value
+  if (filterOwner.value) {
+    list = list.filter(p => p.owner === filterOwner.value)
+  }
+  if (filterPlatform.value) {
+    list = list.filter(p => p.repo?.platform === filterPlatform.value)
+  }
+
+  return [...list].sort((a, b) => {
+    const oa = a.order ?? 999
+    const ob = b.order ?? 999
+    if (oa !== ob) return oa - ob
+    return (a.name || '').localeCompare(b.name || '')
+  })
+})
+
+const groups = computed(() => {
+  if (!grouped.value) return null
+  const map = {}
+  for (const p of filtered.value) {
+    const g = p.group || 'Ungrouped'
+    if (!map[g]) map[g] = []
+    map[g].push(p)
+  }
+  return map
+})
+
+function openDetail(pipeline) {
+  moduleNav.navigateTo('detail', { slug: pipeline.slug })
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="mb-4 flex items-start justify-between flex-wrap gap-3">
+      <div>
+        <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Pipeline Status Board</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Operational overview of AI-First pipeline infrastructure</p>
+      </div>
+
+      <div class="flex items-center gap-2 flex-wrap">
+        <div class="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+          <FilterIcon :size="12" />
+        </div>
+
+        <select
+          v-model="filterOwner"
+          class="text-xs border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+        >
+          <option value="">All owners</option>
+          <option v-for="o in owners" :key="o" :value="o">{{ o }}</option>
+        </select>
+
+        <select
+          v-model="filterPlatform"
+          class="text-xs border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+        >
+          <option value="">All platforms</option>
+          <option v-for="p in platforms" :key="p" :value="p">{{ p }}</option>
+        </select>
+
+        <button
+          class="p-1.5 rounded-lg border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          :class="grouped ? 'bg-primary-50 dark:bg-primary-900/30 border-primary-300 dark:border-primary-600' : ''"
+          title="Toggle grouping"
+          @click="grouped = !grouped"
+        >
+          <component :is="grouped ? ListIcon : LayoutGridIcon" :size="14" class="text-gray-500 dark:text-gray-400" />
+        </button>
+
+        <button
+          v-if="canRefresh"
+          class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg border transition-colors"
+          :class="refreshing
+            ? 'border-primary-300 dark:border-primary-600 bg-primary-50 dark:bg-primary-900/30 text-primary-600 cursor-wait'
+            : 'border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300'"
+          :disabled="refreshing"
+          title="Collect latest run data from GitLab/GitHub"
+          @click="triggerRefresh"
+        >
+          <component :is="refreshing ? LoaderIcon : RefreshCwIcon" :size="12" :class="refreshing ? 'animate-spin' : ''" />
+          {{ refreshing ? 'Collecting...' : 'Refresh' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Refresh result banner -->
+    <div v-if="refreshResult" class="mb-4 text-xs px-3 py-2 rounded-lg" :class="refreshResult.error
+      ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
+      : 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'"
+    >
+      <div class="flex items-center gap-2">
+        <component :is="refreshResult.error ? AlertCircleIcon : CheckCircleIcon" :size="14" class="flex-shrink-0" />
+        <span v-if="refreshResult.error">Refresh failed: {{ refreshResult.error }}</span>
+        <span v-else>
+          Collected {{ refreshResult.collected || 0 }} pipelines<span v-if="refreshResult.skipped">, skipped {{ refreshResult.skipped }}</span><span v-if="refreshResult.errors">, {{ refreshResult.errors }} errors</span>
+        </span>
+      </div>
+      <ul v-if="refreshResult.details?.length" class="mt-1.5 ml-5 space-y-0.5 text-gray-600 dark:text-gray-400">
+        <li v-for="d in refreshResult.details" :key="d.slug" class="flex items-center gap-1.5">
+          <span :class="d.status === 'ok' ? 'text-emerald-500' : d.status === 'skipped' ? 'text-amber-500' : 'text-red-500'">{{ d.status === 'ok' ? '+' : d.status === 'skipped' ? '-' : 'x' }}</span>
+          <span class="font-medium">{{ d.slug }}</span>
+          <span v-if="d.status === 'ok'">— {{ d.runsFound }} runs found</span>
+          <span v-else>— {{ d.reason }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading && pipelines.length === 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div v-for="i in 6" :key="i" class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 animate-pulse">
+        <div class="flex items-center gap-2.5 mb-3">
+          <div class="w-2.5 h-2.5 rounded-full bg-gray-200 dark:bg-gray-600" />
+          <div class="h-4 bg-gray-200 dark:bg-gray-600 rounded w-40" />
+        </div>
+        <div class="space-y-2">
+          <div class="h-3 bg-gray-100 dark:bg-gray-700 rounded w-32" />
+          <div class="h-3 bg-gray-100 dark:bg-gray-700 rounded w-24" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-6 text-center">
+      <div class="w-12 h-12 mx-auto mb-3 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center">
+        <AlertCircleIcon :size="24" class="text-red-500" />
+      </div>
+      <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Error loading pipelines</h3>
+      <p class="text-sm text-red-700 dark:text-red-400">{{ error }}</p>
+      <button class="mt-3 text-sm text-primary-600 hover:text-primary-700 font-medium" @click="load">Retry</button>
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="filtered.length === 0" class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl p-8 text-center">
+      <p class="text-gray-500 dark:text-gray-400">No pipelines found.</p>
+    </div>
+
+    <!-- Grouped -->
+    <template v-else-if="groups">
+      <div v-for="(items, groupName) in groups" :key="groupName" class="mb-6">
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">{{ groupName }}</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <PipelineCard
+            v-for="p in items"
+            :key="p.slug"
+            :pipeline="p"
+            @click="openDetail"
+          />
+        </div>
+      </div>
+    </template>
+
+    <!-- Ungrouped (default) -->
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <PipelineCard
+        v-for="p in filtered"
+        :key="p.slug"
+        :pipeline="p"
+        @click="openDetail"
+      />
+    </div>
+  </div>
+</template>

--- a/modules/pipeline-ops/module.json
+++ b/modules/pipeline-ops/module.json
@@ -1,0 +1,27 @@
+{
+  "name": "Pipeline Ops",
+  "slug": "pipeline-ops",
+  "description": "Operational dashboard for AI-First pipeline infrastructure",
+  "icon": "activity",
+  "order": 6,
+  "defaultEnabled": false,
+  "requires": [],
+  "client": {
+    "entry": "./client/index.js",
+    "navItems": [
+      { "id": "status", "label": "Status Board", "icon": "LayoutGrid", "default": true }
+    ],
+    "hiddenRoutes": {
+      "detail": "status"
+    }
+  },
+  "server": {
+    "entry": "./server/index.js"
+  },
+  "export": {
+    "files": [
+      { "path": "pipeline-ops/config.json", "notes": "Pipeline definitions" },
+      { "path": "pipeline-ops/runs.json", "notes": "Recent run history" }
+    ]
+  }
+}

--- a/modules/pipeline-ops/server/collector.js
+++ b/modules/pipeline-ops/server/collector.js
@@ -1,0 +1,389 @@
+const fetch = require('node-fetch');
+
+const RATE_LIMIT_DELAY = 500;
+
+function resolveToken(pipeline) {
+  const url = pipeline.repo?.url || '';
+  const platform = pipeline.repo?.platform;
+
+  if (platform === 'github') {
+    return process.env.GITHUB_TOKEN || null;
+  }
+
+  try {
+    const hostname = new URL(url).hostname;
+    if (hostname === 'gitlab.cee.redhat.com') {
+      return process.env.GITLAB_TOKEN_INTERNAL || process.env.GITLAB_CEE_REDHAT_DOCS_TOKEN || process.env.GITLAB_TOKEN || null;
+    }
+  } catch { /* invalid URL */ }
+
+  return process.env.GITLAB_TOKEN || null;
+}
+
+function extractRepoPath(repoUrl) {
+  try {
+    const u = new URL(repoUrl);
+    return u.pathname.replace(/^\//, '').replace(/\.git$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function extractGitlabHost(repoUrl) {
+  try {
+    const u = new URL(repoUrl);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return 'https://gitlab.com';
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const GITLAB_STATUS_MAP = {
+  success: 'success',
+  failed: 'failed',
+  canceled: 'canceled',
+  skipped: 'skipped',
+  running: 'running',
+  pending: 'pending',
+  created: 'pending',
+  manual: 'pending',
+};
+
+const GITHUB_CONCLUSION_MAP = {
+  success: 'success',
+  failure: 'failed',
+  cancelled: 'canceled',
+  skipped: 'skipped',
+  timed_out: 'failed',
+  action_required: 'pending',
+};
+
+async function resolveGitlabProject(pipeline, token) {
+  const repoPath = extractRepoPath(pipeline.repo.url);
+  if (!repoPath) throw new Error('Invalid repo URL');
+
+  const host = extractGitlabHost(pipeline.repo.url);
+  const encodedPath = encodeURIComponent(repoPath);
+  const projectUrl = `${host}/api/v4/projects/${encodedPath}`;
+  const authHeaders = { 'Authorization': `Bearer ${token}` };
+
+  const projectRes = await fetch(projectUrl, { headers: authHeaders, timeout: 30000 });
+  if (!projectRes.ok) {
+    const status = projectRes.status;
+    const label = status === 401 ? 'auth failed' : status === 403 ? 'access denied' : status === 404 ? 'repo not found' : `HTTP ${status}`;
+    throw new Error(`GitLab project ${label} (${status})`);
+  }
+  const project = await projectRes.json();
+  return { projectId: project.id, host, authHeaders };
+}
+
+function mapGitlabJob(pl, j) {
+  let queuedSeconds = null;
+  if (j.started_at && j.created_at) {
+    queuedSeconds = Math.round(
+      (new Date(j.started_at).getTime() - new Date(j.created_at).getTime()) / 1000
+    );
+  }
+  return {
+    id: `${pl.id}-${j.id}`,
+    job: j.name,
+    createdAt: j.created_at,
+    startedAt: j.started_at || null,
+    finishedAt: j.finished_at || null,
+    durationSeconds: j.duration ? Math.round(j.duration) : null,
+    queuedSeconds,
+    runnerTags: j.tag_list || [],
+    status: GITLAB_STATUS_MAP[j.status] || j.status,
+    ref: pl.ref,
+    webUrl: j.web_url || pl.web_url,
+    source: pl.source || 'push',
+  };
+}
+
+async function fetchPipelineJobs(projectId, pipelineId, host, authHeaders) {
+  const jobsRes = await fetch(
+    `${host}/api/v4/projects/${projectId}/pipelines/${pipelineId}/jobs?per_page=100`,
+    { headers: authHeaders, timeout: 30000 }
+  );
+  if (!jobsRes.ok) return [];
+  return jobsRes.json();
+}
+
+function matchesJobFilter(jobName, filters) {
+  if (!filters || filters.length === 0) return true;
+  return filters.some(function(pattern) {
+    if (pattern.endsWith('*')) {
+      return jobName.startsWith(pattern.slice(0, -1));
+    }
+    return jobName === pattern;
+  });
+}
+
+const SKIP_STATUSES_TOP = ['manual', 'created', 'pending', 'running', 'preparing'];
+const SKIP_STATUSES_CHILD = ['manual', 'created', 'pending', 'preparing'];
+
+async function fetchGitlabRuns(pipeline, token) {
+  const { projectId, host, authHeaders } = await resolveGitlabProject(pipeline, token);
+
+  await sleep(RATE_LIMIT_DELAY);
+
+  const pipelinesUrl = `${host}/api/v4/projects/${projectId}/pipelines?per_page=20&order_by=updated_at`;
+  const pipelinesRes = await fetch(pipelinesUrl, { headers: authHeaders, timeout: 30000 });
+  if (!pipelinesRes.ok) {
+    throw new Error(`GitLab pipelines fetch failed (${pipelinesRes.status})`);
+  }
+  const pipelinesData = await pipelinesRes.json();
+
+  await sleep(RATE_LIMIT_DELAY);
+
+  let childPipelines = [];
+  try {
+    const childRes = await fetch(
+      `${host}/api/v4/projects/${projectId}/pipelines?per_page=20&order_by=updated_at&source=parent_pipeline`,
+      { headers: authHeaders, timeout: 30000 }
+    );
+    if (childRes.ok) {
+      childPipelines = await childRes.json();
+    }
+  } catch { /* best-effort */ }
+
+  const topLevelIds = new Set(pipelinesData.map(p => p.id));
+  const childOnly = childPipelines.filter(p => !topLevelIds.has(p.id));
+  const allPipelines = [
+    ...pipelinesData.map(p => ({ ...p, _isChild: false })),
+    ...childOnly.map(p => ({ ...p, _isChild: true })),
+  ];
+
+  const jobFilters = pipeline.jobPatterns || pipeline.jobs || [];
+  const allRuns = [];
+  const queue = { waiting: 0, runnerTags: [], oldestWaitingSince: null };
+  const tagSet = new Set();
+
+  for (const pl of allPipelines) {
+    await sleep(RATE_LIMIT_DELAY);
+
+    let jobs;
+    try {
+      jobs = await fetchPipelineJobs(projectId, pl.id, host, authHeaders);
+    } catch {
+      continue;
+    }
+
+    const skipStatuses = pl._isChild ? SKIP_STATUSES_CHILD : SKIP_STATUSES_TOP;
+
+    for (const j of jobs) {
+      if (jobFilters.length > 0 && !matchesJobFilter(j.name, jobFilters)) continue;
+
+      if (j.status === 'waiting_for_resource') {
+        queue.waiting++;
+        for (const tag of j.tag_list || []) tagSet.add(tag);
+        if (!queue.oldestWaitingSince || j.created_at < queue.oldestWaitingSince) {
+          queue.oldestWaitingSince = j.created_at;
+        }
+        allRuns.push(mapGitlabJob(pl, j));
+        continue;
+      }
+
+      if (j.status === 'running') {
+        allRuns.push(mapGitlabJob(pl, j));
+        continue;
+      }
+
+      if (skipStatuses.includes(j.status)) continue;
+
+      allRuns.push(mapGitlabJob(pl, j));
+    }
+  }
+
+  queue.runnerTags = [...tagSet];
+  return { runs: allRuns, queue };
+}
+
+function cronToIntervalMinutes(cron) {
+  if (!cron) return null;
+  const parts = cron.split(/\s+/);
+  if (parts.length < 5) return null;
+  const [minute, hour, dom, month] = parts;
+  if (minute.startsWith('*/') && hour === '*' && dom === '*' && month === '*') {
+    return parseInt(minute.slice(2), 10);
+  }
+  if (hour === '*' && dom === '*' && month === '*' && !minute.includes('/')) {
+    return 60;
+  }
+  if (hour.startsWith('*/') && dom === '*' && month === '*') {
+    return parseInt(hour.slice(2), 10) * 60;
+  }
+  if (hour !== '*' && dom === '*' && month === '*') {
+    const hours = hour.split(',');
+    if (hours.length >= 2) {
+      return Math.round(1440 / hours.length);
+    }
+    return 1440;
+  }
+  return null;
+}
+
+async function fetchGitlabSchedules(projectId, host, authHeaders) {
+  try {
+    const res = await fetch(
+      `${host}/api/v4/projects/${projectId}/pipeline_schedules`,
+      { headers: authHeaders, timeout: 30000 }
+    );
+    if (!res.ok) return [];
+    const schedules = await res.json();
+    return schedules
+      .filter(s => s.active)
+      .map(s => ({
+        cron: s.cron,
+        description: s.description || '',
+        expectedIntervalMinutes: cronToIntervalMinutes(s.cron),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchGithubRuns(pipeline, token) {
+  const repoPath = extractRepoPath(pipeline.repo.url);
+  if (!repoPath) return [];
+
+  const url = `https://api.github.com/repos/${repoPath}/actions/runs?per_page=20`;
+
+  const res = await fetch(url, {
+    headers: {
+      'Authorization': `token ${token}`,
+      'Accept': 'application/vnd.github+json',
+    },
+    timeout: 30000,
+  });
+  if (!res.ok) {
+    const status = res.status;
+    const label = status === 401 ? 'auth failed' : status === 403 ? 'access denied' : status === 404 ? 'repo not found' : `HTTP ${status}`;
+    throw new Error(`GitHub ${label} (${status})`);
+  }
+  const data = await res.json();
+  const runs = data.workflow_runs || [];
+
+  const mapped = runs
+    .filter(r => r.status === 'completed')
+    .map(r => {
+      const startMs = r.run_started_at ? new Date(r.run_started_at).getTime() : null;
+      const endMs = r.updated_at ? new Date(r.updated_at).getTime() : null;
+      const durationSeconds = startMs && endMs ? Math.round((endMs - startMs) / 1000) : null;
+
+      return {
+        id: String(r.id),
+        job: r.name || 'workflow',
+        createdAt: r.created_at,
+        startedAt: r.run_started_at || r.created_at,
+        finishedAt: r.updated_at,
+        durationSeconds,
+        queuedSeconds: null,
+        runnerTags: [],
+        status: GITHUB_CONCLUSION_MAP[r.conclusion] || r.conclusion,
+        ref: r.head_branch,
+        webUrl: r.html_url,
+        source: 'workflow',
+      };
+    });
+
+  return { runs: mapped, queue: { waiting: 0, runnerTags: [], oldestWaitingSince: null } };
+}
+
+function mergeRuns(existing, fresh) {
+  const byId = new Map();
+  for (const run of existing) byId.set(run.id, run);
+  for (const run of fresh) byId.set(run.id, run);
+  return [...byId.values()].sort((a, b) =>
+    new Date(b.startedAt || b.createdAt) - new Date(a.startedAt || a.createdAt)
+  );
+}
+
+function pruneRuns(runs, retentionDays) {
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  return runs.filter(r => {
+    const ts = r.startedAt || r.createdAt;
+    return ts && new Date(ts).getTime() >= cutoff;
+  });
+}
+
+async function collectPipelineRuns(config, existingRuns) {
+  const retentionDays = config.retentionDays || 30;
+  const results = { ...existingRuns };
+  const summary = { collected: 0, skipped: 0, errors: 0, details: [] };
+  const scheduleUpdates = {};
+
+  for (const pipeline of config.pipelines || []) {
+    const token = resolveToken(pipeline);
+    if (!token) {
+      const msg = `No token for ${pipeline.repo?.platform}`;
+      console.warn(`[pipeline-ops] ${msg}, skipping ${pipeline.slug}`);
+      summary.skipped++;
+      summary.details.push({ slug: pipeline.slug, status: 'skipped', reason: msg });
+      continue;
+    }
+
+    const platform = pipeline.repo?.platform;
+    let fetchResult;
+
+    try {
+      if (platform === 'github') {
+        fetchResult = await fetchGithubRuns(pipeline, token);
+      } else {
+        fetchResult = await fetchGitlabRuns(pipeline, token);
+
+        try {
+          const { projectId, host, authHeaders } = await resolveGitlabProject(pipeline, token);
+          const schedules = await fetchGitlabSchedules(projectId, host, authHeaders);
+          if (schedules.length > 0) {
+            const primary = schedules[0];
+            scheduleUpdates[pipeline.slug] = {
+              cron: primary.cron,
+              expectedIntervalMinutes: primary.expectedIntervalMinutes,
+              description: primary.description,
+            };
+          }
+        } catch { /* schedule fetch is best-effort */ }
+      }
+    } catch (err) {
+      console.error(`[pipeline-ops] Collection failed for ${pipeline.slug}: ${err.message}`);
+      summary.errors++;
+      summary.details.push({ slug: pipeline.slug, status: 'error', reason: err.message });
+      continue;
+    }
+
+    const { runs: freshRuns, queue } = fetchResult;
+    const existingPipelineRuns = results[pipeline.slug]?.runs || [];
+    const merged = mergeRuns(existingPipelineRuns, freshRuns);
+    const pruned = pruneRuns(merged, retentionDays);
+
+    results[pipeline.slug] = {
+      lastCheckedAt: new Date().toISOString(),
+      runs: pruned,
+      queue,
+    };
+
+    summary.collected++;
+    summary.details.push({ slug: pipeline.slug, status: 'ok', runsFound: freshRuns.length, queueDepth: queue.waiting });
+    await sleep(RATE_LIMIT_DELAY);
+  }
+
+  return { runs: results, summary, scheduleUpdates };
+}
+
+module.exports = {
+  collectPipelineRuns,
+  resolveToken,
+  extractRepoPath,
+  matchesJobFilter,
+  fetchGitlabRuns,
+  fetchGithubRuns,
+  fetchGitlabSchedules,
+  cronToIntervalMinutes,
+  mergeRuns,
+  pruneRuns,
+};

--- a/modules/pipeline-ops/server/health.js
+++ b/modules/pipeline-ops/server/health.js
@@ -1,0 +1,126 @@
+const NON_TERMINAL = ['waiting_for_resource', 'running', 'pending'];
+
+/**
+ * Compute pipeline health status from run history.
+ *
+ * @param {object} pipeline - Pipeline definition from config.json
+ * @param {object[]} runs - Array of run records, newest first
+ * @param {object} [queue] - Queue snapshot from collector
+ * @returns {object} Health summary
+ */
+function computeHealth(pipeline, runs, queue) {
+  const terminalRuns = (runs || []).filter(r => !NON_TERMINAL.includes(r.status));
+
+  const queueMetrics = queue?.waiting > 0 ? {
+    waiting: queue.waiting,
+    runnerTags: queue.runnerTags || [],
+    oldestWaitingSince: queue.oldestWaitingSince || null,
+  } : null;
+
+  if (terminalRuns.length === 0) {
+    return {
+      healthStatus: 'grey',
+      scheduleAdherence: null,
+      successRate: null,
+      avgDurationSeconds: null,
+      failureStreak: 0,
+      durationTrend: null,
+      lastRunAt: null,
+      lastSuccessAt: null,
+      queue: queueMetrics,
+    };
+  }
+
+  const now = Date.now();
+  const expectedIntervalMs = (pipeline.schedule?.expectedIntervalMinutes || 1440) * 60 * 1000;
+
+  const sorted = [...terminalRuns].sort((a, b) =>
+    new Date(b.startedAt || b.createdAt) - new Date(a.startedAt || a.createdAt)
+  );
+
+  const lastRun = sorted[0];
+  const lastRunAt = lastRun.startedAt || lastRun.createdAt;
+  const successfulRuns = sorted.filter(r => r.status === 'success');
+  const lastSuccessAt = successfulRuns.length > 0
+    ? (successfulRuns[0].startedAt || successfulRuns[0].createdAt)
+    : null;
+
+  const recentWindow = sorted.slice(0, 10);
+  const recentSuccesses = recentWindow.filter(r => r.status === 'success').length;
+  const successRate = recentWindow.length > 0 ? recentSuccesses / recentWindow.length : 0;
+
+  let failureStreak = 0;
+  for (const run of sorted) {
+    if (run.status !== 'success') failureStreak++;
+    else break;
+  }
+
+  const durations = sorted
+    .filter(r => r.durationSeconds != null)
+    .map(r => r.durationSeconds);
+  const avgDurationSeconds = durations.length > 0
+    ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length)
+    : null;
+
+  let durationTrend = null;
+  if (durations.length >= 6) {
+    const recentHalf = durations.slice(0, Math.floor(durations.length / 2));
+    const olderHalf = durations.slice(Math.floor(durations.length / 2));
+    const recentAvg = recentHalf.reduce((a, b) => a + b, 0) / recentHalf.length;
+    const olderAvg = olderHalf.reduce((a, b) => a + b, 0) / olderHalf.length;
+    const change = (recentAvg - olderAvg) / olderAvg;
+    if (change > 0.15) durationTrend = 'increasing';
+    else if (change < -0.15) durationTrend = 'decreasing';
+    else durationTrend = 'stable';
+  }
+
+  const queuedDurations = sorted
+    .filter(r => r.queuedSeconds != null && r.queuedSeconds > 0)
+    .map(r => r.queuedSeconds);
+  const avgQueuedSeconds = queuedDurations.length > 0
+    ? Math.round(queuedDurations.reduce((a, b) => a + b, 0) / queuedDurations.length)
+    : null;
+  const maxQueuedSeconds = queuedDurations.length > 0
+    ? Math.max(...queuedDurations)
+    : null;
+
+  const timeSinceLastSuccess = lastSuccessAt
+    ? now - new Date(lastSuccessAt).getTime()
+    : Infinity;
+  const scheduleAdherence = lastSuccessAt
+    ? timeSinceLastSuccess / expectedIntervalMs
+    : null;
+
+  let healthStatus;
+  if (
+    timeSinceLastSuccess <= expectedIntervalMs &&
+    lastRun.status === 'success' &&
+    successRate >= 0.8
+  ) {
+    healthStatus = 'green';
+  } else if (
+    timeSinceLastSuccess > 2 * expectedIntervalMs ||
+    failureStreak >= 3 ||
+    successRate < 0.5
+  ) {
+    healthStatus = 'red';
+  } else {
+    healthStatus = 'yellow';
+  }
+
+  return {
+    healthStatus,
+    scheduleAdherence,
+    successRate: Math.round(successRate * 100),
+    avgDurationSeconds,
+    failureStreak,
+    durationTrend,
+    lastRunAt,
+    lastSuccessAt,
+    avgQueuedSeconds,
+    maxQueuedSeconds,
+    queue: queueMetrics,
+  };
+}
+
+module.exports = { computeHealth };

--- a/modules/pipeline-ops/server/index.js
+++ b/modules/pipeline-ops/server/index.js
@@ -1,0 +1,274 @@
+const { computeHealth } = require('./health');
+const { collectPipelineRuns } = require('./collector');
+
+/**
+ * @param {import('express').Router} router
+ * @param {import('@shared/server/module-context').ModuleContext} context
+ */
+module.exports = function registerRoutes(router, context) {
+  const { storage, requireAdmin, requireScope } = context;
+  const { readFromStorage, writeToStorage } = storage;
+
+  const DEMO_MODE = process.env.DEMO_MODE === 'true';
+
+  const refreshState = {
+    running: false,
+    startedAt: null,
+    lastResult: null,
+  };
+
+  function loadConfig() {
+    return readFromStorage('pipeline-ops/config.json') || { pipelines: [], retentionDays: 30 };
+  }
+
+  function loadRuns() {
+    return readFromStorage('pipeline-ops/runs.json') || {};
+  }
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/pipelines:
+   *   get:
+   *     tags: [Pipeline Operations]
+   *     summary: All pipelines with computed health status
+   *     responses:
+   *       200:
+   *         description: Array of pipelines with health fields
+   */
+  router.get('/pipelines', requireScope('pipeline-ops:read'), function(req, res) {
+    const config = loadConfig();
+    const runs = loadRuns();
+
+    const pipelines = (config.pipelines || []).map(function(pipeline) {
+      const pipelineData = runs[pipeline.slug] || {};
+      const health = computeHealth(pipeline, pipelineData.runs || [], pipelineData.queue);
+      return { ...pipeline, health };
+    });
+
+    res.json({ pipelines });
+  });
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/pipelines/{slug}:
+   *   get:
+   *     tags: [Pipeline Operations]
+   *     summary: Single pipeline detail with run history
+   *     parameters:
+   *       - name: slug
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Pipeline detail with health and runs
+   *       404:
+   *         description: Pipeline not found
+   */
+  router.get('/pipelines/:slug', requireScope('pipeline-ops:read'), function(req, res) {
+    const config = loadConfig();
+    const runs = loadRuns();
+
+    const pipeline = (config.pipelines || []).find(p => p.slug === req.params.slug);
+    if (!pipeline) {
+      return res.status(404).json({ error: 'Pipeline not found' });
+    }
+
+    const pipelineData = runs[pipeline.slug] || {};
+    const pipelineRuns = pipelineData.runs || [];
+    const health = computeHealth(pipeline, pipelineRuns, pipelineData.queue);
+
+    res.json({
+      ...pipeline,
+      health,
+      runs: pipelineRuns,
+      lastCheckedAt: runs[pipeline.slug]?.lastCheckedAt || null
+    });
+  });
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/config:
+   *   get:
+   *     tags: [Pipeline Operations]
+   *     summary: Pipeline definitions (admin)
+   *     responses:
+   *       200:
+   *         description: Raw pipeline configuration
+   */
+  router.get('/config', requireAdmin, requireScope('pipeline-ops:write'), function(req, res) {
+    res.json(loadConfig());
+  });
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/config:
+   *   post:
+   *     tags: [Pipeline Operations]
+   *     summary: Update pipeline definitions (admin)
+   *     responses:
+   *       200:
+   *         description: Configuration saved
+   *       400:
+   *         description: Invalid configuration
+   */
+  router.post('/config', requireAdmin, requireScope('pipeline-ops:write'), function(req, res) {
+    const body = req.body;
+    if (!body || !Array.isArray(body.pipelines)) {
+      return res.status(400).json({ error: 'pipelines must be an array' });
+    }
+
+    const slugs = body.pipelines.map(p => p.slug).filter(Boolean);
+    const uniqueSlugs = new Set(slugs);
+    if (slugs.length !== uniqueSlugs.size) {
+      return res.status(400).json({ error: 'Duplicate pipeline slugs' });
+    }
+
+    for (const p of body.pipelines) {
+      if (!p.slug || !p.name) {
+        return res.status(400).json({ error: 'Each pipeline requires slug and name' });
+      }
+    }
+
+    writeToStorage('pipeline-ops/config.json', {
+      pipelines: body.pipelines,
+      retentionDays: body.retentionDays || 30
+    });
+
+    res.json({ status: 'saved', count: body.pipelines.length });
+  });
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/refresh/status:
+   *   get:
+   *     tags: [Pipeline Operations]
+   *     summary: Data collector last-run status
+   *     responses:
+   *       200:
+   *         description: Refresh state
+   */
+  router.get('/refresh/status', requireScope('pipeline-ops:read'), function(req, res) {
+    res.json(refreshState);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/refresh:
+   *   post:
+   *     tags: [Pipeline Operations]
+   *     summary: Trigger pipeline run data collection
+   *     responses:
+   *       200:
+   *         description: Collection started or skipped
+   */
+  router.post('/refresh', requireScope('pipeline-ops:read'), function(req, res) {
+    if (DEMO_MODE) {
+      return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' });
+    }
+    if (refreshState.running) {
+      return res.json({ status: 'already_running', startedAt: refreshState.startedAt });
+    }
+
+    refreshState.running = true;
+    refreshState.startedAt = new Date().toISOString();
+    res.json({ status: 'started' });
+
+    const config = loadConfig();
+    const existingRuns = loadRuns();
+
+    collectPipelineRuns(config, existingRuns)
+      .then(function(result) {
+        writeToStorage('pipeline-ops/runs.json', result.runs);
+
+        if (result.scheduleUpdates && Object.keys(result.scheduleUpdates).length > 0) {
+          const currentConfig = loadConfig();
+          let updated = false;
+          for (const p of currentConfig.pipelines) {
+            const sched = result.scheduleUpdates[p.slug];
+            if (!sched) continue;
+            if (!p.schedule) p.schedule = {};
+            p.schedule.cron = sched.cron;
+            if (sched.expectedIntervalMinutes) {
+              p.schedule.expectedIntervalMinutes = sched.expectedIntervalMinutes;
+            }
+            updated = true;
+          }
+          if (updated) {
+            writeToStorage('pipeline-ops/config.json', currentConfig);
+          }
+        }
+
+        refreshState.lastResult = {
+          finishedAt: new Date().toISOString(),
+          ...result.summary,
+        };
+      })
+      .catch(function(err) {
+        console.error('[pipeline-ops] Refresh failed:', err.message);
+        refreshState.lastResult = {
+          finishedAt: new Date().toISOString(),
+          error: err.message,
+        };
+      })
+      .finally(function() {
+        refreshState.running = false;
+      });
+  });
+
+  /**
+   * @openapi
+   * /api/modules/pipeline-ops/runs/bulk:
+   *   post:
+   *     tags: [Pipeline Operations]
+   *     summary: Bulk ingest run data from external collector (admin)
+   *     responses:
+   *       200:
+   *         description: Run data saved
+   *       400:
+   *         description: Invalid payload
+   */
+  router.post('/runs/bulk', requireAdmin, requireScope('pipeline-ops:write'), function(req, res) {
+    const body = req.body;
+    if (!body || typeof body !== 'object') {
+      return res.status(400).json({ error: 'Request body must be an object keyed by pipeline slug' });
+    }
+
+    const existingRuns = loadRuns();
+    const config = loadConfig();
+    const retentionDays = config.retentionDays || 30;
+    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+    for (const [slug, data] of Object.entries(body)) {
+      if (!Array.isArray(data?.runs)) continue;
+
+      const existingPipelineRuns = existingRuns[slug]?.runs || [];
+      const byId = new Map();
+      for (const run of existingPipelineRuns) byId.set(run.id, run);
+      for (const run of data.runs) byId.set(run.id, run);
+
+      const merged = [...byId.values()]
+        .filter(r => new Date(r.startedAt).getTime() >= cutoff)
+        .sort((a, b) => new Date(b.startedAt) - new Date(a.startedAt));
+
+      existingRuns[slug] = {
+        lastCheckedAt: data.lastCheckedAt || new Date().toISOString(),
+        runs: merged,
+      };
+    }
+
+    writeToStorage('pipeline-ops/runs.json', existingRuns);
+    res.json({ status: 'saved', slugs: Object.keys(body) });
+  });
+
+  context.registerDiagnostics(async function() {
+    const config = loadConfig();
+    const runs = loadRuns();
+    return {
+      pipelineCount: (config.pipelines || []).length,
+      hasRunData: Object.keys(runs).length > 0,
+      retentionDays: config.retentionDays || 30
+    };
+  });
+};


### PR DESCRIPTION
New module providing an operational dashboard for AI-First CI pipelines. Collects run data from GitLab CI (including child pipelines) and GitHub Actions, computes health status, surfaces runner queue bottlenecks, and displays duration/success-rate trend charts.

- Status board with card grid, filtering, grouping, and manual refresh
- Pipeline detail view with run history table and Chart.js trend charts
- Runner queue panel showing waiting jobs, wait times, and runner tags
- Data collector with schedule auto-discovery from GitLab API
- Job filtering via exact names or glob patterns (jobPatterns)
- Health computation: green/yellow/red based on success rate and schedule
- OpenShift CronJob manifest for 30-minute automated collection
- Demo fixtures and full test coverage (server + client)