### PR TITLE
fix: copy libcurl deps into runtime image for git HTTPS support

### DIFF
--- a/deploy/core.backend.Dockerfile
+++ b/deploy/core.backend.Dockerfile
@@ -17,6 +17,14 @@ WORKDIR /app
 
 RUN microdnf install -y git-core ca-certificates python3 make gcc gcc-c++ && microdnf clean all
 
+# Collect shared libraries needed by git-remote-https (for HTTPS clone/fetch)
+# The runtime image is distroless-like and lacks libcurl + transitive deps
+RUN mkdir -p /git-libs && \
+    ldd /usr/libexec/git-core/git-remote-https | \
+    awk '/=>/ { print $3 }' | \
+    grep -v -E '/(libc|libpthread|libdl|libm|librt|libresolv|libnss|libgcc_s|libstdc\+\+)\.' | \
+    xargs -I{} cp -L {} /git-libs/
+
 # Trust internal CA
 COPY deploy/certs/internal-root-ca.pem /etc/pki/ca-trust/source/anchors/internal-root-ca.pem
 RUN update-ca-trust
@@ -35,6 +43,9 @@ WORKDIR /app
 # Copy git binary and libexec helpers from build stage
 COPY --from=build /usr/bin/git /usr/bin/git
 COPY --from=build /usr/libexec/git-core /usr/libexec/git-core
+
+# Copy shared libraries required by git-remote-https (collected via ldd in build stage)
+COPY --from=build /git-libs/ /usr/lib64/
 
 # Copy CA trust bundle (internal CA baked in via update-ca-trust)
 COPY --from=build /etc/pki/ca-trust/extracted /etc/pki/ca-trust/extracted


### PR DESCRIPTION
## Summary

- Git-static module sync fails in production because `git-remote-https` can't find `libcurl.so.4` in the hardened runtime image (`hi/nodejs`)
- The Dockerfile already copies the `git` binary and `git-core` helpers from the build stage, but not the shared libraries they depend on
- Uses `ldd` in the build stage to dynamically discover and collect all required shared libraries, then copies them into the runtime image
- Excludes base system libraries (libc, libpthread, libm, etc.) to avoid overwriting the runtime's own copies, which could cause issues if the two base images drift to different versions

**Error fixed:**
```
/usr/libexec/git-core/git-remote-https: error while loading shared libraries: libcurl.so.4: cannot open shared object file: No such file or directory
```

## Test plan

- [ ] Build core backend image: `make build-core-backend-image`
- [ ] Run smoke tests: `make smoke-test-core`
- [ ] Verify git-static module sync works in staging (clone + fetch over HTTPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)