### PR TITLE
fix(pulse-social): make post body clickable to open detail view

### DIFF
--- a/modules/pulse-social/client/components/PostCard.vue
+++ b/modules/pulse-social/client/components/PostCard.vue
@@ -87,6 +87,7 @@
         <!-- Action bar (Twitter-style, always visible) -->
         <ReactionBar
           :reactions="post.reactions || {}"
+          :my-reactions="post.my_reactions || []"
           :comment-count="post.comment_count"
           :post-id="post.id"
           @toggle="handleReaction"

--- a/modules/pulse-social/client/components/PostCard.vue
+++ b/modules/pulse-social/client/components/PostCard.vue
@@ -26,14 +26,34 @@
           <span v-if="post.pinned" class="text-xs" title="Pinned">📌</span>
           <span v-if="post.edited_at" class="text-xs text-gray-400">(edited)</span>
           <span class="flex-1"></span>
-          <!-- Open detail -->
-          <button
-            @click="$emit('open-post', post.id)"
-            class="text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
-            title="Open post"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-          </button>
+          <!-- 3-dot overflow menu (LinkedIn-style) -->
+          <div class="relative">
+            <button
+              @click.stop="menuOpen = !menuOpen"
+              class="w-7 h-7 flex items-center justify-center rounded-full text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-600 dark:hover:text-gray-300 transition-all cursor-pointer opacity-0 group-hover:opacity-100"
+              :class="{ '!opacity-100': menuOpen }"
+              aria-label="Post options"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
+            </button>
+            <div
+              v-if="menuOpen"
+              class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 w-36 z-20"
+            >
+              <button
+                @click.stop="$emit('open-post', post.id); menuOpen = false"
+                class="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
+              >
+                Open post
+              </button>
+              <button
+                @click.stop="$emit('delete-post', post.id); menuOpen = false"
+                class="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer"
+              >
+                Delete post
+              </button>
+            </div>
+          </div>
         </div>
 
         <!-- Body (clickable to open detail) -->
@@ -102,7 +122,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import PersonAvatar from './PersonAvatar.vue'
 import LabelBadge from './LabelBadge.vue'
 import MarkdownRenderer from './MarkdownRenderer.vue'
@@ -115,11 +135,26 @@ const props = defineProps({
   highlight: { type: Boolean, default: false }
 })
 
-const emit = defineEmits(['open-post', 'react', 'comment'])
+const emit = defineEmits(['open-post', 'react', 'comment', 'delete-post'])
 
 const expanded = ref(false)
 const showComments = ref(false)
 const localComments = ref([])
