### PR TITLE
fix(releases): allow spaces in TV/FV delta version names

### DIFF
--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -9,6 +9,7 @@ const {
   classifyFeatures,
   buildExport,
   DEFAULT_RELEASES,
+  jqlSafePattern,
 } = require('../../../server/tv-fv-delta/routes');
 
 // ---------------------------------------------------------------------------
@@ -400,5 +401,112 @@ describe('buildExport', () => {
 describe('DEFAULT_RELEASES', () => {
   it('contains EA1, EA2, and GA in that order', () => {
     expect(DEFAULT_RELEASES).toEqual(['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jqlSafePattern — version name validation
+// ---------------------------------------------------------------------------
+
+describe('jqlSafePattern', () => {
+  it('accepts standard rhoai version names', () => {
+    expect(jqlSafePattern.test('rhoai-3.5')).toBe(true);
+    expect(jqlSafePattern.test('rhoai-3.5.EA1')).toBe(true);
+    expect(jqlSafePattern.test('rhoai-3.5.EA2')).toBe(true);
+    expect(jqlSafePattern.test('rhelai-3.5')).toBe(true);
+  });
+
+  it('accepts version names with spaces (e.g. RHAII-3.5 EA1)', () => {
+    expect(jqlSafePattern.test('RHAII-3.5 EA1')).toBe(true);
+    expect(jqlSafePattern.test('RHAII-3.5 EA2')).toBe(true);
+    expect(jqlSafePattern.test('Some Product 2.0')).toBe(true);
+  });
+
+  it('accepts underscores', () => {
+    expect(jqlSafePattern.test('RHOAI_3_5')).toBe(true);
+  });
+
+  it('rejects JQL injection attempts', () => {
+    expect(jqlSafePattern.test('rhoai-3.5" OR 1=1--')).toBe(false);
+    expect(jqlSafePattern.test('rhoai-3.5; DROP TABLE')).toBe(false);
+    expect(jqlSafePattern.test('rhoai-3.5\' OR')).toBe(false);
+    expect(jqlSafePattern.test('rhoai-3.5)')).toBe(false);
+    expect(jqlSafePattern.test('(rhoai-3.5')).toBe(false);
+  });
+
+  it('rejects empty strings', () => {
+    expect(jqlSafePattern.test('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RHAII version handling (space-separated milestone names)
+// ---------------------------------------------------------------------------
+
+describe('RHAII version handling', () => {
+  it('normVer lowercases RHAII versions with spaces', () => {
+    expect(normVer('RHAII-3.5 EA1')).toBe('rhaii-3.5 ea1');
+    expect(normVer('RHAII-3.5 EA2')).toBe('rhaii-3.5 ea2');
+  });
+
+  it('parseVersions handles RHAII versions', () => {
+    const result = parseVersions('RHAII-3.5 EA1');
+    expect(result.size).toBe(1);
+    expect(result.has('rhaii-3.5 ea1')).toBe(true);
+  });
+
+  it('classifyFeatures matches RHAII releases correctly', () => {
+    const feat = {
+      key: 'RHAISTRAT-200',
+      url: '',
+      summary: 'RHAII feature',
+      status: 'In Progress',
+      target_version: 'RHAII-3.5 EA1',
+      fix_versions: 'RHAII-3.5 EA1',
+      tv_set: parseVersions('RHAII-3.5 EA1'),
+      fv_set: parseVersions('RHAII-3.5 EA1'),
+      color_status: '',
+      product_manager: '',
+      assignee: '',
+      components: [],
+      component: '',
+    };
+    const result = classifyFeatures([feat], ['RHAII-3.5 EA1']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned');
+  });
+
+  it('classifyFeatures detects tv_only for RHAII releases', () => {
+    const feat = {
+      key: 'RHAISTRAT-201',
+      url: '',
+      summary: 'RHAII feature no FV',
+      status: 'New',
+      target_version: 'RHAII-3.5 EA1',
+      fix_versions: '',
+      tv_set: parseVersions('RHAII-3.5 EA1'),
+      fv_set: parseVersions(''),
+      color_status: '',
+      product_manager: '',
+      assignee: '',
+      components: [],
+      component: '',
+    };
+    const result = classifyFeatures([feat], ['RHAII-3.5 EA1']);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('tv_only');
+  });
+
+  it('buildExport generates valid JQL links for RHAII releases with spaces', () => {
+    const classifications = [
+      { release: 'RHAII-3.5 EA1', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['RHAII-3.5 EA1'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const summary = result.executive_summary[0];
+    expect(summary.release).toBe('RHAII-3.5 EA1');
+    expect(summary.total).toBe(1);
+    // JQL links should contain the quoted release name
+    const totalJql = decodeURIComponent(summary.total_jql);
+    expect(totalJql).toContain('"RHAII-3.5 EA1"');
   });
 });

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -12,6 +12,10 @@ const VERSIONS_CACHE_MAX_AGE_MS = 4 * 60 * 60 * 1000 // 4 hours
 const DEFAULT_RELEASES = ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']
 const DEFAULT_JIRA_PROJECT = 'RHAISTRAT'
 
+// JQL-safe release name pattern — allows spaces for version names like "RHAII-3.5 EA1"
+// Injection is prevented by quoteRelease() wrapping names in double quotes for JQL
+const jqlSafePattern = /^[a-zA-Z0-9._ -]+$/
+
 // ---------------------------------------------------------------------------
 // Fetch releases from planning module (Smartsheet SSOT)
 // ---------------------------------------------------------------------------
@@ -29,8 +33,7 @@ function fetchReleasesFromPlanning(storage) {
       return { releases: DEFAULT_RELEASES, source: 'default' }
     }
 
-    const jqlSafe = /^[a-zA-Z0-9._-]+$/
-    const baseVersions = Object.keys(planningData.releases).filter(function(v) { return jqlSafe.test(v) }).sort()
+    const baseVersions = Object.keys(planningData.releases).filter(function(v) { return jqlSafePattern.test(v) }).sort()
     if (baseVersions.length === 0) {
       console.warn('[releases/tv-fv-delta] No releases configured — falling back to DEFAULT_RELEASES. Update the constant if the current release has changed.')
       return { releases: DEFAULT_RELEASES, source: 'default' }
@@ -43,9 +46,9 @@ function fetchReleasesFromPlanning(storage) {
     for (const v of baseVersions) expanded.push(v)
 
     // Filter out any expanded versions that don't pass JQL safety validation
-    const safeExpanded = expanded.filter(function(v) { return jqlSafe.test(v) })
+    const safeExpanded = expanded.filter(function(v) { return jqlSafePattern.test(v) })
     if (safeExpanded.length < expanded.length) {
-      const dropped = expanded.filter(function(v) { return !jqlSafe.test(v) })
+      const dropped = expanded.filter(function(v) { return !jqlSafePattern.test(v) })
       console.warn('[releases/tv-fv-delta] Dropped ' + dropped.length + ' expanded releases that failed JQL safety validation: ' + dropped.join(', '))
     }
 
@@ -441,6 +444,7 @@ module.exports.classifyFeatures = classifyFeatures
 module.exports.buildExport = buildExport
 module.exports.DEFAULT_RELEASES = DEFAULT_RELEASES
 module.exports.DEFAULT_JIRA_PROJECT = DEFAULT_JIRA_PROJECT
+module.exports.jqlSafePattern = jqlSafePattern
 
 function registerRoutes(router, context) {
   const storage = context.storage
@@ -452,8 +456,6 @@ function registerRoutes(router, context) {
   // Refresh state tracking
   const REFRESH_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
   const refreshState = { running: false, lastResult: null, startedAt: null, completedAt: null }
-
-  const jqlSafePattern = /^[a-zA-Z0-9._-]+$/
 
   function triggerBackgroundRefresh(releases, force) {
     if (refreshState.running) return
@@ -519,7 +521,7 @@ function registerRoutes(router, context) {
         const age = Date.now() - new Date(cachedAt).getTime()
         if (age >= CACHE_MAX_AGE_MS) {
           const cachedReleases = (data.metadata.releases || DEFAULT_RELEASES)
-            .filter(function(r) { return typeof r === 'string' && /^[a-zA-Z0-9._-]+$/.test(r) })
+            .filter(function(r) { return typeof r === 'string' && jqlSafePattern.test(r) })
           triggerBackgroundRefresh(cachedReleases.length ? cachedReleases : DEFAULT_RELEASES)
         }
       }
@@ -584,7 +586,7 @@ function registerRoutes(router, context) {
       if (typeof releases[i] !== 'string' || !jqlSafePattern.test(releases[i])) {
         return res.status(400).json({
           error: 'Invalid release name: ' + releases[i],
-          detail: 'Release names must contain only alphanumeric characters, dots, underscores, and hyphens'
+          detail: 'Release names must contain only alphanumeric characters, dots, underscores, hyphens, and spaces'
         })
       }
     }


### PR DESCRIPTION
## Summary
- `jqlSafePattern` regex (`/^[a-zA-Z0-9._-]+$/`) rejected version names containing spaces (e.g. "RHAII-3.5 EA1"), causing the TV/FV delta pipeline to silently return no data for those releases
- Updated pattern to `/^[a-zA-Z0-9._ -]+$/` — spaces are safe in JQL since `quoteRelease()` wraps all version names in double quotes
- Extracted `jqlSafePattern` to a module-level constant for consistency across all 4 validation sites (was duplicated inline in `fetchReleasesFromPlanning` and the GET handler)

## Test plan
- [x] Added `jqlSafePattern` tests — accepts spaces, rejects injection attempts
- [x] Added RHAII version handling tests — normVer, parseVersions, classifyFeatures, buildExport all work with space-containing version names
- [x] All 56 tests pass (`npx vitest run modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)