### PR TITLE
fix(deploy): match build stage Node version to runtime for better-sqlite3

### DIFF
--- a/deploy/backend.Dockerfile
+++ b/deploy/backend.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Install system deps and node_modules
-FROM registry.access.redhat.com/ubi9/nodejs-20-minimal AS build
+FROM registry.access.redhat.com/hi/nodejs:latest AS build
 
 USER 0
 


### PR DESCRIPTION
## Summary

Fixes Pulse Social module crash on startup: `better-sqlite3` native binary was compiled against Node 20 (NODE_MODULE_VERSION 115) but the runtime uses Node 26 (NODE_MODULE_VERSION 147).

## Root Cause

PR #786 changed the runtime base image from `ubi9/nodejs-20-minimal` to `hi/nodejs:latest` (Node 26) but left the build stage on `ubi9/nodejs-20-minimal` (Node 20). Native modules compiled in the build stage are incompatible with the runtime Node version.

## Fix

Use `hi/nodejs:latest` for both build and runtime stages so `better-sqlite3` compiles against the same Node version it will run on.