### PR TITLE
feat: sync testing documentation and add sync requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ Documentation changes must land in the same PR as the code they describe:
 - **Module system changes** → update `docs/MODULES.md`
 - **API route changes** → update the API Routes section in `.claude/CLAUDE.md`
 - **Node.js version changes** → update `README.md` and `CONTRIBUTING.md` to match `package.json` engines field
+- **npm scripts or Makefile commands** (additions, removals, or changes) → update Commands section in `README.md`
+- **Testing stack changes** (test frameworks added/removed from `package.json` devDependencies, test types added/removed from `tests/`, or test-related scripts/Makefile targets added/removed/changed) → update `README.md` (Tech Stack), `docs/MODULES.md` (Testing), and `CONTRIBUTING.md` (Testing)
 
 ## Code Style
 
@@ -109,7 +111,9 @@ npm run dev:server            # Express only (needs .env)
 npm test                      # Run all tests
 npm run test:watch            # Watch mode
 npm run lint                  # Lint check
+npm run build                 # Production build
 npm run validate:modules      # Validate module manifests
+npm run validate:openapi      # Validate OpenAPI annotations
 
 # Container-based tests (requires Docker/Podman)
 make smoke-test               # Run smoke tests against containers

--- a/README.md
+++ b/README.md
@@ -96,13 +96,19 @@ To use the Google Sheets roster sync:
 ## Commands
 
 ```bash
-npm run dev:full     # Start frontend + backend
-npm run dev          # Frontend only (Vite)
-npm run dev:server   # Backend only (Express, needs .env)
-npm test             # Run all tests
-npm run test:watch   # Tests in watch mode
-npm run lint         # ESLint
-npm run build        # Production build
+npm run dev:full              # Start frontend + backend
+npm run dev                   # Frontend only (Vite)
+npm run dev:server            # Backend only (Express, needs .env)
+npm test                      # Run all tests
+npm run test:watch            # Tests in watch mode
+npm run lint                  # ESLint
+npm run build                 # Production build
+npm run validate:modules      # Validate module manifests
+npm run validate:openapi      # Validate OpenAPI annotations
+
+# Container-based tests (requires Docker/Podman)
+make smoke-test               # Run smoke tests against containers
+make test-module MODULE=<name>  # Run integration tests for a module
 ```
 
 ## Tech Stack
@@ -112,7 +118,7 @@ npm run build        # Production build
 - **Auth**: OpenShift OAuth proxy (production), no auth (local dev)
 - **Storage**: Local filesystem (`./data/`), PVC in OpenShift
 - **Hosting**: OpenShift with ArgoCD
-- **Testing**: Vitest
+- **Testing**: Vitest (unit), Playwright (smoke & integration)
 
 ## Deployment
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -260,10 +260,12 @@ The component will be rendered as a tab in the shell's Settings page.
 
 ## Testing
 
+- **Unit tests**: Use Vitest with @vue/test-utils for frontend, Vitest for backend
 - Frontend tests: `modules/your-module/__tests__/client/`
 - Backend tests: `modules/your-module/__tests__/server/` or `modules/your-module/server/__tests__/`
 - Run all tests: `npm test`
 - Module manifest validation: `npm run validate:modules`
+- **Integration tests**: Playwright tests in `tests/integration/` validate module UI (see CONTRIBUTING.md)
 
 ## CODEOWNERS
 


### PR DESCRIPTION
## Purpose

This PR is similar in nature to #806, except this PR is about keeping the testing changes in sync with the existing documentation. This change ensures testing documentation stays consistent across `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `docs/MODULES.md` when the testing stack evolves. 😄 

## Summary of Changes

`README.md` improvements:
  - Update "Tech Stack" to reflect full testing stack (Vitest + Playwright)
  - Expand "Commands" section with validation and container-based tests
 
`docs/MODULES.md` improvements:
- Update "Testing "section to specify frameworks

`AGENTS.md` improvements:
- Add hard constraint requiring testing stack changes to update docs
- Add hard constraint requiring npm scripts/Makefile commands to update `README.md`
