### PR TITLE
feat(releases): PM Hub with Component Release Load Tracking

### DIFF
--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -141,16 +141,6 @@ function colorStatusRing(colorStatus) {
   return 'ring-gray-200 dark:ring-gray-700'
 }
 
-function _stripHtml(html) {
-  var s = html || ''
-  var prev
-  do {
-    prev = s
-    s = s.replace(/<[^>]*>/g, '')
-  } while (s !== prev)
-  return s
-}
-
 defineExpose({ expandAll, collapseAll })
 </script>
 

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -1,0 +1,322 @@
+<script setup>
+import { reactive, computed } from 'vue'
+
+const props = defineProps({
+  groups: { type: Array, default: () => [] },
+  activeFilter: { type: String, default: null }
+})
+
+const JIRA_BASE = 'https://redhat.atlassian.net/browse'
+
+const COMP_STYLE = {
+  bg: 'bg-slate-50 dark:bg-slate-800/40',
+  border: 'border-l-primary-500',
+  badge: 'bg-primary-100 dark:bg-primary-800/40 text-primary-700 dark:text-primary-300',
+  dot: 'bg-primary-500'
+}
+
+var expandedVersions = reactive({})
+var expandedComponents = reactive({})
+
+function toggleVersion(version) {
+  if (expandedVersions[version]) {
+    delete expandedVersions[version]
+  } else {
+    expandedVersions[version] = true
+  }
+}
+
+function isVersionExpanded(version) {
+  return !!expandedVersions[version]
+}
+
+function compGroupKey(version, component) {
+  return version + '::' + component
+}
+
+function toggleComponent(version, component) {
+  var key = compGroupKey(version, component)
+  if (expandedComponents[key]) {
+    delete expandedComponents[key]
+  } else {
+    expandedComponents[key] = true
+  }
+}
+
+function isComponentExpanded(version, component) {
+  return !!expandedComponents[compGroupKey(version, component)]
+}
+
+function expandAll() {
+  var src = filteredGroups.value
+  for (var i = 0; i < src.length; i++) {
+    var g = src[i]
+    expandedVersions[g.version] = true
+    for (var j = 0; j < g.components.length; j++) {
+      expandedComponents[compGroupKey(g.version, g.components[j].component)] = true
+    }
+  }
+}
+
+function collapseAll() {
+  var src = filteredGroups.value
+  for (var i = 0; i < src.length; i++) {
+    var g = src[i]
+    delete expandedVersions[g.version]
+    for (var j = 0; j < g.components.length; j++) {
+      delete expandedComponents[compGroupKey(g.version, g.components[j].component)]
+    }
+  }
+}
+
+function allFeaturesForComponent(comp) {
+  var seen = {}
+  var result = []
+  var lists = [comp.requestedFeatures || [], comp.committedFeatures || []]
+  for (var li = 0; li < lists.length; li++) {
+    for (var fi = 0; fi < lists[li].length; fi++) {
+      var f = lists[li][fi]
+      if (!seen[f.key]) {
+        seen[f.key] = true
+        result.push(f)
+      }
+    }
+  }
+  return result
+}
+
+function filterFeaturesForComp(comp, filter) {
+  var all = allFeaturesForComponent(comp)
+  if (!filter) return all
+
+  var reqKeys = {}
+  var comKeys = {}
+  var reqList = comp.requestedFeatures || []
+  var comList = comp.committedFeatures || []
+  for (var i = 0; i < reqList.length; i++) reqKeys[reqList[i].key] = true
+  for (var j = 0; j < comList.length; j++) comKeys[comList[j].key] = true
+
+  return all.filter(function(f) {
+    if (filter === 'requested') return !!reqKeys[f.key]
+    if (filter === 'committed') return !!comKeys[f.key]
+    if (filter === 'blocked') return !!f.isBlocked
+    return true
+  })
+}
+
+var filteredGroups = computed(function() {
+  var filter = props.activeFilter
+
+  return props.groups.map(function(group) {
+    var filteredComps = group.components.map(function(comp) {
+      var features = filterFeaturesForComp(comp, filter)
+      return Object.assign({}, comp, {
+        displayFeatures: features
+      })
+    }).filter(function(comp) {
+      return comp.displayFeatures.length > 0
+    })
+
+    return Object.assign({}, group, {
+      components: filteredComps
+    })
+  }).filter(function(group) {
+    return group.components.length > 0
+  })
+})
+
+function colorStatusClass(colorStatus) {
+  var s = (colorStatus || '').toLowerCase()
+  if (s === 'green') return 'bg-emerald-500'
+  if (s === 'yellow') return 'bg-amber-400'
+  if (s === 'red') return 'bg-red-500'
+  return 'bg-gray-300 dark:bg-gray-600'
+}
+
+function colorStatusRing(colorStatus) {
+  var s = (colorStatus || '').toLowerCase()
+  if (s === 'green') return 'ring-emerald-200 dark:ring-emerald-800'
+  if (s === 'yellow') return 'ring-amber-200 dark:ring-amber-800'
+  if (s === 'red') return 'ring-red-200 dark:ring-red-800'
+  return 'ring-gray-200 dark:ring-gray-700'
+}
+
+function _stripHtml(html) {
+  var s = html || ''
+  var prev
+  do {
+    prev = s
+    s = s.replace(/<[^>]*>/g, '')
+  } while (s !== prev)
+  return s
+}
+
+defineExpose({ expandAll, collapseAll })
+</script>
+
+<template>
+  <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+    <table class="w-full text-sm border-collapse">
+      <tbody>
+        <template v-for="group in filteredGroups" :key="group.version">
+          <!-- Version group header -->
+          <tr
+            class="cursor-pointer select-none bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-800/80 hover:from-gray-200 hover:to-gray-100 dark:hover:from-gray-750 dark:hover:to-gray-800"
+            @click="toggleVersion(group.version)"
+          >
+            <td colspan="7" class="px-4 py-3.5">
+              <div class="flex items-center gap-3">
+                <svg
+                  class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
+                  :class="{ 'rotate-90': isVersionExpanded(group.version) }"
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+                <span class="font-bold text-gray-900 dark:text-gray-100">{{ group.version }}</span>
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                  {{ group.requestedCount }} requested
+                </span>
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">
+                  {{ group.committedCount }} committed
+                </span>
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold"
+                  :class="group.blockedCount > 0
+                    ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
+                    : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
+                >{{ group.blockedCount }} blocked</span>
+              </div>
+            </td>
+          </tr>
+
+          <template v-if="isVersionExpanded(group.version)">
+            <template v-for="comp in group.components" :key="comp.component">
+              <!-- Component group header -->
+              <tr
+                class="cursor-pointer select-none border-l-4 transition-colors hover:brightness-95 dark:hover:brightness-110"
+                :class="[COMP_STYLE.border, COMP_STYLE.bg]"
+                @click="toggleComponent(group.version, comp.component)"
+              >
+                <td colspan="7" class="px-6 py-2.5">
+                  <div class="flex items-center">
+                    <svg
+                      class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0 mr-2.5"
+                      :class="{ 'rotate-90': isComponentExpanded(group.version, comp.component) }"
+                      fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                    <span class="w-2 h-2 rounded-full flex-shrink-0 mr-1.5" :class="COMP_STYLE.dot" />
+                    <span class="font-semibold text-gray-800 dark:text-gray-200 mr-3">{{ comp.component }}</span>
+                    <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold mr-2 bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300">
+                      {{ comp.requestedCount }} requested
+                    </span>
+                    <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold mr-2 bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300">
+                      {{ comp.committedCount }} committed
+                    </span>
+                    <span
+                      class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold"
+                      :class="comp.blockedCount > 0
+                        ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
+                        : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
+                    >{{ comp.blockedCount }} blocked</span>
+                  </div>
+                </td>
+              </tr>
+
+              <!-- Column headers -->
+              <tr
+                v-if="isComponentExpanded(group.version, comp.component)"
+                class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/80 sticky top-0"
+              >
+                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
+                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
+                <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
+                <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
+                <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
+                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
+                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
+              </tr>
+
+              <!-- Feature rows -->
+              <template v-if="isComponentExpanded(group.version, comp.component)">
+                <tr
+                  v-for="feature in comp.displayFeatures"
+                  :key="feature.key"
+                  class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+                >
+                  <td class="px-3 py-2.5 whitespace-nowrap">
+                    <a
+                      :href="`${JIRA_BASE}/${feature.key}`"
+                      target="_blank"
+                      rel="noopener"
+                      class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
+                    >{{ feature.key }}</a>
+                  </td>
+                  <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
+                    {{ feature.summary }}
+                  </td>
+                  <td class="px-3 py-2.5 text-center">
+                    <div class="flex items-center justify-center gap-1">
+                      <span
+                        v-if="(comp.requestedFeatures || []).some(function(r) { return r.key === feature.key })"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
+                      >REQ</span>
+                      <span
+                        v-if="(comp.committedFeatures || []).some(function(r) { return r.key === feature.key })"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300"
+                      >COM</span>
+                    </div>
+                  </td>
+                  <td class="px-3 py-2.5 text-center">
+                    <span
+                      v-if="feature.colorStatus"
+                      class="inline-block w-3.5 h-3.5 rounded-full ring-2"
+                      :class="[colorStatusClass(feature.colorStatus), colorStatusRing(feature.colorStatus)]"
+                      :title="feature.colorStatus"
+                    />
+                    <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+                  </td>
+                  <td class="px-3 py-2.5 text-center">
+                    <span
+                      v-if="feature.isBlocked"
+                      class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
+                      title="Blocked"
+                    >
+                      <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                      </svg>
+                    </span>
+                    <svg v-else class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </td>
+                  <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                    {{ feature.assignee || '--' }}
+                  </td>
+                  <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                    {{ feature.pmOwner || '--' }}
+                  </td>
+                </tr>
+              </template>
+
+              <!-- Empty state -->
+              <tr v-if="isComponentExpanded(group.version, comp.component) && comp.displayFeatures.length === 0">
+                <td colspan="7" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+                  No features found for {{ comp.component }}
+                </td>
+              </tr>
+            </template>
+          </template>
+        </template>
+        <!-- No matching results for active filter -->
+        <tr v-if="filteredGroups.length === 0 && activeFilter">
+          <td colspan="7" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            No {{ activeFilter }} features found.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1,0 +1,548 @@
+<template>
+  <div class="space-y-6">
+    <div class="flex items-start justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Component Release Load Tracking</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Track component workload distribution across releases.
+        </p>
+      </div>
+      <div class="flex items-center gap-2">
+        <button
+          v-if="groups.length > 0"
+          @click="handleExpandAll"
+          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >Expand All</button>
+        <button
+          v-if="groups.length > 0"
+          @click="handleCollapseAll"
+          class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >Collapse All</button>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-start gap-4">
+      <!-- Jira Component Filter -->
+      <div class="min-w-[280px] max-w-[400px] relative" ref="componentDropdownRef">
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Jira Component</label>
+        <div
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
+          :class="{ 'ring-2 ring-primary-500 border-primary-500': componentDropdownOpen }"
+          @click="openComponentDropdown"
+        >
+          <span
+            v-for="name in selectedComponents"
+            :key="name"
+            class="inline-flex items-center gap-1 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 rounded px-1.5 py-0.5 text-xs font-medium"
+          >
+            {{ name }}
+            <button type="button" class="hover:text-primary-900 dark:hover:text-primary-100" @click.stop="toggleComponent(name)">&times;</button>
+          </span>
+          <input
+            ref="componentInputRef"
+            v-model="componentSearch"
+            type="text"
+            class="flex-1 min-w-[80px] bg-transparent outline-none text-sm placeholder-gray-400 dark:placeholder-gray-500"
+            :placeholder="selectedComponents.length ? '' : 'Search components…'"
+            @focus="componentDropdownOpen = true"
+            @keydown.backspace="onComponentBackspace"
+          />
+        </div>
+        <div
+          v-if="componentDropdownOpen"
+          class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
+        >
+          <div v-if="loadingComponents" class="px-3 py-2 text-xs text-gray-400">Loading…</div>
+          <div v-else-if="filteredComponents.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
+          <button
+            v-for="name in filteredComponents"
+            :key="name"
+            type="button"
+            class="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
+            @mousedown.prevent="toggleComponent(name)"
+          >
+            <span
+              class="w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-xs"
+              :class="selectedComponents.includes(name)
+                ? 'bg-primary-500 border-primary-500 text-white'
+                : 'border-gray-300 dark:border-gray-500'"
+            >
+              <span v-if="selectedComponents.includes(name)">&#10003;</span>
+            </span>
+            {{ name }}
+          </button>
+        </div>
+        <p v-if="componentError" class="text-xs text-red-500 mt-1">{{ componentError }}</p>
+      </div>
+
+      <!-- Release / Version Filter -->
+      <div class="min-w-[280px] max-w-[400px] relative" ref="versionDropdownRef">
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Release</label>
+        <div
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
+          :class="{ 'ring-2 ring-primary-500 border-primary-500': versionDropdownOpen }"
+          @click="openVersionDropdown"
+        >
+          <span
+            v-for="name in selectedVersions"
+            :key="name"
+            class="inline-flex items-center gap-1 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 rounded px-1.5 py-0.5 text-xs font-medium"
+          >
+            {{ name }}
+            <button type="button" class="hover:text-primary-900 dark:hover:text-primary-100" @click.stop="toggleVersion(name)">&times;</button>
+          </span>
+          <input
+            ref="versionInputRef"
+            v-model="versionSearch"
+            type="text"
+            class="flex-1 min-w-[80px] bg-transparent outline-none text-sm placeholder-gray-400 dark:placeholder-gray-500"
+            :placeholder="selectedVersions.length ? '' : 'Search releases…'"
+            @focus="versionDropdownOpen = true"
+            @keydown.backspace="onVersionBackspace"
+          />
+        </div>
+        <div
+          v-if="versionDropdownOpen"
+          class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
+        >
+          <div v-if="loadingVersions" class="px-3 py-2 text-xs text-gray-400">Loading…</div>
+          <div v-else-if="filteredVersions.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
+          <button
+            v-for="name in filteredVersions"
+            :key="name"
+            type="button"
+            class="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
+            @mousedown.prevent="toggleVersion(name)"
+          >
+            <span
+              class="w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-xs"
+              :class="selectedVersions.includes(name)
+                ? 'bg-primary-500 border-primary-500 text-white'
+                : 'border-gray-300 dark:border-gray-500'"
+            >
+              <span v-if="selectedVersions.includes(name)">&#10003;</span>
+            </span>
+            {{ name }}
+          </button>
+        </div>
+        <p v-if="versionError" class="text-xs text-red-500 mt-1">{{ versionError }}</p>
+      </div>
+    </div>
+
+    <!-- Summary cards -->
+    <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <!-- Features Requested -->
+      <div
+        @click="totalRequested > 0 ? setFilter('requested') : undefined"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
+        :class="[
+          activeFilter === 'requested'
+            ? 'border-blue-400 dark:border-blue-500 ring-2 ring-blue-200 dark:ring-blue-800 shadow-sm'
+            : 'border-gray-200 dark:border-gray-700',
+          totalRequested > 0 ? 'cursor-pointer hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600' : ''
+        ]"
+      >
+        <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
+            <svg class="w-3 h-3 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features Requested</span>
+          <svg v-if="activeFilter === 'requested'" class="ml-auto w-3.5 h-3.5 text-blue-500 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <div class="text-2xl font-bold text-blue-600 dark:text-blue-400 ml-7">{{ totalRequested }}</div>
+      </div>
+      <!-- Features Committed -->
+      <div
+        @click="totalCommitted > 0 ? setFilter('committed') : undefined"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
+        :class="[
+          activeFilter === 'committed'
+            ? 'border-emerald-400 dark:border-emerald-500 ring-2 ring-emerald-200 dark:ring-emerald-800 shadow-sm'
+            : 'border-gray-200 dark:border-gray-700',
+          totalCommitted > 0 ? 'cursor-pointer hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-600' : ''
+        ]"
+      >
+        <div class="absolute top-0 left-0 w-1 h-full bg-emerald-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-emerald-100 dark:bg-emerald-900/40">
+            <svg class="w-3 h-3 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features Committed</span>
+          <svg v-if="activeFilter === 'committed'" class="ml-auto w-3.5 h-3.5 text-emerald-500 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400 ml-7">{{ totalCommitted }}</div>
+      </div>
+      <!-- Blocked -->
+      <div
+        @click="totalBlocked > 0 ? setFilter('blocked') : undefined"
+        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
+        :class="[
+          activeFilter === 'blocked'
+            ? 'border-red-400 dark:border-red-500 ring-2 ring-red-200 dark:ring-red-800 shadow-sm'
+            : 'border-gray-200 dark:border-gray-700',
+          totalBlocked > 0 ? 'cursor-pointer hover:shadow-md hover:border-red-300 dark:hover:border-red-600' : ''
+        ]"
+      >
+        <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
+            <svg class="w-3 h-3 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
+          <svg v-if="activeFilter === 'blocked'" class="ml-auto w-3.5 h-3.5 text-red-500 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <div class="text-2xl font-bold ml-7" :class="totalBlocked > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ totalBlocked }}</div>
+      </div>
+      <!-- Versions Selected -->
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-gray-100 dark:bg-gray-700">
+            <svg class="w-3 h-3 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Versions Selected</span>
+        </div>
+        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ groups.length }}</div>
+      </div>
+    </div>
+
+    <!-- Active filter indicator -->
+    <div
+      v-if="activeFilter && groups.length > 0 && !loadingData"
+      class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium"
+      :class="{
+        'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300': activeFilter === 'requested',
+        'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300': activeFilter === 'committed',
+        'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300': activeFilter === 'blocked'
+      }"
+    >
+      <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+      </svg>
+      <span>Showing {{ activeFilter === 'requested' ? 'requested' : activeFilter === 'committed' ? 'committed' : 'blocked' }} features only</span>
+      <button
+        @click="setFilter(null)"
+        class="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold hover:bg-white/50 dark:hover:bg-gray-800/50 transition-colors"
+      >
+        Clear filter
+        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="loadingData" class="flex flex-col items-center justify-center py-16 gap-3">
+      <svg class="animate-spin h-8 w-8 text-primary-500" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+      </svg>
+      <span class="text-sm text-gray-500 dark:text-gray-400">Loading data from Jira…</span>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="dataError" class="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-5 py-4 text-sm text-red-700 dark:text-red-400 flex items-start gap-3">
+      <svg class="w-5 h-5 text-red-500 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+      </svg>
+      {{ dataError }}
+    </div>
+
+    <!-- Empty prompt -->
+    <div v-else-if="groups.length === 0 && !hasFetched" class="text-center py-16 text-gray-400 dark:text-gray-500">
+      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+      <p class="text-sm font-medium">Select components and/or releases to view data.</p>
+    </div>
+
+    <!-- No results -->
+    <div v-else-if="groups.length === 0 && hasFetched" class="text-center py-16 text-gray-400 dark:text-gray-500">
+      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+      </svg>
+      <p class="text-sm font-medium">No features found for the selected filters.</p>
+    </div>
+
+    <!-- Data table -->
+    <ComponentReleaseLoadTable
+      v-if="groups.length > 0 && !loadingData"
+      ref="tableRef"
+      :groups="groups"
+      :activeFilter="activeFilter"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { getApiBase } from '@shared/client/services/api'
+import ComponentReleaseLoadTable from '../components/ComponentReleaseLoadTable.vue'
+
+const API_BASE = '/modules/releases/pm-hub'
+
+var selectedComponents = ref([])
+var selectedVersions = ref([])
+
+var componentSearch = ref('')
+var versionSearch = ref('')
+
+var componentDropdownOpen = ref(false)
+var versionDropdownOpen = ref(false)
+
+var componentDropdownRef = ref(null)
+var versionDropdownRef = ref(null)
+var componentInputRef = ref(null)
+var versionInputRef = ref(null)
+
+var components = ref([])
+var loadingComponents = ref(false)
+var componentError = ref(null)
+
+var versions = ref([])
+var loadingVersions = ref(false)
+var versionError = ref(null)
+
+var groups = ref([])
+var loadingData = ref(false)
+var dataError = ref(null)
+var hasFetched = ref(false)
+var tableRef = ref(null)
+var activeFilter = ref(null)
+
+function setFilter(type) {
+  if (type === null || activeFilter.value === type) {
+    activeFilter.value = null
+  } else {
+    activeFilter.value = type
+  }
+}
+
+var uniqueComponents = computed(function() {
+  var seen = new Set()
+  var result = []
+  for (var i = 0; i < components.value.length; i++) {
+    var name = components.value[i].name
+    if (!seen.has(name)) {
+      seen.add(name)
+      result.push(name)
+    }
+  }
+  return result
+})
+
+var uniqueVersions = computed(function() {
+  var seen = new Set()
+  var result = []
+  for (var i = 0; i < versions.value.length; i++) {
+    var name = versions.value[i].name
+    if (!seen.has(name)) {
+      seen.add(name)
+      result.push(name)
+    }
+  }
+  return result
+})
+
+var filteredComponents = computed(function() {
+  var q = componentSearch.value.toLowerCase().trim()
+  if (!q) return uniqueComponents.value
+  return uniqueComponents.value.filter(function(name) {
+    return name.toLowerCase().includes(q)
+  })
+})
+
+var filteredVersions = computed(function() {
+  var q = versionSearch.value.toLowerCase().trim()
+  if (!q) return uniqueVersions.value
+  return uniqueVersions.value.filter(function(name) {
+    return name.toLowerCase().includes(q)
+  })
+})
+
+var totalRequested = computed(function() {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    count += groups.value[i].requestedCount || 0
+  }
+  return count
+})
+
+var totalCommitted = computed(function() {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    count += groups.value[i].committedCount || 0
+  }
+  return count
+})
+
+var totalBlocked = computed(function() {
+  var count = 0
+  for (var i = 0; i < groups.value.length; i++) {
+    count += groups.value[i].blockedCount || 0
+  }
+  return count
+})
+
+function toggleComponent(name) {
+  var idx = selectedComponents.value.indexOf(name)
+  if (idx >= 0) {
+    selectedComponents.value.splice(idx, 1)
+  } else {
+    selectedComponents.value.push(name)
+  }
+  componentSearch.value = ''
+}
+
+function toggleVersion(name) {
+  var idx = selectedVersions.value.indexOf(name)
+  if (idx >= 0) {
+    selectedVersions.value.splice(idx, 1)
+  } else {
+    selectedVersions.value.push(name)
+  }
+  versionSearch.value = ''
+}
+
+function openComponentDropdown() {
+  componentDropdownOpen.value = true
+  if (componentInputRef.value) componentInputRef.value.focus()
+}
+
+function openVersionDropdown() {
+  versionDropdownOpen.value = true
+  if (versionInputRef.value) versionInputRef.value.focus()
+}
+
+function onComponentBackspace() {
+  if (!componentSearch.value && selectedComponents.value.length) {
+    selectedComponents.value.pop()
+  }
+}
+
+function onVersionBackspace() {
+  if (!versionSearch.value && selectedVersions.value.length) {
+    selectedVersions.value.pop()
+  }
+}
+
+function handleClickOutside(e) {
+  if (componentDropdownRef.value && !componentDropdownRef.value.contains(e.target)) {
+    componentDropdownOpen.value = false
+    componentSearch.value = ''
+  }
+  if (versionDropdownRef.value && !versionDropdownRef.value.contains(e.target)) {
+    versionDropdownOpen.value = false
+    versionSearch.value = ''
+  }
+}
+
+function handleExpandAll() {
+  if (tableRef.value) tableRef.value.expandAll()
+}
+
+function handleCollapseAll() {
+  if (tableRef.value) tableRef.value.collapseAll()
+}
+
+async function fetchComponents() {
+  loadingComponents.value = true
+  componentError.value = null
+  try {
+    var response = await fetch(getApiBase() + API_BASE + '/jira/components')
+    if (!response.ok) {
+      var errData = await response.json().catch(function() { return {} })
+      throw new Error(errData.error || 'HTTP ' + response.status)
+    }
+    var data = await response.json()
+    components.value = data.components || []
+  } catch (err) {
+    componentError.value = err.message
+  } finally {
+    loadingComponents.value = false
+  }
+}
+
+async function fetchVersions() {
+  loadingVersions.value = true
+  versionError.value = null
+  try {
+    var response = await fetch(getApiBase() + API_BASE + '/jira/versions')
+    if (!response.ok) {
+      var errData = await response.json().catch(function() { return {} })
+      throw new Error(errData.error || 'HTTP ' + response.status)
+    }
+    var data = await response.json()
+    versions.value = data.versions || []
+  } catch (err) {
+    versionError.value = err.message
+  } finally {
+    loadingVersions.value = false
+  }
+}
+
+async function loadData() {
+  if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) return
+  loadingData.value = true
+  dataError.value = null
+  hasFetched.value = true
+
+  try {
+    var params = new URLSearchParams()
+    if (selectedComponents.value.length > 0) {
+      params.set('components', selectedComponents.value.join(','))
+    }
+    if (selectedVersions.value.length > 0) {
+      params.set('versions', selectedVersions.value.join(','))
+    }
+
+    var response = await fetch(getApiBase() + API_BASE + '/component-release-load?' + params.toString())
+    if (!response.ok) {
+      var errData = await response.json().catch(function() { return {} })
+      throw new Error(errData.error || 'HTTP ' + response.status)
+    }
+    var data = await response.json()
+    groups.value = data.groups || []
+  } catch (err) {
+    dataError.value = err.message
+    groups.value = []
+  } finally {
+    loadingData.value = false
+  }
+}
+
+watch([selectedComponents, selectedVersions], function() {
+  activeFilter.value = null
+  if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) {
+    groups.value = []
+    hasFetched.value = false
+    return
+  }
+  loadData()
+}, { deep: true })
+
+onMounted(function() {
+  fetchComponents()
+  fetchVersions()
+  document.addEventListener('mousedown', handleClickOutside)
+})
+
+onBeforeUnmount(function() {
+  document.removeEventListener('mousedown', handleClickOutside)
+})
+</script>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -24,7 +24,15 @@
     <div class="flex flex-wrap items-start gap-4">
       <!-- Jira Component Filter -->
       <div class="min-w-[280px] max-w-[400px] relative" ref="componentDropdownRef">
