### PR TITLE
fix(releases): strip .z notation from feature tracking version chips

### DIFF
--- a/modules/releases/__tests__/server/execution/feature-tracking.test.js
+++ b/modules/releases/__tests__/server/execution/feature-tracking.test.js
@@ -381,6 +381,13 @@ describe('normalizeVersionName', function () {
     expect(normalizeVersionName('RHAII-3.5 ga')).toBe('rhaii-3.5ga')
   })
 
+  it('strips .z notation from z-stream releases', function () {
+    expect(normalizeVersionName('rhoai-3.5.z')).toBe('rhoai-3.5')
+    expect(normalizeVersionName('rhoai-3.5.z.EA1')).toBe('rhoai-3.5ea1')
+    expect(normalizeVersionName('RHAI-3.6.z.EA2')).toBe('rhai-3.6ea2')
+    expect(normalizeVersionName('rhelai-3.5.z EA2 release')).toBe('rhelai-3.5ea2')
+  })
+
   it('handles null/empty gracefully', function () {
     expect(normalizeVersionName(null)).toBe('')
     expect(normalizeVersionName('')).toBe('')

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -413,7 +413,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
     function addVersion(releaseNumber) {
       const normalized = stripZStream(releaseNumber)
       const product = extractProduct(normalized)
-      const versionPart = stripZStream((normalized || '').replace(/^[a-z]+-/i, ''))
+      const versionPart = (normalized || '').replace(/^[a-z]+-/i, '')
       if (!versionPart || !product) return
       if (EXCLUDE_VERSION_RE.test(versionPart)) return
       if (!versionMap[versionPart]) {

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -58,8 +58,14 @@ function extractProduct(releaseNumber) {
  *   "rhelai-3.5 EA2 release"   → "rhelai-3.5ea2"
  *   "RHELAI-3.4 EA-1"          → "rhelai-3.4ea1"
  */
+function stripZStream(value) {
+  if (!value) return value
+  return String(value).replace(/\.z\b/gi, '')
+}
+
 function normalizeVersionName(name) {
   let s = (name || '').toLowerCase()
+  s = stripZStream(s)
   if (s.endsWith(' release')) s = s.slice(0, -8)
   s = s.trimEnd()
 
@@ -405,8 +411,9 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
     const versionMap = {}
 
     function addVersion(releaseNumber) {
-      const product = extractProduct(releaseNumber)
-      const versionPart = (releaseNumber || '').replace(/^[a-z]+-/i, '')
+      const normalized = stripZStream(releaseNumber)
+      const product = extractProduct(normalized)
+      const versionPart = stripZStream((normalized || '').replace(/^[a-z]+-/i, ''))
       if (!versionPart || !product) return
       if (EXCLUDE_VERSION_RE.test(versionPart)) return
       if (!versionMap[versionPart]) {


### PR DESCRIPTION
## Summary

- Strip `.z` z-stream notation from Product Pages release numbers in the Feature Tracking page, matching the normalization already applied in delivery analysis (PR #774)
- Adds `stripZStream()` helper and applies it in `normalizeVersionName()` and `addVersion()` so "3.5.z.EA2" displays as "3.5.EA2" and correctly matches Jira fixVersions
- Adds test coverage for z-stream stripping in `normalizeVersionName`

## Test plan

- [ ] Verify prod version chips no longer show `.z` (e.g., "3.5.EA2" instead of "3.5.z.EA2")
- [ ] Verify features load correctly for z-stream releases
- [ ] Run `npm test` — all 38 feature-tracking tests pass


Made with [Cursor](https://cursor.com)