### PR TITLE
feat(releases): add Feature Execution Tracking page

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -284,6 +284,8 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/releases/execution/versions` — unique fix versions
 - `/api/modules/releases/execution/status` — data freshness
 - `/api/modules/releases/execution/config` — fetch config (admin)
+- `/api/modules/releases/execution/tracking/data` — feature tracking data by fixVersion query
+- `/api/modules/releases/execution/tracking/versions` — available portfolio versions for feature tracking
 - `/api/modules/releases/delivery/config` — delivery config (admin)
 - `/api/modules/releases/delivery/product-pages/products` — Product Pages products (admin)
 - `/api/modules/releases/delivery/refresh/status` — delivery refresh status

--- a/modules/releases/__tests__/server/delivery/feature-freeze.test.js
+++ b/modules/releases/__tests__/server/delivery/feature-freeze.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { extractFeatureFreezeDate } from '../../../server/delivery/product-pages.js'
+
+describe('extractFeatureFreezeDate', () => {
+  it('extracts feature freeze date from major_milestones', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Feature Freeze', date_finish: '2026-05-15' },
+        { name: 'RHAI 3.5 GA', date_finish: '2026-08-01' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBe('2026-05-15')
+  })
+
+  it('prefers EA-scoped feature freeze when eaTag is provided', () => {
+    const release = {
+      major_milestones: [
+        { name: 'EA1 Feature Freeze', date_finish: '2026-04-15' },
+        { name: 'Feature Freeze', date_finish: '2026-07-01' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release, 'EA1')).toBe('2026-04-15')
+  })
+
+  it('falls back to generic feature freeze when eaTag does not match', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Feature Freeze', date_finish: '2026-07-01' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release, 'EA2')).toBe('2026-07-01')
+  })
+
+  it('handles "Feature-Freeze" hyphenated name', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Feature-Freeze', date_finish: '2026-05-15' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBe('2026-05-15')
+  })
+
+  it('handles "Feature_Freeze" underscore name', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Feature_Freeze', date_finish: '2026-05-15' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBe('2026-05-15')
+  })
+
+  it('handles "feature freeze" lowercase', () => {
+    const release = {
+      major_milestones: [
+        { name: 'feature freeze', date_finish: '2026-05-15' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBe('2026-05-15')
+  })
+
+  it('skips draft milestones', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Feature Freeze', date_finish: '2026-05-15', draft: true }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBeNull()
+  })
+
+  it('falls back to all_ga_tasks when no milestone matches', () => {
+    const release = {
+      major_milestones: [],
+      all_ga_tasks: [
+        { name: 'Feature Freeze', date_finish: '2026-05-20' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBe('2026-05-20')
+  })
+
+  it('prefers EA-scoped task when eaTag is provided', () => {
+    const release = {
+      major_milestones: [],
+      all_ga_tasks: [
+        { name: 'EA1 Feature Freeze', date_finish: '2026-04-10' },
+        { name: 'Feature Freeze', date_finish: '2026-06-01' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release, 'EA1')).toBe('2026-04-10')
+  })
+
+  it('returns null when no feature freeze exists', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Code Freeze', date_finish: '2026-07-15' },
+        { name: 'RHAI 3.5 GA', date_finish: '2026-08-01' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBeNull()
+  })
+
+  it('returns null for empty release', () => {
+    expect(extractFeatureFreezeDate({})).toBeNull()
+  })
+
+  it('does not match code freeze', () => {
+    const release = {
+      major_milestones: [
+        { name: 'Code Freeze', date_finish: '2026-07-15' }
+      ]
+    }
+    expect(extractFeatureFreezeDate(release)).toBeNull()
+  })
+})

--- a/modules/releases/__tests__/server/execution/feature-tracking.test.js
+++ b/modules/releases/__tests__/server/execution/feature-tracking.test.js
@@ -1,0 +1,388 @@
+import { describe, it, expect } from 'vitest'
+
+const { transformIssue, CUSTOM_FIELDS } = require('../../../server/hygiene/jira-fetch')
+const { findFixVersionAddedDate, findFixVersionRemovedDate, classifyFeature, normalizeVersionName } = require('../../../server/execution/feature-tracking-routes')
+
+function makeRawIssue(overrides) {
+  var fields = {}
+  fields.summary = 'Test feature'
+  fields.issuetype = { name: 'Feature' }
+  fields.status = { name: 'In Progress', statusCategory: { name: 'In Progress' } }
+  fields.assignee = { displayName: 'Jane Doe' }
+  fields.fixVersions = [{ name: 'rhoai-3.5.EA1' }]
+  fields.components = [{ name: 'Model Serving' }]
+  fields.labels = []
+  fields.issuelinks = []
+  fields[CUSTOM_FIELDS.team] = { name: 'Model Serving' }
+  fields[CUSTOM_FIELDS.colorStatus] = { value: 'Green' }
+
+  if (overrides) {
+    Object.assign(fields, overrides)
+  }
+
+  return {
+    key: 'RHAISTRAT-100',
+    fields: fields,
+    renderedFields: {}
+  }
+}
+
+// ─── isBlocked derivation ──────────────────────────────────────────
+
+describe('transformIssue — isBlocked', function () {
+  it('sets isBlocked=false when no issue links exist', function () {
+    var result = transformIssue(makeRawIssue(), {})
+    expect(result.isBlocked).toBe(false)
+  })
+
+  it('sets isBlocked=true when an unresolved inward Blocks link exists', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'Blocks', inward: 'is blocked by' },
+        inwardIssue: {
+          key: 'RHOAIENG-500',
+          fields: { status: { name: 'In Progress' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(true)
+  })
+
+  it('sets isBlocked=false when blocking issue is Closed', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'Blocks', inward: 'is blocked by' },
+        inwardIssue: {
+          key: 'RHOAIENG-500',
+          fields: { status: { name: 'Closed' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(false)
+  })
+
+  it('sets isBlocked=false when blocking issue is Resolved', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'Blocks', inward: 'is blocked by' },
+        inwardIssue: {
+          key: 'RHOAIENG-500',
+          fields: { status: { name: 'Resolved' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(false)
+  })
+
+  it('sets isBlocked=false when blocking issue is Done', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'Blocks', inward: 'is blocked by' },
+        inwardIssue: {
+          key: 'RHOAIENG-500',
+          fields: { status: { name: 'Done' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(false)
+  })
+
+  it('ignores outward Blocks links (this issue blocks something else)', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'Blocks', outward: 'blocks' },
+        outwardIssue: {
+          key: 'RHOAIENG-600',
+          fields: { status: { name: 'In Progress' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(false)
+  })
+
+  it('ignores non-Blocks link types', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'Relates', inward: 'relates to' },
+        inwardIssue: {
+          key: 'RHOAIENG-700',
+          fields: { status: { name: 'In Progress' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(false)
+  })
+
+  it('detects blocked via "is blocked by" inward label', function () {
+    var result = transformIssue(makeRawIssue({
+      issuelinks: [{
+        type: { name: 'SomeType', inward: 'is blocked by' },
+        inwardIssue: {
+          key: 'RHOAIENG-800',
+          fields: { status: { name: 'To Do' } }
+        }
+      }]
+    }), {})
+    expect(result.isBlocked).toBe(true)
+  })
+})
+
+// ─── pmOwner derivation ────────────────────────────────────────────
+
+describe('transformIssue — pmOwner', function () {
+  it('extracts pmOwner from productManager custom field', function () {
+    var overrides = {}
+    overrides[CUSTOM_FIELDS.productManager] = { displayName: 'Bob Smith' }
+    var result = transformIssue(makeRawIssue(overrides), {})
+    expect(result.pmOwner).toBe('Bob Smith')
+  })
+
+  it('returns null when productManager field is not set', function () {
+    var result = transformIssue(makeRawIssue(), {})
+    expect(result.pmOwner).toBeNull()
+  })
+
+  it('returns null when productManager field is null', function () {
+    var overrides = {}
+    overrides[CUSTOM_FIELDS.productManager] = null
+    var result = transformIssue(makeRawIssue(overrides), {})
+    expect(result.pmOwner).toBeNull()
+  })
+})
+
+// ─── productManager custom field ID ────────────────────────────────
+
+describe('CUSTOM_FIELDS', function () {
+  it('includes productManager field ID', function () {
+    expect(CUSTOM_FIELDS.productManager).toBe('customfield_10469')
+  })
+})
+
+// ─── findFixVersionAddedDate ──────────────────────────────────────
+
+describe('findFixVersionAddedDate', function () {
+  it('returns the timestamp when fixVersion was added', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-15T10:30:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          toString: 'rhoai-3.5.EA1'
+        }]
+      }]
+    }
+    expect(findFixVersionAddedDate(changelog, 'rhoai-3.5.EA1')).toBe('2026-05-15T10:30:00.000+0000')
+  })
+
+  it('returns null when fixVersion not found in changelog', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-15T10:30:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          toString: 'rhoai-3.5.EA2'
+        }]
+      }]
+    }
+    expect(findFixVersionAddedDate(changelog, 'rhoai-3.5.EA1')).toBeNull()
+  })
+
+  it('returns null when changelog is empty', function () {
+    expect(findFixVersionAddedDate({ histories: [] }, 'rhoai-3.5.EA1')).toBeNull()
+  })
+
+  it('returns null when changelog is null', function () {
+    expect(findFixVersionAddedDate(null, 'rhoai-3.5.EA1')).toBeNull()
+  })
+
+  it('matches case-insensitively', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-15T10:30:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          toString: 'RHOAI-3.5.EA1'
+        }]
+      }]
+    }
+    expect(findFixVersionAddedDate(changelog, 'rhoai-3.5.EA1')).toBe('2026-05-15T10:30:00.000+0000')
+  })
+
+  it('matches any version in an array of fixVersion names', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-15T10:30:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          toString: 'rhelai-3.5 EA2 release'
+        }]
+      }]
+    }
+    expect(findFixVersionAddedDate(changelog, ['rhelai-3.5EA2', 'rhelai-3.5 EA2 release'])).toBe('2026-05-15T10:30:00.000+0000')
+  })
+})
+
+// ─── findFixVersionRemovedDate ────────────────────────────────────
+
+describe('findFixVersionRemovedDate', function () {
+  it('returns the timestamp when fixVersion was removed', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-20T14:00:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          fromString: 'rhoai-3.5.EA1',
+          toString: ''
+        }]
+      }]
+    }
+    expect(findFixVersionRemovedDate(changelog, 'rhoai-3.5.EA1')).toBe('2026-05-20T14:00:00.000+0000')
+  })
+
+  it('returns the most recent removal when fixVersion was removed multiple times', function () {
+    var changelog = {
+      histories: [
+        {
+          created: '2026-05-10T10:00:00.000+0000',
+          items: [{
+            field: 'Fix Version',
+            fieldId: 'fixVersions',
+            fromString: 'rhoai-3.5.EA1',
+            toString: ''
+          }]
+        },
+        {
+          created: '2026-05-20T14:00:00.000+0000',
+          items: [{
+            field: 'Fix Version',
+            fieldId: 'fixVersions',
+            fromString: 'rhoai-3.5.EA1',
+            toString: 'rhoai-3.6'
+          }]
+        }
+      ]
+    }
+    expect(findFixVersionRemovedDate(changelog, 'rhoai-3.5.EA1')).toBe('2026-05-20T14:00:00.000+0000')
+  })
+
+  it('returns null when fixVersion was never removed', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-15T10:00:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          fromString: '',
+          toString: 'rhoai-3.5.EA1'
+        }]
+      }]
+    }
+    expect(findFixVersionRemovedDate(changelog, 'rhoai-3.5.EA1')).toBeNull()
+  })
+
+  it('matches any version in an array of fixVersion names', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-20T14:00:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          fromString: 'rhelai-3.5 EA2 release',
+          toString: ''
+        }]
+      }]
+    }
+    expect(findFixVersionRemovedDate(changelog, ['rhelai-3.5EA2', 'rhelai-3.5 EA2 release'])).toBe('2026-05-20T14:00:00.000+0000')
+  })
+
+  it('matches case-insensitively', function () {
+    var changelog = {
+      histories: [{
+        created: '2026-05-20T14:00:00.000+0000',
+        items: [{
+          field: 'Fix Version',
+          fieldId: 'fixVersions',
+          fromString: 'RHOAI-3.5.EA1',
+          toString: ''
+        }]
+      }]
+    }
+    expect(findFixVersionRemovedDate(changelog, 'rhoai-3.5.EA1')).toBe('2026-05-20T14:00:00.000+0000')
+  })
+
+  it('returns null when changelog is null', function () {
+    expect(findFixVersionRemovedDate(null, 'rhoai-3.5.EA1')).toBeNull()
+  })
+
+  it('returns null when changelog is empty', function () {
+    expect(findFixVersionRemovedDate({ histories: [] }, 'rhoai-3.5.EA1')).toBeNull()
+  })
+})
+
+// ─── classifyFeature ──────────────────────────────────────────────
+
+describe('classifyFeature', function () {
+  it('returns "added" when fixVersion was applied after freeze date', function () {
+    var feature = { fixVersionAddedAt: '2026-06-01T10:00:00.000+0000' }
+    expect(classifyFeature(feature, '2026-05-20')).toBe('added')
+  })
+
+  it('returns null when fixVersion was applied before freeze date', function () {
+    var feature = { fixVersionAddedAt: '2026-05-10T10:00:00.000+0000' }
+    expect(classifyFeature(feature, '2026-05-20')).toBeNull()
+  })
+
+  it('returns null when no freeze date is available', function () {
+    var feature = { fixVersionAddedAt: '2026-06-01T10:00:00.000+0000' }
+    expect(classifyFeature(feature, null)).toBeNull()
+  })
+
+  it('returns null when fixVersionAddedAt is not available', function () {
+    var feature = { fixVersionAddedAt: null }
+    expect(classifyFeature(feature, '2026-05-20')).toBeNull()
+  })
+})
+
+// ─── normalizeVersionName ─────────────────────────────────────────
+
+describe('normalizeVersionName', function () {
+  it('normalizes dot-separated EA tag (rhoai style)', function () {
+    expect(normalizeVersionName('rhoai-3.5.EA2')).toBe('rhoai-3.5ea2')
+  })
+
+  it('normalizes space-separated EA tag (RHAII style)', function () {
+    expect(normalizeVersionName('RHAII-3.5 EA2')).toBe('rhaii-3.5ea2')
+  })
+
+  it('normalizes concatenated EA tag (rhelai style)', function () {
+    expect(normalizeVersionName('rhelai-3.5EA2')).toBe('rhelai-3.5ea2')
+  })
+
+  it('strips trailing "release" suffix', function () {
+    expect(normalizeVersionName('rhelai-3.5 EA2 release')).toBe('rhelai-3.5ea2')
+  })
+
+  it('normalizes hyphenated EA tag (RHELAI-3.4 EA-1)', function () {
+    expect(normalizeVersionName('RHELAI-3.4 EA-1')).toBe('rhelai-3.4ea1')
+  })
+
+  it('normalizes GA versions consistently', function () {
+    expect(normalizeVersionName('rhoai-3.5')).toBe('rhoai-3.5')
+    expect(normalizeVersionName('RHAII-3.5')).toBe('rhaii-3.5')
+  })
+
+  it('normalizes space-separated GA tag', function () {
+    expect(normalizeVersionName('RHAII-3.5 GA')).toBe('rhaii-3.5ga')
+    expect(normalizeVersionName('RHAII-3.5 ga')).toBe('rhaii-3.5ga')
+  })
+
+  it('handles null/empty gracefully', function () {
+    expect(normalizeVersionName(null)).toBe('')
+    expect(normalizeVersionName('')).toBe('')
+  })
+})

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -93,6 +93,15 @@ function addedCountForGroup(group) {
   return count
 }
 
+function blockedCountForGroup(group) {
+  var count = 0
+  var features = group.features || []
+  for (var i = 0; i < features.length; i++) {
+    if (features[i].isBlocked && features[i].scopeChange !== 'dropped') count++
+  }
+  return count
+}
+
 function formatDate(dateStr) {
   if (!dateStr) return ''
   var d = new Date(dateStr + (dateStr.includes('T') ? '' : 'T00:00:00'))
@@ -197,6 +206,12 @@ defineExpose({ expandAll, collapseAll })
                       ? 'bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300'
                       : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
                   >{{ droppedCountForGroup(group) }} dropped</span>
+                  <span
+                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold"
+                    :class="blockedCountForGroup(group) > 0
+                      ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
+                      : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
+                  >{{ blockedCountForGroup(group) }} blocked</span>
                 </div>
               </td>
             </tr>

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -1,0 +1,273 @@
+<script setup>
+import { reactive } from 'vue'
+
+const props = defineProps({
+  groups: { type: Array, default: () => [] },
+  portfolioVersion: { type: String, default: '' },
+  featureFreezeDate: { type: String, default: null }
+})
+
+const JIRA_BASE = 'https://redhat.atlassian.net/browse'
+
+const expandedPortfolio = reactive({})
+const expandedProducts = reactive({})
+
+function togglePortfolio(version) {
+  if (expandedPortfolio[version]) {
+    delete expandedPortfolio[version]
+  } else {
+    expandedPortfolio[version] = true
+  }
+}
+
+function isPortfolioExpanded(version) {
+  return !!expandedPortfolio[version]
+}
+
+function productGroupKey(version, product) {
+  return version + '::' + product
+}
+
+function toggleProduct(version, product) {
+  var key = productGroupKey(version, product)
+  if (expandedProducts[key]) {
+    delete expandedProducts[key]
+  } else {
+    expandedProducts[key] = true
+  }
+}
+
+function isProductExpanded(version, product) {
+  return !!expandedProducts[productGroupKey(version, product)]
+}
+
+function expandAll() {
+  expandedPortfolio[props.portfolioVersion] = true
+  for (var i = 0; i < props.groups.length; i++) {
+    expandedProducts[productGroupKey(props.portfolioVersion, props.groups[i].product)] = true
+  }
+}
+
+function collapseAll() {
+  delete expandedPortfolio[props.portfolioVersion]
+  for (var i = 0; i < props.groups.length; i++) {
+    delete expandedProducts[productGroupKey(props.portfolioVersion, props.groups[i].product)]
+  }
+}
+
+function totalFeatureCount() {
+  var count = 0
+  for (var i = 0; i < props.groups.length; i++) {
+    count += props.groups[i].featureCount || 0
+  }
+  return count
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return ''
+  var d = new Date(dateStr + (dateStr.includes('T') ? '' : 'T00:00:00'))
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function colorStatusClass(colorStatus) {
+  var s = (colorStatus || '').toLowerCase()
+  if (s === 'green') return 'bg-green-500'
+  if (s === 'yellow') return 'bg-yellow-500'
+  if (s === 'red') return 'bg-red-500'
+  return 'bg-gray-400'
+}
+
+defineExpose({ expandAll, collapseAll })
+</script>
+
+<template>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm border-collapse">
+      <!-- Portfolio release group header -->
+      <tbody>
+        <tr
+          class="cursor-pointer select-none bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
+          @click="togglePortfolio(portfolioVersion)"
+        >
+          <td colspan="8" class="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100">
+            <div class="flex items-center gap-3">
+              <svg
+                class="w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform"
+                :class="{ 'rotate-90': isPortfolioExpanded(portfolioVersion) }"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+              <span>RHAI {{ portfolioVersion }}</span>
+              <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
+                ({{ totalFeatureCount() }} features)
+              </span>
+              <span
+                v-if="featureFreezeDate"
+                class="ml-2 inline-flex items-center gap-1 text-xs font-normal"
+                :class="new Date().toISOString().split('T')[0] >= featureFreezeDate
+                  ? 'text-orange-600 dark:text-orange-400'
+                  : 'text-gray-500 dark:text-gray-400'"
+              >
+                Feature Freeze: {{ formatDate(featureFreezeDate) }}
+              </span>
+            </div>
+          </td>
+        </tr>
+
+        <template v-if="isPortfolioExpanded(portfolioVersion)">
+          <template v-for="group in groups" :key="group.product">
+            <!-- Product group header -->
+            <tr
+              class="cursor-pointer select-none bg-gray-50 dark:bg-gray-750 hover:bg-gray-100 dark:hover:bg-gray-700"
+              @click="toggleProduct(portfolioVersion, group.product)"
+            >
+              <td colspan="8" class="px-6 py-2.5 font-medium text-gray-800 dark:text-gray-200">
+                <div class="flex items-center gap-2.5">
+                  <svg
+                    class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform"
+                    :class="{ 'rotate-90': isProductExpanded(portfolioVersion, group.product) }"
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                  <span>{{ group.label }}</span>
+                  <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
+                    ({{ group.featureCount }} features)
+                  </span>
+                </div>
+              </td>
+            </tr>
+
+            <!-- Column headers (shown when product is expanded) -->
+            <tr
+              v-if="isProductExpanded(portfolioVersion, group.product)"
+              class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+            >
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Feature</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-52">Status Summary</th>
+              <th class="px-3 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-40">Components</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
+            </tr>
+
+            <!-- Feature rows -->
+            <template v-if="isProductExpanded(portfolioVersion, group.product)">
+              <tr
+                v-for="feature in group.features"
+                :key="feature.key"
+                class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                :class="{
+                  'border-l-4 border-l-blue-400 dark:border-l-blue-500 bg-blue-50/30 dark:bg-blue-900/10': feature.scopeChange === 'added',
+                  'opacity-50': feature.scopeChange === 'dropped'
+                }"
+              >
+                <!-- Feature key -->
+                <td class="px-3 py-2 whitespace-nowrap">
+                  <div class="flex items-center gap-1.5">
+                    <a
+                      :href="`${JIRA_BASE}/${feature.key}`"
+                      target="_blank"
+                      rel="noopener"
+                      class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline"
+                      :class="{ 'line-through': feature.scopeChange === 'dropped' }"
+                    >{{ feature.key }}</a>
+                    <span
+                      v-if="feature.scopeChange === 'added'"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
+                    >Late Addition</span>
+                    <span
+                      v-if="feature.scopeChange === 'dropped'"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400"
+                      :title="feature.fixVersionRemovedAt ? 'Removed: ' + formatDate(feature.fixVersionRemovedAt) : 'fixVersion removed'"
+                    >Dropped</span>
+                  </div>
+                </td>
+
+                <!-- Title -->
+                <td class="px-3 py-2">
+                  <span
+                    class="text-sm text-gray-900 dark:text-gray-100"
+                    :class="{ 'line-through text-gray-500 dark:text-gray-500': feature.scopeChange === 'dropped' }"
+                  >{{ feature.summary }}</span>
+                </td>
+
+                <!-- Status Color -->
+                <td class="px-3 py-2 text-center">
+                  <span
+                    v-if="feature.colorStatus"
+                    class="inline-block w-3 h-3 rounded-full"
+                    :class="colorStatusClass(feature.colorStatus)"
+                    :title="feature.colorStatus"
+                  />
+                  <span v-else class="text-gray-400 text-xs">--</span>
+                </td>
+
+                <!-- Status Summary -->
+                <td class="px-3 py-2">
+                  <div
+                    v-if="feature.statusSummary"
+                    class="text-xs text-gray-700 dark:text-gray-300 max-w-[200px] truncate"
+                    :title="feature.statusSummary?.replace(/<[^>]*>/g, '')"
+                    v-html="feature.statusSummary"
+                  />
+                  <span v-else class="text-gray-400 text-xs">--</span>
+                </td>
+
+                <!-- Blocked -->
+                <td class="px-3 py-2 text-center">
+                  <span
+                    v-if="feature.isBlocked"
+                    class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-red-100 dark:bg-red-900/30"
+                    title="Blocked"
+                  >
+                    <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                    </svg>
+                  </span>
+                </td>
+
+                <!-- Components -->
+                <td class="px-3 py-2">
+                  <div class="flex flex-wrap gap-1">
+                    <span
+                      v-for="comp in (feature.components || []).slice(0, 3)"
+                      :key="comp"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                    >{{ comp }}</span>
+                    <span
+                      v-if="(feature.components || []).length > 3"
+                      class="text-[10px] text-gray-400"
+                    >+{{ feature.components.length - 3 }}</span>
+                  </div>
+                </td>
+
+                <!-- Delivery Owner -->
+                <td class="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  {{ feature.assignee || '--' }}
+                </td>
+
+                <!-- PM Owner -->
+                <td class="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  {{ feature.pmOwner || '--' }}
+                </td>
+              </tr>
+            </template>
+
+            <!-- Empty state for product group -->
+            <tr
+              v-if="isProductExpanded(portfolioVersion, group.product) && group.features.length === 0"
+            >
+              <td colspan="8" class="px-8 py-4 text-sm text-gray-500 dark:text-gray-400 italic">
+                No features found for {{ group.releaseNumber }}
+              </td>
+            </tr>
+          </template>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -109,7 +109,13 @@ function formatDate(dateStr) {
 }
 
 function stripHtml(html) {
-  return (html || '').replace(/<[^>]*>/g, '')
+  var input = html || ''
+  var previous
+  do {
+    previous = input
+    input = input.replace(/<[^>]*>/g, '')
+  } while (input !== previous)
+  return input
 }
 
 function colorStatusClass(colorStatus) {

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -9,6 +9,18 @@ const props = defineProps({
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse'
 
+const PRODUCT_COLORS = {
+  rhoai: { bg: 'bg-violet-50 dark:bg-violet-900/15', border: 'border-l-violet-500', badge: 'bg-violet-100 dark:bg-violet-800/40 text-violet-700 dark:text-violet-300', dot: 'bg-violet-500' },
+  rhelai: { bg: 'bg-teal-50 dark:bg-teal-900/15', border: 'border-l-teal-500', badge: 'bg-teal-100 dark:bg-teal-800/40 text-teal-700 dark:text-teal-300', dot: 'bg-teal-500' },
+  rhaii: { bg: 'bg-sky-50 dark:bg-sky-900/15', border: 'border-l-sky-500', badge: 'bg-sky-100 dark:bg-sky-800/40 text-sky-700 dark:text-sky-300', dot: 'bg-sky-500' }
+}
+
+const DEFAULT_COLORS = { bg: 'bg-gray-50 dark:bg-gray-800/50', border: 'border-l-gray-400', badge: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300', dot: 'bg-gray-400' }
+
+function productColors(product) {
+  return PRODUCT_COLORS[product] || DEFAULT_COLORS
+}
+
 const expandedPortfolio = reactive({})
 const expandedProducts = reactive({})
 
@@ -63,6 +75,24 @@ function totalFeatureCount() {
   return count
 }
 
+function droppedCountForGroup(group) {
+  var count = 0
+  var features = group.features || []
+  for (var i = 0; i < features.length; i++) {
+    if (features[i].scopeChange === 'dropped') count++
+  }
+  return count
+}
+
+function addedCountForGroup(group) {
+  var count = 0
+  var features = group.features || []
+  for (var i = 0; i < features.length; i++) {
+    if (features[i].scopeChange === 'added') count++
+  }
+  return count
+}
+
 function formatDate(dateStr) {
   if (!dateStr) return ''
   var d = new Date(dateStr + (dateStr.includes('T') ? '' : 'T00:00:00'))
@@ -71,45 +101,56 @@ function formatDate(dateStr) {
 
 function colorStatusClass(colorStatus) {
   var s = (colorStatus || '').toLowerCase()
-  if (s === 'green') return 'bg-green-500'
-  if (s === 'yellow') return 'bg-yellow-500'
+  if (s === 'green') return 'bg-emerald-500'
+  if (s === 'yellow') return 'bg-amber-400'
   if (s === 'red') return 'bg-red-500'
-  return 'bg-gray-400'
+  return 'bg-gray-300 dark:bg-gray-600'
+}
+
+function colorStatusRing(colorStatus) {
+  var s = (colorStatus || '').toLowerCase()
+  if (s === 'green') return 'ring-emerald-200 dark:ring-emerald-800'
+  if (s === 'yellow') return 'ring-amber-200 dark:ring-amber-800'
+  if (s === 'red') return 'ring-red-200 dark:ring-red-800'
+  return 'ring-gray-200 dark:ring-gray-700'
 }
 
 defineExpose({ expandAll, collapseAll })
 </script>
 
 <template>
-  <div class="overflow-x-auto">
+  <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
     <table class="w-full text-sm border-collapse">
-      <!-- Portfolio release group header -->
       <tbody>
+        <!-- Portfolio release group header -->
         <tr
-          class="cursor-pointer select-none bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
+          class="cursor-pointer select-none bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-800/80 hover:from-gray-200 hover:to-gray-100 dark:hover:from-gray-750 dark:hover:to-gray-800"
           @click="togglePortfolio(portfolioVersion)"
         >
-          <td colspan="8" class="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100">
+          <td colspan="8" class="px-4 py-3.5">
             <div class="flex items-center gap-3">
               <svg
-                class="w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform"
+                class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200"
                 :class="{ 'rotate-90': isPortfolioExpanded(portfolioVersion) }"
-                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
               >
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
               </svg>
-              <span>RHAI {{ portfolioVersion }}</span>
-              <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
-                ({{ totalFeatureCount() }} features)
+              <span class="font-bold text-gray-900 dark:text-gray-100">RHAI {{ portfolioVersion }}</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">
+                {{ totalFeatureCount() }} features
               </span>
               <span
                 v-if="featureFreezeDate"
-                class="ml-2 inline-flex items-center gap-1 text-xs font-normal"
+                class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-semibold"
                 :class="new Date().toISOString().split('T')[0] >= featureFreezeDate
-                  ? 'text-orange-600 dark:text-orange-400'
-                  : 'text-gray-500 dark:text-gray-400'"
+                  ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300'
+                  : 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'"
               >
-                Feature Freeze: {{ formatDate(featureFreezeDate) }}
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                Freeze: {{ formatDate(featureFreezeDate) }}
               </span>
             </div>
           </td>
@@ -119,39 +160,56 @@ defineExpose({ expandAll, collapseAll })
           <template v-for="group in groups" :key="group.product">
             <!-- Product group header -->
             <tr
-              class="cursor-pointer select-none bg-gray-50 dark:bg-gray-750 hover:bg-gray-100 dark:hover:bg-gray-700"
+              class="cursor-pointer select-none border-l-4 transition-colors"
+              :class="[
+                productColors(group.product).border,
+                productColors(group.product).bg,
+                'hover:brightness-95 dark:hover:brightness-110'
+              ]"
               @click="toggleProduct(portfolioVersion, group.product)"
             >
-              <td colspan="8" class="px-6 py-2.5 font-medium text-gray-800 dark:text-gray-200">
+              <td colspan="8" class="px-6 py-2.5">
                 <div class="flex items-center gap-2.5">
                   <svg
-                    class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform"
+                    class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform duration-200"
                     :class="{ 'rotate-90': isProductExpanded(portfolioVersion, group.product) }"
-                    fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
                   >
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                   </svg>
-                  <span>{{ group.label }}</span>
-                  <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
-                    ({{ group.featureCount }} features)
+                  <span class="inline-flex items-center gap-1.5">
+                    <span class="w-2 h-2 rounded-full" :class="productColors(group.product).dot" />
+                    <span class="font-semibold text-gray-800 dark:text-gray-200">{{ group.product.toUpperCase() }}</span>
                   </span>
+                  <span class="text-xs text-gray-500 dark:text-gray-400 font-mono">{{ group.releaseNumber }}</span>
+                  <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold" :class="productColors(group.product).badge">
+                    {{ group.featureCount }}
+                  </span>
+                  <span
+                    v-if="addedCountForGroup(group) > 0"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
+                  >+{{ addedCountForGroup(group) }} late</span>
+                  <span
+                    v-if="droppedCountForGroup(group) > 0"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300"
+                  >{{ droppedCountForGroup(group) }} dropped</span>
                 </div>
               </td>
             </tr>
 
-            <!-- Column headers (shown when product is expanded) -->
+            <!-- Column headers -->
             <tr
               v-if="isProductExpanded(portfolioVersion, group.product)"
-              class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+              class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/80 sticky top-0"
             >
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Feature</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
-              <th class="px-3 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-52">Status Summary</th>
-              <th class="px-3 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-40">Components</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
+              <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
+              <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
+              <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
+              <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-52">Status Summary</th>
+              <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
+              <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-40">Components</th>
+              <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
+              <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
             </tr>
 
             <!-- Feature rows -->
@@ -159,99 +217,110 @@ defineExpose({ expandAll, collapseAll })
               <tr
                 v-for="feature in group.features"
                 :key="feature.key"
-                class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                class="border-b border-gray-100 dark:border-gray-800 transition-colors"
                 :class="{
-                  'border-l-4 border-l-blue-400 dark:border-l-blue-500 bg-blue-50/30 dark:bg-blue-900/10': feature.scopeChange === 'added',
-                  'opacity-50': feature.scopeChange === 'dropped'
+                  'bg-blue-50/50 dark:bg-blue-900/10 border-l-4 border-l-blue-400 dark:border-l-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20': feature.scopeChange === 'added',
+                  'bg-amber-50/30 dark:bg-amber-900/5 border-l-4 border-l-amber-300 dark:border-l-amber-700 opacity-60 hover:opacity-80': feature.scopeChange === 'dropped',
+                  'bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50': !feature.scopeChange
                 }"
               >
                 <!-- Feature key -->
-                <td class="px-3 py-2 whitespace-nowrap">
+                <td class="px-3 py-2.5 whitespace-nowrap">
                   <div class="flex items-center gap-1.5">
                     <a
                       :href="`${JIRA_BASE}/${feature.key}`"
                       target="_blank"
                       rel="noopener"
-                      class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline"
+                      class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
                       :class="{ 'line-through': feature.scopeChange === 'dropped' }"
                     >{{ feature.key }}</a>
                     <span
                       v-if="feature.scopeChange === 'added'"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
-                    >Late Addition</span>
+                      class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-blue-100 dark:bg-blue-800/50 text-blue-700 dark:text-blue-300 shadow-sm"
+                    >
+                      <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+                      </svg>
+                      Late
+                    </span>
                     <span
                       v-if="feature.scopeChange === 'dropped'"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400"
+                      class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-100 dark:bg-amber-800/50 text-amber-700 dark:text-amber-300"
                       :title="feature.fixVersionRemovedAt ? 'Removed: ' + formatDate(feature.fixVersionRemovedAt) : 'fixVersion removed'"
-                    >Dropped</span>
+                    >
+                      <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
+                      </svg>
+                      Dropped
+                    </span>
                   </div>
                 </td>
 
                 <!-- Title -->
-                <td class="px-3 py-2">
+                <td class="px-3 py-2.5">
                   <span
                     class="text-sm text-gray-900 dark:text-gray-100"
-                    :class="{ 'line-through text-gray-500 dark:text-gray-500': feature.scopeChange === 'dropped' }"
+                    :class="{ 'line-through text-gray-400 dark:text-gray-500': feature.scopeChange === 'dropped' }"
                   >{{ feature.summary }}</span>
                 </td>
 
                 <!-- Status Color -->
-                <td class="px-3 py-2 text-center">
+                <td class="px-3 py-2.5 text-center">
                   <span
                     v-if="feature.colorStatus"
-                    class="inline-block w-3 h-3 rounded-full"
-                    :class="colorStatusClass(feature.colorStatus)"
+                    class="inline-block w-3.5 h-3.5 rounded-full ring-2"
+                    :class="[colorStatusClass(feature.colorStatus), colorStatusRing(feature.colorStatus)]"
                     :title="feature.colorStatus"
                   />
-                  <span v-else class="text-gray-400 text-xs">--</span>
+                  <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
                 </td>
 
                 <!-- Status Summary -->
-                <td class="px-3 py-2">
+                <td class="px-3 py-2.5">
                   <div
                     v-if="feature.statusSummary"
-                    class="text-xs text-gray-700 dark:text-gray-300 max-w-[200px] truncate"
+                    class="text-xs text-gray-600 dark:text-gray-300 max-w-[200px] truncate"
                     :title="feature.statusSummary?.replace(/<[^>]*>/g, '')"
                     v-html="feature.statusSummary"
                   />
-                  <span v-else class="text-gray-400 text-xs">--</span>
+                  <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
                 </td>
 
                 <!-- Blocked -->
-                <td class="px-3 py-2 text-center">
+                <td class="px-3 py-2.5 text-center">
                   <span
                     v-if="feature.isBlocked"
-                    class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-red-100 dark:bg-red-900/30"
+                    class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
                     title="Blocked"
                   >
-                    <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
                     </svg>
                   </span>
                 </td>
 
                 <!-- Components -->
-                <td class="px-3 py-2">
+                <td class="px-3 py-2.5">
                   <div class="flex flex-wrap gap-1">
                     <span
                       v-for="comp in (feature.components || []).slice(0, 3)"
                       :key="comp"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 dark:bg-gray-700/80 text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600"
                     >{{ comp }}</span>
                     <span
                       v-if="(feature.components || []).length > 3"
-                      class="text-[10px] text-gray-400"
+                      class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-800"
                     >+{{ feature.components.length - 3 }}</span>
                   </div>
                 </td>
 
                 <!-- Delivery Owner -->
-                <td class="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
                   {{ feature.assignee || '--' }}
                 </td>
 
                 <!-- PM Owner -->
-                <td class="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
                   {{ feature.pmOwner || '--' }}
                 </td>
               </tr>
@@ -261,7 +330,7 @@ defineExpose({ expandAll, collapseAll })
             <tr
               v-if="isProductExpanded(portfolioVersion, group.product) && group.features.length === 0"
             >
-              <td colspan="8" class="px-8 py-4 text-sm text-gray-500 dark:text-gray-400 italic">
+              <td colspan="8" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
                 No features found for {{ group.releaseNumber }}
               </td>
             </tr>

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -108,6 +108,10 @@ function formatDate(dateStr) {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
+function stripHtml(html) {
+  return (html || '').replace(/<[^>]*>/g, '')
+}
+
 function colorStatusClass(colorStatus) {
   var s = (colorStatus || '').toLowerCase()
   if (s === 'green') return 'bg-emerald-500'
@@ -296,12 +300,11 @@ defineExpose({ expandAll, collapseAll })
 
                 <!-- Status Summary -->
                 <td class="px-3 py-2.5">
-                  <div
+                  <span
                     v-if="feature.statusSummary"
-                    class="text-xs text-gray-600 dark:text-gray-300 max-w-[200px] truncate"
-                    :title="feature.statusSummary?.replace(/<[^>]*>/g, '')"
-                    v-html="feature.statusSummary"
-                  />
+                    class="text-xs text-gray-600 dark:text-gray-300 max-w-[200px] truncate block"
+                    :title="stripHtml(feature.statusSummary)"
+                  >{{ stripHtml(feature.statusSummary) }}</span>
                   <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
                 </td>
 

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -109,13 +109,13 @@ function formatDate(dateStr) {
 }
 
 function stripHtml(html) {
-  var input = html || ''
-  var previous
+  var s = html || ''
+  var prev
   do {
-    previous = input
-    input = input.replace(/<[^>]*>/g, '')
-  } while (input !== previous)
-  return input
+    prev = s
+    s = s.replace(/<[^>]*>/g, '')
+  } while (s !== prev)
+  return s
 }
 
 function colorStatusClass(colorStatus) {

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -186,12 +186,16 @@ defineExpose({ expandAll, collapseAll })
                     {{ group.featureCount }}
                   </span>
                   <span
-                    v-if="addedCountForGroup(group) > 0"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
-                  >+{{ addedCountForGroup(group) }} late</span>
+                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold"
+                    :class="addedCountForGroup(group) > 0
+                      ? 'bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300'
+                      : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
+                  >{{ addedCountForGroup(group) > 0 ? '+' : '' }}{{ addedCountForGroup(group) }} late</span>
                   <span
-                    v-if="droppedCountForGroup(group) > 0"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold"
+                    :class="droppedCountForGroup(group) > 0
+                      ? 'bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300'
+                      : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
                   >{{ droppedCountForGroup(group) }} dropped</span>
                 </div>
               </td>

--- a/modules/releases/client/execute/composables/useFeatureTracking.js
+++ b/modules/releases/client/execute/composables/useFeatureTracking.js
@@ -1,0 +1,100 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const STORAGE_KEY = 'releases:feature-tracking-cache'
+const STALE_MS = 5 * 60 * 1000
+
+const trackingData = ref(null)
+const versions = ref([])
+const loading = ref(false)
+const error = ref(null)
+
+function readCache(version) {
+  try {
+    var raw = sessionStorage.getItem(STORAGE_KEY + ':' + version)
+    if (!raw) return null
+    var cached = JSON.parse(raw)
+    if (cached && cached.timestamp && Date.now() - cached.timestamp < STALE_MS) {
+      return cached.data
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+function writeCache(version, data) {
+  try {
+    sessionStorage.setItem(STORAGE_KEY + ':' + version, JSON.stringify({
+      timestamp: Date.now(),
+      data: data
+    }))
+  } catch {
+    // ignore
+  }
+}
+
+function clearCache(version) {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY + ':' + version)
+  } catch {
+    // ignore
+  }
+}
+
+export function useFeatureTracking() {
+  async function loadVersions() {
+    try {
+      var data = await apiRequest('/modules/releases/execution/tracking/versions')
+      versions.value = data.versions || []
+    } catch {
+      versions.value = []
+    }
+  }
+
+  async function loadTrackingData(portfolioVersion, opts) {
+    var skipCache = opts && opts.skipCache
+    if (!skipCache) {
+      var cached = readCache(portfolioVersion)
+      if (cached) {
+        trackingData.value = cached
+        return cached
+      }
+    }
+
+    loading.value = true
+    error.value = null
+
+    try {
+      var url = '/modules/releases/execution/tracking/data?version=' + encodeURIComponent(portfolioVersion)
+      if (skipCache) {
+        url += '&refresh=true'
+      }
+      var data = await apiRequest(url)
+      trackingData.value = data
+      writeCache(portfolioVersion, data)
+      return data
+    } catch (err) {
+      error.value = err.message
+      trackingData.value = null
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refreshTracking(portfolioVersion) {
+    clearCache(portfolioVersion)
+    return loadTrackingData(portfolioVersion, { skipCache: true })
+  }
+
+  return {
+    trackingData,
+    versions,
+    loading,
+    error,
+    loadVersions,
+    loadTrackingData,
+    refreshTracking
+  }
+}

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -1,0 +1,212 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useFeatureTracking } from '../composables/useFeatureTracking.js'
+import FeatureTrackingTable from '../components/FeatureTrackingTable.vue'
+
+const {
+  trackingData,
+  versions,
+  loading,
+  error,
+  loadVersions,
+  loadTrackingData,
+  refreshTracking
+} = useFeatureTracking()
+
+const selectedVersion = ref(null)
+const refreshing = ref(false)
+const tableRef = ref(null)
+
+const portfolioVersions = computed(() => {
+  return (versions.value || []).map(v => v.version)
+})
+
+const currentData = computed(() => trackingData.value)
+const groups = computed(() => currentData.value ? currentData.value.groups || [] : [])
+const featureFreezeDate = computed(() => currentData.value ? currentData.value.featureFreezeDate : null)
+const freezeStatus = computed(() => {
+  if (!featureFreezeDate.value) return 'unknown'
+  var today = new Date().toISOString().split('T')[0]
+  return today >= featureFreezeDate.value ? 'past' : 'future'
+})
+
+const totalFeatures = computed(() => {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    count += groups.value[i].featureCount || 0
+  }
+  return count
+})
+
+const addedCount = computed(() => {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    var features = groups.value[i].features || []
+    for (var j = 0; j < features.length; j++) {
+      if (features[j].scopeChange === 'added') count++
+    }
+  }
+  return count
+})
+
+const droppedCount = computed(() => {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    var features = groups.value[i].features || []
+    for (var j = 0; j < features.length; j++) {
+      if (features[j].scopeChange === 'dropped') count++
+    }
+  }
+  return count
+})
+
+function formatDate(dateStr) {
+  if (!dateStr) return ''
+  var d = new Date(dateStr + (dateStr.includes('T') ? '' : 'T00:00:00'))
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function selectVersion(version) {
+  selectedVersion.value = version
+}
+
+async function handleRefresh() {
+  if (!selectedVersion.value || refreshing.value) return
+  refreshing.value = true
+  try {
+    await refreshTracking(selectedVersion.value)
+  } finally {
+    refreshing.value = false
+  }
+}
+
+function handleExpandAll() {
+  if (tableRef.value) tableRef.value.expandAll()
+}
+
+function handleCollapseAll() {
+  if (tableRef.value) tableRef.value.collapseAll()
+}
+
+watch(selectedVersion, async (v) => {
+  if (v) await loadTrackingData(v)
+})
+
+onMounted(async () => {
+  await loadVersions()
+  if (portfolioVersions.value.length > 0) {
+    selectedVersion.value = portfolioVersions.value[0]
+  }
+})
+</script>
+
+<template>
+  <div>
+    <!-- Header -->
+    <div class="mb-6">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Feature Execution Tracking</h2>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        Track features committed at Feature Freeze across RHOAI, RHAIIS, and RHELAI.
+      </p>
+    </div>
+
+    <!-- Version selector + actions bar -->
+    <div class="flex flex-wrap items-center gap-3 mb-4">
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="v in portfolioVersions"
+          :key="v"
+          @click="selectVersion(v)"
+          class="px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
+          :class="selectedVersion === v
+            ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 ring-1 ring-primary-300 dark:ring-primary-700'
+            : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'"
+        >{{ v }}</button>
+      </div>
+
+      <div class="flex-1" />
+
+      <div class="flex items-center gap-2">
+        <button
+          @click="handleExpandAll"
+          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          :disabled="!currentData"
+        >Expand All</button>
+        <button
+          @click="handleCollapseAll"
+          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          :disabled="!currentData"
+        >Collapse All</button>
+        <button
+          @click="handleRefresh"
+          :disabled="!selectedVersion || refreshing"
+          class="px-3 py-1.5 text-xs font-medium text-white bg-primary-600 rounded hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5"
+        >
+          <svg
+            class="w-3.5 h-3.5"
+            :class="{ 'animate-spin': refreshing }"
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          {{ refreshing ? 'Refreshing...' : 'Refresh' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Summary cards -->
+    <div v-if="currentData && !loading" class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
+        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Features</div>
+        <div class="text-xl font-bold text-gray-900 dark:text-gray-100 mt-1">{{ totalFeatures }}</div>
+      </div>
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
+        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Feature Freeze</div>
+        <div class="text-sm font-semibold mt-1" :class="freezeStatus === 'past' ? 'text-orange-600 dark:text-orange-400' : freezeStatus === 'future' ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'">
+          {{ featureFreezeDate ? formatDate(featureFreezeDate) : 'Not set' }}
+        </div>
+      </div>
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
+        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Late Additions</div>
+        <div class="text-xl font-bold mt-1" :class="addedCount > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'">{{ addedCount }}</div>
+      </div>
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
+        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Dropped</div>
+        <div class="text-xl font-bold mt-1" :class="droppedCount > 0 ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'">{{ droppedCount }}</div>
+      </div>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <svg class="animate-spin h-8 w-8 text-primary-500" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+      </svg>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="error" class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+      {{ error }}
+    </div>
+
+    <!-- Empty state: no version selected -->
+    <div v-else-if="!selectedVersion" class="text-center py-12 text-gray-500 dark:text-gray-400">
+      <p class="text-sm">Select a portfolio version to view feature tracking data.</p>
+    </div>
+
+    <!-- Empty state: no data -->
+    <div v-else-if="currentData && groups.length === 0" class="text-center py-12 text-gray-500 dark:text-gray-400">
+      <p class="text-sm">No feature data available for {{ selectedVersion }}.</p>
+      <p class="text-xs mt-2">Use the Refresh button to fetch data from Jira, or configure releases in the Manage tab.</p>
+    </div>
+
+    <!-- Data table -->
+    <FeatureTrackingTable
+      v-else-if="currentData"
+      ref="tableRef"
+      :groups="groups"
+      :portfolioVersion="selectedVersion"
+      :featureFreezeDate="featureFreezeDate"
+    />
+  </div>
+</template>

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -60,6 +60,17 @@ const droppedCount = computed(() => {
   return count
 })
 
+const blockedCount = computed(() => {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    var features = groups.value[i].features || []
+    for (var j = 0; j < features.length; j++) {
+      if (features[j].isBlocked && features[j].scopeChange !== 'dropped') count++
+    }
+  }
+  return count
+})
+
 function formatDate(dateStr) {
   if (!dateStr) return ''
   var d = new Date(dateStr + (dateStr.includes('T') ? '' : 'T00:00:00'))
@@ -103,44 +114,35 @@ onMounted(async () => {
 <template>
   <div>
     <!-- Header -->
-    <div class="mb-6">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Feature Execution Tracking</h2>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-        Track features committed at Feature Freeze across RHOAI, RHAIIS, and RHELAI.
-      </p>
-    </div>
-
-    <!-- Version selector + actions bar -->
-    <div class="flex flex-wrap items-center gap-3 mb-4">
-      <div class="flex flex-wrap gap-2">
-        <button
-          v-for="v in portfolioVersions"
-          :key="v"
-          @click="selectVersion(v)"
-          class="px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
-          :class="selectedVersion === v
-            ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 ring-1 ring-primary-300 dark:ring-primary-700'
-            : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'"
-        >{{ v }}</button>
+    <div class="mb-5 flex items-start justify-between">
+      <div>
+        <h2 class="text-lg font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-gradient-to-br from-primary-500 to-primary-700 text-white">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+            </svg>
+          </span>
+          Feature Execution Tracking
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 ml-9">
+          Track features committed at Feature Freeze across RHOAI, RHAIIS, and RHELAI.
+        </p>
       </div>
-
-      <div class="flex-1" />
-
       <div class="flex items-center gap-2">
         <button
           @click="handleExpandAll"
-          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           :disabled="!currentData"
         >Expand All</button>
         <button
           @click="handleCollapseAll"
-          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           :disabled="!currentData"
         >Collapse All</button>
         <button
           @click="handleRefresh"
           :disabled="!selectedVersion || refreshing"
-          class="px-3 py-1.5 text-xs font-medium text-white bg-primary-600 rounded hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5"
+          class="px-3 py-1.5 text-xs font-semibold text-white bg-gradient-to-r from-primary-600 to-primary-700 rounded-md hover:from-primary-700 hover:to-primary-800 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-sm flex items-center gap-1.5"
         >
           <svg
             class="w-3.5 h-3.5"
@@ -154,50 +156,131 @@ onMounted(async () => {
       </div>
     </div>
 
-    <!-- Summary cards -->
-    <div v-if="currentData && !loading" class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
-        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Features</div>
-        <div class="text-xl font-bold text-gray-900 dark:text-gray-100 mt-1">{{ totalFeatures }}</div>
+    <!-- Version selector chips -->
+    <div class="mb-5">
+      <div class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-widest mb-2 ml-0.5">Release Version</div>
+      <div class="flex flex-wrap gap-1.5">
+        <button
+          v-for="v in portfolioVersions"
+          :key="v"
+          @click="selectVersion(v)"
+          class="relative px-3.5 py-1.5 text-sm font-semibold rounded-full transition-all duration-150"
+          :class="selectedVersion === v
+            ? 'bg-primary-600 dark:bg-primary-500 text-white shadow-md shadow-primary-500/25 dark:shadow-primary-500/20 scale-[1.02]'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-primary-600 hover:text-primary-700 dark:hover:text-primary-300 hover:shadow-sm'"
+        >
+          {{ v }}
+        </button>
       </div>
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
-        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Feature Freeze</div>
-        <div class="text-sm font-semibold mt-1" :class="freezeStatus === 'past' ? 'text-orange-600 dark:text-orange-400' : freezeStatus === 'future' ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'">
+    </div>
+
+    <!-- Summary cards -->
+    <div v-if="currentData && !loading" class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
+      <!-- Total features -->
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5 group hover:shadow-md transition-shadow">
+        <div class="absolute top-0 left-0 w-1 h-full bg-indigo-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-indigo-100 dark:bg-indigo-900/40">
+            <svg class="w-3 h-3 text-indigo-600 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features</span>
+        </div>
+        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ totalFeatures }}</div>
+      </div>
+
+      <!-- Feature Freeze date -->
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full rounded-l-xl" :class="freezeStatus === 'past' ? 'bg-orange-500' : freezeStatus === 'future' ? 'bg-emerald-500' : 'bg-gray-400'" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded" :class="freezeStatus === 'past' ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-emerald-100 dark:bg-emerald-900/40'">
+            <svg class="w-3 h-3" :class="freezeStatus === 'past' ? 'text-orange-600 dark:text-orange-400' : 'text-emerald-600 dark:text-emerald-400'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Freeze Date</span>
+        </div>
+        <div class="text-sm font-bold ml-7" :class="freezeStatus === 'past' ? 'text-orange-600 dark:text-orange-400' : freezeStatus === 'future' ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-400'">
           {{ featureFreezeDate ? formatDate(featureFreezeDate) : 'Not set' }}
         </div>
       </div>
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
-        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Late Additions</div>
-        <div class="text-xl font-bold mt-1" :class="addedCount > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'">{{ addedCount }}</div>
+
+      <!-- Late additions -->
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
+            <svg class="w-3 h-3 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Late Added</span>
+        </div>
+        <div class="text-2xl font-bold ml-7" :class="addedCount > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'">{{ addedCount }}</div>
       </div>
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
-        <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Dropped</div>
-        <div class="text-xl font-bold mt-1" :class="droppedCount > 0 ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'">{{ droppedCount }}</div>
+
+      <!-- Dropped -->
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full bg-amber-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
+            <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Dropped</span>
+        </div>
+        <div class="text-2xl font-bold ml-7" :class="droppedCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ droppedCount }}</div>
+      </div>
+
+      <!-- Blocked -->
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
+            <svg class="w-3 h-3 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
+        </div>
+        <div class="text-2xl font-bold ml-7" :class="blockedCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ blockedCount }}</div>
       </div>
     </div>
 
     <!-- Loading state -->
-    <div v-if="loading" class="flex items-center justify-center py-12">
+    <div v-if="loading" class="flex flex-col items-center justify-center py-16 gap-3">
       <svg class="animate-spin h-8 w-8 text-primary-500" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
       </svg>
+      <span class="text-sm text-gray-500 dark:text-gray-400">Loading feature data from Jira...</span>
     </div>
 
     <!-- Error state -->
-    <div v-else-if="error" class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+    <div v-else-if="error" class="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-5 py-4 text-sm text-red-700 dark:text-red-400 flex items-start gap-3">
+      <svg class="w-5 h-5 text-red-500 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+      </svg>
       {{ error }}
     </div>
 
     <!-- Empty state: no version selected -->
-    <div v-else-if="!selectedVersion" class="text-center py-12 text-gray-500 dark:text-gray-400">
-      <p class="text-sm">Select a portfolio version to view feature tracking data.</p>
+    <div v-else-if="!selectedVersion" class="text-center py-16 text-gray-400 dark:text-gray-500">
+      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+      <p class="text-sm font-medium">Select a release version above to view feature tracking data.</p>
     </div>
 
     <!-- Empty state: no data -->
-    <div v-else-if="currentData && groups.length === 0" class="text-center py-12 text-gray-500 dark:text-gray-400">
-      <p class="text-sm">No feature data available for {{ selectedVersion }}.</p>
-      <p class="text-xs mt-2">Use the Refresh button to fetch data from Jira, or configure releases in the Manage tab.</p>
+    <div v-else-if="currentData && groups.length === 0" class="text-center py-16 text-gray-400 dark:text-gray-500">
+      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+      </svg>
+      <p class="text-sm font-medium">No feature data available for {{ selectedVersion }}.</p>
+      <p class="text-xs mt-1">Use the Refresh button to fetch data from Jira.</p>
     </div>
 
     <!-- Data table -->

--- a/modules/releases/client/views/ExecuteView.vue
+++ b/modules/releases/client/views/ExecuteView.vue
@@ -18,6 +18,7 @@
     <div class="p-6">
       <OverviewView v-if="activeTab === 'feature-list'" />
       <HygieneView v-else-if="activeTab === 'feature-status'" />
+      <FeatureTrackingView v-else-if="activeTab === 'feature-tracking'" />
     </div>
   </div>
 </template>
@@ -26,12 +27,14 @@
 import { ref, watch, nextTick, inject } from 'vue'
 import OverviewView from '../execute/views/OverviewView.vue'
 import HygieneView from '../execute/views/HygieneView.vue'
+import FeatureTrackingView from '../execute/views/FeatureTrackingView.vue'
 
 const nav = inject('moduleNav')
 
 const tabs = [
   { id: 'feature-list', label: 'Feature List' },
   { id: 'feature-status', label: 'Feature Status' },
+  { id: 'feature-tracking', label: 'Feature Tracking' },
 ]
 
 const VALID_TABS = tabs.map(t => t.id)

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -229,6 +229,49 @@ function extractCodeFreezeDate(release, eaTag) {
 }
 
 /**
+ * Extracts the feature freeze date from a Product Pages release object.
+ * Searches major_milestones and all_ga_tasks for entries matching
+ * "feature freeze" (case-insensitive, with optional hyphen/space).
+ *
+ * For EA-specific releases, pass an optional eaTag (e.g. "EA1") to prefer
+ * a milestone scoped to that EA over a generic one.
+ */
+function extractFeatureFreezeDate(release, eaTag) {
+  const freezePattern = /feature[.\-_\s]*freeze/i
+
+  const milestones = release.major_milestones
+  if (Array.isArray(milestones) && milestones.length > 0) {
+    let bestMatch = null
+    for (const m of milestones) {
+      if (m.draft) continue
+      const name = m.name || ''
+      if (!freezePattern.test(name)) continue
+      if (eaTag && new RegExp(`\\b${eaTag}\\b`, 'i').test(name)) {
+        return m.date_finish || null
+      }
+      bestMatch = m
+    }
+    if (bestMatch?.date_finish) return bestMatch.date_finish
+  }
+
+  const tasks = release.all_ga_tasks
+  if (Array.isArray(tasks) && tasks.length > 0) {
+    let bestMatch = null
+    for (const t of tasks) {
+      const name = t.name || ''
+      if (!freezePattern.test(name)) continue
+      if (eaTag && new RegExp(`\\b${eaTag}\\b`, 'i').test(name)) {
+        return t.date_finish || null
+      }
+      bestMatch = t
+    }
+    if (bestMatch?.date_finish) return bestMatch.date_finish
+  }
+
+  return null
+}
+
+/**
  * Returns the auth status string for the settings UI badge.
  */
 function getAuthStatus() {
@@ -301,7 +344,8 @@ function expandReleaseMilestones(r, productName) {
       productName,
       releaseNumber,
       dueDate: m.date_finish,
-      codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null
+      codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null,
+      featureFreezeDate: extractFeatureFreezeDate(r, eaTag) || null
     }
   })
 }
@@ -405,7 +449,8 @@ async function fetchProductsByShortname(shortnames, config) {
           productName,
           releaseNumber,
           dueDate,
-          codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null
+          codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null,
+          featureFreezeDate: extractFeatureFreezeDate(r, eaTag) || null
         })
       }
     } catch (err) {
@@ -485,6 +530,7 @@ module.exports = {
   extractGaDate,
   extractReleaseDueDate,
   extractCodeFreezeDate,
+  extractFeatureFreezeDate,
   expandReleaseMilestones,
   milestoneToReleaseNumber,
   _resetForTesting

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -59,8 +59,10 @@ function extractProduct(releaseNumber) {
  *   "RHELAI-3.4 EA-1"          → "rhelai-3.4ea1"
  */
 function normalizeVersionName(name) {
-  let s = (name || '').toLowerCase()
-  s = s.replace(/\s+release$/i, '').trimEnd()
+  var s = (name || '').toLowerCase().trimEnd()
+  if (s.endsWith('release') && s.length > 7 && s.charAt(s.length - 8) <= ' ') {
+    s = s.slice(0, s.length - 7).trimEnd()
+  }
   s = s.replace(/(\d)[\s._-]+(?=ea|ga)/gi, '$1')
   s = s.replace(/(ea)-?(\d)/gi, 'ea$2')
   return s

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -59,13 +59,36 @@ function extractProduct(releaseNumber) {
  *   "RHELAI-3.4 EA-1"          → "rhelai-3.4ea1"
  */
 function normalizeVersionName(name) {
-  var s = (name || '').toLowerCase().trimEnd()
-  if (s.endsWith('release') && s.length > 7 && s.charAt(s.length - 8) <= ' ') {
-    s = s.slice(0, s.length - 7).trimEnd()
+  let s = (name || '').toLowerCase()
+  if (s.endsWith(' release')) s = s.slice(0, -8)
+  s = s.trimEnd()
+
+  const SEPS = ' ._-'
+  let result = ''
+  let i = 0
+  while (i < s.length) {
+    const ch = s[i]
+
+    if (SEPS.includes(ch) && i > 0 && s.charCodeAt(i - 1) >= 48 && s.charCodeAt(i - 1) <= 57) {
+      let j = i
+      while (j < s.length && SEPS.includes(s[j])) j++
+      const tag = s.slice(j, j + 2)
+      if (tag === 'ea' || tag === 'ga') {
+        i = j
+        continue
+      }
+    }
+
+    if (ch === 'e' && i + 3 < s.length && s[i + 1] === 'a' && s[i + 2] === '-' && s.charCodeAt(i + 3) >= 48 && s.charCodeAt(i + 3) <= 57) {
+      result += 'ea'
+      i += 3
+      continue
+    }
+
+    result += s[i]
+    i++
   }
-  s = s.replace(/(\d)[\s._-]+(?=ea|ga)/gi, '$1')
-  s = s.replace(/(ea)-?(\d)/gi, 'ea$2')
-  return s
+  return result
 }
 
 const jiraVersionsCache = { versions: null, fetchedAt: 0 }

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -510,9 +510,15 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         var dropped = await fetchDroppedFeatures(pv.fixVersions, jiraRequest, fetchAllJqlResults, currentKeys)
         features = features.concat(dropped)
 
+        var STATUS_ORDER = { red: 0, yellow: 1, green: 2 }
         features.sort(function (a, b) {
           if (a.scopeChange === 'dropped' && b.scopeChange !== 'dropped') return 1
           if (a.scopeChange !== 'dropped' && b.scopeChange === 'dropped') return -1
+          var aColor = STATUS_ORDER[(a.colorStatus || '').toLowerCase()]
+          var bColor = STATUS_ORDER[(b.colorStatus || '').toLowerCase()]
+          var aRank = aColor !== undefined ? aColor : 3
+          var bRank = bColor !== undefined ? bColor : 3
+          if (aRank !== bRank) return aRank - bRank
           return a.key.localeCompare(b.key)
         })
 

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -23,9 +23,9 @@ const DEFAULT_PRODUCTS = ['rhoai', 'rhelai', 'RHAII']
 const DEFAULT_PROJECTS = ['RHAISTRAT', 'RHOAIENG', 'AIPCC', 'RHAIENG', 'INFERENG']
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 
-var EXCLUDE_VERSION_RE = /^\d+\.\d+\.\d+$/
+const EXCLUDE_VERSION_RE = /^\d+\.\d+\.\d+$/
 
-var FIELDS_TO_FETCH = [
+const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
   'components', 'labels', 'issuelinks',
   CUSTOM_FIELDS.team,
@@ -43,8 +43,8 @@ function cacheKey(portfolioVersion) {
  * e.g. "rhoai-3.5.EA1" → "rhoai", "RHAII-3.5" → "rhaii"
  */
 function extractProduct(releaseNumber) {
-  var s = (releaseNumber || '').toLowerCase()
-  var dash = s.indexOf('-')
+  const s = (releaseNumber || '').toLowerCase()
+  const dash = s.indexOf('-')
   return dash > 0 ? s.slice(0, dash) : s
 }
 
@@ -59,15 +59,15 @@ function extractProduct(releaseNumber) {
  *   "RHELAI-3.4 EA-1"          → "rhelai-3.4ea1"
  */
 function normalizeVersionName(name) {
-  var s = (name || '').toLowerCase()
-  s = s.replace(/\s+release\s*$/i, '')
+  let s = (name || '').toLowerCase()
+  s = s.replace(/\s+release$/i, '').trimEnd()
   s = s.replace(/(\d)[\s._-]+(?=ea|ga)/gi, '$1')
   s = s.replace(/(ea)-?(\d)/gi, 'ea$2')
   return s
 }
 
-var jiraVersionsCache = { versions: null, fetchedAt: 0 }
-var VERSIONS_CACHE_TTL_MS = 15 * 60 * 1000
+const jiraVersionsCache = { versions: null, fetchedAt: 0 }
+const VERSIONS_CACHE_TTL_MS = 15 * 60 * 1000
 
 /**
  * Resolve a portfolio version (e.g. "3.5.EA1") to actual Jira fixVersion
@@ -76,25 +76,25 @@ var VERSIONS_CACHE_TTL_MS = 15 * 60 * 1000
  * (e.g. both "rhelai-3.5EA2" and "rhelai-3.5 EA2 release" for rhelai).
  */
 async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn) {
-  var { fetchProjectVersions } = require('../../../../shared/server/jira')
+  const { fetchProjectVersions } = require('../../../../shared/server/jira')
 
   if (!jiraVersionsCache.versions || Date.now() - jiraVersionsCache.fetchedAt > VERSIONS_CACHE_TTL_MS) {
     jiraVersionsCache.versions = await fetchProjectVersions(jiraRequestFn, DEFAULT_PROJECTS)
     jiraVersionsCache.fetchedAt = Date.now()
   }
 
-  var allVersions = jiraVersionsCache.versions
-  var normalizedPortfolio = normalizeVersionName(portfolioVersion)
+  const allVersions = jiraVersionsCache.versions
+  const normalizedPortfolio = normalizeVersionName(portfolioVersion)
 
-  var productMap = {}
+  const productMap = {}
 
-  for (var i = 0; i < allVersions.length; i++) {
-    var v = allVersions[i]
-    var product = extractProduct(v.name)
+  for (let i = 0; i < allVersions.length; i++) {
+    const v = allVersions[i]
+    const product = extractProduct(v.name)
     if (!product) continue
 
-    var normalizedName = normalizeVersionName(v.name)
-    var versionPart = normalizedName.replace(/^[a-z]+-/, '')
+    const normalizedName = normalizeVersionName(v.name)
+    const versionPart = normalizedName.replace(/^[a-z]+-/, '')
 
     if (versionPart === normalizedPortfolio) {
       if (!productMap[product]) {
@@ -109,10 +109,10 @@ async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn) {
     }
   }
 
-  var matched = []
-  var keys = Object.keys(productMap)
-  for (var ki = 0; ki < keys.length; ki++) {
-    var entry = productMap[keys[ki]]
+  const matched = []
+  const keys = Object.keys(productMap)
+  for (let ki = 0; ki < keys.length; ki++) {
+    const entry = productMap[keys[ki]]
     matched.push({
       product: entry.product,
       releaseNumber: entry.fixVersions[0],
@@ -122,10 +122,10 @@ async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn) {
 
   if (matched.length > 0) return matched
 
-  var products = DEFAULT_PRODUCTS
-  var result = []
-  for (var pi = 0; pi < products.length; pi++) {
-    var fv = products[pi] + '-' + portfolioVersion
+  const products = DEFAULT_PRODUCTS
+  const result = []
+  for (let pi = 0; pi < products.length; pi++) {
+    const fv = products[pi] + '-' + portfolioVersion
     result.push({
       product: products[pi].toLowerCase(),
       releaseNumber: fv,
@@ -142,33 +142,33 @@ async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn) {
  * Deduplicates by issue key. Returns transformed feature objects.
  */
 async function fetchFeaturesByFixVersion(fixVersions, jiraRequestFn, fetchAllJqlResultsFn) {
-  var versions = Array.isArray(fixVersions) ? fixVersions : [fixVersions]
-  var projects = DEFAULT_PROJECTS
-  var issueTypes = DEFAULT_ISSUE_TYPES
+  const versions = Array.isArray(fixVersions) ? fixVersions : [fixVersions]
+  const projects = DEFAULT_PROJECTS
+  const issueTypes = DEFAULT_ISSUE_TYPES
 
-  var sanitized = versions.map(function (v) {
+  const sanitized = versions.map(function (v) {
     return '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
   })
 
-  var fixVersionFilter = sanitized.length === 1
+  const fixVersionFilter = sanitized.length === 1
     ? 'fixVersion = ' + sanitized[0]
     : 'fixVersion IN (' + sanitized.join(', ') + ')'
 
-  var jql = 'project IN (' + projects.join(', ') + ')' +
+  const jql = 'project IN (' + projects.join(', ') + ')' +
     ' AND issuetype IN (' + issueTypes.join(', ') + ')' +
     ' AND ' + fixVersionFilter
 
-  var rawIssues = await fetchAllJqlResultsFn(jiraRequestFn, jql, FIELDS_TO_FETCH, {
+  const rawIssues = await fetchAllJqlResultsFn(jiraRequestFn, jql, FIELDS_TO_FETCH, {
     expand: 'renderedFields,changelog'
   })
 
-  var seen = {}
-  var features = []
-  for (var i = 0; i < rawIssues.length; i++) {
-    var raw = rawIssues[i]
+  const seen = {}
+  const features = []
+  for (let i = 0; i < rawIssues.length; i++) {
+    const raw = rawIssues[i]
     if (seen[raw.key]) continue
     seen[raw.key] = true
-    var transformed = transformIssue(raw, {})
+    const transformed = transformIssue(raw, {})
     transformed.fixVersionAddedAt = findFixVersionAddedDate(raw.changelog, versions)
     features.push(transformed)
   }
@@ -185,20 +185,20 @@ async function fetchFeaturesByFixVersion(fixVersions, jiraRequestFn, fetchAllJql
 function findFixVersionAddedDate(changelog, fixVersionNames) {
   if (!changelog || !Array.isArray(changelog.histories)) return null
 
-  var targets = Array.isArray(fixVersionNames) ? fixVersionNames : [fixVersionNames]
-  var normalizedTargets = {}
-  for (var ti = 0; ti < targets.length; ti++) {
+  const targets = Array.isArray(fixVersionNames) ? fixVersionNames : [fixVersionNames]
+  const normalizedTargets = {}
+  for (let ti = 0; ti < targets.length; ti++) {
     normalizedTargets[targets[ti].toLowerCase()] = true
   }
 
-  for (var i = 0; i < changelog.histories.length; i++) {
-    var history = changelog.histories[i]
-    var items = history.items || []
+  for (let i = 0; i < changelog.histories.length; i++) {
+    const history = changelog.histories[i]
+    const items = history.items || []
 
-    for (var j = 0; j < items.length; j++) {
-      var item = items[j]
+    for (let j = 0; j < items.length; j++) {
+      const item = items[j]
       if (item.field !== 'Fix Version' && item.fieldId !== 'fixVersions') continue
-      var toString = (item.toString || '').toLowerCase()
+      const toString = (item.toString || '').toLowerCase()
       if (normalizedTargets[toString]) {
         return history.created
       }
@@ -215,7 +215,7 @@ function classifyFeature(feature, featureFreezeDate) {
   if (!featureFreezeDate) return null
 
   if (feature.fixVersionAddedAt) {
-    var addedDate = feature.fixVersionAddedAt.split('T')[0]
+    const addedDate = feature.fixVersionAddedAt.split('T')[0]
     if (addedDate > featureFreezeDate) {
       return 'added'
     }
@@ -231,39 +231,37 @@ function classifyFeature(feature, featureFreezeDate) {
  * the fixVersion was removed (fixVersionRemovedAt).
  */
 async function fetchDroppedFeatures(fixVersions, jiraRequestFn, fetchAllJqlResultsFn, currentKeys) {
-  var versions = Array.isArray(fixVersions) ? fixVersions : [fixVersions]
-  var projects = DEFAULT_PROJECTS
+  const versions = Array.isArray(fixVersions) ? fixVersions : [fixVersions]
+  const projects = DEFAULT_PROJECTS
 
-  var sanitized = versions.map(function (v) {
+  const sanitized = versions.map(function (v) {
     return '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
   })
 
-  // Build WAS clause: (fixVersion WAS "v1" OR fixVersion WAS "v2")
-  var wasClauses = sanitized.map(function (v) { return 'fixVersion WAS ' + v })
-  var wasFilter = wasClauses.length === 1
+  const wasClauses = sanitized.map(function (v) { return 'fixVersion WAS ' + v })
+  const wasFilter = wasClauses.length === 1
     ? wasClauses[0]
     : '(' + wasClauses.join(' OR ') + ')'
 
-  // Build NOT IN clause to exclude issues that still have the fixVersion
-  var notInFilter = sanitized.length === 1
+  const notInFilter = sanitized.length === 1
     ? 'fixVersion != ' + sanitized[0]
     : 'fixVersion NOT IN (' + sanitized.join(', ') + ')'
 
-  var jql = wasFilter +
+  const jql = wasFilter +
     ' AND ' + notInFilter +
     ' AND issuetype = Feature' +
     ' AND project IN (' + projects.join(', ') + ')'
 
   try {
-    var rawIssues = await fetchAllJqlResultsFn(jiraRequestFn, jql, FIELDS_TO_FETCH, {
+    const rawIssues = await fetchAllJqlResultsFn(jiraRequestFn, jql, FIELDS_TO_FETCH, {
       expand: 'renderedFields,changelog'
     })
 
-    var dropped = []
-    for (var i = 0; i < rawIssues.length; i++) {
-      var raw = rawIssues[i]
+    const dropped = []
+    for (let i = 0; i < rawIssues.length; i++) {
+      const raw = rawIssues[i]
       if (currentKeys[raw.key]) continue
-      var transformed = transformIssue(raw, {})
+      const transformed = transformIssue(raw, {})
       transformed.scopeChange = 'dropped'
       transformed.fixVersionRemovedAt = findFixVersionRemovedDate(raw.changelog, versions)
       dropped.push(transformed)
@@ -284,22 +282,22 @@ async function fetchDroppedFeatures(fixVersions, jiraRequestFn, fetchAllJqlResul
 function findFixVersionRemovedDate(changelog, fixVersionNames) {
   if (!changelog || !Array.isArray(changelog.histories)) return null
 
-  var targets = Array.isArray(fixVersionNames) ? fixVersionNames : [fixVersionNames]
-  var normalizedTargets = {}
-  for (var ti = 0; ti < targets.length; ti++) {
+  const targets = Array.isArray(fixVersionNames) ? fixVersionNames : [fixVersionNames]
+  const normalizedTargets = {}
+  for (let ti = 0; ti < targets.length; ti++) {
     normalizedTargets[targets[ti].toLowerCase()] = true
   }
 
-  var mostRecent = null
+  let mostRecent = null
 
-  for (var i = 0; i < changelog.histories.length; i++) {
-    var history = changelog.histories[i]
-    var items = history.items || []
+  for (let i = 0; i < changelog.histories.length; i++) {
+    const history = changelog.histories[i]
+    const items = history.items || []
 
-    for (var j = 0; j < items.length; j++) {
-      var item = items[j]
+    for (let j = 0; j < items.length; j++) {
+      const item = items[j]
       if (item.field !== 'Fix Version' && item.fieldId !== 'fixVersions') continue
-      var fromString = (item.fromString || '').toLowerCase()
+      const fromString = (item.fromString || '').toLowerCase()
       if (normalizedTargets[fromString]) {
         if (!mostRecent || history.created > mostRecent) {
           mostRecent = history.created
@@ -317,16 +315,16 @@ function findFixVersionRemovedDate(changelog, fixVersionNames) {
  * Also returns the earliest date across products as a portfolio-level fallback.
  */
 function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
-  var ppCache = readFromStorage(PP_CACHE_FILE)
-  var ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
+  const ppCache = readFromStorage(PP_CACHE_FILE)
+  const ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
 
-  var normalizedPortfolio = normalizeVersionName(portfolioVersion)
-  var byProduct = {}
-  var earliest = null
+  const normalizedPortfolio = normalizeVersionName(portfolioVersion)
+  const byProduct = {}
+  let earliest = null
 
-  for (var i = 0; i < ppReleases.length; i++) {
-    var rel = ppReleases[i]
-    var relVersion = normalizeVersionName(rel.releaseNumber).replace(/^[a-z]+-/, '')
+  for (let i = 0; i < ppReleases.length; i++) {
+    const rel = ppReleases[i]
+    const relVersion = normalizeVersionName(rel.releaseNumber).replace(/^[a-z]+-/, '')
     if (relVersion === normalizedPortfolio && rel.featureFreezeDate) {
       byProduct[normalizeVersionName(rel.releaseNumber)] = rel.featureFreezeDate
       if (!earliest || rel.featureFreezeDate < earliest) {
@@ -373,17 +371,17 @@ function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
  */
 
 module.exports = function registerFeatureTrackingRoutes(router, context) {
-  var storage = context.storage
-  var requireAuth = context.requireAuth
-  var requireScope = context.requireScope
+  const storage = context.storage
+  const requireAuth = context.requireAuth
+  const requireScope = context.requireScope
 
   // GET /tracking/versions
   router.get('/tracking/versions', requireAuth, requireScope('releases:read'), function (req, res) {
-    var versionMap = {}
+    const versionMap = {}
 
     function addVersion(releaseNumber) {
-      var product = extractProduct(releaseNumber)
-      var versionPart = (releaseNumber || '').replace(/^[a-z]+-/i, '')
+      const product = extractProduct(releaseNumber)
+      const versionPart = (releaseNumber || '').replace(/^[a-z]+-/i, '')
       if (!versionPart || !product) return
       if (EXCLUDE_VERSION_RE.test(versionPart)) return
       if (!versionMap[versionPart]) {
@@ -394,40 +392,38 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       }
     }
 
-    var registry = readRegistry(storage.readFromStorage)
-    var registryReleases = registry.releases || []
-    for (var ri = 0; ri < registryReleases.length; ri++) {
-      var rel = registryReleases[ri]
+    const registry = readRegistry(storage.readFromStorage)
+    const registryReleases = registry.releases || []
+    for (let ri = 0; ri < registryReleases.length; ri++) {
+      const rel = registryReleases[ri]
       if (rel.state === 'archived') continue
       addVersion(rel.displayName || rel.id || '')
     }
 
-    var ppCache = storage.readFromStorage(PP_CACHE_FILE)
-    var ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
-    for (var pi = 0; pi < ppReleases.length; pi++) {
+    const ppCache = storage.readFromStorage(PP_CACHE_FILE)
+    const ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
+    for (let pi = 0; pi < ppReleases.length; pi++) {
       if (ppReleases[pi].releaseNumber) addVersion(ppReleases[pi].releaseNumber)
     }
 
-    var planningConfig = storage.readFromStorage(PLANNING_CONFIG_FILE)
+    const planningConfig = storage.readFromStorage(PLANNING_CONFIG_FILE)
     if (planningConfig && planningConfig.releases) {
-      var configVersions = Object.keys(planningConfig.releases)
-      for (var ci = 0; ci < configVersions.length; ci++) {
-        var cv = configVersions[ci]
+      const configVersions = Object.keys(planningConfig.releases)
+      for (let ci = 0; ci < configVersions.length; ci++) {
+        const cv = configVersions[ci]
         if (!versionMap[cv] && !EXCLUDE_VERSION_RE.test(cv)) {
           versionMap[cv] = { version: cv, products: [] }
         }
       }
     }
 
-    var versions = Object.keys(versionMap).map(function (k) { return versionMap[k] })
+    const versions = Object.keys(versionMap).map(function (k) { return versionMap[k] })
 
-    // Enrich with earliest feature freeze date per portfolio version
-    for (var vi = 0; vi < versions.length; vi++) {
-      var fd = getFeatureFreezeDatesFromCache(versions[vi].version, storage.readFromStorage)
+    for (let vi = 0; vi < versions.length; vi++) {
+      const fd = getFeatureFreezeDatesFromCache(versions[vi].version, storage.readFromStorage)
       versions[vi].featureFreezeDate = fd.earliest || null
     }
 
-    // Sort by feature freeze date (earliest first); versions without a date go last
     versions.sort(function (a, b) {
       if (a.featureFreezeDate && b.featureFreezeDate) return a.featureFreezeDate.localeCompare(b.featureFreezeDate)
       if (a.featureFreezeDate && !b.featureFreezeDate) return -1
@@ -440,44 +436,42 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
 
   // GET /tracking/data — query Jira by fixVersion
   router.get('/tracking/data', requireAuth, requireScope('releases:read'), async function (req, res) {
-    var version = req.query.version
+    const version = req.query.version
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' })
     }
 
-    var forceRefresh = req.query.refresh === 'true'
+    const forceRefresh = req.query.refresh === 'true'
 
     try {
-      // Check server-side cache
       if (!forceRefresh) {
-        var cached = storage.readFromStorage(cacheKey(version))
+        const cached = storage.readFromStorage(cacheKey(version))
         if (cached && cached.fetchedAt) {
-          var age = Date.now() - new Date(cached.fetchedAt).getTime()
+          const age = Date.now() - new Date(cached.fetchedAt).getTime()
           if (age < CACHE_TTL_MS) {
             return res.json(cached)
           }
         }
       }
 
-      var jira = require('../../../../shared/server/jira')
-      var jiraRequest = jira.jiraRequest
-      var fetchAllJqlResults = jira.fetchAllJqlResults
+      const jira = require('../../../../shared/server/jira')
+      const jiraRequest = jira.jiraRequest
+      const fetchAllJqlResults = jira.fetchAllJqlResults
 
-      var productVersions = await resolveProductVersionsFromJira(version, jiraRequest)
-      var freezeDates = getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
+      const productVersions = await resolveProductVersionsFromJira(version, jiraRequest)
+      const freezeDates = getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
 
-      // Try live PP API if cache doesn't have any freeze dates
       if (!freezeDates.earliest) {
         try {
-          var ppConfig = {
+          const ppConfig = {
             productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com',
             productPagesProductShortnames: DEFAULT_PRODUCTS
           }
-          var livePPReleases = await fetchProductsByShortname(ppConfig.productPagesProductShortnames, ppConfig)
-          var normalizedPV = version.replace(/\s+/g, '.').toLowerCase()
-          for (var pri = 0; pri < livePPReleases.length; pri++) {
-            var pr = livePPReleases[pri]
-            var prVersion = (pr.releaseNumber || '').replace(/^[a-z]+-/i, '').toLowerCase()
+          const livePPReleases = await fetchProductsByShortname(ppConfig.productPagesProductShortnames, ppConfig)
+          const normalizedPV = version.replace(/\s+/g, '.').toLowerCase()
+          for (let pri = 0; pri < livePPReleases.length; pri++) {
+            const pr = livePPReleases[pri]
+            const prVersion = (pr.releaseNumber || '').replace(/^[a-z]+-/i, '').toLowerCase()
             if (prVersion === normalizedPV && pr.featureFreezeDate) {
               freezeDates.byProduct[(pr.releaseNumber || '').toLowerCase()] = pr.featureFreezeDate
               if (!freezeDates.earliest || pr.featureFreezeDate < freezeDates.earliest) {
@@ -490,34 +484,32 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         }
       }
 
-      var groups = []
-      for (var i = 0; i < productVersions.length; i++) {
-        var pv = productVersions[i]
+      const groups = []
+      for (let i = 0; i < productVersions.length; i++) {
+        const pv = productVersions[i]
 
-        var features = await fetchFeaturesByFixVersion(pv.fixVersions, jiraRequest, fetchAllJqlResults)
+        let features = await fetchFeaturesByFixVersion(pv.fixVersions, jiraRequest, fetchAllJqlResults)
 
-        // Classify late additions using per-product freeze date
-        var productFreezeDate = freezeDates.byProduct[normalizeVersionName(pv.fixVersions[0])] || null
-        for (var fi = 0; fi < features.length; fi++) {
+        const productFreezeDate = freezeDates.byProduct[normalizeVersionName(pv.fixVersions[0])] || null
+        for (let fi = 0; fi < features.length; fi++) {
           features[fi].scopeChange = classifyFeature(features[fi], productFreezeDate)
         }
 
-        // Detect dropped features via JQL WAS operator
-        var currentKeys = {}
-        for (var ki = 0; ki < features.length; ki++) {
+        const currentKeys = {}
+        for (let ki = 0; ki < features.length; ki++) {
           currentKeys[features[ki].key] = true
         }
-        var dropped = await fetchDroppedFeatures(pv.fixVersions, jiraRequest, fetchAllJqlResults, currentKeys)
+        const dropped = await fetchDroppedFeatures(pv.fixVersions, jiraRequest, fetchAllJqlResults, currentKeys)
         features = features.concat(dropped)
 
-        var STATUS_ORDER = { red: 0, yellow: 1, green: 2 }
+        const STATUS_ORDER = { red: 0, yellow: 1, green: 2 }
         features.sort(function (a, b) {
           if (a.scopeChange === 'dropped' && b.scopeChange !== 'dropped') return 1
           if (a.scopeChange !== 'dropped' && b.scopeChange === 'dropped') return -1
-          var aColor = STATUS_ORDER[(a.colorStatus || '').toLowerCase()]
-          var bColor = STATUS_ORDER[(b.colorStatus || '').toLowerCase()]
-          var aRank = aColor !== undefined ? aColor : 3
-          var bRank = bColor !== undefined ? bColor : 3
+          const aColor = STATUS_ORDER[(a.colorStatus || '').toLowerCase()]
+          const bColor = STATUS_ORDER[(b.colorStatus || '').toLowerCase()]
+          const aRank = aColor !== undefined ? aColor : 3
+          const bRank = bColor !== undefined ? bColor : 3
           if (aRank !== bRank) return aRank - bRank
           return a.key.localeCompare(b.key)
         })
@@ -547,14 +539,13 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         })
       }
 
-      var responseData = {
+      const responseData = {
         portfolioVersion: version,
         featureFreezeDate: freezeDates.earliest,
         fetchedAt: new Date().toISOString(),
         groups: groups
       }
 
-      // Cache the response
       storage.writeToStorage(cacheKey(version), responseData)
 
       res.json(responseData)

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -1,0 +1,568 @@
+/**
+ * Feature Tracking routes for the releases module.
+ *
+ * Queries Jira directly by fixVersion (e.g. fixVersion = "rhoai-3.5.EA1")
+ * to list all features committed to a release. Uses the Jira changelog to
+ * detect when fixVersion was applied — features added after the Feature
+ * Freeze date are flagged as "Late Additions".
+ *
+ * Grouped by portfolio release (e.g. 3.5.EA1) across products (RHOAI,
+ * RHAIIS, RHELAI). Uses the JQL WAS operator to detect features that
+ * previously had a fixVersion but no longer do (dropped features).
+ */
+
+const { readRegistry } = require('../registry')
+const { fetchProductsByShortname } = require('../delivery/product-pages')
+const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
+
+const PP_CACHE_FILE = 'releases/delivery/product-pages-releases-cache.json'
+const PLANNING_CONFIG_FILE = 'releases/planning/config.json'
+const TRACKING_CACHE_PREFIX = 'releases/execution/tracking-data-'
+const CACHE_TTL_MS = 10 * 60 * 1000
+const DEFAULT_PRODUCTS = ['rhoai', 'rhelai', 'RHAII']
+const DEFAULT_PROJECTS = ['RHAISTRAT', 'RHOAIENG', 'AIPCC', 'RHAIENG', 'INFERENG']
+const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
+
+var EXCLUDE_VERSION_RE = /^\d+\.\d+\.\d+$/
+
+var FIELDS_TO_FETCH = [
+  'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
+  'components', 'labels', 'issuelinks',
+  CUSTOM_FIELDS.team,
+  CUSTOM_FIELDS.statusSummary,
+  CUSTOM_FIELDS.colorStatus,
+  CUSTOM_FIELDS.productManager
+].join(',')
+
+function cacheKey(portfolioVersion) {
+  return TRACKING_CACHE_PREFIX + portfolioVersion + '.json'
+}
+
+/**
+ * Extract the product prefix from a release number.
+ * e.g. "rhoai-3.5.EA1" → "rhoai", "RHAII-3.5" → "rhaii"
+ */
+function extractProduct(releaseNumber) {
+  var s = (releaseNumber || '').toLowerCase()
+  var dash = s.indexOf('-')
+  return dash > 0 ? s.slice(0, dash) : s
+}
+
+/**
+ * Normalize a version string for comparison: lowercase, strip separators
+ * between version number and EA/GA tag, and strip trailing suffixes like
+ * "release". Handles all observed naming conventions:
+ *   "rhoai-3.5.EA2"            → "rhoai-3.5ea2"
+ *   "RHAII-3.5 EA2"            → "rhaii-3.5ea2"
+ *   "rhelai-3.5EA2"            → "rhelai-3.5ea2"
+ *   "rhelai-3.5 EA2 release"   → "rhelai-3.5ea2"
+ *   "RHELAI-3.4 EA-1"          → "rhelai-3.4ea1"
+ */
+function normalizeVersionName(name) {
+  var s = (name || '').toLowerCase()
+  s = s.replace(/\s+release\s*$/i, '')
+  s = s.replace(/(\d)[\s._-]+(?=ea|ga)/gi, '$1')
+  s = s.replace(/(ea)-?(\d)/gi, 'ea$2')
+  return s
+}
+
+var jiraVersionsCache = { versions: null, fetchedAt: 0 }
+var VERSIONS_CACHE_TTL_MS = 15 * 60 * 1000
+
+/**
+ * Resolve a portfolio version (e.g. "3.5.EA1") to actual Jira fixVersion
+ * names by querying the Jira project versions API. Handles different naming
+ * conventions across products, collecting ALL matching fixVersions per product
+ * (e.g. both "rhelai-3.5EA2" and "rhelai-3.5 EA2 release" for rhelai).
+ */
+async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn) {
+  var { fetchProjectVersions } = require('../../../../shared/server/jira')
+
+  if (!jiraVersionsCache.versions || Date.now() - jiraVersionsCache.fetchedAt > VERSIONS_CACHE_TTL_MS) {
+    jiraVersionsCache.versions = await fetchProjectVersions(jiraRequestFn, DEFAULT_PROJECTS)
+    jiraVersionsCache.fetchedAt = Date.now()
+  }
+
+  var allVersions = jiraVersionsCache.versions
+  var normalizedPortfolio = normalizeVersionName(portfolioVersion)
+
+  var productMap = {}
+
+  for (var i = 0; i < allVersions.length; i++) {
+    var v = allVersions[i]
+    var product = extractProduct(v.name)
+    if (!product) continue
+
+    var normalizedName = normalizeVersionName(v.name)
+    var versionPart = normalizedName.replace(/^[a-z]+-/, '')
+
+    if (versionPart === normalizedPortfolio) {
+      if (!productMap[product]) {
+        productMap[product] = {
+          product: product,
+          fixVersions: []
+        }
+      }
+      if (productMap[product].fixVersions.indexOf(v.name) === -1) {
+        productMap[product].fixVersions.push(v.name)
+      }
+    }
+  }
+
+  var matched = []
+  var keys = Object.keys(productMap)
+  for (var ki = 0; ki < keys.length; ki++) {
+    var entry = productMap[keys[ki]]
+    matched.push({
+      product: entry.product,
+      releaseNumber: entry.fixVersions[0],
+      fixVersions: entry.fixVersions
+    })
+  }
+
+  if (matched.length > 0) return matched
+
+  var products = DEFAULT_PRODUCTS
+  var result = []
+  for (var pi = 0; pi < products.length; pi++) {
+    var fv = products[pi] + '-' + portfolioVersion
+    result.push({
+      product: products[pi].toLowerCase(),
+      releaseNumber: fv,
+      fixVersions: [fv]
+    })
+  }
+  return result
+}
+
+/**
+ * Fetch features from Jira by fixVersion(s) with changelog.
+ * Accepts an array of fixVersion names to handle naming variants
+ * (e.g. ["rhelai-3.5EA2", "rhelai-3.5 EA2 release"]).
+ * Deduplicates by issue key. Returns transformed feature objects.
+ */
+async function fetchFeaturesByFixVersion(fixVersions, jiraRequestFn, fetchAllJqlResultsFn) {
+  var versions = Array.isArray(fixVersions) ? fixVersions : [fixVersions]
+  var projects = DEFAULT_PROJECTS
+  var issueTypes = DEFAULT_ISSUE_TYPES
+
+  var sanitized = versions.map(function (v) {
+    return '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+  })
+
+  var fixVersionFilter = sanitized.length === 1
+    ? 'fixVersion = ' + sanitized[0]
+    : 'fixVersion IN (' + sanitized.join(', ') + ')'
+
+  var jql = 'project IN (' + projects.join(', ') + ')' +
+    ' AND issuetype IN (' + issueTypes.join(', ') + ')' +
+    ' AND ' + fixVersionFilter
+
+  var rawIssues = await fetchAllJqlResultsFn(jiraRequestFn, jql, FIELDS_TO_FETCH, {
+    expand: 'renderedFields,changelog'
+  })
+
+  var seen = {}
+  var features = []
+  for (var i = 0; i < rawIssues.length; i++) {
+    var raw = rawIssues[i]
+    if (seen[raw.key]) continue
+    seen[raw.key] = true
+    var transformed = transformIssue(raw, {})
+    transformed.fixVersionAddedAt = findFixVersionAddedDate(raw.changelog, versions)
+    features.push(transformed)
+  }
+
+  return features
+}
+
+/**
+ * Parse changelog to find when a fixVersion was added to the issue.
+ * Accepts a single version name or an array of names to match against
+ * (handles naming variants like "rhelai-3.5EA2" / "rhelai-3.5 EA2 release").
+ * Returns ISO timestamp string or null if not found in changelog.
+ */
+function findFixVersionAddedDate(changelog, fixVersionNames) {
+  if (!changelog || !Array.isArray(changelog.histories)) return null
+
+  var targets = Array.isArray(fixVersionNames) ? fixVersionNames : [fixVersionNames]
+  var normalizedTargets = {}
+  for (var ti = 0; ti < targets.length; ti++) {
+    normalizedTargets[targets[ti].toLowerCase()] = true
+  }
+
+  for (var i = 0; i < changelog.histories.length; i++) {
+    var history = changelog.histories[i]
+    var items = history.items || []
+
+    for (var j = 0; j < items.length; j++) {
+      var item = items[j]
+      if (item.field !== 'Fix Version' && item.fieldId !== 'fixVersions') continue
+      var toString = (item.toString || '').toLowerCase()
+      if (normalizedTargets[toString]) {
+        return history.created
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Classify a feature as late addition based on changelog date vs freeze date.
+ */
+function classifyFeature(feature, featureFreezeDate) {
+  if (!featureFreezeDate) return null
+
+  if (feature.fixVersionAddedAt) {
+    var addedDate = feature.fixVersionAddedAt.split('T')[0]
+    if (addedDate > featureFreezeDate) {
+      return 'added'
+    }
+  }
+
+  return null
+}
+
+/**
+ * Fetch features that previously had a fixVersion but no longer do,
+ * using the JQL WAS operator. Only checks issuetype = Feature.
+ * Returns transformed feature objects marked as dropped, with the date
+ * the fixVersion was removed (fixVersionRemovedAt).
+ */
+async function fetchDroppedFeatures(fixVersions, jiraRequestFn, fetchAllJqlResultsFn, currentKeys) {
+  var versions = Array.isArray(fixVersions) ? fixVersions : [fixVersions]
+  var projects = DEFAULT_PROJECTS
+
+  var sanitized = versions.map(function (v) {
+    return '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+  })
+
+  // Build WAS clause: (fixVersion WAS "v1" OR fixVersion WAS "v2")
+  var wasClauses = sanitized.map(function (v) { return 'fixVersion WAS ' + v })
+  var wasFilter = wasClauses.length === 1
+    ? wasClauses[0]
+    : '(' + wasClauses.join(' OR ') + ')'
+
+  // Build NOT IN clause to exclude issues that still have the fixVersion
+  var notInFilter = sanitized.length === 1
+    ? 'fixVersion != ' + sanitized[0]
+    : 'fixVersion NOT IN (' + sanitized.join(', ') + ')'
+
+  var jql = wasFilter +
+    ' AND ' + notInFilter +
+    ' AND issuetype = Feature' +
+    ' AND project IN (' + projects.join(', ') + ')'
+
+  try {
+    var rawIssues = await fetchAllJqlResultsFn(jiraRequestFn, jql, FIELDS_TO_FETCH, {
+      expand: 'renderedFields,changelog'
+    })
+
+    var dropped = []
+    for (var i = 0; i < rawIssues.length; i++) {
+      var raw = rawIssues[i]
+      if (currentKeys[raw.key]) continue
+      var transformed = transformIssue(raw, {})
+      transformed.scopeChange = 'dropped'
+      transformed.fixVersionRemovedAt = findFixVersionRemovedDate(raw.changelog, versions)
+      dropped.push(transformed)
+    }
+
+    return dropped
+  } catch (err) {
+    console.warn('[feature-tracking] WAS query failed (may not be supported):', err.message)
+    return []
+  }
+}
+
+/**
+ * Parse changelog to find when a fixVersion was removed from the issue.
+ * Looks for Fix Version changelog entries where fromString matches one of
+ * the version names (meaning it was taken away).
+ */
+function findFixVersionRemovedDate(changelog, fixVersionNames) {
+  if (!changelog || !Array.isArray(changelog.histories)) return null
+
+  var targets = Array.isArray(fixVersionNames) ? fixVersionNames : [fixVersionNames]
+  var normalizedTargets = {}
+  for (var ti = 0; ti < targets.length; ti++) {
+    normalizedTargets[targets[ti].toLowerCase()] = true
+  }
+
+  var mostRecent = null
+
+  for (var i = 0; i < changelog.histories.length; i++) {
+    var history = changelog.histories[i]
+    var items = history.items || []
+
+    for (var j = 0; j < items.length; j++) {
+      var item = items[j]
+      if (item.field !== 'Fix Version' && item.fieldId !== 'fixVersions') continue
+      var fromString = (item.fromString || '').toLowerCase()
+      if (normalizedTargets[fromString]) {
+        if (!mostRecent || history.created > mostRecent) {
+          mostRecent = history.created
+        }
+      }
+    }
+  }
+
+  return mostRecent
+}
+
+/**
+ * Get Feature Freeze dates from PP cache, keyed by product release number.
+ * Returns a map: { "rhoai-3.5.EA1": "2026-05-15", "rhelai-3.5.EA1": "2026-04-17", ... }
+ * Also returns the earliest date across products as a portfolio-level fallback.
+ */
+function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
+  var ppCache = readFromStorage(PP_CACHE_FILE)
+  var ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
+
+  var normalizedPortfolio = normalizeVersionName(portfolioVersion)
+  var byProduct = {}
+  var earliest = null
+
+  for (var i = 0; i < ppReleases.length; i++) {
+    var rel = ppReleases[i]
+    var relVersion = normalizeVersionName(rel.releaseNumber).replace(/^[a-z]+-/, '')
+    if (relVersion === normalizedPortfolio && rel.featureFreezeDate) {
+      byProduct[normalizeVersionName(rel.releaseNumber)] = rel.featureFreezeDate
+      if (!earliest || rel.featureFreezeDate < earliest) {
+        earliest = rel.featureFreezeDate
+      }
+    }
+  }
+
+  return { byProduct: byProduct, earliest: earliest }
+}
+
+/**
+ * @openapi
+ * /api/modules/releases/execution/tracking/data:
+ *   get:
+ *     summary: Get feature tracking data by querying Jira fixVersion directly
+ *     tags: [Releases - Feature Tracking]
+ *     parameters:
+ *       - in: query
+ *         name: version
+ *         required: true
+ *         schema: { type: string }
+ *         description: Portfolio version (e.g. 3.5.EA1)
+ *       - in: query
+ *         name: refresh
+ *         schema: { type: boolean }
+ *         description: Force fresh fetch from Jira (skip cache)
+ *     responses:
+ *       200:
+ *         description: Feature tracking data with scope change annotations
+ *       400:
+ *         description: Missing version parameter
+ */
+
+/**
+ * @openapi
+ * /api/modules/releases/execution/tracking/versions:
+ *   get:
+ *     summary: List available portfolio versions for feature tracking
+ *     tags: [Releases - Feature Tracking]
+ *     responses:
+ *       200:
+ *         description: Array of portfolio versions
+ */
+
+module.exports = function registerFeatureTrackingRoutes(router, context) {
+  var storage = context.storage
+  var requireAuth = context.requireAuth
+  var requireScope = context.requireScope
+
+  // GET /tracking/versions
+  router.get('/tracking/versions', requireAuth, requireScope('releases:read'), function (req, res) {
+    var versionMap = {}
+
+    function addVersion(releaseNumber) {
+      var product = extractProduct(releaseNumber)
+      var versionPart = (releaseNumber || '').replace(/^[a-z]+-/i, '')
+      if (!versionPart || !product) return
+      if (EXCLUDE_VERSION_RE.test(versionPart)) return
+      if (!versionMap[versionPart]) {
+        versionMap[versionPart] = { version: versionPart, products: [] }
+      }
+      if (versionMap[versionPart].products.indexOf(product) === -1) {
+        versionMap[versionPart].products.push(product)
+      }
+    }
+
+    var registry = readRegistry(storage.readFromStorage)
+    var registryReleases = registry.releases || []
+    for (var ri = 0; ri < registryReleases.length; ri++) {
+      var rel = registryReleases[ri]
+      if (rel.state === 'archived') continue
+      addVersion(rel.displayName || rel.id || '')
+    }
+
+    var ppCache = storage.readFromStorage(PP_CACHE_FILE)
+    var ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
+    for (var pi = 0; pi < ppReleases.length; pi++) {
+      if (ppReleases[pi].releaseNumber) addVersion(ppReleases[pi].releaseNumber)
+    }
+
+    var planningConfig = storage.readFromStorage(PLANNING_CONFIG_FILE)
+    if (planningConfig && planningConfig.releases) {
+      var configVersions = Object.keys(planningConfig.releases)
+      for (var ci = 0; ci < configVersions.length; ci++) {
+        var cv = configVersions[ci]
+        if (!versionMap[cv] && !EXCLUDE_VERSION_RE.test(cv)) {
+          versionMap[cv] = { version: cv, products: [] }
+        }
+      }
+    }
+
+    var versions = Object.keys(versionMap).map(function (k) { return versionMap[k] })
+
+    // Enrich with earliest feature freeze date per portfolio version
+    for (var vi = 0; vi < versions.length; vi++) {
+      var fd = getFeatureFreezeDatesFromCache(versions[vi].version, storage.readFromStorage)
+      versions[vi].featureFreezeDate = fd.earliest || null
+    }
+
+    // Sort by feature freeze date (earliest first); versions without a date go last
+    versions.sort(function (a, b) {
+      if (a.featureFreezeDate && b.featureFreezeDate) return a.featureFreezeDate.localeCompare(b.featureFreezeDate)
+      if (a.featureFreezeDate && !b.featureFreezeDate) return -1
+      if (!a.featureFreezeDate && b.featureFreezeDate) return 1
+      return b.version.localeCompare(a.version)
+    })
+
+    res.json({ versions: versions })
+  })
+
+  // GET /tracking/data — query Jira by fixVersion
+  router.get('/tracking/data', requireAuth, requireScope('releases:read'), async function (req, res) {
+    var version = req.query.version
+    if (!version) {
+      return res.status(400).json({ error: 'version query parameter is required' })
+    }
+
+    var forceRefresh = req.query.refresh === 'true'
+
+    try {
+      // Check server-side cache
+      if (!forceRefresh) {
+        var cached = storage.readFromStorage(cacheKey(version))
+        if (cached && cached.fetchedAt) {
+          var age = Date.now() - new Date(cached.fetchedAt).getTime()
+          if (age < CACHE_TTL_MS) {
+            return res.json(cached)
+          }
+        }
+      }
+
+      var jira = require('../../../../shared/server/jira')
+      var jiraRequest = jira.jiraRequest
+      var fetchAllJqlResults = jira.fetchAllJqlResults
+
+      var productVersions = await resolveProductVersionsFromJira(version, jiraRequest)
+      var freezeDates = getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
+
+      // Try live PP API if cache doesn't have any freeze dates
+      if (!freezeDates.earliest) {
+        try {
+          var ppConfig = {
+            productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com',
+            productPagesProductShortnames: DEFAULT_PRODUCTS
+          }
+          var livePPReleases = await fetchProductsByShortname(ppConfig.productPagesProductShortnames, ppConfig)
+          var normalizedPV = version.replace(/\s+/g, '.').toLowerCase()
+          for (var pri = 0; pri < livePPReleases.length; pri++) {
+            var pr = livePPReleases[pri]
+            var prVersion = (pr.releaseNumber || '').replace(/^[a-z]+-/i, '').toLowerCase()
+            if (prVersion === normalizedPV && pr.featureFreezeDate) {
+              freezeDates.byProduct[(pr.releaseNumber || '').toLowerCase()] = pr.featureFreezeDate
+              if (!freezeDates.earliest || pr.featureFreezeDate < freezeDates.earliest) {
+                freezeDates.earliest = pr.featureFreezeDate
+              }
+            }
+          }
+        } catch {
+          // PP API not available — continue without freeze dates
+        }
+      }
+
+      var groups = []
+      for (var i = 0; i < productVersions.length; i++) {
+        var pv = productVersions[i]
+
+        var features = await fetchFeaturesByFixVersion(pv.fixVersions, jiraRequest, fetchAllJqlResults)
+
+        // Classify late additions using per-product freeze date
+        var productFreezeDate = freezeDates.byProduct[normalizeVersionName(pv.fixVersions[0])] || null
+        for (var fi = 0; fi < features.length; fi++) {
+          features[fi].scopeChange = classifyFeature(features[fi], productFreezeDate)
+        }
+
+        // Detect dropped features via JQL WAS operator
+        var currentKeys = {}
+        for (var ki = 0; ki < features.length; ki++) {
+          currentKeys[features[ki].key] = true
+        }
+        var dropped = await fetchDroppedFeatures(pv.fixVersions, jiraRequest, fetchAllJqlResults, currentKeys)
+        features = features.concat(dropped)
+
+        features.sort(function (a, b) {
+          if (a.scopeChange === 'dropped' && b.scopeChange !== 'dropped') return 1
+          if (a.scopeChange !== 'dropped' && b.scopeChange === 'dropped') return -1
+          return a.key.localeCompare(b.key)
+        })
+
+        groups.push({
+          label: pv.product.toUpperCase() + ': ' + pv.releaseNumber,
+          product: pv.product,
+          releaseNumber: pv.releaseNumber,
+          featureFreezeDate: productFreezeDate,
+          featureCount: features.filter(function (f) { return f.scopeChange !== 'dropped' }).length,
+          features: features.map(function (f) {
+            return {
+              key: f.key,
+              summary: f.summary || '',
+              colorStatus: f.colorStatus || null,
+              statusSummary: f.statusSummary || null,
+              isBlocked: f.isBlocked || false,
+              components: f.components || [],
+              assignee: f.assignee || null,
+              pmOwner: f.pmOwner || null,
+              status: f.status || null,
+              scopeChange: f.scopeChange || null,
+              fixVersionAddedAt: f.fixVersionAddedAt || null,
+              fixVersionRemovedAt: f.fixVersionRemovedAt || null
+            }
+          })
+        })
+      }
+
+      var responseData = {
+        portfolioVersion: version,
+        featureFreezeDate: freezeDates.earliest,
+        fetchedAt: new Date().toISOString(),
+        groups: groups
+      }
+
+      // Cache the response
+      storage.writeToStorage(cacheKey(version), responseData)
+
+      res.json(responseData)
+    } catch (err) {
+      console.error('[feature-tracking] Error loading tracking data:', err.message)
+      res.status(500).json({ error: 'Failed to load tracking data: ' + err.message })
+    }
+  })
+
+}
+
+module.exports.findFixVersionAddedDate = findFixVersionAddedDate
+module.exports.findFixVersionRemovedDate = findFixVersionRemovedDate
+module.exports.classifyFeature = classifyFeature
+module.exports.extractProduct = extractProduct
+module.exports.normalizeVersionName = normalizeVersionName
+module.exports.resolveProductVersionsFromJira = resolveProductVersionsFromJira

--- a/modules/releases/server/hygiene/jira-fetch.js
+++ b/modules/releases/server/hygiene/jira-fetch.js
@@ -21,6 +21,7 @@ const CUSTOM_FIELDS = {
   colorStatus: 'customfield_10712',
   docsRequired: 'customfield_10665',
   targetEnd: 'customfield_10023',
+  productManager: 'customfield_10469',
   reach: 'customfield_10862',
   impact: 'customfield_10836',
   confidence: 'customfield_10838',
@@ -38,6 +39,7 @@ const PASS1_FIELDS = [
   CUSTOM_FIELDS.colorStatus,
   CUSTOM_FIELDS.docsRequired,
   CUSTOM_FIELDS.targetEnd,
+  CUSTOM_FIELDS.productManager,
   CUSTOM_FIELDS.reach,
   CUSTOM_FIELDS.impact,
   CUSTOM_FIELDS.confidence,
@@ -238,6 +240,30 @@ function transformIssue(rawIssue, rfeMap) {
     }
   }
 
+  // Blocked: check for unresolved inward "Blocks" links
+  const CLOSED_LINK_STATUSES = ['Closed', 'Resolved', 'Done']
+  let isBlocked = false
+  const issueLinks = fields.issuelinks
+  if (Array.isArray(issueLinks)) {
+    for (let bli = 0; bli < issueLinks.length; bli++) {
+      const link = issueLinks[bli]
+      if (!link.inwardIssue) continue
+      const type = link.type || {}
+      if (type.name !== 'Blocks' && type.inward !== 'is blocked by') continue
+      const linkedStatus = link.inwardIssue.fields &&
+        link.inwardIssue.fields.status &&
+        link.inwardIssue.fields.status.name
+      if (CLOSED_LINK_STATUSES.indexOf(linkedStatus) === -1) {
+        isBlocked = true
+        break
+      }
+    }
+  }
+
+  // PM Owner from Product Manager custom field
+  const pmOwnerField = fields[CUSTOM_FIELDS.productManager]
+  const pmOwner = pmOwnerField ? (pmOwnerField.displayName || null) : null
+
   return {
     key: rawIssue.key,
     summary: fields.summary || '',
@@ -260,6 +286,8 @@ function transformIssue(rawIssue, rfeMap) {
     targetEnd: fields[CUSTOM_FIELDS.targetEnd] || null,
     riceStatus: computeRiceStatus(fields),
     riceScore: fields[CUSTOM_FIELDS.riceScore] || null,
+    isBlocked,
+    pmOwner,
     linkedRfeKey,
     linkedRfeApproved,
     // Populated in Pass 2

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -10,6 +10,7 @@ const express = require('express');
 const { registerRegistryRoutes } = require('./registry');
 const registerPlanningRoutes = require('./planning/routes');
 const registerExecutionRoutes = require('./execution/routes');
+const registerFeatureTrackingRoutes = require('./execution/feature-tracking-routes');
 const registerDeliveryRoutes = require('./delivery/routes');
 const registerHygieneRoutes = require('./hygiene/routes');
 const { getAuditLog } = require('./planning/audit-log');
@@ -145,6 +146,12 @@ module.exports = function registerRoutes(router, context) {
     requireAdmin,
     requireScope,
     registerDiagnostics: context.registerDiagnostics || null
+  });
+  registerFeatureTrackingRoutes(executionRouter, {
+    storage,
+    requireAuth,
+    requireReleaseManager,
+    requireScope
   });
   router.use('/execution', executionRouter);
 


### PR DESCRIPTION
## Summary

- **New Feature Tracking sub-tab** under Execute that displays features committed to a release as of Feature Freeze, grouped by product (RHOAI, RHELAI, RHAII)
- **Live Jira queries** by `fixVersion` with changelog expansion to classify features as **Late Additions** (added after freeze date) or **Dropped** (fixVersion removed, detected via JQL `WAS` operator for `issuetype = Feature`)
- **Dynamic version resolution** via Jira's project versions API to handle diverse `fixVersion` naming conventions across products (dots, spaces, suffixes like "release")
- **Per-product Feature Freeze dates** from Product Pages cache, with live API fallback
- **Polished UI** with color-coded summary cards (features, freeze date, late, dropped, blocked), pill-shaped version chips sorted by freeze date, product-colored group headers (violet/teal/sky), status-sorted table rows (red > yellow > green), and scope change badges with inline icons
- **Backend enhancements**: `extractFeatureFreezeDate` for Product Pages, `isBlocked` and `pmOwner` derivation in `transformIssue`, server-side caching with TTL
- **Test coverage**: 37 tests covering `findFixVersionAddedDate`, `findFixVersionRemovedDate`, `classifyFeature`, `normalizeVersionName`, `transformIssue` (isBlocked, pmOwner), and feature freeze extraction

## Test plan

- [ ] Select a portfolio version (e.g. 3.5.EA2) and verify features load for RHOAI, RHELAI, RHAII
- [ ] Verify Late Addition badges appear for features added after freeze date
- [ ] Verify Dropped features appear with amber styling (detected via JQL WAS)
- [ ] Verify status color sort order: red first, then yellow, then green
- [ ] Verify version chips are sorted by feature freeze date (earliest first)
- [ ] Verify Refresh button fetches fresh data from Jira
- [ ] Run `npm test` — all 37 feature-tracking tests pass


Made with [Cursor](https://cursor.com)