### PR TITLE
claude: add integration test enforcement for module changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -203,8 +203,6 @@ To add integration tests for a new module:
 2. Add filter definition in `integration-tests.yml` `detect-changes` job filters section
 3. That's it! The matrix automatically picks up the new module when it changes
 
-**Integration test enforcement:** PRs that modify files in `modules/` (views, components, server routes, server logic) **require** corresponding integration test updates. This is enforced during code review. See `.github/instructions/review.instructions.md` for the full policy and exceptions.
-
 ### Building images on ARM Macs
 Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. See `deploy/OPENSHIFT.md` step 3 for details. This works because the backend has no native Node addons (all pure JS).
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -203,6 +203,8 @@ To add integration tests for a new module:
 2. Add filter definition in `integration-tests.yml` `detect-changes` job filters section
 3. That's it! The matrix automatically picks up the new module when it changes
 
+**Integration test enforcement:** PRs that modify files in `modules/` (views, components, server routes, server logic) **require** corresponding integration test updates. This is enforced during code review. See `.github/instructions/review.instructions.md` for the full policy and exceptions.
+
 ### Building images on ARM Macs
 Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. See `deploy/OPENSHIFT.md` step 3 for details. This works because the backend has no native Node addons (all pure JS).
 

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -39,6 +39,41 @@ You have full Edit and Write access to all files in the repo.
    enforces a minimum operation count; adding a route without its annotation
    will cause the build to fail.
 
+## Integration Test Coverage Validation
+
+As part of the pull request review, you must actively assess whether the developer has introduced module changes that mandate integration test verification.
+
+### 1. Integration Testing Triggers
+
+Evaluate the file diff paths. A pull request **requires an integration test** if changes are made to files within the `modules/` directory:
+
+- **Module Views:** Structural changes within `modules/*/views/` or `modules/*/components/` that combine multiple data sources, implement multi-step workflows, or render complex interactive UI (charts, tables with filtering/sorting, forms with validation).
+
+- **Module Server Routes:** Any new or modified routes in `modules/*/server/routes.js` that implement non-trivial business logic, data aggregation, or stateful operations.
+
+- **Module Server Logic:** Changes to module-specific server files that fetch/transform data from external services (Jira Cloud API, GitHub GraphQL, GitLab GraphQL), implement domain calculations, or orchestrate multi-step operations.
+
+### 2. Validation & Enforcement Workflow
+
+1. **Locate matching tests:** Verify if the PR diff updates or supplements appropriate test modules under `tests/integration/<module>.spec.js` that cover integrated workflow journeys for the modified module.
+
+2. **Flag Non-Compliance:** If any files within `modules/` were changed but **no matching integration test** is detected in the diff:
+   - Generate a critical alert banner in the review output: **`⚠️ Missing Integration Test Warning`**.
+   - Explicitly highlight which module files were modified without verification (e.g., *"You modified data fetching logic inside `modules/releases/server/routes.js` without corresponding integration assertions"* or *"You added a new view in `modules/ai-impact/views/` without integration test coverage"*).
+   - Instruct the developer to add integration test in `tests/integration/<module>.spec.js` that verifies:
+     - Module is visible and clickable in sidebar
+     - Module views load correctly without errors
+     - Module content renders (buttons, inputs, tables, cards)
+     - API endpoints return expected data structure
+     - Interactive workflows complete successfully
+   - Provide a minimal Playwright test snippet when possible (e.g., basic navigation test, API response validation).
+
+3. **Exceptions:** Do not require integration tests for module changes that are:
+   - Pure UI/styling changes (CSS, Tailwind classes) with no logic modifications
+   - Documentation-only updates (comments, JSDoc, README)
+   - Simple configuration changes (module.json metadata updates with no behavioral impact)
+   - Trivial refactorings that don't change behavior (renaming variables, extracting constants)
+
 ## Verdict rules
 
 When used in CI, the reviewer populates a structured JSON output with two fields:

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -49,7 +49,7 @@ Evaluate the file diff paths. A pull request **requires an integration test** if
 
 - **Module Views:** Structural changes within `modules/*/views/` or `modules/*/components/` that combine multiple data sources, implement multi-step workflows, or render complex interactive UI (charts, tables with filtering/sorting, forms with validation).
 
-- **Module Server Routes:** Any new or modified routes in `modules/*/server/routes.js` that implement non-trivial business logic, data aggregation, or stateful operations.
+- **Module Server Routes:** Any new or modified route files within `modules/*/server/` (e.g., `modules/releases/server/planning/routes.js`, `modules/ai-impact/server/assessments/routes.js`) that implement non-trivial business logic, data aggregation, or stateful operations.
 
 - **Module Server Logic:** Changes to module-specific server files that fetch/transform data from external services (Jira Cloud API, GitHub GraphQL, GitLab GraphQL), implement domain calculations, or orchestrate multi-step operations.
 
@@ -59,7 +59,7 @@ Evaluate the file diff paths. A pull request **requires an integration test** if
 
 2. **Flag Non-Compliance:** If any files within `modules/` were changed but **no matching integration test** is detected in the diff:
    - Generate a critical alert banner in the review output: **`⚠️ Missing Integration Test Warning`**.
-   - Explicitly highlight which module files were modified without verification (e.g., *"You modified data fetching logic inside `modules/releases/server/routes.js` without corresponding integration assertions"* or *"You added a new view in `modules/ai-impact/views/` without integration test coverage"*).
+   - Explicitly highlight which module files were modified without verification (e.g., *"You modified data fetching logic inside `modules/releases/server/planning/routes.js` without corresponding integration assertions"* or *"You added a new view in `modules/ai-impact/views/` without integration test coverage"*).
    - Instruct the developer to add integration test in `tests/integration/<module>.spec.js` that verifies:
      - Module is visible and clickable in sidebar
      - Module views load correctly without errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,8 @@ Non-secret config (e.g. `JIRA_HOST`, `DEMO_MODE`) is exempt. See
 - **Validation**: `npm run validate:modules` for module manifests
 - Run `npm test` before committing
 
+**Integration test enforcement:** PRs that modify files in `modules/` (views, components, server routes, server logic) **require** corresponding integration test updates. This is enforced during code review. See `.github/instructions/review.instructions.md` for the full policy and exceptions.
+
 ## Code Review
 
 Review criteria are defined in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,9 @@ Smoke tests run Playwright in a container, so no local browser installation is n
 
 #### Integration tests
 
+> [!IMPORTANT]
+> PRs that modify files in `modules/` (views, components, server routes, server logic) **require** corresponding integration test updates. This is enforced during code review. See [`.github/instructions/review.instructions.md`](.github/instructions/review.instructions.md) for the full policy and exceptions.
+
 Integration tests are run using **Playwright**. They validate that:
 1. Modules are visible _and_ clickable from the sidebar
 1. Modules load in Org Pulse when clicked


### PR DESCRIPTION
## Purpose

This PR adds validation section to `review.instructions.md` that requires integration tests when PRs modify files in modules/ directory. Covers module views, server routes, and backend logic. Reviewers must flag missing tests and provide guidance on Playwright test structure.

Ultimately, we will want to enforce integration tests on files beyond those in `modules` that could impact the UI, but that is out of scope for this PR.

## Note

This PR should be merged first: #701