### PR TITLE
fix: pass resolveSecret to fetchGitlabData in refreshAllGitlab

### DIFF
--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -4246,7 +4246,7 @@ module.exports = function registerRoutes(router, context) {
     try {
       const syncConfig = rosterSyncConfig.loadConfig({ readFromStorage, writeToStorage }) || {};
       const gitlabInstances = syncConfig.gitlabInstances || [];
-      const results = await fetchGitlabData(usernames, { gitlabInstances });
+      const results = await fetchGitlabData(usernames, { gitlabInstances, resolveSecret: context.resolveSecret });
       writeSinglePassResults(results, GITLAB_CACHE_PATH, GITLAB_HISTORY_CACHE_PATH);
       console.log(`[refresh] GitLab: ${Object.keys(results).length} users processed`);
     } catch (err) {


### PR DESCRIPTION
The `refreshAllGitlab()` function (used by the daily cronjob and the module-level refresh API) was calling `fetchGitlabData()` without passing `resolveSecret`. Without it, the default resolver always returns `undefined`, causing every GitLab instance token to appear unset and silently skipping all instances. This overwrote the cache with `totalContributions: 0` for every user.

The per-team and per-person refresh paths already passed `resolveSecret` correctly.

Fixes #825

Generated with [Claude Code](https://claude.ai/code)