### PR TITLE
fix: add CA bundle symlink for git HTTPS in runtime image

### DIFF
--- a/deploy/core.backend.Dockerfile
+++ b/deploy/core.backend.Dockerfile
@@ -50,6 +50,9 @@ COPY --from=build /git-libs/ /usr/lib64/
 # Copy CA trust bundle (internal CA baked in via update-ca-trust)
 COPY --from=build /etc/pki/ca-trust/extracted /etc/pki/ca-trust/extracted
 COPY --from=build /etc/pki/ca-trust/source/anchors/internal-root-ca.pem /etc/pki/ca-trust/source/anchors/internal-root-ca.pem
+# Symlink ca-bundle.crt where libcurl/git expect it (the target was copied above)
+RUN mkdir -p /etc/pki/tls/certs && \
+    ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/tls/certs/ca-bundle.crt
 ENV NODE_EXTRA_CA_CERTS=/etc/pki/ca-trust/source/anchors/internal-root-ca.pem
 
 # Copy node_modules from build stage


### PR DESCRIPTION
## Summary

- Follow-up to #899 — git HTTPS fetch now loads `git-remote-https` successfully, but libcurl can't find the CA certificate bundle
- The CA trust bundle is already copied from the build stage (`/etc/pki/ca-trust/extracted/`), but the standard symlink at `/etc/pki/tls/certs/ca-bundle.crt` was missing in the hardened runtime image
- Adds `ln -s` to create the expected symlink, matching the layout in the UBI9 build image

**Error fixed:**
```
fatal: unable to access 'https://gitlab.cee.redhat.com/...': error setting certificate file: /etc/pki/tls/certs/ca-bundle.crt
```

## Test plan

- [x] Image builds successfully
- [x] `/etc/pki/tls/certs/ca-bundle.crt` symlink resolves to valid CA bundle in container
- [ ] Git-static module sync works against internal GitLab over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)