### PR TITLE
feat(team-tracker): add Autofix tab to team detail page

### DIFF
--- a/AUTOFIX-TAB-PLAN.md
+++ b/AUTOFIX-TAB-PLAN.md
@@ -1,0 +1,472 @@
+# Autofix Tab on Team Detail Page — Design Plan
+
+## Overview
+
+Add an "Autofix" tab to the team detail page in the team-tracker module that shows
+Jira issues for a given team that went through the AI autofix pipeline, along with
+aggregate bug counts and pipeline state breakdown.
+
+## Data Model Analysis
+
+### Autofix Data (ai-impact module)
+
+Autofix data is fetched from Jira projects (AIPCC, RHOAIENG by default) and stored
+at `ai-impact/autofix-data.json`. Each issue has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Jira issue key (e.g., `RHOAIENG-59199`) |
+| `summary` | string | Issue summary |
+| `status` | string | Jira status name |
+| `issueType` | string | Bug, Story, etc. |
+| `priority` | string | Priority name |
+| `created` | string | ISO date |
+| `updated` | string | ISO date |
+| `labels` | string[] | All labels including pipeline labels |
+| `components` | string[] | Jira components (e.g., `["AI Core Platform"]`) |
+| `assignee` | string\|null | Display name |
+| `pipelineState` | string | Classified state — see below |
+
+### Pipeline States
+
+**Triage states:** `triage-pending`, `triage-missing-info`, `triage-not-fixable`, `triage-stale`
+
+**Autofix states:** `autofix-ready`, `autofix-pending`, `autofix-review`,
+`autofix-ci-failing`, `autofix-merged`, `autofix-rejected`, `autofix-max-retries`,
+`autofix-researched`, `autofix-blocked`
+
+### Team-to-Component Mapping
+
+Teams in team-tracker have a `components` array on the **enriched team detail**
+object (`teamDetail`), NOT on the base `team` object from the roster. The components
+are sourced from team metadata via a field definition with `optionsRef: 'component'`
+and populated by `buildEnrichedTeams()` in `org-teams.js:168-174`. Example: team
+"Heimdall" → `teamDetail.components = ["AI Core Platform", "AI Core Platform Security"]`.
+
+**Matching strategy:** Filter autofix issues where `issue.components` intersects with
+`teamDetail.components`. This is the natural mapping since Jira components are already
+aligned with teams.
+
+**Important:** `teamDetail` is fetched asynchronously after the team page loads
+(`fetchTeamDetail()` in `TeamRosterView.vue:487-498`). `TeamAutofixTab` must defer
+its autofix data fetch until `teamDetail?.components` is available (watch for it),
+to avoid briefly showing "no data" while the enriched team data loads.
+
+### API Endpoint
+
+The ai-impact module serves autofix data at:
+```
+GET /api/modules/ai-impact/autofix-data?timeWindow=week|month|3months
+```
+
+Response:
+```json
+{
+  "fetchedAt": "2026-04-22T05:17:38.418Z",
+  "jiraHost": "https://redhat.atlassian.net",
+  "metrics": { ... },
+  "trendData": [...],
+  "issues": [...]
+}
+```
+
+**Key detail:** The endpoint returns ALL `issues` regardless of `timeWindow`. The
+`timeWindow` parameter only affects the pre-computed `metrics` and `trendData` in the
+response. Since we recompute both client-side for the team-filtered subset anyway,
+we should **fetch once** (without a timeWindow param, or with a fixed value) and do
+all time-window filtering locally. This avoids redundant API calls when the user
+changes the time window selector.
+
+### ai-impact Module Dependency
+
+The Autofix tab calls `/api/modules/ai-impact/autofix-data`. If the ai-impact module
+is **disabled** (admin can toggle modules), this endpoint returns 404. The tab must
+handle this gracefully:
+
+1. Check `enabledBuiltInSlugs` (from `useModules()`) to determine if `ai-impact` is
+   enabled before making the API call.
+2. If disabled, show a specific empty state: "The AI Impact module is not enabled.
+   Enable it in Settings to see autofix data."
+3. If the API call fails for other reasons (network error, 500), show a generic error
+   state with retry option.
+
+## Architecture Decision: Cross-Module Data Access
+
+The ai-impact module does **not** declare `export.files` in its `module.json`. Per
+the project's hard constraints, cross-module data access uses API calls at
+`/api/modules/<slug>/`.
+
+**Chosen approach:** The team-tracker client will call
+`/api/modules/ai-impact/autofix-data` and filter issues client-side by matching
+`issue.components` against `teamDetail.components`.
+
+**Why client-side filtering:**
+- The autofix dataset is bounded (hundreds, not thousands of issues)
+- Avoids adding a team-aware endpoint to the ai-impact module
+- The existing endpoint already returns all issues with component data
+- Matches the pattern used by `AutofixContent.vue` which already does client-side
+  component filtering
+- No server-side changes needed in the ai-impact module
+
+**Alternative considered:** Adding a server-side route in team-tracker that reads
+ai-impact data via `readFromStorage`. Rejected because ai-impact doesn't export
+files, so this would violate the module boundary constraint.
+
+## UI Design
+
+### Tab Placement
+
+Append "Autofix" to the end of the existing `visibleTabs` array in `TeamRosterView`:
+
+```
+Overview | Delivery | RFE Backlog | 40/40/20 Allocation | Autofix
+```
+
+The tab is **always visible** (per requirements), with contextual empty states:
+- No components configured → prompt to add components
+- ai-impact module disabled → explain module needs enabling
+- No matching issues → explain no autofix data for this team's components
+
+### Tab Content Layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Summary Cards (3 cards in a row)                               │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
+│  │ Total Issues  │  │ Bugs Fixed   │  │ Success Rate │          │
+│  │     42        │  │ (merged)  18 │  │    72%       │          │
+│  └──────────────┘  └──────────────┘  └──────────────┘          │
+├─────────────────────────────────────────────────────────────────┤
+│  Pipeline Breakdown Bar                                         │
+│  [████ Merged ████ Review ██ Pending █ CI Failing █ Blocked]   │
+├─────────────────────────────────────────────────────────────────┤
+│  Time Window: [Week] [Month] [3 Months]                         │
+│  State Filter: [All ▾]   Search: [____________]                 │
+├─────────────────────────────────────────────────────────────────┤
+│  Issues Table                                                   │
+│  ┌──────────┬──────────────────┬──────┬──────────┬───────────┐ │
+│  │ Key      │ Summary          │ Type │ State    │ Updated   │ │
+│  ├──────────┼──────────────────┼──────┼──────────┼───────────┤ │
+│  │ RHOAI-1  │ Fix cert rotate  │ Bug  │ Merged   │ 2d ago    │ │
+│  │ AIPCC-2  │ Bot too aggro    │ Bug  │ Blocked  │ 5d ago    │ │
+│  └──────────┴──────────────────┴──────┴──────────┴───────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│  Pipeline Funnel Trend Chart                                    │
+│  (Line: Eligible for Autofix, Under Review; Bar: Merged)        │
+│  Filtered to this team's components, same style as AI Impact    │
+├─────────────────────────────────────────────────────────────────┤
+│  Empty State (when team has no components or no matching data): │
+│  "No autofix data available for this team."                     │
+│  "This team has no Jira components configured."                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Summary Cards
+
+1. **Total Issues** — Count of all autofix pipeline issues matching this team's
+   components within the selected time window
+2. **Bugs Fixed by AI** — Count of issues with `pipelineState === 'autofix-merged'`
+   AND `issueType === 'Bug'`
+3. **Success Rate** — `merged / (merged + rejected + maxRetries) * 100`. When
+   terminal count is fewer than 3, show "—" instead of a percentage to avoid
+   misleading metrics from tiny samples (e.g., 1/1 = 100%). Tooltip: "Not enough
+   completed issues to calculate a meaningful rate."
+
+### Pipeline Breakdown Bar
+
+Horizontal stacked bar showing the distribution of pipeline states for the team's
+issues. Color-coded (colors defined locally in `TeamAutofixTab.vue` — see
+"Constants" section below):
+- Merged: indigo
+- Review: blue
+- Pending: gray
+- CI Failing: orange
+- Blocked: yellow
+- Max Retries: red
+- Researched: teal
+
+### Trend Chart
+
+Pipeline funnel trend chart using **Chart.js 4** (already a project dependency) via
+`vue-chartjs` (`Line` + `Bar` composite chart). Rendered client-side from
+team-filtered issues.
+
+**Axes:**
+- X: Weekly date buckets (ISO date labels, e.g., "2026-04-22")
+- Y: Issue count (integer, begin at zero)
+
+**Datasets:**
+- Line: "Eligible for Autofix" (green, filled area) — issues with any `autofix-*` state
+- Line: "Under Review" (blue, filled area) — issues with `autofix-review` state
+- Bar: "Merged" (indigo) — issues with `autofix-merged` state
+
+**Bucket computation:** Same weekly-bucketing logic as `buildTrendData()` in
+`autofix-fetcher.js`, but implemented as a pure ES module function in
+`TeamAutofixTab.vue` (see "Constants" section for why we duplicate rather than
+import).
+
+**Chart options:** Responsive, `maintainAspectRatio: false`, dark-mode aware
+(watch `document.documentElement.classList` for `dark`). Same pattern as
+`AutofixContent.vue:270-280`.
+
+### Filters
+
+- **Time window:** Week / Month / 3 Months (default: Month) — filter by `created` date
+- **State filter:** Dropdown with pipeline state options (defined locally in the
+  component — see "Constants" section)
+- **Search:** Text search on key, summary, assignee
+
+**Note on metrics recomputation:** The server response includes pre-computed `metrics`
+and `trendData`, but these are aggregated across ALL teams. Since the tab filters to
+a single team's components, **all metrics, trend data, and time-window filtering are
+recomputed client-side** from the team-filtered `issues` array. The API is called
+once (without regard to timeWindow) and all subsequent filtering happens locally.
+This mirrors `AutofixContent.vue`'s pattern (lines 101-168) which already recomputes
+when project/component filters are active.
+
+### Issue Table Columns
+
+| Column | Source | Notes |
+|--------|--------|-------|
+| Key | `issue.key` | Linked to Jira (fallback host: `https://redhat.atlassian.net` if `jiraHost` missing from API response) |
+| Summary | `issue.summary` | Truncated with tooltip |
+| Type | `issue.issueType` | Badge (Bug, Story, etc.) |
+| Priority | `issue.priority` | Optional column |
+| Pipeline State | `issue.pipelineState` | Color-coded badge with human-readable label |
+| Assignee | `issue.assignee` | Display name |
+| Updated | `issue.updated` | Relative time (e.g., "2d ago") |
+
+### Empty States
+
+1. **ai-impact module disabled:** "The AI Impact module is not enabled. Enable it in
+   Settings to see autofix data." (Checked via `enabledBuiltInSlugs` before API call.)
+2. **Team has no components:** "This team has no Jira components configured. Add
+   components in team settings to see autofix data."
+3. **No matching issues:** "No autofix issues found for this team's components in
+   the selected time window."
+4. **Autofix data not yet fetched:** "Autofix data has not been loaded yet. An admin
+   can trigger a refresh from the AI Impact settings."
+5. **API error / network failure:** "Failed to load autofix data." with retry button.
+
+## Files to Create/Modify
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `modules/team-tracker/client/components/autofix/TeamAutofixTab.vue` | Main tab component — fetches data, filters by team components, renders summary + table + trend chart |
+| `modules/team-tracker/client/components/autofix/autofix-constants.js` | Pipeline state labels, colors, and `STATE_OPTIONS` (duplicated from ai-impact — see "Constants" section) |
+| `modules/team-tracker/client/services/autofix-api.js` | API client for fetching autofix data from ai-impact module |
+| `modules/team-tracker/__tests__/client/autofix/TeamAutofixTab.test.js` | Unit tests for the tab component |
+| `modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js` | Unit tests for metrics computation and constants |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `modules/team-tracker/client/views/TeamRosterView.vue` | Add "Autofix" to `visibleTabs`, `VALID_TABS`, `TAB_ICONS`, `tabActivated`. Import and render `TeamAutofixTab`. |
+
+### File Count: 6 new, 1 modified
+
+## Implementation Details
+
+### `autofix-api.js`
+
+```js
+import { cachedRequest } from '@shared/client/services/api.js'
+
+export function fetchAutofixData(onData) {
+  return cachedRequest('autofix-data', '/modules/ai-impact/autofix-data', onData)
+}
+```
+
+Uses `cachedRequest(cacheKey, path, onData)` (stale-while-revalidate) so switching
+between tabs doesn't re-fetch every time. The `onData` callback fires with cached
+data first, then fresh data. **No `timeWindow` param** — the endpoint returns all
+issues regardless of timeWindow, and we do all time filtering client-side.
+
+### `autofix-constants.js` — Constants (Duplicated from ai-impact)
+
+Hard constraint #1 forbids cross-module imports. `AutofixContent.vue` (in
+`modules/ai-impact/`) contains pipeline state labels, colors, and the
+`STATE_OPTIONS` array. The metrics computation logic lives in `autofix-fetcher.js`
+(server-side CommonJS, not importable from frontend ES modules). Both must be
+**duplicated** in team-tracker.
+
+```js
+// modules/team-tracker/client/components/autofix/autofix-constants.js
+
+export const STATE_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'triage-pending', label: 'AI Assessing' },
+  { value: 'triage-missing-info', label: 'Missing Info' },
+  // ... (full list from AutofixContent.vue:170-185)
+]
+
+export const STATE_COLORS = {
+  'autofix-merged': { bg: 'bg-indigo-100', text: 'text-indigo-800', ... },
+  'autofix-review': { bg: 'bg-blue-100', text: 'text-blue-800', ... },
+  // ... (derived from AutofixContent.vue badge styles)
+}
+
+export function computeTeamMetrics(issues, timeWindow) {
+  // Port of computeAutofixMetrics from autofix-fetcher.js
+  // Pure ES module function, no external dependencies
+}
+
+export function buildTeamTrendData(issues, timeWindow) {
+  // Port of buildTrendData from autofix-fetcher.js
+  // Weekly bucketing by created date, current pipelineState
+}
+```
+
+**Why duplicate instead of moving to `@shared`:** These constants are specific to
+the autofix pipeline labeling convention. Moving them to shared would create a
+coupling between the shared layer and a module-specific Jira label scheme. The
+duplication is small (~60 lines of constants + ~80 lines of computation) and
+unlikely to drift since the pipeline label set is stable.
+
+### `TeamAutofixTab.vue` — Key Logic
+
+The component will:
+1. Accept `team` and `teamDetail` props (same as other tabs)
+2. Check if ai-impact module is enabled via `enabledBuiltInSlugs` (from
+   `useModules()` composable). If disabled, show module-disabled empty state
+   without making any API call.
+3. **Watch** `teamDetail?.components` — only fetch autofix data once components are
+   available (avoids race condition where `teamDetail` loads after the tab mounts)
+4. Call `fetchAutofixData(onData)` **once** — extract `jiraHost` + `issues` from
+   response. Handle 404 (module disabled at runtime) and network errors gracefully.
+5. Filter issues by component intersection:
+   `issue.components.some(c => teamComponents.has(c))` where
+   `teamComponents = new Set(teamDetail.components)`
+6. Recompute metrics via `computeTeamMetrics(filteredIssues, timeWindow)` and trend
+   data via `buildTeamTrendData(filteredIssues, timeWindow)` — both imported from
+   `autofix-constants.js`. **Time window changes only trigger local recomputation,
+   not a new API call.**
+7. For success rate display: if terminal count < 3, show "—" with tooltip instead
+   of a percentage.
+8. Build Jira links using `jiraHost` from response (fallback: `https://redhat.atlassian.net`)
+9. Render summary cards, pipeline breakdown, trend chart (Chart.js via `vue-chartjs`),
+   and filterable issue table
+
+### TeamRosterView Changes
+
+Add to `tabActivated`:
+```js
+const tabActivated = ref({ overview: true, delivery: false, backlog: false, allocation: false, autofix: false })
+```
+
+Add to `TAB_ICONS`:
+```js
+autofix: '<path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />'
+```
+
+Add to `visibleTabs`:
+```js
+{ id: 'autofix', label: 'Autofix', icon: TAB_ICONS.autofix }
+```
+
+Add to `VALID_TABS`:
+```js
+const VALID_TABS = ['overview', 'delivery', 'backlog', 'allocation', 'autofix']
+```
+
+Add template section:
+```html
+<div v-if="tabActivated.autofix" v-show="activeTab === 'autofix'">
+  <TeamAutofixTab :team="team" :teamDetail="teamDetail" />
+</div>
+```
+
+## Testability
+
+### Unit Tests (`TeamAutofixTab.test.js`)
+
+1. **Renders module-disabled state** when ai-impact is not in `enabledBuiltInSlugs`
+2. **Renders empty state** when `teamDetail` has no components
+3. **Renders empty state** when no matching issues exist
+4. **Defers fetch until teamDetail loads** — does not call API when `teamDetail` is null
+5. **Filters issues by component** — given `teamDetail.components = ["A", "B"]`,
+   only shows issues whose components intersect
+6. **Computes metrics correctly** — total count, bug count, success rate
+7. **Success rate shows "—"** when terminal count < 3
+8. **Pipeline state badges** render with correct labels and colors
+9. **Time window filter** changes displayed issues without re-fetching API
+10. **State filter** narrows displayed issues
+11. **Search filter** matches on key, summary, assignee
+12. **Jira links** use `jiraHost` from API response; fall back to default
+13. **Handles API error** — shows error state with retry button
+
+### Unit Tests (`autofix-constants.test.js`)
+
+1. **`computeTeamMetrics`** — matches `computeAutofixMetrics` output for same input
+2. **`buildTeamTrendData`** — produces correct weekly buckets for each time window
+3. **`STATE_OPTIONS`** — all expected pipeline states are present
+
+### Integration Tests
+
+Per the project's integration test enforcement policy, the implementation PR **must**
+update `tests/integration/people-teams.spec.js` with at least:
+1. Navigate to a team detail page
+2. Click the "Autofix" tab
+3. Verify the tab loads without errors (empty state is expected in demo mode since
+   demo team components don't overlap with autofix fixture components)
+
+The existing `people-teams` path filter in `integration-tests.yml` already watches
+`modules/team-tracker/**`, so these tests will run automatically on PRs.
+
+### Demo Mode
+
+The existing `fixtures/ai-impact/autofix-data.json` fixture will serve data in demo
+mode. The team-tracker's demo teams may not have matching components, so the tab will
+show the empty state in demo mode — which is acceptable and tests that code path.
+
+## Backward Compatibility
+
+- **No breaking changes.** Adding a new tab does not affect existing tabs.
+- **No new API endpoints.** Consumes existing ai-impact endpoint.
+- **No module.json changes** for either module.
+- **No new environment variables or secrets.**
+- **Soft dependency on ai-impact module:** The tab checks `enabledBuiltInSlugs`
+  before calling the ai-impact API. If ai-impact is disabled, the tab shows an
+  explanatory empty state. If ai-impact is enabled but the API call fails (network
+  error, 500), the tab shows an error state with retry. The tab never causes a
+  hard failure — it degrades gracefully in all cases.
+- **URL routing:** The `?tab=autofix` parameter integrates with the existing URL
+  routing scheme in TeamRosterView.
+
+## Deployment
+
+No deployment changes needed. The feature is purely frontend — no new backend
+routes, no data migration, no new environment variables.
+
+## Design Decisions
+
+1. **Component-only matching.** Issues are matched to teams solely by Jira component
+   intersection (`teamDetail.components`, not `team.components`). No assignee-based
+   fallback. This keeps the logic clean and consistent with how components already
+   map to teams.
+2. **Include trend chart.** The tab will include a pipeline funnel trend chart
+   (showing autofix activity over time filtered to this team's components), in
+   addition to summary cards and the issue table. Uses Chart.js 4 via `vue-chartjs`.
+3. **Duplicate constants, don't import cross-module.** Pipeline state labels, colors,
+   `STATE_OPTIONS`, and metrics computation logic are duplicated from ai-impact into
+   `autofix-constants.js` within team-tracker. This respects hard constraint #1 (no
+   cross-module imports). The alternative (moving to `@shared`) was rejected because
+   these are module-specific Jira label conventions, not shared platform concerns.
+4. **Fetch once, filter locally.** The API returns all issues regardless of
+   `timeWindow`. We fetch once and recompute metrics/trends/time-window-filtering
+   entirely client-side. Time window changes don't trigger API calls.
+5. **Graceful module dependency.** Check `enabledBuiltInSlugs` before calling
+   ai-impact API. Handle 404 and errors with specific empty states. The tab never
+   causes a hard failure.
+6. **Minimum sample for success rate.** Terminal count < 3 → show "—" instead of
+   a percentage to avoid misleading metrics from tiny samples.
+7. **Component mapping coverage** is the main risk. If team components don't overlap
+   well with autofix issue components, many teams will see empty states. Production
+   data should be sampled to validate coverage before launch.
+8. **Demo mode tests empty state only.** Demo team components don't overlap with
+   autofix fixture components. Integration tests verify the tab loads without errors
+   in empty state. Aligning fixtures is deferred — keeping module fixtures independent
+   reduces maintenance burden.

--- a/modules/team-tracker/__tests__/client/TeamRosterView.test.js
+++ b/modules/team-tracker/__tests__/client/TeamRosterView.test.js
@@ -96,14 +96,25 @@ vi.mock('@shared/client/composables/useModuleLink', () => ({
   useModuleLink: () => ({ linkTo: () => '#' })
 }))
 
+vi.mock('../../../../src/composables/useModules', () => ({
+  useModules: () => ({
+    enabledBuiltInSlugs: ref(['ai-impact', 'team-tracker'])
+  })
+}))
+
+vi.mock('../../client/services/autofix-api.js', () => ({
+  fetchAutofixData: vi.fn().mockResolvedValue({ issues: [], fetchedAt: null })
+}))
+
 // Mock chart dependencies
 vi.mock('vue-chartjs', () => ({
   Doughnut: { template: '<div></div>', props: ['data', 'options'] },
+  Bar: { template: '<div></div>', props: ['data', 'options'] },
   Line: { template: '<div></div>', props: ['data', 'options'] }
 }))
 vi.mock('chart.js', () => ({
   Chart: { register: vi.fn() },
-  ArcElement: {}, Tooltip: {}, Legend: {},
+  ArcElement: {}, Tooltip: {}, Legend: {}, BarElement: {}, BarController: {},
   CategoryScale: {}, LinearScale: {}, PointElement: {}, LineElement: {}, Filler: {}, Title: {}
 }))
 
@@ -166,11 +177,11 @@ describe('TeamRosterView', () => {
     expect(tabLabels).toContain('RFE Backlog')
   })
 
-  it('always shows all 4 tabs', async () => {
+  it('always shows all 5 tabs', async () => {
     const wrapper = mountView()
     await flushPromises()
     const tabLabels = wrapper.findAll('nav button').map(b => b.text())
-    expect(tabLabels).toHaveLength(4)
+    expect(tabLabels).toHaveLength(5)
   })
 
   it('switches tabs when tab buttons are clicked', async () => {

--- a/modules/team-tracker/__tests__/client/autofix/TeamAutofixTab.test.js
+++ b/modules/team-tracker/__tests__/client/autofix/TeamAutofixTab.test.js
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import TeamAutofixTab from '../../../client/components/autofix/TeamAutofixTab.vue'
+
+const mockEnabledSlugs = ref(['ai-impact', 'team-tracker'])
+
+vi.mock('../../../../../src/composables/useModules', () => ({
+  useModules: () => ({
+    enabledBuiltInSlugs: mockEnabledSlugs
+  })
+}))
+
+const mockFetchAutofixData = vi.fn()
+vi.mock('../../../client/services/autofix-api.js', () => ({
+  fetchAutofixData: (...args) => mockFetchAutofixData(...args)
+}))
+
+// Stub chart.js and vue-chartjs to avoid canvas rendering
+vi.mock('vue-chartjs', () => ({
+  Bar: { template: '<div class="chart-stub"></div>', props: ['data', 'options'] },
+  Line: { template: '<div class="chart-stub"></div>', props: ['data', 'options'] }
+}))
+
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  CategoryScale: {},
+  LinearScale: {},
+  PointElement: {},
+  LineElement: {},
+  BarElement: {},
+  BarController: {},
+  Filler: {},
+  Tooltip: {},
+  Legend: {}
+}))
+
+const sampleIssues = [
+  { key: 'RHOAI-1', summary: 'Fix cert rotate', issueType: 'Bug', priority: 'Major', pipelineState: 'autofix-merged', assignee: 'Alice', components: ['AI Core Platform'], created: '2026-05-20', updated: '2026-05-28', labels: [] },
+  { key: 'RHOAI-2', summary: 'Bot too aggressive', issueType: 'Bug', priority: 'Minor', pipelineState: 'autofix-review', assignee: 'Bob', components: ['AI Core Platform'], created: '2026-05-21', updated: '2026-05-29', labels: [] },
+  { key: 'RHOAI-3', summary: 'Other team issue', issueType: 'Bug', priority: 'Major', pipelineState: 'autofix-merged', assignee: null, components: ['Dashboard'], created: '2026-05-22', updated: '2026-05-30', labels: [] },
+  { key: 'RHOAI-4', summary: 'Rejected fix', issueType: 'Story', priority: 'Major', pipelineState: 'autofix-rejected', assignee: 'Carol', components: ['AI Core Platform'], created: '2026-05-23', updated: '2026-05-31', labels: [] },
+  { key: 'RHOAI-5', summary: 'Max retries hit', issueType: 'Bug', priority: 'Critical', pipelineState: 'autofix-max-retries', assignee: 'Dave', components: ['AI Core Platform', 'Security'], created: '2026-05-24', updated: '2026-06-01', labels: [] }
+]
+
+const sampleApiResponse = {
+  fetchedAt: '2026-06-01T05:00:00Z',
+  jiraHost: 'https://redhat.atlassian.net',
+  metrics: {},
+  trendData: [],
+  issues: sampleIssues
+}
+
+function setupFetchSuccess(data = sampleApiResponse) {
+  mockFetchAutofixData.mockImplementation((onData) => {
+    if (onData) onData(data)
+    return Promise.resolve(data)
+  })
+}
+
+function setupFetchError(err) {
+  mockFetchAutofixData.mockRejectedValue(err)
+}
+
+function mountTab(propsOverrides = {}) {
+  return mount(TeamAutofixTab, {
+    props: {
+      team: { key: 'org::Heimdall', displayName: 'Heimdall' },
+      teamDetail: { components: ['AI Core Platform', 'Security'] },
+      ...propsOverrides
+    }
+  })
+}
+
+describe('TeamAutofixTab', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+    mockFetchAutofixData.mockReset()
+    mockEnabledSlugs.value = ['ai-impact', 'team-tracker']
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Test 1
+  it('renders module-disabled state when ai-impact is not in enabledBuiltInSlugs', () => {
+    mockEnabledSlugs.value = ['team-tracker']
+    const wrapper = mountTab()
+    expect(wrapper.text()).toContain('AI Impact module not enabled')
+    expect(wrapper.text()).toContain('Enable it in Settings')
+    expect(mockFetchAutofixData).not.toHaveBeenCalled()
+  })
+
+  // Test 2
+  it('renders empty state when teamDetail has no components', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: { components: [] } })
+    expect(wrapper.text()).toContain('No components configured')
+    expect(wrapper.text()).toContain('Add components in team settings')
+    expect(mockFetchAutofixData).not.toHaveBeenCalled()
+  })
+
+  // Test 3
+  it('renders empty state when no matching issues exist', async () => {
+    const dataWithNoMatch = {
+      ...sampleApiResponse,
+      issues: [{ key: 'X-1', summary: 'Unrelated', issueType: 'Bug', priority: 'Major', pipelineState: 'autofix-merged', assignee: null, components: ['Other'], created: '2026-05-20', updated: '2026-05-28', labels: [] }]
+    }
+    setupFetchSuccess(dataWithNoMatch)
+    const wrapper = mountTab()
+    await flushPromises()
+    expect(wrapper.text()).toContain('No autofix issues')
+  })
+
+  // Test 4
+  it('defers fetch until teamDetail loads', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: null })
+    await flushPromises()
+    expect(mockFetchAutofixData).not.toHaveBeenCalled()
+
+    // Simulate teamDetail loading
+    await wrapper.setProps({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+    expect(mockFetchAutofixData).toHaveBeenCalledOnce()
+  })
+
+  // Test 5
+  it('filters issues by component intersection', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+    // RHOAI-3 has component 'Dashboard' and should be excluded
+    expect(wrapper.text()).toContain('RHOAI-1')
+    expect(wrapper.text()).toContain('RHOAI-2')
+    expect(wrapper.text()).not.toContain('RHOAI-3')
+    expect(wrapper.text()).toContain('RHOAI-4')
+    expect(wrapper.text()).toContain('RHOAI-5')
+  })
+
+  // Test 6
+  it('computes metrics correctly', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+    // Total matching issues in window: 4 (RHOAI-1, 2, 4, 5 match AI Core Platform)
+    expect(wrapper.text()).toContain('4') // total
+    // Bugs merged: RHOAI-1 (Bug + merged) = 1
+    expect(wrapper.text()).toContain('1') // bugs fixed
+  })
+
+  // Test 7
+  it('shows dash for success rate when terminal count < 3', async () => {
+    const fewIssues = {
+      ...sampleApiResponse,
+      issues: [
+        { key: 'A-1', summary: 'Fix', issueType: 'Bug', priority: 'Major', pipelineState: 'autofix-merged', assignee: null, components: ['AI Core Platform'], created: '2026-05-20', updated: '2026-05-28', labels: [] }
+      ]
+    }
+    setupFetchSuccess(fewIssues)
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+    // Terminal total = 1 (< 3), so should show dash
+    expect(wrapper.text()).toContain('\u2014') // em dash
+  })
+
+  // Test 8
+  it('renders pipeline state badges with correct labels', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('AI Fix Merged')
+    expect(wrapper.text()).toContain('AI Fix Under Review')
+    expect(wrapper.text()).toContain('AI Fix Rejected')
+    expect(wrapper.text()).toContain('AI Max Retries')
+  })
+
+  // Test 9
+  it('time window filter changes displayed issues without re-fetching API', async () => {
+    const issuesWithOldDate = {
+      ...sampleApiResponse,
+      issues: [
+        ...sampleIssues,
+        { key: 'OLD-1', summary: 'Old issue', issueType: 'Bug', priority: 'Major', pipelineState: 'autofix-merged', assignee: null, components: ['AI Core Platform'], created: '2026-05-24', updated: '2026-05-25', labels: [] }
+      ]
+    }
+    setupFetchSuccess(issuesWithOldDate)
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+    const initialCallCount = mockFetchAutofixData.mock.calls.length
+
+    // Switch time window
+    const weekBtn = wrapper.findAll('button').find(b => b.text() === 'Week')
+    await weekBtn.trigger('click')
+    await flushPromises()
+
+    // API not called again
+    expect(mockFetchAutofixData.mock.calls.length).toBe(initialCallCount)
+  })
+
+  // Test 10
+  it('state multi-select filter narrows displayed issues', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+
+    // Open dropdown and check the 'autofix-merged' checkbox
+    const dropdownBtn = wrapper.find('.relative button')
+    await dropdownBtn.trigger('click')
+    await flushPromises()
+
+    const checkboxes = wrapper.findAll('.relative input[type="checkbox"]')
+    const mergedCheckbox = checkboxes.find(cb => {
+      const label = cb.element.parentElement
+      return label && label.textContent.includes('AI Fix Merged')
+    })
+    await mergedCheckbox.trigger('change')
+    await flushPromises()
+
+    // Only RHOAI-1 is merged and has AI Core Platform component
+    const tableRows = wrapper.findAll('tbody tr')
+    expect(tableRows.length).toBe(1)
+    expect(wrapper.text()).toContain('RHOAI-1')
+  })
+
+  // Test 11
+  it('search filter matches on key, summary, assignee', async () => {
+    setupFetchSuccess()
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+
+    const input = wrapper.find('input[type="text"]')
+
+    // Search by assignee
+    await input.setValue('Bob')
+    await flushPromises()
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(1)
+    expect(wrapper.text()).toContain('RHOAI-2')
+  })
+
+  // Test 12
+  it('Jira links use jiraHost from API response', async () => {
+    const customHost = { ...sampleApiResponse, jiraHost: 'https://custom.atlassian.net' }
+    setupFetchSuccess(customHost)
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+
+    const link = wrapper.find('a[href*="RHOAI-1"]')
+    expect(link.attributes('href')).toBe('https://custom.atlassian.net/browse/RHOAI-1')
+  })
+
+  // Test 13
+  it('handles API error and shows error state with retry button', async () => {
+    setupFetchError(new Error('Network failure'))
+    const wrapper = mountTab({ teamDetail: { components: ['AI Core Platform'] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to load autofix data')
+    expect(wrapper.text()).toContain('Network failure')
+
+    // Reset mock for retry
+    setupFetchSuccess()
+    const retryBtn = wrapper.find('button')
+    await retryBtn.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Failed to load autofix data')
+  })
+})

--- a/modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js
+++ b/modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { computeTeamMetrics, buildTeamTrendData, STATE_OPTIONS } from '../../../client/components/autofix/autofix-constants.js'
+
+describe('autofix-constants', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('computeTeamMetrics', () => {
+    it('computes correct metrics for a set of issues', () => {
+      const issues = [
+        { key: 'A-1', created: '2026-05-20', pipelineState: 'autofix-merged', issueType: 'Bug' },
+        { key: 'A-2', created: '2026-05-21', pipelineState: 'autofix-review', issueType: 'Bug' },
+        { key: 'A-3', created: '2026-05-22', pipelineState: 'autofix-rejected', issueType: 'Story' },
+        { key: 'A-4', created: '2026-05-23', pipelineState: 'autofix-max-retries', issueType: 'Bug' },
+        { key: 'A-5', created: '2026-05-24', pipelineState: 'triage-pending', issueType: 'Bug' },
+        { key: 'A-6', created: '2026-01-01', pipelineState: 'autofix-merged', issueType: 'Bug' } // outside month window
+      ]
+
+      const result = computeTeamMetrics(issues, 'month')
+
+      expect(result.windowTotal).toBe(5)
+      expect(result.totalIssues).toBe(6)
+      expect(result.autofixStates.merged).toBe(1)
+      expect(result.autofixStates.review).toBe(1)
+      expect(result.autofixStates.rejected).toBe(1)
+      expect(result.autofixStates.maxRetries).toBe(1)
+      expect(result.terminalTotal).toBe(3) // merged + rejected + maxRetries
+      expect(result.successRate).toBe(33) // 1/3 = 33%
+    })
+  })
+
+  describe('buildTeamTrendData', () => {
+    it('produces correct weekly buckets for month time window', () => {
+      const issues = [
+        { key: 'A-1', created: '2026-05-28', pipelineState: 'autofix-merged' },
+        { key: 'A-2', created: '2026-05-29', pipelineState: 'autofix-review' },
+        { key: 'A-3', created: '2026-05-15', pipelineState: 'triage-pending' }
+      ]
+
+      const result = buildTeamTrendData(issues, 'month')
+
+      expect(result).toHaveLength(8) // month = 8 weekly buckets
+      expect(result[result.length - 1].date).toBe('2026-06-01')
+      // Verify each bucket has expected fields
+      for (const point of result) {
+        expect(point).toHaveProperty('date')
+        expect(point).toHaveProperty('triaged')
+        expect(point).toHaveProperty('autofixed')
+        expect(point).toHaveProperty('merged')
+        expect(point).toHaveProperty('review')
+      }
+    })
+  })
+
+  describe('STATE_OPTIONS', () => {
+    it('contains all expected pipeline states', () => {
+      const values = STATE_OPTIONS.map(o => o.value)
+      expect(values).toContain('all')
+      expect(values).toContain('triage-pending')
+      expect(values).toContain('triage-missing-info')
+      expect(values).toContain('triage-not-fixable')
+      expect(values).toContain('triage-stale')
+      expect(values).toContain('autofix-ready')
+      expect(values).toContain('autofix-pending')
+      expect(values).toContain('autofix-review')
+      expect(values).toContain('autofix-ci-failing')
+      expect(values).toContain('autofix-merged')
+      expect(values).toContain('autofix-rejected')
+      expect(values).toContain('autofix-max-retries')
+      expect(values).toContain('autofix-researched')
+      expect(values).toContain('autofix-blocked')
+    })
+  })
+})

