### PR TITLE
fix: prevent board info bubbles from closing on hover

### DIFF
--- a/modules/ai-impact/client/components/ForYouBoardTab.vue
+++ b/modules/ai-impact/client/components/ForYouBoardTab.vue
@@ -130,8 +130,11 @@ const columnGuidance = {
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <div
-                  class="absolute top-6 z-20 hidden group-hover:block w-64 p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50"
+                  class="absolute top-full pt-1 z-20 hidden group-hover:block w-64"
                   :class="colIdx >= boardColumns.length - 3 ? 'right-0' : 'left-0'"
+                >
+                <div
+                  class="p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50"
                 >
                   <p>{{ columnGuidance[col.id].text }}</p>
                   <a
@@ -140,6 +143,7 @@ const columnGuidance = {
                   >Learn more
                     <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
                   </a>
+                </div>
                 </div>
               </div>
             </div>

--- a/modules/ai-impact/client/components/ForYouBoardTab.vue
+++ b/modules/ai-impact/client/components/ForYouBoardTab.vue
@@ -133,17 +133,17 @@ const columnGuidance = {
                   class="absolute top-full pt-1 z-20 hidden group-hover:block w-64"
                   :class="colIdx >= boardColumns.length - 3 ? 'right-0' : 'left-0'"
                 >
-                <div
-                  class="p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50"
-                >
-                  <p>{{ columnGuidance[col.id].text }}</p>
-                  <a
-                    :href="guideBase + columnGuidance[col.id].guide"
-                    class="inline-flex items-center gap-0.5 mt-2 font-medium text-blue-600 dark:text-blue-400 hover:underline"
-                  >Learn more
-                    <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-                  </a>
-                </div>
+                  <div
+                    class="p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50"
+                  >
+                    <p>{{ columnGuidance[col.id].text }}</p>
+                    <a
+                      :href="guideBase + columnGuidance[col.id].guide"
+                      class="inline-flex items-center gap-0.5 mt-2 font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                    >Learn more
+                      <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- The info bubble tooltips on the AI Impact "State of the Union" board columns used `top-6` positioning, creating a gap between the hover trigger icon and the tooltip. Moving the mouse from the icon toward the tooltip (e.g. to click "Learn more") left the CSS `group-hover` area, causing the tooltip to disappear.
- Wraps the tooltip in an outer positioning div using `top-full pt-1` so the hoverable area is continuous — the padding bridges the visual gap without breaking hover state.

## Test plan
- [ ] Open AI Impact → State of the Union → Board tab
- [ ] Hover over an info (ⓘ) icon on any column header
- [ ] Move mouse from the icon into the tooltip and click the "Learn more" link — tooltip should stay open

🤖 Generated with [Claude Code](https://claude.com/claude-code)