### PR TITLE
feat(product-builds): add wheel collections view with dependency graph

### DIFF
--- a/modules/product-builds/client/components/DependencyGraph.vue
+++ b/modules/product-builds/client/components/DependencyGraph.vue
@@ -1,0 +1,201 @@
+<script setup>
+import { watch, nextTick, markRaw } from 'vue'
+import { VueFlow, useVueFlow } from '@vue-flow/core'
+import { MiniMap } from '@vue-flow/minimap'
+import { Controls } from '@vue-flow/controls'
+import { Background } from '@vue-flow/background'
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import '@vue-flow/minimap/dist/style.css'
+import '@vue-flow/controls/dist/style.css'
+import GraphPackageNode from './graph/GraphPackageNode.vue'
+import GraphPackageSelector from './graph/GraphPackageSelector.vue'
+import { useDependencyGraph } from '../composables/useDependencyGraph.js'
+
+const props = defineProps({
+  dependencyGraphJson: { type: String, required: true },
+})
+
+const {
+  packageList,
+  selectedPackage,
+  showBuildDeps,
+  nodes,
+  edges,
+  incomingDeps,
+  outgoingDeps,
+  stats,
+  error,
+} = useDependencyGraph(props.dependencyGraphJson)
+
+const nodeTypes = { package: markRaw(GraphPackageNode) }
+
+const { fitView } = useVueFlow({ id: 'dependency-graph' })
+
+watch(nodes, () => {
+  if (nodes.value.length > 0) {
+    nextTick(() => {
+      setTimeout(() => fitView({ padding: 0.2, duration: 0 }), 100)
+    })
+  }
+})
+
+function onNodeClick({ node }) {
+  const key = node.id === 'root' ? '' : node.id
+  selectedPackage.value = key
+}
+
+function selectFromList(key) {
+  selectedPackage.value = key
+}
+
+function miniMapColor(node) {
+  if (node.data.isSelected) return '#f0ab00'
+  if (node.data.isRoot) return '#3e8635'
+  if (node.data.preBuilt) return '#009596'
+  return '#0066cc'
+}
+</script>
+
+<template>
+  <div v-if="error" class="p-4 bg-red-50 dark:bg-red-900/20 rounded text-sm text-red-700 dark:text-red-300">
+    {{ error }}
+  </div>
+
+  <template v-else>
+    <!-- Legend -->
+    <div class="flex flex-wrap gap-5 py-2 px-3 bg-gray-50 dark:bg-gray-800 rounded text-sm mb-3">
+      <span class="font-semibold text-gray-700 dark:text-gray-300 mr-1">Legend:</span>
+      <span class="flex items-center gap-2">
+        <svg width="40" height="2"><line x1="0" y1="1" x2="40" y2="1" stroke="#0066cc" stroke-width="2" /></svg>
+        <span class="text-gray-600 dark:text-gray-400">Install-time</span>
+      </span>
+      <span class="flex items-center gap-2">
+        <svg width="40" height="2"><line x1="0" y1="1" x2="40" y2="1" stroke="#6a6e73" stroke-width="2" stroke-dasharray="5,5" /></svg>
+        <span class="text-gray-600 dark:text-gray-400">Build-time</span>
+      </span>
+      <span class="flex items-center gap-2">
+        <span class="inline-block w-[30px] h-[18px] border-2 border-dashed border-gray-500 rounded bg-white dark:bg-gray-700" />
+        <span class="text-gray-600 dark:text-gray-400">Build-only packages</span>
+      </span>
+    </div>
+
+    <!-- Package selector -->
+    <GraphPackageSelector
+      :packages="packageList"
+      :model-value="selectedPackage"
+      @update:model-value="selectedPackage = $event"
+    />
+
+    <!-- Build deps toggle -->
+    <label
+      v-if="selectedPackage"
+      class="flex items-center gap-2 mb-3 text-sm text-gray-700 dark:text-gray-300 cursor-pointer"
+    >
+      <input v-model="showBuildDeps" type="checkbox" class="rounded" />
+      Show build-time dependencies
+    </label>
+
+    <!-- Empty state -->
+    <div
+      v-if="!selectedPackage"
+      class="h-96 flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 p-10"
+    >
+      <svg class="w-12 h-12 text-gray-400 dark:text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+      </svg>
+      <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300">Select a package to explore dependencies</h3>
+      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 text-center max-w-md">
+        Choose a package from the dropdown above to view all dependency paths
+        from the root to that package, and from the package to its leaf dependencies.
+      </p>
+      <p class="mt-4 text-xs text-gray-400 dark:text-gray-500">
+        {{ packageList.length }} packages available in this collection
+      </p>
+    </div>
+
+    <!-- Graph + details -->
+    <template v-else>
+      <div class="h-[600px] w-full rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+        <VueFlow
+          id="dependency-graph"
+          :nodes="nodes"
+          :edges="edges"
+          :node-types="nodeTypes"
+          :min-zoom="0.1"
+          :max-zoom="2"
+          fit-view-on-init
+          @node-click="onNodeClick"
+        >
+          <Background />
+          <Controls />
+          <MiniMap :node-color="miniMapColor" mask-color="rgba(0,0,0,0.1)" />
+        </VueFlow>
+      </div>
+
+      <!-- Stats -->
+      <div class="mt-1 text-xs text-gray-500 dark:text-gray-400 text-right">
+        Showing {{ stats.shownNodes }} of {{ stats.totalPackages }} packages, {{ stats.shownEdges }} dependencies
+      </div>
+
+      <!-- Direct dependencies -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-5 mt-5">
+        <!-- Incoming -->
+        <div>
+          <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            Packages depending on this ({{ incomingDeps.length }})
+          </h4>
+          <div v-if="incomingDeps.length === 0" class="p-3 bg-gray-50 dark:bg-gray-800 rounded text-sm text-gray-500 dark:text-gray-400">
+            No packages depend on this package
+          </div>
+          <div v-else class="max-h-[300px] overflow-y-auto border border-gray-200 dark:border-gray-700 rounded">
+            <div
+              v-for="dep in incomingDeps"
+              :key="dep.key"
+              class="px-3 py-2 border-b border-gray-100 dark:border-gray-700 last:border-b-0 text-[13px] font-mono cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+              @click="selectFromList(dep.key)"
+            >
+              <div class="font-medium text-blue-600 dark:text-blue-400">
+                {{ dep.key === '' ? 'Top level' : dep.key }}
+              </div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {{ dep.req }}
+                <span :class="(dep.reqType === 'install' || dep.reqType === 'toplevel') ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400'" class="ml-2">
+                  ({{ (dep.reqType === 'install' || dep.reqType === 'toplevel') ? 'install' : 'build-time' }})
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Outgoing -->
+        <div>
+          <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            Direct dependencies ({{ outgoingDeps.length }})
+          </h4>
+          <div v-if="outgoingDeps.length === 0" class="p-3 bg-gray-50 dark:bg-gray-800 rounded text-sm text-gray-500 dark:text-gray-400">
+            No direct dependencies
+          </div>
+          <div v-else class="max-h-[300px] overflow-y-auto border border-gray-200 dark:border-gray-700 rounded">
+            <div
+              v-for="dep in outgoingDeps"
+              :key="dep.key"
+              class="px-3 py-2 border-b border-gray-100 dark:border-gray-700 last:border-b-0 text-[13px] font-mono cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+              @click="selectFromList(dep.key)"
+            >
+              <div class="font-medium text-blue-600 dark:text-blue-400">
+                {{ dep.key === '' ? 'Top level' : dep.key }}
+              </div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                {{ dep.req }}
+                <span :class="(dep.reqType === 'install' || dep.reqType === 'toplevel') ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400'" class="ml-2">
+                  ({{ (dep.reqType === 'install' || dep.reqType === 'toplevel') ? 'install' : 'build-time' }})
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </template>
+</template>

--- a/modules/product-builds/client/components/DependencyGraph.vue
+++ b/modules/product-builds/client/components/DependencyGraph.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { watch, nextTick, markRaw } from 'vue'
-import { VueFlow, useVueFlow } from '@vue-flow/core'
+import { ref, watch, nextTick, markRaw } from 'vue'
+import { VueFlow } from '@vue-flow/core'
 import { MiniMap } from '@vue-flow/minimap'
 import { Controls } from '@vue-flow/controls'
 import { Background } from '@vue-flow/background'