+const menuOpen = ref(false)
+
+function handleMenuClickOutside(e) {
+  if (menuOpen.value && !e.target.closest('[aria-label="Post options"]') && !e.target.closest('[aria-label="Post options"] + div')) {
+    menuOpen.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleMenuClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleMenuClickOutside)
+})
 
 const truncated = computed(() => {
   if (!props.post.body) return false

--- a/modules/pulse-social/client/components/PostCard.vue
+++ b/modules/pulse-social/client/components/PostCard.vue
@@ -74,7 +74,7 @@
           </div>
           <button
             v-if="truncated && !expanded"
-            @click="expanded = true"
+            @click.stop="expanded = true"
             class="text-primary-600 dark:text-primary-400 text-sm font-medium hover:underline mt-0.5 cursor-pointer"
           >
             Show more

--- a/modules/pulse-social/client/components/PostCard.vue
+++ b/modules/pulse-social/client/components/PostCard.vue
@@ -38,7 +38,7 @@
             </button>
             <div
               v-if="menuOpen"
-              class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 w-36 z-20"
+              class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 w-44 z-20"
             >
               <button
                 @click.stop="$emit('open-post', post.id); menuOpen = false"
@@ -47,10 +47,18 @@
                 Open post
               </button>
               <button
+                v-if="isOwnPost"
                 @click.stop="$emit('delete-post', post.id); menuOpen = false"
                 class="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer"
               >
-                Delete post
+                Delete my post
+              </button>
+              <button
+                v-else-if="isAdmin"
+                @click.stop="$emit('delete-post', post.id); menuOpen = false"
+                class="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer"
+              >
+                Remove (admin)
               </button>
             </div>
           </div>
@@ -129,6 +137,7 @@ import MarkdownRenderer from './MarkdownRenderer.vue'
 import AttachmentPreview from './AttachmentPreview.vue'
 import ReactionBar from './ReactionBar.vue'
 import InlineComment from './InlineComment.vue'
+import { useAuth } from '@shared/client/composables/useAuth'
 
 const props = defineProps({
   post: { type: Object, required: true },
@@ -137,10 +146,19 @@ const props = defineProps({
 
 const emit = defineEmits(['open-post', 'react', 'comment', 'delete-post'])
 
+const { user, isAdmin: authIsAdmin } = useAuth()
+
 const expanded = ref(false)
 const showComments = ref(false)
 const localComments = ref([])
 const menuOpen = ref(false)
+
+const isOwnPost = computed(() => {
+  const uid = user.value?.uid || user.value?.email || ''
+  return props.post.author_uid === uid
+})
+
+const isAdmin = computed(() => authIsAdmin.value)
 
 function handleMenuClickOutside(e) {
   if (menuOpen.value && !e.target.closest('[aria-label="Post options"]') && !e.target.closest('[aria-label="Post options"] + div')) {

--- a/modules/pulse-social/client/components/PostCard.vue
+++ b/modules/pulse-social/client/components/PostCard.vue
@@ -2,7 +2,7 @@
   <article
     role="article"
     :aria-labelledby="'post-author-' + post.id"
-    class="px-5 py-5 transition-colors hover:bg-gray-50/50 dark:hover:bg-gray-800/30"
+    class="px-5 py-5 transition-colors hover:bg-gray-50/50 dark:hover:bg-gray-800/30 group"
     :class="[highlightClass]"
     :data-post-id="post.id"
   >
@@ -25,10 +25,19 @@
           <time :datetime="post.created_at" :title="fullDate" class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ relativeTime }}</time>
           <span v-if="post.pinned" class="text-xs" title="Pinned">📌</span>
           <span v-if="post.edited_at" class="text-xs text-gray-400">(edited)</span>
+          <span class="flex-1"></span>
+          <!-- Open detail -->
+          <button
+            @click="$emit('open-post', post.id)"
+            class="text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
+            title="Open post"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+          </button>
         </div>
 
-        <!-- Body -->
-        <div class="text-[15px] text-gray-800 dark:text-gray-200 leading-relaxed mt-1.5">
+        <!-- Body (clickable to open detail) -->
+        <div @click="$emit('open-post', post.id)" class="text-[15px] text-gray-800 dark:text-gray-200 leading-relaxed mt-1.5 cursor-pointer">
           <div v-if="truncated && !expanded" class="line-clamp-4 post-fade">
             <MarkdownRenderer :content="post.body" />
           </div>

--- a/modules/pulse-social/client/components/ReactionBar.vue
+++ b/modules/pulse-social/client/components/ReactionBar.vue
@@ -12,7 +12,9 @@
         class="relative flex items-center gap-1 px-2.5 py-1 rounded-full text-xs transition-all cursor-pointer hover:scale-105 active:scale-95 border"
         :class="poppingEmoji === emoji
           ? 'reaction-burst border-primary-300 dark:border-primary-600 bg-primary-50 dark:bg-primary-900/30'
-          : 'border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 hover:border-gray-300 dark:hover:border-gray-500'"
+          : isMyReaction(emoji)
+            ? 'border-primary-300 dark:border-primary-600 bg-primary-50 dark:bg-primary-900/20'
+            : 'border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 hover:border-gray-300 dark:hover:border-gray-500'"
       >
         <span class="text-sm leading-none">{{ emojiIcons[emoji] }}</span>
         <span class="font-medium text-gray-700 dark:text-gray-300 tabular-nums" :class="{ 'count-bump': bumpingEmoji === emoji }">{{ count }}</span>
@@ -92,6 +94,7 @@ import { apiRequest } from '@shared/client/services/api'
 
 const props = defineProps({
   reactions: { type: Object, default: () => ({}) },
+  myReactions: { type: Array, default: () => [] },
   commentCount: { type: Number, default: 0 },
   postId: { type: String, default: '' }
 })
@@ -168,6 +171,10 @@ function handleClickOutsidePicker(e) {
 
 function isEmojiActive(emoji) {
   return (props.reactions[emoji] || 0) > 0
+}
+
+function isMyReaction(emoji) {
+  return props.myReactions.includes(emoji)
 }
 
 function animateAndEmit(emoji) {

--- a/modules/pulse-social/client/composables/useFeed.js
+++ b/modules/pulse-social/client/composables/useFeed.js
@@ -71,10 +71,17 @@ export function useFeed() {
     posts.value = posts.value.filter(p => p.id !== postId)
   }
 
-  function updatePostReactions(postId, reactions) {
-    const update = (list) => list.map(p =>
-      p.id === postId ? { ...p, reactions, reaction_count: Object.values(reactions).reduce((s, c) => s + c, 0) } : p
-    )
+  function updatePostReactions(postId, reactions, toggledEmoji) {
+    const update = (list) => list.map(p => {
+      if (p.id !== postId) return p
+      let myReactions = [...(p.my_reactions || [])]
+      if (toggledEmoji) {
+        const idx = myReactions.indexOf(toggledEmoji)
+        if (idx >= 0) myReactions.splice(idx, 1)
+        else myReactions.push(toggledEmoji)
+      }
+      return { ...p, reactions, my_reactions: myReactions, reaction_count: Object.values(reactions).reduce((s, c) => s + c, 0) }
+    })
     pinnedPosts.value = update(pinnedPosts.value)
     posts.value = update(posts.value)
   }

--- a/modules/pulse-social/client/views/FeedView.vue
+++ b/modules/pulse-social/client/views/FeedView.vue
@@ -146,6 +146,16 @@
         </div>
       </div>
     </aside>
+
+    <!-- Delete confirmation modal -->
+    <ConfirmDialog
+      :visible="!!deletingPostId"
+      title="Delete this post?"
+      message="This will permanently delete the post and all its comments. This can't be undone."
+      confirm-label="Delete"
+      @confirm="confirmDeletePost"
+      @cancel="deletingPostId = null"
+    />
   </div>
 </template>
 
@@ -156,6 +166,7 @@ import PostCard from '../components/PostCard.vue'
 import TimeGroup from '../components/TimeGroup.vue'
 import EmptyFeed from '../components/EmptyFeed.vue'
 import FeedSkeleton from '../components/FeedSkeleton.vue'
+import ConfirmDialog from '../components/ConfirmDialog.vue'
 import { useFeed } from '../composables/useFeed'
 import { useReactions } from '../composables/useReactions'
 
@@ -163,6 +174,7 @@ const nav = inject('moduleNav')
 const feed = useFeed()
 const { toggleReaction } = useReactions()
 const highlightedPostId = ref(null)
+const deletingPostId = ref(null)
 
 const stats = ref({ postsThisWeek: 0, totalReactions: 0, postersThisWeek: 0, totalComments: 0 })
 const trendingLabels = ref([])
@@ -274,7 +286,12 @@ function focusComposer() {
 }
 
 async function handleDeletePost(postId) {
-  if (!confirm('Delete this post? This cannot be undone.')) return
+  deletingPostId.value = postId
+}
+
+async function confirmDeletePost() {
+  const postId = deletingPostId.value
+  deletingPostId.value = null
   try {
     const { apiRequest } = await import('@shared/client/services/api')
     await apiRequest(`/modules/pulse-social/posts/${postId}`, { method: 'DELETE' })

--- a/modules/pulse-social/client/views/FeedView.vue
+++ b/modules/pulse-social/client/views/FeedView.vue
@@ -42,6 +42,7 @@
               @open-post="navigateToPost"
               @react="handleReaction"
               @comment="handleComment"
+              @delete-post="handleDeletePost"
             />
           </div>
 
@@ -57,6 +58,7 @@
                 @open-post="navigateToPost"
                 @react="handleReaction"
                 @comment="handleComment"
+                @delete-post="handleDeletePost"
               />
             </div>
           </template>
@@ -269,5 +271,16 @@ function loadMore() {
 
 function focusComposer() {
   window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+async function handleDeletePost(postId) {
+  if (!confirm('Delete this post? This cannot be undone.')) return
+  try {
+    const { apiRequest } = await import('@shared/client/services/api')
+    await apiRequest(`/modules/pulse-social/posts/${postId}`, { method: 'DELETE' })
+    feed.removePost(postId)
+  } catch (err) {
+    console.error('[pulse-social] Delete error:', err)
+  }
 }
 </script>

--- a/modules/pulse-social/client/views/FeedView.vue
+++ b/modules/pulse-social/client/views/FeedView.vue
@@ -258,7 +258,7 @@ async function handleReaction({ postId, emoji }) {
 
   const result = await toggleReaction(postId, emoji, post.reactions || {})
   if (result.success) {
-    feed.updatePostReactions(postId, result.reactions)
+    feed.updatePostReactions(postId, result.reactions, emoji)
   }
 }
 
@@ -285,7 +285,7 @@ function focusComposer() {
   window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
-async function handleDeletePost(postId) {
+function handleDeletePost(postId) {
   deletingPostId.value = postId
 }
 

--- a/modules/pulse-social/client/views/PostDetailView.vue
+++ b/modules/pulse-social/client/views/PostDetailView.vue
@@ -53,7 +53,7 @@
                 @click="showDeleteConfirm = true; menuOpen = false"
                 class="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer"
               >
-                Delete post
+                {{ isOwnPost ? 'Delete my post' : 'Remove (admin)' }}
               </button>
             </div>
           </div>
@@ -201,9 +201,10 @@ const userUid = ref('')
 
 const currentUserUid = computed(() => user.value?.uid || user.value?.email || '')
 const isAdmin = computed(() => authIsAdmin.value)
+const isOwnPost = computed(() => post.value?.author_uid === currentUserUid.value)
 const canDelete = computed(() => {
   if (!post.value) return false
-  return post.value.author_uid === currentUserUid.value || isAdmin.value
+  return isOwnPost.value || isAdmin.value
 })
 
 const fullDate = computed(() => {

--- a/modules/pulse-social/server/index.js
+++ b/modules/pulse-social/server/index.js
@@ -78,7 +78,8 @@ module.exports = function registerRoutes(router, context) {
         team: req.query.team,
         author: req.query.author,
         mentioning: req.query.mentioning,
-        search: req.query.search
+        search: req.query.search,
+        currentUserUid: req.userUid || req.userEmail
       })
       res.json(result)
     } catch (err) {

--- a/modules/pulse-social/server/posts.js
+++ b/modules/pulse-social/server/posts.js
@@ -78,16 +78,16 @@ function getPostById(id) {
   }
 }
 
-function listPosts({ before, limit = 20, label, team, author, mentioning, search }) {
+function listPosts({ before, limit = 20, label, team, author, mentioning, search, currentUserUid }) {
   limit = Math.min(Math.max(1, parseInt(limit) || 20), 50)
 
-  const pinnedPosts = buildPinnedQuery({ label, team, author, mentioning, search })
-  const { posts, nextCursor } = buildFeedQuery({ before, limit, label, team, author, mentioning, search })
+  const pinnedPosts = buildPinnedQuery({ label, team, author, mentioning, search, currentUserUid })
+  const { posts, nextCursor } = buildFeedQuery({ before, limit, label, team, author, mentioning, search, currentUserUid })
 
   return { pinned: pinnedPosts, posts, nextCursor }
 }
 
-function buildPinnedQuery({ label, team, author, mentioning, search }) {
+function buildPinnedQuery({ label, team, author, mentioning, search, currentUserUid }) {
   const db = getDb()
   const conditions = ['p.pinned = 1']
   const params = []
@@ -106,10 +106,10 @@ function buildPinnedQuery({ label, team, author, mentioning, search }) {
   `
 
   const posts = db.prepare(sql).all(...params)
-  return posts.map(enrichListPost)
+  return posts.map(row => enrichListPost(row, currentUserUid))
 }
 
-function buildFeedQuery({ before, limit, label, team, author, mentioning, search }) {
+function buildFeedQuery({ before, limit, label, team, author, mentioning, search, currentUserUid }) {
   const db = getDb()
   const conditions = ['p.pinned = 0']
   const params = []
@@ -135,7 +135,7 @@ function buildFeedQuery({ before, limit, label, team, author, mentioning, search
 
   const rows = db.prepare(sql).all(...params)
   const hasMore = rows.length > limit
-  const posts = (hasMore ? rows.slice(0, limit) : rows).map(enrichListPost)
+  const posts = (hasMore ? rows.slice(0, limit) : rows).map(row => enrichListPost(row, currentUserUid))
   const nextCursor = hasMore ? posts[posts.length - 1].created_at : null
 
   return { posts, nextCursor }
@@ -168,7 +168,7 @@ function appendFilterConditions(conditions, params, { label, team, author, menti
   }
 }
 
-function enrichListPost(row) {
+function enrichListPost(row, currentUserUid) {
   const db = getDb()
   const reactions = db.prepare(`
     SELECT emoji, COUNT(*) as count FROM reactions
@@ -178,6 +178,13 @@ function enrichListPost(row) {
   const reactionSummary = {}
   for (const r of reactions) {
     reactionSummary[r.emoji] = r.count
+  }
+
+  let myReactions = []
+  if (currentUserUid) {
+    myReactions = db.prepare(`
+      SELECT emoji FROM reactions WHERE post_id = ? AND comment_id IS NULL AND user_uid = ?
+    `).all(row.id, currentUserUid).map(r => r.emoji)
   }
 
   const recentComments = db.prepare(`
@@ -203,6 +210,7 @@ function enrichListPost(row) {
     comment_count: row.comment_count,
     reaction_count: row.reaction_count,
     reactions: reactionSummary,
+    my_reactions: myReactions,
     recent_comments: recentComments,
     attachments
   }
@@ -322,7 +330,7 @@ function getRecentPosts(limit = 5) {
     LIMIT ?
   `).all(limit)
 
-  return posts.map(enrichListPost)
+  return posts.map(row => enrichListPost(row, null))
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Clicking on a post's body text navigates to the post detail view
- Adds an "open post" icon (external link) visible on hover for discoverability
- Allows users to access delete functionality and full comment thread from the feed

## Context

Currently there's no way to open a post's detail view from the feed unless it has comments with a "View all" link. This makes it impossible to delete posts or view the full thread for posts with 0 comments.