### PR TITLE
refactor: remove direct allocation refresh call from shell

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -837,17 +837,7 @@ export default {
       this.showRefreshModal = false
       this.isRefreshing = true
       try {
-        const refreshes = [refreshMetrics({ scope: 'all', force, sources })]
-        if (this.enabledBuiltInSlugs?.includes('team-tracker')) {
-          refreshes.push(
-            apiRequest('/modules/team-tracker/allocation/refresh', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ hardRefresh: force })
-            }).catch(err => console.error('Allocation refresh failed:', err))
-          )
-        }
-        await Promise.all(refreshes)
+        await refreshMetrics({ scope: 'all', force, sources })
         this.showToast('Refresh started — data will update shortly')
       } catch (err) {
         console.error('Failed to start refresh:', err)


### PR DESCRIPTION
## Summary

- Removes the direct `/modules/team-tracker/allocation/refresh` API call from `App.vue`'s `handleRefreshAllConfirm` method
- The allocation refresh handler is already registered in the refresh registry (`context.registerRefresh('allocation', { order: 40 })`) in `modules/team-tracker/server/allocation/routes.js`, so the shell doesn't need module-specific refresh logic
- The module's allocation refresh route remains available for manual triggers from the Allocation tab UI

## Context

Part of platform modularization (step 1.3 built the refresh registry; this removes a leftover direct module call from the shell).

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (no new failures)
- [ ] Verify CronJob (`POST /api/admin/refresh-all`) still triggers allocation refresh via the registry
- [ ] Verify manual allocation refresh from the Allocation tab still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)