### PR TITLE
fix(releases): include RHOAI and RHAII GA releases in risk dashboard

### DIFF
--- a/modules/releases/__tests__/server/delivery/product-pages.test.js
+++ b/modules/releases/__tests__/server/delivery/product-pages.test.js
@@ -36,6 +36,160 @@ describe('product-pages', () => {
     })
   })
 
+  describe('extractReleaseDueDate', () => {
+    it('extracts EA1 date from milestones for an EA-specific release', () => {
+      const release = {
+        shortname: 'rhoai-3.5.EA1',
+        major_milestones: [
+          { name: 'rhoai-3.5 EA1 release', date_finish: '2026-06-17' },
+          { name: 'rhoai-3.5 GA', date_finish: '2026-08-20' }
+        ]
+      }
+      expect(productPages.extractReleaseDueDate(release)).toBe('2026-06-17')
+    })
+
+    it('extracts EA2 date from milestones for an EA2-specific release', () => {
+      const release = {
+        shortname: 'rhoai-3.5.EA2',
+        major_milestones: [
+          { name: 'rhoai-3.5 EA1 release', date_finish: '2026-06-17' },
+          { name: 'rhoai-3.5 EA2 release', date_finish: '2026-07-16' },
+          { name: 'rhoai-3.5 GA', date_finish: '2026-08-20' }
+        ]
+      }
+      expect(productPages.extractReleaseDueDate(release)).toBe('2026-07-16')
+    })
+
+    it('falls back to ga_date for EA releases with no matching milestone', () => {
+      const release = {
+        shortname: 'rhoai-3.5.EA1',
+        major_milestones: [],
+        ga_date: '2026-06-17'
+      }
+      expect(productPages.extractReleaseDueDate(release)).toBe('2026-06-17')
+    })
+
+    it('skips draft milestones for EA releases', () => {
+      const release = {
+        shortname: 'rhoai-3.5.EA1',
+        major_milestones: [
+          { name: 'rhoai-3.5 EA1 release', date_finish: '2026-06-17', draft: true }
+        ],
+        ga_date: '2026-06-20'
+      }
+      expect(productPages.extractReleaseDueDate(release)).toBe('2026-06-20')
+    })
+
+    it('falls back to all_ga_tasks when no milestone matches for EA release', () => {
+      const release = {
+        shortname: 'rhoai-3.5.EA1',
+        major_milestones: [],
+        all_ga_tasks: [
+          { name: 'EA1 target', date_finish: '2026-06-17' }
+        ]
+      }
+      expect(productPages.extractReleaseDueDate(release)).toBe('2026-06-17')
+    })
+
+    it('delegates to extractGaDate for GA releases (no EA in shortname)', () => {
+      const release = {
+        shortname: 'rhoai-3.5',
+        major_milestones: [
+          { name: 'rhoai-3.5 GA', date_finish: '2026-08-20' }
+        ]
+      }
+      expect(productPages.extractReleaseDueDate(release)).toBe('2026-08-20')
+    })
+
+    it('returns null when no date can be found for GA release', () => {
+      const release = { shortname: 'rhoai-3.5' }
+      expect(productPages.extractReleaseDueDate(release)).toBeNull()
+    })
+  })
+
+  describe('expandReleaseMilestones', () => {
+    it('expands EA + GA milestones into separate entries (rhelai style)', () => {
+      const release = {
+        shortname: 'rhelai-3.5',
+        major_milestones: [
+          { name: 'rhelai-3.5 EA1 release', date_finish: '2026-06-18' },
+          { name: 'rhelai-3.5 EA2 release', date_finish: '2026-07-16' },
+          { name: 'rhelai-3.5 GA', date_finish: '2026-08-20' }
+        ]
+      }
+      const result = productPages.expandReleaseMilestones(release, 'RHELAI')
+      expect(result).toHaveLength(3)
+      expect(result.map(r => r.releaseNumber)).toEqual([
+        'rhelai-3.5.EA1', 'rhelai-3.5.EA2', 'rhelai-3.5'
+      ])
+    })
+
+    it('expands "GA Release" milestone names (RHAII style)', () => {
+      const release = {
+        shortname: 'RHAII-3.5',
+        major_milestones: [
+          { name: 'RHAI-3.5 EA1 Release', date_finish: '2026-06-17' },
+          { name: 'RHAI-3.5 EA2 Release', date_finish: '2026-07-16' },
+          { name: 'RHAI-3.5 GA Release', date_finish: '2026-08-20' }
+        ]
+      }
+      const result = productPages.expandReleaseMilestones(release, 'RHAII')
+      expect(result).toHaveLength(3)
+      const ga = result.find(r => r.releaseNumber === 'RHAII-3.5')
+      expect(ga).toBeTruthy()
+      expect(ga.dueDate).toBe('2026-08-20')
+    })
+
+    it('excludes noise milestones that happen to mention GA', () => {
+      const release = {
+        shortname: 'RHAII-3.5',
+        major_milestones: [
+          { name: 'RHAI-3.5 EA1 Release', date_finish: '2026-06-17' },
+          { name: 'rpms release 1 month before the 3.5 GA', date_finish: '2026-07-20' },
+          { name: 'RHAII-3.5 GA final RC available', date_finish: '2026-08-06' },
+          { name: 'RHAI-3.5 GA Release', date_finish: '2026-08-20' }
+        ]
+      }
+      const result = productPages.expandReleaseMilestones(release, 'RHAII')
+      const releaseNumbers = result.map(r => r.releaseNumber)
+      expect(releaseNumbers).toContain('RHAII-3.5.EA1')
+      expect(releaseNumbers).toContain('RHAII-3.5')
+      expect(releaseNumbers).not.toContain('RHAII-3.5.GA')
+    })
+
+    it('skips draft milestones', () => {
+      const release = {
+        shortname: 'rhelai-3.5',
+        major_milestones: [
+          { name: 'rhelai-3.5 EA1 release', date_finish: '2026-06-18' },
+          { name: 'rhelai-3.5 GA', date_finish: '2026-08-20', draft: true }
+        ]
+      }
+      const result = productPages.expandReleaseMilestones(release, 'RHELAI')
+      expect(result).toBeNull()
+    })
+
+    it('returns null when only one milestone exists', () => {
+      const release = {
+        shortname: 'rhelai-3.5',
+        major_milestones: [
+          { name: 'rhelai-3.5 GA', date_finish: '2026-08-20' }
+        ]
+      }
+      expect(productPages.expandReleaseMilestones(release, 'RHELAI')).toBeNull()
+    })
+
+    it('returns null when no milestones match EA/GA pattern', () => {
+      const release = {
+        shortname: 'rhelai-3.5',
+        major_milestones: [
+          { name: 'Code Freeze', date_finish: '2026-07-15' }
+        ]
+      }
+      expect(productPages.expandReleaseMilestones(release, 'RHELAI')).toBeNull()
+    })
+  })
+
   describe('extractCodeFreezeDate', () => {
     it('extracts code freeze date from major_milestones', () => {
       const release = {

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -141,6 +141,51 @@ function extractGaDate(release) {
 }
 
 /**
+ * Extracts the due date for any Product Pages release — GA or EA.
+ *
+ * RHOAI publishes separate Product Pages rows per phase (rhoai-3.5.EA1,
+ * rhoai-3.5.EA2, rhoai-3.5), unlike RHELAI/RHAII which bundle phases as
+ * milestones in one row and go through expandReleaseMilestones().
+ *
+ * For EA-specific releases (shortname contains EA1, EA2, etc.), searches
+ * milestones matching that EA tag first, since extractGaDate() intentionally
+ * skips EA milestones.  Falls back to extractGaDate() for GA releases.
+ */
+function extractReleaseDueDate(release) {
+  const shortname = release.shortname || release.name || ''
+  const eaMatch = shortname.match(/\b(EA\d?)\b/i)
+
+  if (eaMatch) {
+    const eaTag = eaMatch[1]
+    const eaPattern = new RegExp(`\\b${eaTag}\\b`, 'i')
+
+    const milestones = release.major_milestones
+    if (Array.isArray(milestones)) {
+      for (const m of milestones) {
+        if (m.draft) continue
+        if (eaPattern.test(m.name || '') && m.date_finish) {
+          return m.date_finish
+        }
+      }
+    }
+
+    const tasks = release.all_ga_tasks
+    if (Array.isArray(tasks)) {
+      for (const t of tasks) {
+        if (eaPattern.test(t.name || '') && t.date_finish) {
+          return t.date_finish
+        }
+      }
+    }
+
+    // ga_date on EA releases often holds the EA target date
+    if (release.ga_date) return release.ga_date
+  }
+
+  return extractGaDate(release)
+}
+
+/**
  * Extracts the code freeze date from a Product Pages release object.
  * Searches major_milestones and all_ga_tasks for entries matching
  * "code freeze" (case-insensitive, with optional hyphen/space).
@@ -224,9 +269,15 @@ function expandReleaseMilestones(r, productName) {
     if (!RELEASE_MILESTONE_PATTERN.test(name)) return false
     // Must be an EA release or a standalone GA milestone
     const isEaRelease = /\bEA\d?\b/i.test(name) && /release|GA\b/i.test(name)
-    // GA milestone: short name ending in "GA" (e.g. "rhelai-3.4 GA", "rhaiis-3.4 GA")
-    // Exclude long descriptive milestones that just happen to mention GA
-    const isGa = /\bGA\s*$/i.test(name) && !/\bEA\d?\b/i.test(name) && name.split(/\s+/).length <= 4
+    // GA milestone: name ending in "GA" or "GA Release" without EA tag.
+    // Matches "rhelai-3.4 GA", "RHAI-3.5 GA Release", but not
+    // "rpms release 1 month before the 3.4 GA" (too long) or
+    // "RHAII-3.5 GA final RC available" (doesn't end in GA/Release).
+    const hasNoEa = !/\bEA\d?\b/i.test(name)
+    const isGa = hasNoEa && (
+      (/\bGA\s*$/i.test(name) && name.split(/\s+/).length <= 4) ||
+      /\bGA\s+Release\s*$/i.test(name)
+    )
     return isEaRelease || isGa
   })
 
@@ -343,15 +394,18 @@ async function fetchProductsByShortname(shortnames, config) {
           continue
         }
 
-        // Single-milestone or no-milestone release — use extractGaDate
-        const gaDate = extractGaDate(r)
-        if (!gaDate) continue
+        // Single-milestone or no-milestone release (e.g. RHOAI per-phase rows)
+        const dueDate = extractReleaseDueDate(r)
+        if (!dueDate) continue
 
+        const releaseNumber = r.shortname || r.name || ''
+        const eaMatch = releaseNumber.match(/\b(EA\d?)\b/i)
+        const eaTag = eaMatch ? eaMatch[1] : null
         releases.push({
           productName,
-          releaseNumber: r.shortname || r.name || '',
-          dueDate: gaDate,
-          codeFreezeDate: extractCodeFreezeDate(r) || null
+          releaseNumber,
+          dueDate,
+          codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null
         })
       }
     } catch (err) {
@@ -434,7 +488,9 @@ module.exports = {
   fetchAllProducts,
   getAuthStatus,
   extractGaDate,
+  extractReleaseDueDate,
   extractCodeFreezeDate,
+  expandReleaseMilestones,
   milestoneToReleaseNumber,
   _resetForTesting
 }


### PR DESCRIPTION
## Summary

- **RHOAI missing from all groups:** RHOAI publishes separate Product Pages rows per phase (`rhoai-3.5.EA1`, `rhoai-3.5.EA2`, `rhoai-3.5`), which bypass `expandReleaseMilestones()`. They fell through to `extractGaDate()`, which intentionally skips EA milestones — silently dropping all RHOAI EA releases. Added `extractReleaseDueDate()` that detects EA releases by shortname and extracts the matching EA milestone date.
- **RHAII GA missing from RHAI 3.5 group:** RHAII bundles all phases in one Product Pages row. Its GA milestone is named `RHAI-3.5 GA Release`, but `expandReleaseMilestones()` required names to **end** with "GA" (`/\bGA\s*$/i`). Relaxed the `isGa` pattern to also match names ending with "GA Release", while still excluding noise like "RHAII-3.5 GA final RC available".
- Also passes `eaTag` to `extractCodeFreezeDate()` for RHOAI per-phase rows so EA releases get phase-specific code freeze dates.

## Test plan

- [x] 13 new unit tests covering `extractReleaseDueDate` (7) and `expandReleaseMilestones` (6)
- [x] All 3,454 existing tests pass
- [x] Lint clean
- [ ] Verify on staging that RHOAI appears in RHAI 3.5.EA1, 3.5.EA2, and 3.5 groups
- [ ] Verify RHAII-3.5 GA appears in the RHAI 3.5 group


Made with [Cursor](https://cursor.com)