@@ -30,12 +30,16 @@ const {
 
 const nodeTypes = { package: markRaw(GraphPackageNode) }
 
-const { fitView } = useVueFlow({ id: 'dependency-graph' })
+const vueFlowInstance = ref(null)
+
+function onPaneReady(instance) {
+  vueFlowInstance.value = instance
+}
 
 watch(nodes, () => {
-  if (nodes.value.length > 0) {
+  if (nodes.value.length > 0 && vueFlowInstance.value) {
     nextTick(() => {
-      setTimeout(() => fitView({ padding: 0.2, duration: 0 }), 100)
+      setTimeout(() => vueFlowInstance.value.fitView({ padding: 0.2, duration: 0 }), 100)
     })
   }
 })
@@ -118,13 +122,13 @@ function miniMapColor(node) {
     <template v-else>
       <div class="h-[600px] w-full rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
         <VueFlow
-          id="dependency-graph"
           :nodes="nodes"
           :edges="edges"
           :node-types="nodeTypes"
           :min-zoom="0.1"
           :max-zoom="2"
           fit-view-on-init
+          @pane-ready="onPaneReady"
           @node-click="onNodeClick"
         >
           <Background />

--- a/modules/product-builds/client/components/DependencyGraph.vue
+++ b/modules/product-builds/client/components/DependencyGraph.vue
@@ -45,8 +45,8 @@ watch(nodes, () => {
 })
 
 function onNodeClick({ node }) {
-  const key = node.id === 'root' ? '' : node.id
-  selectedPackage.value = key
+  if (node.id === 'root') return
+  selectedPackage.value = node.id
 }
 
 function selectFromList(key) {

--- a/modules/product-builds/client/components/graph/GraphPackageNode.vue
+++ b/modules/product-builds/client/components/graph/GraphPackageNode.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps({
+  data: { type: Object, required: true },
+  id: { type: String, required: true },
+})
+</script>
+
+<template>
+  <Handle type="target" :position="Position.Top" class="!bg-gray-500" />
+
+  <div
+    class="px-3 py-2 min-w-[120px] text-center text-xs font-mono cursor-pointer select-none rounded-lg border-2"
+    :class="{
+      'bg-yellow-50 dark:bg-yellow-900/30 border-yellow-500 shadow-[0_0_12px_rgba(240,171,0,0.6)] border-4': data.isSelected,
+      'bg-green-50 dark:bg-green-900/20 border-green-600 dark:border-green-500 font-bold': !data.isSelected && data.isRoot,
+      'bg-teal-50 dark:bg-teal-900/20 border-teal-500': !data.isSelected && !data.isRoot && data.preBuilt,
+      'bg-white dark:bg-gray-800 border-blue-600 dark:border-blue-400': !data.isSelected && !data.isRoot && !data.preBuilt,
+      'border-dashed !border-gray-500': data.isBuildOnly && !data.isSelected,
+    }"
+  >
+    <div>{{ data.label }}</div>
+    <div
+      v-if="data.preBuilt && !data.isSelected"
+      class="text-[10px] text-teal-600 dark:text-teal-400 mt-0.5"
+    >
+      (pre-built)
+    </div>
+  </div>
+
+  <Handle type="source" :position="Position.Bottom" class="!bg-gray-500" />
+</template>

--- a/modules/product-builds/client/components/graph/GraphPackageSelector.vue
+++ b/modules/product-builds/client/components/graph/GraphPackageSelector.vue
@@ -1,0 +1,149 @@
+<script setup>
+import { ref, computed, nextTick } from 'vue'
+import { onClickOutside } from '@vueuse/core'
+
+const props = defineProps({
+  packages: { type: Array, required: true },
+  modelValue: { type: String, default: null },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const isOpen = ref(false)
+const filterText = ref('')
+const focusedIndex = ref(-1)
+const containerRef = ref(null)
+const inputRef = ref(null)
+
+onClickOutside(containerRef, () => {
+  isOpen.value = false
+})
+
+const filteredPackages = computed(() => {
+  if (!filterText.value) return props.packages
+  const search = filterText.value.toLowerCase()
+  return props.packages.filter(pkg => pkg.displayLabel.toLowerCase().includes(search))
+})
+
+const selectedLabel = computed(() => {
+  if (!props.modelValue) return ''
+  const pkg = props.packages.find(p => p.key === props.modelValue)
+  return pkg ? pkg.displayLabel : props.modelValue
+})
+
+function openDropdown() {
+  isOpen.value = true
+  filterText.value = ''
+  focusedIndex.value = -1
+  nextTick(() => inputRef.value?.focus())
+}
+
+function toggleDropdown() {
+  if (isOpen.value) {
+    isOpen.value = false
+  } else {
+    openDropdown()
+  }
+}
+
+function selectPackage(key) {
+  emit('update:modelValue', key)
+  isOpen.value = false
+  filterText.value = ''
+}
+
+function clearSelection() {
+  emit('update:modelValue', null)
+  filterText.value = ''
+}
+
+function onKeydown(event) {
+  const list = filteredPackages.value
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    focusedIndex.value = Math.min(focusedIndex.value + 1, list.length - 1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    focusedIndex.value = Math.max(focusedIndex.value - 1, 0)
+  } else if (event.key === 'Enter' && focusedIndex.value >= 0 && focusedIndex.value < list.length) {
+    event.preventDefault()
+    selectPackage(list[focusedIndex.value].key)
+  } else if (event.key === 'Escape') {
+    isOpen.value = false
+  }
+}
+</script>
+
+<template>
+  <div
+    ref="containerRef"
+    class="flex items-center gap-3 py-2 px-3 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 mb-3"
+  >
+    <label class="text-sm font-semibold text-gray-900 dark:text-gray-100 whitespace-nowrap">
+      Select Package:
+    </label>
+
+    <div class="relative flex-1 max-w-[500px]">
+      <button
+        v-if="!isOpen"
+        type="button"
+        class="w-full text-left px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:border-gray-400 dark:hover:border-gray-500"
+        @click="toggleDropdown"
+      >
+        <span v-if="modelValue" class="font-mono">{{ selectedLabel }}</span>
+        <span v-else class="text-gray-400 dark:text-gray-500">Choose a package...</span>
+      </button>
+
+      <div v-else>
+        <input
+          ref="inputRef"
+          v-model="filterText"
+          type="text"
+          class="w-full px-3 py-1.5 text-sm border border-blue-500 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 outline-none"
+          placeholder="Search packages..."
+          @keydown="onKeydown"
+        />
+      </div>
+
+      <ul
+        v-if="isOpen"
+        class="absolute z-50 left-0 right-0 mt-1 max-h-60 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg"
+      >
+        <li
+          v-if="filteredPackages.length === 0"
+          class="px-3 py-2 text-sm text-gray-400 dark:text-gray-500"
+        >
+          No packages found
+        </li>
+        <li
+          v-for="(pkg, index) in filteredPackages"
+          :key="pkg.key"
+          class="px-3 py-1.5 text-[13px] font-mono cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+          :class="{ 'bg-blue-50 dark:bg-blue-900/30': index === focusedIndex }"
+          @click="selectPackage(pkg.key)"
+        >
+          {{ pkg.displayLabel }}
+          <span
+            v-if="pkg.preBuilt"
+            class="text-[11px] text-teal-600 dark:text-teal-400 italic ml-2 font-sans"
+          >
+            (pre-built)
+          </span>
+        </li>
+      </ul>
+    </div>
+
+    <button
+      v-if="modelValue"
+      type="button"
+      class="text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
+      @click="clearSelection"
+    >
+      Clear
+    </button>
+
+    <span class="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+      {{ packages.length }} {{ packages.length === 1 ? 'package' : 'packages' }}
+    </span>
+  </div>
+</template>

--- a/modules/product-builds/client/composables/useDependencyGraph.js
+++ b/modules/product-builds/client/composables/useDependencyGraph.js
@@ -1,0 +1,108 @@
+import { ref, shallowRef, computed, watch } from 'vue'
+import {
+  parseGraphJson,
+  extractPackageList,
+  extractGraphSubset,
+  toVueFlowElements,
+  filterBuildDeps,
+  extractDirectDependencies,
+} from '../utils/graphUtils.js'
+
+export function useDependencyGraph(dependencyGraphJson) {
+  let fullGraphData = null
+  const packageList = ref([])
+  const selectedPackage = ref(null)
+  const showBuildDeps = ref(true)
+  const nodes = shallowRef([])
+  const edges = shallowRef([])
+  const incomingDeps = ref([])
+  const outgoingDeps = ref([])
+  const error = ref(null)
+
+  const stats = computed(() => ({
+    shownNodes: nodes.value.length,
+    totalPackages: packageList.value.length,
+    shownEdges: edges.value.length,
+  }))
+
+  const isReady = computed(() => packageList.value.length > 0)
+
+  function init(jsonString) {
+    try {
+      error.value = null
+      fullGraphData = parseGraphJson(jsonString)
+      packageList.value = extractPackageList(fullGraphData)
+    } catch (err) {
+      error.value = err.message || 'Failed to load dependency graph'
+      fullGraphData = null
+      packageList.value = []
+    }
+  }
+
+  function selectPackage(key) {
+    const graphKey = key === 'root' ? '' : key
+    selectedPackage.value = graphKey
+  }
+
+  function clearSelection() {
+    selectedPackage.value = null
+  }
+
+  watch([() => selectedPackage.value, () => showBuildDeps.value], () => {
+    if (!selectedPackage.value || !fullGraphData) {
+      nodes.value = []
+      edges.value = []
+      incomingDeps.value = []
+      outgoingDeps.value = []
+      return
+    }
+
+    try {
+      const subsetData = extractGraphSubset(fullGraphData, selectedPackage.value)
+      if (!subsetData) {
+        error.value = 'Invalid package selection'
+        return
+      }
+
+      let { nodes: n, edges: e } = toVueFlowElements(subsetData, selectedPackage.value)
+
+      if (!showBuildDeps.value) {
+        const filtered = filterBuildDeps(n, e, selectedPackage.value)
+        n = filtered.nodes
+        e = filtered.edges
+      }
+
+      nodes.value = n
+      edges.value = e
+
+      const deps = extractDirectDependencies(
+        fullGraphData,
+        selectedPackage.value,
+        showBuildDeps.value
+      )
+      incomingDeps.value = deps.incoming
+      outgoingDeps.value = deps.outgoing
+    } catch (err) {
+      error.value = err.message || 'Failed to render graph subset'
+    }
+  })
+
+  if (dependencyGraphJson) {
+    init(dependencyGraphJson)
+  }
+
+  return {
+    packageList,
+    selectedPackage,
+    showBuildDeps,
+    nodes,
+    edges,
+    incomingDeps,
+    outgoingDeps,
+    stats,
+    isReady,
+    error,
+    selectPackage,
+    clearSelection,
+  }
+}

--- a/modules/product-builds/client/composables/useDependencyGraph.js
+++ b/modules/product-builds/client/composables/useDependencyGraph.js
@@ -49,7 +49,7 @@ export function useDependencyGraph(dependencyGraphJson) {
   }
 
   watch([() => selectedPackage.value, () => showBuildDeps.value], () => {
-    if (!selectedPackage.value || !fullGraphData) {
+    if (selectedPackage.value === null || !fullGraphData) {
       nodes.value = []
       edges.value = []
       incomingDeps.value = []

--- a/modules/product-builds/client/composables/useWheelCollections.js
+++ b/modules/product-builds/client/composables/useWheelCollections.js
@@ -1,0 +1,211 @@
+import { ref, computed } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const BASE = '/modules/product-builds'
+const ITEMS_PER_PAGE = 20
+
+export function useWheelBrowse() {
+  const artifacts = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+  const offset = ref(0)
+  const hasNext = ref(false)
+  const sortColumn = ref('created_at')
+  const sortDirection = ref('desc')
+  const searchValue = ref('')
+
+  const pageNumber = computed(() => Math.floor(offset.value / ITEMS_PER_PAGE) + 1)
+  const hasPrevious = computed(() => offset.value > 0)
+
+  const buildSequences = ref({})
+  const buildSequencesLoading = ref(false)
+
+  async function load() {
+    loading.value = true
+    error.value = null
+    buildSequences.value = {}
+    try {
+      const params = new URLSearchParams({
+        type: 'wheels-collections',
+        limit: String(ITEMS_PER_PAGE + 1),
+        offset: String(offset.value),
+        sort_by: sortColumn.value,
+        sort_order: sortDirection.value,
+        count_limit: '1000'
+      })
+      if (searchValue.value) {
+        params.set('version_pattern', searchValue.value)
+      }
+      const data = await apiRequest(`${BASE}/artifacts?${params}`)
+      const items = Array.isArray(data) ? data : []
+      hasNext.value = items.length > ITEMS_PER_PAGE
+      artifacts.value = items.slice(0, ITEMS_PER_PAGE)
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+    loadBuildSequences()
+  }
+
+  async function loadBuildSequences() {
+    const keys = artifacts.value.map(a => a.key).filter(Boolean)
+    if (!keys.length) return
+    buildSequencesLoading.value = true
+    try {
+      const data = await apiRequest(`${BASE}/artifacts/build-sequences?keys=${keys.map(encodeURIComponent).join(',')}`)
+      buildSequences.value = data || {}
+    } catch {
+      buildSequences.value = {}
+    } finally {
+      buildSequencesLoading.value = false
+    }
+  }
+
+  function nextPage() {
+    if (!hasNext.value) return
+    offset.value += ITEMS_PER_PAGE
+    load()
+  }
+
+  function previousPage() {
+    if (offset.value === 0) return
+    offset.value = Math.max(0, offset.value - ITEMS_PER_PAGE)
+    load()
+  }
+
+  function toggleSort(column) {
+    if (sortColumn.value === column) {
+      sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+    } else {
+      sortColumn.value = column
+      sortDirection.value = 'asc'
+    }
+    offset.value = 0
+    load()
+  }
+
+  function search(value) {
+    searchValue.value = value
+    offset.value = 0
+    load()
+  }
+
+  return {
+    artifacts, loading, error,
+    pageNumber, hasPrevious, hasNext,
+    sortColumn, sortDirection, searchValue,
+    buildSequences, buildSequencesLoading,
+    load, nextPage, previousPage, toggleSort, search
+  }
+}
+
+export function useWheelPackageSearch() {
+  const results = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+  const offset = ref(0)
+  const hasMore = ref(false)
+
+  const pageNumber = computed(() => Math.floor(offset.value / ITEMS_PER_PAGE) + 1)
+  const hasPrevious = computed(() => offset.value > 0)
+
+  async function search(packageName, filters = {}, newOffset = 0) {
+    if (!packageName?.trim()) return
+    loading.value = true
+    error.value = null
+    if (newOffset === 0) results.value = null
+
+    try {
+      const params = new URLSearchParams()
+      if (filters.product_key && filters.product_key !== 'all') {
+        params.set('product_key', filters.product_key)
+        if (filters.series && filters.series !== 'all') {
+          params.set('series', filters.series)
+        }
+      }
+      if (filters.variant && filters.variant !== 'all') {
+        params.set('variant_filter', filters.variant)
+      }
+      params.set('limit', String(ITEMS_PER_PAGE))
+      params.set('offset', String(newOffset))
+
+      const queryString = params.toString()
+      const url = `${BASE}/artifacts/wheels/build-history/${encodeURIComponent(packageName)}${queryString ? '?' + queryString : ''}`
+      const data = await apiRequest(url)
+      const items = Array.isArray(data) ? data : []
+
+      hasMore.value = items.length === ITEMS_PER_PAGE
+      offset.value = newOffset
+      results.value = items
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function nextPage(packageName, filters) {
+    search(packageName, filters, offset.value + ITEMS_PER_PAGE)
+  }
+
+  function previousPage(packageName, filters) {
+    search(packageName, filters, Math.max(0, offset.value - ITEMS_PER_PAGE))
+  }
+
+  function reset() {
+    results.value = null
+    offset.value = 0
+    hasMore.value = false
+    error.value = null
+  }
+
+  return {
+    results, loading, error,
+    pageNumber, hasPrevious, hasMore,
+    search, nextPage, previousPage, reset
+  }
+}
+
+export function useWheelFilters() {
+  const products = ref([])
+  const variants = ref([])
+  const series = ref([])
+  const loaded = ref(false)
+
+  async function loadFilters() {
+    if (loaded.value) return
+    try {
+      const filterResult = await apiRequest(`${BASE}/artifacts/wheels-collections/filters`).catch(() => ({ product_keys: [], variants: [] }))
+      variants.value = filterResult.variants || []
+
+      const productKeys = filterResult.product_keys || []
+      if (productKeys.length > 0) {
+        const allProducts = []
+        for (const key of productKeys) {
+          try {
+            const p = await apiRequest(`${BASE}/products/${encodeURIComponent(key)}`)
+            allProducts.push(p)
+          } catch { /* skip unavailable products */ }
+        }
+        products.value = allProducts
+      }
+      loaded.value = true
+    } catch { /* silently fail */ }
+  }
+
+  async function loadSeries(productKey) {
+    if (!productKey || productKey === 'all') {
+      series.value = []
+      return
+    }
+    try {
+      const data = await apiRequest(`${BASE}/series?product_key=${encodeURIComponent(productKey)}&supported_only=false&limit=100&offset=0`)
+      series.value = Array.isArray(data) ? data : []
+    } catch {
+      series.value = []
+    }
+  }
+
+  return { products, variants, series, loadFilters, loadSeries }
+}

--- a/modules/product-builds/client/index.js
+++ b/modules/product-builds/client/index.js
@@ -7,8 +7,8 @@ export const routes = {
   'rhel-ai': ProductView,
   'base-images': ProductView,
   'builder-images': ProductView,
-  'wheel-collections': ProductView,
   'series-detail': defineAsyncComponent(() => import('./views/SeriesDetailView.vue')),
+  'wheel-collections': defineAsyncComponent(() => import('./views/WheelCollectionsView.vue')),
   'drop-detail': defineAsyncComponent(() => import('./views/DropDetailView.vue')),
   'artifact-detail': defineAsyncComponent(() => import('./views/ArtifactDetailView.vue')),
 }

--- a/modules/product-builds/client/utils/formatting.js
+++ b/modules/product-builds/client/utils/formatting.js
@@ -58,6 +58,24 @@ export function formatDuration(start, end) {
   return `${s}s`
 }
 
+export function getCommitUrl(artifact) {
+  const commit = artifact?.commit || artifact?.labels?.['git.commit'] || artifact?.labels?.['org.opencontainers.image.revision'] || artifact?.labels?.['vcs-ref']
+  if (!commit) return null
+
+  let repoUrl = null
+  if (artifact.git_repository) {
+    repoUrl = typeof artifact.git_repository === 'string' ? artifact.git_repository : artifact.git_repository?.url
+  }
+  if (!repoUrl) {
+    const labels = artifact.labels || {}
+    repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
+  }
+  if (!repoUrl || typeof repoUrl !== 'string') return null
+
+  const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
+  return `${baseUrl}/-/commit/${commit}`
+}
+
 export function getAcceleratorInfo(art) {
   const labels = art?.labels || {}
   let accel = art?.variant ? art.variant.split('-')[0] : null

--- a/modules/product-builds/client/utils/graphUtils.js
+++ b/modules/product-builds/client/utils/graphUtils.js
@@ -1,0 +1,316 @@
+import dagre from '@dagrejs/dagre'
+
+export function parseGraphJson(jsonString) {
+  if (!jsonString || typeof jsonString !== 'string') {
+    throw new Error('Invalid graph JSON: must be a non-empty string')
+  }
+  const graphData = JSON.parse(jsonString)
+
+  // Pre-build reverse adjacency map (child → parents) for fast ancestor lookups
+  const reverseAdj = new Map()
+  Object.entries(graphData).forEach(([sourceKey, nodeData]) => {
+    if (!nodeData.edges) return
+    nodeData.edges.forEach(edge => {
+      if (!reverseAdj.has(edge.key)) reverseAdj.set(edge.key, [])
+      reverseAdj.get(edge.key).push(sourceKey)
+    })
+  })
+  Object.defineProperty(graphData, '_reverseAdj', { value: reverseAdj, enumerable: false })
+
+  return graphData
+}
+
+export function extractPackageList(graphData) {
+  if (!graphData || typeof graphData !== 'object') return []
+
+  return Object.keys(graphData)
+    .filter(key => key !== '')
+    .sort()
+    .map(key => {
+      const [packageName, version] = key.split('==')
+      return {
+        key,
+        packageName,
+        version,
+        displayLabel: key,
+        preBuilt: graphData[key]?.pre_built || false,
+      }
+    })
+}
+
+export function extractGraphSubset(graphData, selectedPackageKey) {
+  if (!graphData || typeof graphData !== 'object') return null
+  if (!selectedPackageKey || !graphData[selectedPackageKey]) return null
+
+  const reverseAdj = graphData._reverseAdj || new Map()
+
+  // BFS backwards to find all ancestors
+  const ancestors = new Set([selectedPackageKey])
+  const ancestorQueue = [selectedPackageKey]
+  while (ancestorQueue.length > 0) {
+    const key = ancestorQueue.shift()
+    const parents = reverseAdj.get(key)
+    if (!parents) continue
+    for (const parent of parents) {
+      if (!ancestors.has(parent)) {
+        ancestors.add(parent)
+        ancestorQueue.push(parent)
+      }
+    }
+  }
+
+  const descendants = new Set([selectedPackageKey])
+  const queue = [selectedPackageKey]
+
+  while (queue.length > 0) {
+    const currentKey = queue.shift()
+    const nodeData = graphData[currentKey]
+    if (!nodeData?.edges) continue
+
+    nodeData.edges.forEach(edge => {
+      if (!descendants.has(edge.key)) {
+        descendants.add(edge.key)
+        queue.push(edge.key)
+      }
+    })
+  }
+
+  const allNodes = new Set([...ancestors, ...descendants])
+  const subset = {}
+
+  allNodes.forEach(nodeKey => {
+    const nodeData = graphData[nodeKey]
+    if (!nodeData) return
+    subset[nodeKey] = {
+      ...nodeData,
+      edges: nodeData.edges ? nodeData.edges.filter(edge => allNodes.has(edge.key)) : [],
+    }
+  })
+
+  return subset
+}
+
+function buildRequirementIndex(graphData) {
+  const index = {}
+  Object.entries(graphData).forEach(([sourceKey, nodeData]) => {
+    if (!nodeData.edges) return
+    nodeData.edges.forEach(edge => {
+      if (!index[edge.key]) index[edge.key] = []
+      index[edge.key].push({
+        source: sourceKey === '' ? 'Top level' : sourceKey,
+        req: edge.req,
+        reqType: edge.req_type,
+      })
+    })
+  })
+  return index
+}
+
+function getEdgeStyle(reqType) {
+  if (reqType === 'install' || reqType === 'toplevel') {
+    return { stroke: '#0066cc', strokeWidth: 2 }
+  }
+  return { stroke: '#6a6e73', strokeWidth: 2, strokeDasharray: '5,5' }
+}
+
+function applyDagreLayout(nodes, edges, options = {}) {
+  const { rankdir = 'TB', nodesep = 50, ranksep = 80 } = options
+
+  const g = new dagre.graphlib.Graph()
+  g.setGraph({ rankdir, nodesep, ranksep, ranker: 'tight-tree' })
+  g.setDefaultEdgeLabel(() => ({}))
+
+  nodes.forEach(node => g.setNode(node.id, { width: 150, height: 40 }))
+  edges.forEach(edge => g.setEdge(edge.source, edge.target))
+
+  dagre.layout(g)
+
+  return nodes.map(node => {
+    const pos = g.node(node.id)
+    return { ...node, position: { x: pos.x - 75, y: pos.y - 20 } }
+  })
+}
+
+export function toVueFlowElements(graphData, selectedPackageKey) {
+  if (!graphData || typeof graphData !== 'object') {
+    throw new Error('Invalid graph data: must be an object')
+  }
+
+  const requirementIndex = buildRequirementIndex(graphData)
+
+  const hasInstallEdge = new Set()
+  Object.entries(graphData).forEach(([, nodeData]) => {
+    if (!nodeData.edges) return
+    nodeData.edges.forEach(edge => {
+      if (edge.req_type === 'install' || edge.req_type === 'toplevel') {
+        hasInstallEdge.add(edge.key)
+      }
+    })
+  })
+
+  const buildOnlyNodes = new Set()
+  Object.keys(graphData).forEach(packageKey => {
+    if (packageKey === '') return
+    const hasIncoming = requirementIndex[packageKey]?.length > 0
+    if (hasIncoming && !hasInstallEdge.has(packageKey)) {
+      buildOnlyNodes.add(packageKey)
+    }
+  })
+
+  const nodes = Object.entries(graphData).map(([packageKey, nodeData]) => {
+    const isRoot = packageKey === ''
+    const nodeId = isRoot ? 'root' : packageKey
+    let packageName, version
+
+    if (isRoot) {
+      packageName = 'Top level'
+      version = null
+    } else {
+      const parts = packageKey.split('==')
+      packageName = parts[0]
+      version = parts[1] || null
+    }
+
+    return {
+      id: nodeId,
+      type: 'package',
+      data: {
+        label: isRoot ? 'Top level' : packageKey,
+        packageName,
+        version,
+        preBuilt: nodeData.pre_built || false,
+        isRoot,
+        isBuildOnly: buildOnlyNodes.has(packageKey),
+        isSelected: nodeId === selectedPackageKey ||
+          (nodeId === 'root' && selectedPackageKey === ''),
+      },
+      position: { x: 0, y: 0 },
+    }
+  })
+
+  const edges = []
+  const nodeIdSet = new Set(nodes.map(n => n.id))
+  const edgeSet = new Set()
+
+  Object.entries(graphData).forEach(([sourceKey, nodeData]) => {
+    const sourceId = sourceKey === '' ? 'root' : sourceKey
+    if (!nodeData.edges) return
+
+    nodeData.edges.forEach(edge => {
+      const targetId = edge.key === '' ? 'root' : edge.key
+      const edgeId = `${sourceId}->${targetId}`
+
+      if (edgeSet.has(edgeId)) return
+      if (!nodeIdSet.has(sourceId) || !nodeIdSet.has(targetId)) return
+
+      edgeSet.add(edgeId)
+      edges.push({
+        id: edgeId,
+        source: sourceId,
+        target: targetId,
+        type: 'default',
+        animated: false,
+        style: getEdgeStyle(edge.req_type),
+        markerEnd: {
+          type: 'arrowclosed',
+          color: (edge.req_type === 'install' || edge.req_type === 'toplevel') ? '#0066cc' : '#6a6e73',
+        },
+        data: { reqType: edge.req_type, req: edge.req },
+      })
+    })
+  })
+
+  const layoutedNodes = applyDagreLayout(nodes, edges)
+  return { nodes: layoutedNodes, edges }
+}
+
+export function filterBuildDeps(nodes, edges, selectedPackageKey) {
+  const selectedNodeId = selectedPackageKey === '' ? 'root' : selectedPackageKey
+
+  let filteredEdges = edges.filter(edge => {
+    const reqType = edge.data?.reqType
+    return reqType === 'install' || reqType === 'toplevel'
+  })
+
+  let filteredNodes = nodes.filter(node => !node.data.isBuildOnly)
+
+  const forwardAdj = new Map()
+  const reverseAdj = new Map()
+  filteredEdges.forEach(edge => {
+    if (!forwardAdj.has(edge.source)) forwardAdj.set(edge.source, new Set())
+    forwardAdj.get(edge.source).add(edge.target)
+    if (!reverseAdj.has(edge.target)) reverseAdj.set(edge.target, new Set())
+    reverseAdj.get(edge.target).add(edge.source)
+  })
+
+  const reachableForward = new Set([selectedNodeId])
+  let queue = [selectedNodeId]
+  while (queue.length > 0) {
+    const id = queue.shift()
+    const neighbors = forwardAdj.get(id)
+    if (neighbors) {
+      neighbors.forEach(n => {
+        if (!reachableForward.has(n)) {
+          reachableForward.add(n)
+          queue.push(n)
+        }
+      })
+    }
+  }
+
+  const reachableBackward = new Set([selectedNodeId])
+  queue = [selectedNodeId]
+  while (queue.length > 0) {
+    const id = queue.shift()
+    const preds = reverseAdj.get(id)
+    if (preds) {
+      preds.forEach(p => {
+        if (!reachableBackward.has(p)) {
+          reachableBackward.add(p)
+          queue.push(p)
+        }
+      })
+    }
+  }
+
+  const reachable = new Set([...reachableForward, ...reachableBackward])
+  filteredNodes = filteredNodes.filter(node => reachable.has(node.id))
+  filteredEdges = filteredEdges.filter(
+    edge => reachable.has(edge.source) && reachable.has(edge.target)
+  )
+
+  filteredNodes = applyDagreLayout(filteredNodes, filteredEdges)
+  return { nodes: filteredNodes, edges: filteredEdges }
+}
+
+export function extractDirectDependencies(fullGraphData, selectedPackageKey, showBuildDeps) {
+  const selectedNodeData = fullGraphData[selectedPackageKey]
+
+  let outgoing = selectedNodeData?.edges?.map(edge => ({
+    key: edge.key,
+    req: edge.req,
+    reqType: edge.req_type,
+  })) || []
+
+  if (!showBuildDeps) {
+    outgoing = outgoing.filter(dep =>
+      dep.reqType === 'install' || dep.reqType === 'toplevel'
+    )
+  }
+
+  // Use reverse adjacency map to find incoming deps without scanning full graph
+  const incoming = []
+  const reverseAdj = fullGraphData._reverseAdj || new Map()
+  const parents = reverseAdj.get(selectedPackageKey) || []
+  for (const parentKey of parents) {
+    const parentData = fullGraphData[parentKey]
+    if (!parentData?.edges) continue
+    for (const edge of parentData.edges) {
+      if (edge.key !== selectedPackageKey) continue
+      if (!showBuildDeps && edge.req_type !== 'install' && edge.req_type !== 'toplevel') continue
+      incoming.push({ key: parentKey, req: edge.req, reqType: edge.req_type })
+    }
+  }
+
+  return { incoming, outgoing }
+}

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, inject, defineAsyncComponent } from 'vue'
 import { useArtifactDetail } from '../composables/useArtifacts'
-import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo } from '../utils/formatting'
+import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo, getCommitUrl } from '../utils/formatting'
 
 const DependencyGraph = defineAsyncComponent(() => import('../components/DependencyGraph.vue'))
 
@@ -165,23 +165,6 @@ function copyToClipboard(value) {
   navigator.clipboard.writeText(value)
   copiedValue.value = value
   setTimeout(() => { copiedValue.value = null }, 1500)
-}
-
-function getCommitUrl(art) {
-  const commit = art?.commit || art?.labels?.['git.commit'] || art?.labels?.['org.opencontainers.image.revision'] || art?.labels?.['vcs-ref']
-  if (!commit) return null
-
-  let repoUrl = null
-  if (art.git_repository) {
-    repoUrl = typeof art.git_repository === 'string' ? art.git_repository : art.git_repository?.url
-  }
-  if (!repoUrl) {
-    const labels = art.labels || {}
-    repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
-  }
-  if (!repoUrl || typeof repoUrl !== 'string') return null
-  const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
-  return `${baseUrl}/-/commit/${commit}`
 }
 
 function getDigestUrl(art) {

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -1,7 +1,9 @@
 <script setup>
-import { ref, reactive, computed, watch, onMounted, inject } from 'vue'
+import { ref, reactive, computed, watch, onMounted, inject, defineAsyncComponent } from 'vue'
 import { useArtifactDetail } from '../composables/useArtifacts'
 import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo } from '../utils/formatting'
+
+const DependencyGraph = defineAsyncComponent(() => import('../components/DependencyGraph.vue'))
 
 const nav = inject('moduleNav')
 const { artifact, wheels, containers, loading, error, loadArtifact, loadWheels, loadContainers } = useArtifactDetail()
@@ -170,16 +172,12 @@ function getCommitUrl(art) {
   if (!commit) return null
 
   let repoUrl = null
-  if (art.type === 'wheels-collections') {
-    repoUrl = 'https://gitlab.com/redhat/rhel-ai/rhaiis/pipeline'
-  } else {
-    if (art.git_repository) {
-      repoUrl = typeof art.git_repository === 'string' ? art.git_repository : art.git_repository?.url
-    }
-    if (!repoUrl) {
-      const labels = art.labels || {}
-      repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
-    }
+  if (art.git_repository) {
+    repoUrl = typeof art.git_repository === 'string' ? art.git_repository : art.git_repository?.url
+  }
+  if (!repoUrl) {
+    const labels = art.labels || {}
+    repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
   }
   if (!repoUrl || typeof repoUrl !== 'string') return null
   const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
@@ -682,7 +680,7 @@ const otherLabels = computed(() => {
             <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
           </button>
         </div>
-        <p class="text-sm text-gray-500 dark:text-gray-400 italic">Not implemented yet</p>
+        <DependencyGraph :dependency-graph-json="artifact.dependency_graph" />
       </div>
     </template>
   </div>

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -3,7 +3,7 @@ import { onMounted, inject, ref, computed, reactive, watch } from 'vue'
 import { useDropDetail } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { apiRequest } from '@shared/client/services/api'
-import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration } from '../utils/formatting'
+import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getCommitUrl } from '../utils/formatting'
 import DropTimeline from '../components/DropTimeline.vue'
 
 const BASE = '/modules/product-builds'
@@ -146,15 +146,6 @@ function getRegistryUrl(key) {
     return `https://catalog.redhat.com/en/search?searchType=All&q=${encodeURIComponent(path)}&p=1`
   }
   return null
-}
-
-function getCommitUrl(artifact) {
-  if (!artifact?.commit) return null
-  const labels = artifact.labels || {}
-  const repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['vcs-url']
-  if (!repoUrl) return null
-  const clean = repoUrl.replace(/\.git$/, '')
-  return `${clean}/commit/${artifact.commit}`
 }
 
 function downloadPackagesAsJson(artifactKey) {

--- a/modules/product-builds/client/views/WheelCollectionsView.vue
+++ b/modules/product-builds/client/views/WheelCollectionsView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onUnmounted, inject } from 'vue'
 import { useWheelBrowse, useWheelPackageSearch, useWheelFilters } from '../composables/useWheelCollections'
-import { formatDate, envBadgeClass, archBadgeClass } from '../utils/formatting'
+import { formatDate, envBadgeClass, archBadgeClass, getCommitUrl } from '../utils/formatting'
 import { apiRequest, getApiBase } from '@shared/client/services/api'
 import { impersonatingUid } from '@shared/client/state/impersonation'
 
@@ -106,24 +106,6 @@ function downloadBuildSequence(key) {
   a.download = `${safeName}-build-sequence.json`
   a.click()
   URL.revokeObjectURL(url)
-}
-
-function getCommitUrl(artifact) {
-  const commit = artifact?.commit || artifact?.labels?.['git.commit'] || artifact?.labels?.['org.opencontainers.image.revision'] || artifact?.labels?.['vcs-ref']
-  if (!commit) return null
-
-  let repoUrl = null
-  if (artifact.git_repository) {
-    repoUrl = typeof artifact.git_repository === 'string' ? artifact.git_repository : artifact.git_repository?.url
-  }
-  if (!repoUrl) {
-    const labels = artifact.labels || {}
-    repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
-  }
-  if (!repoUrl || typeof repoUrl !== 'string') return null
-
-  const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
-  return `${baseUrl}/-/commit/${commit}`
 }
 
 function formatCommit(commit) {

--- a/modules/product-builds/client/views/WheelCollectionsView.vue
+++ b/modules/product-builds/client/views/WheelCollectionsView.vue
@@ -1,0 +1,931 @@
+<script setup>
+import { ref, reactive, computed, watch, onMounted, onUnmounted, inject } from 'vue'
+import { useWheelBrowse, useWheelPackageSearch, useWheelFilters } from '../composables/useWheelCollections'
+import { formatDate, envBadgeClass, archBadgeClass } from '../utils/formatting'
+import { apiRequest, getApiBase } from '@shared/client/services/api'
+
+const nav = inject('moduleNav')
+
+const activeTab = ref('browse-all')
+
+// --- Browse All tab ---
+const browse = useWheelBrowse()
+const searchInput = ref('')
+let searchTimeout = null
+
+function onSearchInput(value) {
+  searchInput.value = value
+  clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => browse.search(value), 500)
+}
+
+function clearSearch() {
+  searchInput.value = ''
+  clearTimeout(searchTimeout)
+  browse.search('')
+}
+
+function getSortIndicator(column) {
+  if (browse.sortColumn.value !== column) return '▲'
+  return browse.sortDirection.value === 'asc' ? '▲' : '▼'
+}
+
+function getSortIndicatorClass(column) {
+  return browse.sortColumn.value === column ? 'text-primary-600 dark:text-blue-400' : 'text-gray-300 dark:text-gray-600'
+}
+
+function parseBuildSequence(key) {
+  const json = browse.buildSequences.value[key]
+  if (!json) return null
+  try {
+    const entries = JSON.parse(json)
+    if (!Array.isArray(entries)) return null
+    const newBuilds = []
+    const prebuilt = []
+    const skipped = []
+    for (const e of entries) {
+      if (e.skipped) skipped.push(e)
+      else if (e.prebuilt) prebuilt.push(e)
+      else newBuilds.push(e)
+    }
+    return { total: entries.length, newBuilds, prebuilt, skipped }
+  } catch { return null }
+}
+
+const openPopover = ref(null)
+
+function togglePopover(key) {
+  openPopover.value = openPopover.value === key ? null : key
+}
+
+function closePopover() {
+  openPopover.value = null
+}
+
+// --- Container hover popover ---
+const containerCache = reactive({})
+const containerHover = ref(null)
+let containerHoverTimer = null
+
+async function onContainerMouseEnter(artifactKey) {
+  containerHover.value = artifactKey
+  if (!containerCache[artifactKey]) {
+    containerCache[artifactKey] = { loading: true, data: null, error: null }
+    try {
+      const data = await apiRequest(`/modules/product-builds/artifacts/${encodeURIComponent(artifactKey)}/containers`)
+      containerCache[artifactKey] = { loading: false, data: Array.isArray(data) ? data : [], error: null }
+    } catch {
+      containerCache[artifactKey] = { loading: false, data: null, error: 'Failed to load' }
+    }
+  }
+}
+
+function onContainerMouseLeave() {
+  clearTimeout(containerHoverTimer)
+  containerHoverTimer = setTimeout(() => { containerHover.value = null }, 200)
+}
+
+function onContainerPopoverEnter() {
+  clearTimeout(containerHoverTimer)
+}
+
+function onContainerPopoverLeave() {
+  containerHover.value = null
+}
+
+function downloadBuildSequence(key) {
+  const json = browse.buildSequences.value[key]
+  if (!json) return
+  const safeName = (key || 'build-sequence').replace(/[^a-zA-Z0-9\-_+.]/g, '_').substring(0, 100)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${safeName}-build-sequence.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function getCommitUrl(artifact) {
+  const commit = artifact?.commit || artifact?.labels?.['git.commit']
+  if (!commit) return null
+
+  let repoUrl = null
+  if (artifact.git_repository) {
+    repoUrl = typeof artifact.git_repository === 'string'
+      ? artifact.git_repository
+      : artifact.git_repository.url
+  }
+  if (!repoUrl) {
+    repoUrl = artifact.labels?.['vcs-ref'] ? null : artifact.labels?.['io.openshift.build.source-location']
+  }
+  if (!repoUrl) return null
+
+  const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
+  return `${baseUrl}/-/commit/${commit}`
+}
+
+function formatCommit(commit) {
+  if (!commit) return ''
+  return commit.substring(0, 8)
+}
+
+// --- Search by Package tab ---
+const pkgSearch = useWheelPackageSearch()
+const filters = useWheelFilters()
+const packageName = ref('')
+const selectedProduct = ref('all')
+const selectedSeries = ref('all')
+const selectedVariant = ref('all')
+let filtersInitialized = false
+
+const currentFilters = computed(() => ({
+  product_key: selectedProduct.value,
+  series: selectedSeries.value,
+  variant: selectedVariant.value
+}))
+
+function handlePackageSearch() {
+  pkgSearch.search(packageName.value, currentFilters.value)
+}
+
+function handleSearchNextPage() {
+  pkgSearch.nextPage(packageName.value, currentFilters.value)
+}
+
+function handleSearchPreviousPage() {
+  pkgSearch.previousPage(packageName.value, currentFilters.value)
+}
+
+watch(selectedProduct, (val) => {
+  selectedSeries.value = 'all'
+  filters.loadSeries(val)
+})
+
+watch([selectedProduct, selectedSeries, selectedVariant], () => {
+  if (packageName.value.trim() && pkgSearch.results.value !== null) {
+    handlePackageSearch()
+  }
+})
+
+watch(activeTab, (tab) => {
+  if (tab === 'search-package' && !filtersInitialized) {
+    filtersInitialized = true
+    filters.loadFilters()
+  }
+})
+
+// --- Artifacts tab ---
+const ITEMS_PER_PAGE = 10
+const AVAILABLE_ARCHS = ['aarch64', 'ppc64le', 's390x', 'x86_64']
+const AVAILABLE_ACCELS = ['cpu', 'cuda', 'gaudi', 'neuron', 'rocm', 'spyre', 'tpu']
+const DATE_RANGE_OPTIONS = [
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: '90d', label: 'Last 90 days' },
+]
+const GROUP_BY_OPTIONS = [
+  { value: 'accelerator', label: 'Accelerator' },
+  { value: 'architecture', label: 'Architecture' },
+  { value: 'all', label: 'All' },
+]
+
+const artifactsGroupBy = ref('accelerator')
+const artifactsArchFilter = ref('')
+const artifactsAccelFilter = ref('')
+const artifactsDateFilter = ref('')
+const artifactsData = ref(null)
+const artifactsLoading = ref(false)
+const artifactsError = ref(null)
+const artifactsOffset = ref(0)
+const artifactsPage = ref(1)
+const artifactsHasNext = ref(false)
+const artifactsTotalPages = ref(null)
+const artifactsTotalApprox = ref(false)
+const expandedGroups = ref(new Set())
+let artifactsInitialized = false
+
+const artifactsIsGrouped = computed(() => artifactsGroupBy.value !== 'all')
+const showArtifactsArchFilter = computed(() => artifactsGroupBy.value !== 'architecture')
+const showArtifactsAccelFilter = computed(() => artifactsGroupBy.value !== 'accelerator')
+const artifactsHasActiveFilters = computed(() =>
+  (showArtifactsArchFilter.value && artifactsArchFilter.value) ||
+  artifactsDateFilter.value ||
+  (showArtifactsAccelFilter.value && artifactsAccelFilter.value)
+)
+
+async function loadArtifactsData() {
+  const params = { type: 'wheels-collections', limit: ITEMS_PER_PAGE }
+  if (artifactsIsGrouped.value) {
+    params.group_by = artifactsGroupBy.value
+  } else {
+    params.offset = artifactsOffset.value
+    params.limit = ITEMS_PER_PAGE + 1
+  }
+  if (artifactsArchFilter.value && showArtifactsArchFilter.value) params.architectures = artifactsArchFilter.value
+  if (artifactsAccelFilter.value && showArtifactsAccelFilter.value) params.accelerator = artifactsAccelFilter.value
+  if (artifactsDateFilter.value) params.date_range = artifactsDateFilter.value
+
+  try {
+    artifactsLoading.value = true
+    artifactsError.value = null
+    const qs = new URLSearchParams(params).toString()
+
+    if (artifactsIsGrouped.value) {
+      const data = await apiRequest(`/modules/product-builds/artifacts?${qs}`)
+      artifactsData.value = data
+      if (data?.groups) {
+        expandedGroups.value = new Set(Object.keys(data.groups))
+      }
+    } else {
+      const response = await fetch(`${getApiBase()}/modules/product-builds/artifacts?${qs}`)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const data = await response.json()
+      const items = Array.isArray(data) ? data : []
+      artifactsHasNext.value = items.length > ITEMS_PER_PAGE
+      artifactsData.value = items.slice(0, ITEMS_PER_PAGE)
+
+      const totalCount = response.headers.get('X-Total-Count')
+      if (totalCount) {
+        artifactsTotalApprox.value = totalCount.includes('+')
+        const count = parseInt(totalCount.replace('+', ''))
+        artifactsTotalPages.value = Math.ceil(count / ITEMS_PER_PAGE)
+      } else {
+        artifactsTotalPages.value = null
+        artifactsTotalApprox.value = false
+      }
+    }
+  } catch (err) {
+    artifactsError.value = err.message || 'Failed to load artifacts'
+  } finally {
+    artifactsLoading.value = false
+  }
+}
+
+function resetArtifactsPagination() {
+  artifactsOffset.value = 0
+  artifactsPage.value = 1
+  artifactsHasNext.value = false
+  artifactsTotalPages.value = null
+  artifactsTotalApprox.value = false
+}
+
+function artifactsNextPage() {
+  artifactsOffset.value += ITEMS_PER_PAGE
+  artifactsPage.value++
+  loadArtifactsData()
+}
+
+function artifactsPreviousPage() {
+  artifactsOffset.value = Math.max(0, artifactsOffset.value - ITEMS_PER_PAGE)
+  artifactsPage.value = Math.max(1, artifactsPage.value - 1)
+  loadArtifactsData()
+}
+
+function handleViewAll(groupKey, groupedBy) {
+  artifactsGroupBy.value = 'all'
+  if (groupedBy === 'accelerator') artifactsAccelFilter.value = groupKey
+  else if (groupedBy === 'architecture') artifactsArchFilter.value = groupKey
+  resetArtifactsPagination()
+}
+
+function clearArtifactFilters() {
+  artifactsArchFilter.value = ''
+  artifactsAccelFilter.value = ''
+  artifactsDateFilter.value = ''
+  artifactsGroupBy.value = 'accelerator'
+  resetArtifactsPagination()
+}
+
+function toggleArtifactGroup(key) {
+  const next = new Set(expandedGroups.value)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  expandedGroups.value = next
+}
+
+function getDropName(artifact) {
+  const dropKey = artifact.drop_keys?.[0]
+  if (!dropKey) return null
+  return dropKey.replace('rhai-', '')
+}
+
+function navigateToDropFromArtifact(dropKey) {
+  nav.navigateTo('drop-detail', { key: dropKey, product: 'rhai' })
+}
+
+watch([artifactsGroupBy, artifactsArchFilter, artifactsAccelFilter, artifactsDateFilter], () => {
+  resetArtifactsPagination()
+  loadArtifactsData()
+})
+
+function navigateToArtifact(artifactKey) {
+  nav.navigateTo('artifact-detail', { key: artifactKey, product: 'rhai' })
+}
+
+watch(activeTab, (tab) => {
+  if (tab === 'artifacts' && !artifactsInitialized) {
+    artifactsInitialized = true
+    loadArtifactsData()
+  }
+})
+
+onMounted(() => {
+  browse.load()
+})
+
+onUnmounted(() => clearTimeout(searchTimeout))
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Header -->
+    <div>
+      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Wheel Collections</h1>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        Browse wheel collection releases or search for specific packages across releases
+      </p>
+    </div>
+
+    <!-- Tabs -->
+    <div class="border-b border-gray-200 dark:border-gray-700">
+      <nav class="flex gap-4">
+        <button
+          v-for="tab in [
+            { key: 'browse-all', label: 'Browse All' },
+            { key: 'search-package', label: 'Search by Package' },
+            { key: 'artifacts', label: 'Artifacts' },
+          ]"
+          :key="tab.key"
+          @click="activeTab = tab.key"
+          class="py-2 text-sm font-medium border-b-2 transition-colors"
+          :class="activeTab === tab.key
+            ? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+            : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+        >{{ tab.label }}</button>
+      </nav>
+    </div>
+
+    <!-- ==================== Browse All Tab ==================== -->
+    <div v-if="activeTab === 'browse-all'" class="space-y-4">
+      <!-- Search bar -->
+      <div class="flex items-center gap-3">
+        <div class="relative" style="width: 400px">
+          <input
+            type="text"
+            :value="searchInput"
+            @input="onSearchInput($event.target.value)"
+            placeholder="Search by key, variant, or commit"
+            class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 pr-8"
+          />
+          <button
+            v-if="searchInput"
+            @click="clearSearch"
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >&times;</button>
+        </div>
+        <span v-if="browse.loading.value" class="text-sm text-gray-500 dark:text-gray-400">Loading...</span>
+      </div>
+
+      <!-- Table -->
+      <div v-if="browse.error.value" class="text-sm text-red-600 dark:text-red-400">{{ browse.error.value }}</div>
+      <div v-else-if="!browse.loading.value && browse.artifacts.value.length === 0" class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+        {{ browse.searchValue.value ? 'No wheel collections match your search.' : 'No wheel collections found.' }}
+      </div>
+      <template v-if="browse.artifacts.value.length > 0">
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th
+                  @click="browse.toggleSort('key')"
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                  style="width: 30%"
+                >Key <span :class="getSortIndicatorClass('key')" class="ml-1">{{ getSortIndicator('key') }}</span></th>
+                <th
+                  @click="browse.toggleSort('variant')"
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                  style="width: 12%"
+                >Variant <span :class="getSortIndicatorClass('variant')" class="ml-1">{{ getSortIndicator('variant') }}</span></th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 10%">Architectures</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 14%">Packages</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 10%">Used In</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 8%">Commit</th>
+                <th
+                  @click="browse.toggleSort('created_at')"
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                  style="width: 16%"
+                >Created <span :class="getSortIndicatorClass('created_at')" class="ml-1">{{ getSortIndicator('created_at') }}</span></th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="art in browse.artifacts.value"
+                :key="art.key"
+                @click="navigateToArtifact(art.key)"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+              >
+                <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 break-all font-mono">
+                  <span @click.stop="navigateToArtifact(art.key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ art.variant || '—' }}</td>
+                <td class="px-4 py-3">
+                  <div class="flex gap-1 flex-wrap">
+                    <span
+                      v-for="arch in (art.archs || [])"
+                      :key="arch"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                      :class="archBadgeClass(arch)"
+                    >{{ arch }}</span>
+                    <span v-if="!art.archs?.length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-sm" @click.stop>
+                  <template v-if="parseBuildSequence(art.key)">
+                    <div class="relative inline-flex items-center gap-1">
+                      <button
+                        @click="togglePopover(art.key)"
+                        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50 cursor-pointer transition-colors"
+                      >
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
+                        {{ parseBuildSequence(art.key).total }} packages
+                      </button>
+                      <button
+                        @click="downloadBuildSequence(art.key)"
+                        class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                        title="Download build sequence as JSON"
+                      >
+                        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+                      </button>
+                      <!-- Popover -->
+                      <div
+                        v-if="openPopover === art.key"
+                        class="absolute left-0 top-full mt-1 z-50 w-96 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-lg"
+                      >
+                        <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+                          <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">Build Sequence Summary</span>
+                          <button @click="closePopover" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
+                        </div>
+                        <div class="px-3 py-2 max-h-80 overflow-y-auto space-y-3">
+                          <div v-if="parseBuildSequence(art.key).newBuilds.length">
+                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">New Builds ({{ parseBuildSequence(art.key).newBuilds.length }})</div>
+                            <div class="flex flex-wrap gap-1">
+                              <span v-for="e in parseBuildSequence(art.key).newBuilds" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
+                            </div>
+                          </div>
+                          <div v-if="parseBuildSequence(art.key).prebuilt.length">
+                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">Pre-built ({{ parseBuildSequence(art.key).prebuilt.length }})</div>
+                            <div class="flex flex-wrap gap-1">
+                              <span v-for="e in parseBuildSequence(art.key).prebuilt" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
+                            </div>
+                          </div>
+                          <div v-if="parseBuildSequence(art.key).skipped.length">
+                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">Skipped ({{ parseBuildSequence(art.key).skipped.length }})</div>
+                            <div class="flex flex-wrap gap-1">
+                              <span v-for="e in parseBuildSequence(art.key).skipped" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </template>
+                  <template v-else-if="browse.buildSequencesLoading.value">
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500">
+                      <svg class="animate-spin h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                      </svg>
+                      Loading…
+                    </span>
+                  </template>
+                  <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                </td>
+                <td class="px-4 py-3 text-sm" @click.stop>
+                  <div v-if="art.container_count > 0" class="relative inline-block">
+                    <span
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 cursor-default"
+                      @mouseenter="onContainerMouseEnter(art.key)"
+                      @mouseleave="onContainerMouseLeave"
+                    >{{ art.container_count }} container{{ art.container_count !== 1 ? 's' : '' }}</span>
+                    <!-- Container popover -->
+                    <div
+                      v-if="containerHover === art.key"
+                      class="absolute left-0 top-full mt-1 z-50 w-96 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-lg"
+                      @mouseenter="onContainerPopoverEnter"
+                      @mouseleave="onContainerPopoverLeave"
+                    >
+                      <div class="px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+                        <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">Container{{ art.container_count !== 1 ? 's' : '' }}</span>
+                      </div>
+                      <div class="px-3 py-2 max-h-60 overflow-y-auto">
+                        <div v-if="containerCache[art.key]?.loading" class="text-sm text-gray-500 dark:text-gray-400">Loading containers…</div>
+                        <div v-else-if="containerCache[art.key]?.error" class="text-sm text-red-600 dark:text-red-400">Failed to load containers</div>
+                        <ul v-else-if="containerCache[art.key]?.data?.length" class="list-disc pl-5 space-y-1">
+                          <li v-for="c in containerCache[art.key].data.slice(0, 10)" :key="c.key" class="text-xs">
+                            <span class="font-mono text-gray-800 dark:text-gray-200 break-all">{{ c.key }}</span>
+                            <span v-if="c.variant" class="text-gray-500 dark:text-gray-400 ml-1">({{ c.variant }})</span>
+                          </li>
+                        </ul>
+                        <div v-else class="text-sm text-gray-500 dark:text-gray-400">No containers found</div>
+                        <div v-if="containerCache[art.key]?.data?.length > 10" class="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700 text-[11px] text-gray-500 dark:text-gray-400 italic">
+                          Showing first 10 of {{ art.container_count }} containers
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                </td>
+                <td class="px-4 py-3 text-sm font-mono" @click.stop>
+                  <a
+                    v-if="art.commit && getCommitUrl(art)"
+                    :href="getCommitUrl(art)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary-600 dark:text-blue-400 hover:underline"
+                  >{{ formatCommit(art.commit) }}</a>
+                  <span v-else-if="art.commit" class="text-gray-600 dark:text-gray-300">{{ formatCommit(art.commit) }}</span>
+                  <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(art.created_at) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        <div class="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+          <span>Showing {{ browse.artifacts.value.length }} wheel collections{{ browse.pageNumber.value > 1 ? ` (page ${browse.pageNumber.value})` : '' }}</span>
+          <div v-if="browse.hasPrevious.value || browse.hasNext.value" class="flex items-center gap-2">
+            <button
+              :disabled="!browse.hasPrevious.value"
+              @click="browse.previousPage()"
+              class="px-3 py-1 rounded border text-sm font-medium transition-colors"
+              :class="browse.hasPrevious.value
+                ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
+            >Previous</button>
+            <span>Page {{ browse.pageNumber.value }}</span>
+            <button
+              :disabled="!browse.hasNext.value"
+              @click="browse.nextPage()"
+              class="px-3 py-1 rounded border text-sm font-medium transition-colors"
+              :class="browse.hasNext.value
+                ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
+            >Next</button>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <!-- ==================== Search by Package Tab ==================== -->
+    <div v-if="activeTab === 'search-package'" class="space-y-4">
+      <!-- Search form -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+        <form @submit.prevent="handlePackageSearch" class="flex gap-4 items-end flex-wrap">
+          <div class="flex-1" style="min-width: 250px">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Package Name <span class="text-red-500">*</span></label>
+            <input
+              v-model="packageName"
+              type="text"
+              placeholder="e.g., vllm, transformers, numpy"
+              class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+              @keydown.enter.prevent="handlePackageSearch"
+            />
+          </div>
+
+          <div style="min-width: 180px">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Product</label>
+            <select
+              v-model="selectedProduct"
+              class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+            >
+              <option value="all">All Products</option>
+              <option v-for="p in filters.products.value" :key="p.key" :value="p.key">{{ p.short_name || p.key }}</option>
+            </select>
+          </div>
+
+          <div style="min-width: 150px">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Series</label>
+            <select
+              v-model="selectedSeries"
+              :disabled="selectedProduct === 'all' || filters.series.value.length === 0"
+              class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+              :title="selectedProduct === 'all' ? 'Select a specific product to filter by series' : 'Filter by version series'"
+            >
+              <option value="all">All Series</option>
+              <option v-for="s in filters.series.value" :key="s" :value="s">{{ s }}</option>
+            </select>
+          </div>
+
+          <div style="min-width: 150px">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Variant</label>
+            <select
+              v-model="selectedVariant"
+              class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+            >
+              <option value="all">All Variants</option>
+              <option v-for="v in filters.variants.value" :key="v" :value="v">{{ v }}</option>
+            </select>
+          </div>
+
+          <button
+            type="submit"
+            :disabled="!packageName.trim() || pkgSearch.loading.value"
+            class="px-4 py-1.5 rounded-lg text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <span v-if="pkgSearch.loading.value" class="inline-flex items-center gap-2">
+              <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+              </svg>
+              Searching...
+            </span>
+            <span v-else>Search</span>
+          </button>
+        </form>
+      </div>
+
+      <!-- Search error -->
+      <div v-if="pkgSearch.error.value" class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-700 dark:text-red-400">
+        {{ pkgSearch.error.value }}
+      </div>
+
+      <!-- Search results -->
+      <template v-if="pkgSearch.results.value !== null && !pkgSearch.loading.value">
+        <div v-if="pkgSearch.results.value.length === 0" class="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-3 text-sm text-blue-700 dark:text-blue-400">
+          No releases found containing package "{{ packageName }}"
+        </div>
+
+        <template v-else>
+          <div class="text-sm text-gray-500 dark:text-gray-400">
+            Showing {{ pkgSearch.results.value.length }} release{{ pkgSearch.results.value.length !== 1 ? 's' : '' }} containing "{{ packageName }}"
+            {{ pkgSearch.pageNumber.value > 1 ? ` — Page ${pkgSearch.pageNumber.value}` : '' }}
+          </div>
+
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead class="bg-gray-50 dark:bg-gray-900/50">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 40%">Collection</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 20%">Variant</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 20%">Package Version</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 20%">Created</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                <tr
+                  v-for="result in pkgSearch.results.value"
+                  :key="result.artifact_key"
+                  @click="navigateToArtifact(result.artifact_key)"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+                >
+                  <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 break-all font-mono">
+                    <span @click.stop="navigateToArtifact(result.artifact_key)" class="hover:underline cursor-pointer">{{ result.artifact_key }}</span>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ result.variant || '—' }}</td>
+                  <td class="px-4 py-3">
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ result.package_version }}</span>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(result.created_at) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Search pagination -->
+          <div v-if="pkgSearch.hasPrevious.value || pkgSearch.hasMore.value" class="flex items-center justify-end gap-2 text-sm">
+            <button
+              :disabled="!pkgSearch.hasPrevious.value"
+              @click="handleSearchPreviousPage"
+              class="px-3 py-1 rounded border text-sm font-medium transition-colors"
+              :class="pkgSearch.hasPrevious.value
+                ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
+            >Previous</button>
+            <span class="text-gray-500 dark:text-gray-400">Page {{ pkgSearch.pageNumber.value }}</span>
+            <button
+              :disabled="!pkgSearch.hasMore.value"
+              @click="handleSearchNextPage"
+              class="px-3 py-1 rounded border text-sm font-medium transition-colors"
+              :class="pkgSearch.hasMore.value
+                ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
+            >Next</button>
+          </div>
+        </template>
+      </template>
+    </div>
+
+    <!-- ==================== Artifacts Tab ==================== -->
+    <div v-if="activeTab === 'artifacts'" class="space-y-4">
+      <!-- Filter bar -->
+      <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-3">
+        <div class="flex flex-wrap gap-4 items-end">
+          <!-- Group By -->
+          <div style="min-width: 140px">
+            <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Group By</label>
+            <select v-model="artifactsGroupBy" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+              <option v-for="opt in GROUP_BY_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+            </select>
+          </div>
+
+          <!-- Architecture -->
+          <div v-if="showArtifactsArchFilter" style="min-width: 150px">
+            <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Architecture</label>
+            <select v-model="artifactsArchFilter" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+              <option value="">All</option>
+              <option v-for="arch in AVAILABLE_ARCHS" :key="arch" :value="arch">{{ arch }}</option>
+            </select>
+          </div>
+
+          <!-- Accelerator -->
+          <div v-if="showArtifactsAccelFilter" style="min-width: 150px">
+            <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Accelerator</label>
+            <select v-model="artifactsAccelFilter" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+              <option value="">All</option>
+              <option v-for="accel in AVAILABLE_ACCELS" :key="accel" :value="accel">{{ accel }}</option>
+            </select>
+          </div>
+
+          <!-- Date Range -->
+          <div style="min-width: 150px">
+            <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Date Range</label>
+            <select v-model="artifactsDateFilter" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+              <option value="">All time</option>
+              <option v-for="d in DATE_RANGE_OPTIONS" :key="d.value" :value="d.value">{{ d.label }}</option>
+            </select>
+          </div>
+
+          <!-- Clear all -->
+          <button
+            v-if="artifactsHasActiveFilters"
+            @click="clearArtifactFilters"
+            class="ml-auto px-4 py-1.5 rounded-lg text-sm font-semibold text-white bg-red-600 hover:bg-red-700 transition-colors"
+          >Clear all filters</button>
+        </div>
+      </div>
+
+      <!-- Loading / Error -->
+      <div v-if="artifactsLoading && !artifactsData" class="text-sm text-gray-500 dark:text-gray-400">Loading artifacts…</div>
+      <div v-if="artifactsError" class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-700 dark:text-red-400">{{ artifactsError }}</div>
+
+      <!-- Grouped mode -->
+      <template v-if="artifactsIsGrouped && artifactsData?.groups && !artifactsError">
+        <div v-if="Object.keys(artifactsData.groups).length === 0 && !artifactsLoading" class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+          No artifacts match the current filters.
+        </div>
+        <div v-for="groupKey in Object.keys(artifactsData.groups)" :key="groupKey" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <div
+            @click="toggleArtifactGroup(groupKey)"
+            class="flex items-center gap-2 px-4 py-3 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700 cursor-pointer select-none"
+          >
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform" :class="{ 'rotate-90': expandedGroups.has(groupKey) }" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+            <span
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+              :class="artifactsData.grouped_by === 'architecture' ? archBadgeClass(groupKey) : 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'"
+            >{{ groupKey }}</span>
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ artifactsData.groups[groupKey].count }}</span>
+          </div>
+          <template v-if="expandedGroups.has(groupKey)">
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-900/30">
+                  <tr>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                    <th v-if="artifactsData.groups[groupKey].artifacts.some(a => a.series)" class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Series</th>
+                    <th v-if="artifactsData.groups[groupKey].artifacts.some(a => a.environments?.length)" class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Environment</th>
+                    <th v-if="artifactsData.grouped_by !== 'architecture'" class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Architectures</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Commit</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Drop</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                  <tr
+                    v-for="art in artifactsData.groups[groupKey].artifacts"
+                    :key="art.key"
+                    @click="navigateToArtifact(art.key)"
+                    class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+                  >
+                    <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 break-all font-mono">
+                      <span @click.stop="navigateToArtifact(art.key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
+                    </td>
+                    <td v-if="artifactsData.groups[groupKey].artifacts.some(a => a.series)" class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ art.series || '—' }}</td>
+                    <td v-if="artifactsData.groups[groupKey].artifacts.some(a => a.environments?.length)" class="px-4 py-3" @click.stop>
+                      <div class="flex gap-1 flex-wrap">
+                        <span v-for="env in (art.environments || [])" :key="env" class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="envBadgeClass(env)">{{ env }}</span>
+                        <span v-if="!art.environments?.length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                      </div>
+                    </td>
+                    <td v-if="artifactsData.grouped_by !== 'architecture'" class="px-4 py-3" @click.stop>
+                      <div class="flex gap-1 flex-wrap">
+                        <span v-for="arch in (art.archs || [])" :key="arch" class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="archBadgeClass(arch)">{{ arch }}</span>
+                        <span v-if="!art.archs?.length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                      </div>
+                    </td>
+                    <td class="px-4 py-3 text-sm font-mono" @click.stop>
+                      <a v-if="art.commit && getCommitUrl(art)" :href="getCommitUrl(art)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ formatCommit(art.commit) }}</a>
+                      <span v-else-if="art.commit" class="text-gray-600 dark:text-gray-300">{{ formatCommit(art.commit) }}</span>
+                      <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                    </td>
+                    <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(art.created_at) }}</td>
+                    <td class="px-4 py-3 text-sm" @click.stop>
+                      <span v-if="getDropName(art)" @click="navigateToDropFromArtifact(art.drop_keys[0])" class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer">{{ getDropName(art) }}</span>
+                      <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div v-if="artifactsData.groups[groupKey].count > artifactsData.groups[groupKey].artifacts.length" class="py-3 text-center border-t border-gray-200 dark:border-gray-700">
+              <button @click="handleViewAll(groupKey, artifactsData.grouped_by)" class="text-sm font-medium text-primary-600 dark:text-blue-400 hover:underline">
+                View all {{ artifactsData.groups[groupKey].count }} artifacts
+              </button>
+            </div>
+          </template>
+        </div>
+      </template>
+
+      <!-- Ungrouped mode -->
+      <template v-if="!artifactsIsGrouped && Array.isArray(artifactsData) && !artifactsError">
+        <div v-if="artifactsData.length === 0 && !artifactsLoading" class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+          No artifacts match the current filters.
+        </div>
+        <div v-else class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th v-if="artifactsData.some(a => a.series)" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Series</th>
+                <th v-if="artifactsData.some(a => a.environments?.length)" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Environment</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Architectures</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Commit</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Drop</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="art in artifactsData"
+                :key="art.key"
+                @click="navigateToArtifact(art.key)"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
+              >
+                <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 break-all font-mono">
+                  <span @click.stop="navigateToArtifact(art.key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
+                </td>
+                <td v-if="artifactsData.some(a => a.series)" class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ art.series || '—' }}</td>
+                <td v-if="artifactsData.some(a => a.environments?.length)" class="px-4 py-3" @click.stop>
+                  <div class="flex gap-1 flex-wrap">
+                    <span v-for="env in (art.environments || [])" :key="env" class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="envBadgeClass(env)">{{ env }}</span>
+                    <span v-if="!art.environments?.length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3" @click.stop>
+                  <div class="flex gap-1 flex-wrap">
+                    <span v-for="arch in (art.archs || [])" :key="arch" class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="archBadgeClass(arch)">{{ arch }}</span>
+                    <span v-if="!art.archs?.length" class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-sm font-mono" @click.stop>
+                  <a v-if="art.commit && getCommitUrl(art)" :href="getCommitUrl(art)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ formatCommit(art.commit) }}</a>
+                  <span v-else-if="art.commit" class="text-gray-600 dark:text-gray-300">{{ formatCommit(art.commit) }}</span>
+                  <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(art.created_at) }}</td>
+                <td class="px-4 py-3 text-sm" @click.stop>
+                  <span v-if="getDropName(art)" @click="navigateToDropFromArtifact(art.drop_keys[0])" class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer">{{ getDropName(art) }}</span>
+                  <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        <div v-if="artifactsPage > 1 || artifactsHasNext" class="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+          <span>Page {{ artifactsPage }}<template v-if="artifactsTotalPages"> of {{ artifactsTotalPages }}{{ artifactsTotalApprox ? '+' : '' }}</template></span>
+          <div class="flex items-center gap-2">
+            <button
+              :disabled="artifactsPage <= 1"
+              @click="artifactsPreviousPage"
+              class="px-3 py-1 rounded border text-sm font-medium transition-colors"
+              :class="artifactsPage > 1
+                ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
+            >Previous</button>
+            <button
+              :disabled="!artifactsHasNext"
+              @click="artifactsNextPage"
+              class="px-3 py-1 rounded border text-sm font-medium transition-colors"
+              :class="artifactsHasNext
+                ? 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
+            >Next</button>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/modules/product-builds/client/views/WheelCollectionsView.vue
+++ b/modules/product-builds/client/views/WheelCollectionsView.vue
@@ -3,6 +3,7 @@ import { ref, reactive, computed, watch, onMounted, onUnmounted, inject } from '
 import { useWheelBrowse, useWheelPackageSearch, useWheelFilters } from '../composables/useWheelCollections'
 import { formatDate, envBadgeClass, archBadgeClass } from '../utils/formatting'
 import { apiRequest, getApiBase } from '@shared/client/services/api'
