### PR TITLE
fix(releases): hide Features/RFEs tabs and summary cards from Outcomes dashboard

### DIFF
--- a/modules/releases/__tests__/client/plan/health-components.test.js
+++ b/modules/releases/__tests__/client/plan/health-components.test.js
@@ -476,14 +476,6 @@ describe('BigRockExpandedRow', function() {
     expect(wrapper.text()).toContain('BLOCKED, MILESTONE_MISS')
   })
 
-  it('renders "View all in Features tab" link', function() {
-    var wrapper = mountExpanded({ features: sampleFeatures, rockName: 'MaaS' })
-    var viewLink = wrapper.findAll('a').filter(function(a) { return a.text().includes('View all in Features tab') })
-    expect(viewLink.length).toBe(1)
-    expect(viewLink[0].attributes('href')).toContain('#/releases/plan?tab=health')
-    expect(viewLink[0].attributes('href')).toContain('bigRock=MaaS')
-  })
-
   it('shows override indicator (M) when feature has override', function() {
     var wrapper = mountExpanded({ features: sampleFeatures })
     var overrideIndicators = wrapper.findAll('span').filter(function(s) { return s.text() === 'M' })

--- a/modules/releases/client/plan/components/BigRockExpandedRow.vue
+++ b/modules/releases/client/plan/components/BigRockExpandedRow.vue
@@ -1,7 +1,6 @@
 <script setup>
-import { computed } from 'vue'
 
-const props = defineProps({
+defineProps({
   features: { type: Array, default: () => [] },
   colspan: { type: Number, default: 7 },
   loading: { type: Boolean, default: false },
@@ -19,10 +18,6 @@ function truncate(text, max) {
   return text.length > max ? text.slice(0, max) + '...' : text
 }
 
-var featuresTabHref = computed(function() {
-  if (!props.rockName) return '#/releases/plan?tab=health'
-  return '#/releases/plan?tab=health&bigRock=' + encodeURIComponent(props.rockName)
-})
 </script>
 
 <template>
@@ -90,12 +85,6 @@ var featuresTabHref = computed(function() {
           </tr>
         </tbody>
       </table>
-      <div class="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700">
-        <a
-          :href="featuresTabHref"
-          class="text-xs text-primary-600 dark:text-blue-400 hover:underline"
-        >View all in Features tab &rarr;</a>
-      </div>
     </div>
   </td>
 </template>

--- a/modules/releases/client/plan/views/DashboardView.vue
+++ b/modules/releases/client/plan/views/DashboardView.vue
@@ -5,18 +5,14 @@ import { useReleaseHealth } from '../composables/useReleaseHealth'
 import { useBigRockEditor } from '../composables/useBigRockEditor'
 import { useFilters } from '../composables/useFilters'
 import { useHealthAggregation } from '../composables/useHealthAggregation'
-import { useReleaseDistribution } from '../composables/useReleaseDistribution'
 import { useRefreshPolling } from '../composables/useRefreshPolling'
 import { useClickOutside } from '../composables/useClickOutside'
 import { exportMarkdown as exportMd, exportCsv as exportCsvFile } from '../utils/outcomes-export'
 import { formatDate } from '@shared/client'
-import SummaryCards from '../components/SummaryCards.vue'
 import BigRocksTable from '../components/BigRocksTable.vue'
 import BigRockEditPanel from '../components/BigRockEditPanel.vue'
 import BigRockDeleteDialog from '../components/BigRockDeleteDialog.vue'
 import NewReleaseDialog from '../components/NewReleaseDialog.vue'
-import FeaturesTable from '../components/FeaturesTable.vue'
-import RfesTable from '../components/RfesTable.vue'
 import FilterBar from '../components/FilterBar.vue'
 import ReleaseSelector from '../components/ReleaseSelector.vue'
 import RecentActivity from '../components/RecentActivity.vue'
@@ -62,20 +58,14 @@ useRefreshPolling(refreshing, checkRefreshStatus, function() {
 const features = computed(() => candidates.value ? candidates.value.features || [] : [])
 const rfes = computed(() => candidates.value ? candidates.value.rfes || [] : [])
 const bigRocks = computed(() => candidates.value ? candidates.value.bigRocks || [] : [])
-const summary = computed(() => candidates.value ? candidates.value.summary : null)
 const filterOptions = computed(() => candidates.value ? candidates.value.filterOptions || {} : {})
 const jiraBaseUrl = computed(() => candidates.value ? candidates.value.jiraBaseUrl || '' : '')
 const demoMode = computed(() => candidates.value ? candidates.value.demoMode : false)
 
 const {
-  healthByKey,
-  rfeKeyToHealth,
   rockHealth,
-  rockFeatures,
-  tier1HealthSummary
+  rockFeatures
 } = useHealthAggregation(healthData, features, rfes, bigRocks)
-
-const { releaseDistribution } = useReleaseDistribution(features)
 const warning = computed(() => candidates.value ? candidates.value.warning : null)
 const pipelineWarnings = computed(() => candidates.value ? candidates.value.pipelineWarnings || [] : [])
 const canEdit = computed(() => !demoMode.value && permissions.value && permissions.value.canEdit)
@@ -97,18 +87,12 @@ const {
 const moduleNav = inject('moduleNav', null)
 
 const tabs = [
-  { id: 'big-rocks', label: 'Big Rocks' },
-  { id: 'features', label: 'Features' },
-  { id: 'rfes', label: 'RFEs' }
+  { id: 'big-rocks', label: 'Big Rocks' }
 ]
 
-const featureCount = computed(() => filteredFeatures.value.length)
-const rfeCount = computed(() => filteredRfes.value.length)
 const bigRockCount = computed(() => filteredBigRocks.value.length)
 
 function tabCount(tabId) {
-  if (tabId === 'features') return featureCount.value
-  if (tabId === 'rfes') return rfeCount.value
   if (tabId === 'big-rocks') return bigRockCount.value
   return 0
 }
@@ -306,7 +290,6 @@ onMounted(async function() {
     var p = moduleNav.params.value
     if (p.bigRock) {
       selectedRock.value = p.bigRock
-      activeTab.value = 'features'
     }
   }
 })
@@ -377,9 +360,6 @@ onMounted(async function() {
     </div>
 
     <template v-if="candidates">
-      <!-- Summary -->
-      <SummaryCards :summary="summary" :tier1HealthSummary="tier1HealthSummary" :releaseDistribution="releaseDistribution" />
-
       <!-- Tabs -->
       <div>
         <div class="flex items-center justify-between border-b border-gray-200 dark:border-gray-700">
@@ -473,24 +453,6 @@ onMounted(async function() {
           @addRock="handleAddRock"
           @deleteRock="handleDeleteRock"
           @reorder="handleReorder"
-        />
-      </div>
-      <div v-if="activeTab === 'features'" id="panel-features" role="tabpanel" aria-labelledby="tab-features">
-        <FeaturesTable
-          :features="filteredFeatures"
-          :bigRocks="bigRocks"
-          :jiraBaseUrl="jiraBaseUrl"
-          :summary="summary"
-          :healthByKey="healthByKey"
-        />
-      </div>
-      <div v-if="activeTab === 'rfes'" id="panel-rfes" role="tabpanel" aria-labelledby="tab-rfes">
-        <RfesTable
-          :rfes="filteredRfes"
-          :bigRocks="bigRocks"
-          :jiraBaseUrl="jiraBaseUrl"
-          :summary="summary"
-          :rfeKeyToHealth="rfeKeyToHealth"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Remove Feature Summary, Outcome Health, and Milestone Coverage summary cards from the Outcomes Dashboard
- Hide Features and RFEs tabs, leaving only the Big Rocks tab
- Remove "View all in Features tab" link from BigRockExpandedRow
- Component files preserved for future re-enablement

## Test plan
- [ ] Verify Outcomes Dashboard shows only Big Rocks tab (no Features/RFEs tabs)
- [ ] Verify no summary cards appear above the tab bar
- [ ] Verify Big Rocks table and editing still work as expected
- [ ] Verify Health, Feature Readiness, and PM Hub views are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)