### PR TITLE
fix(releases): strip .z notation from Feature Status version chips

### DIFF
--- a/modules/releases/server/execution/routes.js
+++ b/modules/releases/server/execution/routes.js
@@ -17,6 +17,11 @@ const { logAudit } = require('../planning/audit-log');
 
 const DATA_PREFIX = 'releases/execution';
 
+function stripZStream(value) {
+  if (!value) return value
+  return String(value).replace(/\.z\b/gi, '')
+}
+
 /**
  * @openapi
  * /api/modules/releases/execution/features:
@@ -149,8 +154,9 @@ module.exports = function registerExecutionRoutes(router, context) {
 
     const versionFilter = req.query.version;
     if (versionFilter) {
+      const normalizedFilter = stripZStream(versionFilter);
       features = features.filter(f =>
-        f.fixVersions && f.fixVersions.includes(versionFilter)
+        f.fixVersions && f.fixVersions.some(v => stripZStream(v) === normalizedFilter)
       );
     }
 
@@ -251,7 +257,7 @@ module.exports = function registerExecutionRoutes(router, context) {
     const versions = new Set();
     for (const f of index.features) {
       for (const v of (f.fixVersions || [])) {
-        versions.add(v);
+        versions.add(stripZStream(v));
       }
     }
 


### PR DESCRIPTION
## Summary

- Strip `.z` z-stream notation from the Feature Status tab's version chips (execution `/versions` endpoint), matching the fix already applied in Feature Tracking (#788) and Delivery (#774)
- Also normalizes the `/features` version filter so filtering by "rhoai-3.5.EA2" correctly matches features stored with "rhoai-3.5.z.EA2"

## Test plan

- [ ] Verify Feature Status version chips no longer show `.z` (e.g., "rhoai-3.5.EA2" instead of "rhoai-3.5.z.EA2")
- [ ] Verify filtering by a version still returns the correct features
- [ ] Run `npm run lint` — clean


Made with [Cursor](https://cursor.com)