### PR TITLE
feat(releases): PM Hub enhancements — Pillar filter, component grouping, curated releases

### DIFF
--- a/modules/releases/__tests__/server/pm-hub/pillar-config.test.js
+++ b/modules/releases/__tests__/server/pm-hub/pillar-config.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+
+const { validatePillarConfig, DEFAULT_PILLAR_CONFIG } = require('../../../server/pm-hub/routes')
+
+describe('validatePillarConfig', function () {
+  it('accepts valid config', function () {
+    expect(validatePillarConfig({
+      pillars: [
+        { name: 'Inference', components: ['llm-d', 'vllm'] },
+        { name: 'Data', components: ['SDG'] }
+      ]
+    })).toBe(null)
+  })
+
+  it('accepts empty pillars array', function () {
+    expect(validatePillarConfig({ pillars: [] })).toBe(null)
+  })
+
+  it('rejects missing pillars field', function () {
+    expect(validatePillarConfig({})).toMatch(/pillars must be an array/)
+  })
+
+  it('rejects null input', function () {
+    expect(validatePillarConfig(null)).toMatch(/pillars must be an array/)
+  })
+
+  it('rejects pillar without name', function () {
+    expect(validatePillarConfig({
+      pillars: [{ components: ['a'] }]
+    })).toMatch(/must have a name/)
+  })
+
+  it('rejects pillar with empty name', function () {
+    expect(validatePillarConfig({
+      pillars: [{ name: '', components: [] }]
+    })).toMatch(/must have a name/)
+  })
+
+  it('rejects pillar without components array', function () {
+    expect(validatePillarConfig({
+      pillars: [{ name: 'Test', components: 'not-array' }]
+    })).toMatch(/must have a components array/)
+  })
+
+  it('rejects non-string component entries', function () {
+    expect(validatePillarConfig({
+      pillars: [{ name: 'Test', components: [123] }]
+    })).toMatch(/must be strings/)
+  })
+})
+
+describe('DEFAULT_PILLAR_CONFIG', function () {
+  it('has four pillars', function () {
+    expect(DEFAULT_PILLAR_CONFIG.pillars).toHaveLength(4)
+  })
+
+  it('includes Inference, Data, Agents, Platform', function () {
+    var names = DEFAULT_PILLAR_CONFIG.pillars.map(function (p) { return p.name })
+    expect(names).toEqual(['Inference', 'Data', 'Agents', 'Platform'])
+  })
+
+  it('each pillar has at least one component', function () {
+    for (var i = 0; i < DEFAULT_PILLAR_CONFIG.pillars.length; i++) {
+      expect(DEFAULT_PILLAR_CONFIG.pillars[i].components.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('passes its own validation', function () {
+    expect(validatePillarConfig(DEFAULT_PILLAR_CONFIG)).toBe(null)
+  })
+})

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -113,6 +113,7 @@ var componentGroups = computed(function() {
             status: feat.status,
             colorStatus: feat.colorStatus,
             statusSummary: feat.statusSummary,
+            releaseType: feat.releaseType,
             isBlocked: feat.isBlocked,
             components: feat.components,
             assignee: feat.assignee,
@@ -200,7 +201,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="8" class="px-4 py-3.5">
+            <td colspan="9" class="px-4 py-3.5">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -236,6 +237,7 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Product</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
@@ -284,6 +286,13 @@ defineExpose({ expandAll, collapseAll })
               </td>
               <td class="px-3 py-2.5 text-center">
                 <span
+                  v-if="feature.releaseType"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300"
+                >{{ feature.releaseType }}</span>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
                   v-if="feature.colorStatus"
                   class="inline-block w-3.5 h-3.5 rounded-full ring-2"
                   :class="[colorStatusClass(feature.colorStatus), colorStatusRing(feature.colorStatus)]"
@@ -316,7 +325,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="8" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="9" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -324,7 +333,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No matching results for active filter -->
         <tr v-if="componentGroups.length === 0 && activeFilter">
-          <td colspan="8" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="9" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No {{ activeFilter }} features found.
           </td>
         </tr>

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -15,114 +15,151 @@ const COMP_STYLE = {
   dot: 'bg-primary-500'
 }
 
-var expandedVersions = reactive({})
 var expandedComponents = reactive({})
 
-function toggleVersion(version) {
-  if (expandedVersions[version]) {
-    delete expandedVersions[version]
+function toggleComponent(component) {
+  if (expandedComponents[component]) {
+    delete expandedComponents[component]
   } else {
-    expandedVersions[version] = true
+    expandedComponents[component] = true
   }
 }
 
-function isVersionExpanded(version) {
-  return !!expandedVersions[version]
-}
-
-function compGroupKey(version, component) {
-  return version + '::' + component
-}
-
-function toggleComponent(version, component) {
-  var key = compGroupKey(version, component)
-  if (expandedComponents[key]) {
-    delete expandedComponents[key]
-  } else {
-    expandedComponents[key] = true
-  }
-}
-
-function isComponentExpanded(version, component) {
-  return !!expandedComponents[compGroupKey(version, component)]
+function isComponentExpanded(component) {
+  return !!expandedComponents[component]
 }
 
 function expandAll() {
-  var src = filteredGroups.value
+  var src = componentGroups.value
   for (var i = 0; i < src.length; i++) {
-    var g = src[i]
-    expandedVersions[g.version] = true
-    for (var j = 0; j < g.components.length; j++) {
-      expandedComponents[compGroupKey(g.version, g.components[j].component)] = true
-    }
+    expandedComponents[src[i].component] = true
   }
 }
 
 function collapseAll() {
-  var src = filteredGroups.value
+  var src = componentGroups.value
   for (var i = 0; i < src.length; i++) {
-    var g = src[i]
-    delete expandedVersions[g.version]
-    for (var j = 0; j < g.components.length; j++) {
-      delete expandedComponents[compGroupKey(g.version, g.components[j].component)]
-    }
+    delete expandedComponents[src[i].component]
   }
 }
 
-function allFeaturesForComponent(comp) {
-  var seen = {}
-  var result = []
-  var lists = [comp.requestedFeatures || [], comp.committedFeatures || []]
-  for (var li = 0; li < lists.length; li++) {
-    for (var fi = 0; fi < lists[li].length; fi++) {
-      var f = lists[li][fi]
-      if (!seen[f.key]) {
-        seen[f.key] = true
-        result.push(f)
+function extractProduct(versionName) {
+  if (!versionName) return versionName
+  var lower = versionName.toLowerCase()
+  if (lower.startsWith('rhoai')) return 'RHOAI'
+  if (lower.startsWith('rhelai')) return 'RHELAI'
+  if (lower.startsWith('rhaii')) return 'RHAII'
+  return versionName.split('-')[0] || versionName
+}
+
+var componentGroups = computed(function() {
+  var filter = props.activeFilter
+  var compMap = {}
+
+  for (var gi = 0; gi < props.groups.length; gi++) {
+    var group = props.groups[gi]
+    var version = group.version
+
+    for (var ci = 0; ci < group.components.length; ci++) {
+      var comp = group.components[ci]
+      var cName = comp.component
+
+      if (!compMap[cName]) {
+        compMap[cName] = {
+          component: cName,
+          features: {},
+          requestedCount: 0,
+          committedCount: 0,
+          blockedCount: 0
+        }
+      }
+
+      var cg = compMap[cName]
+
+      var reqList = comp.requestedFeatures || []
+      var comList = comp.committedFeatures || []
+
+      var reqKeys = {}
+      var comKeys = {}
+      for (var ri = 0; ri < reqList.length; ri++) reqKeys[reqList[ri].key] = true
+      for (var cmi = 0; cmi < comList.length; cmi++) comKeys[comList[cmi].key] = true
+
+      var allFeatures = []
+      var seen = {}
+      var lists = [reqList, comList]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!seen[f.key]) {
+            seen[f.key] = true
+            allFeatures.push(f)
+          }
+        }
+      }
+
+      for (var ai = 0; ai < allFeatures.length; ai++) {
+        var feat = allFeatures[ai]
+        var isReq = !!reqKeys[feat.key]
+        var isCom = !!comKeys[feat.key]
+
+        if (filter === 'requested' && !isReq) continue
+        if (filter === 'committed' && !isCom) continue
+        if (filter === 'blocked' && !feat.isBlocked) continue
+
+        if (!cg.features[feat.key]) {
+          cg.features[feat.key] = {
+            key: feat.key,
+            summary: feat.summary,
+            status: feat.status,
+            colorStatus: feat.colorStatus,
+            statusSummary: feat.statusSummary,
+            isBlocked: feat.isBlocked,
+            components: feat.components,
+            assignee: feat.assignee,
+            pmOwner: feat.pmOwner,
+            products: [],
+            isRequested: false,
+            isCommitted: false
+          }
+        }
+
+        var entry = cg.features[feat.key]
+        var product = extractProduct(version)
+        if (entry.products.indexOf(product) === -1) {
+          entry.products.push(product)
+        }
+        if (isReq) entry.isRequested = true
+        if (isCom) entry.isCommitted = true
       }
     }
   }
+
+  var result = []
+  var compNames = Object.keys(compMap).sort()
+  for (var ni = 0; ni < compNames.length; ni++) {
+    var cm = compMap[compNames[ni]]
+    var featureList = Object.values(cm.features)
+    if (featureList.length === 0) continue
+
+    var reqCount = 0
+    var comCount = 0
+    var blkCount = 0
+    for (var fli = 0; fli < featureList.length; fli++) {
+      if (featureList[fli].isRequested) reqCount++
+      if (featureList[fli].isCommitted) comCount++
+      if (featureList[fli].isBlocked) blkCount++
+    }
+
+    result.push({
+      component: cm.component,
+      features: featureList,
+      requestedCount: reqCount,
+      committedCount: comCount,
+      blockedCount: blkCount
+    })
+  }
+
   return result
-}
-
-function filterFeaturesForComp(comp, filter) {
-  var all = allFeaturesForComponent(comp)
-  if (!filter) return all
-
-  var reqKeys = {}
-  var comKeys = {}
-  var reqList = comp.requestedFeatures || []
-  var comList = comp.committedFeatures || []
-  for (var i = 0; i < reqList.length; i++) reqKeys[reqList[i].key] = true
-  for (var j = 0; j < comList.length; j++) comKeys[comList[j].key] = true
-
-  return all.filter(function(f) {
-    if (filter === 'requested') return !!reqKeys[f.key]
-    if (filter === 'committed') return !!comKeys[f.key]
-    if (filter === 'blocked') return !!f.isBlocked
-    return true
-  })
-}
-
-var filteredGroups = computed(function() {
-  var filter = props.activeFilter
-
-  return props.groups.map(function(group) {
-    var filteredComps = group.components.map(function(comp) {
-      var features = filterFeaturesForComp(comp, filter)
-      return Object.assign({}, comp, {
-        displayFeatures: features
-      })
-    }).filter(function(comp) {
-      return comp.displayFeatures.length > 0
-    })
-
-    return Object.assign({}, group, {
-      components: filteredComps
-    })
-  }).filter(function(group) {
-    return group.components.length > 0
-  })
 })
 
 function colorStatusClass(colorStatus) {
@@ -141,6 +178,14 @@ function colorStatusRing(colorStatus) {
   return 'ring-gray-200 dark:ring-gray-700'
 }
 
+function productBadgeClass(product) {
+  var p = (product || '').toUpperCase()
+  if (p === 'RHOAI') return 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300'
+  if (p === 'RHELAI') return 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300'
+  if (p === 'RHAII') return 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300'
+  return 'bg-gray-100 dark:bg-gray-700/60 text-gray-600 dark:text-gray-400'
+}
+
 defineExpose({ expandAll, collapseAll })
 </script>
 
@@ -148,161 +193,138 @@ defineExpose({ expandAll, collapseAll })
   <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
     <table class="w-full text-sm border-collapse">
       <tbody>
-        <template v-for="group in filteredGroups" :key="group.version">
-          <!-- Version group header -->
+        <template v-for="comp in componentGroups" :key="comp.component">
+          <!-- Component group header -->
           <tr
-            class="cursor-pointer select-none bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-800/80 hover:from-gray-200 hover:to-gray-100 dark:hover:from-gray-750 dark:hover:to-gray-800"
-            @click="toggleVersion(group.version)"
+            class="cursor-pointer select-none border-l-4 transition-colors bg-gradient-to-r from-gray-100 to-gray-50 dark:from-gray-800 dark:to-gray-800/80 hover:from-gray-200 hover:to-gray-100 dark:hover:from-gray-750 dark:hover:to-gray-800"
+            :class="COMP_STYLE.border"
+            @click="toggleComponent(comp.component)"
           >
-            <td colspan="7" class="px-4 py-3.5">
+            <td colspan="8" class="px-4 py-3.5">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
-                  :class="{ 'rotate-90': isVersionExpanded(group.version) }"
+                  :class="{ 'rotate-90': isComponentExpanded(comp.component) }"
                   fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
                 >
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
-                <span class="font-bold text-gray-900 dark:text-gray-100">{{ group.version }}</span>
+                <span class="w-2 h-2 rounded-full flex-shrink-0" :class="COMP_STYLE.dot" />
+                <span class="font-bold text-gray-900 dark:text-gray-100">{{ comp.component }}</span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                  {{ group.requestedCount }} requested
+                  {{ comp.requestedCount }} requested
                 </span>
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">
-                  {{ group.committedCount }} committed
+                  {{ comp.committedCount }} committed
                 </span>
                 <span
                   class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold"
-                  :class="group.blockedCount > 0
+                  :class="comp.blockedCount > 0
                     ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
                     : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
-                >{{ group.blockedCount }} blocked</span>
+                >{{ comp.blockedCount }} blocked</span>
               </div>
             </td>
           </tr>
 
-          <template v-if="isVersionExpanded(group.version)">
-            <template v-for="comp in group.components" :key="comp.component">
-              <!-- Component group header -->
-              <tr
-                class="cursor-pointer select-none border-l-4 transition-colors hover:brightness-95 dark:hover:brightness-110"
-                :class="[COMP_STYLE.border, COMP_STYLE.bg]"
-                @click="toggleComponent(group.version, comp.component)"
-              >
-                <td colspan="7" class="px-6 py-2.5">
-                  <div class="flex items-center">
-                    <svg
-                      class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0 mr-2.5"
-                      :class="{ 'rotate-90': isComponentExpanded(group.version, comp.component) }"
-                      fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
-                    >
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                    </svg>
-                    <span class="w-2 h-2 rounded-full flex-shrink-0 mr-1.5" :class="COMP_STYLE.dot" />
-                    <span class="font-semibold text-gray-800 dark:text-gray-200 mr-3">{{ comp.component }}</span>
-                    <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold mr-2 bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300">
-                      {{ comp.requestedCount }} requested
-                    </span>
-                    <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold mr-2 bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300">
-                      {{ comp.committedCount }} committed
-                    </span>
-                    <span
-                      class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold"
-                      :class="comp.blockedCount > 0
-                        ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
-                        : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
-                    >{{ comp.blockedCount }} blocked</span>
-                  </div>
-                </td>
-              </tr>
+          <!-- Column headers -->
+          <tr
+            v-if="isComponentExpanded(comp.component)"
+            class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/80 sticky top-0"
+          >
+            <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
+            <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Product</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
+            <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
+            <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
+          </tr>
 
-              <!-- Column headers -->
-              <tr
-                v-if="isComponentExpanded(group.version, comp.component)"
-                class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/80 sticky top-0"
-              >
-                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
-                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
-                <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
-                <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
-                <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
-                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
-                <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
-              </tr>
-
-              <!-- Feature rows -->
-              <template v-if="isComponentExpanded(group.version, comp.component)">
-                <tr
-                  v-for="feature in comp.displayFeatures"
-                  :key="feature.key"
-                  class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+          <!-- Feature rows -->
+          <template v-if="isComponentExpanded(comp.component)">
+            <tr
+              v-for="feature in comp.features"
+              :key="feature.key"
+              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+            >
+              <td class="px-3 py-2.5 whitespace-nowrap">
+                <a
+                  :href="`${JIRA_BASE}/${feature.key}`"
+                  target="_blank"
+                  rel="noopener"
+                  class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
+                >{{ feature.key }}</a>
+              </td>
+              <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
+                {{ feature.summary }}
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <div class="flex items-center justify-center gap-1 flex-wrap">
+                  <span
+                    v-for="prod in feature.products"
+                    :key="prod"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold"
+                    :class="productBadgeClass(prod)"
+                  >{{ prod }}</span>
+                </div>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <div class="flex items-center justify-center gap-1">
+                  <span
+                    v-if="feature.isRequested"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
+                  >REQ</span>
+                  <span
+                    v-if="feature.isCommitted"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300"
+                  >COM</span>
+                </div>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
+                  v-if="feature.colorStatus"
+                  class="inline-block w-3.5 h-3.5 rounded-full ring-2"
+                  :class="[colorStatusClass(feature.colorStatus), colorStatusRing(feature.colorStatus)]"
+                  :title="feature.colorStatus"
+                />
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
+                  v-if="feature.isBlocked"
+                  class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
+                  title="Blocked"
                 >
-                  <td class="px-3 py-2.5 whitespace-nowrap">
-                    <a
-                      :href="`${JIRA_BASE}/${feature.key}`"
-                      target="_blank"
-                      rel="noopener"
-                      class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
-                    >{{ feature.key }}</a>
-                  </td>
-                  <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
-                    {{ feature.summary }}
-                  </td>
-                  <td class="px-3 py-2.5 text-center">
-                    <div class="flex items-center justify-center gap-1">
-                      <span
-                        v-if="(comp.requestedFeatures || []).some(function(r) { return r.key === feature.key })"
-                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
-                      >REQ</span>
-                      <span
-                        v-if="(comp.committedFeatures || []).some(function(r) { return r.key === feature.key })"
-                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300"
-                      >COM</span>
-                    </div>
-                  </td>
-                  <td class="px-3 py-2.5 text-center">
-                    <span
-                      v-if="feature.colorStatus"
-                      class="inline-block w-3.5 h-3.5 rounded-full ring-2"
-                      :class="[colorStatusClass(feature.colorStatus), colorStatusRing(feature.colorStatus)]"
-                      :title="feature.colorStatus"
-                    />
-                    <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
-                  </td>
-                  <td class="px-3 py-2.5 text-center">
-                    <span
-                      v-if="feature.isBlocked"
-                      class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
-                      title="Blocked"
-                    >
-                      <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-                      </svg>
-                    </span>
-                    <svg v-else class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </td>
-                  <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                    {{ feature.assignee || '--' }}
-                  </td>
-                  <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                    {{ feature.pmOwner || '--' }}
-                  </td>
-                </tr>
-              </template>
-
-              <!-- Empty state -->
-              <tr v-if="isComponentExpanded(group.version, comp.component) && comp.displayFeatures.length === 0">
-                <td colspan="7" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
-                  No features found for {{ comp.component }}
-                </td>
-              </tr>
-            </template>
+                  <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                  </svg>
+                </span>
+                <svg v-else class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </td>
+              <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                {{ feature.assignee || '--' }}
+              </td>
+              <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                {{ feature.pmOwner || '--' }}
+              </td>
+            </tr>
           </template>
+
+          <!-- Empty state -->
+          <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
+            <td colspan="8" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+              No features found for {{ comp.component }}
+            </td>
+          </tr>
         </template>
+
         <!-- No matching results for active filter -->
-        <tr v-if="filteredGroups.length === 0 && activeFilter">
-          <td colspan="7" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+        <tr v-if="componentGroups.length === 0 && activeFilter">
+          <td colspan="8" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No {{ activeFilter }} features found.
           </td>
         </tr>

--- a/modules/releases/client/plan/components/PillarConfigPanel.vue
+++ b/modules/releases/client/plan/components/PillarConfigPanel.vue
@@ -1,0 +1,196 @@
+<template>
+  <div v-if="open" class="fixed inset-0 z-[100] flex justify-end" @mousedown.self="$emit('close')">
+    <div class="w-full max-w-lg bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 flex flex-col h-full">
+      <!-- Header -->
+      <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+        <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Pillar Configuration</h3>
+        <button
+          @click="$emit('close')"
+          class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+        >
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          Define which Jira components belong to each pillar. Components are matched using substring matching against Jira's component names.
+        </p>
+
+        <div v-for="(pillar, pi) in draft" :key="pi" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <!-- Pillar header -->
+          <div class="flex items-center gap-2 px-3 py-2.5 bg-gray-50 dark:bg-gray-800">
+            <button
+              type="button"
+              @click="toggleExpand(pi)"
+              class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors"
+            >
+              <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-90': expanded[pi] }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+            <input
+              v-model="pillar.name"
+              class="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
+              placeholder="Pillar name"
+            />
+            <span class="text-[10px] text-gray-400 dark:text-gray-500 font-medium">{{ pillar.components.length }}</span>
+            <button
+              type="button"
+              @click="removePillar(pi)"
+              class="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-gray-400 hover:text-red-500 transition-colors"
+              title="Remove pillar"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Components list (expandable) -->
+          <div v-if="expanded[pi]" class="px-3 py-2 space-y-1.5 border-t border-gray-100 dark:border-gray-700">
+            <div v-for="(comp, ci) in pillar.components" :key="ci" class="flex items-center gap-1.5">
+              <input
+                v-model="pillar.components[ci]"
+                class="flex-1 text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+              />
+              <button
+                type="button"
+                @click="removeComponent(pi, ci)"
+                class="p-0.5 rounded text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <button
+              type="button"
+              @click="addComponent(pi)"
+              class="flex items-center gap-1 text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium mt-1"
+            >
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+              Add component
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          @click="addPillar"
+          class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+          </svg>
+          Add Pillar
+        </button>
+      </div>
+
+      <!-- Footer -->
+      <div class="px-5 py-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <span v-if="saveError" class="text-xs text-red-500">{{ saveError }}</span>
+        <span v-else-if="saveSuccess" class="text-xs text-emerald-600 dark:text-emerald-400">Saved</span>
+        <span v-else />
+        <div class="flex items-center gap-2">
+          <button
+            @click="$emit('close')"
+            class="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+          >Cancel</button>
+          <button
+            @click="save"
+            :disabled="saving"
+            class="px-4 py-1.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md transition-colors disabled:opacity-50"
+          >{{ saving ? 'Saving…' : 'Save' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { getApiBase } from '@shared/client/services/api'
+
+var props = defineProps({
+  open: { type: Boolean, default: false },
+  config: { type: Object, default: function() { return { pillars: [] } } }
+})
+
+var emit = defineEmits(['close', 'saved'])
+
+var draft = ref([])
+var expanded = ref({})
+var saving = ref(false)
+var saveError = ref(null)
+var saveSuccess = ref(false)
+
+watch(function() { return props.open }, function(isOpen) {
+  if (isOpen) {
+    draft.value = JSON.parse(JSON.stringify(props.config.pillars || []))
+    expanded.value = {}
+    saveError.value = null
+    saveSuccess.value = false
+  }
+})
+
+function toggleExpand(idx) {
+  expanded.value = Object.assign({}, expanded.value, { [idx]: !expanded.value[idx] })
+}
+
+function addPillar() {
+  draft.value.push({ name: '', components: [] })
+  expanded.value = Object.assign({}, expanded.value, { [draft.value.length - 1]: true })
+}
+
+function removePillar(idx) {
+  draft.value.splice(idx, 1)
+}
+
+function addComponent(pillarIdx) {
+  draft.value[pillarIdx].components.push('')
+}
+
+function removeComponent(pillarIdx, compIdx) {
+  draft.value[pillarIdx].components.splice(compIdx, 1)
+}
+
+async function save() {
+  saving.value = true
+  saveError.value = null
+  saveSuccess.value = false
+
+  var cleaned = draft.value
+    .filter(function(p) { return p.name.trim() })
+    .map(function(p) {
+      return {
+        name: p.name.trim(),
+        components: p.components.filter(function(c) { return c.trim() }).map(function(c) { return c.trim() })
+      }
+    })
+
+  try {
+    var response = await fetch(getApiBase() + '/modules/releases/pm-hub/pillar-config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pillars: cleaned })
+    })
+    if (!response.ok) {
+      var errData = await response.json().catch(function() { return {} })
+      throw new Error(errData.error || 'HTTP ' + response.status)
+    }
+    var data = await response.json()
+    saveSuccess.value = true
+    emit('saved', data)
+  } catch (err) {
+    saveError.value = err.message
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -190,8 +190,7 @@
           v-if="versionDropdownOpen"
           class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
         >
-          <div v-if="loadingVersions" class="px-3 py-2 text-xs text-gray-400">Loading…</div>
-          <div v-else-if="filteredVersions.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
+          <div v-if="filteredVersions.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
           <button
             v-for="name in filteredVersions"
             :key="name"
@@ -448,18 +447,31 @@ var uniqueComponents = computed(function() {
   return result
 })
 
-var uniqueVersions = computed(function() {
-  var seen = new Set()
+var PORTFOLIO_VERSIONS = [
+  { label: '3.5 EA1', jiraVersions: ['rhoai-3.5.EA1', 'rhelai-3.5 EA1 release', 'RHAII-3.5 EA1'] },
+  { label: '3.5 EA2', jiraVersions: ['rhoai-3.5.EA2', 'rhelai-3.5 EA2 release', 'RHAII-3.5 EA2'] },
+  { label: '3.5', jiraVersions: ['rhoai-3.5', 'rhelai-3.5', 'RHAII-3.5'] },
+  { label: '3.6 EA1', jiraVersions: ['rhoai-3.6.EA1', 'rhelai-3.6 EA1 release', 'RHAII-3.6 EA1'] },
+  { label: '3.6 EA2', jiraVersions: ['rhoai-3.6.EA2', 'rhelai-3.6 EA2 release', 'RHAII-3.6 EA2'] },
+  { label: '3.6', jiraVersions: ['rhoai-3.6', 'rhelai-3.6', 'RHAII-3.6'] }
+]
+
+var portfolioVersionLabels = PORTFOLIO_VERSIONS.map(function(v) { return v.label })
+
+function resolveJiraVersions(selectedLabels) {
   var result = []
-  for (var i = 0; i < versions.value.length; i++) {
-    var name = versions.value[i].name
-    if (!seen.has(name)) {
-      seen.add(name)
-      result.push(name)
+  for (var i = 0; i < selectedLabels.length; i++) {
+    var pv = PORTFOLIO_VERSIONS.find(function(v) { return v.label === selectedLabels[i] })
+    if (pv) {
+      for (var j = 0; j < pv.jiraVersions.length; j++) {
+        if (result.indexOf(pv.jiraVersions[j]) === -1) {
+          result.push(pv.jiraVersions[j])
+        }
+      }
     }
   }
   return result
-})
+}
 
 var pillarNames = computed(function() {
   return pillarConfig.value.pillars.map(function(p) { return p.name })
@@ -515,8 +527,8 @@ var filteredComponents = computed(function() {
 
 var filteredVersions = computed(function() {
   var q = versionSearch.value.toLowerCase().trim()
-  if (!q) return uniqueVersions.value
-  return uniqueVersions.value.filter(function(name) {
+  if (!q) return portfolioVersionLabels
+  return portfolioVersionLabels.filter(function(name) {
     return name.toLowerCase().includes(q)
   })
 })
@@ -694,7 +706,8 @@ async function loadData() {
       params.set('components', selectedComponents.value.join(','))
     }
     if (selectedVersions.value.length > 0) {
-      params.set('versions', selectedVersions.value.join(','))
+      var jiraVersions = resolveJiraVersions(selectedVersions.value)
+      params.set('versions', jiraVersions.join(','))
     }
 
     var response = await fetch(getApiBase() + API_BASE + '/component-release-load?' + params.toString())
@@ -713,8 +726,10 @@ async function loadData() {
 }
 
 watch(selectedPillars, function() {
-  if (selectedPillars.value.length > 0 && selectedComponents.value.length > 0) {
-    selectedComponents.value = selectedComponents.value.filter(componentMatchesPillar)
+  if (selectedPillars.value.length > 0) {
+    selectedComponents.value = pillarFilteredComponents.value.slice()
+  } else {
+    selectedComponents.value = []
   }
 }, { deep: true })
 

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -209,7 +209,6 @@
             {{ name }}
           </button>
         </div>
-        <p v-if="versionError" class="text-xs text-red-500 mt-1">{{ versionError }}</p>
       </div>
     </div>
 
@@ -414,10 +413,6 @@ var pillarPanelOpen = ref(false)
 var components = ref([])
 var loadingComponents = ref(false)
 var componentError = ref(null)
-
-var versions = ref([])
-var loadingVersions = ref(false)
-var versionError = ref(null)
 
 var groups = ref([])
 var loadingData = ref(false)
@@ -676,24 +671,6 @@ async function fetchComponents() {
   }
 }
 
-async function fetchVersions() {
-  loadingVersions.value = true
-  versionError.value = null
-  try {
-    var response = await fetch(getApiBase() + API_BASE + '/jira/versions')
-    if (!response.ok) {
-      var errData = await response.json().catch(function() { return {} })
-      throw new Error(errData.error || 'HTTP ' + response.status)
-    }
-    var data = await response.json()
-    versions.value = data.versions || []
-  } catch (err) {
-    versionError.value = err.message
-  } finally {
-    loadingVersions.value = false
-  }
-}
-
 async function loadData() {
   if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) return
   loadingData.value = true
@@ -746,7 +723,6 @@ watch([selectedComponents, selectedVersions], function() {
 onMounted(function() {
   fetchPillarConfig()
   fetchComponents()
-  fetchVersions()
   document.addEventListener('mousedown', handleClickOutside)
 })
 

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -299,9 +299,9 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" />
             </svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Versions Selected</span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Releases Selected</span>
         </div>
-        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ groups.length }}</div>
+        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ selectedVersions.length }}</div>
       </div>
     </div>
 

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -9,6 +9,16 @@
       </div>
       <div class="flex items-center gap-2">
         <button
+          @click="pillarPanelOpen = true"
+          class="p-1.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+          title="Configure pillars"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+        <button
           v-if="groups.length > 0"
           @click="handleExpandAll"
           class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -22,6 +32,65 @@
     </div>
 
     <div class="flex flex-wrap items-start gap-4">
+      <!-- Pillar Filter -->
+      <div class="min-w-[200px] max-w-[280px] relative" ref="pillarDropdownRef">
+        <div class="flex items-center justify-between mb-1">
+          <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Pillar</label>
+          <button
+            v-if="selectedPillars.length > 0"
+            type="button"
+            @click="selectedPillars = []; pillarSearch = ''"
+            class="text-[10px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+          >Clear</button>
+        </div>
+        <div
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
+          :class="{ 'ring-2 ring-primary-500 border-primary-500': pillarDropdownOpen }"
+          @click="openPillarDropdown"
+        >
+          <span
+            v-for="name in selectedPillars"
+            :key="name"
+            class="inline-flex items-center gap-1 bg-violet-100 dark:bg-violet-900/50 text-violet-700 dark:text-violet-300 rounded px-1.5 py-0.5 text-xs font-medium"
+          >
+            {{ name }}
+            <button type="button" class="hover:text-violet-900 dark:hover:text-violet-100" @click.stop="togglePillar(name)">&times;</button>
+          </span>
+          <input
+            ref="pillarInputRef"
+            v-model="pillarSearch"
+            type="text"
+            class="flex-1 min-w-[60px] bg-transparent outline-none text-sm placeholder-gray-400 dark:placeholder-gray-500"
+            :placeholder="selectedPillars.length ? '' : 'Select pillar…'"
+            @focus="pillarDropdownOpen = true"
+            @keydown.backspace="onPillarBackspace"
+          />
+        </div>
+        <div
+          v-if="pillarDropdownOpen"
+          class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
+        >
+          <div v-if="filteredPillarNames.length === 0" class="px-3 py-2 text-xs text-gray-400">No pillars</div>
+          <button
+            v-for="name in filteredPillarNames"
+            :key="name"
+            type="button"
+            class="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
+            @mousedown.prevent="togglePillar(name)"
+          >
+            <span
+              class="w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-xs"
+              :class="selectedPillars.includes(name)
+                ? 'bg-violet-500 border-violet-500 text-white'
+                : 'border-gray-300 dark:border-gray-500'"
+            >
+              <span v-if="selectedPillars.includes(name)">&#10003;</span>
+            </span>
+            {{ name }}
+          </button>
+        </div>
+      </div>
+
       <!-- Jira Component Filter -->
       <div class="min-w-[280px] max-w-[400px] relative" ref="componentDropdownRef">
         <div class="flex items-center justify-between mb-1">
@@ -302,6 +371,14 @@
       :groups="groups"
       :activeFilter="activeFilter"
     />
+
+    <!-- Pillar config panel -->
+    <PillarConfigPanel
+      :open="pillarPanelOpen"
+      :config="pillarConfig"
+      @close="pillarPanelOpen = false"
+      @saved="onPillarConfigSaved"
+    />
   </div>
 </template>
 
@@ -309,22 +386,31 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
 import ComponentReleaseLoadTable from '../components/ComponentReleaseLoadTable.vue'
+import PillarConfigPanel from '../components/PillarConfigPanel.vue'
 
 const API_BASE = '/modules/releases/pm-hub'
 
+var selectedPillars = ref([])
 var selectedComponents = ref([])
 var selectedVersions = ref([])
 
+var pillarSearch = ref('')
 var componentSearch = ref('')
 var versionSearch = ref('')
 
+var pillarDropdownOpen = ref(false)
 var componentDropdownOpen = ref(false)
 var versionDropdownOpen = ref(false)
 
+var pillarDropdownRef = ref(null)
+var pillarInputRef = ref(null)
 var componentDropdownRef = ref(null)
 var versionDropdownRef = ref(null)
 var componentInputRef = ref(null)
 var versionInputRef = ref(null)
+
+var pillarConfig = ref({ pillars: [] })
+var pillarPanelOpen = ref(false)
 
 var components = ref([])
 var loadingComponents = ref(false)
@@ -375,10 +461,54 @@ var uniqueVersions = computed(function() {
   return result
 })
 
+var pillarNames = computed(function() {
+  return pillarConfig.value.pillars.map(function(p) { return p.name })
+})
+
+var filteredPillarNames = computed(function() {
+  var q = pillarSearch.value.toLowerCase().trim()
+  if (!q) return pillarNames.value
+  return pillarNames.value.filter(function(name) {
+    return name.toLowerCase().includes(q)
+  })
+})
+
+var pillarAllowedComponents = computed(function() {
+  if (selectedPillars.value.length === 0) return null
+  var allowed = new Set()
+  for (var pi = 0; pi < selectedPillars.value.length; pi++) {
+    var pillar = pillarConfig.value.pillars.find(function(p) { return p.name === selectedPillars.value[pi] })
+    if (!pillar) continue
+    for (var ci = 0; ci < pillar.components.length; ci++) {
+      allowed.add(pillar.components[ci].toLowerCase())
+    }
+  }
+  return allowed
+})
+
+function componentMatchesPillar(jiraName) {
+  var allowed = pillarAllowedComponents.value
+  if (!allowed) return true
+  var lower = jiraName.toLowerCase()
+  var iter = allowed.values()
+  var next = iter.next()
+  while (!next.done) {
+    var entry = next.value
+    if (lower.includes(entry) || entry.includes(lower)) return true
+    next = iter.next()
+  }
+  return false
+}
+
+var pillarFilteredComponents = computed(function() {
+  if (!pillarAllowedComponents.value) return uniqueComponents.value
+  return uniqueComponents.value.filter(componentMatchesPillar)
+})
+
 var filteredComponents = computed(function() {
   var q = componentSearch.value.toLowerCase().trim()
-  if (!q) return uniqueComponents.value
-  return uniqueComponents.value.filter(function(name) {
+  if (!q) return pillarFilteredComponents.value
+  return pillarFilteredComponents.value.filter(function(name) {
     return name.toLowerCase().includes(q)
   })
 })
@@ -414,6 +544,27 @@ var totalBlocked = computed(function() {
   }
   return count
 })
+
+function togglePillar(name) {
+  var idx = selectedPillars.value.indexOf(name)
+  if (idx >= 0) {
+    selectedPillars.value.splice(idx, 1)
+  } else {
+    selectedPillars.value.push(name)
+  }
+  pillarSearch.value = ''
+}
+
+function openPillarDropdown() {
+  pillarDropdownOpen.value = true
+  if (pillarInputRef.value) pillarInputRef.value.focus()
+}
+
+function onPillarBackspace() {
+  if (!pillarSearch.value && selectedPillars.value.length) {
+    selectedPillars.value.pop()
+  }
+}
 
 function toggleComponent(name) {
   var idx = selectedComponents.value.indexOf(name)
@@ -458,6 +609,10 @@ function onVersionBackspace() {
 }
 
 function handleClickOutside(e) {
+  if (pillarDropdownRef.value && !pillarDropdownRef.value.contains(e.target)) {
+    pillarDropdownOpen.value = false
+    pillarSearch.value = ''
+  }
   if (componentDropdownRef.value && !componentDropdownRef.value.contains(e.target)) {
     componentDropdownOpen.value = false
     componentSearch.value = ''
@@ -474,6 +629,21 @@ function handleExpandAll() {
 
 function handleCollapseAll() {
   if (tableRef.value) tableRef.value.collapseAll()
+}
+
+function onPillarConfigSaved(newConfig) {
+  pillarConfig.value = newConfig
+  pillarPanelOpen.value = false
+}
+
+async function fetchPillarConfig() {
+  try {
+    var response = await fetch(getApiBase() + API_BASE + '/pillar-config')
+    if (response.ok) {
+      var data = await response.json()
+      pillarConfig.value = data
+    }
+  } catch (e) { void e }
 }
 
 async function fetchComponents() {
@@ -542,6 +712,12 @@ async function loadData() {
   }
 }
 
+watch(selectedPillars, function() {
+  if (selectedPillars.value.length > 0 && selectedComponents.value.length > 0) {
+    selectedComponents.value = selectedComponents.value.filter(componentMatchesPillar)
+  }
+}, { deep: true })
+
 watch([selectedComponents, selectedVersions], function() {
   activeFilter.value = null
   if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) {
@@ -553,6 +729,7 @@ watch([selectedComponents, selectedVersions], function() {
 }, { deep: true })
 
 onMounted(function() {
+  fetchPillarConfig()
   fetchComponents()
   fetchVersions()
   document.addEventListener('mousedown', handleClickOutside)

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -49,6 +49,7 @@ const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
   'components', 'labels', 'issuelinks',
   CUSTOM_FIELDS.team,
+  CUSTOM_FIELDS.releaseType,
   CUSTOM_FIELDS.statusSummary,
   CUSTOM_FIELDS.colorStatus,
   CUSTOM_FIELDS.productManager
@@ -326,6 +327,7 @@ module.exports = function registerPmHubRoutes(router, context) {
           status: f.status || null,
           colorStatus: f.colorStatus || null,
           statusSummary: f.statusSummary || null,
+          releaseType: f.releaseType || null,
           isBlocked: f.isBlocked || false,
           components: f.components || [],
           assignee: f.assignee || null,

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -9,6 +9,41 @@
 const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
 
 const PM_HUB_PROJECTS = ['RHAIENG', 'RHOAIENG', 'INFERENG', 'AIPCC', 'RHAISTRAT', 'RHAIRFE']
+const PILLAR_CONFIG_FILE = 'releases/pm-hub/pillar-config.json'
+
+var DEFAULT_PILLAR_CONFIG = {
+  pillars: [
+    {
+      name: 'Inference',
+      components: ['llm-d', 'vllm', 'Inference Midstream', 'llm-compressor', 'Optimized Models', 'Model Validation', 'Tool calling', 'AI security -model validation', 'Model Serving Runtimes', 'Serving Orchestration', 'PSAP']
+    },
+    {
+      name: 'Data',
+      components: ['EvalHub / Model Eval', 'AutoRAG / RAG', 'AutoML', 'Development platform', 'Data Processing', 'SDG', 'Training Hub', 'Fine Tuning / Kubeflow-Dev', 'Kubeflow Training', 'Ray Training', 'Inference Time Techniques']
+    },
+    {
+      name: 'Agents',
+      components: ['GenAI Studio', 'AgentOps', 'AgentDev', 'OGX (formerly Llama Stack) core', 'Agentic and AI Tooling Experience', 'PSAP agentic', 'Model Context Protocol']
+    },
+    {
+      name: 'Platform',
+      components: ['MaaS', 'AI Gateway', 'GPUaaS', 'AI Hub', 'Observability', 'AI Safety', 'AI Navigator', 'Feature Store', 'Notebook Server', 'Notebook images and extensions', 'AI Pipelines', 'AI Core Platform', 'MLflow', 'AI Core Dashboard']
+    }
+  ]
+}
+
+function validatePillarConfig(data) {
+  if (!data || !Array.isArray(data.pillars)) return 'pillars must be an array'
+  for (var i = 0; i < data.pillars.length; i++) {
+    var p = data.pillars[i]
+    if (!p.name || typeof p.name !== 'string') return 'pillar at index ' + i + ' must have a name string'
+    if (!Array.isArray(p.components)) return 'pillar "' + p.name + '" must have a components array'
+    for (var j = 0; j < p.components.length; j++) {
+      if (typeof p.components[j] !== 'string') return 'components in pillar "' + p.name + '" must be strings'
+    }
+  }
+  return null
+}
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
@@ -138,6 +173,64 @@ module.exports = function registerPmHubRoutes(router, context) {
    *       503:
    *         description: Jira client not configured
    */
+  /**
+   * @openapi
+   * /api/modules/releases/pm-hub/pillar-config:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get pillar-to-component mapping config
+   *     description: Returns the pillar configuration used to group Jira components. Seeds defaults if none exists.
+   *     responses:
+   *       200:
+   *         description: Pillar config object with pillars array
+   */
+  router.get('/pillar-config', context.requireAuth, context.requireScope('releases:read'), function(req, res) {
+    var storage = context.storage
+    var config = storage.readFromStorage(PILLAR_CONFIG_FILE)
+    if (!config) {
+      config = DEFAULT_PILLAR_CONFIG
+      storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+    }
+    res.json(config)
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/pm-hub/pillar-config:
+   *   put:
+   *     tags: [Releases]
+   *     summary: Update pillar-to-component mapping config
+   *     description: Saves an updated pillar configuration. Admin only.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               pillars:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   properties:
+   *                     name: { type: string }
+   *                     components: { type: array, items: { type: string } }
+   *     responses:
+   *       200:
+   *         description: Updated pillar config
+   *       400:
+   *         description: Invalid config shape
+   */
+  router.put('/pillar-config', context.requireAuth, context.requireScope('releases:write'), function(req, res) {
+    var err = validatePillarConfig(req.body)
+    if (err) {
+      return res.status(400).json({ error: err })
+    }
+    var config = { pillars: req.body.pillars }
+    context.storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+    res.json(config)
+  })
+
   router.get('/component-release-load', context.requireAuth, context.requireScope('releases:read'), async function(req, res) {
     if (!jiraClient) {
       return res.status(503).json({ error: 'Jira client not configured' })
@@ -320,3 +413,7 @@ module.exports = function registerPmHubRoutes(router, context) {
     }
   })
 }
+
+module.exports.DEFAULT_PILLAR_CONFIG = DEFAULT_PILLAR_CONFIG
+module.exports.validatePillarConfig = validatePillarConfig
+module.exports.PILLAR_CONFIG_FILE = PILLAR_CONFIG_FILE

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -253,4 +253,15 @@ test.describe('Releases PM Hub @releases', () => {
     const body = await res.json();
     expect(body.error).toContain('filter');
   });
+
+  test('pillar-config endpoint returns valid config', async ({ request }) => {
+    const res = await request.get('/api/modules/releases/pm-hub/pillar-config');
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body).toHaveProperty('pillars');
+    expect(Array.isArray(body.pillars)).toBe(true);
+    expect(body.pillars.length).toBeGreaterThan(0);
+    expect(body.pillars[0]).toHaveProperty('name');
+    expect(body.pillars[0]).toHaveProperty('components');
+  });
 });


### PR DESCRIPTION
## Summary

- **Pillar filter**: Add an editable Pillar filter (Inference, Data, Agents, Platform) before the Jira Component dropdown in PM Hub. Selecting a pillar auto-fills components using substring matching. Pillar-to-component mapping is stored in `releases/pm-hub/pillar-config.json` and editable via a settings panel (gear icon).
- **Component-grouped table**: Restructure the report table to group features by Component instead of Version > Component. Each feature row now shows color-coded Product badges (RHOAI, RHELAI, RHAII) and a Release Type column (Jira `cf[10851]`).
- **Curated release versions**: Replace the dynamic Jira version list with curated portfolio releases (3.5 EA1, 3.5 EA2, 3.5, 3.6 EA1, 3.6 EA2, 3.6) that each resolve to multiple Jira version names.
- **Backend**: New `GET/PUT /pillar-config` endpoints with OpenAPI annotations, default seeding, and validation.
- **Tests**: 12 unit tests for pillar config validation/defaults, integration test for the pillar-config endpoint.

## Test plan

- [ ] Verify Pillar dropdown shows 4 pillars and auto-fills components on selection
- [ ] Verify settings panel (gear icon) allows editing pillar-component mappings
- [ ] Verify Release dropdown shows curated versions (3.5 EA1, 3.5 EA2, 3.5, etc.)
- [ ] Verify table groups by component with Product and Release Type columns
- [ ] Verify "Releases Selected" card shows correct count
- [ ] Run `npm test` — all tests pass


Made with [Cursor](https://cursor.com)