+import { impersonatingUid } from '@shared/client/state/impersonation'
 
 const nav = inject('moduleNav')
 
@@ -34,23 +35,24 @@ function getSortIndicatorClass(column) {
   return browse.sortColumn.value === column ? 'text-primary-600 dark:text-blue-400' : 'text-gray-300 dark:text-gray-600'
 }
 
-function parseBuildSequence(key) {
-  const json = browse.buildSequences.value[key]
-  if (!json) return null
-  try {
-    const entries = JSON.parse(json)
-    if (!Array.isArray(entries)) return null
-    const newBuilds = []
-    const prebuilt = []
-    const skipped = []
-    for (const e of entries) {
-      if (e.skipped) skipped.push(e)
-      else if (e.prebuilt) prebuilt.push(e)
-      else newBuilds.push(e)
-    }
-    return { total: entries.length, newBuilds, prebuilt, skipped }
-  } catch { return null }
-}
+const parsedBuildSequences = computed(() => {
+  const map = {}
+  for (const [key, json] of Object.entries(browse.buildSequences.value)) {
+    if (!json) continue
+    try {
+      const entries = JSON.parse(json)
+      if (!Array.isArray(entries)) continue
+      const newBuilds = [], prebuilt = [], skipped = []
+      for (const e of entries) {
+        if (e.skipped) skipped.push(e)
+        else if (e.prebuilt) prebuilt.push(e)
+        else newBuilds.push(e)
+      }
+      map[key] = { total: entries.length, newBuilds, prebuilt, skipped }
+    } catch { /* skip */ }
+  }
+  return map
+})
 
 const openPopover = ref(null)
 
