### PR TITLE
fix(pulse-social): fix My Posts not showing user's own posts

### DIFF
--- a/modules/pulse-social/client/views/MyPostsView.vue
+++ b/modules/pulse-social/client/views/MyPostsView.vue
@@ -116,8 +116,7 @@ async function loadPosts(append = false) {
   error.value = null
 
   try {
-    const uid = user.value?.uid || user.value?.email || ''
-    const params = new URLSearchParams({ author: uid })
+    const params = new URLSearchParams({ mine: 'true' })
     if (append && nextCursor.value) params.set('before', nextCursor.value)
 
     const data = await apiRequest(`${API_BASE}/posts?${params}`)

--- a/modules/pulse-social/server/index.js
+++ b/modules/pulse-social/server/index.js
@@ -71,15 +71,16 @@ module.exports = function registerRoutes(router, context) {
    */
   router.get('/posts', ...readAuth, function(req, res) {
     try {
+      const currentUserUid = req.userUid || req.userEmail
       const result = listPosts({
         before: req.query.before,
         limit: req.query.limit,
         label: req.query.label,
         team: req.query.team,
-        author: req.query.author,
+        author: req.query.mine === 'true' ? currentUserUid : req.query.author,
         mentioning: req.query.mentioning,
         search: req.query.search,
-        currentUserUid: req.userUid || req.userEmail
+        currentUserUid
       })
       res.json(result)
     } catch (err) {


### PR DESCRIPTION
## Summary

My Posts view showed empty because of a UID mismatch between client and server.

## Root Cause

The server stores `author_uid` from `req.userUid` (e.g. `dipgupta`) but the client was sending `user.email` (e.g. `dipgupta@cluster.local`) as the author filter. These don't match.

## Fix

Added `mine=true` query parameter that resolves server-side to `req.userUid`, ensuring the filter always matches what was stored. No client-side UID guessing needed.