### PR TITLE
fix(releases): accurate feature freeze dates + clickable filter cards

### DIFF
--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { useFeatureTracking } from '../composables/useFeatureTracking.js'
 import FeatureTrackingTable from '../components/FeatureTrackingTable.vue'
 
@@ -16,6 +16,7 @@ const {
 const selectedVersion = ref(null)
 const refreshing = ref(false)
 const tableRef = ref(null)
+const activeFilter = ref(null)
 
 const portfolioVersions = computed(() => {
   return (versions.value || []).map(v => v.version)
@@ -71,6 +72,34 @@ const blockedCount = computed(() => {
   return count
 })
 
+function setFilter(type) {
+  if (type === null || activeFilter.value === type) {
+    activeFilter.value = null
+  } else {
+    activeFilter.value = type
+    nextTick(() => {
+      if (tableRef.value) tableRef.value.expandAll()
+    })
+  }
+}
+
+const filteredGroups = computed(() => {
+  if (!activeFilter.value) return groups.value
+  return groups.value.map(g => {
+    const filtered = (g.features || []).filter(f => {
+      if (activeFilter.value === 'added') return f.scopeChange === 'added'
+      if (activeFilter.value === 'dropped') return f.scopeChange === 'dropped'
+      if (activeFilter.value === 'blocked') return f.isBlocked && f.scopeChange !== 'dropped'
+      return true
+    })
+    return {
+      ...g,
+      features: filtered,
+      featureCount: filtered.filter(f => f.scopeChange !== 'dropped').length
+    }
+  }).filter(g => g.features.length > 0)
+})
+
 function formatDate(dateStr) {
   if (!dateStr) return ''
   var d = new Date(dateStr + (dateStr.includes('T') ? '' : 'T00:00:00'))
@@ -100,6 +129,7 @@ function handleCollapseAll() {
 }
 
 watch(selectedVersion, async (v) => {
+  activeFilter.value = null
   if (v) await loadTrackingData(v)
 })
 
@@ -176,8 +206,14 @@ onMounted(async () => {
 
     <!-- Summary cards -->
     <div v-if="currentData && !loading" class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
-      <!-- Total features -->
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5 group hover:shadow-md transition-shadow">
+      <!-- Total features (click = clear filter) -->
+      <div
+        @click="setFilter(null)"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 cursor-pointer transition-all duration-150 hover:shadow-md"
+        :class="!activeFilter
+          ? 'border-indigo-400 dark:border-indigo-500 ring-2 ring-indigo-200 dark:ring-indigo-800 shadow-sm'
+          : 'border-gray-200 dark:border-gray-700 hover:border-indigo-300 dark:hover:border-indigo-600'"
+      >
         <div class="absolute top-0 left-0 w-1 h-full bg-indigo-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-indigo-100 dark:bg-indigo-900/40">
@@ -186,6 +222,7 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features</span>
+          <span v-if="activeFilter" class="ml-auto text-[10px] text-indigo-500 dark:text-indigo-400 font-medium">Show all</span>
         </div>
         <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ totalFeatures }}</div>
       </div>
@@ -207,7 +244,18 @@ onMounted(async () => {
       </div>
 
       <!-- Late additions -->
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+      <div
+        @click="addedCount > 0 ? setFilter('added') : undefined"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
+        :class="[
+          activeFilter === 'added'
+            ? 'border-blue-400 dark:border-blue-500 ring-2 ring-blue-200 dark:ring-blue-800 shadow-sm'
+            : 'border-gray-200 dark:border-gray-700',
+          addedCount > 0
+            ? 'cursor-pointer hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600'
+            : ''
+        ]"
+      >
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
@@ -216,12 +264,26 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Late Added</span>
+          <svg v-if="activeFilter === 'added'" class="ml-auto w-3.5 h-3.5 text-blue-500 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
         </div>
         <div class="text-2xl font-bold ml-7" :class="addedCount > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'">{{ addedCount }}</div>
       </div>
 
       <!-- Dropped -->
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+      <div
+        @click="droppedCount > 0 ? setFilter('dropped') : undefined"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
+        :class="[
+          activeFilter === 'dropped'
+            ? 'border-amber-400 dark:border-amber-500 ring-2 ring-amber-200 dark:ring-amber-800 shadow-sm'
+            : 'border-gray-200 dark:border-gray-700',
+          droppedCount > 0
+            ? 'cursor-pointer hover:shadow-md hover:border-amber-300 dark:hover:border-amber-600'
+            : ''
+        ]"
+      >
         <div class="absolute top-0 left-0 w-1 h-full bg-amber-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
@@ -230,12 +292,26 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Dropped</span>
+          <svg v-if="activeFilter === 'dropped'" class="ml-auto w-3.5 h-3.5 text-amber-500 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
         </div>
         <div class="text-2xl font-bold ml-7" :class="droppedCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ droppedCount }}</div>
       </div>
 
       <!-- Blocked -->
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+      <div
+        @click="blockedCount > 0 ? setFilter('blocked') : undefined"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
+        :class="[
+          activeFilter === 'blocked'
+            ? 'border-red-400 dark:border-red-500 ring-2 ring-red-200 dark:ring-red-800 shadow-sm'
+            : 'border-gray-200 dark:border-gray-700',
+          blockedCount > 0
+            ? 'cursor-pointer hover:shadow-md hover:border-red-300 dark:hover:border-red-600'
+            : ''
+        ]"
+      >
         <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
@@ -244,6 +320,9 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
+          <svg v-if="activeFilter === 'blocked'" class="ml-auto w-3.5 h-3.5 text-red-500 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
         </div>
         <div class="text-2xl font-bold ml-7" :class="blockedCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ blockedCount }}</div>
       </div>
@@ -283,13 +362,37 @@ onMounted(async () => {
       <p class="text-xs mt-1">Use the Refresh button to fetch data from Jira.</p>
     </div>
 
-    <!-- Data table -->
-    <FeatureTrackingTable
-      v-else-if="currentData"
-      ref="tableRef"
-      :groups="groups"
-      :portfolioVersion="selectedVersion"
-      :featureFreezeDate="featureFreezeDate"
-    />
+    <!-- Data table (with optional filter indicator) -->
+    <template v-else-if="currentData">
+      <div
+        v-if="activeFilter"
+        class="mb-3 flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium"
+        :class="{
+          'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300': activeFilter === 'added',
+          'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300': activeFilter === 'dropped',
+          'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300': activeFilter === 'blocked'
+        }"
+      >
+        <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+        </svg>
+        <span>Showing {{ activeFilter === 'added' ? 'late added' : activeFilter }} features only</span>
+        <button
+          @click="setFilter(null)"
+          class="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold hover:bg-white/50 dark:hover:bg-gray-800/50 transition-colors"
+        >
+          Clear filter
+          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <FeatureTrackingTable
+        ref="tableRef"
+        :groups="filteredGroups"
+        :portfolioVersion="selectedVersion"
+        :featureFreezeDate="featureFreezeDate"
+      />
+    </template>
   </div>
 </template>

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -551,6 +551,121 @@ async function fetchAllProducts(config) {
   }
 }
 
+/**
+ * Fetches accurate feature freeze dates from Product Pages schedule tasks.
+ *
+ * The releases list endpoint provides only major_milestones which lack
+ * EA-specific feature freeze entries. This function fetches the detailed
+ * schedule for each release entity to find granular freeze dates per EA.
+ *
+ * Strategy per product:
+ *  1. Try to find an exact EA release (e.g. rhoai-3.5.EA1) — its schedule
+ *     should contain a generic "Feature Freeze" task.
+ *  2. Fall back to the parent release (e.g. rhelai-3.5) — its schedule
+ *     should contain EA-scoped tasks like "EA1 Feature Freeze".
+ *
+ * @param {string} portfolioVersion  e.g. "3.5.EA1", "3.5"
+ * @param {string[]} productShortnames  e.g. ['rhoai', 'rhelai', 'RHAII']
+ * @param {object}  config  { productPagesBaseUrl }
+ * @returns {Promise<{ byProduct: Object<string,string>, earliest: string|null }>}
+ */
+async function fetchFeatureFreezeDatesFromSchedule(portfolioVersion, productShortnames, config) {
+  const token = await getProductPagesToken(config)
+  if (!token) return { byProduct: {}, earliest: null }
+
+  const baseUrl = (config.productPagesBaseUrl || 'https://productpages.redhat.com').replace(/\/+$/, '')
+
+  const eaMatch = portfolioVersion.match(/\b(EA\d?)\b/i)
+  const eaTag = eaMatch ? eaMatch[1].toUpperCase() : null
+  const baseVersion = portfolioVersion.replace(/[\s._-]*EA\d?\s*/gi, '').replace(/^[\s.]+|[\s.]+$/g, '')
+
+  const byProduct = {}
+  let earliest = null
+  const headers = { Accept: 'application/json', Authorization: `Bearer ${token}` }
+
+  for (const shortname of productShortnames) {
+    try {
+      const releasesUrl = `${baseUrl}/api/v7/releases/?product__shortname=${encodeURIComponent(shortname)}`
+      const relResponse = await fetch(releasesUrl, { headers, signal: AbortSignal.timeout(15000) })
+      if (!relResponse.ok) continue
+
+      const relPayload = await relResponse.json()
+      const rows = Array.isArray(relPayload) ? relPayload : (relPayload.releases || relPayload.items || [])
+
+      // Build search candidates in priority order: exact EA release, then parent
+      const candidates = []
+      if (eaTag) {
+        candidates.push(`${shortname}-${baseVersion}.${eaTag}`)
+        candidates.push(`${shortname}-${baseVersion}${eaTag}`)
+        candidates.push(`${shortname}-${baseVersion} ${eaTag}`)
+      }
+      candidates.push(`${shortname}-${baseVersion}`)
+
+      let releaseId = null
+      let matchedShortname = null
+      let matchedExactEa = false
+
+      for (const candidate of candidates) {
+        const norm = candidate.toLowerCase().replace(/[\s._-]+/g, '')
+        for (const r of rows) {
+          if (!r.id) continue
+          const rn = (r.shortname || '').toLowerCase().replace(/[\s._-]+/g, '')
+          if (rn === norm) {
+            releaseId = r.id
+            matchedShortname = r.shortname || candidate
+            matchedExactEa = eaTag ? /ea\d?/i.test(r.shortname || '') : false
+            break
+          }
+        }
+        if (releaseId) break
+      }
+
+      if (!releaseId) continue
+
+      // Fetch schedule tasks filtered to "feature freeze"
+      const schedUrl = `${baseUrl}/api/v7/schedule-tasks/?entity_id=${releaseId}&q=${encodeURIComponent('feature freeze')}`
+      const schedResponse = await fetch(schedUrl, { headers, signal: AbortSignal.timeout(15000) })
+      if (!schedResponse.ok) continue
+
+      const schedPayload = await schedResponse.json()
+      const tasks = Array.isArray(schedPayload)
+        ? schedPayload
+        : (schedPayload.data || schedPayload.results || schedPayload.result || [])
+
+      const freezePattern = /feature[.\-_\s]*freeze/i
+      let bestDate = null
+
+      for (const task of tasks) {
+        if (task.draft) continue
+        const name = task.name || ''
+        if (!freezePattern.test(name)) continue
+
+        if (eaTag && !matchedExactEa) {
+          // Parent release: look for EA-specific freeze tasks
+          if (new RegExp(`\\b${eaTag}\\b`, 'i').test(name)) {
+            bestDate = task.date_finish || null
+            break
+          }
+        }
+        // For exact EA releases, or as a generic fallback
+        if (!bestDate && task.date_finish) {
+          bestDate = task.date_finish
+        }
+      }
+
+      if (bestDate) {
+        const key = (matchedExactEa ? matchedShortname : `${shortname}-${baseVersion}${eaTag ? '.' + eaTag : ''}`).toLowerCase()
+        byProduct[key] = bestDate
+        if (!earliest || bestDate < earliest) earliest = bestDate
+      }
+    } catch (err) {
+      console.error(`[product-pages] Schedule fetch failed for "${shortname}":`, err.message)
+    }
+  }
+
+  return { byProduct, earliest }
+}
+
 function _resetForTesting() {
   cachedToken = { token: null, expiresAt: 0 }
   pendingTokenRequest = null
@@ -561,6 +676,7 @@ module.exports = {
   init,
   getProductPagesToken,
   fetchProductsByShortname,
+  fetchFeatureFreezeDatesFromSchedule,
   fetchAllProducts,
   getAuthStatus,
   extractGaDate,

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -570,19 +570,23 @@ async function fetchAllProducts(config) {
  * @returns {Promise<{ byProduct: Object<string,string>, earliest: string|null }>}
  */
 async function fetchFeatureFreezeDatesFromSchedule(portfolioVersion, productShortnames, config) {
+  const version = Array.isArray(portfolioVersion) ? portfolioVersion[0] : portfolioVersion
+  const versionStr = String(version || '')
+  if (!versionStr) return { byProduct: {}, earliest: null }
+
   const token = await getProductPagesToken(config)
   if (!token) return { byProduct: {}, earliest: null }
 
   const baseUrl = (config.productPagesBaseUrl || 'https://productpages.redhat.com').replace(/\/+$/, '')
 
-  const eaMatch = portfolioVersion.match(/\b(EA\d?)\b/i)
+  const eaMatch = versionStr.match(/\b(EA\d?)\b/i)
   const eaTag = eaMatch ? eaMatch[1].toUpperCase() : null
-  let baseVersion = portfolioVersion
+  let baseVersion = versionStr
   if (eaMatch) {
-    baseVersion = portfolioVersion.slice(0, eaMatch.index).replace(/[\s._-]+$/, '') +
-      portfolioVersion.slice(eaMatch.index + eaMatch[0].length).replace(/^[\s._-]+/, '')
+    baseVersion = versionStr.slice(0, eaMatch.index).replace(/[\s._-]+$/, '') +
+      versionStr.slice(eaMatch.index + eaMatch[0].length).replace(/^[\s._-]+/, '')
   }
-  baseVersion = baseVersion.replace(/^[\s.]+|[\s.]+$/g, '')
+  baseVersion = baseVersion.replace(/^[\s.]+/, '').replace(/[\s.]+$/, '')
 
   const byProduct = {}
   let earliest = null

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -15,10 +15,6 @@ let productsCache = { products: null, expiresAt: 0 }
 // Module-level secrets, set once via init()
 let _secrets = {}
 
-function escapeRegExp(value) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 function init(secrets) {
   _secrets = secrets || {}
 }
@@ -581,7 +577,12 @@ async function fetchFeatureFreezeDatesFromSchedule(portfolioVersion, productShor
 
   const eaMatch = portfolioVersion.match(/\b(EA\d?)\b/i)
   const eaTag = eaMatch ? eaMatch[1].toUpperCase() : null
-  const baseVersion = portfolioVersion.replace(/[\s._-]*EA\d?\s*/gi, '').replace(/^[\s.]+|[\s.]+$/g, '')
+  let baseVersion = portfolioVersion
+  if (eaMatch) {
+    baseVersion = portfolioVersion.slice(0, eaMatch.index).replace(/[\s._-]+$/, '') +
+      portfolioVersion.slice(eaMatch.index + eaMatch[0].length).replace(/^[\s._-]+/, '')
+  }
+  baseVersion = baseVersion.replace(/^[\s.]+|[\s.]+$/g, '')
 
   const byProduct = {}
   let earliest = null
@@ -646,9 +647,15 @@ async function fetchFeatureFreezeDatesFromSchedule(portfolioVersion, productShor
 
         if (eaTag && !matchedExactEa) {
           // Parent release: look for EA-specific freeze tasks
-          if (new RegExp(`\\b${escapeRegExp(eaTag)}\\b`, 'i').test(name)) {
-            bestDate = task.date_finish || null
-            break
+          const nameUpper = name.toUpperCase()
+          const eaIdx = nameUpper.indexOf(eaTag)
+          if (eaIdx !== -1) {
+            const before = eaIdx === 0 || /\W/.test(name[eaIdx - 1])
+            const after = eaIdx + eaTag.length >= name.length || /\W/.test(name[eaIdx + eaTag.length])
+            if (before && after) {
+              bestDate = task.date_finish || null
+              break
+            }
           }
         }
         // For exact EA releases, or as a generic fallback

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -15,6 +15,10 @@ let productsCache = { products: null, expiresAt: 0 }
 // Module-level secrets, set once via init()
 let _secrets = {}
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function init(secrets) {
   _secrets = secrets || {}
 }
@@ -642,7 +646,7 @@ async function fetchFeatureFreezeDatesFromSchedule(portfolioVersion, productShor
 
         if (eaTag && !matchedExactEa) {
           // Parent release: look for EA-specific freeze tasks
-          if (new RegExp(`\\b${eaTag}\\b`, 'i').test(name)) {
+          if (new RegExp(`\\b${escapeRegExp(eaTag)}\\b`, 'i').test(name)) {
             bestDate = task.date_finish || null
             break
           }

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -474,8 +474,8 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
   // GET /tracking/data — query Jira by fixVersion
   router.get('/tracking/data', requireAuth, requireScope('releases:read'), async function (req, res) {
     const version = req.query.version
-    if (!version) {
-      return res.status(400).json({ error: 'version query parameter is required' })
+    if (typeof version !== 'string' || !version.trim()) {
+      return res.status(400).json({ error: 'version query parameter must be a non-empty string' })
     }
 
     const forceRefresh = req.query.refresh === 'true'

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -12,7 +12,7 @@
  */
 
 const { readRegistry } = require('../registry')
-const { fetchProductsByShortname } = require('../delivery/product-pages')
+const { fetchFeatureFreezeDatesFromSchedule } = require('../delivery/product-pages')
 const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
 
 const PP_CACHE_FILE = 'releases/delivery/product-pages-releases-cache.json'
@@ -501,26 +501,20 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       if (!freezeDates.earliest) {
         try {
           const ppConfig = {
-            productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com',
-            productPagesProductShortnames: DEFAULT_PRODUCTS
+            productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com'
           }
-          const livePPReleases = await fetchProductsByShortname(ppConfig.productPagesProductShortnames, ppConfig)
-          const normalizedPV = normalizeVersionName(version)
-          for (let pri = 0; pri < livePPReleases.length; pri++) {
-            const pr = livePPReleases[pri]
-            const prVersion = normalizeVersionName(pr.releaseNumber || '').replace(/^[a-z]+-/, '')
-            if (prVersion === normalizedPV && pr.featureFreezeDate) {
-              const key = normalizeVersionName(pr.releaseNumber || '')
-              if (!freezeDates.byProduct[key] || pr.featureFreezeDate < freezeDates.byProduct[key]) {
-                freezeDates.byProduct[key] = pr.featureFreezeDate
-              }
-              if (!freezeDates.earliest || pr.featureFreezeDate < freezeDates.earliest) {
-                freezeDates.earliest = pr.featureFreezeDate
-              }
+          const scheduleDates = await fetchFeatureFreezeDatesFromSchedule(version, DEFAULT_PRODUCTS, ppConfig)
+          for (const [key, date] of Object.entries(scheduleDates.byProduct)) {
+            const normKey = normalizeVersionName(key)
+            if (!freezeDates.byProduct[normKey] || date < freezeDates.byProduct[normKey]) {
+              freezeDates.byProduct[normKey] = date
+            }
+            if (!freezeDates.earliest || date < freezeDates.earliest) {
+              freezeDates.earliest = date
             }
           }
         } catch {
-          // PP API not available — continue without freeze dates
+          // PP schedule API not available — continue without freeze dates
         }
       }
 


### PR DESCRIPTION
## Summary

- **Fetch feature freeze dates from PP schedule API**: The releases list endpoint only provides `major_milestones` which lack EA-specific feature freeze entries, causing all 3.5 releases to show the same generic GA freeze date (Jul 17). Added `fetchFeatureFreezeDatesFromSchedule` that queries the PP schedule tasks API (`GET /api/v7/schedule-tasks/?entity_id=<id>&q=feature+freeze`) to find granular per-EA freeze dates. Scoped to the Feature Tracking tab only.

- **Clickable summary cards as table filters**: The 4 summary cards (Features, Late Added, Dropped, Blocked) now act as toggle filters on the table below. Clicking a card filters to show only matching features; clicking again clears it. Active card gets a colored ring highlight with an "x" dismiss icon. A filter banner above the table shows which filter is active. Groups auto-expand when a filter is applied. Freeze Date card remains non-interactive.

## Test plan

- [ ] Verify Feature Tracking freeze dates are accurate per release after Refresh (requires PP API auth on prod)
- [ ] Click "Late Added" card — table filters to show only late-added features
- [ ] Click "Dropped" card — table filters to dropped features only
- [ ] Click "Blocked" card — table filters to blocked features only
- [ ] Click "Features" card or "Clear filter" — resets to show all
- [ ] Click same active card again — toggles filter off
- [ ] Switch versions — filter resets automatically
- [ ] `npm test` — 3581 tests pass
- [ ] `npm run lint` — clean


Made with [Cursor](https://cursor.com)