### PR TITLE
feat(releases): multi-select filters, hygiene fix, direct Jira query

### DIFF
--- a/modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js
@@ -1,0 +1,360 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FeatureReadinessFilterBar from '../../../client/plan/components/FeatureReadinessFilterBar.vue'
+
+var FILTER_META = {
+  bigRocks: ['AI Training', 'Model Management', 'AI Serving'],
+  targetVersions: ['RHOAI 2.19', 'RHOAI 2.20'],
+  fixVersions: ['RHOAI-2.19'],
+  components: ['Dashboard', 'Model Serving', 'Pipelines'],
+  priorities: ['Blocker', 'Critical', 'Major', 'Normal'],
+  teams: ['DW Team', 'MR Team', 'Platform Team']
+}
+
+function defaultModelValue() {
+  return {
+    outcome: [],
+    targetVersion: [],
+    fixVersion: [],
+    component: [],
+    priority: [],
+    team: [],
+    readiness: null
+  }
+}
+
+function findButtonByText(wrapper, text) {
+  return wrapper.findAll('button').filter(function(b) { return b.text().includes(text) })
+}
+
+describe('FeatureReadinessFilterBar', function() {
+
+  // ─── Rendering ───
+
+  it('renders readiness single-select dropdown', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    var selects = wrapper.findAll('select')
+    expect(selects.length).toBeGreaterThanOrEqual(1)
+    var readinessSelect = selects[0]
+    expect(readinessSelect.text()).toContain('All')
+    expect(readinessSelect.text()).toContain('Ready')
+    expect(readinessSelect.text()).toContain('Not Ready')
+  })
+
+  it('renders multi-select buttons for all 6 filter types', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    expect(wrapper.text()).toContain('All outcomes')
+    expect(wrapper.text()).toContain('All versions')
+    expect(wrapper.text()).toContain('All fix versions')
+    expect(wrapper.text()).toContain('All components')
+    expect(wrapper.text()).toContain('All teams')
+    expect(wrapper.text()).toContain('All priorities')
+  })
+
+  it('hides filter buttons when filterMeta is empty', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: {}, modelValue: defaultModelValue() }
+    })
+    expect(wrapper.text()).not.toContain('All outcomes')
+    expect(wrapper.text()).not.toContain('All components')
+  })
+
+  it('hides clear button when no filters active', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    var clearBtn = findButtonByText(wrapper, 'Clear filters')
+    if (clearBtn.length > 0) {
+      expect(clearBtn[0].isVisible()).toBe(false)
+    }
+  })
+
+  // ─── Dropdown interaction ───
+
+  it('opens outcome dropdown on click and shows options', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var outcomeBtn = findButtonByText(wrapper, 'All outcomes')
+    expect(outcomeBtn.length).toBe(1)
+    await outcomeBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('AI Training')
+    expect(wrapper.text()).toContain('Model Management')
+    expect(wrapper.text()).toContain('AI Serving')
+    wrapper.unmount()
+  })
+
+  it('opens component dropdown on click and shows options', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var compBtn = findButtonByText(wrapper, 'All components')
+    expect(compBtn.length).toBe(1)
+    await compBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('Dashboard')
+    expect(wrapper.text()).toContain('Model Serving')
+    expect(wrapper.text()).toContain('Pipelines')
+    wrapper.unmount()
+  })
+
+  it('closes one dropdown when another is opened', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var outcomeBtn = findButtonByText(wrapper, 'All outcomes')
+    await outcomeBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('AI Training')
+
+    var teamBtn = findButtonByText(wrapper, 'All teams')
+    await teamBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('DW Team')
+
+    var checkboxes = wrapper.findAll('input[type="checkbox"]')
+    var outcomeCheckboxes = checkboxes.filter(function(cb) {
+      var label = cb.element.closest('label')
+      return label && label.textContent.includes('AI Training')
+    })
+    expect(outcomeCheckboxes.length).toBe(0)
+    wrapper.unmount()
+  })
+
+  // ─── Filter value toggling ───
+
+  it('emits update:modelValue when checkbox is toggled in outcome dropdown', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var outcomeBtn = findButtonByText(wrapper, 'All outcomes')
+    await outcomeBtn[0].trigger('click')
+
+    var checkboxes = wrapper.findAll('input[type="checkbox"]')
+    expect(checkboxes.length).toBeGreaterThan(0)
+    await checkboxes[0].setValue(true)
+
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted[0][0].outcome).toContain('AI Training')
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue when checkbox is toggled in priority dropdown', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var priorityBtn = findButtonByText(wrapper, 'All priorities')
+    await priorityBtn[0].trigger('click')
+
+    var checkboxes = wrapper.findAll('input[type="checkbox"]')
+    expect(checkboxes.length).toBeGreaterThan(0)
+    await checkboxes[0].setValue(true)
+
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted[0][0].priority.length).toBe(1)
+    wrapper.unmount()
+  })
+
+  it('emits update:modelValue when checkbox is toggled in team dropdown', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var teamBtn = findButtonByText(wrapper, 'All teams')
+    await teamBtn[0].trigger('click')
+
+    var checkboxes = wrapper.findAll('input[type="checkbox"]')
+    await checkboxes[0].setValue(true)
+
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted[0][0].team.length).toBe(1)
+    wrapper.unmount()
+  })
+
+  // ─── Button labels ───
+
+  it('shows single value when one item selected', function() {
+    var mv = defaultModelValue()
+    mv.outcome = ['AI Training']
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    expect(wrapper.text()).toContain('AI Training')
+    expect(wrapper.text()).not.toContain('All outcomes')
+  })
+
+  it('shows count when multiple items selected', function() {
+    var mv = defaultModelValue()
+    mv.priority = ['Major', 'Critical']
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    expect(wrapper.text()).toContain('2 selected')
+  })
+
+  it('shows "All" label when no items selected', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    expect(wrapper.text()).toContain('All outcomes')
+    expect(wrapper.text()).toContain('All versions')
+    expect(wrapper.text()).toContain('All components')
+  })
+
+  // ─── Active filter styling ───
+
+  it('shows clear button when filters are active', function() {
+    var mv = defaultModelValue()
+    mv.outcome = ['AI Training']
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    var clearBtn = findButtonByText(wrapper, 'Clear filters')
+    expect(clearBtn.length).toBeGreaterThan(0)
+  })
+
+  it('shows clear button when readiness filter is set', function() {
+    var mv = defaultModelValue()
+    mv.readiness = 'ready'
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    var clearBtn = findButtonByText(wrapper, 'Clear filters')
+    expect(clearBtn.length).toBeGreaterThan(0)
+  })
+
+  // ─── Clear filters ───
+
+  it('emits cleared modelValue when clear button is clicked', async function() {
+    var mv = defaultModelValue()
+    mv.outcome = ['AI Training']
+    mv.priority = ['Major']
+    mv.readiness = 'ready'
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    var clearBtn = findButtonByText(wrapper, 'Clear filters')
+    expect(clearBtn.length).toBeGreaterThan(0)
+    await clearBtn[0].trigger('click')
+
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    var cleared = emitted[emitted.length - 1][0]
+    expect(cleared.outcome).toEqual([])
+    expect(cleared.priority).toEqual([])
+    expect(cleared.readiness).toBeNull()
+    expect(cleared.targetVersion).toEqual([])
+    expect(cleared.fixVersion).toEqual([])
+    expect(cleared.component).toEqual([])
+    expect(cleared.team).toEqual([])
+  })
+
+  // ─── Readiness single-select ───
+
+  it('emits readiness update when select changes', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    var selects = wrapper.findAll('select')
+    await selects[0].setValue('ready')
+
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted[0][0].readiness).toBe('ready')
+  })
+
+  it('emits null readiness when "All" is selected', async function() {
+    var mv = defaultModelValue()
+    mv.readiness = 'ready'
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    var selects = wrapper.findAll('select')
+    await selects[0].setValue('')
+
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted[0][0].readiness).toBeNull()
+  })
+
+  // ─── Checkbox state reflects modelValue ───
+
+  it('shows checked checkboxes for already-selected values', async function() {
+    var mv = defaultModelValue()
+    mv.outcome = ['AI Training']
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv },
+      attachTo: document.body
+    })
+    var outcomeBtn = findButtonByText(wrapper, 'AI Training')
+    if (outcomeBtn.length > 0) {
+      await outcomeBtn[0].trigger('click')
+      var checkboxes = wrapper.findAll('input[type="checkbox"]')
+      var checked = checkboxes.filter(function(cb) { return cb.element.checked })
+      expect(checked.length).toBeGreaterThanOrEqual(1)
+    }
+    wrapper.unmount()
+  })
+
+  // ─── Unchecking removes value ───
+
+  it('removes value from array when checkbox is unchecked', async function() {
+    var mv = defaultModelValue()
+    mv.component = ['Dashboard']
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv },
+      attachTo: document.body
+    })
+    var compBtn = findButtonByText(wrapper, 'Dashboard')
+    if (compBtn.length > 0) {
+      await compBtn[0].trigger('click')
+      var checkboxes = wrapper.findAll('input[type="checkbox"]')
+      var dashboardCb = checkboxes.filter(function(cb) {
+        var label = cb.element.closest('label')
+        return label && label.textContent.includes('Dashboard')
+      })
+      if (dashboardCb.length > 0) {
+        await dashboardCb[0].setValue(false)
+        var emitted = wrapper.emitted('update:modelValue')
+        expect(emitted).toBeDefined()
+        var last = emitted[emitted.length - 1][0]
+        expect(last.component).toEqual([])
+      }
+    }
+    wrapper.unmount()
+  })
+
+  // ─── Active button styling ───
+
+  it('applies active styling to button with selected values', function() {
+    var mv = defaultModelValue()
+    mv.outcome = ['AI Training']
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: mv }
+    })
+    var outcomeBtn = findButtonByText(wrapper, 'AI Training')
+    expect(outcomeBtn.length).toBe(1)
+    var classes = outcomeBtn[0].classes().join(' ')
+    expect(classes).toContain('primary')
+  })
+
+  it('applies default styling to button with no selected values', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    var outcomeBtn = findButtonByText(wrapper, 'All outcomes')
+    expect(outcomeBtn.length).toBe(1)
+    var classes = outcomeBtn[0].classes().join(' ')
+    expect(classes).toContain('border-gray-300')
+    expect(classes).not.toContain('border-primary-400')
+  })
+})

