### PR TITLE
Remove unused GET/POST /teams endpoint

### DIFF
--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -2592,61 +2592,6 @@ module.exports = function registerRoutes(router, context) {
 
   /**
    * @openapi
-   * /api/modules/team-tracker/teams:
-   *   get:
-   *     tags: ['TT: Sprints']
-   *     summary: Get sprint board team config
-   *     responses:
-   *       200:
-   *         description: Sprint board team configuration
-   */
-  router.get('/teams', requireScope('roster:read'), function(req, res) {
-    try {
-      const data = readFromStorage('teams.json');
-      if (!data) {
-        return res.json({ teams: [] });
-      }
-      res.json(data);
-    } catch (error) {
-      console.error('Read teams error:', error);
-      res.status(500).json({ error: error.message });
-    }
-  });
-
-  /**
-   * @openapi
-   * /api/modules/team-tracker/teams:
-   *   post:
-   *     tags: ['TT: Sprints']
-   *     summary: Save sprint board team config
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         application/json:
-   *           schema:
-   *             type: object
-   *     responses:
-   *       200:
-   *         description: Team config saved
-   *       403:
-   *         description: Forbidden — admin access required
-   */
-  router.post('/teams', requireAdmin, requireScope('roster:write'), function(req, res) {
-    try {
-      const { teams } = req.body;
-      if (!teams || !Array.isArray(teams)) {
-        return res.status(400).json({ error: 'Request must include "teams" array' });
-      }
-      writeToStorage('teams.json', { teams });
-      res.json({ success: true, teams });
-    } catch (error) {
-      console.error('Save teams error:', error);
-      res.status(500).json({ error: error.message });
-    }
-  });
-
-  /**
-   * @openapi
    * /api/modules/team-tracker/dashboard-summary:
    *   get:
    *     tags: ['TT: Sprints']

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -1549,7 +1549,6 @@ if (ttRouter && enabledSlugs.has('team-tracker')) {
     '/api/last-refreshed': '/last-refreshed',
     '/api/refresh': '/refresh',
     '/api/jira-name-cache': '/jira-name-cache',
-    '/api/teams': '/teams',
     '/api/trend': '/trend',
     '/api/admin/roster-sync': '/admin/roster-sync',
     '/api/admin/jira-sync': '/admin/jira-sync',


### PR DESCRIPTION
## Summary
- Removes the dead `GET /api/modules/team-tracker/teams` and `POST /api/modules/team-tracker/teams` sprint board config endpoints — not called by any frontend code
- Removes the legacy `/api/teams` forward in `dev-server.js`
- The UI exclusively uses `/api/modules/team-tracker/structure/teams` (org roster) for all team operations

## Test plan
- [x] `npm test` — all tests pass (pre-existing failures in unrelated worktree only)
- [x] `npm run lint` — clean
- [x] `npm run validate:openapi` — passes
- [x] Grep confirmed zero frontend references to this endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)