### PR TITLE
feat: Add Node.js version sync requirement to agent conventions + update out of sync docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Documentation changes must land in the same PR as the code they describe:
 - **New shared exports** → update `shared/API.md`
 - **Module system changes** → update `docs/MODULES.md`
 - **API route changes** → update the API Routes section in `.claude/CLAUDE.md`
+- **Node.js version changes** → update `README.md` and `CONTRIBUTING.md` to match `package.json` engines field
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Node.js 18+** and npm
+- **Node.js 20+** and npm
 - **Red Hat VPN** connection (for LDAP roster sync)
 - A **Jira Cloud API token** for live data — [create one here](https://id.atlassian.com/manage-profile/security/api-tokens)
 - Or just use **Demo Mode** (no credentials needed)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For real Jira and GitHub data:
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - Red Hat VPN (required for LDAP roster sync)
 - @redhat.com Google account
 


### PR DESCRIPTION
## Purpose

This PR updates the README to reflect the current, minimum Node.js  version, and makes sure the Node.js version in the docs is always in sync with package.json via `AGENTS.md`.

## Summary of Changes

- Update `README.md` to mention Node.js 20
- Update `AGENTS.md` to ensure in the future that the Node.js version in `package.json` always matches the documentation