### PR TITLE
fix(releases): always query PP schedule API for freeze dates

### DIFF
--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -498,24 +498,24 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       const productVersions = await resolveProductVersionsFromJira(version, jiraRequest)
       const freezeDates = getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
 
-      if (!freezeDates.earliest) {
-        try {
-          const ppConfig = {
-            productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com'
-          }
-          const scheduleDates = await fetchFeatureFreezeDatesFromSchedule(version, DEFAULT_PRODUCTS, ppConfig)
-          for (const [key, date] of Object.entries(scheduleDates.byProduct)) {
-            const normKey = normalizeVersionName(key)
-            if (!freezeDates.byProduct[normKey] || date < freezeDates.byProduct[normKey]) {
-              freezeDates.byProduct[normKey] = date
-            }
-            if (!freezeDates.earliest || date < freezeDates.earliest) {
-              freezeDates.earliest = date
-            }
-          }
-        } catch {
-          // PP schedule API not available — continue without freeze dates
+      // Always try the schedule API — it returns EA-specific freeze dates
+      // that the releases list endpoint and cache often lack.
+      try {
+        const ppConfig = {
+          productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com'
         }
+        const scheduleDates = await fetchFeatureFreezeDatesFromSchedule(version, DEFAULT_PRODUCTS, ppConfig)
+        for (const [key, date] of Object.entries(scheduleDates.byProduct)) {
+          const normKey = normalizeVersionName(key)
+          if (!freezeDates.byProduct[normKey] || date < freezeDates.byProduct[normKey]) {
+            freezeDates.byProduct[normKey] = date
+          }
+          if (!freezeDates.earliest || date < freezeDates.earliest) {
+            freezeDates.earliest = date
+          }
+        }
+      } catch {
+        // PP schedule API not available — fall back to cache dates
       }
 
       const groups = []


### PR DESCRIPTION
## Summary

- Removes the `if (!freezeDates.earliest)` guard that prevented the Product Pages schedule API from being queried when the cache already had dates
- On prod, the PP cache contains a generic Jul 17 date from the expanded `rhoai-3.5` GA entry, which was being used for all 3.5 releases (EA1, EA2, GA) — the schedule API call that returns accurate EA-specific dates was never reached
- Now the schedule API is always consulted, and its per-product EA-specific freeze dates override the less accurate cache values

## Root cause

The `fetchFeatureFreezeDatesFromSchedule` function (added in PR #824) was wrapped in `if (!freezeDates.earliest)`, meaning it only ran when the cache had **no** freeze dates. But on prod the cache already had the wrong date, so the fallback never triggered.

## Test plan

- [x] All 3581 tests pass
- [x] Lint clean
- [ ] After deploy, verify 3.5 EA1, EA2, and GA show distinct feature freeze dates on prod


Made with [Cursor](https://cursor.com)