### PR TITLE
ci: add merge_group no-op for Claude Review and AI Config Guard

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,6 +10,7 @@ on:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -23,11 +24,21 @@ permissions:
   id-token: write
 
 jobs:
+  # Merge queue no-op: the real review already ran on the PR. The queue just
+  # needs the "Claude Review" check name to exist and pass.
+  merge-queue-pass:
+    name: Claude Review
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Merge queue — skipping review (already passed on PR)"
+
   claude-review:
     name: Claude Review
     timeout-minutes: 20
     if: |
-      (github.event_name == 'pull_request' &&
+      github.event_name != 'merge_group' &&
+      ((github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]' &&
@@ -42,7 +53,7 @@ jobs:
        github.event.comment.author_association != 'NONE' &&
        github.event.comment.author_association != 'FIRST_TIMER' &&
        github.event.comment.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch'))
     runs-on: ubuntu-latest
     steps:
       - name: Determine review context

--- a/.github/workflows/guard-ai-configs.yml
+++ b/.github/workflows/guard-ai-configs.yml
@@ -26,9 +26,32 @@ on:
       - opened
       - synchronize
       - reopened
+  merge_group:
 
 jobs:
+  # Merge queue no-op: the real guard check already ran on the PR. The queue
+  # just needs the "AI Config Guard" commit status to exist and pass.
+  merge-queue-pass:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      STATUS_CONTEXT: "AI Config Guard"
+    steps:
+      - name: Set success status for merge queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context="${STATUS_CONTEXT}" \
+            -f description="Merge queue — already verified on PR"
+
   check-ai-configs:
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # To post comments and read reviews


### PR DESCRIPTION
## Summary

Follow-up to #912. Adds `merge_group` support to the remaining two required status checks:

- **claude-review.yml**: Adds a lightweight `merge-queue-pass` job (same "Claude Review" check name) that immediately succeeds for merge queue events. The real review already ran on the PR.
- **guard-ai-configs.yml**: Adds a `merge-queue-pass` job that posts a success commit status for merge queue events. The real guard check already ran on the PR.

Both workflows gate their existing jobs to skip `merge_group` events, avoiding unnecessary work (no Vertex AI spend for Claude review, no PR-context-dependent logic for the config guard).

### After this merges

All required status checks now support `merge_group`. The remaining Phase 2 steps (repo settings) can proceed:

1. Enable "Require merge queue" in the ruleset
2. Disable "Require branches to be up to date before merging"
3. Verify GitHub App has merge queue bypass for deploy PRs

## Test plan

- [ ] CI passes (validates existing `pull_request` paths still work)
- [ ] After merge, enable merge queue and verify these checks auto-pass on queue entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)