### PR TITLE
feat: add refresh handler descriptions and per-handler refresh

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -492,6 +492,7 @@ module.exports = function registerRoutes(router, context) {
       order: 50,           // lower runs first (default: 100)
       timeout: 300000,     // per-handler timeout in ms (default: 5 min)
       cadence: '12h',      // how often to run (default: '24h')
+      description: 'Fetches external data and stores it locally.',
       handler: async function(options) {
         // Fetch and store data
         const data = await fetchExternalData()
@@ -511,6 +512,7 @@ module.exports = function registerRoutes(router, context) {
 | `order` | number | 100 | Execution order — lower runs first. Handlers at the same order run in parallel |
 | `timeout` | number | 300000 | Per-handler timeout in ms |
 | `cadence` | string | `'24h'` | How often the handler should run. Formats: `'15m'`, `'12h'`, `'1d'` |
+| `description` | string | null | Human-readable description shown in the admin Settings UI |
 | `status` | function | null | Async function returning current status (legacy, used when no runs have occurred) |
 
 ### Cadence

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -193,6 +193,7 @@ module.exports = function registerFeatureRoutes(router, context) {
     context.registerRefresh('feature-sync', {
       order: 60,
       timeout: 600000,
+      description: 'Syncs AI Impact feature data from Jira, updating local feature records.',
       handler: async function() {
         await runSync(readFromStorage, writeToStorageAtomic);
       }

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -346,6 +346,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('refresh', {
       order: 50,
       timeout: 600000,
+      description: 'Refreshes AI Impact component assessments and onboarding data from Jira.',
       handler: async function() {
         await runAiImpactRefresh();
       }

--- a/modules/ai-impact/server/test-plans/routes.js
+++ b/modules/ai-impact/server/test-plans/routes.js
@@ -314,6 +314,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     context.registerRefresh('test-plan-sync', {
       order: 60,
       timeout: 600000,
+      description: 'Syncs test plan data from Jira, updating local test plan records.',
       handler: async function() {
         if (DEMO_MODE) return;
         await runSync(readFromStorage, writeToStorageAtomic);

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -2093,6 +2093,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('delivery', {
       order: 70,
       timeout: 600000,
+      description: 'Refreshes delivery analysis data — team velocity, completion rates, and delivery trends.',
       handler: async function() {
         if (DEMO_MODE) return { status: 'skipped', message: 'Refresh disabled in demo mode' }
         return runDeliveryRefresh()

--- a/modules/releases/server/execution/routes.js
+++ b/modules/releases/server/execution/routes.js
@@ -406,6 +406,7 @@ module.exports = function registerExecutionRoutes(router, context) {
   const handlerConfig = {
     order: 70,
     timeout: 600000,
+    description: 'Fetches execution pipeline data from GitLab CI artifacts for release tracking.',
     handler: async function(options) {
       options = options || {};
       if (options.skipCooldown) {
@@ -474,6 +475,7 @@ module.exports = function registerExecutionRoutes(router, context) {
         order: 75,
         cadence: syncIntervalHours + 'h',
         timeout: 120000,
+        description: 'Enriches execution data with Jira issue details, status transitions, and tracking reconciliation.',
         handler: enrichmentHandler
       });
     }

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -705,6 +705,7 @@ module.exports = function registerHygieneRoutes(router, context) {
     context.registerRefresh('hygiene', {
       order: 70,
       timeout: 600000,
+      description: 'Fetches feature data from Jira and evaluates hygiene rules across active releases.',
       handler: async function() {
         return runHygieneRefreshAll({ skipCooldown: true, user: 'system' });
       }

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -744,6 +744,7 @@ function registerRegistryRoutes(router, context) {
     context.registerRefresh('registry-sync', {
       order: 65,
       timeout: 300000,
+      description: 'Syncs the release registry from Product Pages, updating release metadata and versions.',
       handler: async function() {
         return runRegistrySync(storage);
       }

--- a/modules/team-tracker/server/allocation/routes.js
+++ b/modules/team-tracker/server/allocation/routes.js
@@ -235,6 +235,7 @@ module.exports = function registerAllocationRoutes(router, context) {
   if (context.registerRefresh) context.registerRefresh('allocation', {
     order: 40,
     timeout: 600000,
+    description: 'Fetches sprint data from Jira boards and classifies issues for team allocation tracking.',
     handler: async function(options) {
       await runAllocationRefresh(options);
     },

--- a/modules/team-tracker/server/index.js
+++ b/modules/team-tracker/server/index.js
@@ -4241,6 +4241,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('roster-sync', {
       order: 10,
       timeout: 600000,
+      description: 'Syncs the team roster from IPA LDAP and Google Sheets, enriching with GitHub/GitLab usernames.',
       handler: async function() {
         if (DEMO_MODE) return;
         await consolidatedSync.runConsolidatedSync(storage, { ...context.secrets, resolveSecret: context.resolveSecret });
@@ -4253,6 +4254,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('metrics', {
       order: 20,
       timeout: 1800000,
+      description: 'Refreshes per-person Jira metrics (resolved issues, story points) with a 365-day lookback.',
       handler: async function() {
         await refreshAllMetrics();
       },
@@ -4269,6 +4271,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('github', {
       order: 30,
       timeout: 600000,
+      description: 'Fetches GitHub contribution stats (commits, PRs, reviews) for all roster members via GraphQL.',
       handler: async function() {
         await refreshAllGithub();
       }
@@ -4277,6 +4280,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('gitlab', {
       order: 30,
       timeout: 600000,
+      description: 'Fetches GitLab contribution stats for all roster members across configured instances.',
       handler: async function() {
         await refreshAllGitlab();
       }
@@ -4285,6 +4289,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerRefresh('snapshots', {
       order: 80,
       timeout: 300000,
+      description: 'Generates daily team snapshots for historical trend tracking.',
       handler: async function() {
         await generateAllSnapshots();
       }

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -829,6 +829,42 @@ app.post('/api/admin/refresh/:module', requireAdmin, requireScope('admin:manage'
 
 /**
  * @openapi
+ * /api/admin/refresh/handler/{handlerId}:
+ *   post:
+ *     tags: [Admin]
+ *     summary: Run a single refresh handler by ID (admin only)
+ *     parameters:
+ *       - in: path
+ *         name: handlerId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Full handler ID (e.g. "team-tracker:roster-sync")
+ *     responses:
+ *       202:
+ *         description: Handler started
+ *       404:
+ *         description: Handler not found
+ *       409:
+ *         description: Refresh already in progress
+ */
+app.post('/api/admin/refresh/handler/:handlerId', requireAdmin, requireScope('admin:manage'), function(req, res) {
+  if (refreshRegistry.isRunning()) {
+    return res.status(409).json({ error: 'Refresh is already running' });
+  }
+  const handlerId = req.params.handlerId;
+  const handler = refreshRegistry.get(handlerId);
+  if (!handler) {
+    return res.status(404).json({ error: 'No handler registered with id "' + handlerId + '"' });
+  }
+  refreshRegistry.runOne(handlerId, { skipCooldown: true }).catch(function(err) {
+    console.error('[refresh-handler] runOne error for %s:', handlerId, err.message);
+  });
+  res.status(202).json({ status: 'started', handler: handlerId });
+});
+
+/**
+ * @openapi
  * /api/admin/refresh/status:
  *   get:
  *     tags: [Admin]
@@ -1562,6 +1598,7 @@ refreshRegistry.register('platform:backup', {
   order: 200,
   cadence: '24h',
   timeout: 120000,
+  description: 'Creates a backup of all data files to S3 and applies retention policy.',
   handler: async function() {
     if (!process.env.AWS_BACKUP_BUCKET) {
       return { status: 'skipped', reason: 'AWS_BACKUP_BUCKET not configured' };

--- a/shared/server/__tests__/refresh-registry.test.js
+++ b/shared/server/__tests__/refresh-registry.test.js
@@ -45,6 +45,18 @@ describe('refresh-registry', () => {
     expect(registry.get('fast').cadence).toBe('12h')
   })
 
+  it('stores description on registered handler', () => {
+    const registry = createRefreshRegistry()
+    registry.register('desc', { handler: vi.fn(), description: 'Syncs data from Jira' })
+    expect(registry.get('desc').description).toBe('Syncs data from Jira')
+  })
+
+  it('defaults description to null when not provided', () => {
+    const registry = createRefreshRegistry()
+    registry.register('no-desc', { handler: vi.fn() })
+    expect(registry.get('no-desc').description).toBeNull()
+  })
+
   it('defaults cadence to 24h when not specified', () => {
     const registry = createRefreshRegistry()
     registry.register('default', { handler: vi.fn() })
@@ -435,6 +447,71 @@ describe('refresh-registry', () => {
 
     await registry.runModule('mod-a')
     expect(calls).toEqual(['ran'])
+  })
+
+  // --- runOne ---
+
+  it('runOne runs a single handler by id', async () => {
+    const registry = createRefreshRegistry()
+    const calls = []
+    registry.register('mod:a', { handler: async () => { calls.push('a'); return 'ok' }, order: 10 })
+    registry.register('mod:b', { handler: async () => { calls.push('b') }, order: 20 })
+
+    const results = await registry.runOne('mod:a')
+    expect(calls).toEqual(['a'])
+    expect(results['mod:a'].success).toBe(true)
+  })
+
+  it('runOne throws for unknown handler id', async () => {
+    const registry = createRefreshRegistry()
+    await expect(registry.runOne('nonexistent')).rejects.toThrow('No handler registered with id "nonexistent"')
+  })
+
+  it('runOne updates progress and preserves other handlers in lastRun', async () => {
+    const registry = createRefreshRegistry()
+    registry.register('mod:a', { handler: async () => 'done', order: 10 })
+    registry.register('mod:b', { handler: async () => 'also', order: 10 })
+
+    await registry.runOne('mod:a')
+    const status = await registry.getStatus()
+    expect(status.running).toBe(false)
+    expect(status.handlers['mod:a'].state).toBe('completed')
+    expect(status.handlers['mod:b'].registered).toBe(true)
+  })
+
+  it('runOne ignores cadence — runs even if recently completed', async () => {
+    const mockStorage = {
+      readFromStorage: vi.fn().mockReturnValue({
+        completedAt: Date.now(),
+        progress: {
+          'a': {
+            state: 'completed',
+            order: 10,
+            completedAt: Date.now(),
+            lastSuccessfulRun: Date.now(),
+            cadence: '24h'
+          }
+        }
+      }),
+      writeToStorage: vi.fn()
+    }
+    const registry = createRefreshRegistry(mockStorage)
+    const calls = []
+    registry.register('a', { handler: async () => { calls.push('ran') }, order: 10, cadence: '24h' })
+
+    await registry.runOne('a')
+    expect(calls).toEqual(['ran'])
+  })
+
+  it('runOne throws mutex error if refresh is already running', async () => {
+    const registry = createRefreshRegistry()
+    let resolve
+    registry.register('slow', { handler: () => new Promise(r => { resolve = r }) })
+
+    const p = registry.runOne('slow')
+    await expect(registry.runOne('slow')).rejects.toThrow('Refresh is already running')
+    resolve()
+    await p
   })
 
   // --- Cadence filtering ---
@@ -857,5 +934,32 @@ describe('refresh-registry', () => {
     expect(status.handlers['a'].cadenceOverride).toBeNull()
     expect(status.handlers['a'].lastSuccessfulRun).toBeTypeOf('number')
     expect(status.handlers['a'].nextDueAt).toBeTypeOf('number')
+  })
+
+  it('getStatus includes description after run', async () => {
+    const mockStorage = {
+      readFromStorage: vi.fn().mockReturnValue(null),
+      writeToStorage: vi.fn()
+    }
+    const registry = createRefreshRegistry(mockStorage)
+    registry.register('a', { handler: async () => 'ok', description: 'Syncs data' })
+    registry.register('b', { handler: async () => 'ok' })
+
+    const result = await registry.runAll({ force: true })
+    if (result.execution) await result.execution
+
+    const status = await registry.getStatus()
+    expect(status.handlers['a'].description).toBe('Syncs data')
+    expect(status.handlers['b'].description).toBeNull()
+  })
+
+  it('getStatus includes description in never-run state', async () => {
+    const registry = createRefreshRegistry()
+    registry.register('a', { handler: vi.fn(), description: 'Fetches metrics' })
+    registry.register('b', { handler: vi.fn() })
+
+    const status = await registry.getStatus()
+    expect(status.handlers['a'].description).toBe('Fetches metrics')
+    expect(status.handlers['b'].description).toBeNull()
   })
 })

--- a/shared/server/refresh-registry.js
+++ b/shared/server/refresh-registry.js
@@ -439,7 +439,7 @@ function createRefreshRegistry(storage) {
       // Enrich with description from live registry
       for (var mid in merged) {
         var mConfig = entries.get(mid)
-        if (mConfig && mConfig.description) {
+        if (mConfig) {
           merged[mid] = { ...merged[mid], description: mConfig.description }
         }
       }

--- a/shared/server/refresh-registry.js
+++ b/shared/server/refresh-registry.js
@@ -116,7 +116,8 @@ function createRefreshRegistry(storage) {
       status: typeof config.status === 'function' ? config.status : null,
       order: typeof config.order === 'number' ? config.order : DEFAULT_ORDER,
       timeout: typeof config.timeout === 'number' ? config.timeout : null,
-      cadence: cadence
+      cadence: cadence,
+      description: typeof config.description === 'string' ? config.description : null
     })
   }
 
@@ -389,6 +390,40 @@ function createRefreshRegistry(storage) {
     }
   }
 
+  async function runOne(id, options = {}) {
+    if (running) {
+      throw new Error('Refresh is already running')
+    }
+    const config = entries.get(id)
+    if (!config) {
+      throw new Error('No handler registered with id "' + id + '"')
+    }
+    running = true
+    progress = {}
+
+    try {
+      // runOne ignores cadence — manual trigger always runs
+      const results = await runEntries([[id, config]], options)
+      return results
+    } finally {
+      running = false
+      var baseline = {}
+      if (lastRun) {
+        Object.assign(baseline, lastRun.progress)
+      } else {
+        for (var [baseId, baseConfig] of entries) {
+          baseline[baseId] = { registered: true, order: baseConfig.order }
+        }
+      }
+      lastRun = {
+        completedAt: Date.now(),
+        progress: Object.assign(baseline, progress),
+        results: {}
+      }
+      persistLastRun()
+    }
+  }
+
   async function getStatus() {
     if (running) {
       // Build baseline from previous run or registered stubs, then overlay current progress
@@ -400,9 +435,17 @@ function createRefreshRegistry(storage) {
           baseline[baseId] = { registered: true, order: baseConfig.order }
         }
       }
+      var merged = Object.assign(baseline, progress)
+      // Enrich with description from live registry
+      for (var mid in merged) {
+        var mConfig = entries.get(mid)
+        if (mConfig && mConfig.description) {
+          merged[mid] = { ...merged[mid], description: mConfig.description }
+        }
+      }
       return {
         running: true,
-        handlers: Object.assign(baseline, progress)
+        handlers: merged
       }
     }
 
@@ -418,6 +461,7 @@ function createRefreshRegistry(storage) {
           enriched.cadence = cadenceStr
           enriched.baseCadence = config.cadence || DEFAULT_CADENCE
           enriched.cadenceOverride = cadenceOverrides[id] || null
+          enriched.description = config.description || null
           if (enriched.lastSuccessfulRun) {
             enriched.nextDueAt = enriched.lastSuccessfulRun + parseCadence(cadenceStr)
           }
@@ -438,13 +482,13 @@ function createRefreshRegistry(storage) {
         try {
           const s = await config.status()
           const ec = getEffectiveCadence(id, config)
-          status[id] = { ...s, order: config.order, cadence: ec.cadenceStr, baseCadence: config.cadence || DEFAULT_CADENCE, cadenceOverride: cadenceOverrides[id] || null }
+          status[id] = { ...s, order: config.order, cadence: ec.cadenceStr, baseCadence: config.cadence || DEFAULT_CADENCE, cadenceOverride: cadenceOverrides[id] || null, description: config.description || null }
         } catch (err) {
-          status[id] = { error: err.message, order: config.order }
+          status[id] = { error: err.message, order: config.order, description: config.description || null }
         }
       } else {
         const ec = getEffectiveCadence(id, config)
-        status[id] = { registered: true, order: config.order, cadence: ec.cadenceStr, baseCadence: config.cadence || DEFAULT_CADENCE, cadenceOverride: cadenceOverrides[id] || null }
+        status[id] = { registered: true, order: config.order, cadence: ec.cadenceStr, baseCadence: config.cadence || DEFAULT_CADENCE, cadenceOverride: cadenceOverrides[id] || null, description: config.description || null }
       }
     }
     return {
@@ -489,7 +533,7 @@ function createRefreshRegistry(storage) {
   }
 
   return {
-    register, get, getAll, runAll, runModule, getStatus, isRunning,
+    register, get, getAll, runAll, runModule, runOne, getStatus, isRunning,
     setCadenceOverride, getCadenceOverrides, parseCadence
   }
 }

--- a/src/components/RefreshSettings.vue
+++ b/src/components/RefreshSettings.vue
@@ -8,6 +8,7 @@ const statusData = ref(null)
 const loading = ref(true)
 const refreshingAll = ref(false)
 const refreshingModules = ref({})
+const refreshingHandlers = ref({})
 let pollTimer = null
 
 const CADENCE_PRESETS = ['15m', '1h', '6h', '12h', '24h']
@@ -137,6 +138,7 @@ function startPolling() {
       stopPolling()
       refreshingAll.value = false
       refreshingModules.value = {}
+      refreshingHandlers.value = {}
     }
   }, 3000)
 }
@@ -176,6 +178,24 @@ async function refreshModule(slug) {
       emit('toast', { type: 'warning', message: 'A refresh is already running' })
     } else if (e.status === 404) {
       emit('toast', { type: 'error', message: 'No handlers registered for ' + formatModuleName(slug) })
+    } else {
+      emit('toast', { type: 'error', message: e.message || 'Failed to start refresh' })
+    }
+  }
+}
+
+async function refreshHandler(handler) {
+  refreshingHandlers.value[handler.id] = true
+  try {
+    await apiRequest('/admin/refresh/handler/' + encodeURIComponent(handler.id), { method: 'POST' })
+    emit('toast', { type: 'success', message: handler.displayName + ' refresh started' })
+    startPolling()
+  } catch (e) {
+    refreshingHandlers.value[handler.id] = false
+    if (e.status === 409) {
+      emit('toast', { type: 'warning', message: 'A refresh is already running' })
+    } else if (e.status === 404) {
+      emit('toast', { type: 'error', message: 'Handler not found: ' + handler.displayName })
     } else {
       emit('toast', { type: 'error', message: e.message || 'Failed to start refresh' })
     }
@@ -288,14 +308,23 @@ onUnmounted(() => {
         <div class="w-20 text-center flex-shrink-0">Next Run</div>
         <div class="w-20 text-center flex-shrink-0">Status</div>
         <div class="w-16 text-right flex-shrink-0">Last Run</div>
+        <div class="w-8 flex-shrink-0"></div>
       </div>
 
       <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
         <div v-for="handler in group.handlers" :key="handler.id" class="px-4 py-2.5 flex items-center gap-3">
           <!-- Handler name -->
-          <div class="flex-1 min-w-0">
+          <div class="flex-1 min-w-0 flex items-center">
             <span class="text-sm text-gray-900 dark:text-gray-100">{{ handler.displayName }}</span>
             <span class="text-xs text-gray-400 dark:text-gray-500 ml-1.5 tabular-nums">#{{ handler.order || 100 }}</span>
+            <span v-if="handler.description" class="relative ml-1.5 group">
+              <svg class="h-3.5 w-3.5 text-gray-400 dark:text-gray-500 cursor-help hover:text-gray-600 dark:hover:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span class="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-2.5 py-1.5 text-xs text-white bg-gray-900 dark:bg-gray-700 rounded shadow-lg whitespace-normal w-64 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-opacity z-10 pointer-events-none">
+                {{ handler.description }}
+              </span>
+            </span>
           </div>
 
           <!-- Cadence select — always visible -->
@@ -375,6 +404,24 @@ onUnmounted(() => {
           <span class="text-xs text-gray-400 dark:text-gray-500 w-16 text-right flex-shrink-0 tabular-nums">
             {{ getHandlerTime(handler) || '' }}
           </span>
+
+          <!-- Per-handler refresh button -->
+          <div class="w-8 flex-shrink-0 flex justify-center">
+            <button
+              @click="refreshHandler(handler)"
+              :disabled="isRunning || refreshingHandlers[handler.id]"
+              class="p-1 rounded text-gray-400 dark:text-gray-500 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400"
+              :title="'Run ' + handler.displayName"
+            >
+              <svg v-if="getHandlerState(handler) === 'running' || refreshingHandlers[handler.id]" class="animate-spin h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <svg v-else class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Adds an optional `description` field to the refresh handler registration config, shown as info bubble tooltips in the admin Settings UI
- Adds per-handler refresh: `runOne()` registry method, `POST /api/admin/refresh/handler/:handlerId` API endpoint, and a refresh icon button on each handler row
- All 15 existing refresh handlers now include descriptive text explaining what they do
- Per-handler refresh ignores cadence (same as per-module refresh) — manual clicks always execute

## Changes

- **Registry** (`shared/server/refresh-registry.js`): `description` field on config, threaded through all 3 `getStatus()` code paths; new `runOne(id)` method
- **API** (`server/dev-server.js`): `POST /api/admin/refresh/handler/:handlerId` with OpenAPI annotation
- **Frontend** (`src/components/RefreshSettings.vue`): info circle icon with hover tooltip; per-handler refresh button (circular arrows icon) with spinner state
- **Modules**: `description` added to all `registerRefresh()` calls across team-tracker (6), ai-impact (3), releases (5), and platform:backup (1)
- **Docs** (`docs/MODULES.md`): `description` field added to RefreshConfig table and example
- **Tests**: 9 new tests — 2 for description storage, 5 for `runOne()`, 2 for description in `getStatus()`

## Test plan

- [x] `npm test` — all 68 refresh-registry tests pass (was 56)
- [x] `npm run lint` — clean
- [x] `npm run validate:openapi` — passes
- [ ] Visual check: open Settings > Data Refresh, verify info icons appear and tooltips show on hover
- [ ] Visual check: verify per-handler refresh button appears, click one, confirm it runs and status updates
- [ ] Verify clicking a handler refresh while another is running shows "already running" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)