### PR TITLE
ci: require smoke and integration tests before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,39 @@ jobs:
 
       - name: Run AI Eng smoke tests
         run: make smoke-test
+
+  smoke-test-status:
+    name: Smoke Test Status
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [test, smoke-test-core, smoke-test-ai-eng]
+    permissions:
+      statuses: write
+    steps:
+      - name: Set commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "${{ needs.test.outputs.app }}" != "true" ]; then
+            STATE="success"
+            DESC="No code changes — smoke tests skipped"
+          elif [ "${{ needs.test.result }}" != "success" ]; then
+            STATE="failure"
+            DESC="Test & Build failed — smoke tests did not run"
+          elif [ "${{ needs.smoke-test-core.result }}" = "success" ] && \
+               [ "${{ needs.smoke-test-ai-eng.result }}" = "success" ]; then
+            STATE="success"
+            DESC="All smoke tests passed"
+          else
+            STATE="failure"
+            DESC="Smoke tests failed"
+          fi
+
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state="$STATE" \
+            -f context="Smoke Tests" \
+            -f description="$DESC" \
+            -f target_url="$RUN_URL"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,9 +3,6 @@ name: Integration Tests
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'modules/**'
-      - 'tests/integration/**'
 
 concurrency:
   group: integration-tests-${{ github.ref }}
@@ -93,3 +90,39 @@ jobs:
         uses: ./.github/actions/test-org-pulse-module
         with:
           module: ${{ matrix.module }}
+
+  integration-test-status:
+    name: Integration Test Status
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [detect-changes, run-tests]
+    permissions:
+      statuses: write
+    steps:
+      - name: Set commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          MODULES='${{ needs.detect-changes.outputs.enabled-modules }}'
+          if [ "$MODULES" = "[]" ] || [ -z "$MODULES" ]; then
+            STATE="success"
+            DESC="No module changes — integration tests skipped"
+          elif [ "${{ needs.run-tests.result }}" = "success" ]; then
+            STATE="success"
+            DESC="All integration tests passed"
+          elif [ "${{ needs.run-tests.result }}" = "skipped" ]; then
+            STATE="success"
+            DESC="No module changes — integration tests skipped"
+          else
+            STATE="failure"
+            DESC="Integration tests failed"
+          fi
+
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state="$STATE" \
+            -f context="Integration Tests" \
+            -f description="$DESC" \
+            -f target_url="$RUN_URL"


### PR DESCRIPTION
## Summary

- Adds consolidating status jobs to `ci.yml` and `integration-tests.yml` that post commit statuses via the GitHub API (same pattern as AI Config Guard)
- When code/module changes are detected, the status reflects actual test results; when no relevant changes exist, a success status is posted with a "skipped" description
- Removes the `paths` filter from `integration-tests.yml` so the workflow always triggers (change detection is already handled internally by `dorny/paths-filter`)
- GitHub ruleset updated to require both `Smoke Tests` and `Integration Tests` status contexts

## How it works

| Scenario | Smoke Tests status | Integration Tests status |
|----------|-------------------|-------------------------|
| No code changes (e.g. docs-only PR) | success — "skipped" | success — "skipped" |
| Code changes, tests pass | success | success (or skipped if no modules changed) |
| Code changes, tests fail | failure | failure |

## Test plan

- [ ] Open a docs-only PR and verify both status checks show as "skipped" success
- [ ] Open a code PR and verify smoke/integration tests run and status reflects results
- [ ] Verify this PR's own checks pass (the workflow changes are self-testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)