--- a/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
+++ b/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
@@ -1,0 +1,480 @@
+<template>
+  <!-- Empty state: ai-impact module disabled -->
+  <div v-if="!aiImpactEnabled" class="text-center py-16 text-gray-500 dark:text-gray-400">
+    <svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+    </svg>
+    <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">AI Impact module not enabled</h3>
+    <p class="text-sm max-w-md mx-auto">The AI Impact module is not enabled. Enable it in Settings to see autofix data.</p>
+  </div>
+
+  <!-- Empty state: team has no components -->
+  <div v-else-if="!teamComponents.length" class="text-center py-16 text-gray-500 dark:text-gray-400">
+    <svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+    <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">No components configured</h3>
+    <p class="text-sm max-w-md mx-auto">This team has no Jira components configured. Add components in team settings to see autofix data.</p>
+  </div>
+
+  <!-- Loading state -->
+  <div v-else-if="loading" class="flex items-center justify-center py-12">
+    <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+  </div>
+
+  <!-- Error state -->
+  <div v-else-if="error" class="text-center py-16 text-gray-500 dark:text-gray-400">
+    <svg class="mx-auto h-12 w-12 text-red-300 dark:text-red-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+    </svg>
+    <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">Failed to load autofix data</h3>
+    <p class="text-sm max-w-md mx-auto mb-4">{{ error }}</p>
+    <button @click="fetchData" class="px-4 py-2 text-sm bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors">
+      Retry
+    </button>
+  </div>
+
+  <!-- Empty state: data not yet fetched -->
+  <div v-else-if="dataNotFetched" class="text-center py-16 text-gray-500 dark:text-gray-400">
+    <svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+    </svg>
+    <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">Autofix data not loaded</h3>
+    <p class="text-sm max-w-md mx-auto">Autofix data has not been loaded yet. An admin can trigger a refresh from the AI Impact settings.</p>
+  </div>
+
+  <!-- Main content -->
+  <div v-else>
+    <!-- Empty state: no matching issues -->
+    <div v-if="teamIssues.length === 0" class="text-center py-16 text-gray-500 dark:text-gray-400">
+      <svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+      </svg>
+      <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">No autofix issues</h3>
+      <p class="text-sm max-w-md mx-auto">No autofix issues found for this team's components in the selected time window.</p>
+    </div>
+
+    <template v-else>
+      <!-- Summary Cards -->
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <p class="text-sm text-gray-500 dark:text-gray-400">Total Issues</p>
+          <p class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ metrics.windowTotal }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <p class="text-sm text-gray-500 dark:text-gray-400">Bugs Fixed by AI</p>
+          <p class="text-2xl font-bold text-green-600 dark:text-green-400">{{ bugsMerged }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <p class="text-sm text-gray-500 dark:text-gray-400">Success Rate</p>
+          <p class="text-2xl font-bold text-gray-900 dark:text-gray-100" :title="successRateTooltip">
+            {{ successRateDisplay }}
+          </p>
+        </div>
+      </div>
+
+      <!-- Pipeline Breakdown Bar -->
+      <div v-if="pipelineSegments.length > 0" class="mb-6">
+        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Pipeline Breakdown</h4>
+        <div class="flex h-6 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700">
+          <div
+            v-for="seg in pipelineSegments"
+            :key="seg.state"
+            :class="seg.color"
+            :style="{ width: seg.pct + '%' }"
+            :title="`${seg.label}: ${seg.count}`"
+            class="transition-all"
+          ></div>
+        </div>
+        <div class="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs text-gray-500 dark:text-gray-400">
+          <span v-for="seg in pipelineSegments" :key="seg.state" class="flex items-center gap-1">
+            <span :class="seg.color" class="inline-block w-2.5 h-2.5 rounded-full"></span>
+            {{ seg.label }}: {{ seg.count }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Filters -->
+      <div class="flex flex-wrap items-center gap-3 mb-4">
+        <div class="flex rounded-md overflow-hidden border border-gray-300 dark:border-gray-600">
+          <button
+            v-for="tw in timeWindows"
+            :key="tw.value"
+            @click="timeWindow = tw.value"
+            class="px-3 py-1.5 text-xs font-medium transition-colors"
+            :class="timeWindow === tw.value
+              ? 'bg-primary-600 text-white'
+              : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'"
+          >
+            {{ tw.label }}
+          </button>
+        </div>
+        <div class="relative" ref="stateDropdownRef">
+          <button
+            @click="stateDropdownOpen = !stateDropdownOpen"
+            class="text-sm border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 flex items-center gap-1.5 min-w-[140px]"
+          >
+            <span>{{ stateFilterLabel }}</span>
+            <svg class="w-3.5 h-3.5 ml-auto shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+          </button>
+          <div
+            v-if="stateDropdownOpen"
+            class="absolute z-20 mt-1 w-56 max-h-64 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-1"
+          >
+            <label
+              v-for="opt in stateFilterOptions"
+              :key="opt.value"
+              class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                :checked="stateFilter.includes(opt.value)"
+                @change="toggleStateFilter(opt.value)"
+                class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+              />
+              {{ opt.label }}
+            </label>
+          </div>
+        </div>
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search key, summary, assignee..."
+          class="text-sm border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 w-64"
+        />
+      </div>
+
+      <!-- Issues Table -->
+      <div class="overflow-x-auto mb-6">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200 dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
+              <th class="pb-2 pr-4 font-medium">Key</th>
+              <th class="pb-2 pr-4 font-medium">Summary</th>
+              <th class="pb-2 pr-4 font-medium">Type</th>
+              <th class="pb-2 pr-4 font-medium">Priority</th>
+              <th class="pb-2 pr-4 font-medium">Pipeline State</th>
+              <th class="pb-2 pr-4 font-medium">Assignee</th>
+              <th class="pb-2 font-medium">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="issue in displayedIssues"
+              :key="issue.key"
+              class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+            >
+              <td class="py-2 pr-4">
+                <a
+                  :href="`${jiraHost}/browse/${issue.key}`"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
+                >{{ issue.key }}</a>
+              </td>
+              <td class="py-2 pr-4 max-w-xs truncate" :title="issue.summary">{{ issue.summary }}</td>
+              <td class="py-2 pr-4">
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                  {{ issue.issueType }}
+                </span>
+              </td>
+              <td class="py-2 pr-4 text-gray-600 dark:text-gray-400">{{ issue.priority }}</td>
+              <td class="py-2 pr-4">
+                <span
+                  :class="getStateColorClass(issue.pipelineState)"
+                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                >{{ getStateLabel(issue.pipelineState) }}</span>
+              </td>
+              <td class="py-2 pr-4 text-gray-600 dark:text-gray-400">{{ issue.assignee || '—' }}</td>
+              <td class="py-2 text-gray-500 dark:text-gray-400">{{ formatRelativeDate(issue.updated) }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-if="displayedIssues.length === 0" class="text-center text-gray-400 dark:text-gray-500 py-6 text-sm">
+          No issues match the current filters.
+        </p>
+      </div>
+
+      <!-- Trend Chart -->
+      <div v-if="trendData.length > 0 && hasTrendActivity" class="mt-6">
+        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Pipeline Funnel Trend</h4>
+        <div class="h-64 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <Bar :data="funnelChartData" :options="funnelChartOptions" />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  BarController,
+  Filler,
+  Tooltip,
+  Legend
+} from 'chart.js'
+import { useModules } from '../../../../../src/composables/useModules'
+import { fetchAutofixData } from '../../services/autofix-api.js'
+import {
+  STATE_OPTIONS,
+  PIPELINE_BAR_SEGMENTS,
+  stateLabel,
+  stateColorClass,
+  computeTeamMetrics,
+  buildTeamTrendData
+} from './autofix-constants.js'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, BarController, Filler, Tooltip, Legend)
+
+const props = defineProps({
+  team: { type: Object, default: null },
+  teamDetail: { type: Object, default: null }
+})
+
+const { enabledBuiltInSlugs } = useModules()
+
+const isDark = ref(false)
+let darkObserver = null
+onMounted(() => {
+  isDark.value = document.documentElement.classList.contains('dark')
+  darkObserver = new MutationObserver(() => {
+    isDark.value = document.documentElement.classList.contains('dark')
+  })
+  darkObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+  document.addEventListener('click', handleClickOutside)
+})
+onBeforeUnmount(() => {
+  if (darkObserver) darkObserver.disconnect()
+  document.removeEventListener('click', handleClickOutside)
+})
+
+const textColor = computed(() => isDark.value ? 'rgba(209, 213, 219, 1)' : 'rgba(107, 114, 128, 1)')
+const gridColor = computed(() => isDark.value ? 'rgba(75, 85, 99, 0.5)' : 'rgba(229, 231, 235, 1)')
+
+const loading = ref(false)
+const error = ref(null)
+const rawData = ref(null)
+const fetched = ref(false)
+const timeWindow = ref('month')
+const stateFilter = ref([])
+const stateDropdownOpen = ref(false)
+const stateDropdownRef = ref(null)
+const searchQuery = ref('')
+
+const stateFilterOptions = STATE_OPTIONS.filter(o => o.value !== 'all')
+const timeWindows = [
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+  { value: '3months', label: '3 Months' }
+]
+
+const aiImpactEnabled = computed(() => {
+  const slugs = enabledBuiltInSlugs.value
+  if (!slugs) return true // not loaded yet, assume enabled
+  return slugs.includes('ai-impact')
+})
+
+const teamComponents = computed(() => props.teamDetail?.components || [])
+
+const jiraHost = computed(() => rawData.value?.jiraHost || 'https://redhat.atlassian.net')
+
+const dataNotFetched = computed(() => fetched.value && !rawData.value?.fetchedAt)
+
+const teamComponentSet = computed(() => new Set(teamComponents.value))
+
+const teamIssues = computed(() => {
+  if (!rawData.value?.issues || teamComponentSet.value.size === 0) return []
+  return rawData.value.issues.filter(issue =>
+    (issue.components || []).some(c => teamComponentSet.value.has(c))
+  )
+})
+
+const metrics = computed(() => computeTeamMetrics(teamIssues.value, timeWindow.value))
+
+const bugsMerged = computed(() => {
+  const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  return teamIssues.value.filter(i =>
+    new Date(i.created) >= cutoff &&
+    i.pipelineState === 'autofix-merged' &&
+    i.issueType === 'Bug'
+  ).length
+})
+
+const successRateDisplay = computed(() => {
+  if (metrics.value.terminalTotal < 3) return '\u2014'
+  return metrics.value.successRate + '%'
+})
+
+const successRateTooltip = computed(() => {
+  if (metrics.value.terminalTotal < 3) return 'Not enough completed issues to calculate a meaningful rate.'
+  return `${metrics.value.autofixStates.merged} merged / ${metrics.value.terminalTotal} terminal`
+})
+
+const pipelineSegments = computed(() => {
+  const total = teamIssues.value.length
+  if (total === 0) return []
+  const counts = {}
+  for (const issue of teamIssues.value) {
+    counts[issue.pipelineState] = (counts[issue.pipelineState] || 0) + 1
+  }
+  return PIPELINE_BAR_SEGMENTS
+    .map(seg => ({
+      ...seg,
+      count: counts[seg.state] || 0,
+      pct: ((counts[seg.state] || 0) / total * 100)
+    }))
+    .filter(seg => seg.count > 0)
+})
+
+const timeFilteredIssues = computed(() => {
+  const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  return teamIssues.value.filter(i => new Date(i.created) >= cutoff)
+})
+
+const displayedIssues = computed(() => {
+  return timeFilteredIssues.value.filter(issue => {
+    const matchesState = stateFilter.value.length === 0 || stateFilter.value.includes(issue.pipelineState)
+    const q = searchQuery.value.toLowerCase()
+    const matchesSearch = !q ||
+      issue.key.toLowerCase().includes(q) ||
+      issue.summary.toLowerCase().includes(q) ||
+      (issue.assignee && issue.assignee.toLowerCase().includes(q))
+    return matchesState && matchesSearch
+  })
+})
+
+const trendData = computed(() => buildTeamTrendData(teamIssues.value, timeWindow.value))
+
+const hasTrendActivity = computed(() => trendData.value.some(p => p.triaged > 0))
+
+const funnelChartData = computed(() => ({
+  labels: trendData.value.map(p => p.date),
+  datasets: [
+    {
+      label: 'Eligible for Autofix',
+      data: trendData.value.map(p => p.autofixed),
+      borderColor: '#10b981',
+      backgroundColor: 'rgba(16, 185, 129, 0.1)',
+      fill: true,
+      tension: 0.3,
+      type: 'line',
+      yAxisID: 'y',
+      pointRadius: 3,
+      borderWidth: 2
+    },
+    {
+      label: 'Under Review',
+      data: trendData.value.map(p => p.review || 0),
+      borderColor: '#3b82f6',
+      backgroundColor: 'rgba(59, 130, 246, 0.1)',
+      fill: true,
+      tension: 0.3,
+      type: 'line',
+      yAxisID: 'y',
+      pointRadius: 3,
+      borderWidth: 2
+    },
+    {
+      label: 'Merged',
+      data: trendData.value.map(p => p.merged),
+      backgroundColor: 'rgba(99, 102, 241, 0.5)',
+      type: 'bar',
+      yAxisID: 'y'
+    }
+  ]
+}))
+
+const funnelChartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: true, position: 'top', labels: { font: { size: 11 }, color: textColor.value } }
+  },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value, maxRotation: 0 }, grid: { color: gridColor.value } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, color: textColor.value, precision: 0 }, title: { display: true, text: 'Issues (count)', font: { size: 11 }, color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+const stateFilterLabel = computed(() => {
+  if (stateFilter.value.length === 0) return 'All States'
+  if (stateFilter.value.length === 1) {
+    const opt = stateFilterOptions.find(o => o.value === stateFilter.value[0])
+    return opt ? opt.label : stateFilter.value[0]
+  }
+  return `${stateFilter.value.length} states`
+})
+
+function toggleStateFilter(value) {
+  const idx = stateFilter.value.indexOf(value)
+  if (idx >= 0) {
+    stateFilter.value = stateFilter.value.filter(v => v !== value)
+  } else {
+    stateFilter.value = [...stateFilter.value, value]
+  }
+}
+
+function handleClickOutside(e) {
+  if (stateDropdownRef.value && !stateDropdownRef.value.contains(e.target)) {
+    stateDropdownOpen.value = false
+  }
+}
+
+function getStateLabel(state) { return stateLabel(state) }
+function getStateColorClass(state) { return stateColorClass(state) }
+
+function formatRelativeDate(iso) {
+  if (!iso) return ''
+  const diff = Date.now() - new Date(iso).getTime()
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+  if (days === 0) return 'today'
+  if (days === 1) return '1d ago'
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}
+
+async function fetchData() {
+  loading.value = true
+  error.value = null
+  try {
+    await fetchAutofixData((data) => {
+      rawData.value = data
+    })
+    fetched.value = true
+  } catch (err) {
+    if (err?.status === 404) {
+      error.value = 'The AI Impact module endpoint is unavailable.'
+    } else {
+      error.value = err?.message || 'An unexpected error occurred.'
+    }
+    fetched.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+// Defer fetch until teamDetail.components is available
+watch(
+  () => props.teamDetail?.components,
+  (components) => {
+    if (components && components.length > 0 && !fetched.value && aiImpactEnabled.value) {
+      fetchData()
+    }
+  },
+  { immediate: true }
+)
+</script>

--- a/modules/team-tracker/client/components/autofix/autofix-constants.js
+++ b/modules/team-tracker/client/components/autofix/autofix-constants.js
@@ -1,0 +1,130 @@
+/**
+ * Autofix pipeline constants — duplicated from ai-impact module.
+ * Cross-module imports are forbidden (hard constraint #1), so these
+ * are maintained as a local copy. The pipeline label set is stable.
+ */
+
+export const STATE_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'triage-pending', label: 'AI Assessing' },
+  { value: 'triage-missing-info', label: 'Missing Info' },
+  { value: 'triage-not-fixable', label: 'Not AI-Fixable' },
+  { value: 'triage-stale', label: 'Stale' },
+  { value: 'autofix-ready', label: 'Queued for AI' },
+  { value: 'autofix-pending', label: 'AI Working' },
+  { value: 'autofix-review', label: 'AI Fix Under Review' },
+  { value: 'autofix-ci-failing', label: 'AI Fix CI Failing' },
+  { value: 'autofix-merged', label: 'AI Fix Merged' },
+  { value: 'autofix-rejected', label: 'AI Fix Rejected' },
+  { value: 'autofix-max-retries', label: 'AI Max Retries' },
+  { value: 'autofix-researched', label: 'AI Researched' },
+  { value: 'autofix-blocked', label: 'AI Blocked' }
+]
+
+export const PIPELINE_BAR_SEGMENTS = [
+  { state: 'autofix-merged', label: 'Merged', color: 'bg-indigo-500' },
+  { state: 'autofix-review', label: 'Review', color: 'bg-blue-500' },
+  { state: 'autofix-pending', label: 'Pending', color: 'bg-gray-400' },
+  { state: 'autofix-ci-failing', label: 'CI Failing', color: 'bg-orange-500' },
+  { state: 'autofix-blocked', label: 'Blocked', color: 'bg-yellow-500' },
+  { state: 'autofix-max-retries', label: 'Max Retries', color: 'bg-red-500' },
+  { state: 'autofix-researched', label: 'Researched', color: 'bg-teal-500' }
+]
+
+export function stateLabel(state) {
+  const opt = STATE_OPTIONS.find(o => o.value === state)
+  return opt ? opt.label : state
+}
+
+export function stateColorClass(state) {
+  if (state === 'autofix-merged') return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  if (state === 'autofix-researched') return 'bg-teal-100 dark:bg-teal-500/20 text-teal-700 dark:text-teal-400'
+  if (state === 'autofix-review') return 'bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400'
+  if (state === 'autofix-ci-failing') return 'bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400'
+  if (state === 'autofix-pending' || state === 'autofix-ready') return 'bg-indigo-100 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-400'
+  if (state === 'autofix-rejected') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+  if (state === 'autofix-max-retries') return 'bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400'
+  if (state === 'autofix-blocked' || state === 'triage-missing-info') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
+  if (state === 'triage-not-fixable') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+  if (state === 'triage-stale') return 'bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400'
+  return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+}
+
+/**
+ * Compute autofix metrics for a set of team-filtered issues.
+ * Mirrors computeAutofixMetrics() from ai-impact autofix-fetcher.js.
+ */
+export function computeTeamMetrics(issues, timeWindow) {
+  const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  const windowIssues = issues.filter(i => new Date(i.created) >= cutoff)
+
+  const triageTotal = windowIssues.filter(i =>
+    i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')
+  ).length
+
+  const triageVerdicts = {
+    ready: windowIssues.filter(i => i.pipelineState.startsWith('autofix-')).length,
+    missingInfo: windowIssues.filter(i => i.pipelineState === 'triage-missing-info').length,
+    notFixable: windowIssues.filter(i => i.pipelineState === 'triage-not-fixable').length,
+    stale: windowIssues.filter(i => i.pipelineState === 'triage-stale').length,
+    pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length
+  }
+
+  const autofixStates = {
+    ready: windowIssues.filter(i => i.pipelineState === 'autofix-ready').length,
+    pending: windowIssues.filter(i => i.pipelineState === 'autofix-pending').length,
+    review: windowIssues.filter(i => i.pipelineState === 'autofix-review').length,
+    ciFailing: windowIssues.filter(i => i.pipelineState === 'autofix-ci-failing').length,
+    merged: windowIssues.filter(i => i.pipelineState === 'autofix-merged').length,
+    rejected: windowIssues.filter(i => i.pipelineState === 'autofix-rejected').length,
+    maxRetries: windowIssues.filter(i => i.pipelineState === 'autofix-max-retries').length,
+    researched: windowIssues.filter(i => i.pipelineState === 'autofix-researched').length,
+    blocked: windowIssues.filter(i => i.pipelineState === 'autofix-blocked').length
+  }
+
+  const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries
+  const successRate = terminalTotal > 0 ? Math.round((autofixStates.merged / terminalTotal) * 100) : 0
+
+  return {
+    triageTotal,
+    triageVerdicts,
+    autofixStates,
+    autofixTotal: triageVerdicts.ready,
+    successRate,
+    terminalTotal,
+    windowTotal: windowIssues.length,
+    totalIssues: issues.length
+  }
+}
+
+/**
+ * Build weekly-bucketed trend data from team-filtered issues.
+ * Mirrors buildTrendData() from ai-impact autofix-fetcher.js.
+ */
+export function buildTeamTrendData(issues, timeWindow) {
+  const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13
+  const now = new Date()
+  const points = []
+  for (let w = weekCounts - 1; w >= 0; w--) {
+    const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000)
+    const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000)
+    const weekIssues = issues.filter(i => {
+      const d = new Date(i.created)
+      return d >= weekStart && d < weekEnd
+    })
+    const triaged = weekIssues.filter(i => i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')).length
+    const autofixed = weekIssues.filter(i => i.pipelineState.startsWith('autofix-')).length
+    const merged = weekIssues.filter(i => i.pipelineState === 'autofix-merged').length
+    const review = weekIssues.filter(i => i.pipelineState === 'autofix-review').length
+    points.push({
+      date: weekEnd.toISOString().slice(0, 10),
+      triaged,
+      autofixed,
+      merged,
+      review,
+      total: weekIssues.length
+    })
+  }
+  return points
+}

