### PR TITLE
fix: expose Create Snapshot button in Commitment Tracking UI

### DIFF
--- a/modules/releases/client/reports/CommitmentTrackingReport.vue
+++ b/modules/releases/client/reports/CommitmentTrackingReport.vue
@@ -15,7 +15,6 @@
       </div>
     </div>
 
-
     <!-- Filter bar with snapshot creation -->
     <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 mb-6">
       <div class="flex flex-wrap items-center gap-4 mb-3">

--- a/modules/releases/client/reports/CommitmentTrackingReport.vue
+++ b/modules/releases/client/reports/CommitmentTrackingReport.vue
@@ -15,30 +15,6 @@
       </div>
     </div>
 
-    <!-- Data refresh section -->
-    <div class="bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700 p-3 mb-4">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <button
-            @click="refreshCurrentStatus"
-            :disabled="refreshing"
-            class="px-3 py-1.5 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {{ refreshing ? 'Refreshing...' : 'Refresh Current Status' }}
-          </button>
-          <span v-if="lastRefresh" class="text-xs text-gray-500 dark:text-gray-400">
-            Updated {{ lastRefresh }}
-          </span>
-          <span v-if="refreshError" class="text-xs text-red-600 dark:text-red-400">
-            {{ refreshError }}
-          </span>
-        </div>
-        <div v-if="cacheAge !== null" class="text-xs" :class="cacheIsStale ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'">
-          <span v-if="cacheIsStale">⚠ Data is {{ cacheAge }}h old</span>
-          <span v-else>Cache: {{ cacheAge }}h old</span>
-        </div>
-      </div>
-    </div>
 
     <!-- Filter bar with snapshot creation -->
     <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 mb-6">
@@ -72,13 +48,16 @@
         </div>
       </div>
 
-      <!-- Snapshot creation (only show when version+phase selected and no data loaded yet) -->
-      <div v-if="selectedVersion && selectedPhase && !data && !loading && error?.includes('No snapshot')"
+      <!-- Snapshot creation (always show when version+phase selected) -->
+      <div v-if="selectedVersion && selectedPhase"
            class="border-t border-gray-200 dark:border-gray-700 pt-3">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm text-gray-600 dark:text-gray-400">
+            <p v-if="!data && error?.includes('No snapshot')" class="text-sm text-gray-600 dark:text-gray-400">
               No baseline snapshot exists for <span class="font-medium">{{ selectedVersion }} {{ selectedPhase }}</span>
+            </p>
+            <p v-else class="text-sm text-gray-600 dark:text-gray-400">
+              Create a new baseline snapshot for <span class="font-medium">{{ selectedVersion }} {{ selectedPhase }}</span>
             </p>
             <p v-if="snapshotError" class="text-xs text-red-600 dark:text-red-400 mt-1">
               {{ snapshotError }}
@@ -321,13 +300,8 @@ const { data, loading, error, loadCommitment, releases, loadReleases } = useComm
 
 const selectedVersion = ref('')
 const selectedPhase = ref('')
-const refreshing = ref(false)
-const lastRefresh = ref(null)
 const creatingSnapshot = ref(false)
-const refreshError = ref(null)
 const snapshotError = ref(null)
-const cacheAge = ref(null)
-const cacheIsStale = ref(false)
 const expandedSections = ref({
   delivered: false,
   added: false,
@@ -385,43 +359,6 @@ function goBack() {
   nav.navigateTo('reports')
 }
 
-async function refreshCurrentStatus() {
-  refreshing.value = true
-  refreshError.value = null
-  const TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
-
-  try {
-    // Create timeout promise
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('Refresh timed out after 10 minutes. Try again or check server logs.')), TIMEOUT_MS)
-    })
-
-    // Race between fetch and timeout
-    const fetchPromise = fetch('/api/modules/releases/delivery/refresh', { method: 'POST' })
-    const response = await Promise.race([fetchPromise, timeoutPromise])
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
-      throw new Error(errorData.error || `Server error: ${response.status}`)
-    }
-
-    lastRefresh.value = new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
-
-    // Reload releases list to pick up any new versions
-    await loadReleases()
-
-    // Reload current commitment data if version/phase selected
-    if (selectedVersion.value && selectedPhase.value) {
-      await loadCommitment(selectedVersion.value, selectedPhase.value)
-    }
-  } catch (err) {
-    console.error('[CommitmentTracking] Refresh failed:', err)
-    refreshError.value = err.message
-  } finally {
-    refreshing.value = false
-  }
-}
-
 async function createSnapshot() {
   if (!selectedVersion.value || !selectedPhase.value) return
   creatingSnapshot.value = true
@@ -444,24 +381,7 @@ async function createSnapshot() {
   }
 }
 
-async function checkCacheAge() {
-  try {
-    const response = await fetch('/api/modules/releases/delivery/refresh/status')
-    if (!response.ok) return
-    const status = await response.json()
-    if (status.lastResult?.completedAt) {
-      const ageMs = Date.now() - new Date(status.lastResult.completedAt).getTime()
-      const ageHours = Math.floor(ageMs / (1000 * 60 * 60))
-      cacheAge.value = ageHours
-      cacheIsStale.value = ageHours > 24
-    }
-  } catch (err) {
-    console.error('[CommitmentTracking] Failed to check cache age:', err)
-  }
-}
-
 onMounted(() => {
   loadReleases()
-  checkCacheAge()
 })
 </script>


### PR DESCRIPTION
## Problem

In production, the Commitment Tracking report shows old/incorrect snapshot data but users can't create fresh snapshots because the "Create Snapshot" button only appears when NO snapshot exists.

Additionally, the "Refresh Current Status" button was hitting the wrong endpoint (`/api/modules/releases/delivery/refresh`) which refreshes delivery analysis cache, not commitment tracking data.

## Solution

1. **Always show "Create Snapshot" button** when version+phase selected (not just when snapshot missing)
2. **Remove "Refresh Current Status" button** that was hitting wrong endpoint
3. **Remove unused state and functions** related to delivery refresh entanglement

## Impact

Users can now create fresh snapshots in production to replace old baseline data:
- 3.4 EA1: Update from 50 features (wrong) to 154 features (correct)
- 3.5 EA1: Update from 10 features (wrong) to 214 features (correct)
- 3.6 EA1: Update from 0 features (wrong) to 9 features (correct)

Commitment tracking is now fully decoupled from delivery analysis.

## Testing

1. Navigate to Releases → Reports → Commitment Tracking
2. Select any version + phase
3. Verify "Create Snapshot" button appears in filter section
4. Click to create fresh baseline snapshot
5. Data refreshes automatically with new snapshot