--- a/modules/releases/client/plan/components/FeatureReadinessFilterBar.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessFilterBar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 
 const props = defineProps({
   filterMeta: {
@@ -9,54 +9,102 @@ const props = defineProps({
   modelValue: {
     type: Object,
     default: () => ({
-      outcome: null,
-      targetVersion: null,
-      fixVersion: null,
-      component: null,
-      priority: null,
-      team: null,
-      readiness: null,
-      needsAttention: false
+      outcome: [],
+      targetVersion: [],
+      fixVersion: [],
+      component: [],
+      priority: [],
+      team: [],
+      readiness: null
     })
   }
 })
 
 const emit = defineEmits(['update:modelValue'])
 
-function update(key, value) {
-  emit('update:modelValue', { ...props.modelValue, [key]: value })
+const outcomeOpen = ref(false)
+const targetVersionOpen = ref(false)
+const fixVersionOpen = ref(false)
+const componentOpen = ref(false)
+const teamOpen = ref(false)
+const priorityOpen = ref(false)
+
+const outcomeRef = ref(null)
+const targetVersionRef = ref(null)
+const fixVersionRef = ref(null)
+const componentRef = ref(null)
+const teamRef = ref(null)
+const priorityRef = ref(null)
+
+function closeAll() {
+  outcomeOpen.value = false
+  targetVersionOpen.value = false
+  fixVersionOpen.value = false
+  componentOpen.value = false
+  teamOpen.value = false
+  priorityOpen.value = false
 }
 
-function toggleNeedsAttention() {
-  update('needsAttention', !props.modelValue.needsAttention)
+function toggleDropdown(name) {
+  var map = { outcome: outcomeOpen, targetVersion: targetVersionOpen, fixVersion: fixVersionOpen, component: componentOpen, team: teamOpen, priority: priorityOpen }
+  var wasOpen = map[name].value
+  closeAll()
+  if (!wasOpen) map[name].value = true
+}
+
+function handleClickOutside(event) {
+  var refs = [outcomeRef, targetVersionRef, fixVersionRef, componentRef, teamRef, priorityRef]
+  for (var i = 0; i < refs.length; i++) {
+    if (refs[i].value && refs[i].value.contains(event.target)) return
+  }
+  closeAll()
+}
+
+onMounted(function() { document.addEventListener('click', handleClickOutside) })
+onUnmounted(function() { document.removeEventListener('click', handleClickOutside) })
+
+function toggleValue(key, value) {
+  var current = (props.modelValue[key] || []).slice()
+  var idx = current.indexOf(value)
+  if (idx === -1) current.push(value)
+  else current.splice(idx, 1)
+  emit('update:modelValue', { ...props.modelValue, [key]: current })
+}
+
+function updateReadiness(value) {
+  emit('update:modelValue', { ...props.modelValue, readiness: value })
 }
 
 function clearFilters() {
   emit('update:modelValue', {
-    outcome: null,
-    targetVersion: null,
-    fixVersion: null,
-    component: null,
-    priority: null,
-    team: null,
-    readiness: null,
-    needsAttention: false
+    outcome: [],
+    targetVersion: [],
+    fixVersion: [],
+    component: [],
+    priority: [],
+    team: [],
+    readiness: null
   })
 }
 
 const hasActiveFilters = computed(() => {
   const f = props.modelValue
   return !!(
-    f.outcome ||
-    f.targetVersion ||
-    f.fixVersion ||
-    f.component ||
-    f.priority ||
-    f.team ||
-    f.readiness ||
-    f.needsAttention
+    (f.outcome && f.outcome.length) ||
+    (f.targetVersion && f.targetVersion.length) ||
+    (f.fixVersion && f.fixVersion.length) ||
+    (f.component && f.component.length) ||
+    (f.priority && f.priority.length) ||
+    (f.team && f.team.length) ||
+    f.readiness
   )
 })
+
+function multiLabel(selected, allLabel) {
+  if (!selected || selected.length === 0) return allLabel
+  if (selected.length === 1) return selected[0]
+  return selected.length + ' selected'
+}
 
 const outcomes = computed(() => props.filterMeta.bigRocks || [])
 const targetVersions = computed(() => props.filterMeta.targetVersions || [])
@@ -64,17 +112,22 @@ const fixVersions = computed(() => props.filterMeta.fixVersions || [])
 const components = computed(() => props.filterMeta.components || [])
 const priorities = computed(() => props.filterMeta.priorities || [])
 const teams = computed(() => props.filterMeta.teams || [])
+
+const btnClass = 'flex items-center gap-1.5 cursor-pointer text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400'
+const btnActiveClass = 'flex items-center gap-1.5 cursor-pointer text-xs rounded-md border border-primary-400 dark:border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400'
+const dropdownClass = 'absolute z-50 mt-1 w-64 max-h-60 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg'
+const optionClass = 'flex items-center gap-2 px-3 py-1.5 text-xs text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer'
 </script>
 
 <template>
   <div class="flex flex-wrap items-center gap-3 py-3 px-4 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
 
-    <!-- Readiness -->
+    <!-- Readiness (single-select) -->
     <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Readiness</label>
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Readiness</label>
       <select
         :value="modelValue.readiness || ''"
-        @change="update('readiness', $event.target.value || null)"
+        @change="updateReadiness($event.target.value || null)"
         class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
       >
         <option value="">All</option>
@@ -83,112 +136,113 @@ const teams = computed(() => props.filterMeta.teams || [])
       </select>
     </div>
 
-    <!-- Outcome / Big Rock -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Outcome</label>
-      <select
-        :value="modelValue.outcome || ''"
-        @change="update('outcome', $event.target.value || null)"
-        class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <option value="">All outcomes</option>
-        <option v-for="o in outcomes" :key="o" :value="o" class="text-xs">{{ o }}</option>
-      </select>
+    <!-- Outcome -->
+    <div v-if="outcomes.length > 0" class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Outcome</label>
+      <div ref="outcomeRef" class="relative">
+        <button type="button" @click="toggleDropdown('outcome')" @keydown.escape="outcomeOpen = false" :aria-expanded="outcomeOpen" aria-haspopup="listbox" :class="(modelValue.outcome || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.outcome, 'All outcomes') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="outcomeOpen" role="group" :class="dropdownClass" @keydown.escape="outcomeOpen = false">
+          <label v-for="o in outcomes" :key="o" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.outcome || []).includes(o)" @change="toggleValue('outcome', o)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ o }}</span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <!-- Target Version -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Target Version</label>
-      <select
-        :value="modelValue.targetVersion || ''"
-        @change="update('targetVersion', $event.target.value || null)"
-        class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <option value="">All versions</option>
-        <option v-for="r in targetVersions" :key="r" :value="r" class="text-xs">{{ r }}</option>
-      </select>
+    <div v-if="targetVersions.length > 0" class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Target Version</label>
+      <div ref="targetVersionRef" class="relative">
+        <button type="button" @click="toggleDropdown('targetVersion')" @keydown.escape="targetVersionOpen = false" :aria-expanded="targetVersionOpen" aria-haspopup="listbox" :class="(modelValue.targetVersion || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.targetVersion, 'All versions') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="targetVersionOpen" role="group" :class="dropdownClass" @keydown.escape="targetVersionOpen = false">
+          <label v-for="tv in targetVersions" :key="tv" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.targetVersion || []).includes(tv)" @change="toggleValue('targetVersion', tv)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ tv }}</span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <!-- Fix Version -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Fix Version</label>
-      <select
-        :value="modelValue.fixVersion || ''"
-        @change="update('fixVersion', $event.target.value || null)"
-        class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <option value="">All fix versions</option>
-        <option v-for="fv in fixVersions" :key="fv" :value="fv" class="text-xs">{{ fv }}</option>
-      </select>
+    <div v-if="fixVersions.length > 0" class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Fix Version</label>
+      <div ref="fixVersionRef" class="relative">
+        <button type="button" @click="toggleDropdown('fixVersion')" @keydown.escape="fixVersionOpen = false" :aria-expanded="fixVersionOpen" aria-haspopup="listbox" :class="(modelValue.fixVersion || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.fixVersion, 'All fix versions') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="fixVersionOpen" role="group" :class="dropdownClass" @keydown.escape="fixVersionOpen = false">
+          <label v-for="fv in fixVersions" :key="fv" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.fixVersion || []).includes(fv)" @change="toggleValue('fixVersion', fv)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ fv }}</span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <!-- Component -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Component</label>
-      <select
-        :value="modelValue.component || ''"
-        @change="update('component', $event.target.value || null)"
-        class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <option value="">All components</option>
-        <option v-for="c in components" :key="c" :value="c" class="text-xs">{{ c }}</option>
-      </select>
+    <div v-if="components.length > 0" class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Component</label>
+      <div ref="componentRef" class="relative">
+        <button type="button" @click="toggleDropdown('component')" @keydown.escape="componentOpen = false" :aria-expanded="componentOpen" aria-haspopup="listbox" :class="(modelValue.component || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.component, 'All components') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="componentOpen" role="group" :class="dropdownClass" @keydown.escape="componentOpen = false">
+          <label v-for="c in components" :key="c" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.component || []).includes(c)" @change="toggleValue('component', c)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ c }}</span>
+          </label>
+        </div>
+      </div>
     </div>
 