-        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Jira Component</label>
+        <div class="flex items-center justify-between mb-1">
+          <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Jira Component</label>
+          <button
+            v-if="selectedComponents.length > 0"
+            type="button"
+            @click="selectedComponents = []; componentSearch = ''"
+            class="text-[10px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+          >Clear</button>
+        </div>
         <div
           class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
           :class="{ 'ring-2 ring-primary-500 border-primary-500': componentDropdownOpen }"
@@ -77,7 +85,15 @@
 
       <!-- Release / Version Filter -->
       <div class="min-w-[280px] max-w-[400px] relative" ref="versionDropdownRef">
-        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Release</label>
+        <div class="flex items-center justify-between mb-1">
+          <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Release</label>
+          <button
+            v-if="selectedVersions.length > 0"
+            type="button"
+            @click="selectedVersions = []; versionSearch = ''"
+            class="text-[10px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+          >Clear</button>
+        </div>
         <div
           class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
           :class="{ 'ring-2 ring-primary-500 border-primary-500': versionDropdownOpen }"

--- a/modules/releases/client/plan/views/PmHubView.vue
+++ b/modules/releases/client/plan/views/PmHubView.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <div v-if="!selectedReport">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <button
+          v-for="report in reports"
+          :key="report.id"
+          class="group text-left bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 cursor-pointer hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200"
+          :aria-label="report.label"
+          @click="selectedReport = report"
+        >
+          <div class="flex items-start gap-3">
+            <div class="flex-shrink-0 w-8 h-8 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center group-hover:bg-primary-100 dark:group-hover:bg-primary-900/50 transition-colors">
+              <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+              </svg>
+            </div>
+            <div class="min-w-0">
+              <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">{{ report.label }}</h3>
+              <p class="text-xs text-gray-500 dark:text-gray-400">{{ report.description }}</p>
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+    <div v-else>
+      <button
+        class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white flex items-center gap-1 mb-4"
+        @click="selectedReport = null"
+      >
+        &larr; Back to PM Hub
+      </button>
+      <component :is="selectedReport.component" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { defineAsyncComponent } from 'vue'
+
+const reports = [
+  {
+    id: 'component-release-load',
+    label: 'Component Release Load Tracking',
+    description: 'Track component workload distribution across releases to identify capacity risks and balance engineering load.',
+    component: defineAsyncComponent(() => import('./ComponentReleaseLoadReport.vue'))
+  }
+]
+
+const selectedReport = ref(null)
+</script>

