### PR TITLE
fix(releases): strip .z from registry displayName and id

### DIFF
--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -14,6 +14,11 @@ const REGISTRY_FILE = 'releases/registry.json';
 const SCHEMA_VERSION = 1;
 
 const VALID_STATES = ['active', 'archived'];
+
+function stripZStream(value) {
+  if (!value) return value
+  return String(value).replace(/\.z\b/gi, '')
+}
 // Fields controlled by Product Pages — cannot be edited locally on PP-sourced releases
 const PP_MANAGED_FIELDS = ['displayName', 'productPagesShortname', 'productPagesVersion', 'milestones'];
 
@@ -63,8 +68,8 @@ function validateRelease(release) {
 function normalizeRelease(input) {
   const now = new Date().toISOString();
   return {
-    id: input.id.trim().toLowerCase(),
-    displayName: input.displayName.trim(),
+    id: stripZStream(input.id.trim()).toLowerCase(),
+    displayName: stripZStream(input.displayName.trim()),
     fixVersions: Array.isArray(input.fixVersions) ? input.fixVersions : [],
     productPagesShortname: input.productPagesShortname || null,
     productPagesVersion: input.productPagesVersion || null,
@@ -221,13 +226,13 @@ async function runRegistrySync(storage, options) {
     const releaseNumber = ppRelease.releaseNumber || '';
     if (!releaseNumber) continue;
 
-    const id = releaseNumber.toLowerCase().replace(/\s+/g, '-');
+    const id = stripZStream(releaseNumber).toLowerCase().replace(/\s+/g, '-');
     if (!/^[a-z0-9][a-z0-9._-]*$/.test(id)) continue;
 
     discoveredIds.add(id);
     discovered.push({
       id,
-      displayName: releaseNumber,
+      displayName: stripZStream(releaseNumber),
       productName: ppRelease.productName,
       dueDate: ppRelease.dueDate,
       codeFreezeDate: ppRelease.codeFreezeDate
@@ -239,7 +244,7 @@ async function runRegistrySync(storage, options) {
       if (existing.state === 'archived') continue;
 
       if (existing.source === 'product-pages') {
-        existing.displayName = releaseNumber;
+        existing.displayName = stripZStream(releaseNumber);
         existing.productPagesShortname = releaseNumber.split('-')[0] || existing.productPagesShortname;
         existing.productPagesVersion = releaseNumber;
         existing.milestones = {

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -16,9 +16,10 @@ const SCHEMA_VERSION = 1;
 const VALID_STATES = ['active', 'archived'];
 
 function stripZStream(value) {
-  if (!value) return value
-  return String(value).replace(/\.z\b/gi, '')
+  if (!value) return value;
+  return String(value).replace(/\.z\b/gi, '');
 }
+
 // Fields controlled by Product Pages — cannot be edited locally on PP-sourced releases
 const PP_MANAGED_FIELDS = ['displayName', 'productPagesShortname', 'productPagesVersion', 'milestones'];
 
@@ -448,7 +449,7 @@ function registerRegistryRoutes(router, context) {
     }
 
     const registry = readRegistry(readFromStorage);
-    const normalizedId = req.body.id.trim().toLowerCase();
+    const normalizedId = stripZStream(req.body.id.trim()).toLowerCase();
 
     if (registry.releases.some(r => r.id === normalizedId)) {
       return res.status(400).json({ error: `Release with id "${normalizedId}" already exists` });


### PR DESCRIPTION
## Summary

- Adds `stripZStream()` to the release registry so `.z` notation (e.g. `rhoai-3.5.z`, `rhoai-3.5.z.EA2`) is stripped from `displayName` and `id` at the source
- Applied in `normalizeRelease()` (covers manual creates) and the Product Pages discovery sync path (covers auto-discovered releases)
- Fixes the Feature Status tab showing `.z` versions — it reads from the registry, unlike the Feature List tab which already had its own `stripZStream` in the execution routes

## Root cause

Product Pages returns shortnames like `rhoai-3.5.z` which were stored as-is in the registry. The Feature Status tab (`HygieneView.vue`) reads versions from `/modules/releases/registry` → `displayName`, so `.z` versions appeared in the UI.

## Test plan

- [x] All 3717 tests pass
- [x] Lint clean
- [ ] After deploy, existing `.z` entries will be cleaned on next PP discovery sync


Made with [Cursor](https://cursor.com)