@@ -107,19 +109,18 @@ function downloadBuildSequence(key) {
 }
 
 function getCommitUrl(artifact) {
-  const commit = artifact?.commit || artifact?.labels?.['git.commit']
+  const commit = artifact?.commit || artifact?.labels?.['git.commit'] || artifact?.labels?.['org.opencontainers.image.revision'] || artifact?.labels?.['vcs-ref']
   if (!commit) return null
 
   let repoUrl = null
   if (artifact.git_repository) {
-    repoUrl = typeof artifact.git_repository === 'string'
-      ? artifact.git_repository
-      : artifact.git_repository.url
+    repoUrl = typeof artifact.git_repository === 'string' ? artifact.git_repository : artifact.git_repository?.url
   }
   if (!repoUrl) {
-    repoUrl = artifact.labels?.['vcs-ref'] ? null : artifact.labels?.['io.openshift.build.source-location']
+    const labels = artifact.labels || {}
+    repoUrl = labels['git.url'] || labels['org.opencontainers.image.source'] || labels['url'] || null
   }
-  if (!repoUrl) return null
+  if (!repoUrl || typeof repoUrl !== 'string') return null
 
   const baseUrl = repoUrl.replace(/\.git$/, '').replace(/\/$/, '')
   return `${baseUrl}/-/commit/${commit}`
@@ -238,7 +239,9 @@ async function loadArtifactsData() {
         expandedGroups.value = new Set(Object.keys(data.groups))
       }
     } else {
-      const response = await fetch(`${getApiBase()}/modules/product-builds/artifacts?${qs}`)
+      const fetchHeaders = {}
+      if (impersonatingUid.value) fetchHeaders['X-Impersonate-Uid'] = impersonatingUid.value
+      const response = await fetch(`${getApiBase()}/modules/product-builds/artifacts?${qs}`, { headers: fetchHeaders })
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
       const data = await response.json()
       const items = Array.isArray(data) ? data : []
@@ -307,11 +310,14 @@ function toggleArtifactGroup(key) {
 function getDropName(artifact) {
   const dropKey = artifact.drop_keys?.[0]
   if (!dropKey) return null
-  return dropKey.replace('rhai-', '')
+  const productKey = artifact.product_key || 'rhai'
+  return dropKey.replace(`${productKey}-`, '')
 }
 
-function navigateToDropFromArtifact(dropKey) {
-  nav.navigateTo('drop-detail', { key: dropKey, product: 'rhai' })
+function navigateToDropFromArtifact(artifact) {
+  const dropKey = artifact.drop_keys?.[0]
+  if (!dropKey) return
+  nav.navigateTo('drop-detail', { key: dropKey, product: artifact.product_key || 'rhai' })
 }
 
 watch([artifactsGroupBy, artifactsArchFilter, artifactsAccelFilter, artifactsDateFilter], () => {
@@ -319,8 +325,8 @@ watch([artifactsGroupBy, artifactsArchFilter, artifactsAccelFilter, artifactsDat
   loadArtifactsData()
 })
 
-function navigateToArtifact(artifactKey) {
-  nav.navigateTo('artifact-detail', { key: artifactKey, product: 'rhai' })
+function navigateToArtifact(artifactKey, productKey) {
+  nav.navigateTo('artifact-detail', { key: artifactKey, product: productKey || 'rhai' })
 }
 
 watch(activeTab, (tab) => {
@@ -334,7 +340,7 @@ onMounted(() => {
   browse.load()
 })
 
-onUnmounted(() => clearTimeout(searchTimeout))
+onUnmounted(() => { clearTimeout(searchTimeout); clearTimeout(containerHoverTimer) })
 </script>
 
 <template>
@@ -441,14 +447,14 @@ onUnmounted(() => clearTimeout(searchTimeout))
                   </div>
                 </td>
                 <td class="px-4 py-3 text-sm" @click.stop>
-                  <template v-if="parseBuildSequence(art.key)">
+                  <template v-if="parsedBuildSequences[art.key]">
                     <div class="relative inline-flex items-center gap-1">
                       <button
                         @click="togglePopover(art.key)"
                         class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50 cursor-pointer transition-colors"
                       >
                         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
-                        {{ parseBuildSequence(art.key).total }} packages
+                        {{ parsedBuildSequences[art.key].total }} packages
                       </button>
                       <button
                         @click="downloadBuildSequence(art.key)"
@@ -467,22 +473,22 @@ onUnmounted(() => clearTimeout(searchTimeout))
                           <button @click="closePopover" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
                         </div>
                         <div class="px-3 py-2 max-h-80 overflow-y-auto space-y-3">
-                          <div v-if="parseBuildSequence(art.key).newBuilds.length">
-                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">New Builds ({{ parseBuildSequence(art.key).newBuilds.length }})</div>
+                          <div v-if="parsedBuildSequences[art.key].newBuilds.length">
+                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">New Builds ({{ parsedBuildSequences[art.key].newBuilds.length }})</div>
                             <div class="flex flex-wrap gap-1">
-                              <span v-for="e in parseBuildSequence(art.key).newBuilds" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
+                              <span v-for="e in parsedBuildSequences[art.key].newBuilds" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
                             </div>
                           </div>
-                          <div v-if="parseBuildSequence(art.key).prebuilt.length">
-                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">Pre-built ({{ parseBuildSequence(art.key).prebuilt.length }})</div>
+                          <div v-if="parsedBuildSequences[art.key].prebuilt.length">
+                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">Pre-built ({{ parsedBuildSequences[art.key].prebuilt.length }})</div>
                             <div class="flex flex-wrap gap-1">
-                              <span v-for="e in parseBuildSequence(art.key).prebuilt" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
+                              <span v-for="e in parsedBuildSequences[art.key].prebuilt" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
                             </div>
                           </div>
-                          <div v-if="parseBuildSequence(art.key).skipped.length">
-                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">Skipped ({{ parseBuildSequence(art.key).skipped.length }})</div>
+                          <div v-if="parsedBuildSequences[art.key].skipped.length">
+                            <div class="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">Skipped ({{ parsedBuildSequences[art.key].skipped.length }})</div>
                             <div class="flex flex-wrap gap-1">
-                              <span v-for="e in parseBuildSequence(art.key).skipped" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
+                              <span v-for="e in parsedBuildSequences[art.key].skipped" :key="e.name" class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">{{ e.name }}=={{ e.version }}</span>
                             </div>
                           </div>
                         </div>
@@ -805,11 +811,11 @@ onUnmounted(() => clearTimeout(searchTimeout))
                   <tr
                     v-for="art in artifactsData.groups[groupKey].artifacts"
                     :key="art.key"
-                    @click="navigateToArtifact(art.key)"
+                    @click="navigateToArtifact(art.key, art.product_key)"
                     class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
                   >
                     <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 break-all font-mono">
-                      <span @click.stop="navigateToArtifact(art.key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
+                      <span @click.stop="navigateToArtifact(art.key, art.product_key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
                     </td>
                     <td v-if="artifactsData.groups[groupKey].artifacts.some(a => a.series)" class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ art.series || '—' }}</td>
                     <td v-if="artifactsData.groups[groupKey].artifacts.some(a => a.environments?.length)" class="px-4 py-3" @click.stop>
@@ -831,7 +837,7 @@ onUnmounted(() => clearTimeout(searchTimeout))
                     </td>
                     <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(art.created_at) }}</td>
                     <td class="px-4 py-3 text-sm" @click.stop>
-                      <span v-if="getDropName(art)" @click="navigateToDropFromArtifact(art.drop_keys[0])" class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer">{{ getDropName(art) }}</span>
+                      <span v-if="getDropName(art)" @click="navigateToDropFromArtifact(art)" class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer">{{ getDropName(art) }}</span>
                       <span v-else class="text-gray-400 dark:text-gray-500">—</span>
                     </td>
                   </tr>
@@ -869,11 +875,11 @@ onUnmounted(() => clearTimeout(searchTimeout))
               <tr
                 v-for="art in artifactsData"
                 :key="art.key"
-                @click="navigateToArtifact(art.key)"
+                @click="navigateToArtifact(art.key, art.product_key)"
                 class="hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer transition-colors"
               >
                 <td class="px-4 py-3 text-sm font-medium text-primary-600 dark:text-blue-400 break-all font-mono">
-                  <span @click.stop="navigateToArtifact(art.key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
+                  <span @click.stop="navigateToArtifact(art.key, art.product_key)" class="hover:underline cursor-pointer">{{ art.key }}</span>
                 </td>
                 <td v-if="artifactsData.some(a => a.series)" class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ art.series || '—' }}</td>
                 <td v-if="artifactsData.some(a => a.environments?.length)" class="px-4 py-3" @click.stop>
@@ -895,7 +901,7 @@ onUnmounted(() => clearTimeout(searchTimeout))
                 </td>
                 <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ formatDate(art.created_at) }}</td>
                 <td class="px-4 py-3 text-sm" @click.stop>
