### PR TITLE
fix(deploy): add build deps for better-sqlite3 and fix smoke tests

### DIFF
--- a/deploy/backend.Dockerfile
+++ b/deploy/backend.Dockerfile
@@ -4,7 +4,7 @@ USER 0
 
 WORKDIR /app
 
-RUN microdnf install -y git ca-certificates && microdnf clean all
+RUN microdnf install -y git ca-certificates python3 make gcc gcc-c++ && microdnf clean all
 
 # Trust internal CA for git and Node.js HTTPS connections
 COPY deploy/certs/internal-root-ca.pem /etc/pki/ca-trust/source/anchors/internal-root-ca.pem

--- a/deploy/frontend.Dockerfile
+++ b/deploy/frontend.Dockerfile
@@ -6,7 +6,7 @@ USER 0
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts && npm rebuild esbuild
 
 COPY index.html vite.config.mjs tailwind.config.mjs postcss.config.mjs ./
 COPY src/ ./src/

--- a/modules/pulse-social/module.json
+++ b/modules/pulse-social/module.json
@@ -20,3 +20,4 @@
     "entry": "./server/index.js"
   }
 }
+

--- a/tests/smoke/app-loads.spec.js
+++ b/tests/smoke/app-loads.spec.js
@@ -24,12 +24,14 @@ test.describe('Frontend Smoke Tests', () => {
       });
     });
 
-    // Listen for console errors
+    // Listen for console errors (ignore expected 404s from missing backend in container tests)
     page.on('console', msg => {
       if (msg.type() === 'error') {
+        const text = msg.text()
+        if (text.includes('Failed to load resource') && text.includes('404')) return
         page.errors.push({
           type: 'console.error',
-          message: msg.text()
+          message: text
         });
       }
     });


### PR DESCRIPTION
## Summary

- Backend Dockerfile: add python3, make, gcc, g++ for better-sqlite3 native compilation
- Frontend Dockerfile: use --ignore-scripts to skip native modules (only needs JS for Vite), rebuild esbuild explicitly
- Smoke tests: filter expected 404s from missing backend in container tests
- Trigger backend image rebuild to include pulse-social module

## Context

The Pulse Social module added `better-sqlite3` as a dependency which requires native compilation. The UBI9 Node.js minimal images don't include Python/gcc, causing both Docker builds to fail after PR #780 was merged.

The smoke tests also fail because the FeedWidget on the home page calls the API (404 with no backend in container test env).

## Test Plan

- [ ] Backend Docker image builds successfully with better-sqlite3
- [ ] Frontend Docker image builds successfully (skips native modules)
- [ ] Smoke tests pass (404s from missing backend are filtered)
- [ ] Backend image is pushed and deployed with pulse-social module