### PR TITLE
feat(releases): TV/FV delta analysis pipeline

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,13 +46,23 @@ jobs:
             upstream-pulse:
               - 'modules/upstream-pulse/**'
               - 'tests/integration/upstream-pulse.spec.js'
+            tv-fv-delta:
+              - 'modules/releases/server/tv-fv-delta/**'
+              - 'modules/releases/server/index.js'
+              - 'modules/releases/client/views/TvFvDeltaView.vue'
+              - 'modules/releases/client/composables/use*TvFv*'
+              - 'modules/releases/client/composables/useReleasePicker.js'
+              - 'modules/releases/client/composables/useComponentBreakdown.js'
+              - 'modules/releases/client/components/FeatureTable.vue'
+              - 'modules/releases/client/components/ClickableCount.vue'
+              - 'tests/integration/tv-fv-delta.spec.js'
 
       - name: Build module matrix
         id: build-matrix
         run: |
           # If shared test files changed, then test all modules
           if [ "${{ steps.filter.outputs.shared-test-files }}" == "true" ]; then
-            MODULES='["ai-impact", "system-health", "people-teams", "upstream-pulse"]'
+            MODULES='["ai-impact", "system-health", "people-teams", "upstream-pulse", "tv-fv-delta"]'
           else
             # Otherwise, use the modules that have direct changes
             MODULES='${{ steps.filter.outputs.changes }}'

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -312,7 +312,7 @@ describe('buildExport', () => {
       { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
       { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
-    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
 
     expect(result.metadata.releases).toEqual(['rhoai-3.5']);
     expect(result.metadata.total_features).toBe(2);
@@ -330,7 +330,7 @@ describe('buildExport', () => {
     const classifications = [
       { release: 'rhoai-3.5', category: 'tv_only', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
-    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const jql = decodeURIComponent(result.executive_summary[0].tv_only_jql);
     // Must NOT contain "OR fixVersion not in" — that was the bug
     expect(jql).not.toContain('OR fixVersion not in');
@@ -341,7 +341,7 @@ describe('buildExport', () => {
     const classifications = [
       { release: 'rhoai-3.5', category: 'fv_only', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
-    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const jql = decodeURIComponent(result.executive_summary[0].fv_only_jql);
     expect(jql).not.toContain('OR "Target Version" not in');
     expect(jql).toContain('"Target Version" is EMPTY');
@@ -352,7 +352,7 @@ describe('buildExport', () => {
       { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
       { release: 'rhoai-3.5', category: 'mismatched', key: 'X-2', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
-    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     expect(result.releases['rhoai-3.5'].aligned).toHaveLength(1);
     expect(result.releases['rhoai-3.5'].mismatched).toHaveLength(1);
     expect(result.releases['rhoai-3.5'].tv_only).toHaveLength(0);
@@ -363,7 +363,7 @@ describe('buildExport', () => {
       { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
       { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
     ];
-    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', ['Dashboard', 'Notebooks']);
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', ['Dashboard', 'Notebooks'], 'RHAISTRAT');
     expect(result.component_breakdown).toHaveLength(2);
 
     const dash = result.component_breakdown.find(c => c.component === 'Dashboard');
@@ -381,12 +381,12 @@ describe('buildExport', () => {
       { release: 'v1', category: 'aligned', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
       { release: 'v1', category: 'tv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
-    const result = buildExport(classifications, ['v1'], '2026-01-01T00:00:00Z', []);
+    const result = buildExport(classifications, ['v1'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     expect(result.executive_summary[0].alignment_pct).toBe(66.7);
   });
 
   it('handles empty classifications gracefully', () => {
-    const result = buildExport([], ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const result = buildExport([], ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     expect(result.executive_summary[0].total).toBe(0);
     expect(result.executive_summary[0].alignment_pct).toBe(0);
     expect(result.releases['rhoai-3.5']).toBeDefined();

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -1,0 +1,404 @@
+import { describe, it, expect } from 'vitest';
+
+const {
+  normVer,
+  parseVersions,
+  extractVersionNames,
+  isZStream,
+  normalizeIssue,
+  classifyFeatures,
+  buildExport,
+  DEFAULT_RELEASES,
+} = require('../../../server/tv-fv-delta/routes');
+
+// ---------------------------------------------------------------------------
+// normVer
+// ---------------------------------------------------------------------------
+
+describe('normVer', () => {
+  it('lowercases version strings', () => {
+    expect(normVer('RHOAI-3.5')).toBe('rhoai-3.5');
+  });
+
+  it('normalises RHOAI_ prefix to rhoai- format', () => {
+    expect(normVer('RHOAI_3_5')).toBe('rhoai-3.5');
+  });
+
+  it('strips .0 from RHOAI_ prefixed versions', () => {
+    expect(normVer('RHOAI_3.0_5')).toBe('rhoai-3.5');
+  });
+
+  it('trims whitespace', () => {
+    expect(normVer('  rhoai-3.5  ')).toBe('rhoai-3.5');
+  });
+
+  it('returns null for empty, null, undefined, or "null"/"undefined" strings', () => {
+    expect(normVer(null)).toBeNull();
+    expect(normVer(undefined)).toBeNull();
+    expect(normVer('')).toBeNull();
+    expect(normVer('null')).toBeNull();
+    expect(normVer('undefined')).toBeNull();
+  });
+
+  it('leaves already-lowercase versions unchanged', () => {
+    expect(normVer('rhoai-3.5.ea1')).toBe('rhoai-3.5.ea1');
+  });
+
+  it('does not strip .0 from double-digit major versions (RHOAI_10.0_5)', () => {
+    expect(normVer('RHOAI_10.0_5')).toBe('rhoai-10.5');
+  });
+
+  it('handles lowercase rhoai_ prefix', () => {
+    expect(normVer('rhoai_3_5')).toBe('rhoai-3.5');
+  });
+
+  it('handles mixed case rhoai_ prefix', () => {
+    expect(normVer('Rhoai_3_5')).toBe('rhoai-3.5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVersions
+// ---------------------------------------------------------------------------
+
+describe('parseVersions', () => {
+  it('returns empty set for falsy input', () => {
+    expect(parseVersions(null).size).toBe(0);
+    expect(parseVersions('').size).toBe(0);
+    expect(parseVersions(undefined).size).toBe(0);
+  });
+
+  it('parses comma-separated version strings', () => {
+    const result = parseVersions('rhoai-3.5, rhoai-3.5.EA1');
+    expect(result.size).toBe(2);
+    expect(result.has('rhoai-3.5')).toBe(true);
+    expect(result.has('rhoai-3.5.ea1')).toBe(true);
+  });
+
+  it('normalises each version', () => {
+    const result = parseVersions('RHOAI_3_5');
+    expect(result.has('rhoai-3.5')).toBe(true);
+  });
+
+  it('filters out null results from normalisation', () => {
+    const result = parseVersions('rhoai-3.5, , null');
+    expect(result.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractVersionNames
+// ---------------------------------------------------------------------------
+
+describe('extractVersionNames', () => {
+  it('extracts names from fixVersions array', () => {
+    const result = extractVersionNames([{ name: 'rhoai-3.5' }, { name: 'rhoai-3.5.EA1' }]);
+    expect(result).toBe('rhoai-3.5, rhoai-3.5.EA1');
+  });
+
+  it('returns empty string for non-array input', () => {
+    expect(extractVersionNames(null)).toBe('');
+    expect(extractVersionNames(undefined)).toBe('');
+    expect(extractVersionNames('string')).toBe('');
+  });
+
+  it('handles objects without name property', () => {
+    expect(extractVersionNames([{}, { name: 'v1' }])).toBe('v1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isZStream
+// ---------------------------------------------------------------------------
+
+describe('isZStream', () => {
+  it('detects z-stream patch releases', () => {
+    expect(isZStream('rhoai-3.4.1')).toBe(true);
+    expect(isZStream('rhoai-3.5.2')).toBe(true);
+    expect(isZStream('rhoai-2.16.3')).toBe(true);
+    expect(isZStream('RHOAI-3.4.1')).toBe(true);
+  });
+
+  it('does not flag GA releases', () => {
+    expect(isZStream('rhoai-3.5')).toBe(false);
+    expect(isZStream('rhoai-3.4')).toBe(false);
+  });
+
+  it('does not flag EA releases', () => {
+    expect(isZStream('rhoai-3.5.EA1')).toBe(false);
+    expect(isZStream('rhoai-3.5.EA2')).toBe(false);
+    expect(isZStream('rhoai-3.5.ea1')).toBe(false);
+  });
+
+  it('returns false for null/undefined/empty', () => {
+    expect(isZStream(null)).toBe(false);
+    expect(isZStream(undefined)).toBe(false);
+    expect(isZStream('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeIssue
+// ---------------------------------------------------------------------------
+
+describe('normalizeIssue', () => {
+  const JIRA_BROWSE = 'https://redhat.atlassian.net/browse';
+
+  function makeIssue(overrides = {}) {
+    return {
+      key: 'RHAISTRAT-100',
+      fields: {
+        summary: 'Test feature',
+        status: { name: 'In Progress' },
+        fixVersions: [{ name: 'rhoai-3.5' }],
+        components: [{ name: 'Dashboard' }],
+        assignee: { displayName: 'Jane Doe' },
+        customfield_10855: [{ name: 'rhoai-3.5' }], // Target Version
+        customfield_10712: { value: 'Green' }, // Color Status
+        customfield_10469: { displayName: 'John PM' }, // Product Manager
+        ...overrides,
+      },
+    };
+  }
+
+  it('extracts key, url, and summary', () => {
+    const result = normalizeIssue(makeIssue());
+    expect(result.key).toBe('RHAISTRAT-100');
+    expect(result.url).toBe(JIRA_BROWSE + '/RHAISTRAT-100');
+    expect(result.summary).toBe('Test feature');
+  });
+
+  it('truncates long summaries to 120 chars', () => {
+    const result = normalizeIssue(makeIssue({ summary: 'A'.repeat(200) }));
+    expect(result.summary.length).toBe(120);
+  });
+
+  it('extracts target version from array of objects', () => {
+    const result = normalizeIssue(makeIssue());
+    expect(result.target_version).toBe('rhoai-3.5');
+    expect(result.tv_set.has('rhoai-3.5')).toBe(true);
+  });
+
+  it('extracts target version from string', () => {
+    const result = normalizeIssue(makeIssue({ customfield_10855: 'rhoai-3.5' }));
+    expect(result.target_version).toBe('rhoai-3.5');
+  });
+
+  it('extracts target version from object with value', () => {
+    const result = normalizeIssue(makeIssue({ customfield_10855: { value: 'rhoai-3.5' } }));
+    expect(result.target_version).toBe('rhoai-3.5');
+  });
+
+  it('extracts fix versions', () => {
+    const result = normalizeIssue(makeIssue());
+    expect(result.fix_versions).toBe('rhoai-3.5');
+    expect(result.fv_set.has('rhoai-3.5')).toBe(true);
+  });
+
+  it('extracts components', () => {
+    const result = normalizeIssue(makeIssue());
+    expect(result.components).toEqual(['Dashboard']);
+    expect(result.component).toBe('Dashboard');
+  });
+
+  it('handles missing fields gracefully', () => {
+    const result = normalizeIssue({ key: 'X-1', fields: {} });
+    expect(result.target_version).toBe('');
+    expect(result.fix_versions).toBe('');
+    expect(result.status).toBe('');
+    expect(result.assignee).toBe('');
+    expect(result.color_status).toBe('');
+    expect(result.product_manager).toBe('');
+    expect(result.components).toEqual([]);
+  });
+
+  it('handles color status as string', () => {
+    const result = normalizeIssue(makeIssue({ customfield_10712: 'Red' }));
+    expect(result.color_status).toBe('Red');
+  });
+
+  it('handles product manager as string', () => {
+    const result = normalizeIssue(makeIssue({ customfield_10469: 'Jane PM' }));
+    expect(result.product_manager).toBe('Jane PM');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyFeatures
+// ---------------------------------------------------------------------------
+
+describe('classifyFeatures', () => {
+  function makeFeat(tv, fv) {
+    return {
+      key: 'X-1',
+      url: '',
+      summary: 'test',
+      status: '',
+      target_version: tv,
+      fix_versions: fv,
+      tv_set: parseVersions(tv),
+      fv_set: parseVersions(fv),
+      color_status: '',
+      product_manager: '',
+      assignee: '',
+      components: [],
+      component: '',
+    };
+  }
+
+  it('classifies aligned features (TV == FV)', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned');
+  });
+
+  it('classifies tv_only (TV set, no FV at all)', () => {
+    const feats = [makeFeat('rhoai-3.5', '')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('tv_only');
+  });
+
+  it('classifies fv_only (FV set, no TV at all)', () => {
+    const feats = [makeFeat('', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('fv_only');
+  });
+
+  it('classifies mismatched (TV set, FV set to different release)', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5.EA1')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('mismatched');
+  });
+
+  it('classifies mismatched (FV set, TV set to different release)', () => {
+    const feats = [makeFeat('rhoai-3.5.EA1', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('mismatched');
+  });
+
+  it('skips features with no match to any release', () => {
+    const feats = [makeFeat('rhoai-3.4', 'rhoai-3.4')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(0);
+  });
+
+  it('creates one classification per release match', () => {
+    const feats = [makeFeat('rhoai-3.5, rhoai-3.5.EA1', 'rhoai-3.5, rhoai-3.5.EA1')];
+    const result = classifyFeatures(feats, ['rhoai-3.5', 'rhoai-3.5.EA1']);
+    expect(result).toHaveLength(2);
+    expect(result.every(r => r.category === 'aligned')).toBe(true);
+  });
+
+  it('handles case-insensitive matching via normVer', () => {
+    const feats = [makeFeat('RHOAI-3.5', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildExport
+// ---------------------------------------------------------------------------
+
+describe('buildExport', () => {
+  it('produces executive_summary with correct structure', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+
+    expect(result.metadata.releases).toEqual(['rhoai-3.5']);
+    expect(result.metadata.total_features).toBe(2);
+    expect(result.executive_summary).toHaveLength(1);
+
+    const summary = result.executive_summary[0];
+    expect(summary.release).toBe('rhoai-3.5');
+    expect(summary.total).toBe(2);
+    expect(summary.aligned).toBe(1);
+    expect(summary.tv_only).toBe(1);
+    expect(summary.alignment_pct).toBe(50);
+  });
+
+  it('generates correct JQL links for tv_only (fixVersion is EMPTY, not OR)', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const jql = decodeURIComponent(result.executive_summary[0].tv_only_jql);
+    // Must NOT contain "OR fixVersion not in" — that was the bug
+    expect(jql).not.toContain('OR fixVersion not in');
+    expect(jql).toContain('fixVersion is EMPTY');
+  });
+
+  it('generates correct JQL links for fv_only (Target Version is EMPTY, not OR)', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'fv_only', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    const jql = decodeURIComponent(result.executive_summary[0].fv_only_jql);
+    expect(jql).not.toContain('OR "Target Version" not in');
+    expect(jql).toContain('"Target Version" is EMPTY');
+  });
+
+  it('buckets features into per-release category lists', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'mismatched', key: 'X-2', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    expect(result.releases['rhoai-3.5'].aligned).toHaveLength(1);
+    expect(result.releases['rhoai-3.5'].mismatched).toHaveLength(1);
+    expect(result.releases['rhoai-3.5'].tv_only).toHaveLength(0);
+  });
+
+  it('builds component breakdown from classifications', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', ['Dashboard', 'Notebooks']);
+    expect(result.component_breakdown).toHaveLength(2);
+
+    const dash = result.component_breakdown.find(c => c.component === 'Dashboard');
+    expect(dash.total).toBe(2);
+    expect(dash.aligned).toBe(1);
+    expect(dash.tv_only).toBe(1);
+
+    const nb = result.component_breakdown.find(c => c.component === 'Notebooks');
+    expect(nb.total).toBe(0);
+  });
+
+  it('computes alignment_pct correctly', () => {
+    const classifications = [
+      { release: 'v1', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'v1', category: 'aligned', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'v1', category: 'tv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['v1'], '2026-01-01T00:00:00Z', []);
+    expect(result.executive_summary[0].alignment_pct).toBe(66.7);
+  });
+
+  it('handles empty classifications gracefully', () => {
+    const result = buildExport([], ['rhoai-3.5'], '2026-01-01T00:00:00Z', []);
+    expect(result.executive_summary[0].total).toBe(0);
+    expect(result.executive_summary[0].alignment_pct).toBe(0);
+    expect(result.releases['rhoai-3.5']).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_RELEASES
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_RELEASES', () => {
+  it('contains EA1, EA2, and GA in that order', () => {
+    expect(DEFAULT_RELEASES).toEqual(['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']);
+  });
+});

--- a/modules/releases/client/components/ClickableCount.vue
+++ b/modules/releases/client/components/ClickableCount.vue
@@ -1,0 +1,51 @@
+<script setup>
+defineProps({
+  count: { type: Number, required: true },
+  jql: { type: String, default: '' },
+  items: { type: Array, default: () => [] },
+  color: { type: String, default: '' },
+  label: { type: String, default: '' },
+})
+
+const emit = defineEmits(['drill-down'])
+</script>
+
+<template>
+  <a
+    v-if="jql"
+    :href="jql"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="inline-flex items-center gap-1 font-semibold underline decoration-dotted hover:decoration-solid cursor-pointer transition-colors"
+    :class="{
+      'text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300': color === 'red',
+      'text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300': color === 'yellow',
+      'text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300': color === 'green',
+      'text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300': !color || color === 'default',
+      'text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300': color === 'muted',
+    }"
+    :title="label ? `${label}: ${count} — click to view in Jira` : `${count} — click to view in Jira`"
+  >
+    {{ count }}
+    <svg class="w-3 h-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+    </svg>
+  </a>
+  <button
+    v-else-if="items.length > 0"
+    class="font-semibold underline decoration-dotted hover:decoration-solid cursor-pointer transition-colors"
+    :class="{
+      'text-red-600 dark:text-red-400': color === 'red',
+      'text-yellow-600 dark:text-yellow-400': color === 'yellow',
+      'text-green-600 dark:text-green-400': color === 'green',
+      'text-blue-600 dark:text-blue-400': !color || color === 'default',
+    }"
+    :title="label ? `${label}: ${count} — click to see list` : `${count} — click to see list`"
+    @click="emit('drill-down', items)"
+  >
+    {{ count }}
+  </button>
+  <span v-else class="font-semibold text-gray-600 dark:text-gray-400">
+    {{ count }}
+  </span>
+</template>

--- a/modules/releases/client/components/FeatureTable.vue
+++ b/modules/releases/client/components/FeatureTable.vue
@@ -1,0 +1,164 @@
+<script setup>
+import { ref, computed } from 'vue'
+
+function parentKeyUrl(feat) {
+  if (feat.url) {
+    const base = feat.url.substring(0, feat.url.lastIndexOf('/'))
+    return base + '/' + feat.parent_key
+  }
+  return 'https://redhat.atlassian.net/browse/' + feat.parent_key
+}
+
+const props = defineProps({
+  features: { type: Array, required: true },
+  columns: {
+    type: Array,
+    default: () => ['key', 'summary', 'status', 'color_status', 'assignee'],
+  },
+  title: { type: String, default: '' },
+  maxRows: { type: Number, default: 0 },
+})
+
+const sortCol = ref(null)
+const sortDir = ref('asc')
+
+function toggleSort(col) {
+  if (sortCol.value === col) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortCol.value = col
+    sortDir.value = 'asc'
+  }
+}
+
+const sortedFeatures = computed(() => {
+  if (!sortCol.value) return props.features
+  const col = sortCol.value
+  const dir = sortDir.value === 'asc' ? 1 : -1
+  return [...props.features].sort((a, b) => {
+    const va = (a[col] ?? '')
+    const vb = (b[col] ?? '')
+    if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir
+    return String(va).localeCompare(String(vb)) * dir
+  })
+})
+
+const columnLabels = {
+  key: 'Key',
+  summary: 'Summary',
+  status: 'Status',
+  color_status: 'Color',
+  assignee: 'Assignee',
+  team: 'Team',
+  days_since_update: 'Days Stale',
+  parent_key: 'Outcome',
+  has_status_summary: 'Has Summary',
+  hops: 'Hops',
+  hop_path: 'Drift Path',
+  product_manager: 'PM',
+  target_version: 'TV',
+  fix_versions: 'FV',
+  component: 'Component',
+}
+
+function colorBadgeClass(color) {
+  const c = (color || '').toLowerCase()
+  if (c === 'red') return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+  if (c === 'yellow') return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
+  if (c === 'green') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+}
+</script>
+
+<template>
+  <div>
+    <h4 v-if="title" class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+      {{ title }} ({{ features.length }})
+    </h4>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm border border-gray-200 dark:border-gray-700">
+        <thead>
+          <tr class="bg-gray-50 dark:bg-gray-800">
+            <th
+              v-for="col in columns"
+              :key="col"
+              class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+              @click="toggleSort(col)"
+            >
+              {{ columnLabels[col] || col }}
+              <span v-if="sortCol === col" class="ml-0.5">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+          <tr
+            v-for="(feat, idx) in (maxRows > 0 ? sortedFeatures.slice(0, maxRows) : sortedFeatures)"
+            :key="feat.key || idx"
+            class="hover:bg-gray-50 dark:hover:bg-gray-800/50"
+          >
+            <td
+              v-for="col in columns"
+              :key="col"
+              class="px-3 py-2 whitespace-nowrap"
+            >
+              <!-- Key column: clickable link to Jira -->
+              <a
+                v-if="col === 'key' && feat.url"
+                :href="feat.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-blue-600 dark:text-blue-400 hover:underline font-mono text-xs"
+              >
+                {{ feat.key }}
+              </a>
+              <!-- Summary: truncated, full on hover -->
+              <span
+                v-else-if="col === 'summary'"
+                class="max-w-xs truncate block"
+                :title="feat.summary"
+              >
+                {{ feat.summary }}
+              </span>
+              <!-- Color status: badge -->
+              <span
+                v-else-if="col === 'color_status' && feat.color_status"
+                class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
+                :class="colorBadgeClass(feat.color_status)"
+              >
+                {{ feat.color_status }}
+              </span>
+              <!-- Boolean columns -->
+              <span
+                v-else-if="col === 'has_status_summary'"
+                class="text-xs"
+                :class="feat[col] ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'"
+              >
+                {{ feat[col] ? 'Yes' : 'No' }}
+              </span>
+              <!-- Parent key: link to Jira -->
+              <a
+                v-else-if="col === 'parent_key' && feat.parent_key"
+                :href="parentKeyUrl(feat)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-blue-600 dark:text-blue-400 hover:underline font-mono text-xs"
+              >
+                {{ feat.parent_key }}
+              </a>
+              <!-- Default: plain text -->
+              <span v-else class="text-gray-700 dark:text-gray-300 text-xs">
+                {{ feat[col] ?? '' }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p
+      v-if="maxRows > 0 && features.length > maxRows"
+      class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+    >
+      Showing {{ maxRows }} of {{ features.length }} features
+    </p>
+  </div>
+</template>

--- a/modules/releases/client/composables/useComponentBreakdown.js
+++ b/modules/releases/client/composables/useComponentBreakdown.js
@@ -1,0 +1,61 @@
+import { computed } from 'vue'
+
+/** Per-release component breakdown computation. */
+export function useComponentBreakdown(data, releaseData) {
+  const releaseComponentBreakdown = computed(() => {
+    if (!releaseData.value || !data.value) return []
+
+    const allFeatures = [
+      ...releaseData.value.aligned.map(f => ({ ...f, category: 'aligned' })),
+      ...releaseData.value.tv_only.map(f => ({ ...f, category: 'tv_only' })),
+      ...releaseData.value.fv_only.map(f => ({ ...f, category: 'fv_only' })),
+      ...releaseData.value.mismatched.map(f => ({ ...f, category: 'mismatched' })),
+    ]
+
+    const compMap = {}
+    for (const feat of allFeatures) {
+      const comps = Array.isArray(feat.components)
+        ? feat.components
+        : (feat.component ? feat.component.split(', ').map(c => c.trim()).filter(Boolean) : [])
+      for (const comp of comps) {
+        if (!compMap[comp]) {
+          compMap[comp] = {
+            component: comp, total: 0, aligned: 0,
+            tv_only: 0, fv_only: 0, mismatched: 0, keys: new Set(),
+          }
+        }
+        if (!compMap[comp].keys.has(feat.key)) {
+          compMap[comp].keys.add(feat.key)
+          compMap[comp].total++
+          compMap[comp][feat.category]++
+        }
+      }
+    }
+
+    const allComponentNames = data.value.metadata?.all_components || []
+
+    let compList
+    if (allComponentNames.length > 0) {
+      compList = allComponentNames.map(compName => {
+        const c = compMap[compName]
+        if (!c) {
+          return { component: compName, total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 0 }
+        }
+        return {
+          component: compName, total: c.total, aligned: c.aligned,
+          tv_only: c.tv_only, fv_only: c.fv_only, mismatched: c.mismatched,
+          alignment_pct: c.total ? Math.round(1000 * c.aligned / c.total) / 10 : 0,
+        }
+      })
+    } else {
+      compList = Object.values(compMap).map(c => ({
+        component: c.component, total: c.total, aligned: c.aligned, tv_only: c.tv_only, fv_only: c.fv_only, mismatched: c.mismatched,
+        alignment_pct: c.total ? Math.round(1000 * c.aligned / c.total) / 10 : 0,
+      }))
+    }
+
+    return compList.sort((a, b) => b.total - a.total || a.component.localeCompare(b.component))
+  })
+
+  return { releaseComponentBreakdown }
+}

--- a/modules/releases/client/composables/useReleasePicker.js
+++ b/modules/releases/client/composables/useReleasePicker.js
@@ -1,0 +1,145 @@
+import { ref, computed } from 'vue'
+
+/** Release picker state and logic. */
+export function useReleasePicker(data, registryReleases, jiraVersions) {
+  const chosenReleases = ref([])
+  const pickerOpen = ref(false)
+  const pickerRef = ref(null)
+  const chosenVersionNames = ref(new Set())
+  const versionSearch = ref('')
+
+  /** Pick the next N releases whose code freeze is in the future (or most recent if all past) */
+  function autoSelectReleases(releases, count = 3) {
+    const now = Date.now()
+    const withDates = releases
+      .filter(r => r.state === 'active' && r.fixVersions?.length)
+      .map(r => ({
+        ...r,
+        freezeTs: r.milestones?.codeFreeze ? new Date(r.milestones.codeFreeze).getTime() : null,
+        gaTs: r.milestones?.ga ? new Date(r.milestones.ga).getTime() : null,
+      }))
+
+    const upcoming = withDates
+      .filter(r => r.freezeTs && r.freezeTs > now)
+      .sort((a, b) => a.freezeTs - b.freezeTs)
+
+    if (upcoming.length >= count) return upcoming.slice(0, count)
+
+    const past = withDates
+      .filter(r => !r.freezeTs || r.freezeTs <= now)
+      .sort((a, b) => (b.freezeTs || 0) - (a.freezeTs || 0))
+
+    return [...upcoming, ...past].slice(0, count)
+  }
+
+  function formatDate(dateStr) {
+    if (!dateStr) return ''
+    return new Date(dateStr).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  }
+
+  /** Whether a version is present in the currently loaded data */
+  function isInCurrentData(name) {
+    return data.value?.metadata?.releases?.includes(name) ?? false
+  }
+
+  /** All available versions for the dropdown — registry releases + Jira versions, deduplicated */
+  const availableVersions = computed(() => {
+    const seen = new Set()
+    const result = []
+
+    for (const rel of registryReleases.value) {
+      for (const fv of (rel.fixVersions || [])) {
+        if (!seen.has(fv)) {
+          seen.add(fv)
+          result.push({
+            name: fv,
+            displayName: rel.displayName,
+            codeFreeze: rel.milestones?.codeFreeze || null,
+            source: 'registry',
+          })
+        }
+      }
+    }
+
+    for (const v of jiraVersions.value) {
+      if (!seen.has(v.name)) {
+        seen.add(v.name)
+        result.push({
+          name: v.name,
+          displayName: v.name,
+          codeFreeze: null,
+          releaseDate: v.releaseDate,
+          released: v.released,
+          source: 'jira',
+        })
+      }
+    }
+
+    return result
+  })
+
+  /** Filtered versions for the dropdown search */
+  const filteredVersions = computed(() => {
+    const q = versionSearch.value.toLowerCase().trim()
+    if (!q) return availableVersions.value
+    return availableVersions.value.filter(v => v.name.toLowerCase().includes(q) || v.displayName.toLowerCase().includes(q))
+  })
+
+  /** The version name strings that are currently selected */
+  const allSelectedVersions = computed(() => [...chosenVersionNames.value])
+
+  function toggleVersion(name) {
+    const s = new Set(chosenVersionNames.value)
+    if (s.has(name)) {
+      s.delete(name)
+    } else {
+      s.add(name)
+    }
+    chosenVersionNames.value = s
+  }
+
+  function removeVersion(name) {
+    const s = new Set(chosenVersionNames.value)
+    s.delete(name)
+    chosenVersionNames.value = s
+    // Keep a release object only if it has other fixVersions still selected
+    chosenReleases.value = chosenReleases.value.filter(r => {
+      const fvs = r.fixVersions || []
+      const wasRelevant = fvs.includes(name)
+      const hasOtherSelected = fvs.some(fv => fv !== name && s.has(fv))
+      return !wasRelevant || hasOtherSelected
+    })
+  }
+
+  /** Enrich chosen version names with display info */
+  const chosenVersionsDisplay = computed(() => {
+    return allSelectedVersions.value.map(name => {
+      const info = availableVersions.value.find(v => v.name === name)
+      return info || { name, displayName: name, source: 'manual' }
+    })
+  })
+
+  function handleClickOutside(e) {
+    if (pickerRef.value && !pickerRef.value.contains(e.target)) {
+      pickerOpen.value = false
+    }
+  }
+
+  return {
+    chosenReleases,
+    pickerOpen,
+    pickerRef,
+    chosenVersionNames,
+    versionSearch,
+    availableVersions,
+    filteredVersions,
+    allSelectedVersions,
+    chosenVersionsDisplay,
+    autoSelectReleases,
+    formatDate,
+    isInCurrentData,
+    toggleVersion,
+    removeVersion,
+    handleClickOutside,
+  }
+}

--- a/modules/releases/client/composables/useTvFvData.js
+++ b/modules/releases/client/composables/useTvFvData.js
@@ -129,6 +129,7 @@ export function useTvFvData() {
         }
       }, 3000)
     } catch (e) {
+      console.warn('[useTvFvData] triggerRefresh failed:', e.message)
       refreshing.value = false
       // Only show error if no data to display (avoid hiding valid data on 403)
       if (!data.value) error.value = e.message

--- a/modules/releases/client/composables/useTvFvData.js
+++ b/modules/releases/client/composables/useTvFvData.js
@@ -1,0 +1,158 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client'
+
+const MAX_POLL_RETRIES = 24 // 24 x 5s = 2 minutes max
+
+/** TV/FV delta data fetching, refresh, and polling. */
+export function useTvFvData() {
+  const data = ref(null)
+  const loading = ref(true)
+  const error = ref(null)
+  const refreshing = ref(false)
+  const selectedRelease = ref('')
+
+  // Owned refs for registry and version data
+  const registryReleases = ref([])
+  const jiraVersions = ref([])
+
+  let pipelinePollTimeout = null
+  let refreshPollInterval = null
+  let pollRetryCount = 0
+  let _alive = true // unmount guard
+
+  async function fetchRegistry() {
+    try {
+      const result = await apiRequest('/modules/releases/registry')
+      registryReleases.value = (result.releases || []).filter(r => r.state === 'active')
+      return registryReleases.value
+    } catch (e) {
+      console.warn('[useTvFvData] fetchRegistry failed:', e.message)
+      return []
+    }
+  }
+
+  async function fetchVersions() {
+    try {
+      const result = await apiRequest('/modules/releases/tv-fv-delta/versions')
+      jiraVersions.value = result.versions || []
+    } catch (e) {
+      console.warn('[useTvFvData] fetchVersions failed:', e.message)
+    }
+  }
+
+  async function fetchData() {
+    if (!_alive) return
+    try {
+      const result = await apiRequest('/modules/releases/tv-fv-delta')
+      if (!_alive) return
+      if (result._noCache) {
+        loading.value = false
+        refreshing.value = true
+        pollRetryCount++
+        if (pollRetryCount < MAX_POLL_RETRIES) {
+          if (pipelinePollTimeout) clearTimeout(pipelinePollTimeout)
+          pipelinePollTimeout = setTimeout(fetchData, 5000)
+        } else {
+          error.value = 'Data pipeline is taking too long. Try refreshing manually.'
+          refreshing.value = false
+          loading.value = false
+        }
+        return
+      }
+      pollRetryCount = 0
+      error.value = null
+      data.value = result
+      refreshing.value = !!result._refreshing
+      loading.value = false
+
+      // Poll to detect when background refresh completes
+      if (result._refreshing && !refreshPollInterval) {
+        refreshPollInterval = setInterval(async () => {
+          if (!_alive) { clearInterval(refreshPollInterval); refreshPollInterval = null; return }
+          try {
+            const status = await apiRequest('/modules/releases/tv-fv-delta/refresh/status')
+            if (!status.running) {
+              clearInterval(refreshPollInterval)
+              refreshPollInterval = null
+              await fetchData()
+            }
+          } catch (e) {
+            console.warn('[useTvFvData] refresh status poll failed:', e.message)
+            clearInterval(refreshPollInterval)
+            refreshPollInterval = null
+            refreshing.value = false
+          }
+        }, 5000)
+      }
+      if (result.metadata?.releases?.length && !selectedRelease.value) {
+        selectedRelease.value = result.metadata.releases[0]
+      }
+    } catch (e) {
+      if (!_alive) return
+      error.value = e.message
+      loading.value = false
+      refreshing.value = false
+      pollRetryCount = 0
+    }
+  }
+
+  async function triggerRefresh(releases) {
+    if (refreshing.value) return
+    refreshing.value = true
+    try {
+      const versions = releases?.value ?? releases ?? []
+      const body = versions.length
+        ? { releases: versions }
+        : {}
+      await apiRequest('/modules/releases/tv-fv-delta/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (refreshPollInterval) { clearInterval(refreshPollInterval); refreshPollInterval = null }
+      refreshPollInterval = setInterval(async () => {
+        if (!_alive) { clearInterval(refreshPollInterval); refreshPollInterval = null; return }
+        try {
+          const status = await apiRequest('/modules/releases/tv-fv-delta/refresh/status')
+          if (!status.running) {
+            clearInterval(refreshPollInterval)
+            refreshPollInterval = null
+            refreshing.value = false
+            selectedRelease.value = ''
+            await fetchData()
+          }
+        } catch (e) {
+          console.warn('[useTvFvData] refresh status poll failed:', e.message)
+          clearInterval(refreshPollInterval)
+          refreshPollInterval = null
+          refreshing.value = false
+        }
+      }, 3000)
+    } catch (e) {
+      refreshing.value = false
+      // Only show error if no data to display (avoid hiding valid data on 403)
+      if (!data.value) error.value = e.message
+    }
+  }
+
+  function cleanup() {
+    _alive = false
+    if (pipelinePollTimeout) clearTimeout(pipelinePollTimeout)
+    if (refreshPollInterval) clearInterval(refreshPollInterval)
+  }
+
+  return {
+    data,
+    loading,
+    error,
+    refreshing,
+    selectedRelease,
+    registryReleases,
+    jiraVersions,
+    fetchRegistry,
+    fetchVersions,
+    fetchData,
+    triggerRefresh,
+    cleanup,
+  }
+}

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -18,5 +18,11 @@ export const reports = [
     label: 'Program Hygiene Report',
     description: 'Cross-version hygiene summary with violation breakdowns by rule, team, and version. Designed for program-level reporting.',
     component: defineAsyncComponent(() => import('./ProgramHygieneReport.vue'))
+  },
+  {
+    id: 'tv-fv-delta',
+    label: 'TV vs FV Delta',
+    description: 'Target Version (PM intent) vs Fix Version (engineering commitment) — alignment, mismatches, and component breakdown.',
+    component: defineAsyncComponent(() => import('../views/TvFvDeltaView.vue'))
   }
 ]

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -1,0 +1,456 @@
+<script setup>
+import { computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import ClickableCount from '../components/ClickableCount.vue'
+import FeatureTable from '../components/FeatureTable.vue'
+import { useReleasePicker } from '../composables/useReleasePicker'
+import { useComponentBreakdown } from '../composables/useComponentBreakdown'
+import { useTvFvData } from '../composables/useTvFvData'
+
+const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
+
+// ---------------------------------------------------------------------------
+// Composables
+// ---------------------------------------------------------------------------
+
+// Data fetching needs allSelectedVersions from picker, but picker needs data from fetching.
+// We initialise data first (useTvFvData creates the ref), then pass it to the picker.
+const {
+  data, loading, error, refreshing, selectedRelease,
+  registryReleases, jiraVersions,
+  fetchRegistry, fetchVersions, fetchData, triggerRefresh, cleanup,
+} = useTvFvData()
+
+const {
+  chosenReleases, pickerOpen, pickerRef,
+  chosenVersionNames, versionSearch,
+  availableVersions, filteredVersions, allSelectedVersions,
+  chosenVersionsDisplay,
+  autoSelectReleases, formatDate, isInCurrentData,
+  toggleVersion, removeVersion, handleClickOutside,
+} = useReleasePicker(data, registryReleases, jiraVersions)
+
+// Wrap triggerRefresh to pass the picker's allSelectedVersions
+const doRefresh = () => triggerRefresh(allSelectedVersions)
+
+const releaseData = computed(() => {
+  if (!data.value || !selectedRelease.value) return null
+  return data.value.releases[selectedRelease.value]
+})
+
+const releaseSummary = computed(() => {
+  if (!data.value) return null
+  return data.value.executive_summary.find(s => s.release === selectedRelease.value)
+})
+
+const filteredSummary = computed(() => {
+  if (!data.value) return []
+  const summary = data.value.executive_summary
+  if (!chosenVersionNames.value.size) return summary
+
+  // Start with data rows that match chosen versions
+  const rows = summary.filter(row => chosenVersionNames.value.has(row.release))
+
+  // Add placeholder rows for chosen versions not yet in data (pending refresh)
+  const existingReleases = new Set(summary.map(r => r.release))
+  for (const name of chosenVersionNames.value) {
+    if (!existingReleases.has(name)) {
+      rows.push({
+        release: name, total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0,
+        alignment_pct: 0, _pending: true,
+      })
+    }
+  }
+  return rows
+})
+
+const { releaseComponentBreakdown } = useComponentBreakdown(data, releaseData)
+
+// ---------------------------------------------------------------------------
+// Auto-refresh when selection includes releases not yet in data
+// ---------------------------------------------------------------------------
+
+let refreshDebounce = null
+
+watch(chosenVersionNames, (names) => {
+  if (!names.size || !data.value) return
+  const existing = new Set(data.value.metadata?.releases || [])
+  const hasNew = [...names].some(n => !existing.has(n))
+  if (!hasNew) return
+
+  if (refreshDebounce) clearTimeout(refreshDebounce)
+  refreshDebounce = setTimeout(() => doRefresh(), 800)
+})
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+onMounted(async () => {
+  document.addEventListener('click', handleClickOutside)
+  await Promise.all([fetchRegistry(), fetchVersions()])
+  // Seed picker from registry auto-selection
+  if (!chosenReleases.value.length && registryReleases.value.length) {
+    const auto = autoSelectReleases(registryReleases.value)
+    chosenReleases.value = auto
+    const names = new Set()
+    for (const rel of auto) {
+      for (const fv of (rel.fixVersions || [])) names.add(fv)
+    }
+    if (names.size) chosenVersionNames.value = names
+  }
+  await fetchData()
+  // If registry was empty and we have cached data, seed from cached releases
+  if (!chosenVersionNames.value.size && data.value?.metadata?.releases?.length) {
+    chosenVersionNames.value = new Set(data.value.metadata.releases)
+  }
+
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+  if (refreshDebounce) clearTimeout(refreshDebounce)
+  cleanup()
+})
+</script>
+
+<template>
+  <div class="max-w-7xl mx-auto p-6">
+    <!-- Header -->
+    <div class="mb-6 flex items-start justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          TV vs FV Delta
+        </h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Target Version (PM intent) vs Fix Version (engineering commitment)
+        </p>
+      </div>
+      <button
+        @click="doRefresh"
+        :disabled="refreshing"
+        class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+        :class="refreshing
+          ? 'border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+          : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'"
+      >
+        {{ refreshing ? 'Refreshing...' : 'Refresh from Jira' }}
+      </button>
+    </div>
+
+    <div v-if="loading" class="text-gray-500 dark:text-gray-400">Loading...</div>
+    <div v-else-if="error" class="text-red-600 dark:text-red-400">{{ error }}</div>
+    <div v-else-if="!data && refreshing" class="text-center py-12 text-gray-500 dark:text-gray-400">
+      <p class="text-lg font-medium mb-2">Fetching data for the first time...</p>
+      <p class="text-sm">The pipeline is running. This page will update automatically.</p>
+    </div>
+
+    <template v-else-if="data">
+      <!-- Metadata -->
+      <div class="text-xs text-gray-400 dark:text-gray-500 mb-4">
+        Data fetched: {{ new Date(data.metadata.data_timestamp).toLocaleString() }}
+        &middot;
+        Report generated: {{ new Date(data.metadata.generated_at).toLocaleString() }}
+        &middot;
+        <span class="italic">Counts reflect data at fetch time; live Jira may differ</span>
+      </div>
+
+      <!-- Executive Summary -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-6">
+        <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Executive Summary</h2>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/50">
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Release</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Total</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Aligned</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">TV-Only</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">FV-Only</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Mismatched</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Alignment</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="row in filteredSummary"
+                :key="row.release"
+                class="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer"
+                :class="{ 'bg-blue-50/50 dark:bg-blue-900/10': row.release === selectedRelease }"
+                @click="!row._pending ? selectedRelease = row.release : null"
+              >
+                <td class="px-4 py-2 font-mono text-xs font-medium" :class="row._pending ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">
+                  {{ row.release }}
+                  <span v-if="row._pending" class="ml-1 text-[10px] text-amber-500 dark:text-amber-400 italic">(refreshing data...)</span>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <template v-if="!row._pending">
+                    <ClickableCount :count="row.total" :jql="row.total_jql" label="Total features" />
+                  </template>
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount v-if="!row._pending" :count="row.aligned" :jql="row.aligned_jql" color="green" label="Aligned" />
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount v-if="!row._pending" :count="row.tv_only" :jql="row.tv_only_jql" color="yellow" label="TV-only" />
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount v-if="!row._pending" :count="row.fv_only" :jql="row.fv_only_jql" color="muted" label="FV-only" />
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount v-if="!row._pending" :count="row.mismatched" :jql="row.mismatched_jql" color="red" label="Mismatched" />
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <span v-if="!row._pending"
+                    class="font-semibold"
+                    :class="{
+                      'text-red-600 dark:text-red-400': row.alignment_pct < 50,
+                      'text-yellow-600 dark:text-yellow-400': row.alignment_pct >= 50 && row.alignment_pct < 75,
+                      'text-green-600 dark:text-green-400': row.alignment_pct >= 75,
+                    }"
+                  >
+                    {{ row.alignment_pct }}%
+                  </span>
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Release selector -->
+      <div class="flex items-center gap-2 mb-6 flex-wrap">
+        <button
+          v-for="v in chosenVersionsDisplay"
+          :key="v.name"
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+          :class="isInCurrentData(v.name)
+            ? (v.name === selectedRelease
+              ? 'bg-blue-600 text-white border-blue-600 dark:border-blue-500'
+              : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700')
+            : 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700 border-dashed'"
+          @click="isInCurrentData(v.name) ? selectedRelease = v.name : null"
+        >
+          {{ v.name }}
+          <span
+            @click.stop="removeVersion(v.name)"
+            class="ml-0.5 opacity-40 hover:opacity-100 transition-opacity cursor-pointer"
+            title="Remove"
+          >&times;</span>
+        </button>
+        <!-- Add release dropdown -->
+        <div class="relative" ref="pickerRef">
+          <button
+            @click.stop="pickerOpen = !pickerOpen"
+            class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md border border-dashed border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+          >
+            + Add release
+          </button>
+          <div
+            v-if="pickerOpen"
+            class="absolute z-20 mt-1 left-0 w-80 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-lg"
+            @click.stop
+          >
+            <div class="p-2 border-b border-gray-200 dark:border-gray-700">
+              <input
+                v-model="versionSearch"
+                type="text"
+                placeholder="Search versions..."
+                class="w-full px-2.5 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div class="max-h-64 overflow-y-auto">
+              <button
+                v-for="v in filteredVersions"
+                :key="v.name"
+                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center justify-between gap-2 transition-colors"
+                :class="{ 'bg-blue-50 dark:bg-blue-900/20': chosenVersionNames.has(v.name) }"
+                @click.stop="toggleVersion(v.name)"
+              >
+                <div class="min-w-0">
+                  <span class="font-medium text-gray-900 dark:text-gray-100">{{ v.displayName }}</span>
+                  <span v-if="v.codeFreeze" class="ml-2 text-xs text-gray-400">CF {{ formatDate(v.codeFreeze) }}</span>
+                  <span v-else-if="v.releaseDate" class="ml-2 text-xs text-gray-400">{{ v.released ? 'Released' : 'Due' }} {{ formatDate(v.releaseDate) }}</span>
+                </div>
+                <span v-if="chosenVersionNames.has(v.name)" class="text-blue-500 flex-shrink-0">&#10003;</span>
+              </button>
+              <div v-if="!filteredVersions.length" class="px-3 py-4 text-center text-xs text-gray-400">
+                {{ availableVersions.length ? 'No matches' : 'No versions available' }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Refresh indicator -->
+        <span
+          v-if="refreshing"
+          class="px-2.5 py-1.5 text-xs font-medium rounded-md bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border border-amber-300 dark:border-amber-700"
+        >
+          Analyzing...
+        </span>
+      </div>
+
+      <!-- Category lists for selected release -->
+      <div v-if="releaseData">
+        <!-- TV-Only -->
+        <details class="group bg-white dark:bg-gray-800 rounded-lg border border-yellow-200 dark:border-yellow-800 overflow-hidden mb-4">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-yellow-50 dark:hover:bg-yellow-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
+              <span class="text-sm font-semibold text-yellow-700 dark:text-yellow-400">
+                TV-Only — PM targeted, no ENG commitment ({{ releaseData.tv_only.length }})
+              </span>
+            </span>
+            <a
+              v-if="releaseSummary"
+              :href="releaseSummary.tv_only_jql"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              @click.stop
+            >
+              View in Jira &rarr;
+            </a>
+          </summary>
+          <FeatureTable
+            :features="releaseData.tv_only"
+            :columns="FEATURE_COLS"
+          />
+        </details>
+
+        <!-- FV-Only -->
+        <details class="group bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-4">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 flex items-center justify-between [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
+              <span class="text-sm font-semibold text-gray-600 dark:text-gray-400">
+                FV-Only — ENG committed, not PM-planned ({{ releaseData.fv_only.length }})
+              </span>
+            </span>
+            <a
+              v-if="releaseSummary"
+              :href="releaseSummary.fv_only_jql"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              @click.stop
+            >
+              View in Jira &rarr;
+            </a>
+          </summary>
+          <FeatureTable
+            :features="releaseData.fv_only"
+            :columns="FEATURE_COLS"
+          />
+        </details>
+
+        <!-- Mismatched -->
+        <details v-if="releaseData.mismatched.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-red-200 dark:border-red-800 overflow-hidden mb-4">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
+              <span class="text-sm font-semibold text-red-700 dark:text-red-400">
+                Mismatched — TV and FV disagree ({{ releaseData.mismatched.length }})
+              </span>
+            </span>
+            <a
+              v-if="releaseSummary"
+              :href="releaseSummary.mismatched_jql"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              @click.stop
+            >
+              View in Jira &rarr;
+            </a>
+          </summary>
+          <FeatureTable
+            :features="releaseData.mismatched"
+            :columns="FEATURE_COLS"
+          />
+        </details>
+
+        <!-- Aligned -->
+        <details class="group bg-white dark:bg-gray-800 rounded-lg border border-green-200 dark:border-green-800 overflow-hidden mb-4">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
+              <span class="text-sm font-semibold text-green-700 dark:text-green-400">
+                Aligned — TV == FV ({{ releaseData.aligned.length }})
+              </span>
+            </span>
+            <a
+              v-if="releaseSummary"
+              :href="releaseSummary.aligned_jql"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              @click.stop
+            >
+              View in Jira &rarr;
+            </a>
+          </summary>
+          <FeatureTable
+            :features="releaseData.aligned"
+            :columns="FEATURE_COLS"
+          />
+        </details>
+      </div>
+
+      <!-- Component Breakdown (per-release) -->
+      <details v-if="releaseComponentBreakdown.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-4">
+        <summary class="list-none px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 flex items-center [&::-webkit-details-marker]:hidden">
+          <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform mr-2">&#9654;</span>
+          <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">Component Breakdown</span>
+        </summary>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/50">
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Component</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Total</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Aligned</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">TV-Only</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">FV-Only</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Mismatched</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Alignment</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="comp in releaseComponentBreakdown"
+                :key="comp.component"
+                class="hover:bg-gray-50 dark:hover:bg-gray-800/50"
+              >
+                <td class="px-4 py-2 text-gray-900 dark:text-gray-100">{{ comp.component }}</td>
+                <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">{{ comp.total }}</td>
+                <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">{{ comp.aligned }}</td>
+                <td class="px-4 py-2 text-right text-yellow-600 dark:text-yellow-400">{{ comp.tv_only }}</td>
+                <td class="px-4 py-2 text-right text-gray-500 dark:text-gray-400">{{ comp.fv_only }}</td>
+                <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">{{ comp.mismatched }}</td>
+                <td class="px-4 py-2 text-right">
+                  <span
+                    class="font-semibold"
+                    :class="{
+                      'text-red-600 dark:text-red-400': comp.alignment_pct < 50,
+                      'text-yellow-600 dark:text-yellow-400': comp.alignment_pct >= 50 && comp.alignment_pct < 75,
+                      'text-green-600 dark:text-green-400': comp.alignment_pct >= 75,
+                    }"
+                  >
+                    {{ comp.alignment_pct }}%
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </template>
+  </div>
+</template>

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -13,6 +13,7 @@ const registerExecutionRoutes = require('./execution/routes');
 const registerFeatureTrackingRoutes = require('./execution/feature-tracking-routes');
 const registerDeliveryRoutes = require('./delivery/routes');
 const registerHygieneRoutes = require('./hygiene/routes');
+const registerTvFvDeltaRoutes = require('./tv-fv-delta/routes');
 const { getAuditLog } = require('./planning/audit-log');
 
 /**
@@ -216,6 +217,16 @@ module.exports = function registerRoutes(router, context) {
     isRefreshRunning: context.isRefreshRunning || null
   });
   router.use('/hygiene', hygieneRouter);
+
+  // TV/FV Delta sub-router (mounted at /api/modules/releases/tv-fv-delta/)
+  const tvFvDeltaRouter = express.Router();
+  registerTvFvDeltaRoutes(tvFvDeltaRouter, {
+    storage,
+    requireAuth,
+    requireScope,
+    registerDiagnostics: context.registerDiagnostics || null
+  });
+  router.use('/tv-fv-delta', tvFvDeltaRouter);
 
   // ─── Unified Audit Routes ───
 

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -1,0 +1,686 @@
+const { jiraRequest, JIRA_HOST, fetchAllJqlResults, fetchProjectVersions } = require('../../../../shared/server/jira')
+
+const JIRA_BROWSE = JIRA_HOST + '/browse'
+const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
+const CACHE_KEY = 'releases/tv-fv-delta.json'
+const CACHE_MAX_AGE_MS = 60 * 60 * 1000 // 1 hour
+const VERSIONS_CACHE_KEY = 'releases/tv-fv-delta-versions.json'
+const VERSIONS_CACHE_MAX_AGE_MS = 4 * 60 * 60 * 1000 // 4 hours
+
+// Default releases — EA1, EA2, then GA (timeline order)
+// Fallback if Smartsheet/planning releases are not configured
+const DEFAULT_RELEASES = ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']
+const DEFAULT_JIRA_PROJECT = 'RHAISTRAT'
+
+// ---------------------------------------------------------------------------
+// Fetch releases from planning module (Smartsheet SSOT)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch configured releases from planning module and expand to EA1, EA2, GA variants.
+ * Returns array of release strings in timeline order: [...EA1s, ...EA2s, ...GAs]
+ */
+function fetchReleasesFromPlanning(storage) {
+  try {
+    // Try to read from planning module's config
+    const planningData = storage.readFromStorage('releases/planning/config.json')
+    if (!planningData || !planningData.releases) {
+      console.warn('[releases/tv-fv-delta] No planning config found — falling back to DEFAULT_RELEASES. Update the constant if the current release has changed.')
+      return { releases: DEFAULT_RELEASES, source: 'default' }
+    }
+
+    const jqlSafe = /^[a-zA-Z0-9._-]+$/
+    const baseVersions = Object.keys(planningData.releases).filter(function(v) { return jqlSafe.test(v) }).sort()
+    if (baseVersions.length === 0) {
+      console.warn('[releases/tv-fv-delta] No releases configured — falling back to DEFAULT_RELEASES. Update the constant if the current release has changed.')
+      return { releases: DEFAULT_RELEASES, source: 'default' }
+    }
+
+    // Expand each base version to EA1, EA2, GA (timeline order: all EA1s, all EA2s, all GAs)
+    const expanded = []
+    for (const v of baseVersions) expanded.push(v + '.EA1')
+    for (const v of baseVersions) expanded.push(v + '.EA2')
+    for (const v of baseVersions) expanded.push(v)
+
+    // Filter out any expanded versions that don't pass JQL safety validation
+    const safeExpanded = expanded.filter(function(v) { return jqlSafe.test(v) })
+    if (safeExpanded.length < expanded.length) {
+      const dropped = expanded.filter(function(v) { return !jqlSafe.test(v) })
+      console.warn('[releases/tv-fv-delta] Dropped ' + dropped.length + ' expanded releases that failed JQL safety validation: ' + dropped.join(', '))
+    }
+
+    console.log('[releases/tv-fv-delta] Fetched ' + baseVersions.length + ' base releases from planning, expanded to ' + safeExpanded.length + ' variants')
+    return { releases: safeExpanded, source: 'planning' }
+  } catch (err) {
+    console.error('[releases/tv-fv-delta] Failed to fetch releases from planning:', err.message)
+    console.warn('[releases/tv-fv-delta] Falling back to DEFAULT_RELEASES — data may be stale if current release has changed.')
+    return { releases: DEFAULT_RELEASES, source: 'default' }
+  }
+}
+
+// Jira custom field IDs
+const CF_TARGET_VERSION = 'customfield_10855'
+const CF_COLOR_STATUS = 'customfield_10712'
+const CF_PRODUCT_MANAGER = 'customfield_10469'
+
+// JQL fields to fetch
+const JQL_FIELDS = [
+  'summary', 'status', 'fixVersions', 'components', 'assignee',
+  CF_TARGET_VERSION, CF_COLOR_STATUS, CF_PRODUCT_MANAGER
+].join(',')
+
+// ---------------------------------------------------------------------------
+// Version normalisation
+// ---------------------------------------------------------------------------
+
+function normVer(v) {
+  if (!v || v === 'null' || v === 'undefined') return null
+  v = String(v).trim()
+  const upper = v.toUpperCase()
+  if (upper.startsWith('RHOAI_')) {
+    v = 'rhoai-' + upper.slice(6).replace(/\.0(?=_|$)/g, '').replace(/_/g, '.')
+  }
+  return v.toLowerCase()
+}
+
+function parseVersions(vStr) {
+  if (!vStr) return new Set()
+  return new Set(
+    String(vStr).split(',')
+      .map(function(s) { return normVer(s.trim()) })
+      .filter(Boolean)
+  )
+}
+
+function extractVersionNames(fixVersions) {
+  if (!Array.isArray(fixVersions)) return ''
+  return fixVersions.map(function(v) { return v.name }).filter(Boolean).join(', ')
+}
+
+/**
+ * Detect z-stream (patch) releases — e.g. rhoai-3.4.1, rhoai-3.5.2.
+ * These carry bug fixes only, not features, so they don't belong in TV/FV analysis.
+ * Pattern: rhoai-X.Y.Z where Z is purely numeric (vs EA1, EA2 which are feature milestones).
+ */
+function isZStream(versionName) {
+  if (!versionName) return false
+  // Match rhoai-<major>.<minor>.<patch> where patch is a number
+  return /^rhoai-\d+\.\d+\.\d+$/i.test(versionName.trim())
+}
+
+// ---------------------------------------------------------------------------
+// Fetch all components from Jira project
+// ---------------------------------------------------------------------------
+
+async function fetchAllComponents(jiraProject) {
+  try {
+    const response = await jiraRequest('/rest/api/2/project/' + jiraProject + '/components')
+    if (!Array.isArray(response)) return []
+    return response.map(function(c) { return c.name }).filter(Boolean).sort()
+  } catch (err) {
+    console.error('[releases/tv-fv-delta] Failed to fetch components:', err.message)
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JQL URL builder
+// ---------------------------------------------------------------------------
+
+function jqlUrl(jql) {
+  return JIRA_SEARCH + encodeURIComponent(jql)
+}
+
+/** Quote a release name for JQL (versions with dots/hyphens need quoting) */
+function quoteRelease(name) {
+  return '"' + name.replace(/"/g, '\\"') + '"'
+}
+
+// ---------------------------------------------------------------------------
+// Issue normalisation
+// ---------------------------------------------------------------------------
+
+function normalizeIssue(issue) {
+  const fields = issue.fields || {}
+
+  // Target version — may be string or array-of-objects
+  const tvRaw = fields[CF_TARGET_VERSION]
+  let tvStr = ''
+  if (Array.isArray(tvRaw)) {
+    tvStr = tvRaw.map(function(v) { return typeof v === 'object' ? (v.name || v.value || '') : String(v) }).join(', ')
+  } else if (tvRaw && typeof tvRaw === 'object') {
+    tvStr = tvRaw.name || tvRaw.value || ''
+  } else if (tvRaw) {
+    tvStr = String(tvRaw)
+  }
+
+  // Fix versions
+  const fvStr = extractVersionNames(fields.fixVersions)
+
+  // Components
+  let components = []
+  if (Array.isArray(fields.components)) {
+    components = fields.components.map(function(c) { return c.name || '' }).filter(Boolean)
+  }
+
+  // Color status — may be string or object with value
+  const csRaw = fields[CF_COLOR_STATUS]
+  let colorStatus = ''
+  if (csRaw) {
+    colorStatus = typeof csRaw === 'object' ? (csRaw.value || '') : String(csRaw)
+  }
+
+  // Product manager — may be user object or string
+  const pmRaw = fields[CF_PRODUCT_MANAGER]
+  let pm = ''
+  if (pmRaw) {
+    pm = typeof pmRaw === 'object' ? (pmRaw.displayName || pmRaw.name || '') : String(pmRaw)
+  }
+
+  // Assignee
+  const assigneeRaw = fields.assignee
+  let assignee = ''
+  if (assigneeRaw) {
+    assignee = assigneeRaw.displayName || assigneeRaw.name || ''
+  }
+
+  // Status
+  let status = ''
+  if (fields.status) {
+    status = fields.status.name || ''
+  }
+
+  return {
+    key: issue.key,
+    url: JIRA_BROWSE + '/' + issue.key,
+    summary: String(fields.summary || '').slice(0, 120),
+    status: status,
+    target_version: tvStr,
+    fix_versions: fvStr,
+    tv_set: parseVersions(tvStr),
+    fv_set: parseVersions(fvStr),
+    color_status: colorStatus,
+    product_manager: pm,
+    assignee: assignee,
+    components: components,
+    component: components.join(', ')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Classification engine
+// ---------------------------------------------------------------------------
+
+function classifyFeatures(features, releases) {
+  const classifications = []
+
+  for (let ri = 0; ri < releases.length; ri++) {
+    const release = releases[ri]
+    const relNorm = normVer(release)
+
+    for (let fi = 0; fi < features.length; fi++) {
+      const feat = features[fi]
+      const tvMatch = feat.tv_set.has(relNorm)
+      const fvMatch = feat.fv_set.has(relNorm)
+
+      if (!tvMatch && !fvMatch) continue
+
+      let cat
+      if (tvMatch && fvMatch) {
+        cat = 'aligned'
+      } else if (tvMatch && !fvMatch) {
+        cat = feat.fv_set.size > 0 ? 'mismatched' : 'tv_only'
+      } else {
+        cat = feat.tv_set.size > 0 ? 'mismatched' : 'fv_only'
+      }
+
+      classifications.push({
+        release: release,
+        category: cat,
+        key: feat.key,
+        url: feat.url,
+        summary: feat.summary,
+        status: feat.status,
+        target_version: feat.target_version,
+        fix_versions: feat.fix_versions,
+        color_status: feat.color_status,
+        product_manager: feat.product_manager,
+        assignee: feat.assignee,
+        team: '',  // team derivation requires org config — left empty for now
+        components: feat.components,
+        component: feat.component
+      })
+    }
+  }
+
+  return classifications
+}
+
+// ---------------------------------------------------------------------------
+// Build export payload
+// ---------------------------------------------------------------------------
+
+function buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject) {
+  const baseJql = 'project = ' + jiraProject + ' AND issuetype = Feature'
+
+  const executiveSummary = []
+  const releaseBuckets = {}
+
+  for (let ri = 0; ri < releases.length; ri++) {
+    const release = releases[ri]
+    const items = classifications.filter(function(c) { return c.release === release })
+    const nTotal = items.length
+
+    const cats = { aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0 }
+    for (let i = 0; i < items.length; i++) {
+      cats[items[i].category]++
+    }
+
+    const alignPct = nTotal > 0 ? Math.round(1000 * cats.aligned / nTotal) / 10 : 0
+
+    executiveSummary.push({
+      release: release,
+      total: nTotal,
+      total_jql: jqlUrl(baseJql + ' AND ("Target Version" in (' + quoteRelease(release) + ') OR fixVersion in (' + quoteRelease(release) + '))'),
+      aligned: cats.aligned,
+      aligned_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion in (' + quoteRelease(release) + ')'),
+      tv_only: cats.tv_only,
+      tv_only_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion is EMPTY'),
+      fv_only: cats.fv_only,
+      fv_only_jql: jqlUrl(baseJql + ' AND fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is EMPTY'),
+      mismatched: cats.mismatched,
+      mismatched_jql: jqlUrl(baseJql + ' AND (("Target Version" in (' + quoteRelease(release) + ') AND fixVersion is not EMPTY AND fixVersion not in (' + quoteRelease(release) + ')) OR (fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is not EMPTY AND "Target Version" not in (' + quoteRelease(release) + ')))'),
+      alignment_pct: alignPct
+    })
+
+    // Per-release feature lists
+    const bucket = { aligned: [], tv_only: [], fv_only: [], mismatched: [] }
+    for (let ci = 0; ci < items.length; ci++) {
+      const item = items[ci]
+      const row = {
+        key: item.key,
+        url: item.url,
+        summary: item.summary,
+        status: item.status,
+        color_status: item.color_status,
+        product_manager: item.product_manager,
+        assignee: item.assignee,
+        team: item.team,
+        components: item.components,
+        component: item.component,
+        target_version: item.target_version,
+        fix_versions: item.fix_versions
+      }
+      bucket[item.category].push(row)
+    }
+    releaseBuckets[release] = bucket
+  }
+
+  // Component breakdown — deduplicate by issue key per component
+  // When a feature appears in multiple releases, pick the worst category:
+  // mismatched > tv_only > fv_only > aligned (show the most actionable state)
+  const CATEGORY_PRIORITY = { mismatched: 3, tv_only: 2, fv_only: 1, aligned: 0 }
+  const compMap = {}
+  for (let ki = 0; ki < classifications.length; ki++) {
+    const cl = classifications[ki]
+    const comps = cl.components || []
+    if (comps.length === 0) continue
+    for (let cj = 0; cj < comps.length; cj++) {
+      const compName = comps[cj]
+      if (!compMap[compName]) {
+        compMap[compName] = {} // key -> category
+      }
+      const prev = compMap[compName][cl.key]
+      if (!prev || CATEGORY_PRIORITY[cl.category] > CATEGORY_PRIORITY[prev]) {
+        compMap[compName][cl.key] = cl.category
+      }
+    }
+  }
+
+  // Build component breakdown from ALL Jira components (even if 0 features)
+  const allCompNames = allComponents && allComponents.length > 0 ? allComponents : Object.keys(compMap).sort()
+  const componentBreakdown = []
+
+  for (let cn = 0; cn < allCompNames.length; cn++) {
+    const name = allCompNames[cn]
+    const data = compMap[name]
+    let total = 0
+    let aligned = 0
+    let tv_only = 0
+    let fv_only = 0
+    let mismatched = 0
+
+    if (data) {
+      const entries = Object.values(data)
+      total = entries.length
+      for (let ei = 0; ei < entries.length; ei++) {
+        if (entries[ei] === 'aligned') aligned++
+        else if (entries[ei] === 'tv_only') tv_only++
+        else if (entries[ei] === 'fv_only') fv_only++
+        else if (entries[ei] === 'mismatched') mismatched++
+      }
+    }
+
+    const compQ = '"' + name.replace(/"/g, '\\"') + '"'
+    componentBreakdown.push({
+      component: name,
+      total: total,
+      total_jql: jqlUrl(baseJql + ' AND component = ' + compQ + ' AND ("Target Version" in (' + releases.map(quoteRelease).join(', ') + ') OR fixVersion in (' + releases.map(quoteRelease).join(', ') + '))'),
+      aligned: aligned,
+      tv_only: tv_only,
+      fv_only: fv_only,
+      mismatched: mismatched,
+      alignment_pct: total > 0 ? Math.round(1000 * aligned / total) / 10 : 0
+    })
+  }
+  componentBreakdown.sort(function(a, b) { return b.total - a.total || a.component.localeCompare(b.component) })
+
+  return {
+    metadata: {
+      generated_at: new Date().toISOString(),
+      data_timestamp: fetchTimestamp,
+      releases: releases,
+      total_features: classifications.length,
+      all_components: allComponents || []
+    },
+    executive_summary: executiveSummary,
+    releases: releaseBuckets,
+    component_breakdown: componentBreakdown
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + classify pipeline
+// ---------------------------------------------------------------------------
+
+async function fetchAndClassify(releases, storage, jiraProject) {
+  const fetchTimestamp = new Date().toISOString()
+
+  // Fetch all components from Jira (for complete breakdown)
+  console.log('[releases/tv-fv-delta] Fetching all components from ' + jiraProject)
+  const allComponents = await fetchAllComponents(jiraProject)
+  console.log('[releases/tv-fv-delta] Fetched ' + allComponents.length + ' components from Jira')
+
+  // Build JQL: features that have TV or FV in any of the target releases
+  const releaseList = releases.map(quoteRelease).join(', ')
+  const jql = 'project = ' + jiraProject + ' AND issuetype = Feature AND ("Target Version" in (' + releaseList + ') OR fixVersion in (' + releaseList + '))'
+
+  console.log('[releases/tv-fv-delta] Fetching features: ' + jql)
+  const issues = await fetchAllJqlResults(jiraRequest, jql, JQL_FIELDS)
+  console.log('[releases/tv-fv-delta] Fetched ' + issues.length + ' issues from Jira')
+
+  // Normalise
+  const features = issues.map(normalizeIssue)
+
+  // Classify
+  const classifications = classifyFeatures(features, releases)
+  console.log('[releases/tv-fv-delta] Classified ' + classifications.length + ' feature-release pairs')
+
+  // Build export
+  const result = buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject)
+
+  // Cache
+  storage.writeToStorage(CACHE_KEY, result)
+  console.log('[releases/tv-fv-delta] Cached TV/FV delta (' + classifications.length + ' classifications, ' + (allComponents ? allComponents.length : 0) + ' components)')
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+// Exported for testing
+module.exports = registerRoutes
+module.exports.normVer = normVer
+module.exports.parseVersions = parseVersions
+module.exports.extractVersionNames = extractVersionNames
+module.exports.isZStream = isZStream
+module.exports.normalizeIssue = normalizeIssue
+module.exports.classifyFeatures = classifyFeatures
+module.exports.buildExport = buildExport
+module.exports.DEFAULT_RELEASES = DEFAULT_RELEASES
+module.exports.DEFAULT_JIRA_PROJECT = DEFAULT_JIRA_PROJECT
+
+function registerRoutes(router, context) {
+  const storage = context.storage
+  const requireAuth = context.requireAuth
+  const requireScope = context.requireScope
+  const config = context.config || {}
+  const JIRA_PROJECT = config.jiraProject || DEFAULT_JIRA_PROJECT
+
+  // Refresh state tracking
+  const REFRESH_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
+  const refreshState = { running: false, lastResult: null, startedAt: null, completedAt: null }
+
+  const jqlSafePattern = /^[a-zA-Z0-9._-]+$/
+
+  function triggerBackgroundRefresh(releases, force) {
+    if (refreshState.running) return
+    if (!force && refreshState.completedAt) {
+      const elapsed = Date.now() - new Date(refreshState.completedAt).getTime()
+      if (elapsed < REFRESH_COOLDOWN_MS) return
+    }
+
+    // Validate all release names before starting (defense-in-depth)
+    const safeReleases = releases.filter(function(r) { return typeof r === 'string' && jqlSafePattern.test(r) })
+    if (safeReleases.length === 0) return
+    releases = safeReleases
+
+    refreshState.running = true
+    refreshState.startedAt = new Date().toISOString()
+
+    console.log('[releases/tv-fv-delta] Background refresh started')
+    setImmediate(function() {
+      fetchAndClassify(releases, storage, JIRA_PROJECT)
+      .then(function(result) {
+        refreshState.running = false
+        refreshState.completedAt = new Date().toISOString()
+        refreshState.lastResult = {
+          status: 'success',
+          message: result.metadata.total_features + ' feature-release pairs classified',
+          completedAt: new Date().toISOString()
+        }
+        console.log('[releases/tv-fv-delta] Background refresh completed')
+      })
+      .catch(function(err) {
+        refreshState.running = false
+        refreshState.completedAt = new Date().toISOString()
+        refreshState.lastResult = {
+          status: 'error',
+          message: err.message,
+          completedAt: new Date().toISOString()
+        }
+        console.error('[releases/tv-fv-delta] Background refresh failed:', err.message)
+      })
+    })
+  }
+
+  /**
+   * @openapi
+   * /api/modules/releases/tv-fv-delta:
+   *   get:
+   *     tags: ['Releases']
+   *     summary: Get TV vs FV delta analysis
+   *     description: Returns cached data with stale-while-revalidate. Triggers background refresh if cache is stale.
+   *     responses:
+   *       200:
+   *         description: TV/FV delta data with per-release breakdowns
+   *       404:
+   *         description: No data available — trigger a refresh
+   */
+  router.get('/', requireAuth, requireScope('releases:read'), function (req, res) {
+    const data = storage.readFromStorage(CACHE_KEY)
+
+    if (data) {
+      // Check staleness
+      const cachedAt = data.metadata && data.metadata.generated_at
+      if (cachedAt) {
+        const age = Date.now() - new Date(cachedAt).getTime()
+        if (age >= CACHE_MAX_AGE_MS) {
+          const cachedReleases = (data.metadata.releases || DEFAULT_RELEASES)
+            .filter(function(r) { return typeof r === 'string' && /^[a-zA-Z0-9._-]+$/.test(r) })
+          triggerBackgroundRefresh(cachedReleases.length ? cachedReleases : DEFAULT_RELEASES)
+        }
+      }
+      return res.json({
+        ...data,
+        _refreshing: refreshState.running
+      })
+    }
+
+    // No cache — trigger first fetch using planning config if available
+    triggerBackgroundRefresh(fetchReleasesFromPlanning(storage).releases)
+    res.status(202).json({
+      _refreshing: true,
+      _noCache: true,
+      message: 'Data pipeline is running for the first time. Refresh the page in a few moments.'
+    })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/tv-fv-delta/refresh:
+   *   post:
+   *     tags: ['Releases']
+   *     summary: Trigger a refresh of TV/FV delta data from Jira
+   *     security: [{ auth: [] }]
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               releases:
+   *                 type: array
+   *                 items: { type: string }
+   *                 description: Release versions to analyse (defaults to EA1, EA2, 3.5)
+   *     responses:
+   *       200:
+   *         description: Refresh started or already running
+   */
+  router.post('/refresh', requireAuth, requireScope('releases:write'), function (req, res) {
+    if (refreshState.running) {
+      return res.json({ status: 'already_running', startedAt: refreshState.startedAt })
+    }
+
+    let releases
+    if (req.body && Array.isArray(req.body.releases) && req.body.releases.length > 0) {
+      // User-provided releases
+      releases = req.body.releases
+    } else {
+      // Auto-discover from planning module (Smartsheet SSOT)
+      releases = fetchReleasesFromPlanning(storage).releases
+    }
+
+    // Cap releases array to prevent excessive API load
+    const MAX_RELEASES = 50
+    if (releases.length > MAX_RELEASES) {
+      return res.status(400).json({ error: 'Too many releases (max ' + MAX_RELEASES + ')' })
+    }
+
+    // Validate each release string to prevent JQL injection
+    for (let i = 0; i < releases.length; i++) {
+      if (typeof releases[i] !== 'string' || !jqlSafePattern.test(releases[i])) {
+        return res.status(400).json({
+          error: 'Invalid release name: ' + releases[i],
+          detail: 'Release names must contain only alphanumeric characters, dots, underscores, and hyphens'
+        })
+      }
+    }
+
+    triggerBackgroundRefresh(releases, true)
+    res.json({ status: 'started', releases: releases })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/tv-fv-delta/refresh/status:
+   *   get:
+   *     tags: ['Releases']
+   *     summary: Check status of the TV/FV delta refresh
+   *     responses:
+   *       200:
+   *         description: Refresh state
+   */
+  router.get('/refresh/status', requireAuth, requireScope('releases:read'), function (req, res) {
+    res.json(refreshState)
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/tv-fv-delta/releases:
+   *   get:
+   *     tags: ['Releases']
+   *     summary: Get configured releases from planning module (Smartsheet SSOT)
+   *     responses:
+   *       200:
+   *         description: Release list expanded to EA1, EA2, GA variants
+   */
+  router.get('/releases', requireAuth, requireScope('releases:read'), function (req, res) {
+    try {
+      const result = fetchReleasesFromPlanning(storage)
+      res.json({
+        releases: result.releases,
+        source: result.source,
+        fetchedAt: new Date().toISOString()
+      })
+    } catch (err) {
+      console.error('[releases/tv-fv-delta] Failed to fetch releases:', err.message)
+      res.status(500).json({ error: 'Failed to fetch releases' })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/tv-fv-delta/versions:
+   *   get:
+   *     tags: ['Releases']
+   *     summary: Get all fix versions from the Jira project
+   *     responses:
+   *       200:
+   *         description: All project fix versions with release dates
+   */
+  router.get('/versions', requireAuth, requireScope('releases:read'), async function (req, res) {
+    // Check cache first
+    const cached = storage.readFromStorage(VERSIONS_CACHE_KEY)
+    if (cached && cached.fetchedAt) {
+      const age = Date.now() - new Date(cached.fetchedAt).getTime()
+      if (age < VERSIONS_CACHE_MAX_AGE_MS) {
+        return res.json(cached)
+      }
+    }
+
+    try {
+      const allVersions = await fetchProjectVersions(jiraRequest, [JIRA_PROJECT])
+      if (!Array.isArray(allVersions)) {
+        const result = { versions: [], fetchedAt: new Date().toISOString() }
+        storage.writeToStorage(VERSIONS_CACHE_KEY, result)
+        return res.json(result)
+      }
+      const versions = allVersions
+        .filter(function(v) { return !v.archived && !isZStream(v.name) })
+        .sort(function(a, b) { return (a.name || '').localeCompare(b.name || '') })
+
+      const result = { versions: versions, fetchedAt: new Date().toISOString() }
+      storage.writeToStorage(VERSIONS_CACHE_KEY, result)
+      res.json(result)
+    } catch (err) {
+      console.error('[releases/tv-fv-delta] Failed to fetch versions:', err.message)
+      // Return stale cache if available
+      if (cached) return res.json(cached)
+      res.status(502).json({ error: 'Failed to fetch versions from Jira' })
+    }
+  })
+
+  // Diagnostics hook
+  if (context.registerDiagnostics) {
+    context.registerDiagnostics(async function () {
+      const tvfv = storage.readFromStorage(CACHE_KEY)
+      return {
+        tvFvDelta: tvfv ? { generatedAt: tvfv.metadata?.generated_at, releases: tvfv.metadata?.releases } : null,
+        refresh: refreshState
+      }
+    })
+  }
+}

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -1924,9 +1924,20 @@ const EXPORT_RATE_MAX = 5;
 const EXPORT_RATE_WINDOW_MS = 10 * 60_000;
 const exportRateCounts = new Map();
 
+// Periodic cleanup of expired rate limit entries (every 60s)
+setInterval(function() {
+  const now = Date.now();
+  for (const [key, value] of exportRateCounts.entries()) {
+    if (now - value.windowStart >= EXPORT_RATE_WINDOW_MS) {
+      exportRateCounts.delete(key);
+    }
+  }
+}, 60_000).unref();
+
 function exportRateLimit(req, res, next) {
   const email = req.userEmail;
   const now = Date.now();
+
   const entry = exportRateCounts.get(email);
   if (!entry || now - entry.windowStart >= EXPORT_RATE_WINDOW_MS) {
     exportRateCounts.set(email, { windowStart: now, count: 1 });

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1,0 +1,1431 @@
+const { test, expect } = require('@playwright/test');
+const { DEFAULT_PAGE_WAIT_TIME } = require('./constants');
+const { setupErrorTracking, logCapturedErrors } = require('./helpers');
+
+/**
+ * Integration tests for TV/FV Delta view (Releases module → Reports hub)
+ *
+ * Tests verify:
+ * - View loads via Reports hub (/#/releases/reports?report=tv-fv-delta)
+ * - Release picker renders with auto-selected versions
+ * - API endpoints are called (registry, versions, tv-fv-delta)
+ * - Executive summary table renders with correct columns
+ * - Release tab switching works
+ * - Category sections (TV-Only, FV-Only, Mismatched, Aligned) render
+ * - Component breakdown updates per release
+ * - Collapsible sections work (details/summary)
+ * - Feature tables are sortable
+ * - Jira links are present and correct
+ *
+ * Tag: @tv-fv-delta
+ * Usage: npx playwright test --grep @tv-fv-delta
+ */
+
+// ---------------------------------------------------------------------------
+// Fixture data for deterministic tests
+// ---------------------------------------------------------------------------
+
+const FIXTURE_DATA = {
+  metadata: {
+    generated_at: '2026-05-17T10:00:00.000Z',
+    data_timestamp: '2026-05-17T09:00:00.000Z',
+    releases: ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5'],
+    total_features: 12
+  },
+  executive_summary: [
+    {
+      release: 'rhoai-3.5.EA1',
+      total: 5, aligned: 3, tv_only: 1, fv_only: 0, mismatched: 1,
+      alignment_pct: 60,
+      total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea1',
+      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea1',
+      tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-ea1',
+      fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-ea1',
+      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea1'
+    },
+    {
+      release: 'rhoai-3.5.EA2',
+      total: 4, aligned: 2, tv_only: 1, fv_only: 1, mismatched: 0,
+      alignment_pct: 50,
+      total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea2',
+      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea2',
+      tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-ea2',
+      fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-ea2',
+      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea2'
+    },
+    {
+      release: 'rhoai-3.5',
+      total: 3, aligned: 3, tv_only: 0, fv_only: 0, mismatched: 0,
+      alignment_pct: 100,
+      total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-35',
+      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-35',
+      tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-35',
+      fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-35',
+      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-35'
+    }
+  ],
+  releases: {
+    'rhoai-3.5.EA1': {
+      aligned: [
+        { key: 'RHAISTRAT-100', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-100', summary: 'Aligned feature A', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
+        { key: 'RHAISTRAT-101', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-101', summary: 'Aligned feature B', status: 'New', color_status: 'Yellow', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Training' },
+        { key: 'RHAISTRAT-102', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-102', summary: 'Aligned feature C', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev Three', team: 'Team A', component: 'Serving' }
+      ],
+      tv_only: [
+        { key: 'RHAISTRAT-200', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-200', summary: 'TV-only feature X', status: 'New', color_status: 'Red', product_manager: 'PM Gamma', assignee: 'Dev Four', team: 'Team C', component: 'Dashboard' }
+      ],
+      fv_only: [],
+      mismatched: [
+        { key: 'RHAISTRAT-300', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-300', summary: 'Mismatched feature Z', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Alpha', assignee: 'Dev Five', team: 'Team A', component: 'Serving, Training', target_version: 'rhoai-3.5.EA1', fix_versions: 'rhoai-3.5.EA2' }
+      ]
+    },
+    'rhoai-3.5.EA2': {
+      aligned: [
+        { key: 'RHAISTRAT-400', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-400', summary: 'EA2 aligned A', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
+        { key: 'RHAISTRAT-401', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-401', summary: 'EA2 aligned B', status: 'New', color_status: '', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Notebooks' }
+      ],
+      tv_only: [
+        { key: 'RHAISTRAT-500', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-500', summary: 'EA2 TV-only', status: 'Backlog', color_status: '', product_manager: 'PM Gamma', assignee: '', team: '', component: 'Pipelines' }
+      ],
+      fv_only: [
+        { key: 'RHAISTRAT-600', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-600', summary: 'EA2 FV-only', status: 'In Progress', color_status: 'Green', product_manager: '', assignee: 'Dev Six', team: 'Team D', component: 'Model Registry' }
+      ],
+      mismatched: []
+    },
+    'rhoai-3.5': {
+      aligned: [
+        { key: 'RHAISTRAT-700', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-700', summary: 'GA aligned A', status: 'Done', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
+        { key: 'RHAISTRAT-701', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-701', summary: 'GA aligned B', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Training' },
+        { key: 'RHAISTRAT-702', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-702', summary: 'GA aligned C', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev Three', team: 'Team A', component: 'Serving' }
+      ],
+      tv_only: [],
+      fv_only: [],
+      mismatched: []
+    }
+  },
+  component_breakdown: []
+};
+
+// ---------------------------------------------------------------------------
+// Module manifest for releases (TV/FV Delta lives under Reports, not as a nav item)
+// ---------------------------------------------------------------------------
+
+const RELEASES_MANIFEST = {
+  name: 'Releases',
+  slug: 'releases',
+  defaultEnabled: true,
+  description: 'Unified release lifecycle: planning, execution tracking, and delivery readiness',
+  icon: 'rocket',
+  order: 10,
+  client: {
+    entry: './client/index.js',
+    navItems: [
+      { id: 'registry', label: 'Manage', icon: 'Database', requireRole: 'release-manager' },
+      { id: 'plan', label: 'Plan', icon: 'ClipboardList', default: true },
+      { id: 'execute', label: 'Execute', icon: 'GitBranch' },
+      { id: 'deliver', label: 'Deliver', icon: 'Rocket' },
+      { id: 'reports', label: 'Reports', icon: 'BarChart3' },
+      { id: 'audit', label: 'Audit', icon: 'History', requireRole: 'release-manager' }
+    ]
+  },
+  server: { entry: './server/index.js' }
+};
+
+// ---------------------------------------------------------------------------
+// Fixture data for release registry and Jira versions (release picker)
+// ---------------------------------------------------------------------------
+
+const REGISTRY_DATA = {
+  releases: [
+    {
+      id: 'rhoai-3.5-ea1',
+      displayName: 'RHOAI 3.5 EA1',
+      state: 'active',
+      fixVersions: ['rhoai-3.5.EA1'],
+      milestones: { codeFreeze: '2026-06-01', ga: '2026-07-01' },
+    },
+    {
+      id: 'rhoai-3.5-ea2',
+      displayName: 'RHOAI 3.5 EA2',
+      state: 'active',
+      fixVersions: ['rhoai-3.5.EA2'],
+      milestones: { codeFreeze: '2026-07-01', ga: '2026-08-01' },
+    },
+    {
+      id: 'rhoai-3.5',
+      displayName: 'RHOAI 3.5',
+      state: 'active',
+      fixVersions: ['rhoai-3.5'],
+      milestones: { codeFreeze: '2026-08-01', ga: '2026-09-01' },
+    },
+  ],
+};
+
+// z-stream releases (e.g. rhoai-3.4.1) are filtered server-side — they carry
+// bug fixes only, not features, so they don't appear in TV/FV analysis.
+const JIRA_VERSIONS_DATA = {
+  versions: [
+    { name: 'rhoai-3.5.EA1', released: false, releaseDate: '2026-07-01' },
+    { name: 'rhoai-3.5.EA2', released: false, releaseDate: '2026-08-01' },
+    { name: 'rhoai-3.5', released: false, releaseDate: '2026-09-01' },
+    { name: 'rhoai-3.4', released: true, releaseDate: '2026-03-01' },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helper: mock all API endpoints the app needs to boot + TV/FV data
+// ---------------------------------------------------------------------------
+
+async function mockAllApis(page, tvfvData) {
+  // Playwright matches routes LIFO — register catch-all FIRST (lowest priority),
+  // then specific routes AFTER (higher priority, override catch-all).
+
+  // Catch-all for other /api calls — return empty JSON to avoid 401
+  await page.route('**/api/**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({})
+    });
+  });
+
+  // Mock module manifests (needed for sidebar rendering)
+  await page.route('**/api/built-in-modules/manifests', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([RELEASES_MANIFEST])
+    });
+  });
+
+  // Mock module state
+  await page.route('**/api/built-in-modules/state', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ 'releases': true })
+    });
+  });
+
+  // Mock auth/roles (user identity)
+  await page.route('**/api/roles/me', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ email: 'test@test.com', displayName: 'Test User', roles: ['admin'] })
+    });
+  });
+
+  // Mock site config
+  await page.route('**/api/site-config', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ title: 'Org Pulse', teamDataSource: 'in-app' })
+    });
+  });
+
+  // Mock messages
+  await page.route('**/api/messages', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
+  // Mock release registry (for release picker auto-selection)
+  await page.route('**/api/modules/releases/registry', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(REGISTRY_DATA)
+    });
+  });
+
+  // Mock Jira versions (for release picker dropdown)
+  await page.route('**/api/modules/releases/tv-fv-delta/versions', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(JIRA_VERSIONS_DATA)
+    });
+  });
+
+  // Mock refresh status (not running)
+  await page.route('**/api/modules/releases/tv-fv-delta/refresh/status', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ running: false })
+    });
+  });
+
+  // Mock the TV/FV delta endpoint (registered last = highest priority)
+  await page.route('**/api/modules/releases/tv-fv-delta', route => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true })
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(tvfvData || FIXTURE_DATA)
+      });
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: filter out expected console noise (auth, WebSocket)
+// ---------------------------------------------------------------------------
+
+const NOISE_PATTERNS = [
+  /401/,
+  /Unauthorized/,
+  /WebSocket/i,
+  /ws\/chat/,
+  /no valid credentials/i,
+  /Failed to load resource/,
+];
+
+function relevantErrors(page) {
+  return (page.errors || []).filter(err => {
+    return !NOISE_PATTERNS.some(pat => pat.test(err.message));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+test.describe('TV/FV Delta — View Loading @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should load the view without JavaScript errors', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render the page heading and subtitle', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const heading = page.getByRole('heading', { name: 'TV vs FV Delta' });
+    await expect(heading).toBeVisible();
+
+    const subtitle = page.locator('text=Target Version (PM intent) vs Fix Version (engineering commitment)');
+    await expect(subtitle).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render metadata line with timestamps and staleness note', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const metadata = page.locator('text=Counts reflect data at fetch time');
+    await expect(metadata).toBeVisible();
+
+    const dataFetched = page.locator('text=Data fetched');
+    await expect(dataFetched).toBeVisible();
+
+    const reportGenerated = page.locator('text=Report generated');
+    await expect(reportGenerated).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should call the TV/FV delta API endpoint', async ({ page }) => {
+    const apiRequests = [];
+    page.on('request', request => {
+      if (request.url().includes('/api/modules/releases/tv-fv-delta')) {
+        apiRequests.push({
+          url: request.url(),
+          method: request.method()
+        });
+      }
+    });
+
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const getRequests = apiRequests.filter(r => r.method === 'GET');
+    expect(getRequests.length).toBeGreaterThan(0);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render the executive summary table with correct headers', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summaryHeading = page.locator('h2:has-text("Executive Summary")');
+    await expect(summaryHeading).toBeVisible();
+
+    // Verify all column headers
+    const headers = ['Release', 'Total', 'Aligned', 'TV-Only', 'FV-Only', 'Mismatched', 'Alignment'];
+    for (const header of headers) {
+      const th = page.locator('th', { hasText: new RegExp(`^${header}$`, 'i') }).first();
+      await expect(th).toBeVisible();
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render one row per release in timeline order', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Find the executive summary table
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+    const rows = summarySection.locator('tbody tr');
+    await expect(rows).toHaveCount(3);
+
+    // Verify release order: EA1, EA2, 3.5
+    const firstRow = rows.nth(0);
+    await expect(firstRow).toContainText('rhoai-3.5.EA1');
+    const secondRow = rows.nth(1);
+    await expect(secondRow).toContainText('rhoai-3.5.EA2');
+    const thirdRow = rows.nth(2);
+    await expect(thirdRow).toContainText('rhoai-3.5');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should display correct counts in executive summary', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+
+    // EA1 row: total=5, aligned=3, tv_only=1, fv_only=0, mismatched=1, alignment=60%
+    const ea1Row = summarySection.locator('tbody tr').nth(0);
+    await expect(ea1Row).toContainText('60%');
+
+    // rhoai-3.5 row: 100% alignment
+    const gaRow = summarySection.locator('tbody tr').nth(2);
+    await expect(gaRow).toContainText('100%');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should colour-code alignment percentages', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+
+    // EA2 has 50% alignment → yellow
+    const ea2Pct = summarySection.locator('tbody tr').nth(1).locator('span.font-semibold').last();
+    const ea2Classes = await ea2Pct.getAttribute('class');
+    expect(ea2Classes).toContain('text-yellow-600');
+
+    // rhoai-3.5 has 100% alignment → green
+    const gaPct = summarySection.locator('tbody tr').nth(2).locator('span.font-semibold').last();
+    const gaClasses = await gaPct.getAttribute('class');
+    expect(gaClasses).toContain('text-green-600');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should highlight the selected release row', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+
+    // First release (EA1) should be selected by default
+    const ea1Row = summarySection.locator('tbody tr').nth(0);
+    const ea1Classes = await ea1Row.getAttribute('class');
+    expect(ea1Classes).toContain('bg-blue-50');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should select release when clicking executive summary row', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+
+    // Click on the EA2 row
+    const ea2Row = summarySection.locator('tbody tr').nth(1);
+    await ea2Row.click();
+    await page.waitForTimeout(500);
+
+    // EA2 row should now be highlighted
+    const ea2Classes = await ea2Row.getAttribute('class');
+    expect(ea2Classes).toContain('bg-blue-50');
+
+    // EA1 row should no longer be highlighted
+    const ea1Row = summarySection.locator('tbody tr').nth(0);
+    const ea1Classes = await ea1Row.getAttribute('class');
+    expect(ea1Classes).not.toContain('bg-blue-50');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render executive summary counts as clickable Jira links', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // ClickableCount renders as <a> tags that open Jira
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+    const jiraLinks = summarySection.locator('tbody a[href*="atlassian.net"]');
+    const linkCount = await jiraLinks.count();
+    // Each row has Total, Aligned, TV-Only, FV-Only, Mismatched = 5 links per row × 3 rows = 15
+    expect(linkCount).toBeGreaterThanOrEqual(9); // at least 3 per row
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render release chip buttons for all releases', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    for (const release of ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']) {
+      const chip = page.locator('button', { hasText: release }).first();
+      await expect(chip).toBeVisible();
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should highlight the active release tab', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // EA1 is selected by default → should have blue background
+    const ea1Tab = page.locator('button', { hasText: 'rhoai-3.5.EA1' });
+    const ea1Classes = await ea1Tab.getAttribute('class');
+    expect(ea1Classes).toContain('bg-blue-600');
+
+    // EA2 should NOT have blue background
+    const ea2Tab = page.locator('button', { hasText: 'rhoai-3.5.EA2' });
+    const ea2Classes = await ea2Tab.getAttribute('class');
+    expect(ea2Classes).not.toContain('bg-blue-600');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should switch release when clicking a tab', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Click EA2 tab
+    const ea2Tab = page.locator('button', { hasText: 'rhoai-3.5.EA2' });
+    await ea2Tab.click();
+    await page.waitForTimeout(500);
+
+    // EA2 tab should now be active
+    const ea2Classes = await ea2Tab.getAttribute('class');
+    expect(ea2Classes).toContain('bg-blue-600');
+
+    // EA1 tab should no longer be active
+    const ea1Tab = page.locator('button', { hasText: 'rhoai-3.5.EA1' });
+    const ea1Classes = await ea1Tab.getAttribute('class');
+    expect(ea1Classes).not.toContain('bg-blue-600');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render all four category sections for EA1', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // EA1 has: aligned (3), tv_only (1), fv_only (0), mismatched (1)
+    await expect(page.locator('summary:has-text("TV-Only")')).toBeVisible();
+    await expect(page.locator('summary:has-text("Aligned")')).toBeVisible();
+    await expect(page.locator('summary:has-text("Mismatched")')).toBeVisible();
+    // FV-Only should render even with 0 items (empty table)
+    await expect(page.locator('summary:has-text("FV-Only")')).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show correct counts in category headings', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // EA1 selected by default
+    await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
+    await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("Mismatched")')).toContainText('(1)');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should update category counts when switching releases', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // EA1: tv_only=1
+    await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
+
+    // Switch to rhoai-3.5 (GA): tv_only=0, aligned=3
+    await page.locator('button', { hasText: 'rhoai-3.5' }).last().click();
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(0)');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show "View in Jira" links on each category section', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const jiraLinks = page.locator('summary a:has-text("View in Jira")');
+    const count = await jiraLinks.count();
+    // Should have "View in Jira" on each visible category section
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should hide Mismatched section when count is zero', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Switch to EA2 which has 0 mismatched
+    await page.locator('button', { hasText: 'rhoai-3.5.EA2' }).click();
+    await page.waitForTimeout(500);
+
+    // Mismatched section should be hidden (v-if="releaseData.mismatched.length")
+    const mismatched = page.locator('summary:has-text("Mismatched")');
+    await expect(mismatched).toHaveCount(0);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Collapsible Behaviour @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should start with all category sections collapsed', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // All <details> should be closed by default (no 'open' attribute)
+    const detailsElements = page.locator('details');
+    const count = await detailsElements.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const isOpen = await detailsElements.nth(i).getAttribute('open');
+      expect(isOpen).toBeNull();
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should expand a section when clicking its summary', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Click the TV-Only summary to expand
+    const tvOnlySummary = page.locator('summary:has-text("TV-Only")');
+    await tvOnlySummary.click();
+    await page.waitForTimeout(300);
+
+    // The details element should now be open
+    const tvOnlyDetails = page.locator('details:has(summary:has-text("TV-Only"))');
+    const isOpen = await tvOnlyDetails.getAttribute('open');
+    expect(isOpen).not.toBeNull();
+
+    // Should show the feature table
+    const table = tvOnlyDetails.locator('table');
+    await expect(table).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should retain open/closed state when switching releases', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Open TV-Only and Aligned sections
+    await page.locator('summary:has-text("TV-Only")').click();
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(300);
+
+    // Verify they're open
+    const tvOnlyOpen = await page.locator('details:has(summary:has-text("TV-Only"))').getAttribute('open');
+    expect(tvOnlyOpen).not.toBeNull();
+    const alignedOpen = await page.locator('details:has(summary:has-text("Aligned"))').getAttribute('open');
+    expect(alignedOpen).not.toBeNull();
+
+    // FV-Only should still be closed
+    const fvOnlyClosed = await page.locator('details:has(summary:has-text("FV-Only"))').getAttribute('open');
+    expect(fvOnlyClosed).toBeNull();
+
+    // Switch to EA2
+    await page.locator('button', { hasText: 'rhoai-3.5.EA2' }).click();
+    await page.waitForTimeout(500);
+
+    // TV-Only and Aligned should STILL be open
+    const tvOnlyStillOpen = await page.locator('details:has(summary:has-text("TV-Only"))').getAttribute('open');
+    expect(tvOnlyStillOpen).not.toBeNull();
+    const alignedStillOpen = await page.locator('details:has(summary:has-text("Aligned"))').getAttribute('open');
+    expect(alignedStillOpen).not.toBeNull();
+
+    // FV-Only should still be closed
+    const fvOnlyStillClosed = await page.locator('details:has(summary:has-text("FV-Only"))').getAttribute('open');
+    expect(fvOnlyStillClosed).toBeNull();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should have disclosure triangles that rotate on open', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // The disclosure triangle is a span with ▶ (&#9654;) inside summary
+    // When open, it gets group-open:rotate-90 via CSS
+    const tvOnlyDetails = page.locator('details:has(summary:has-text("TV-Only"))');
+    const triangle = tvOnlyDetails.locator('summary span').first();
+    await expect(triangle).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render feature rows when section is expanded', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Aligned section (has 3 features for EA1)
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(300);
+
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const rows = alignedDetails.locator('tbody tr');
+    await expect(rows).toHaveCount(3);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render feature keys as clickable Jira links', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand TV-Only section
+    await page.locator('summary:has-text("TV-Only")').click();
+    await page.waitForTimeout(300);
+
+    const tvOnlyDetails = page.locator('details:has(summary:has-text("TV-Only"))');
+    const keyLink = tvOnlyDetails.locator('a[href*="RHAISTRAT-200"]');
+    await expect(keyLink).toBeVisible();
+    const href = await keyLink.getAttribute('href');
+    expect(href).toContain('redhat.atlassian.net/browse/RHAISTRAT-200');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should display correct columns for all categories (including TV/FV)', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Aligned section
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(300);
+
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const headers = alignedDetails.locator('thead th');
+
+    // All categories now include: Key, Summary, Status, TV, FV, Color, PM, Assignee, Team, Component
+    const expectedHeaders = ['Key', 'Summary', 'Status', 'TV', 'FV', 'Color', 'PM', 'Assignee', 'Team', 'Component'];
+    const count = await headers.count();
+    expect(count).toBe(expectedHeaders.length);
+
+    for (let i = 0; i < expectedHeaders.length; i++) {
+      await expect(headers.nth(i)).toContainText(expectedHeaders[i]);
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should display TV/FV columns in all categories', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Test that TV-Only, Aligned, and Mismatched all have TV/FV columns
+    const categories = ['TV-Only', 'Aligned', 'Mismatched'];
+
+    for (const category of categories) {
+      await page.locator(`summary:has-text("${category}")`).click();
+      await page.waitForTimeout(300);
+
+      const categoryDetails = page.locator(`details:has(summary:has-text("${category}"))`);
+      const headers = categoryDetails.locator('thead th');
+      const count = await headers.count();
+
+      // All categories have 10 columns including TV and FV
+      expect(count).toBe(10);
+
+      // Verify TV and FV headers exist
+      const headerTexts = [];
+      for (let i = 0; i < count; i++) {
+        headerTexts.push(await headers.nth(i).textContent());
+      }
+      expect(headerTexts.some(h => h.includes('TV'))).toBe(true);
+      expect(headerTexts.some(h => h.includes('FV'))).toBe(true);
+
+      // Collapse for next iteration
+      await page.locator(`summary:has-text("${category}")`).click();
+      await page.waitForTimeout(200);
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render color status as badges', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Aligned section
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(300);
+
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    // Color badges have rounded-full class
+    const badges = alignedDetails.locator('span.rounded-full');
+    const badgeCount = await badges.count();
+    expect(badgeCount).toBeGreaterThan(0);
+
+    // First feature has Green color status
+    const firstBadge = badges.first();
+    await expect(firstBadge).toContainText('Green');
+    const badgeClasses = await firstBadge.getAttribute('class');
+    expect(badgeClasses).toContain('bg-green-100');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should sort columns when clicking headers', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Aligned section (3 features)
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(300);
+
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+
+    // Get initial key order
+    const getKeys = async () => {
+      const links = alignedDetails.locator('tbody a[href*="RHAISTRAT"]');
+      const keys = [];
+      const count = await links.count();
+      for (let i = 0; i < count; i++) {
+        keys.push(await links.nth(i).textContent());
+      }
+      return keys;
+    };
+
+    const initialKeys = await getKeys();
+    expect(initialKeys).toHaveLength(3);
+
+    // Click the Key header to sort ascending
+    const keyHeader = alignedDetails.locator('thead th', { hasText: 'Key' });
+    await keyHeader.click();
+    await page.waitForTimeout(300);
+
+    // Should show sort indicator
+    const sortIndicator = keyHeader.locator('span');
+    await expect(sortIndicator).toBeVisible();
+
+    // Click again to sort descending
+    await keyHeader.click();
+    await page.waitForTimeout(300);
+
+    const descKeys = await getKeys();
+    // Descending: 102, 101, 100
+    expect(descKeys[0]).toBe('RHAISTRAT-102');
+    expect(descKeys[2]).toBe('RHAISTRAT-100');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should update feature rows when switching releases', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Aligned section — EA1 has 3 aligned
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(300);
+
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    let rows = alignedDetails.locator('tbody tr');
+    await expect(rows).toHaveCount(3);
+
+    // Switch to EA2 — has 2 aligned
+    await page.locator('button', { hasText: 'rhoai-3.5.EA2' }).click();
+    await page.waitForTimeout(500);
+
+    rows = alignedDetails.locator('tbody tr');
+    await expect(rows).toHaveCount(2);
+
+    // Verify the keys changed (EA2 features)
+    const firstKey = alignedDetails.locator('tbody a[href*="RHAISTRAT"]').first();
+    await expect(firstKey).toContainText('RHAISTRAT-400');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render component breakdown section', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const compBreakdown = page.locator('summary:has-text("Component Breakdown")');
+    await expect(compBreakdown).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show per-release component data (EA1 has Serving with 3 features)', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Component Breakdown
+    await page.locator('summary:has-text("Component Breakdown")').click();
+    await page.waitForTimeout(300);
+
+    const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
+    // EA1: Serving appears in RHAISTRAT-100, 102, 300 = 3 features (meets >= 2 threshold)
+    const servingRow = compSection.locator('tbody tr', { hasText: 'Serving' });
+    await expect(servingRow).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should update component breakdown when switching releases', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Component Breakdown
+    await page.locator('summary:has-text("Component Breakdown")').click();
+    await page.waitForTimeout(300);
+
+    const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
+
+    // EA1 component rows — verify something rendered before switching
+    const ea1Rows = await compSection.locator('tbody tr').count();
+    expect(ea1Rows).toBeGreaterThan(0);
+
+    // Switch to rhoai-3.5 (GA) — different components
+    await page.locator('button', { hasText: 'rhoai-3.5' }).last().click();
+    await page.waitForTimeout(500);
+
+    // GA has Serving (RHAISTRAT-700, 702) = 2 features
+    const gaRows = await compSection.locator('tbody tr').count();
+    // The counts should differ since different releases have different feature distributions
+    // At minimum, the component breakdown should have rendered something
+    expect(gaRows).toBeGreaterThanOrEqual(1);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should display correct component breakdown columns', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Component Breakdown
+    await page.locator('summary:has-text("Component Breakdown")').click();
+    await page.waitForTimeout(300);
+
+    const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
+    const headers = compSection.locator('thead th');
+
+    const expectedHeaders = ['Component', 'Total', 'Aligned', 'TV-Only', 'FV-Only', 'Mismatched', 'Alignment'];
+    const count = await headers.count();
+    expect(count).toBe(expectedHeaders.length);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should colour-code component alignment percentages', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Component Breakdown
+    await page.locator('summary:has-text("Component Breakdown")').click();
+    await page.waitForTimeout(300);
+
+    const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
+    const pctSpans = compSection.locator('tbody span.font-semibold');
+    const count = await pctSpans.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Each percentage span should have a colour class
+    for (let i = 0; i < count; i++) {
+      const classes = await pctSpans.nth(i).getAttribute('class');
+      const hasColor = classes.includes('text-red-600') ||
+                       classes.includes('text-yellow-600') ||
+                       classes.includes('text-green-600');
+      expect(hasColor).toBe(true);
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should display TV and FV values in table cells', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Mismatched section (has both TV and FV populated)
+    await page.locator('summary:has-text("Mismatched")').click();
+    await page.waitForTimeout(300);
+
+    const mismatchedDetails = page.locator('details:has(summary:has-text("Mismatched"))');
+    const firstRow = mismatchedDetails.locator('tbody tr').first();
+
+    // Should show rhoai-3.5.EA1 in TV column and rhoai-3.5.EA2 in FV column (from fixture)
+    await expect(firstRow).toContainText('rhoai-3.5.EA1');
+    await expect(firstRow).toContainText('rhoai-3.5.EA2');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show components with zero features when all_components is available', async ({ page }) => {
+    // Mock with all_components metadata
+    const dataWithAllComponents = {
+      ...FIXTURE_DATA,
+      metadata: {
+        ...FIXTURE_DATA.metadata,
+        all_components: ['Serving', 'Training', 'Dashboard', 'Pipelines', 'Model Registry', 'Notebooks', 'Unused Component A', 'Unused Component B']
+      }
+    };
+
+    await mockAllApis(page, dataWithAllComponents);
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Component Breakdown
+    await page.locator('summary:has-text("Component Breakdown")').click();
+    await page.waitForTimeout(300);
+
+    const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
+
+    // Should show components with 0 features
+    await expect(compSection.locator('text=Unused Component A')).toBeVisible();
+    await expect(compSection.locator('text=Unused Component B')).toBeVisible();
+
+    // Verify they show 0 counts
+    const unusedRow = compSection.locator('tr:has-text("Unused Component A")');
+    await expect(unusedRow.locator('td').nth(1)).toContainText('0'); // Total column
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should sync release selection between executive summary and tabs', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+
+    // Click EA2 row in executive summary
+    const ea2Row = summarySection.locator('tbody tr').nth(1);
+    await ea2Row.click();
+    await page.waitForTimeout(500);
+
+    // EA2 tab should now be active (highlighted)
+    const ea2Tab = page.locator('button', { hasText: 'rhoai-3.5.EA2' });
+    const ea2Classes = await ea2Tab.getAttribute('class');
+    expect(ea2Classes).toContain('bg-blue-600');
+
+    // Now click EA1 tab
+    const ea1Tab = page.locator('button', { hasText: 'rhoai-3.5.EA1' });
+    await ea1Tab.click();
+    await page.waitForTimeout(500);
+
+    // EA1 executive summary row should now be highlighted
+    const ea1ExecRow = summarySection.locator('tbody tr').nth(0);
+    const ea1RowClasses = await ea1ExecRow.getAttribute('class');
+    expect(ea1RowClasses).toContain('bg-blue-50');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should handle features with multiple comma-separated components', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Expand Mismatched section (RHAISTRAT-300 has "Serving, Training")
+    await page.locator('summary:has-text("Mismatched")').click();
+    await page.waitForTimeout(300);
+
+    const mismatchedDetails = page.locator('details:has(summary:has-text("Mismatched"))');
+    const componentCell = mismatchedDetails.locator('tbody tr:has-text("RHAISTRAT-300")').locator('td').last();
+
+    // Should show both components
+    await expect(componentCell).toContainText('Serving');
+    await expect(componentCell).toContainText('Training');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show refresh button and handle click', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const refreshButton = page.locator('button:has-text("Refresh from Jira")');
+    await expect(refreshButton).toBeVisible();
+    await expect(refreshButton).toBeEnabled();
+
+    // Button should be clickable (we're not testing the actual refresh, just the UI)
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should display staleness warning message', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Should show staleness note
+    const staleNote = page.locator('text=Counts reflect data at fetch time');
+    await expect(staleNote).toBeVisible();
+
+    // Should show both timestamps
+    await expect(page.locator('text=Data fetched')).toBeVisible();
+    await expect(page.locator('text=Report generated')).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — No Data State @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should handle 404 (no data) gracefully', async ({ page }) => {
+    // Mock bootstrap APIs but override TV/FV to return 404
+    await mockAllApis(page);
+    await page.unroute('**/api/modules/releases/tv-fv-delta');
+    await page.route('**/api/modules/releases/tv-fv-delta', route => {
+      route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'No TV/FV delta data available.' })
+      });
+    });
+
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Either shows an error or renders empty — neither should crash
+    // The key assertion is no JS errors
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should handle 202 (pipeline running) gracefully', async ({ page }) => {
+    // Mock bootstrap APIs but override TV/FV to return 202
+    await mockAllApis(page);
+    await page.unroute('**/api/modules/releases/tv-fv-delta');
+    await page.route('**/api/modules/releases/tv-fv-delta', route => {
+      route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          _refreshing: true,
+          _noCache: true,
+          message: 'Data pipeline is running for the first time.'
+        })
+      });
+    });
+
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Should not crash — loading or message state is acceptable
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+
+test.describe('TV/FV Delta — Release Picker @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await mockAllApis(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render release chips from auto-selected registry versions', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Auto-selected versions appear as chip buttons below exec summary
+    for (const release of ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']) {
+      await expect(page.locator('button', { hasText: release }).first()).toBeVisible();
+    }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show "+ Add release" button', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const addButton = page.locator('button:has-text("+ Add release")');
+    await expect(addButton).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should open dropdown when clicking "+ Add release"', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Click the add button
+    await page.locator('button:has-text("+ Add release")').click();
+    await page.waitForTimeout(300);
+
+    // Dropdown should be visible with search input
+    const searchInput = page.locator('input[placeholder="Search versions..."]');
+    await expect(searchInput).toBeVisible();
+
+    // Should show Jira versions in the dropdown (z-stream releases like rhoai-3.4.1 are filtered server-side)
+    await expect(page.locator('button:has-text("rhoai-3.4")')).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should filter versions when typing in search', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Open dropdown
+    await page.locator('button:has-text("+ Add release")').click();
+    await page.waitForTimeout(300);
+
+    // Type in search
+    const searchInput = page.locator('input[placeholder="Search versions..."]');
+    await searchInput.fill('3.4');
+    await page.waitForTimeout(300);
+
+    // Should show only 3.4 versions (z-stream rhoai-3.4.1 is filtered out server-side)
+    const dropdownButtons = page.locator('.max-h-64 button');
+    const count = await dropdownButtons.count();
+    expect(count).toBe(1);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should close dropdown when clicking outside', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Open dropdown
+    await page.locator('button:has-text("+ Add release")').click();
+    await page.waitForTimeout(300);
+
+    // Verify dropdown is open
+    const searchInput = page.locator('input[placeholder="Search versions..."]');
+    await expect(searchInput).toBeVisible();
+
+    // Click outside the dropdown
+    await page.locator('h1:has-text("TV vs FV Delta")').click();
+    await page.waitForTimeout(300);
+
+    // Dropdown should be closed
+    await expect(searchInput).not.toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should remove a version chip when clicking its x button', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // All 3 release chips should be visible
+    const ea1Chip = page.locator('button', { hasText: 'rhoai-3.5.EA1' }).first();
+    await expect(ea1Chip).toBeVisible();
+
+    // Click the x (×) on the EA1 chip
+    await ea1Chip.locator('span[title="Remove"]').click();
+    await page.waitForTimeout(300);
+
+    // EA1 chip should be gone
+    await expect(ea1Chip).not.toBeVisible();
+    // Others still present
+    await expect(page.locator('button', { hasText: 'rhoai-3.5.EA2' }).first()).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should call registry and versions endpoints on load', async ({ page }) => {
+    const apiRequests = [];
+    page.on('request', request => {
+      const url = request.url();
+      if (url.includes('/api/modules/releases/registry') ||
+          url.includes('/api/modules/releases/tv-fv-delta/versions')) {
+        apiRequests.push({ url, method: request.method() });
+      }
+    });
+
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Both registry and versions should have been fetched
+    const registryReqs = apiRequests.filter(r => r.url.includes('/registry'));
+    const versionReqs = apiRequests.filter(r => r.url.includes('/versions'));
+    expect(registryReqs.length).toBeGreaterThan(0);
+    expect(versionReqs.length).toBeGreaterThan(0);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -632,7 +632,8 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
 
     // Switch to rhoai-3.5 (GA): tv_only=0, aligned=3
-    await page.locator('button', { hasText: 'rhoai-3.5' }).last().click();
+    // Use negative lookahead to match only the GA chip (not EA1/EA2)
+    await page.locator('button', { hasText: /rhoai-3\.5(?!\.)/ }).click();
     await page.waitForTimeout(500);
 
     await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
@@ -1031,7 +1032,7 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     expect(ea1Rows).toBeGreaterThan(0);
 
     // Switch to rhoai-3.5 (GA) — different components
-    await page.locator('button', { hasText: 'rhoai-3.5' }).last().click();
+    await page.locator('button', { hasText: /rhoai-3\.5(?!\.)/ }).click();
     await page.waitForTimeout(500);
 
     // GA has Serving (RHAISTRAT-700, 702) = 2 features


### PR DESCRIPTION
## Summary
- TV vs FV (Target Version vs Fix Version) delta analysis — shows alignment, mismatches, and gaps between PM intent and ENG commitment per release
- Stale-while-revalidate caching with background refresh and polling
- Release picker sourcing from both registry and Jira project versions
- Auto-refresh when selecting releases not yet in cached data (800ms debounce)
- Executive summary with pending placeholders for in-flight refreshes
- JQL injection prevention via pattern validation on all code paths
- Component breakdown with deduplicated worst-category classification
- Clickable Jira counts throughout (all totals link to filtered issue lists)
- Graceful error handling: transient errors don't hide valid cached data

## Test plan
- [ ] Unit tests pass (`npm test -- --testPathPattern=tv-fv-delta`)
- [ ] Integration test spec included (`tests/integration/tv-fv-delta.spec.js`)
- [ ] Manual test: load page, verify executive summary renders with default releases
- [ ] Manual test: add/remove releases via picker, verify auto-refresh triggers
- [ ] Manual test: verify pending placeholder rows show "(refreshing data...)" during refresh
- [ ] Manual test: click counts to verify Jira links open correct filtered views

🤖 Generated with [Claude Code](https://claude.com/claude-code)