### PR TITLE
fix(nav): move Releases above AI Impact in sidebar

### DIFF
--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -4,7 +4,7 @@
   "defaultEnabled": true,
   "description": "Unified release lifecycle: planning, execution tracking, and delivery readiness",
   "icon": "rocket",
-  "order": 10,
+  "order": 3,
   "client": {
     "entry": "./client/index.js",
     "navItems": [


### PR DESCRIPTION
## Summary
- Changes Releases module nav order from 10 to 3, placing it above AI Impact (order 5) in the sidebar

## Test plan
- [ ] Verify Releases appears above AI Impact in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)