### PR TITLE
fix(releases): correct feature freeze dates for EA releases

### DIFF
--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -433,7 +433,10 @@ async function fetchProductsByShortname(shortnames, config) {
         const expanded = expandReleaseMilestones(r, productName)
         if (expanded) {
           for (const entry of expanded) {
-            if (entry.dueDate) releases.push(entry)
+            if (entry.dueDate) {
+              entry._expanded = true
+              releases.push(entry)
+            }
           }
           continue
         }
@@ -463,9 +466,34 @@ async function fetchProductsByShortname(shortnames, config) {
     }
   }
 
-  // Include ALL releases (past and future) for commitment tracking
-  // Commitment tracking needs historical data to compare against snapshots
-  return releases
+  // De-duplicate: when a product has both a parent release (rhoai-3.5) that
+  // gets expanded into EA entries AND individual EA releases (rhoai-3.5.EA1),
+  // the expanded entries inherit the parent's generic Feature Freeze date
+  // which is wrong for EA milestones. Prefer individual releases over expanded.
+  const deduped = new Map()
+  for (const entry of releases) {
+    const key = (entry.releaseNumber || '').toLowerCase().replace(/[\s._-]+/g, '')
+    const existing = deduped.get(key)
+    if (!existing) {
+      deduped.set(key, entry)
+      continue
+    }
+    // Individual (non-expanded) entries always win over expanded ones
+    if (existing._expanded && !entry._expanded) {
+      deduped.set(key, entry)
+    } else if (!existing._expanded && entry._expanded) {
+      // Keep existing individual entry
+    } else if (entry.featureFreezeDate && (!existing.featureFreezeDate || entry.featureFreezeDate < existing.featureFreezeDate)) {
+      deduped.set(key, entry)
+    }
+  }
+
+  // Strip the internal flag before returning
+  const result = [...deduped.values()]
+  for (const entry of result) {
+    delete entry._expanded
+  }
+  return result
 }
 
 /**

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -244,6 +244,7 @@ async function discoverReleasesFromJira(storage, config) {
       releaseNumber: version,
       dueDate: meta.dueDate || null,
       codeFreezeDate: meta.codeFreezeDate || null,
+      featureFreezeDate: meta.featureFreezeDate || null,
       featureCount: featureCounts.get(version) || 0
     })
   }
@@ -302,7 +303,8 @@ async function fetchOpenReleases(storage, config) {
         productName: r.productName || r.product_name || r.product || r.product_shortname || '',
         releaseNumber: r.releaseNumber || r.release_number || r.name || '',
         dueDate: toIsoDate(r.dueDate || r.due_date || r.gaDate || r.ga_date || r.date_finish || r.date_start),
-        codeFreezeDate: toIsoDate(r.codeFreezeDate || r.code_freeze_date || r.codeFreeze || r.code_freeze) || null
+        codeFreezeDate: toIsoDate(r.codeFreezeDate || r.code_freeze_date || r.codeFreeze || r.code_freeze) || null,
+        featureFreezeDate: toIsoDate(r.featureFreezeDate || r.feature_freeze_date || r.featureFreeze || r.feature_freeze) || null
       }))
       .filter(r => r.productName && r.releaseNumber && r.dueDate)
     storage.writeToStorage('releases/delivery/product-pages-releases-cache.json', {
@@ -1586,7 +1588,8 @@ module.exports = function registerRoutes(router, context) {
         productName: r.productName,
         releaseNumber: r.releaseNumber,
         dueDate: toIsoDate(r.dueDate),
-        codeFreezeDate: toIsoDate(r.codeFreezeDate) || null
+        codeFreezeDate: toIsoDate(r.codeFreezeDate) || null,
+        featureFreezeDate: toIsoDate(r.featureFreezeDate) || null
       })).filter(r => r.productName && r.releaseNumber && r.dueDate)
 
       if (normalized.length === 0) {

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -357,7 +357,12 @@ function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
     const rel = ppReleases[i]
     const relVersion = normalizeVersionName(rel.releaseNumber).replace(/^[a-z]+-/, '')
     if (relVersion === normalizedPortfolio && rel.featureFreezeDate) {
-      byProduct[normalizeVersionName(rel.releaseNumber)] = rel.featureFreezeDate
+      const key = normalizeVersionName(rel.releaseNumber)
+      // Prefer the earliest date per product to avoid parent GA dates
+      // overriding EA-specific dates from expanded entries
+      if (!byProduct[key] || rel.featureFreezeDate < byProduct[key]) {
+        byProduct[key] = rel.featureFreezeDate
+      }
       if (!earliest || rel.featureFreezeDate < earliest) {
         earliest = rel.featureFreezeDate
       }
@@ -500,12 +505,15 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
             productPagesProductShortnames: DEFAULT_PRODUCTS
           }
           const livePPReleases = await fetchProductsByShortname(ppConfig.productPagesProductShortnames, ppConfig)
-          const normalizedPV = version.replace(/\s+/g, '.').toLowerCase()
+          const normalizedPV = normalizeVersionName(version)
           for (let pri = 0; pri < livePPReleases.length; pri++) {
             const pr = livePPReleases[pri]
-            const prVersion = (pr.releaseNumber || '').replace(/^[a-z]+-/i, '').toLowerCase()
+            const prVersion = normalizeVersionName(pr.releaseNumber || '').replace(/^[a-z]+-/, '')
             if (prVersion === normalizedPV && pr.featureFreezeDate) {
-              freezeDates.byProduct[(pr.releaseNumber || '').toLowerCase()] = pr.featureFreezeDate
+              const key = normalizeVersionName(pr.releaseNumber || '')
+              if (!freezeDates.byProduct[key] || pr.featureFreezeDate < freezeDates.byProduct[key]) {
+                freezeDates.byProduct[key] = pr.featureFreezeDate
+              }
               if (!freezeDates.earliest || pr.featureFreezeDate < freezeDates.earliest) {
                 freezeDates.earliest = pr.featureFreezeDate
               }


### PR DESCRIPTION
## Summary

- **De-duplicate expanded vs individual releases** in `fetchProductsByShortname`: when a product (e.g. RHOAI) has both a parent release (`rhoai-3.5`) that gets expanded into EA entries AND individual EA releases (`rhoai-3.5.EA1`), the expanded entries inherit the parent's generic Feature Freeze date (Jul 17 = GA freeze), producing wrong dates. Individual releases now always take precedence.
- **Preserve `featureFreezeDate` in all delivery cache write paths**: the legacy URL path, manual upload path, and Jira discovery path were all missing `featureFreezeDate`, so any cache written by those paths lost feature freeze dates entirely.
- **Consistent normalization in feature tracking fallback**: use `normalizeVersionName` in the live PP API fallback (handles `.z` versions, separators, etc.) and prefer the earliest date per product in the cache lookup.

## Test plan

- [ ] Verify Feature Tracking page shows correct freeze dates for 3.5.EA1 (Apr 17), 3.5.EA2 (May 18), 3.5 (Jun 19) after a Refresh
- [ ] Verify no regression on version chips or feature data
- [ ] `npm test` — 3509 tests pass
- [ ] `npm run lint` — clean


Made with [Cursor](https://cursor.com)