--- a/modules/team-tracker/client/services/autofix-api.js
+++ b/modules/team-tracker/client/services/autofix-api.js
@@ -1,0 +1,6 @@
+import { cachedRequest } from '@shared/client/services/api.js'
+
+export function fetchAutofixData(onData) {
+  /* eslint-disable-next-line org-pulse/no-cross-module-imports -- approved cross-module API call; guarded by enabledBuiltInSlugs check */
+  return cachedRequest('autofix-data', '/modules/ai-impact/autofix-data', onData)
+}

--- a/modules/team-tracker/client/views/TeamRosterView.vue
+++ b/modules/team-tracker/client/views/TeamRosterView.vue
@@ -322,6 +322,11 @@
         </div>
       </div>
 
+      <!-- Autofix Tab -->
+      <div v-if="tabActivated.autofix" v-show="activeTab === 'autofix'">
+        <TeamAutofixTab :team="team" :teamDetail="teamDetail" />
+      </div>
+
       <!-- Refresh Modal -->
       <RefreshModal
         v-if="showRefreshModal"
@@ -339,6 +344,7 @@ import TeamOverviewTab from '../components/TeamOverviewTab.vue'
 import TeamDeliveryTab from '../components/TeamDeliveryTab.vue'
 import TeamBacklogTab from '../components/TeamBacklogTab.vue'
 import TeamAllocationTab from '../components/TeamAllocationTab.vue'
