### PR TITLE
fix: normalize z-stream releases and filter past-due from Delivery views

### DIFF
--- a/modules/releases/client/deliver/views/MainView.vue
+++ b/modules/releases/client/deliver/views/MainView.vue
@@ -92,7 +92,19 @@ const filter = inject('releaseFilter')
 const analysisState = inject('analysisState')
 const { loading, refreshing, error, analysis, refreshAnalysis } = analysisState
 
-const allReleases = computed(() => filter.filteredReleases.value)
+const allReleases = computed(() => {
+  const releases = filter.filteredReleases.value
+
+  // Filter to current/future releases only (hide past-due releases like 3.4)
+  const now = new Date()
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+
+  return releases.filter(r => {
+    const due = new Date(`${r.dueDate}T00:00:00Z`)
+    if (Number.isNaN(due.getTime())) return true // Keep if no date
+    return due >= today // Hide if due date passed
+  })
+})
 
 const groupedByVersion = computed(() => {
   const map = new Map()

--- a/modules/releases/client/deliver/views/ProjectBreakdownView.vue
+++ b/modules/releases/client/deliver/views/ProjectBreakdownView.vue
@@ -382,7 +382,19 @@ const { loading, refreshing, error, analysis, refreshAnalysis } = analysisState
 
 function normalizeType(t) { return (t || '').toLowerCase().trim() }
 
-const allReleases = computed(() => filter.filteredReleases.value)
+const allReleases = computed(() => {
+  const releases = filter.filteredReleases.value
+
+  // Filter to current/future releases only (hide past-due releases like 3.4)
+  const now = new Date()
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+
+  return releases.filter(r => {
+    const due = new Date(`${r.dueDate}T00:00:00Z`)
+    if (Number.isNaN(due.getTime())) return true // Keep if no date
+    return due >= today // Hide if due date passed
+  })
+})
 
 const enrichedReleases = computed(() =>
   allReleases.value.map(r => ({

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -19,11 +19,26 @@ function normalizeText(value) {
   return String(value || '').trim().toLowerCase()
 }
 
+/**
+ * Normalizes release/fix version names by removing z-stream notation.
+ * Z-stream releases (async/minor updates) should group with parent version.
+ * Examples:
+ *   "rhoai-3.5.z" → "rhoai-3.5"
+ *   "rhoai-3.5.z.EA1" → "rhoai-3.5.EA1"
+ *   "RHAI 3.5.z" → "RHAI 3.5"
+ */
+function normalizeReleaseNumber(value) {
+  if (!value) return value
+  // Remove .z notation (z-stream releases)
+  return String(value).replace(/\.z\b/gi, '')
+}
+
 function normalizeKey(value) {
   // Remove common suffixes like " release", " GA", etc. before normalizing
   let normalized = normalizeText(value);
   normalized = normalized.replace(/\s+release$/i, ''); // "rhelai-3.5 EA1 release" → "rhelai-3.5 ea1"
   normalized = normalized.replace(/\s+ga$/i, '');      // "RHAII-3.5 GA" → "rhaii-3.5"
+  normalized = normalized.replace(/\.z\b/gi, '');      // "rhoai-3.5.z.EA1" → "rhoai-3.5.ea1"
   return normalized.replace(/[^a-z0-9]/g, '');
 }
 
@@ -381,9 +396,12 @@ function buildAnalysis(releases, issues, fieldMeta, config) {
   const releaseByText = new Map()
   const releaseByKey = new Map()
   for (const r of releases) {
+    // Normalize release number to remove z-stream notation
+    const normalizedReleaseNumber = normalizeReleaseNumber(r.releaseNumber)
+
     const entry = {
       productName: r.productName,
-      releaseNumber: r.releaseNumber,
+      releaseNumber: normalizedReleaseNumber,
       dueDate: r.dueDate,
       codeFreezeDate: r.codeFreezeDate || null,
       teams: {},
@@ -405,8 +423,8 @@ function buildAnalysis(releases, issues, fieldMeta, config) {
       },
       risk: 'green'
     }
-    releaseByText.set(normalizeText(r.releaseNumber), entry)
-    const k = normalizeKey(r.releaseNumber)
+    releaseByText.set(normalizeText(normalizedReleaseNumber), entry)
+    const k = normalizeKey(normalizedReleaseNumber)
     if (!releaseByKey.has(k)) releaseByKey.set(k, entry)
   }
 


### PR DESCRIPTION
## Summary
Fixes Product Pages integration for RHOAI, RHELAI, and RHAII releases in the Delivery module:

1. **Frontend date filtering** — Hide past-due releases (like 3.4) from Delivery tab views
2. **Z-stream normalization** — Strip `.z` notation from release numbers to group z-stream releases with parent versions

## Changes

### Frontend (Delivery Views Only)
- [MainView.vue](modules/releases/client/deliver/views/MainView.vue#L91-L106) — Risk Dashboard: filter to current/future releases
- [ProjectBreakdownView.vue](modules/releases/client/deliver/views/ProjectBreakdownView.vue#L385-L400) — Component Breakdown: filter to current/future releases

Intentionally **not** filtered:
- ConformaExceptionsView — compliance tracking needs historical exceptions
- PostReleaseDefectsView — quality tracking needs historical bugs

### Backend (Delivery Module Only)
- [routes.js](modules/releases/server/delivery/routes.js#L18-L41) — Added `normalizeReleaseNumber()` to strip `.z` notation
  - `"rhoai-3.5.z.EA1"` → `"rhoai-3.5.EA1"`
  - `"RHAI 3.5.z"` → `"RHAI 3.5"`
- Applied normalization when creating release entries from Product Pages data

## Testing
- [x] Verified date filtering hides 3.4 in MainView and ProjectBreakdownView
- [x] Verified Commitment Tracking still shows ALL releases including 3.4
- [x] Verified z-stream notation normalization groups releases correctly
- [x] Verified ConformaExceptionsView and PostReleaseDefectsView retain historical data

## Scope
**CRITICAL:** Changes isolated to Releases > Deliver tab only. No impact to:
- Commitment Tracking reports (still shows all historical data)
- Other modules or functionality
- Backend data completeness (analysis-cache.json still contains all releases)

Related: #762 (Product Pages integration)