### PR TITLE
fix(ci): use GitHub App token for Claude review autofix pushes

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,6 +33,19 @@ jobs:
     steps:
       - run: echo "Merge queue — skipping review (already passed on PR)"
 
+  # When the Claude review pushes an autofix commit via the GitHub App token,
+  # the synchronize event fires with actor=rhai-org-pulse[bot]. We don't want
+  # to re-run the full review (infinite loop), but "Claude Review" is a
+  # required check — so we need this no-op job to satisfy the gate.
+  autofix-pass:
+    name: Claude Review
+    if: |
+      github.event_name != 'merge_group' &&
+      (github.actor == 'rhai-org-pulse[bot]' || github.actor == 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Autofix push by ${{ github.actor }} — review already passed, skipping re-review"
+
   claude-review:
     name: Claude Review
     timeout-minutes: 20

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,11 +42,13 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]' &&
+       github.actor != 'rhai-org-pulse[bot]' &&
        github.actor != 'dependabot[bot]') ||
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name != github.repository &&
        github.event.pull_request.draft != true &&
-       github.actor != 'github-actions[bot]') ||
+       github.actor != 'github-actions[bot]' &&
+       github.actor != 'rhai-org-pulse[bot]') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
@@ -117,11 +119,23 @@ jobs:
 
       # --- Same-repo setup (full checkout, Node.js, git identity) ---
 
+      # Generate a GitHub App token so that autofix pushes trigger downstream
+      # workflows (CI, Integration Tests, etc.). The default GITHUB_TOKEN does
+      # not trigger other workflows — this is a GitHub anti-recursion safeguard.
+      - name: Generate GitHub App token
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node.js
         if: steps.check-paths.outputs.needs_review == 'true' && steps.context.outputs.is_fork != 'true' && steps.fork-guard.outputs.is_fork != 'true'
@@ -251,9 +265,6 @@ jobs:
                  - Issues found and fixed (with brief descriptions)
                  - Issues found but NOT fixed (with explanations of why)
                  - If no issues were found, say so briefly
-               - NOTE: CI (the "Test & Build" check) will NOT automatically run on
-                 your autofix commit. Mention this in your summary so the PR author
-                 knows to re-run CI if needed.
 
             5. **Set review verdict**: Follow the "Verdict rules" section in
                `.github/instructions/review.instructions.md` to populate the


### PR DESCRIPTION
## Problem

When the Claude code review workflow pushes autofix commits, the downstream required checks (CI, Integration Tests, CodeQL) don't re-run. This is because pushes made with the default `GITHUB_TOKEN` don't trigger other workflows — it's a GitHub anti-recursion safeguard.

See [PR #916](https://github.com/red-hat-data-services/rhai-org-pulse/pull/916) for an example: Claude pushed commit `0a934021` but only Guard AI Configurations ran on it — CI and Integration Tests were never triggered.

## Fix

- **Use a GitHub App token** for the checkout step in the Claude review workflow (same `APP_ID`/`APP_PRIVATE_KEY` secrets already used in `sync-preprod.yml`). When `actions/checkout` uses the app token, git pushes are attributed to the app bot rather than `github-actions[bot]`, and GitHub allows downstream workflows to trigger.
- **Add `rhai-org-pulse[bot]` to the actor exclusion list** so the Claude review doesn't re-trigger on its own autofix push (infinite loop prevention).
- **Remove the stale prompt note** telling Claude to warn PR authors that CI won't re-run on autofix commits — it will now.