### PR TITLE
feat(ai-impact): split action groups and add stage tooltips on State of the Union

### DIFF
--- a/modules/ai-impact/__tests__/client/ForYouCard.test.js
+++ b/modules/ai-impact/__tests__/client/ForYouCard.test.js
@@ -105,6 +105,26 @@ describe('ForYouCard', () => {
     expect(link.attributes('href')).toBe('https://jira.example.com/browse/RHAIRFE-100')
   })
 
+  it('shows stage hover popup with info icon', () => {
+    const wrapper = mount(ForYouCard, {
+      props: { item: makeItem() }
+    })
+    const popupContainer = wrapper.find('.group')
+    expect(popupContainer.exists()).toBe(true)
+    // info icon SVG is present in the badge
+    expect(popupContainer.find('svg').exists()).toBe(true)
+    // hover popup text
+    expect(popupContainer.text()).toContain('failed the quality rubric')
+  })
+
+  it('shows passed-with-caveats hover popup', () => {
+    const wrapper = mount(ForYouCard, {
+      props: { item: makeItem({ state: { id: 'passed-with-caveats', label: 'Passed with Caveats', color: 'amber', order: 1 } }) }
+    })
+    const popupContainer = wrapper.find('.group')
+    expect(popupContainer.text()).toContain('BOTH rubric-pass AND needs-attention')
+  })
+
   it('truncates long summary', () => {
     const longSummary = 'A'.repeat(130)
     const wrapper = mount(ForYouCard, {

--- a/modules/ai-impact/__tests__/client/useForYou.test.js
+++ b/modules/ai-impact/__tests__/client/useForYou.test.js
@@ -312,9 +312,24 @@ describe('actionGroups', () => {
     const features = ref({})
     const { actionGroups } = useForYou(rosterData, user, rfeData, features, assessments, fieldDefinitions)
     const groupIds = actionGroups.value.map(g => g.id)
-    expect(groupIds).toContain('revise-rfes')
+    expect(groupIds).toContain('failed-rubric')
     expect(groupIds).toContain('advance-rfes')
+    expect(groupIds).not.toContain('passed-with-caveats')
     expect(groupIds).not.toContain('review-features')
+  })
+
+  it('separates failed-rubric from passed-with-caveats', () => {
+    const rfeData = ref({
+      issues: [
+        { key: 'RFE-1', summary: 'Failed', components: [], labels: ['rfe-creator-needs-attention'], linkedFeature: null, priority: 'High', created: '2025-01-01' },
+        { key: 'RFE-2', summary: 'Caveats', components: [], labels: ['rfe-creator-autofix-rubric-pass', 'rfe-creator-needs-attention'], linkedFeature: null, priority: 'Medium', created: '2025-01-01' }
+      ]
+    })
+    const features = ref({})
+    const { actionGroups } = useForYou(rosterData, user, rfeData, features, assessments, fieldDefinitions)
+    const groupMap = Object.fromEntries(actionGroups.value.map(g => [g.id, g]))
+    expect(groupMap['failed-rubric'].items.map(i => i.key)).toEqual(['RFE-1'])
+    expect(groupMap['passed-with-caveats'].items.map(i => i.key)).toEqual(['RFE-2'])
   })
 
   it('returns empty array when no action items', () => {

--- a/modules/ai-impact/client/components/ForYouCard.vue
+++ b/modules/ai-impact/client/components/ForYouCard.vue
@@ -12,6 +12,21 @@ const emit = defineEmits(['navigate'])
 
 const componentsExpanded = ref(false)
 
+const stageTooltip = computed(() => {
+  const tooltips = {
+    'needs-revision': 'Has needs-attention label but NOT rubric-pass — failed the quality rubric and could not be auto-fixed.',
+    'passed-with-caveats': 'Has BOTH rubric-pass AND needs-attention labels — passed scoring but flagged for minor issues the automation could not resolve.',
+    'ready-to-advance': 'Has rubric-pass or tech-reviewed label, no scope label yet — quality gate passed, ready to queue.',
+    'queued-for-pipeline': 'Has quality label + scope label — waiting for the automated pipeline to create a strategy feature.',
+    'not-assessed': 'No pipeline labels yet — waiting for the quality rubric to run.',
+    'rejected': 'AI review recommended rejecting this feature.',
+    'revise-required': 'AI review found issues with feasibility, testability, scope, or architecture.',
+    'awaiting-signoff': 'AI review passed — waiting for human sign-off from a staff engineer or SME.',
+    'signed-off': 'Reviewed and approved by a human engineer.'
+  }
+  return tooltips[props.item.state.id] || ''
+})
+
 const accentClass = computed(() => {
   const color = props.item.state.color
   return {
@@ -212,9 +227,22 @@ const hiddenComponentCount = computed(() => {
           <span class="text-xs uppercase font-medium text-gray-400 dark:text-gray-500">{{ item.type }}</span>
         </div>
         <div class="flex items-center gap-2 shrink-0">
-          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="stageBadgeClass">
-            {{ item.state.label }}
-          </span>
+          <div class="relative group">
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium cursor-help"
+              :class="stageBadgeClass"
+            >
+              {{ item.state.label }}
+              <svg class="h-3 w-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </span>
+            <div class="absolute top-full right-0 pt-1 z-20 hidden group-hover:block w-64">
+              <div class="p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                <p>{{ stageTooltip }}</p>
+              </div>
+            </div>
+          </div>
           <span
             v-if="item.priority && item.priority !== 'None' && item.priority !== 'Undefined'"
             class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"

--- a/modules/ai-impact/client/components/ForYouCard.vue
+++ b/modules/ai-impact/client/components/ForYouCard.vue
@@ -237,7 +237,7 @@ const hiddenComponentCount = computed(() => {
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </span>
-            <div class="absolute top-full right-0 pt-1 z-20 hidden group-hover:block w-64">
+            <div v-if="stageTooltip" class="absolute top-full right-0 pt-1 z-20 hidden group-hover:block w-64">
               <div class="p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
                 <p>{{ stageTooltip }}</p>
               </div>

--- a/modules/ai-impact/client/composables/useForYou.js
+++ b/modules/ai-impact/client/composables/useForYou.js
@@ -300,17 +300,20 @@ export function useForYou(rosterData, user, rfeData, features, assessments, fiel
 
   const actionGroups = computed(() => {
     const groups = [
-      { id: 'revise-rfes', label: 'RFEs Needing Revision', items: [] },
+      { id: 'failed-rubric', label: 'RFEs Failed Rubric', items: [] },
+      { id: 'passed-with-caveats', label: 'RFEs Passed with Caveats', items: [] },
       { id: 'advance-rfes', label: 'RFEs Ready for Feature Creation', items: [] },
       { id: 'review-features', label: 'Features Needing Review', items: [] }
     ]
     for (const item of actionNeeded.value) {
-      if (item.type === 'rfe' && ['needs-revision', 'passed-with-caveats'].includes(item.state.id)) {
+      if (item.type === 'rfe' && item.state.id === 'needs-revision') {
         groups[0].items.push(item)
-      } else if (item.type === 'rfe' && item.state.id === 'ready-to-advance') {
+      } else if (item.type === 'rfe' && item.state.id === 'passed-with-caveats') {
         groups[1].items.push(item)
-      } else if (item.type === 'feature') {
+      } else if (item.type === 'rfe' && item.state.id === 'ready-to-advance') {
         groups[2].items.push(item)
+      } else if (item.type === 'feature') {
+        groups[3].items.push(item)
       }
     }
     return groups.filter(g => g.items.length > 0)


### PR DESCRIPTION
## Summary

- **Split "RFEs Needing Revision" action group** into two separate groups: "RFEs Failed Rubric" (`needs-attention` without `rubric-pass`) and "RFEs Passed with Caveats" (both labels present), so users can prioritize which to address first
- **Add hover popups on stage badges** (matching the Board tab's existing tooltip pattern) explaining the Jira label combinations that determine each state — helps users understand what each classification means without leaving the page

## Context

User feedback: the "Needs Revision" group lumped together RFEs that failed the rubric entirely with ones that passed but had minor caveats. Splitting them makes it easier to triage and prioritize.

## Test plan

- [x] `useForYou.test.js` — updated existing action group test, added new test for the split
- [x] `ForYouCard.test.js` — added tests for hover popup content on `needs-revision` and `passed-with-caveats` badges
- [ ] Manual: verify the two groups render separately in the Actions tab
- [ ] Manual: hover over a stage badge and confirm the popup appears with label explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)