--- a/modules/releases/client/plan/views/PmHubView.vue
+++ b/modules/releases/client/plan/views/PmHubView.vue
@@ -36,8 +36,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { defineAsyncComponent } from 'vue'
+import { ref, defineAsyncComponent } from 'vue'
 
 const reports = [
   {

--- a/modules/releases/client/views/DeliverView.vue
+++ b/modules/releases/client/views/DeliverView.vue
@@ -38,7 +38,6 @@ import { useReleaseFilter } from '../deliver/composables/useReleaseFilter.js'
 import ReleaseChipBar from '../deliver/components/ReleaseChipBar.vue'
 
 const RiskDashboard = defineAsyncComponent(() => import('../deliver/views/MainView.vue'))
-const ComponentBreakdown = defineAsyncComponent(() => import('../deliver/views/ProjectBreakdownView.vue'))
 const ConformaInsights = defineAsyncComponent(() => import('../deliver/views/ConformaExceptionsView.vue'))
 const PostReleaseDefects = defineAsyncComponent(() => import('../deliver/views/PostReleaseDefectsView.vue'))
 
@@ -53,7 +52,6 @@ provide('analysisState', { loading, refreshing, error, analysis, refreshAnalysis
 
 const tabs = [
   { id: 'risk-dashboard', label: 'Risk Dashboard' },
-  { id: 'component-breakdown', label: 'Component Breakdown' },
   { id: 'conforma-insights', label: 'Conforma Insights' },
   { id: 'post-release-defects', label: 'Post-Release Defects' },
 ]
@@ -62,7 +60,6 @@ const activeTab = ref('risk-dashboard')
 
 const componentMap = {
   'risk-dashboard': RiskDashboard,
-  'component-breakdown': ComponentBreakdown,
   'conforma-insights': ConformaInsights,
   'post-release-defects': PostReleaseDefects,
 }

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -18,6 +18,7 @@
     <div class="p-6">
       <DashboardView v-if="activeTab === 'outcomes'" />
       <HealthDashboardView v-else-if="activeTab === 'health'" />
+      <PmHubView v-else-if="activeTab === 'pm-hub'" />
     </div>
   </div>
 </template>
@@ -26,10 +27,12 @@
 import { ref } from 'vue'
 import DashboardView from '../plan/views/DashboardView.vue'
 import HealthDashboardView from '../plan/views/HealthDashboardView.vue'
+import PmHubView from '../plan/views/PmHubView.vue'
 
 const tabs = [
   { id: 'outcomes', label: 'Outcomes' },
   { id: 'health', label: 'Health' },
+  { id: 'pm-hub', label: 'PM Hub' },
 ]
 
 const activeTab = ref('outcomes')

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -14,6 +14,7 @@ const registerFeatureTrackingRoutes = require('./execution/feature-tracking-rout
 const registerDeliveryRoutes = require('./delivery/routes');
 const registerHygieneRoutes = require('./hygiene/routes');
 const registerTvFvDeltaRoutes = require('./tv-fv-delta/routes');
+const registerPmHubRoutes = require('./pm-hub/routes');
 const { getAuditLog } = require('./planning/audit-log');
 
 /**
@@ -227,6 +228,16 @@ module.exports = function registerRoutes(router, context) {
     registerDiagnostics: context.registerDiagnostics || null
   });
   router.use('/tv-fv-delta', tvFvDeltaRouter);
+
+  // PM Hub sub-router (mounted at /api/modules/releases/pm-hub/)
+  var pmHubRouter = express.Router();
+  registerPmHubRoutes(pmHubRouter, {
+    requireAuth,
+    requireScope,
+    jira,
+    storage
+  });
+  router.use('/pm-hub', pmHubRouter);
 
   // ─── Unified Audit Routes ───
 

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -1,0 +1,319 @@
+/**
+ * PM Hub sub-router for the releases module.
+ * Mounted at /api/modules/releases/pm-hub/ by the parent router.
+ *
+ * Provides endpoints for cross-project Jira metadata (components, versions)
+ * and component-level release load data used by PM Hub reports.
+ */
+
+const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
+
+const PM_HUB_PROJECTS = ['RHAIENG', 'RHOAIENG', 'INFERENG', 'AIPCC', 'RHAISTRAT', 'RHAIRFE']
+const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
+const FIELDS_TO_FETCH = [
+  'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
+  'components', 'labels', 'issuelinks',
+  CUSTOM_FIELDS.team,
+  CUSTOM_FIELDS.statusSummary,
+  CUSTOM_FIELDS.colorStatus,
+  CUSTOM_FIELDS.productManager
+].join(',')
+
+/**
+ * @param {import('express').Router} router
+ * @param {{ requireAuth: Function, requireScope: Function, jira: object, storage: object }} context
+ */
+module.exports = function registerPmHubRoutes(router, context) {
+  var jiraClient = context.jira || null
+  var _storage = context.storage || null
+
+  /**
+   * @openapi
+   * /api/modules/releases/pm-hub/jira/components:
+   *   get:
+   *     tags: [Releases]
+   *     summary: List Jira components across PM Hub projects
+   *     description: Returns components from RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE
+   *     responses:
+   *       200:
+   *         description: Array of components with project keys
+   *       503:
+   *         description: Jira client not configured
+   */
+  router.get('/jira/components', context.requireAuth, context.requireScope('releases:read'), async function(req, res) {
+    if (!jiraClient) {
+      return res.status(503).json({ error: 'Jira client not configured' })
+    }
+
+    try {
+      var components = []
+
+      for (var i = 0; i < PM_HUB_PROJECTS.length; i++) {
+        var project = PM_HUB_PROJECTS[i]
+        try {
+          var data = await jiraClient.jiraRequest(
+            '/rest/api/3/project/' + encodeURIComponent(project) + '/components'
+          )
+          var arr = Array.isArray(data) ? data : []
+          for (var j = 0; j < arr.length; j++) {
+            var name = String(arr[j].name || '').trim()
+            if (!name) continue
+            components.push({
+              id: String(arr[j].id || ''),
+              name: name,
+              project: project
+            })
+          }
+        } catch (err) {
+          console.warn('[releases/pm-hub] Failed to fetch components for ' + project + ': ' + err.message)
+        }
+      }
+
+      components.sort(function(a, b) { return a.name.localeCompare(b.name) })
+
+      res.json({ components: components, projects: PM_HUB_PROJECTS })
+    } catch (err) {
+      console.error('[releases/pm-hub] Components fetch failed:', err.message)
+      res.status(500).json({ error: 'Failed to fetch Jira components' })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/pm-hub/jira/versions:
+   *   get:
+   *     tags: [Releases]
+   *     summary: List Jira versions across PM Hub projects
+   *     description: Returns versions from RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE
+   *     responses:
+   *       200:
+   *         description: Array of versions with project keys
+   *       503:
+   *         description: Jira client not configured
+   */
+  router.get('/jira/versions', context.requireAuth, context.requireScope('releases:read'), async function(req, res) {
+    if (!jiraClient) {
+      return res.status(503).json({ error: 'Jira client not configured' })
+    }
+
+    try {
+      var versions = await jiraClient.fetchProjectVersions(PM_HUB_PROJECTS)
+
+      versions.sort(function(a, b) { return a.name.localeCompare(b.name) })
+
+      res.json({ versions: versions, projects: PM_HUB_PROJECTS })
+    } catch (err) {
+      console.error('[releases/pm-hub] Versions fetch failed:', err.message)
+      res.status(500).json({ error: 'Failed to fetch Jira versions' })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/pm-hub/component-release-load:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get component release load tracking data
+   *     description: >
+   *       Queries Jira for Features/Initiatives grouped by version then component.
+   *       F Requested = issues where Target Version (cf[10855]) matches a selected version.
+   *       F Committed = issues where fixVersion matches a selected version.
+   *     parameters:
+   *       - in: query
+   *         name: components
+   *         schema: { type: string }
+   *         description: Comma-separated Jira component names
+   *       - in: query
+   *         name: versions
+   *         schema: { type: string }
+   *         description: Comma-separated Jira version names
+   *     responses:
+   *       200:
+   *         description: Grouped feature data with requested and committed counts
+   *       400:
+   *         description: Missing required filters
+   *       503:
+   *         description: Jira client not configured
+   */
+  router.get('/component-release-load', context.requireAuth, context.requireScope('releases:read'), async function(req, res) {
+    if (!jiraClient) {
+      return res.status(503).json({ error: 'Jira client not configured' })
+    }
+
+    var componentNames = req.query.components ? req.query.components.split(',').map(function(s) { return s.trim() }).filter(Boolean) : []
+    var versionNames = req.query.versions ? req.query.versions.split(',').map(function(s) { return s.trim() }).filter(Boolean) : []
+
+    if (componentNames.length === 0 && versionNames.length === 0) {
+      return res.status(400).json({ error: 'At least one component or version filter is required' })
+    }
+
+    try {
+      var baseParts = [
+        'project IN (' + PM_HUB_PROJECTS.join(', ') + ')',
+        'issuetype IN (' + DEFAULT_ISSUE_TYPES.join(', ') + ')'
+      ]
+
+      var componentClause = ''
+      if (componentNames.length > 0) {
+        var escapedComp = componentNames.map(function(c) {
+          return '"' + c.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+        })
+        componentClause = 'component IN (' + escapedComp.join(', ') + ')'
+      }
+
+      var escapedVer = versionNames.map(function(v) {
+        return '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+      })
+
+      var fieldsWithTv = FIELDS_TO_FETCH + ',' + CUSTOM_FIELDS.targetVersion
+
+      // Query 1: F Requested — Target Version (cf[10855]) matches selected versions
+      var requestedIssues = []
+      if (versionNames.length > 0) {
+        var tvJqlParts = baseParts.slice()
+        if (componentClause) tvJqlParts.push(componentClause)
+        tvJqlParts.push('cf[10855] IN (' + escapedVer.join(', ') + ')')
+        var tvJql = tvJqlParts.join(' AND ')
+        requestedIssues = await jiraClient.fetchAllJqlResults(tvJql, fieldsWithTv, { expand: 'renderedFields' })
+      }
+
+      // Query 2: F Committed — fixVersion matches selected versions
+      var committedIssues = []
+      if (versionNames.length > 0) {
+        var fvJqlParts = baseParts.slice()
+        if (componentClause) fvJqlParts.push(componentClause)
+        fvJqlParts.push('fixVersion IN (' + escapedVer.join(', ') + ')')
+        var fvJql = fvJqlParts.join(' AND ')
+        committedIssues = await jiraClient.fetchAllJqlResults(fvJql, fieldsWithTv, { expand: 'renderedFields' })
+      } else if (componentNames.length > 0) {
+        var compOnlyParts = baseParts.slice()
+        compOnlyParts.push(componentClause)
+        var compJql = compOnlyParts.join(' AND ')
+        committedIssues = await jiraClient.fetchAllJqlResults(compJql, fieldsWithTv, { expand: 'renderedFields' })
+      }
+
+      function extractTargetVersions(rawIssue) {
+        var tvField = rawIssue.fields && rawIssue.fields[CUSTOM_FIELDS.targetVersion]
+        if (!tvField) return []
+        var arr = Array.isArray(tvField) ? tvField : [tvField]
+        var result = []
+        for (var i = 0; i < arr.length; i++) {
+          var name = arr[i] && (arr[i].name || arr[i].value)
+          if (name) result.push(String(name).trim())
+        }
+        return result
+      }
+
+      var versionGroups = {}
+
+      function ensureGroup(vName, cName) {
+        if (!versionGroups[vName]) {
+          versionGroups[vName] = { version: vName, components: {} }
+        }
+        if (!versionGroups[vName].components[cName]) {
+          versionGroups[vName].components[cName] = {
+            component: cName,
+            requestedFeatures: [],
+            committedFeatures: [],
+            requestedCount: 0,
+            committedCount: 0,
+            blockedCount: 0
+          }
+        }
+        return versionGroups[vName].components[cName]
+      }
+
+      function buildFeatureObj(f) {
+        return {
+          key: f.key,
+          summary: f.summary || '',
+          status: f.status || null,
+          colorStatus: f.colorStatus || null,
+          statusSummary: f.statusSummary || null,
+          isBlocked: f.isBlocked || false,
+          components: f.components || [],
+          assignee: f.assignee || null,
+          pmOwner: f.pmOwner || null
+        }
+      }
+
+      // Process requested issues (Target Version matches)
+      for (var ri = 0; ri < requestedIssues.length; ri++) {
+        var raw = requestedIssues[ri]
+        var f = transformIssue(raw, {})
+        var tvNames = extractTargetVersions(raw)
+        var compList = f.components && f.components.length > 0 ? f.components : ['No Component']
+
+        for (var tvi = 0; tvi < tvNames.length; tvi++) {
+          var tvName = tvNames[tvi]
+          if (versionNames.indexOf(tvName) === -1) continue
+
+          for (var ci = 0; ci < compList.length; ci++) {
+            var cName = compList[ci]
+            if (componentNames.length > 0 && componentNames.indexOf(cName) === -1) continue
+            var group = ensureGroup(tvName, cName)
+            if (!group.requestedFeatures.some(function(e) { return e.key === f.key })) {
+              group.requestedFeatures.push(buildFeatureObj(f))
+              group.requestedCount++
+            }
+          }
+        }
+      }
+
+      // Process committed issues (Fix Version matches)
+      for (var cii = 0; cii < committedIssues.length; cii++) {
+        var rawC = committedIssues[cii]
+        var fc = transformIssue(rawC, {})
+        var fvList = fc.fixVersions && fc.fixVersions.length > 0 ? fc.fixVersions : ['Unversioned']
+        var compListC = fc.components && fc.components.length > 0 ? fc.components : ['No Component']
+
+        for (var fvi = 0; fvi < fvList.length; fvi++) {
+          var fvName = fvList[fvi]
+          if (versionNames.length > 0 && versionNames.indexOf(fvName) === -1) continue
+
+          for (var cci = 0; cci < compListC.length; cci++) {
+            var cNameC = compListC[cci]
+            if (componentNames.length > 0 && componentNames.indexOf(cNameC) === -1) continue
+            var groupC = ensureGroup(fvName, cNameC)
+            if (!groupC.committedFeatures.some(function(e) { return e.key === fc.key })) {
+              groupC.committedFeatures.push(buildFeatureObj(fc))
+              groupC.committedCount++
+              if (fc.isBlocked) groupC.blockedCount++
+            }
+          }
+        }
+      }
+
+      var groups = Object.keys(versionGroups).sort().map(function(vKey) {
+        var vg = versionGroups[vKey]
+        var compGroups = Object.keys(vg.components).sort().map(function(cKey) {
+          return vg.components[cKey]
+        })
+        var totalRequested = 0
+        var totalCommitted = 0
+        var totalBlocked = 0
+        for (var cgi = 0; cgi < compGroups.length; cgi++) {
+          totalRequested += compGroups[cgi].requestedCount
+          totalCommitted += compGroups[cgi].committedCount
+          totalBlocked += compGroups[cgi].blockedCount
+        }
+        return {
+          version: vg.version,
+          components: compGroups,
+          requestedCount: totalRequested,
+          committedCount: totalCommitted,
+          blockedCount: totalBlocked
+        }
+      })
+
+      res.json({
+        groups: groups,
+        fetchedAt: new Date().toISOString(),
+        filters: { components: componentNames, versions: versionNames }
+      })
+    } catch (err) {
+      console.error('[releases/pm-hub] Component release load fetch failed:', err.message)
+      res.status(500).json({ error: 'Failed to fetch component release load data: ' + err.message })
+    }
+  })
+}

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -45,26 +45,30 @@ module.exports = function registerPmHubRoutes(router, context) {
     }
 
     try {
-      var components = []
-
-      for (var i = 0; i < PM_HUB_PROJECTS.length; i++) {
-        var project = PM_HUB_PROJECTS[i]
-        try {
-          var data = await jiraClient.jiraRequest(
+      var results = await Promise.allSettled(
+        PM_HUB_PROJECTS.map(function(project) {
+          return jiraClient.jiraRequest(
             '/rest/api/3/project/' + encodeURIComponent(project) + '/components'
-          )
-          var arr = Array.isArray(data) ? data : []
-          for (var j = 0; j < arr.length; j++) {
-            var name = String(arr[j].name || '').trim()
-            if (!name) continue
-            components.push({
-              id: String(arr[j].id || ''),
-              name: name,
-              project: project
-            })
-          }
-        } catch (err) {
-          console.warn('[releases/pm-hub] Failed to fetch components for ' + project + ': ' + err.message)
+          ).then(function(data) { return { project: project, data: data } })
+        })
+      )
+
+      var components = []
+      for (var i = 0; i < results.length; i++) {
+        if (results[i].status === 'rejected') {
+          console.warn('[releases/pm-hub] Failed to fetch components for ' + PM_HUB_PROJECTS[i] + ': ' + results[i].reason.message)
+          continue
+        }
+        var project = results[i].value.project
+        var arr = Array.isArray(results[i].value.data) ? results[i].value.data : []
+        for (var j = 0; j < arr.length; j++) {
+          var name = String(arr[j].name || '').trim()
+          if (!name) continue
+          components.push({
+            id: String(arr[j].id || ''),
+            name: name,
+            project: project
+          })
         }
       }
 

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -25,7 +25,6 @@ const FIELDS_TO_FETCH = [
  */
 module.exports = function registerPmHubRoutes(router, context) {
   var jiraClient = context.jira || null
-  var _storage = context.storage || null
 
   /**
    * @openapi
@@ -313,7 +312,7 @@ module.exports = function registerPmHubRoutes(router, context) {
       })
     } catch (err) {
       console.error('[releases/pm-hub] Component release load fetch failed:', err.message)
-      res.status(500).json({ error: 'Failed to fetch component release load data: ' + err.message })
+      res.status(500).json({ error: 'Failed to fetch component release load data' })
     }
   })
 }

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -164,3 +164,79 @@ test.describe('Releases Views @releases', () => {
     await testView(page, 'audit', 'Audit');
   });
 });
+
+/**
+ * PM Hub
+ *
+ * Verify the PM Hub tab loads under Plan, the Component Release Load Tracking
+ * report card is visible and clickable, and the PM Hub API endpoints respond.
+ */
+test.describe('Releases PM Hub @releases', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should show PM Hub tab under Plan and load report card', async ({ page }) => {
+    await page.goto('/#/releases/plan');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const pmHubTab = page.locator('button', { hasText: 'PM Hub' });
+    await expect(pmHubTab).toBeVisible();
+
+    await pmHubTab.click();
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const reportCard = page.locator('text=Component Release Load Tracking');
+    await expect(reportCard.first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('should open Component Release Load report with filter dropdowns', async ({ page }) => {
+    await page.goto('/#/releases/plan');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await page.locator('button', { hasText: 'PM Hub' }).click();
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const reportCard = page.locator('.cursor-pointer', { hasText: 'Component Release Load Tracking' });
+    await reportCard.first().click();
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const componentFilter = page.locator('text=Jira Component');
+    const releaseFilter = page.locator('text=Release');
+    await expect(componentFilter.first()).toBeVisible();
+    await expect(releaseFilter.first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('PM Hub API endpoints should respond', async ({ request }) => {
+    const componentsRes = await request.get('/api/modules/releases/pm-hub/jira/components');
+    expect(componentsRes.ok()).toBe(true);
+    const componentsBody = await componentsRes.json();
+    expect(componentsBody).toHaveProperty('components');
+    expect(componentsBody).toHaveProperty('projects');
+    expect(Array.isArray(componentsBody.components)).toBe(true);
+
+    const versionsRes = await request.get('/api/modules/releases/pm-hub/jira/versions');
+    expect(versionsRes.ok()).toBe(true);
+    const versionsBody = await versionsRes.json();
+    expect(versionsBody).toHaveProperty('versions');
+    expect(versionsBody).toHaveProperty('projects');
+    expect(Array.isArray(versionsBody.versions)).toBe(true);
+  });
+
+  test('component-release-load endpoint requires filters', async ({ request }) => {
+    const res = await request.get('/api/modules/releases/pm-hub/component-release-load');
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('filter');
+  });
+});


### PR DESCRIPTION
## Summary
- **New PM Hub tab** under Plan with a "Component Release Load Tracking" report that queries Jira for features by component and release across 6 projects (RHAIENG, RHOAIENG, INFERENG, AIPCC, RHAISTRAT, RHAIRFE)
- Searchable **multi-select dropdowns** for Jira Component (119 unique) and Release filters with clear buttons, dynamically updating an expandable table showing Features Requested (Target Version), Features Committed (Fix Version), and Blocked counts
- **Clickable summary cards** (Features Requested, Features Committed, Blocked) that filter the table below
- **Removes the Component Breakdown tab** from the Deliver view (superseded by PM Hub)

## Test plan
- [ ] Navigate to Releases > Plan > PM Hub and verify the tab loads
- [ ] Click "Component Release Load Tracking" report card and verify it opens
- [ ] Select components and/or releases from the dropdowns — table should update dynamically
- [ ] Verify multi-select works: search, select multiple, remove chips, use Clear button
- [ ] Click summary cards (Features Requested / Committed / Blocked) and verify the table filters correctly
- [ ] Click an active summary card again to clear the filter
- [ ] Verify the Component Breakdown tab is no longer visible under Deliver
- [ ] Expand/Collapse All buttons work correctly
- [ ] Feature rows show correct REQ/COM tags and blocked status


Made with [Cursor](https://cursor.com)