### PR TITLE
fix: complete commitment tracking isolation - version dropdown

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -297,6 +297,7 @@ All routes prefixed with `/api`. Authenticated via OAuth proxy in production.
 - `/api/modules/releases/delivery/quality/bugs` — cumulative bug data for selected versions
 - `/api/modules/releases/delivery/quality/components` — components with bug counts
 - `/api/modules/releases/delivery/quality/debug` — debug diagnostics for bug count issues (admin)
+- `/api/modules/releases/delivery/commitment/versions` — get available versions for commitment tracking (independent of delivery analysis)
 - `/api/modules/releases/delivery/commitment/:version/:phase` — commitment tracking data for a release phase
 - `/api/modules/releases/delivery/releases-metadata` — releases metadata (product names, dates)
 - `/api/modules/releases/hygiene/features` — hygiene features for a version

--- a/modules/releases/client/reports/composables/useCommitmentTracking.js
+++ b/modules/releases/client/reports/composables/useCommitmentTracking.js
@@ -43,47 +43,15 @@ export function useCommitmentTracking() {
   async function loadReleases() {
     releasesLoading.value = true
     try {
-      const response = await fetch(`${API_BASE}/analysis`)
+      // Use commitment tracking versions endpoint (independent of delivery analysis)
+      const response = await fetch(`${API_BASE}/commitment/versions`)
       if (!response.ok) {
-        throw new Error('Failed to load releases')
+        throw new Error('Failed to load versions for commitment tracking')
       }
-      const analysisData = await response.json()
-
-      // Extract unique release versions from delivery analysis
-      // Extract version numbers from various formats:
-      // - "3.5" (simple)
-      // - "rhoai-3.5" (product prefix)
-      // - "rhoai-3.5.EA1" (product + phase)
-      // - "RHAII-3.5 EA1" (product + space + phase)
-      const uniqueVersions = new Set()
-      const allReleases = analysisData.releases || []
-
-      for (const release of allReleases) {
-        const fullVersion = release.releaseNumber
-        if (!fullVersion) continue
-
-        // Extract X.Y version number from various formats
-        const match = fullVersion.match(/(\d+\.\d+)/)
-        if (match) {
-          const version = match[1]
-          const [major, minor] = version.split('.').map(Number)
-          // Only include 3.4 and above (auto-discovers future versions)
-          if (major > 3 || (major === 3 && minor >= 4)) {
-            uniqueVersions.add(version)
-          }
-        }
-      }
-
-      // Convert to array and sort
-      releases.value = Array.from(uniqueVersions)
-        .sort((a, b) => {
-          const [aMajor, aMinor] = a.split('.').map(Number)
-          const [bMajor, bMinor] = b.split('.').map(Number)
-          return aMajor !== bMajor ? aMajor - bMajor : aMinor - bMinor
-        })
-        .map(version => ({ version }))
+      const data = await response.json()
+      releases.value = data.versions || []
     } catch (err) {
-      console.error('Failed to load releases:', err)
+      console.error('Failed to load commitment tracking versions:', err)
       releases.value = []
     } finally {
       releasesLoading.value = false

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -1271,7 +1271,7 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: No snapshot found for this version/phase
    */
-  router.get('/commitment/:version/:phase', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/commitment/:version/:phase', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
       const { version, phase } = req.params
 
@@ -1294,28 +1294,55 @@ module.exports = function registerRoutes(router, context) {
         return res.status(404).json({ error: `No snapshot found for ${version} ${phase}. Use the "Create Snapshot" button above.` })
       }
 
-      // Load delivery analysis
-      const analysisCache = readFromStorage('releases/delivery/analysis-cache.json')
-      if (!analysisCache?.data) {
-        return res.status(500).json({ error: 'Delivery analysis data not available' })
-      }
+      // Query Jira directly for current state (independent of delivery analysis cache)
+      const config = getConfig(readFromStorage)
+      const commitmentJql = config.commitmentTrackingJql || 'cf[10855] is not EMPTY'
 
-      // Aggregate ALL releases that match this version (e.g., "3.5" matches "rhoai-3.5", "rhoai-3.5.EA1", "RHAII-3.5", etc.)
+      const projectsFilter = config.jiraAllProjects
+        ? ''
+        : `project in (${config.projectKeys.map(k => `"${k}"`).join(', ')}) AND `
+
+      const jql = `${projectsFilter}issuetype = Feature AND ${commitmentJql} ORDER BY key ASC`
+
+      console.log(`[releases/delivery] Fetching current feature status for commitment tracking comparison`)
+
+      const allFeatures = await fetchAllJqlResults(
+        jiraRequest,
+        jql,
+        'summary,status,components,customfield_10855,customfield_18834',
+        { maxResults: 100 }
+      )
+
+      // Filter to features matching this version
       const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
       const versionPattern = new RegExp(`\\b${escaped}\\b`)
-      const matchingReleases = analysisCache.data.releases.filter(r => versionPattern.test(r.releaseNumber))
 
-      // Collect all issues from matching releases - filter to Features only for commitment tracking
       const deliveryIssues = []
       const seenKeys = new Set()
-      for (const release of matchingReleases) {
-        for (const issue of release.issues || []) {
-          // Deduplicate by key (same issue may appear in multiple releases)
-          // Filter to Features only (commitment tracking is for Features, not Stories/Tasks/Bugs)
-          if (!seenKeys.has(issue.key) && issue.issueType === 'Feature') {
-            deliveryIssues.push(issue)
-            seenKeys.add(issue.key)
-          }
+
+      for (const issue of allFeatures) {
+        const targetVersions = issue.fields?.customfield_10855 || []
+        const hasMatchingVersion = targetVersions.some(v => {
+          const val = v?.name || v?.value || ''
+          return versionPattern.test(val)
+        })
+
+        if (hasMatchingVersion && !seenKeys.has(issue.key)) {
+          const components = (issue.fields?.components || []).map(c => c.name).filter(Boolean)
+          const deliveryOwner = issue.fields?.customfield_18834?.displayName || null
+          const status = issue.fields?.status?.name || 'Unknown'
+          const statusBucket = statusCategoryBucket(issue.fields?.status)
+
+          deliveryIssues.push({
+            key: issue.key,
+            summary: issue.fields?.summary || '',
+            status,
+            statusBucket,
+            components,
+            deliveryOwner,
+            fixVersion: targetVersions[0]?.name || targetVersions[0]?.value || null
+          })
+          seenKeys.add(issue.key)
         }
       }
 

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -1453,7 +1453,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: List of available versions
    */
-  router.get('/commitment/versions', async function(req, res) {
+  router.get('/commitment/versions', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
       const config = getConfig(readFromStorage)
       const commitmentJql = config.commitmentTrackingJql || 'cf[10855] is not EMPTY'

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -1417,6 +1417,81 @@ module.exports = function registerRoutes(router, context) {
 
   /**
    * @openapi
+   * /api/modules/releases/delivery/commitment/versions:
+   *   get:
+   *     summary: Get available versions for commitment tracking
+   *     description: Discovers versions from Jira using commitmentTrackingJql (independent of delivery analysis)
+   *     tags: [Releases - Delivery]
+   *     responses:
+   *       200:
+   *         description: List of available versions
+   */
+  router.get('/commitment/versions', async function(req, res) {
+    try {
+      const config = getConfig(readFromStorage)
+      const commitmentJql = config.commitmentTrackingJql || 'cf[10855] is not EMPTY'
+
+      // Build project filter
+      const projectsFilter = config.jiraAllProjects
+        ? ''
+        : `project in (${config.projectKeys.map(k => `"${k}"`).join(', ')}) AND `
+
+      // Query Jira for all Features with Target Version
+      const jql = `${projectsFilter}issuetype = Feature AND ${commitmentJql} ORDER BY key ASC`
+
+      console.log(`[releases/delivery] Discovering versions with commitment tracking JQL: ${commitmentJql}`)
+
+      const allFeatures = await fetchAllJqlResults(
+        jiraRequest,
+        jql,
+        'key,customfield_10855',
+        { maxResults: 100 }
+      )
+
+      console.log(`[releases/delivery] Fetched ${allFeatures.length} features from Jira`)
+
+      // Extract unique version numbers (X.Y format)
+      const uniqueVersions = new Set()
+
+      for (const issue of allFeatures) {
+        const targetVersions = issue.fields?.customfield_10855 || []
+
+        for (const v of targetVersions) {
+          // Target Version field returns Jira version objects with 'name' property
+          const val = v?.name || v?.value || ''
+          // Extract X.Y version number
+          const match = val.match(/(\d+\.\d+)/)
+          if (match) {
+            const version = match[1]
+            const [major, minor] = version.split('.').map(Number)
+            // Only include 3.4 and above
+            if (major > 3 || (major === 3 && minor >= 4)) {
+              uniqueVersions.add(version)
+            }
+          }
+        }
+      }
+
+      // Convert to sorted array
+      const versions = Array.from(uniqueVersions)
+        .sort((a, b) => {
+          const [aMajor, aMinor] = a.split('.').map(Number)
+          const [bMajor, bMinor] = b.split('.').map(Number)
+          return aMajor !== bMajor ? aMajor - bMajor : aMinor - bMinor
+        })
+        .map(version => ({ version }))
+
+      console.log(`[releases/delivery] Found ${versions.length} versions for commitment tracking: ${versions.map(v => v.version).join(', ')}`)
+
+      res.json({ versions })
+    } catch (error) {
+      console.error('[releases/delivery] commitment versions discovery error:', error)
+      res.status(500).json({ error: error.message })
+    }
+  })
+
+  /**
+   * @openapi
    * /api/modules/releases/delivery/commitment/snapshot/{version}/{phase}:
    *   post:
    *     summary: Create commitment snapshot by querying Jira directly
@@ -1500,7 +1575,8 @@ module.exports = function registerRoutes(router, context) {
       for (const issue of allFeatures) {
         const targetVersions = issue.fields?.customfield_10855 || []
         const hasMatchingVersion = targetVersions.some(v => {
-          const val = v?.value || ''
+          // Target Version field returns Jira version objects with 'name' property
+          const val = v?.name || v?.value || ''
           return versionPattern.test(val)
         })
 


### PR DESCRIPTION
## Problem

PR #778 isolated snapshot creation from delivery analysis, but **not the version dropdown**. Production still doesn't show 3.4/3.6 because the dropdown reads from  (delivery analysis cache).

## Solution

Complete the isolation by making the version dropdown query Jira directly.

### Changes

1. **New endpoint**: `GET /api/modules/releases/delivery/commitment/versions`
   - Queries Jira directly using `commitmentTrackingJql`
   - Returns versions in X.Y format (3.4, 3.5, 3.6+)
   - Completely independent of delivery analysis

2. **Frontend updated**: `useCommitmentTracking.js`
   - Calls `/commitment/versions` instead of `/delivery/analysis`
   - Simplified logic - no more parsing delivery analysis cache

3. **Bug fix**: Target Version field parsing
   - Was using `v.value` (wrong)
   - Now uses `v.name` (correct for Jira version objects)
   - Applied to both versions endpoint and snapshot endpoint

## Testing

Verified locally:
```bash
$ curl http://localhost:3001/api/modules/releases/delivery/commitment/versions | jq -r '.versions[] | .version'
3.4
3.5
3.6
```

## Impact

After merge, commitment tracking will show all versions (3.4, 3.5, 3.6) in the dropdown AND in snapshot creation. Complete isolation from delivery analysis achieved.

Fixes production issue where 3.4/3.6 weren't appearing in the version dropdown.