### PR TITLE
fix: copy gzip into runtime image for backup compression

### DIFF
--- a/deploy/core.backend.Dockerfile
+++ b/deploy/core.backend.Dockerfile
@@ -44,6 +44,7 @@ WORKDIR /app
 COPY --from=build /usr/bin/git /usr/bin/git
 COPY --from=build /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=build /usr/bin/tar /usr/bin/tar
+COPY --from=build /usr/bin/gzip /usr/bin/gzip
 
 # Copy shared libraries required by git-remote-https (collected via ldd in build stage)
 COPY --from=build /git-libs/ /usr/lib64/

--- a/deploy/core.backend.Dockerfile
+++ b/deploy/core.backend.Dockerfile
@@ -40,7 +40,7 @@ USER 0
 
 WORKDIR /app
 
-# Copy git and tar binaries from build stage
+# Copy git, tar, and gzip binaries from build stage
 COPY --from=build /usr/bin/git /usr/bin/git
 COPY --from=build /usr/libexec/git-core /usr/libexec/git-core
 COPY --from=build /usr/bin/tar /usr/bin/tar


### PR DESCRIPTION
## Summary

- `tar -czf` shells out to `gzip` for compression, which is missing from the hardened runtime image
- Copies `/usr/bin/gzip` from the build stage

Previous fixes: #899 (libcurl), #906 (CA bundle), #908 (tar)

## Test plan

- [x] Image builds successfully
- [x] `gzip` works inside the container
- [ ] Data backup completes successfully in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)