### PR TITLE
fix(ci): allow fork PR authors in read-only Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -271,6 +271,7 @@ jobs:
         with:
           use_vertex: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           track_progress: true
           display_report: "true"
           allowed_bots: "claude"


### PR DESCRIPTION
## Summary

- The `claude-code-action` checks the PR actor's repository permission level and rejects users with only `read` access
- Fork PR contributors (like external collaborators) typically have read-only access, causing the "Claude Code Review (Read-Only)" step to fail with `Actor does not have write permissions to the repository`
- Adds `allowed_non_write_users: "*"` to the fork review step — safe because the step is already restricted to read-only tools (`Read`, `Glob`, `Grep`, `gh pr diff/view/comment`) with no edit, write, or push capability

## Context

This fixes the Claude Review failure on [PR #786](https://github.com/red-hat-data-services/rhai-org-pulse/pull/786) ([failed run](https://github.com/red-hat-data-services/rhai-org-pulse/actions/runs/26753720539)).

## Test plan

- [ ] Merge this PR, then re-run the Claude Review workflow on PR #786 — it should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)