-    <!-- Team / Delivery Owner -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Team</label>
-      <select
-        :value="modelValue.team || ''"
-        @change="update('team', $event.target.value || null)"
-        class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <option value="">All teams</option>
-        <option v-for="t in teams" :key="t" :value="t" class="text-xs">{{ t }}</option>
-      </select>
+    <!-- Team -->
+    <div v-if="teams.length > 0" class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Team</label>
+      <div ref="teamRef" class="relative">
+        <button type="button" @click="toggleDropdown('team')" @keydown.escape="teamOpen = false" :aria-expanded="teamOpen" aria-haspopup="listbox" :class="(modelValue.team || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.team, 'All teams') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="teamOpen" role="group" :class="dropdownClass" @keydown.escape="teamOpen = false">
+          <label v-for="t in teams" :key="t" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.team || []).includes(t)" @change="toggleValue('team', t)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ t }}</span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <!-- Priority -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Priority</label>
-      <select
-        :value="modelValue.priority || ''"
-        @change="update('priority', $event.target.value || null)"
-        class="text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <option value="">All priorities</option>
-        <option v-for="p in priorities" :key="p" :value="p" class="text-xs">{{ p }}</option>
-      </select>
+    <div v-if="priorities.length > 0" class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Priority</label>
+      <div ref="priorityRef" class="relative">
+        <button type="button" @click="toggleDropdown('priority')" @keydown.escape="priorityOpen = false" :aria-expanded="priorityOpen" aria-haspopup="listbox" :class="(modelValue.priority || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.priority, 'All priorities') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="priorityOpen" role="group" :class="dropdownClass" @keydown.escape="priorityOpen = false">
+          <label v-for="p in priorities" :key="p" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.priority || []).includes(p)" @change="toggleValue('priority', p)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ p }}</span>
+          </label>
+        </div>
+      </div>
     </div>
 