+import TeamAutofixTab from '../components/autofix/TeamAutofixTab.vue'
 import TeamFieldEditor from '../components/TeamFieldEditor.vue'
 import RefreshModal from '@shared/client/components/RefreshModal.vue'
 import { useRoster } from '@shared/client/composables/useRoster'
@@ -639,13 +645,14 @@ async function saveBoards() {
 
 // --- Tabs ---
 const activeTab = ref('overview')
-const tabActivated = ref({ overview: true, delivery: false, backlog: false, allocation: false })
+const tabActivated = ref({ overview: true, delivery: false, backlog: false, allocation: false, autofix: false })
 
 const TAB_ICONS = {
   overview: '<path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />',
   delivery: '<path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />',
   backlog: '<path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />',
   allocation: '<path stroke-linecap="round" stroke-linejoin="round" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z" /><path stroke-linecap="round" stroke-linejoin="round" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />',
+  autofix: '<path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />',
 }
 
 const teamHasAllocationBoards = computed(() => {
@@ -658,9 +665,10 @@ const visibleTabs = computed(() => [
   { id: 'delivery', label: 'Delivery', icon: TAB_ICONS.delivery },
   { id: 'backlog', label: 'RFE Backlog', icon: TAB_ICONS.backlog },
   { id: 'allocation', label: '40/40/20 Allocation', icon: TAB_ICONS.allocation },
+  { id: 'autofix', label: 'Autofix', icon: TAB_ICONS.autofix },
 ])
 
-const VALID_TABS = ['overview', 'delivery', 'backlog', 'allocation']
+const VALID_TABS = ['overview', 'delivery', 'backlog', 'allocation', 'autofix']
 let updatingFromUrl = false
 
 watch(activeTab, (tab) => {

--- a/tests/integration/people-teams.spec.js
+++ b/tests/integration/people-teams.spec.js
@@ -186,6 +186,44 @@ test.describe('People & Teams Views @people-teams', () => {
 });
 
 /**
+ * Team Detail — Autofix Tab
+ *
+ * Verify the Autofix tab on a team detail page loads without errors.
+ * In demo mode, the tab shows an empty state (fixture components don't
+ * overlap with autofix fixture data), which is the expected behavior.
+ */
+test.describe('People & Teams Autofix Tab @people-teams', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should load Autofix tab on team detail page', async ({ page }) => {
+    // Navigate to a team detail page (Platform team from fixtures)
+    await page.goto('/#/team-tracker/team-detail?teamKey=achen::Platform');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Click the Autofix tab
+    const autofixTab = page.locator('nav button').filter({ hasText: 'Autofix' });
+    await expect(autofixTab).toBeVisible();
+    await autofixTab.click();
+    await page.waitForTimeout(1000);
+
+    // Verify the tab loaded — expect an empty state in demo mode
+    // (team components don't overlap with autofix fixture components)
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
+
+    // Verify no JavaScript errors occurred
+    expect(page.errors).toHaveLength(0);
+  });
+});
+
+/**
  * People Directory
  *
  * Verify the People Directory view shows roster data from fixtures


### PR DESCRIPTION
## Summary

Adds an "Autofix" tab to the team detail page in the team-tracker module that shows Jira issues for a given team that went through the AI autofix pipeline.

- **Summary cards**: Total Issues, Bugs Fixed by AI, Success Rate (with small-sample guard)
- **Pipeline breakdown bar**: Visual distribution of autofix pipeline states
- **Trend chart**: Chart.js pipeline funnel trend filtered to team components
- **Filterable issue table**: 7 columns with multi-select state filter, time window toggle, and text search
- **5 empty states**: Module disabled, no components, no matching issues, data not fetched, API error with retry
- **Cross-module data access**: Client-side API call to `/api/modules/ai-impact/autofix-data`, filtering by `teamDetail.components` intersection
- **Fetch-once pattern**: Single API call, all time window/state/search filtering done client-side

### Files changed

| File | Change |
|------|--------|
| `modules/team-tracker/client/components/autofix/TeamAutofixTab.vue` | New — main tab component |
| `modules/team-tracker/client/components/autofix/autofix-constants.js` | New — pipeline state labels, colors, metrics computation |
| `modules/team-tracker/client/services/autofix-api.js` | New — cached API client |
| `modules/team-tracker/client/views/TeamRosterView.vue` | Modified — add Autofix tab |
| `modules/team-tracker/__tests__/client/autofix/TeamAutofixTab.test.js` | New — 13 unit tests |
| `modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js` | New — 3 unit tests |
| `modules/team-tracker/__tests__/client/TeamRosterView.test.js` | Modified — updated tab count |
| `tests/integration/people-teams.spec.js` | Modified — Autofix tab integration test |
| `AUTOFIX-TAB-PLAN.md` | New — design plan |

## Test plan

- [x] `npm test` — all 16 new tests pass, existing tests unaffected
- [x] `npm run lint` — clean
- [ ] `make test-module MODULE=team-tracker` — integration test verifies tab loads
- [ ] Visual check in dev mode with production autofix data

🤖 Generated with [Claude Code](https://claude.com/claude-code)