-                  <span v-if="getDropName(art)" @click="navigateToDropFromArtifact(art.drop_keys[0])" class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer">{{ getDropName(art) }}</span>
+                  <span v-if="getDropName(art)" @click="navigateToDropFromArtifact(art)" class="text-primary-600 dark:text-blue-400 hover:underline cursor-pointer">{{ getDropName(art) }}</span>
                   <span v-else class="text-gray-400 dark:text-gray-500">—</span>
                 </td>
               </tr>

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -288,6 +288,92 @@ module.exports = function registerRoutes(router, context) {
 
   /**
    * @openapi
+   * /api/modules/product-builds/artifacts/build-sequences:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get build sequence summaries for a batch of artifacts
+   *     description: Returns build_sequence_summary JSON strings for up to 50 artifact keys. Used by list views to populate package detail columns on demand.
+   *     parameters:
+   *       - name: keys
+   *         in: query
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Comma-separated list of artifact keys (max 50)
+   *     responses:
+   *       200:
+   *         description: Object mapping each key to its build_sequence_summary string (or null)
+   *       400:
+   *         description: Too many keys (over 50)
+   */
+  router.get('/artifacts/build-sequences', function(req, res) {
+    upstream('/artifacts/build-sequences', req, res);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/artifacts/wheels-collections/filters:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get wheel collection filter options
+   *     description: Returns available product keys and variants for wheel-collection artifacts, used to populate filter dropdowns.
+   *     responses:
+   *       200:
+   *         description: Object with product_keys (string[]) and variants (string[])
+   */
+  router.get('/artifacts/wheels-collections/filters', function(req, res) {
+    upstream('/artifacts/wheels-collections/filters', req, res);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/artifacts/wheels/build-history/{packageName}:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Search wheel collections by package name
+   *     description: Finds wheel-collection artifacts that contain the specified Python package in their build sequence.
+   *     parameters:
+   *       - name: packageName
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Python package name to search for (e.g. vllm, transformers)
+   *       - name: product_key
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by product key
+   *       - name: series
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by version series (requires product_key)
+   *       - name: variant_filter
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by variant
+   *       - name: limit
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           default: 20
+   *       - name: offset
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           default: 0
+   *     responses:
+   *       200:
+   *         description: Array of objects with artifact_key, variant, package_version, created_at
+   */
+  router.get('/artifacts/wheels/build-history/:packageName', function(req, res) {
+    upstream(`/artifacts/wheels/build-history/${encodeURIComponent(req.params.packageName)}`, req, res);
+  });
+
+  /**
+   * @openapi
    * /api/modules/product-builds/artifacts:
    *   get:
    *     tags: [Product Builds]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "version": "1.0.18",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1063.0",
+        "@dagrejs/dagre": "^3.0.0",
+        "@vue-flow/background": "^1.3.2",
+        "@vue-flow/controls": "^1.1.3",
+        "@vue-flow/core": "^1.48.2",
+        "@vue-flow/minimap": "^1.5.4",
         "@vueuse/core": "^14.3.0",
         "adm-zip": "^0.5.17",
         "async-retry": "^1.3.3",
@@ -771,6 +776,21 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -2370,6 +2390,150 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vue-flow/background": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/background/-/background-1.3.2.tgz",
+      "integrity": "sha512-eJPhDcLj1wEo45bBoqTXw1uhl0yK2RaQGnEINqvvBsAFKh/camHJd5NPmOdS1w+M9lggc9igUewxaEd3iCQX2w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/controls": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vue-flow/controls/-/controls-1.1.3.tgz",
+      "integrity": "sha512-XCf+G+jCvaWURdFlZmOjifZGw3XMhN5hHlfMGkWh9xot+9nH9gdTZtn+ldIJKtarg3B21iyHU8JjKDhYcB6JMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/core": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.48.2.tgz",
+      "integrity": "sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "^10.5.0",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/shared": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue-flow/minimap": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@vue-flow/minimap/-/minimap-1.5.4.tgz",
+      "integrity": "sha512-l4C+XTAXnRxsRpUdN7cAVFBennC1sVRzq4bDSpVK+ag7tdMczAnhFYGgbLkUw3v3sY6gokyWwMl8CDonp8eB2g==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.28",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
@@ -3706,6 +3870,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",
+    "@dagrejs/dagre": "^3.0.0",
+    "@vue-flow/background": "^1.3.2",
+    "@vue-flow/controls": "^1.1.3",
+    "@vue-flow/core": "^1.48.2",
+    "@vue-flow/minimap": "^1.5.4",
     "@vueuse/core": "^14.3.0",
     "adm-zip": "^0.5.17",
     "async-retry": "^1.3.3",


### PR DESCRIPTION
Add dedicated Wheel Collections page with three tabs:
- Browse All: searchable, sortable, paginated artifact listing with build sequence popovers and container hover details
- Search by Package: find packages across wheel collections with product/variant filters
- Artifacts: grouped (by accelerator/architecture) or paginated flat listing with filtering by architecture, accelerator, and date range

Add interactive dependency graph to artifact detail page for wheels-collections using Vue Flow and Dagre for hierarchical layout. Supports package selection, subset rendering, build-time dependency toggle, and clickable node navigation.

Fix commit URLs to derive repository from artifact git_repository field instead of hardcoding to rhaiis pipeline repo.