### PR TITLE
ci: use gate jobs instead of Status API for fork PR compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,33 +143,18 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [test, smoke-test-core, smoke-test-ai-eng]
-    permissions:
-      statuses: write
     steps:
-      - name: Set commit status
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: Evaluate smoke test results
         run: |
           if [ "${{ needs.test.outputs.app }}" != "true" ]; then
-            STATE="success"
-            DESC="No code changes — smoke tests skipped"
+            echo "No code changes — smoke tests skipped"
           elif [ "${{ needs.test.result }}" != "success" ]; then
-            STATE="failure"
-            DESC="Test & Build failed — smoke tests did not run"
+            echo "Test & Build failed — smoke tests did not run"
+            exit 1
           elif [ "${{ needs.smoke-test-core.result }}" = "success" ] && \
                [ "${{ needs.smoke-test-ai-eng.result }}" = "success" ]; then
-            STATE="success"
-            DESC="All smoke tests passed"
+            echo "All smoke tests passed"
           else
-            STATE="failure"
-            DESC="Smoke tests failed"
+            echo "Smoke tests failed"
+            exit 1
           fi
-
-          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-            -f state="$STATE" \
-            -f context="Smoke Tests" \
-            -f description="$DESC" \
-            -f target_url="$RUN_URL"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -96,33 +96,17 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [detect-changes, run-tests]
-    permissions:
-      statuses: write
     steps:
-      - name: Set commit status
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: Evaluate integration test results
         run: |
           MODULES='${{ needs.detect-changes.outputs.enabled-modules }}'
           if [ "$MODULES" = "[]" ] || [ -z "$MODULES" ]; then
-            STATE="success"
-            DESC="No module changes — integration tests skipped"
+            echo "No module changes — integration tests skipped"
           elif [ "${{ needs.run-tests.result }}" = "success" ]; then
-            STATE="success"
-            DESC="All integration tests passed"
+            echo "All integration tests passed"
           elif [ "${{ needs.run-tests.result }}" = "skipped" ]; then
-            STATE="success"
-            DESC="No module changes — integration tests skipped"
+            echo "No module changes — integration tests skipped"
           else
-            STATE="failure"
-            DESC="Integration tests failed"
+            echo "Integration tests failed"
+            exit 1
           fi
-
-          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-            -f state="$STATE" \
-            -f context="Integration Tests" \
-            -f description="$DESC" \
-            -f target_url="$RUN_URL"


### PR DESCRIPTION
## Summary

- Replace commit status API calls in `Smoke Test Status` and `Integration Test Status` jobs with simple pass/fail gate jobs
- Fork PRs get a read-only `GITHUB_TOKEN`, so the `gh api repos/.../statuses/...` calls always fail with HTTP 403 — this broke PR #882
- Gate jobs evaluate `needs.*.result` and `exit 0` or `exit 1` — GitHub Actions creates check runs automatically, no API calls or permissions needed

## Ruleset update required

After merging, update the branch ruleset to require the new check run names instead of the old status context names:

| Old (status context) | New (check run) |
|---|---|
| `Smoke Tests` | `CI / Smoke Test Status` |
| `Integration Tests` | `Integration Tests / Integration Test Status` |

Verify the exact names in the GitHub UI after the first workflow run on this PR.

## Test plan

- [ ] Verify this PR's own CI passes (the gate jobs should succeed since Test & Build will pass)
- [ ] Confirm the check run names in the GitHub UI match expectations
- [ ] After merge: update ruleset, then verify a fork PR (e.g. #882) is no longer blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)