-    <!-- Needs Attention toggle -->
-    <div class="flex flex-col gap-0.5">
-      <label class="text-sm font-medium text-gray-600 dark:text-gray-400">Needs Attention</label>
-      <button
-        type="button"
-        @click="toggleNeedsAttention"
-        :aria-pressed="modelValue.needsAttention"
-        class="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-        :class="modelValue.needsAttention
-          ? 'bg-amber-100 dark:bg-amber-900/40 border-amber-300 dark:border-amber-600 text-amber-800 dark:text-amber-300'
-          : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
-      >
-        <span aria-hidden="true">⚠</span>
-        {{ modelValue.needsAttention ? 'On' : 'Off' }}
-      </button>
-    </div>
-
-    <!-- Clear filters button -->
+    <!-- Clear filters -->
     <div v-if="hasActiveFilters" class="flex flex-col gap-0.5 justify-end">
-      <span class="text-sm font-medium text-transparent select-none">Clear</span>
-      <button
-        type="button"
-        @click="clearFilters"
-        class="inline-flex items-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-transparent hover:border-gray-300 dark:hover:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400"
-      >
-        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
+      <span class="text-xs font-medium text-transparent select-none">Clear</span>
+      <button type="button" @click="clearFilters" class="inline-flex items-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 border border-transparent hover:border-gray-300 dark:hover:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400">
+        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
         Clear filters
       </button>
     </div>

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -20,25 +20,23 @@ const selectedFeature = ref(null)
 const selectedVersion = ref('')
 
 const filters = ref({
-  outcome: null,
-  targetVersion: null,
-  fixVersion: null,
-  component: null,
-  priority: null,
-  team: null,
-  readiness: null,
-  needsAttention: false
+  outcome: [],
+  targetVersion: [],
+  fixVersion: [],
+  component: [],
+  priority: [],
+  team: [],
+  readiness: null
 })
 
 function matchesFilters(feature) {
   const f = filters.value
-  if (f.outcome && feature.bigRock !== f.outcome) return false
-  if (f.targetVersion && !(feature.targetVersions || []).includes(f.targetVersion)) return false
-  if (f.fixVersion && feature.fixVersion !== f.fixVersion) return false
-  if (f.component && !(feature.components || []).includes(f.component)) return false
-  if (f.priority && feature.priority !== f.priority) return false
-  if (f.team && feature.team !== f.team) return false
-  if (f.needsAttention && !feature.needsAttention) return false
+  if (f.outcome.length && !f.outcome.includes(feature.bigRock)) return false
+  if (f.targetVersion.length && !(feature.targetVersions || []).some(function(tv) { return f.targetVersion.includes(tv) })) return false
+  if (f.fixVersion.length && !f.fixVersion.includes(feature.fixVersion)) return false
+  if (f.component.length && !(feature.components || []).some(function(c) { return f.component.includes(c) })) return false
+  if (f.priority.length && !f.priority.includes(feature.priority)) return false
+  if (f.team.length && !f.team.includes(feature.team)) return false
   if (f.readiness === 'ready' && feature.confidence === 'not-ready') return false
   if (f.readiness === 'not-ready' && feature.confidence !== 'not-ready') return false
   if (selectedVersion.value) {
@@ -62,13 +60,12 @@ const filteredFeatures = computed(() => {
 const readyCounts = computed(() => {
   var all = pendingReview.value.concat(ready.value).filter(function(f) {
     const fv = filters.value
-    if (fv.outcome && f.bigRock !== fv.outcome) return false
-    if (fv.targetVersion && !(f.targetVersions || []).includes(fv.targetVersion)) return false
-    if (fv.fixVersion && f.fixVersion !== fv.fixVersion) return false
-    if (fv.component && !(f.components || []).includes(fv.component)) return false
-    if (fv.priority && f.priority !== fv.priority) return false
-    if (fv.team && f.team !== fv.team) return false
-    if (fv.needsAttention && !f.needsAttention) return false
+    if (fv.outcome.length && !fv.outcome.includes(f.bigRock)) return false
+    if (fv.targetVersion.length && !(f.targetVersions || []).some(function(tv) { return fv.targetVersion.includes(tv) })) return false
+    if (fv.fixVersion.length && !fv.fixVersion.includes(f.fixVersion)) return false
+    if (fv.component.length && !(f.components || []).some(function(c) { return fv.component.includes(c) })) return false
+    if (fv.priority.length && !fv.priority.includes(f.priority)) return false
+    if (fv.team.length && !fv.team.includes(f.team)) return false
     if (selectedVersion.value) {
       if (!(f.targetVersions || []).some(function(tv) {
         return tv === selectedVersion.value || tv.indexOf(selectedVersion.value) !== -1 || selectedVersion.value.indexOf(tv) !== -1

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1454,4 +1454,181 @@ describe('buildFeatureReadiness', function() {
     })
   })
 
+
+  describe('hygiene alias lookup', function() {
+    it('finds hygiene cache via registry displayName when config key differs', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var violations = [{ id: 'stale-status-summary', name: 'Stale', category: 'timeliness', message: 'Stale' }]
+      var hygieneCache = {
+        features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
+      }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var registryData = {
+        releases: [
+          { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: ['RHOAI-3.6'], state: 'active', milestones: {} }
+        ]
+      }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/registry.json': registryData,
+        'releases/hygiene/features-RHOAI 3.6.json': hygieneCache
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready[0].violations).toEqual(violations)
+    })
+
+    it('finds hygiene cache via registry id alias', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var violations = [{ id: 'missing-assignee', name: 'No assignee', category: 'ownership', message: 'No assignee' }]
+      var hygieneCache = {
+        features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
+      }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var registryData = {
+        releases: [
+          { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: ['RHOAI-3.6'], state: 'active', milestones: {} }
+        ]
+      }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/registry.json': registryData,
+        'releases/hygiene/features-rhoai-3.6.json': hygieneCache
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.pendingReview[0].violations).toEqual(violations)
+      expect(result.pendingReview[0].readinessGates.noBlockingViolations).toBe(false)
+    })
+
+    it('prefers direct config key match over alias', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var directViolations = [{ id: 'stale-status-summary', name: 'Direct', category: 'timeliness', message: 'Direct' }]
+      var aliasViolations = [{ id: 'missing-assignee', name: 'Alias', category: 'ownership', message: 'Alias' }]
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var registryData = {
+        releases: [
+          { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: [], state: 'active', milestones: {} }
+        ]
+      }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/registry.json': registryData,
+        'releases/hygiene/features-3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'A', violations: directViolations } } },
+        'releases/hygiene/features-RHOAI 3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'A', violations: aliasViolations } } }
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready[0].violations).toEqual(directViolations)
+    })
+  })
+
+  describe('hygieneIndex independent of teamIndex', function() {
+    it('indexes violations separately from team across versions', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var violations = [{ id: 'stale-status-summary', name: 'Stale', category: 'timeliness', message: 'Stale' }]
+      var config = { releases: { '3.5': { release: '3.5' }, '3.6': { release: '3.6' } } }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': config,
+        'releases/planning/health-cache-3.5-all.json': healthCache,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/hygiene/features-3.5.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha' } } },
+        'releases/hygiene/features-3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', violations: violations } } }
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready[0].team).toBe('Alpha')
+      expect(result.ready[0].violations).toEqual(violations)
+    })
+  })
+
+  describe('released version filtering', function() {
+    it('excludes features whose target versions are all archived', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80, targetRelease: '3.6' }] }
+      var registryData = {
+        releases: [
+          { id: 'rhoai-3.6', displayName: '3.6', fixVersions: [], state: 'archived', milestones: {} }
+        ]
+      }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/registry.json': registryData
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready).toHaveLength(0)
+      expect(result.pendingReview).toHaveLength(0)
+    })
+
+    it('excludes features whose target versions have past GA date', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80, targetRelease: '3.6' }] }
+      var registryData = {
+        releases: [
+          { id: 'rhoai-3.6', displayName: '3.6', fixVersions: [], state: 'active', milestones: { ga: '2020-01-01' } }
+        ]
+      }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/registry.json': registryData
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready).toHaveLength(0)
+      expect(result.pendingReview).toHaveLength(0)
+    })
+
+    it('includes features targeting active versions with future GA date', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80, targetRelease: '3.6' }] }
+      var registryData = {
+        releases: [
+          { id: 'rhoai-3.6', displayName: '3.6', fixVersions: [], state: 'active', milestones: { ga: '2099-01-01' } }
+        ]
+      }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache,
+        'releases/registry.json': registryData
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready).toHaveLength(1)
+    })
+
+    it('includes features when no registry exists', function() {
+      var store = makeFeaturesStore({
+        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+      })
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80 }] }
+      var readFromStorage = makeReadFromStorage({
+        'ai-impact/features.json': store,
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache
+      })
+      var result = buildFeatureReadiness(readFromStorage)
+      expect(result.ready).toHaveLength(1)
+    })
+  })
 })

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -148,11 +148,52 @@ function buildFeatureReadiness(readFromStorage) {
   var teamIndex = new Map()
   var hygieneIndex = new Map()
 
+  var registry = readFromStorage('releases/registry.json')
+  var registryReleases = (registry && registry.releases) || []
+
+  var versionAliasMap = {}
+  var releasedVersions = new Set()
+  for (var ri = 0; ri < registryReleases.length; ri++) {
+    var rel = registryReleases[ri]
+    var aliases = [rel.displayName, rel.id].concat(rel.fixVersions || []).filter(Boolean)
+    for (var ai = 0; ai < aliases.length; ai++) {
+      versionAliasMap[aliases[ai]] = aliases
+    }
+    var isArchived = rel.state === 'archived'
+    var gaDate = rel.milestones && (rel.milestones.gaDate || rel.milestones.ga)
+    var isReleased = false
+    if (gaDate) {
+      var gaTime = new Date(gaDate + 'T00:00:00Z').getTime()
+      if (!isNaN(gaTime) && Date.now() > gaTime) isReleased = true
+    }
+    if (isArchived || isReleased) {
+      for (var rvi = 0; rvi < aliases.length; rvi++) {
+        releasedVersions.add(aliases[rvi])
+      }
+    }
+  }
+
   var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
+
+  for (var cvi = 0; cvi < configuredVersions.length; cvi++) {
+    var cv = configuredVersions[cvi]
+    if (!versionAliasMap[cv]) {
+      for (var ri2 = 0; ri2 < registryReleases.length; ri2++) {
+        var rel2 = registryReleases[ri2]
+        var a2 = [rel2.displayName, rel2.id].concat(rel2.fixVersions || []).filter(Boolean)
+        for (var ai2 = 0; ai2 < a2.length; ai2++) {
+          if (a2[ai2].indexOf(cv) !== -1 || cv.indexOf(a2[ai2]) !== -1) {
+            versionAliasMap[cv] = a2
+            break
+          }
+        }
+        if (versionAliasMap[cv]) break
+      }
+    }
+  }
 
   for (var vi = 0; vi < configuredVersions.length; vi++) {
     var ver = configuredVersions[vi]
-
     var candidateCache = readFromStorage('releases/planning/candidates-cache-' + ver + '.json')
     if (candidateCache && candidateCache.data && Array.isArray(candidateCache.data.features)) {
       var candidates = candidateCache.data.features
@@ -172,13 +213,21 @@ function buildFeatureReadiness(readFromStorage) {
     }
 
     var hygieneData = readFromStorage('releases/hygiene/features-' + ver + '.json')
+    if (!hygieneData && versionAliasMap[ver]) {
+      var hygieneAliases = versionAliasMap[ver]
+      for (var ali = 0; ali < hygieneAliases.length && !hygieneData; ali++) {
+        if (hygieneAliases[ali] !== ver) {
+          hygieneData = readFromStorage('releases/hygiene/features-' + hygieneAliases[ali] + '.json')
+        }
+      }
+    }
     if (hygieneData && hygieneData.features) {
       var hkeys = Object.keys(hygieneData.features)
       for (var ti = 0; ti < hkeys.length; ti++) {
         var feat = hygieneData.features[hkeys[ti]]
-        if (feat && !teamIndex.has(hkeys[ti])) {
-          if (feat.team) teamIndex.set(hkeys[ti], feat.team)
-          if (feat.violations) hygieneIndex.set(hkeys[ti], feat.violations)
+        if (feat) {
+          if (!teamIndex.has(hkeys[ti]) && feat.team) teamIndex.set(hkeys[ti], feat.team)
+          if (!hygieneIndex.has(hkeys[ti]) && feat.violations) hygieneIndex.set(hkeys[ti], feat.violations)
         }
       }
     }
@@ -406,6 +455,18 @@ function buildFeatureReadiness(readFromStorage) {
     }
     return b.rubricTotal - a.rubricTotal
   }
+
+  function isReleasedFeature(feature) {
+    var tvs = feature.targetVersions || []
+    if (tvs.length === 0) return false
+    for (var tvi2 = 0; tvi2 < tvs.length; tvi2++) {
+      if (!releasedVersions.has(tvs[tvi2])) return false
+    }
+    return true
+  }
+
+  pendingReview = pendingReview.filter(function(f) { return !isReleasedFeature(f) })
+  ready = ready.filter(function(f) { return !isReleasedFeature(f) })
 
   pendingReview.sort(sortFeatures)
   ready.sort(sortFeatures)


### PR DESCRIPTION
## Summary

- **Multi-select filter bar**: Converted 6 filter dropdowns (Outcome, Target Version, Fix Version, Component, Team, Priority) to checkbox-based multi-select with AND semantics across filter groups and OR within each group
- **Hygiene data lookup fix**: Fixed version alias resolution so hygiene violations and team data load correctly even when config keys don't exactly match registry entries
- **Removed released version filter**: Removed `isReleasedFeature()` filter that was dropping features targeting versions with past GA dates
- **Direct Jira query**: Added `feature-query.js` that queries Jira directly for all open RHAISTRAT features (`project = RHAISTRAT AND status NOT IN (Closed, Resolved)`). The feature list now uses a three-pass approach: (1) strat-creator features enriched with Jira + cache data, (2) health-pipeline features from caches, (3) Jira-only features not in passes 1/2. Falls back to cache-only when Jira credentials are unavailable.

## Test plan

- 154 backend tests pass (`feature-readiness.test.js` + `feature-query.test.js`)
- 22 client-side FilterBar component tests pass
- Tests cover: JQL construction, issue normalization, pass 3 Jira-only features, deduplication across passes, readiness gates for Jira-only features, label-based review status derivation, filter metadata population, backward compatibility with null jiraFeatures