### PR TITLE
fix: copy tar binary into runtime image for data backups

### DIFF
--- a/deploy/core.backend.Dockerfile
+++ b/deploy/core.backend.Dockerfile
@@ -40,9 +40,10 @@ USER 0
 
 WORKDIR /app
 
-# Copy git binary and libexec helpers from build stage
+# Copy git and tar binaries from build stage
 COPY --from=build /usr/bin/git /usr/bin/git
 COPY --from=build /usr/libexec/git-core /usr/libexec/git-core
+COPY --from=build /usr/bin/tar /usr/bin/tar
 
 # Copy shared libraries required by git-remote-https (collected via ldd in build stage)
 COPY --from=build /git-libs/ /usr/lib64/


### PR DESCRIPTION
## Summary

- Third fix for the hardened runtime image (`hi/nodejs`) missing standard utilities
- The backup system (`shared/server/backup.js`) shells out to `tar` for creating/restoring data archives, but `tar` doesn't exist in the distroless-like runtime image
- Copies `/usr/bin/tar` from the UBI9 build stage (same pattern as git)

Previous fixes: #899 (libcurl for git), #906 (CA bundle symlink)

## Test plan

- [x] Image builds successfully
- [x] `tar --version` works inside the container
- [ ] Data backup creates/restores successfully in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)