### PR TITLE
feat(releases): PM Hub filter pane + leads enhancement

### DIFF
--- a/modules/releases/__tests__/server/pm-hub/pillar-config.test.js
+++ b/modules/releases/__tests__/server/pm-hub/pillar-config.test.js
@@ -42,10 +42,31 @@ describe('validatePillarConfig', function () {
     })).toMatch(/must have a components array/)
   })
 
-  it('rejects non-string component entries', function () {
+  it('rejects non-string/non-object component entries', function () {
     expect(validatePillarConfig({
       pillars: [{ name: 'Test', components: [123] }]
-    })).toMatch(/must be strings/)
+    })).toMatch(/must be strings or objects/)
+  })
+
+  it('accepts object components with name, pmLead, engLead', function () {
+    expect(validatePillarConfig({
+      pillars: [{ name: 'Test', components: [
+        { name: 'Comp A', pmLead: 'Alice', engLead: 'Bob' },
+        { name: 'Comp B', pmLead: '', engLead: '' }
+      ] }]
+    })).toBe(null)
+  })
+
+  it('accepts mixed string and object components', function () {
+    expect(validatePillarConfig({
+      pillars: [{ name: 'Test', components: ['plain-string', { name: 'Obj Comp', pmLead: 'X', engLead: 'Y' }] }]
+    })).toBe(null)
+  })
+
+  it('rejects object component without name', function () {
+    expect(validatePillarConfig({
+      pillars: [{ name: 'Test', components: [{ pmLead: 'Alice' }] }]
+    })).toMatch(/must be strings or objects/)
   })
 })
 
@@ -63,6 +84,13 @@ describe('DEFAULT_PILLAR_CONFIG', function () {
     for (var i = 0; i < DEFAULT_PILLAR_CONFIG.pillars.length; i++) {
       expect(DEFAULT_PILLAR_CONFIG.pillars[i].components.length).toBeGreaterThan(0)
     }
+  })
+
+  it('components have name, pmLead, and engLead fields', function () {
+    var first = DEFAULT_PILLAR_CONFIG.pillars[0].components[0]
+    expect(first).toHaveProperty('name')
+    expect(first).toHaveProperty('pmLead')
+    expect(first).toHaveProperty('engLead')
   })
 
   it('passes its own validation', function () {

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -3,16 +3,13 @@ import { reactive, computed } from 'vue'
 
 const props = defineProps({
   groups: { type: Array, default: () => [] },
-  activeFilter: { type: String, default: null },
   componentLeads: { type: Object, default: () => ({}) }
 })
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse'
 
 const COMP_STYLE = {
-  bg: 'bg-slate-50 dark:bg-slate-800/40',
   border: 'border-l-primary-500',
-  badge: 'bg-primary-100 dark:bg-primary-800/40 text-primary-700 dark:text-primary-300',
   dot: 'bg-primary-500'
 }
 
@@ -65,7 +62,6 @@ function extractProduct(versionName) {
 }
 
 var componentGroups = computed(function() {
-  var filter = props.activeFilter
   var compMap = {}
 
   for (var gi = 0; gi < props.groups.length; gi++) {
@@ -79,10 +75,7 @@ var componentGroups = computed(function() {
       if (!compMap[cName]) {
         compMap[cName] = {
           component: cName,
-          features: {},
-          requestedCount: 0,
-          committedCount: 0,
-          blockedCount: 0
+          features: {}
         }
       }
 
@@ -113,10 +106,6 @@ var componentGroups = computed(function() {
         var feat = allFeatures[ai]
         var isReq = !!reqKeys[feat.key]
         var isCom = !!comKeys[feat.key]
-
-        if (filter === 'requested' && !isReq) continue
-        if (filter === 'committed' && !isCom) continue
-        if (filter === 'blocked' && !feat.isBlocked) continue
 
         if (!cg.features[feat.key]) {
           cg.features[feat.key] = {
@@ -363,10 +352,10 @@ defineExpose({ expandAll, collapseAll })
           </tr>
         </template>
 
-        <!-- No matching results for active filter -->
-        <tr v-if="componentGroups.length === 0 && activeFilter">
+        <!-- No results -->
+        <tr v-if="componentGroups.length === 0">
           <td colspan="9" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
-            No {{ activeFilter }} features found.
+            No features match the current filters.
           </td>
         </tr>
       </tbody>

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -3,7 +3,8 @@ import { reactive, computed } from 'vue'
 
 const props = defineProps({
   groups: { type: Array, default: () => [] },
-  activeFilter: { type: String, default: null }
+  activeFilter: { type: String, default: null },
+  componentLeads: { type: Object, default: () => ({}) }
 })
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse'
@@ -41,6 +42,17 @@ function collapseAll() {
   for (var i = 0; i < src.length; i++) {
     delete expandedComponents[src[i].component]
   }
+}
+
+function getLeads(componentName) {
+  var lower = (componentName || '').toLowerCase()
+  var leads = props.componentLeads
+  if (leads[lower]) return leads[lower]
+  var keys = Object.keys(leads)
+  for (var i = 0; i < keys.length; i++) {
+    if (lower.includes(keys[i]) || keys[i].includes(lower)) return leads[keys[i]]
+  }
+  return null
 }
 
 function extractProduct(versionName) {
@@ -201,7 +213,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="9" class="px-4 py-3.5">
+            <td colspan="9" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -224,6 +236,26 @@ defineExpose({ expandAll, collapseAll })
                     ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
                     : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
                 >{{ comp.blockedCount }} blocked</span>
+              </div>
+              <div v-if="getLeads(comp.component)" class="flex items-center gap-5 mt-2 ml-[38px]">
+                <div v-if="getLeads(comp.component).pmLead" class="flex items-center gap-1.5">
+                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/40">
+                    <svg class="w-3 h-3 text-violet-600 dark:text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                    </svg>
+                  </span>
+                  <span class="text-[11px] font-bold text-violet-600 dark:text-violet-400 uppercase tracking-wide">PM</span>
+                  <span class="text-xs text-gray-700 dark:text-gray-300 font-medium">{{ getLeads(comp.component).pmLead }}</span>
+                </div>
+                <div v-if="getLeads(comp.component).engLead" class="flex items-center gap-1.5">
+                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-sky-100 dark:bg-sky-900/40">
+                    <svg class="w-3 h-3 text-sky-600 dark:text-sky-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                    </svg>
+                  </span>
+                  <span class="text-[11px] font-bold text-sky-600 dark:text-sky-400 uppercase tracking-wide">Eng</span>
+                  <span class="text-xs text-gray-700 dark:text-gray-300 font-medium">{{ getLeads(comp.component).engLead }}</span>
+                </div>
               </div>
             </td>
           </tr>

--- a/modules/releases/client/plan/components/PillarConfigPanel.vue
+++ b/modules/releases/client/plan/components/PillarConfigPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="open" class="fixed inset-0 z-[100] flex justify-end" @mousedown.self="$emit('close')">
-    <div class="w-full max-w-lg bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 flex flex-col h-full">
+    <div class="w-full max-w-2xl bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 flex flex-col h-full">
       <!-- Header -->
       <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
         <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Pillar Configuration</h3>
@@ -17,7 +17,7 @@
       <!-- Body -->
       <div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
         <p class="text-xs text-gray-500 dark:text-gray-400">
-          Define which Jira components belong to each pillar. Components are matched using substring matching against Jira's component names.
+          Define which Jira components belong to each pillar, along with their PM and Engineering leads.
         </p>
 
         <div v-for="(pillar, pi) in draft" :key="pi" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
@@ -51,32 +51,51 @@
           </div>
 
           <!-- Components list (expandable) -->
-          <div v-if="expanded[pi]" class="px-3 py-2 space-y-1.5 border-t border-gray-100 dark:border-gray-700">
-            <div v-for="(comp, ci) in pillar.components" :key="ci" class="flex items-center gap-1.5">
-              <input
-                v-model="pillar.components[ci]"
-                class="flex-1 text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
-              />
+          <div v-if="expanded[pi]" class="border-t border-gray-100 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800">
+            <div v-for="(comp, ci) in pillar.components" :key="ci" class="px-3 py-2">
+              <div class="flex items-center gap-1.5">
+                <input
+                  v-model="comp.name"
+                  class="flex-1 text-sm font-medium bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2 py-1 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+                  placeholder="Component name"
+                />
+                <button
+                  type="button"
+                  @click="removeComponent(pi, ci)"
+                  class="p-0.5 rounded text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <div class="flex items-center gap-2 mt-1.5 ml-0.5">
+                <label class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase w-7 flex-shrink-0">PM</label>
+                <input
+                  v-model="comp.pmLead"
+                  class="flex-1 text-xs bg-white dark:bg-gray-800/60 border border-gray-200 dark:border-gray-600 rounded px-2 py-0.5 text-gray-600 dark:text-gray-400 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
+                  placeholder="PM Lead"
+                />
+                <label class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase w-7 flex-shrink-0">Eng</label>
+                <input
+                  v-model="comp.engLead"
+                  class="flex-1 text-xs bg-white dark:bg-gray-800/60 border border-gray-200 dark:border-gray-600 rounded px-2 py-0.5 text-gray-600 dark:text-gray-400 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
+                  placeholder="Engineering Lead"
+                />
+              </div>
+            </div>
+            <div class="px-3 py-2">
               <button
                 type="button"
-                @click="removeComponent(pi, ci)"
-                class="p-0.5 rounded text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                @click="addComponent(pi)"
+                class="flex items-center gap-1 text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium"
               >
-                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
                 </svg>
+                Add component
               </button>
             </div>
-            <button
-              type="button"
-              @click="addComponent(pi)"
-              class="flex items-center gap-1 text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium mt-1"
-            >
-              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-              </svg>
-              Add component
-            </button>
           </div>
         </div>
 
@@ -130,9 +149,19 @@ var saving = ref(false)
 var saveError = ref(null)
 var saveSuccess = ref(false)
 
+function normalizeComponent(c) {
+  if (typeof c === 'string') return { name: c, pmLead: '', engLead: '' }
+  return { name: c.name || '', pmLead: c.pmLead || '', engLead: c.engLead || '' }
+}
+
 watch(function() { return props.open }, function(isOpen) {
   if (isOpen) {
-    draft.value = JSON.parse(JSON.stringify(props.config.pillars || []))
+    draft.value = (props.config.pillars || []).map(function(p) {
+      return {
+        name: p.name,
+        components: (p.components || []).map(normalizeComponent)
+      }
+    })
     expanded.value = {}
     saveError.value = null
     saveSuccess.value = false
@@ -153,7 +182,7 @@ function removePillar(idx) {
 }
 
 function addComponent(pillarIdx) {
-  draft.value[pillarIdx].components.push('')
+  draft.value[pillarIdx].components.push({ name: '', pmLead: '', engLead: '' })
 }
 
 function removeComponent(pillarIdx, compIdx) {
@@ -170,7 +199,11 @@ async function save() {
     .map(function(p) {
       return {
         name: p.name.trim(),
-        components: p.components.filter(function(c) { return c.trim() }).map(function(c) { return c.trim() })
+        components: p.components
+          .filter(function(c) { return c.name.trim() })
+          .map(function(c) {
+            return { name: c.name.trim(), pmLead: (c.pmLead || '').trim(), engLead: (c.engLead || '').trim() }
+          })
       }
     })
 

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -368,6 +368,7 @@
       ref="tableRef"
       :groups="groups"
       :activeFilter="activeFilter"
+      :componentLeads="componentLeads"
     />
 
     <!-- Pillar config panel -->
@@ -472,6 +473,21 @@ var pillarNames = computed(function() {
   return pillarConfig.value.pillars.map(function(p) { return p.name })
 })
 
+var componentLeads = computed(function() {
+  var map = {}
+  var pillars = pillarConfig.value.pillars || []
+  for (var pi = 0; pi < pillars.length; pi++) {
+    var comps = pillars[pi].components || []
+    for (var ci = 0; ci < comps.length; ci++) {
+      var c = comps[ci]
+      if (typeof c === 'object' && c !== null && c.name) {
+        map[c.name.toLowerCase()] = { pmLead: c.pmLead || '', engLead: c.engLead || '' }
+      }
+    }
+  }
+  return map
+})
+
 var filteredPillarNames = computed(function() {
   var q = pillarSearch.value.toLowerCase().trim()
   if (!q) return pillarNames.value
@@ -487,7 +503,9 @@ var pillarAllowedComponents = computed(function() {
     var pillar = pillarConfig.value.pillars.find(function(p) { return p.name === selectedPillars.value[pi] })
     if (!pillar) continue
     for (var ci = 0; ci < pillar.components.length; ci++) {
-      allowed.add(pillar.components[ci].toLowerCase())
+      var pc = pillar.components[ci]
+      var pcName = typeof pc === 'string' ? pc : (pc && pc.name) || ''
+      if (pcName) allowed.add(pcName.toLowerCase())
     }
   }
   return allowed

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -102,6 +102,8 @@
           </div>
         </div>
 
+        <p v-if="componentError" class="text-xs text-red-500 self-end pb-1">{{ componentError }}</p>
+
         <!-- Release -->
         <div class="relative min-w-[180px] flex-1 max-w-[260px]" ref="versionDropdownRef">
           <label class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1 block">Release</label>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-6">
+  <div class="space-y-5">
     <div class="flex items-start justify-between">
       <div>
         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Component Release Load Tracking</h2>
@@ -31,334 +31,285 @@
       </div>
     </div>
 
-    <div class="flex flex-wrap items-start gap-4">
-      <!-- Pillar Filter -->
-      <div class="min-w-[200px] max-w-[280px] relative" ref="pillarDropdownRef">
-        <div class="flex items-center justify-between mb-1">
-          <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Pillar</label>
-          <button
-            v-if="selectedPillars.length > 0"
-            type="button"
-            @click="selectedPillars = []; pillarSearch = ''"
-            class="text-[10px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
-          >Clear</button>
+    <!-- ═══ FILTER PANE ═══ -->
+    <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50/60 dark:bg-gray-800/40">
+      <!-- Pane header -->
+      <div class="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-800/60">
+        <div class="flex items-center gap-2">
+          <svg class="w-4 h-4 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+          </svg>
+          <span class="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Filters</span>
+          <span v-if="activeFilterCount > 0" class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary-500 text-white text-[10px] font-bold">{{ activeFilterCount }}</span>
         </div>
-        <div
-          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
-          :class="{ 'ring-2 ring-primary-500 border-primary-500': pillarDropdownOpen }"
-          @click="openPillarDropdown"
-        >
-          <span
-            v-for="name in selectedPillars"
-            :key="name"
-            class="inline-flex items-center gap-1 bg-violet-100 dark:bg-violet-900/50 text-violet-700 dark:text-violet-300 rounded px-1.5 py-0.5 text-xs font-medium"
+        <button
+          v-if="activeFilterCount > 0"
+          @click="clearAllFilters"
+          class="text-[11px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+        >Clear All</button>
+      </div>
+
+      <!-- Row 1: Data filters -->
+      <div class="px-4 py-3 flex flex-wrap items-start gap-3 border-b border-gray-100 dark:border-gray-700/50">
+        <!-- Pillar -->
+        <div class="relative min-w-[180px] flex-1 max-w-[260px]" ref="pillarDropdownRef">
+          <label class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1 block">Pillar</label>
+          <div
+            class="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 cursor-text flex flex-wrap items-center gap-1 min-h-[32px] text-xs"
+            :class="{ 'ring-1 ring-primary-400 border-primary-400': pillarDropdownOpen }"
+            @click="openPillarDropdown"
           >
-            {{ name }}
-            <button type="button" class="hover:text-violet-900 dark:hover:text-violet-100" @click.stop="togglePillar(name)">&times;</button>
-          </span>
-          <input
-            ref="pillarInputRef"
-            v-model="pillarSearch"
-            type="text"
-            class="flex-1 min-w-[60px] bg-transparent outline-none text-sm placeholder-gray-400 dark:placeholder-gray-500"
-            :placeholder="selectedPillars.length ? '' : 'Select pillar…'"
-            @focus="pillarDropdownOpen = true"
-            @keydown.backspace="onPillarBackspace"
-          />
-        </div>
-        <div
-          v-if="pillarDropdownOpen"
-          class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
-        >
-          <div v-if="filteredPillarNames.length === 0" class="px-3 py-2 text-xs text-gray-400">No pillars</div>
-          <button
-            v-for="name in filteredPillarNames"
-            :key="name"
-            type="button"
-            class="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-            @mousedown.prevent="togglePillar(name)"
-          >
-            <span
-              class="w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-xs"
-              :class="selectedPillars.includes(name)
-                ? 'bg-violet-500 border-violet-500 text-white'
-                : 'border-gray-300 dark:border-gray-500'"
-            >
-              <span v-if="selectedPillars.includes(name)">&#10003;</span>
+            <span v-for="name in selectedPillars" :key="name" class="inline-flex items-center gap-0.5 bg-violet-100 dark:bg-violet-900/50 text-violet-700 dark:text-violet-300 rounded px-1.5 py-0.5 text-[11px] font-medium">
+              {{ name }}
+              <button type="button" class="hover:text-violet-900 dark:hover:text-violet-100" @click.stop="togglePillar(name)">&times;</button>
             </span>
-            {{ name }}
-          </button>
+            <input ref="pillarInputRef" v-model="pillarSearch" type="text" class="flex-1 min-w-[50px] bg-transparent outline-none text-xs placeholder-gray-400 dark:placeholder-gray-500" :placeholder="selectedPillars.length ? '' : 'All'" @focus="pillarDropdownOpen = true" @keydown.backspace="onPillarBackspace" />
+          </div>
+          <div v-if="pillarDropdownOpen" class="absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg">
+            <div v-if="filteredPillarNames.length === 0" class="px-3 py-2 text-xs text-gray-400">No pillars</div>
+            <button v-for="name in filteredPillarNames" :key="name" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="togglePillar(name)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="selectedPillars.includes(name) ? 'bg-violet-500 border-violet-500 text-white' : 'border-gray-300 dark:border-gray-500'">
+                <span v-if="selectedPillars.includes(name)">&#10003;</span>
+              </span>
+              {{ name }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Jira Component -->
+        <div class="relative min-w-[220px] flex-[2] max-w-[400px]" ref="componentDropdownRef">
+          <label class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1 block">Jira Component</label>
+          <div
+            class="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 cursor-text flex flex-wrap items-center gap-1 min-h-[32px] text-xs"
+            :class="{ 'ring-1 ring-primary-400 border-primary-400': componentDropdownOpen }"
+            @click="openComponentDropdown"
+          >
+            <span v-for="name in selectedComponents" :key="name" class="inline-flex items-center gap-0.5 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 rounded px-1.5 py-0.5 text-[11px] font-medium">
+              {{ name }}
+              <button type="button" class="hover:text-primary-900 dark:hover:text-primary-100" @click.stop="toggleComponent(name)">&times;</button>
+            </span>
+            <input ref="componentInputRef" v-model="componentSearch" type="text" class="flex-1 min-w-[60px] bg-transparent outline-none text-xs placeholder-gray-400 dark:placeholder-gray-500" :placeholder="selectedComponents.length ? '' : 'Search…'" @focus="componentDropdownOpen = true" @keydown.backspace="onComponentBackspace" />
+          </div>
+          <div v-if="componentDropdownOpen" class="absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg">
+            <div v-if="loadingComponents" class="px-3 py-2 text-xs text-gray-400">Loading…</div>
+            <div v-else-if="filteredComponents.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
+            <button v-for="name in filteredComponents" :key="name" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="toggleComponent(name)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="selectedComponents.includes(name) ? 'bg-primary-500 border-primary-500 text-white' : 'border-gray-300 dark:border-gray-500'">
+                <span v-if="selectedComponents.includes(name)">&#10003;</span>
+              </span>
+              {{ name }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Release -->
+        <div class="relative min-w-[180px] flex-1 max-w-[260px]" ref="versionDropdownRef">
+          <label class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1 block">Release</label>
+          <div
+            class="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 cursor-text flex flex-wrap items-center gap-1 min-h-[32px] text-xs"
+            :class="{ 'ring-1 ring-primary-400 border-primary-400': versionDropdownOpen }"
+            @click="openVersionDropdown"
+          >
+            <span v-for="name in selectedVersions" :key="name" class="inline-flex items-center gap-0.5 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 rounded px-1.5 py-0.5 text-[11px] font-medium">
+              {{ name }}
+              <button type="button" class="hover:text-primary-900 dark:hover:text-primary-100" @click.stop="toggleVersion(name)">&times;</button>
+            </span>
+            <input ref="versionInputRef" v-model="versionSearch" type="text" class="flex-1 min-w-[50px] bg-transparent outline-none text-xs placeholder-gray-400 dark:placeholder-gray-500" :placeholder="selectedVersions.length ? '' : 'All'" @focus="versionDropdownOpen = true" @keydown.backspace="onVersionBackspace" />
+          </div>
+          <div v-if="versionDropdownOpen" class="absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg">
+            <div v-if="filteredVersions.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
+            <button v-for="name in filteredVersions" :key="name" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="toggleVersion(name)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="selectedVersions.includes(name) ? 'bg-primary-500 border-primary-500 text-white' : 'border-gray-300 dark:border-gray-500'">
+                <span v-if="selectedVersions.includes(name)">&#10003;</span>
+              </span>
+              {{ name }}
+            </button>
+          </div>
         </div>
       </div>
 
-      <!-- Jira Component Filter -->
-      <div class="min-w-[280px] max-w-[400px] relative" ref="componentDropdownRef">
-        <div class="flex items-center justify-between mb-1">
-          <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Jira Component</label>
+      <!-- Row 2: Result filters (only when data loaded) -->
+      <div v-if="groups.length > 0 && !loadingData" class="px-4 py-2.5 flex flex-wrap items-center gap-2">
+        <!-- Product -->
+        <div class="relative" ref="productDropdownRef">
           <button
-            v-if="selectedComponents.length > 0"
             type="button"
-            @click="selectedComponents = []; componentSearch = ''"
-            class="text-[10px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
-          >Clear</button>
-        </div>
-        <div
-          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
-          :class="{ 'ring-2 ring-primary-500 border-primary-500': componentDropdownOpen }"
-          @click="openComponentDropdown"
-        >
-          <span
-            v-for="name in selectedComponents"
-            :key="name"
-            class="inline-flex items-center gap-1 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 rounded px-1.5 py-0.5 text-xs font-medium"
+            @click="productDropdownOpen = !productDropdownOpen"
+            class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+            :class="filterProduct.length > 0 ? 'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-300 dark:border-indigo-700 text-indigo-700 dark:text-indigo-300' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
           >
-            {{ name }}
-            <button type="button" class="hover:text-primary-900 dark:hover:text-primary-100" @click.stop="toggleComponent(name)">&times;</button>
-          </span>
-          <input
-            ref="componentInputRef"
-            v-model="componentSearch"
-            type="text"
-            class="flex-1 min-w-[80px] bg-transparent outline-none text-sm placeholder-gray-400 dark:placeholder-gray-500"
-            :placeholder="selectedComponents.length ? '' : 'Search components…'"
-            @focus="componentDropdownOpen = true"
-            @keydown.backspace="onComponentBackspace"
-          />
-        </div>
-        <div
-          v-if="componentDropdownOpen"
-          class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
-        >
-          <div v-if="loadingComponents" class="px-3 py-2 text-xs text-gray-400">Loading…</div>
-          <div v-else-if="filteredComponents.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
-          <button
-            v-for="name in filteredComponents"
-            :key="name"
-            type="button"
-            class="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-            @mousedown.prevent="toggleComponent(name)"
-          >
-            <span
-              class="w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-xs"
-              :class="selectedComponents.includes(name)
-                ? 'bg-primary-500 border-primary-500 text-white'
-                : 'border-gray-300 dark:border-gray-500'"
-            >
-              <span v-if="selectedComponents.includes(name)">&#10003;</span>
-            </span>
-            {{ name }}
+            Product
+            <span v-if="filterProduct.length > 0" class="bg-indigo-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-[9px]">{{ filterProduct.length }}</span>
           </button>
+          <div v-if="productDropdownOpen" class="absolute z-50 mt-1 w-40 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-1">
+            <button v-for="p in availableProducts" :key="p" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="toggleFilter('filterProduct', p)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="filterProduct.includes(p) ? 'bg-indigo-500 border-indigo-500 text-white' : 'border-gray-300 dark:border-gray-500'"><span v-if="filterProduct.includes(p)">&#10003;</span></span>
+              {{ p }}
+            </button>
+          </div>
         </div>
-        <p v-if="componentError" class="text-xs text-red-500 mt-1">{{ componentError }}</p>
-      </div>
 
-      <!-- Release / Version Filter -->
-      <div class="min-w-[280px] max-w-[400px] relative" ref="versionDropdownRef">
-        <div class="flex items-center justify-between mb-1">
-          <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Release</label>
+        <!-- Type -->
+        <div class="inline-flex items-center rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 overflow-hidden">
           <button
-            v-if="selectedVersions.length > 0"
             type="button"
-            @click="selectedVersions = []; versionSearch = ''"
-            class="text-[10px] font-medium text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
-          >Clear</button>
-        </div>
-        <div
-          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-2 py-1.5 cursor-text flex flex-wrap items-center gap-1 min-h-[38px]"
-          :class="{ 'ring-2 ring-primary-500 border-primary-500': versionDropdownOpen }"
-          @click="openVersionDropdown"
-        >
-          <span
-            v-for="name in selectedVersions"
-            :key="name"
-            class="inline-flex items-center gap-1 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 rounded px-1.5 py-0.5 text-xs font-medium"
-          >
-            {{ name }}
-            <button type="button" class="hover:text-primary-900 dark:hover:text-primary-100" @click.stop="toggleVersion(name)">&times;</button>
-          </span>
-          <input
-            ref="versionInputRef"
-            v-model="versionSearch"
-            type="text"
-            class="flex-1 min-w-[80px] bg-transparent outline-none text-sm placeholder-gray-400 dark:placeholder-gray-500"
-            :placeholder="selectedVersions.length ? '' : 'Search releases…'"
-            @focus="versionDropdownOpen = true"
-            @keydown.backspace="onVersionBackspace"
-          />
-        </div>
-        <div
-          v-if="versionDropdownOpen"
-          class="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
-        >
-          <div v-if="filteredVersions.length === 0" class="px-3 py-2 text-xs text-gray-400">No matches</div>
+            @click="toggleFilter('filterType', 'requested')"
+            class="px-2.5 py-1 text-[11px] font-medium transition-colors"
+            :class="filterType.includes('requested') ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'"
+          >REQ</button>
+          <span class="w-px h-4 bg-gray-200 dark:bg-gray-600" />
           <button
-            v-for="name in filteredVersions"
-            :key="name"
             type="button"
-            class="w-full text-left px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-            @mousedown.prevent="toggleVersion(name)"
+            @click="toggleFilter('filterType', 'committed')"
+            class="px-2.5 py-1 text-[11px] font-medium transition-colors"
+            :class="filterType.includes('committed') ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'"
+          >COM</button>
+        </div>
+
+        <!-- Release Type -->
+        <div class="relative" ref="releaseTypeDropdownRef">
+          <button
+            type="button"
+            @click="releaseTypeDropdownOpen = !releaseTypeDropdownOpen"
+            class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+            :class="filterReleaseType.length > 0 ? 'bg-purple-50 dark:bg-purple-900/30 border-purple-300 dark:border-purple-700 text-purple-700 dark:text-purple-300' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
           >
-            <span
-              class="w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center text-xs"
-              :class="selectedVersions.includes(name)
-                ? 'bg-primary-500 border-primary-500 text-white'
-                : 'border-gray-300 dark:border-gray-500'"
-            >
-              <span v-if="selectedVersions.includes(name)">&#10003;</span>
-            </span>
-            {{ name }}
+            Release Type
+            <span v-if="filterReleaseType.length > 0" class="bg-purple-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-[9px]">{{ filterReleaseType.length }}</span>
           </button>
+          <div v-if="releaseTypeDropdownOpen" class="absolute z-50 mt-1 w-48 max-h-48 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-1">
+            <div v-if="availableReleaseTypes.length === 0" class="px-3 py-2 text-xs text-gray-400">None</div>
+            <button v-for="rt in availableReleaseTypes" :key="rt" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="toggleFilter('filterReleaseType', rt)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="filterReleaseType.includes(rt) ? 'bg-purple-500 border-purple-500 text-white' : 'border-gray-300 dark:border-gray-500'"><span v-if="filterReleaseType.includes(rt)">&#10003;</span></span>
+              {{ rt }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Status -->
+        <div class="inline-flex items-center gap-1">
+          <button v-for="s in ['Green', 'Yellow', 'Red']" :key="s" type="button" @click="toggleFilter('filterStatus', s)" class="w-5 h-5 rounded-full ring-2 transition-all" :class="[statusDotClass(s), filterStatus.includes(s) ? 'ring-offset-2 ring-offset-white dark:ring-offset-gray-800 scale-110' : 'ring-transparent opacity-50 hover:opacity-80']" :title="s" />
+        </div>
+
+        <!-- Blocked -->
+        <button
+          type="button"
+          @click="filterBlocked = filterBlocked === null ? true : filterBlocked === true ? false : null"
+          class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+          :class="filterBlocked === true ? 'bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-700 dark:text-red-300' : filterBlocked === false ? 'bg-emerald-50 dark:bg-emerald-900/30 border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
+        >
+          {{ filterBlocked === true ? 'Blocked' : filterBlocked === false ? 'Not Blocked' : 'Blocked' }}
+        </button>
+
+        <!-- Delivery Owner -->
+        <div class="relative" ref="delOwnerDropdownRef">
+          <button
+            type="button"
+            @click="delOwnerDropdownOpen = !delOwnerDropdownOpen"
+            class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+            :class="filterDelOwner.length > 0 ? 'bg-amber-50 dark:bg-amber-900/30 border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-300' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
+          >
+            Delivery Owner
+            <span v-if="filterDelOwner.length > 0" class="bg-amber-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-[9px]">{{ filterDelOwner.length }}</span>
+          </button>
+          <div v-if="delOwnerDropdownOpen" class="absolute z-50 mt-1 w-56 max-h-48 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-1">
+            <input v-model="delOwnerSearch" type="text" class="w-full px-3 py-1.5 text-xs border-b border-gray-100 dark:border-gray-700 outline-none bg-transparent placeholder-gray-400" placeholder="Search…" />
+            <div v-if="filteredDelOwners.length === 0" class="px-3 py-2 text-xs text-gray-400">None</div>
+            <button v-for="o in filteredDelOwners" :key="o" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="toggleFilter('filterDelOwner', o)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="filterDelOwner.includes(o) ? 'bg-amber-500 border-amber-500 text-white' : 'border-gray-300 dark:border-gray-500'"><span v-if="filterDelOwner.includes(o)">&#10003;</span></span>
+              {{ o }}
+            </button>
+          </div>
+        </div>
+
+        <!-- PM Owner -->
+        <div class="relative" ref="pmOwnerDropdownRef">
+          <button
+            type="button"
+            @click="pmOwnerDropdownOpen = !pmOwnerDropdownOpen"
+            class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+            :class="filterPmOwner.length > 0 ? 'bg-violet-50 dark:bg-violet-900/30 border-violet-300 dark:border-violet-700 text-violet-700 dark:text-violet-300' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
+          >
+            PM Owner
+            <span v-if="filterPmOwner.length > 0" class="bg-violet-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-[9px]">{{ filterPmOwner.length }}</span>
+          </button>
+          <div v-if="pmOwnerDropdownOpen" class="absolute z-50 mt-1 w-56 max-h-48 overflow-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-1">
+            <input v-model="pmOwnerSearch" type="text" class="w-full px-3 py-1.5 text-xs border-b border-gray-100 dark:border-gray-700 outline-none bg-transparent placeholder-gray-400" placeholder="Search…" />
+            <div v-if="filteredPmOwners.length === 0" class="px-3 py-2 text-xs text-gray-400">None</div>
+            <button v-for="o in filteredPmOwners" :key="o" type="button" class="w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2" @mousedown.prevent="toggleFilter('filterPmOwner', o)">
+              <span class="w-3.5 h-3.5 rounded border flex-shrink-0 flex items-center justify-center text-[9px]" :class="filterPmOwner.includes(o) ? 'bg-violet-500 border-violet-500 text-white' : 'border-gray-300 dark:border-gray-500'"><span v-if="filterPmOwner.includes(o)">&#10003;</span></span>
+              {{ o }}
+            </button>
+          </div>
         </div>
       </div>
     </div>
 
     <!-- Summary cards -->
     <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-4 gap-3">
-      <!-- Features Requested -->
-      <div
-        @click="totalRequested > 0 ? setFilter('requested') : undefined"
-        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
-        :class="[
-          activeFilter === 'requested'
-            ? 'border-blue-400 dark:border-blue-500 ring-2 ring-blue-200 dark:ring-blue-800 shadow-sm'
-            : 'border-gray-200 dark:border-gray-700',
-          totalRequested > 0 ? 'cursor-pointer hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600' : ''
-        ]"
-      >
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
-            <svg class="w-3 h-3 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-            </svg>
+            <svg class="w-3 h-3 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features Requested</span>
-          <svg v-if="activeFilter === 'requested'" class="ml-auto w-3.5 h-3.5 text-blue-500 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Requested</span>
         </div>
         <div class="text-2xl font-bold text-blue-600 dark:text-blue-400 ml-7">{{ totalRequested }}</div>
       </div>
-      <!-- Features Committed -->
-      <div
-        @click="totalCommitted > 0 ? setFilter('committed') : undefined"
-        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
-        :class="[
-          activeFilter === 'committed'
-            ? 'border-emerald-400 dark:border-emerald-500 ring-2 ring-emerald-200 dark:ring-emerald-800 shadow-sm'
-            : 'border-gray-200 dark:border-gray-700',
-          totalCommitted > 0 ? 'cursor-pointer hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-600' : ''
-        ]"
-      >
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-emerald-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-emerald-100 dark:bg-emerald-900/40">
-            <svg class="w-3 h-3 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
+            <svg class="w-3 h-3 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features Committed</span>
-          <svg v-if="activeFilter === 'committed'" class="ml-auto w-3.5 h-3.5 text-emerald-500 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Committed</span>
         </div>
         <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400 ml-7">{{ totalCommitted }}</div>
       </div>
-      <!-- Blocked -->
-      <div
-        @click="totalBlocked > 0 ? setFilter('blocked') : undefined"
-        class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
-        :class="[
-          activeFilter === 'blocked'
-            ? 'border-red-400 dark:border-red-500 ring-2 ring-red-200 dark:ring-red-800 shadow-sm'
-            : 'border-gray-200 dark:border-gray-700',
-          totalBlocked > 0 ? 'cursor-pointer hover:shadow-md hover:border-red-300 dark:hover:border-red-600' : ''
-        ]"
-      >
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
-            <svg class="w-3 h-3 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-            </svg>
+            <svg class="w-3 h-3 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /></svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
-          <svg v-if="activeFilter === 'blocked'" class="ml-auto w-3.5 h-3.5 text-red-500 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
         </div>
         <div class="text-2xl font-bold ml-7" :class="totalBlocked > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ totalBlocked }}</div>
       </div>
-      <!-- Versions Selected -->
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-gray-100 dark:bg-gray-700">
-            <svg class="w-3 h-3 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" />
-            </svg>
+            <svg class="w-3 h-3 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" /></svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Releases Selected</span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Releases</span>
         </div>
         <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ selectedVersions.length }}</div>
       </div>
     </div>
 
-    <!-- Active filter indicator -->
-    <div
-      v-if="activeFilter && groups.length > 0 && !loadingData"
-      class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium"
-      :class="{
-        'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300': activeFilter === 'requested',
-        'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300': activeFilter === 'committed',
-        'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300': activeFilter === 'blocked'
-      }"
-    >
-      <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-      </svg>
-      <span>Showing {{ activeFilter === 'requested' ? 'requested' : activeFilter === 'committed' ? 'committed' : 'blocked' }} features only</span>
-      <button
-        @click="setFilter(null)"
-        class="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold hover:bg-white/50 dark:hover:bg-gray-800/50 transition-colors"
-      >
-        Clear filter
-        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-
-    <!-- Loading state -->
+    <!-- Loading -->
     <div v-if="loadingData" class="flex flex-col items-center justify-center py-16 gap-3">
-      <svg class="animate-spin h-8 w-8 text-primary-500" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-      </svg>
+      <svg class="animate-spin h-8 w-8 text-primary-500" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" /><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" /></svg>
       <span class="text-sm text-gray-500 dark:text-gray-400">Loading data from Jira…</span>
     </div>
 
-    <!-- Error state -->
+    <!-- Error -->
     <div v-else-if="dataError" class="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-5 py-4 text-sm text-red-700 dark:text-red-400 flex items-start gap-3">
-      <svg class="w-5 h-5 text-red-500 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
-      </svg>
+      <svg class="w-5 h-5 text-red-500 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" /></svg>
       {{ dataError }}
     </div>
 
     <!-- Empty prompt -->
     <div v-else-if="groups.length === 0 && !hasFetched" class="text-center py-16 text-gray-400 dark:text-gray-500">
-      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
+      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
       <p class="text-sm font-medium">Select components and/or releases to view data.</p>
     </div>
 
     <!-- No results -->
     <div v-else-if="groups.length === 0 && hasFetched" class="text-center py-16 text-gray-400 dark:text-gray-500">
-      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-      </svg>
+      <svg class="w-12 h-12 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" /></svg>
       <p class="text-sm font-medium">No features found for the selected filters.</p>
     </div>
 
@@ -366,8 +317,7 @@
     <ComponentReleaseLoadTable
       v-if="groups.length > 0 && !loadingData"
       ref="tableRef"
-      :groups="groups"
-      :activeFilter="activeFilter"
+      :groups="clientFilteredGroups"
       :componentLeads="componentLeads"
     />
 
@@ -404,8 +354,8 @@ var versionDropdownOpen = ref(false)
 var pillarDropdownRef = ref(null)
 var pillarInputRef = ref(null)
 var componentDropdownRef = ref(null)
-var versionDropdownRef = ref(null)
 var componentInputRef = ref(null)
+var versionDropdownRef = ref(null)
 var versionInputRef = ref(null)
 
 var pillarConfig = ref({ pillars: [] })
@@ -420,15 +370,242 @@ var loadingData = ref(false)
 var dataError = ref(null)
 var hasFetched = ref(false)
 var tableRef = ref(null)
-var activeFilter = ref(null)
 
-function setFilter(type) {
-  if (type === null || activeFilter.value === type) {
-    activeFilter.value = null
+var filterProduct = ref([])
+var filterType = ref([])
+var filterReleaseType = ref([])
+var filterStatus = ref([])
+var filterBlocked = ref(null)
+var filterDelOwner = ref([])
+var filterPmOwner = ref([])
+
+var productDropdownOpen = ref(false)
+var productDropdownRef = ref(null)
+var releaseTypeDropdownOpen = ref(false)
+var releaseTypeDropdownRef = ref(null)
+var delOwnerDropdownOpen = ref(false)
+var delOwnerDropdownRef = ref(null)
+var delOwnerSearch = ref('')
+var pmOwnerDropdownOpen = ref(false)
+var pmOwnerDropdownRef = ref(null)
+var pmOwnerSearch = ref('')
+
+var availableProducts = ['RHOAI', 'RHELAI', 'RHAII']
+
+function statusDotClass(s) {
+  if (s === 'Green') return 'bg-emerald-500 ring-emerald-300 dark:ring-emerald-700'
+  if (s === 'Yellow') return 'bg-amber-400 ring-amber-300 dark:ring-amber-700'
+  if (s === 'Red') return 'bg-red-500 ring-red-300 dark:ring-red-700'
+  return 'bg-gray-400 ring-gray-300'
+}
+
+var filterRefs = {
+  filterProduct: filterProduct,
+  filterType: filterType,
+  filterReleaseType: filterReleaseType,
+  filterStatus: filterStatus,
+  filterDelOwner: filterDelOwner,
+  filterPmOwner: filterPmOwner
+}
+
+function toggleFilter(filterName, value) {
+  var arrRef = filterRefs[filterName]
+  if (arrRef) toggleInArray(arrRef, value)
+}
+
+function toggleInArray(arrRef, value) {
+  var idx = arrRef.value.indexOf(value)
+  if (idx >= 0) {
+    arrRef.value.splice(idx, 1)
   } else {
-    activeFilter.value = type
+    arrRef.value.push(value)
   }
 }
+
+var activeFilterCount = computed(function() {
+  var count = selectedPillars.value.length + selectedComponents.value.length + selectedVersions.value.length
+  count += filterProduct.value.length + filterType.value.length + filterReleaseType.value.length
+  count += filterStatus.value.length + filterDelOwner.value.length + filterPmOwner.value.length
+  if (filterBlocked.value !== null) count++
+  return count
+})
+
+function clearAllFilters() {
+  selectedPillars.value = []
+  pillarSearch.value = ''
+  selectedComponents.value = []
+  componentSearch.value = ''
+  selectedVersions.value = []
+  versionSearch.value = ''
+  filterProduct.value = []
+  filterType.value = []
+  filterReleaseType.value = []
+  filterStatus.value = []
+  filterBlocked.value = null
+  filterDelOwner.value = []
+  filterPmOwner.value = []
+}
+
+function extractProduct(versionName) {
+  if (!versionName) return versionName
+  var lower = versionName.toLowerCase()
+  if (lower.startsWith('rhoai')) return 'RHOAI'
+  if (lower.startsWith('rhelai')) return 'RHELAI'
+  if (lower.startsWith('rhaii')) return 'RHAII'
+  return versionName.split('-')[0] || versionName
+}
+
+function flattenFeatures() {
+  var result = []
+  var seen = {}
+  for (var gi = 0; gi < groups.value.length; gi++) {
+    var g = groups.value[gi]
+    var version = g.version
+    for (var ci = 0; ci < g.components.length; ci++) {
+      var comp = g.components[ci]
+      var lists = [comp.requestedFeatures || [], comp.committedFeatures || []]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!seen[f.key]) {
+            seen[f.key] = true
+            result.push({
+              releaseType: f.releaseType,
+              assignee: f.assignee,
+              pmOwner: f.pmOwner,
+              product: extractProduct(version)
+            })
+          }
+        }
+      }
+    }
+  }
+  return result
+}
+
+var availableReleaseTypes = computed(function() {
+  var feats = flattenFeatures()
+  var set = new Set()
+  for (var i = 0; i < feats.length; i++) {
+    if (feats[i].releaseType) set.add(feats[i].releaseType)
+  }
+  return Array.from(set).sort()
+})
+
+var availableDelOwners = computed(function() {
+  var feats = flattenFeatures()
+  var set = new Set()
+  for (var i = 0; i < feats.length; i++) {
+    if (feats[i].assignee) set.add(feats[i].assignee)
+  }
+  return Array.from(set).sort()
+})
+
+var availablePmOwners = computed(function() {
+  var feats = flattenFeatures()
+  var set = new Set()
+  for (var i = 0; i < feats.length; i++) {
+    if (feats[i].pmOwner) set.add(feats[i].pmOwner)
+  }
+  return Array.from(set).sort()
+})
+
+var filteredDelOwners = computed(function() {
+  var q = delOwnerSearch.value.toLowerCase().trim()
+  if (!q) return availableDelOwners.value
+  return availableDelOwners.value.filter(function(o) { return o.toLowerCase().includes(q) })
+})
+
+var filteredPmOwners = computed(function() {
+  var q = pmOwnerSearch.value.toLowerCase().trim()
+  if (!q) return availablePmOwners.value
+  return availablePmOwners.value.filter(function(o) { return o.toLowerCase().includes(q) })
+})
+
+var hasClientFilters = computed(function() {
+  return filterProduct.value.length > 0 || filterType.value.length > 0 || filterReleaseType.value.length > 0 || filterStatus.value.length > 0 || filterBlocked.value !== null || filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0
+})
+
+var clientFilteredGroups = computed(function() {
+  if (!hasClientFilters.value) return groups.value
+
+  return groups.value.map(function(g) {
+    var version = g.version
+    var product = extractProduct(version)
+
+    if (filterProduct.value.length > 0 && filterProduct.value.indexOf(product) === -1) {
+      return Object.assign({}, g, { components: [] })
+    }
+
+    var filteredComps = g.components.map(function(comp) {
+      var reqList = comp.requestedFeatures || []
+      var comList = comp.committedFeatures || []
+      var reqKeys = {}
+      var comKeys = {}
+      for (var ri = 0; ri < reqList.length; ri++) reqKeys[reqList[ri].key] = true
+      for (var cmi = 0; cmi < comList.length; cmi++) comKeys[comList[cmi].key] = true
+
+      var allFeatures = []
+      var seen = {}
+      var lists = [reqList, comList]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!seen[f.key]) {
+            seen[f.key] = true
+            allFeatures.push(f)
+          }
+        }
+      }
+
+      var filtered = allFeatures.filter(function(f) {
+        var isReq = !!reqKeys[f.key]
+        var isCom = !!comKeys[f.key]
+
+        if (filterType.value.length > 0) {
+          var matches = false
+          if (filterType.value.indexOf('requested') >= 0 && isReq) matches = true
+          if (filterType.value.indexOf('committed') >= 0 && isCom) matches = true
+          if (!matches) return false
+        }
+        if (filterReleaseType.value.length > 0 && filterReleaseType.value.indexOf(f.releaseType || '') === -1) return false
+        if (filterStatus.value.length > 0) {
+          var cs = (f.colorStatus || '').toLowerCase()
+          var match = false
+          for (var si = 0; si < filterStatus.value.length; si++) {
+            if (filterStatus.value[si].toLowerCase() === cs) { match = true; break }
+          }
+          if (!match) return false
+        }
+        if (filterBlocked.value === true && !f.isBlocked) return false
+        if (filterBlocked.value === false && f.isBlocked) return false
+        if (filterDelOwner.value.length > 0 && filterDelOwner.value.indexOf(f.assignee || '') === -1) return false
+        if (filterPmOwner.value.length > 0 && filterPmOwner.value.indexOf(f.pmOwner || '') === -1) return false
+        return true
+      })
+
+      var newReq = []
+      var newCom = []
+      for (var nfi = 0; nfi < filtered.length; nfi++) {
+        var ff = filtered[nfi]
+        if (reqKeys[ff.key]) newReq.push(ff)
+        if (comKeys[ff.key]) newCom.push(ff)
+      }
+
+      return Object.assign({}, comp, {
+        requestedFeatures: newReq,
+        committedFeatures: newCom,
+        requestedCount: newReq.length,
+        committedCount: newCom.length,
+        blockedCount: filtered.filter(function(ff) { return ff.isBlocked }).length
+      })
+    }).filter(function(comp) {
+      return (comp.requestedFeatures.length + comp.committedFeatures.length) > 0
+    })
+
+    return Object.assign({}, g, { components: filteredComps })
+  }).filter(function(g) { return g.components.length > 0 })
+})
 
 var uniqueComponents = computed(function() {
   var seen = new Set()
@@ -460,9 +637,7 @@ function resolveJiraVersions(selectedLabels) {
     var pv = PORTFOLIO_VERSIONS.find(function(v) { return v.label === selectedLabels[i] })
     if (pv) {
       for (var j = 0; j < pv.jiraVersions.length; j++) {
-        if (result.indexOf(pv.jiraVersions[j]) === -1) {
-          result.push(pv.jiraVersions[j])
-        }
+        if (result.indexOf(pv.jiraVersions[j]) === -1) result.push(pv.jiraVersions[j])
       }
     }
   }
@@ -491,9 +666,7 @@ var componentLeads = computed(function() {
 var filteredPillarNames = computed(function() {
   var q = pillarSearch.value.toLowerCase().trim()
   if (!q) return pillarNames.value
-  return pillarNames.value.filter(function(name) {
-    return name.toLowerCase().includes(q)
-  })
+  return pillarNames.value.filter(function(name) { return name.toLowerCase().includes(q) })
 })
 
 var pillarAllowedComponents = computed(function() {
@@ -533,50 +706,36 @@ var pillarFilteredComponents = computed(function() {
 var filteredComponents = computed(function() {
   var q = componentSearch.value.toLowerCase().trim()
   if (!q) return pillarFilteredComponents.value
-  return pillarFilteredComponents.value.filter(function(name) {
-    return name.toLowerCase().includes(q)
-  })
+  return pillarFilteredComponents.value.filter(function(name) { return name.toLowerCase().includes(q) })
 })
 
 var filteredVersions = computed(function() {
   var q = versionSearch.value.toLowerCase().trim()
   if (!q) return portfolioVersionLabels
-  return portfolioVersionLabels.filter(function(name) {
-    return name.toLowerCase().includes(q)
-  })
+  return portfolioVersionLabels.filter(function(name) { return name.toLowerCase().includes(q) })
 })
 
 var totalRequested = computed(function() {
   var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    count += groups.value[i].requestedCount || 0
-  }
+  for (var i = 0; i < groups.value.length; i++) count += groups.value[i].requestedCount || 0
   return count
 })
 
 var totalCommitted = computed(function() {
   var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    count += groups.value[i].committedCount || 0
-  }
+  for (var i = 0; i < groups.value.length; i++) count += groups.value[i].committedCount || 0
   return count
 })
 
 var totalBlocked = computed(function() {
   var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    count += groups.value[i].blockedCount || 0
-  }
+  for (var i = 0; i < groups.value.length; i++) count += groups.value[i].blockedCount || 0
   return count
 })
 
 function togglePillar(name) {
   var idx = selectedPillars.value.indexOf(name)
-  if (idx >= 0) {
-    selectedPillars.value.splice(idx, 1)
-  } else {
-    selectedPillars.value.push(name)
-  }
+  if (idx >= 0) { selectedPillars.value.splice(idx, 1) } else { selectedPillars.value.push(name) }
   pillarSearch.value = ''
 }
 
@@ -586,28 +745,18 @@ function openPillarDropdown() {
 }
 
 function onPillarBackspace() {
-  if (!pillarSearch.value && selectedPillars.value.length) {
-    selectedPillars.value.pop()
-  }
+  if (!pillarSearch.value && selectedPillars.value.length) selectedPillars.value.pop()
 }
 
 function toggleComponent(name) {
   var idx = selectedComponents.value.indexOf(name)
-  if (idx >= 0) {
-    selectedComponents.value.splice(idx, 1)
-  } else {
-    selectedComponents.value.push(name)
-  }
+  if (idx >= 0) { selectedComponents.value.splice(idx, 1) } else { selectedComponents.value.push(name) }
   componentSearch.value = ''
 }
 
 function toggleVersion(name) {
   var idx = selectedVersions.value.indexOf(name)
-  if (idx >= 0) {
-    selectedVersions.value.splice(idx, 1)
-  } else {
-    selectedVersions.value.push(name)
-  }
+  if (idx >= 0) { selectedVersions.value.splice(idx, 1) } else { selectedVersions.value.push(name) }
   versionSearch.value = ''
 }
 
@@ -622,39 +771,25 @@ function openVersionDropdown() {
 }
 
 function onComponentBackspace() {
-  if (!componentSearch.value && selectedComponents.value.length) {
-    selectedComponents.value.pop()
-  }
+  if (!componentSearch.value && selectedComponents.value.length) selectedComponents.value.pop()
 }
 
 function onVersionBackspace() {
-  if (!versionSearch.value && selectedVersions.value.length) {
-    selectedVersions.value.pop()
-  }
+  if (!versionSearch.value && selectedVersions.value.length) selectedVersions.value.pop()
 }
 
 function handleClickOutside(e) {
-  if (pillarDropdownRef.value && !pillarDropdownRef.value.contains(e.target)) {
-    pillarDropdownOpen.value = false
-    pillarSearch.value = ''
-  }
-  if (componentDropdownRef.value && !componentDropdownRef.value.contains(e.target)) {
-    componentDropdownOpen.value = false
-    componentSearch.value = ''
-  }
-  if (versionDropdownRef.value && !versionDropdownRef.value.contains(e.target)) {
-    versionDropdownOpen.value = false
-    versionSearch.value = ''
-  }
+  if (pillarDropdownRef.value && !pillarDropdownRef.value.contains(e.target)) { pillarDropdownOpen.value = false; pillarSearch.value = '' }
+  if (componentDropdownRef.value && !componentDropdownRef.value.contains(e.target)) { componentDropdownOpen.value = false; componentSearch.value = '' }
+  if (versionDropdownRef.value && !versionDropdownRef.value.contains(e.target)) { versionDropdownOpen.value = false; versionSearch.value = '' }
+  if (productDropdownRef.value && !productDropdownRef.value.contains(e.target)) { productDropdownOpen.value = false }
+  if (releaseTypeDropdownRef.value && !releaseTypeDropdownRef.value.contains(e.target)) { releaseTypeDropdownOpen.value = false }
+  if (delOwnerDropdownRef.value && !delOwnerDropdownRef.value.contains(e.target)) { delOwnerDropdownOpen.value = false; delOwnerSearch.value = '' }
+  if (pmOwnerDropdownRef.value && !pmOwnerDropdownRef.value.contains(e.target)) { pmOwnerDropdownOpen.value = false; pmOwnerSearch.value = '' }
 }
 
-function handleExpandAll() {
-  if (tableRef.value) tableRef.value.expandAll()
-}
-
-function handleCollapseAll() {
-  if (tableRef.value) tableRef.value.collapseAll()
-}
+function handleExpandAll() { if (tableRef.value) tableRef.value.expandAll() }
+function handleCollapseAll() { if (tableRef.value) tableRef.value.collapseAll() }
 
 function onPillarConfigSaved(newConfig) {
   pillarConfig.value = newConfig
@@ -697,14 +832,11 @@ async function loadData() {
 
   try {
     var params = new URLSearchParams()
-    if (selectedComponents.value.length > 0) {
-      params.set('components', selectedComponents.value.join(','))
-    }
+    if (selectedComponents.value.length > 0) params.set('components', selectedComponents.value.join(','))
     if (selectedVersions.value.length > 0) {
       var jiraVersions = resolveJiraVersions(selectedVersions.value)
       params.set('versions', jiraVersions.join(','))
     }
-
     var response = await fetch(getApiBase() + API_BASE + '/component-release-load?' + params.toString())
     if (!response.ok) {
       var errData = await response.json().catch(function() { return {} })
@@ -729,7 +861,6 @@ watch(selectedPillars, function() {
 }, { deep: true })
 
 watch([selectedComponents, selectedVersions], function() {
-  activeFilter.value = null
   if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) {
     groups.value = []
     hasFetched.value = false

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -95,9 +95,6 @@ function validatePillarConfig(data) {
   return null
 }
 
-function _getComponentName(comp) {
-  return typeof comp === 'string' ? comp : (comp && comp.name) || ''
-}
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
@@ -269,7 +266,16 @@ module.exports = function registerPmHubRoutes(router, context) {
    *                   type: object
    *                   properties:
    *                     name: { type: string }
-   *                     components: { type: array, items: { type: string } }
+   *                     components:
+   *                       type: array
+   *                       items:
+   *                         oneOf:
+   *                           - type: string
+   *                           - type: object
+   *                             properties:
+   *                               name: { type: string }
+   *                               pmLead: { type: string }
+   *                               engLead: { type: string }
    *     responses:
    *       200:
    *         description: Updated pillar config

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -15,19 +15,66 @@ var DEFAULT_PILLAR_CONFIG = {
   pillars: [
     {
       name: 'Inference',
-      components: ['llm-d', 'vllm', 'Inference Midstream', 'llm-compressor', 'Optimized Models', 'Model Validation', 'Tool calling', 'AI security -model validation', 'Model Serving Runtimes', 'Serving Orchestration', 'PSAP']
+      components: [
+        { name: 'llm-d', pmLead: 'Naina Singh', engLead: 'Anish Asthana' },
+        { name: 'vllm', pmLead: 'Yuchen Fama', engLead: 'Ashraf Bhuiyan' },
+        { name: 'Inference Midstream', pmLead: 'Erwan Gallen', engLead: 'Selbi Nuryyeva' },
+        { name: 'llm-compressor', pmLead: 'Rob Greenberg', engLead: 'Dipika Sikka' },
+        { name: 'Optimized Models', pmLead: 'Rob Greenberg', engLead: 'Alexandre Marques' },
+        { name: 'Model Validation', pmLead: 'Rob Greenberg', engLead: 'Aviran Badli' },
+        { name: 'Tool calling', pmLead: 'Rob Greenberg, Yuchen Fama', engLead: 'Cat Weeks, Aviran Badli, Ben Browning' },
+        { name: 'AI security -model validation', pmLead: 'Rob Greenberg, William Caban, Adam Bellusci', engLead: 'Stuart Battersby, Dominik Dahlem, Aviran Badli' },
+        { name: 'Model Serving Runtimes', pmLead: 'Adam Bellusci', engLead: 'Steven Grubb' },
+        { name: 'Serving Orchestration', pmLead: 'Adam Bellusci', engLead: 'Yuan Tang' },
+        { name: 'PSAP', pmLead: 'Yuchen Fama', engLead: 'Ashish Kamra' }
+      ]
     },
     {
       name: 'Data',
-      components: ['EvalHub / Model Eval', 'AutoRAG / RAG', 'AutoML', 'Development platform', 'Data Processing', 'SDG', 'Training Hub', 'Fine Tuning / Kubeflow-Dev', 'Kubeflow Training', 'Ray Training', 'Inference Time Techniques']
+      components: [
+        { name: 'EvalHub / Model Eval', pmLead: 'William Caban', engLead: 'Rui Vieira, Marius Danciu' },
+        { name: 'AutoRAG / RAG', pmLead: 'Suhas Kashyap', engLead: 'Lukasz Cmielowski' },
+        { name: 'AutoML', pmLead: 'Aditi Saluja', engLead: 'Lukasz Cmielowski' },
+        { name: 'Development platform', pmLead: 'Jehlum Pandit', engLead: 'Doug Hellmann' },
+        { name: 'Data Processing', pmLead: 'Jehlum Pandit', engLead: 'Francisco Arceo, Chris Bynum' },
+        { name: 'SDG', pmLead: 'Aditi Saluja', engLead: 'Abhishek Bhanwaldar' },
+        { name: 'Training Hub', pmLead: 'Aditi Saluja', engLead: 'Mustafa Eyceoz' },
+        { name: 'Fine Tuning / Kubeflow-Dev', pmLead: 'Aditi Saluja', engLead: 'Brian Gallagher' },
+        { name: 'Kubeflow Training', pmLead: 'Christoph Görn', engLead: 'Umberto Manganiello' },
+        { name: 'Ray Training', pmLead: 'Christoph Görn', engLead: 'Laura Fitzgerald' },
+        { name: 'Inference Time Techniques', pmLead: 'Luke Inglis', engLead: 'Yi Zheng' }
+      ]
     },
     {
       name: 'Agents',
-      components: ['GenAI Studio', 'AgentOps', 'AgentDev', 'OGX (formerly Llama Stack) core', 'Agentic and AI Tooling Experience', 'PSAP agentic', 'Model Context Protocol']
+      components: [
+        { name: 'GenAI Studio', pmLead: 'Peter Double', engLead: 'Eder Ignatowicz' },
+        { name: 'AgentOps', pmLead: 'Adel Zaalouk', engLead: 'Roland Huß, Dimitri Saridakis' },
+        { name: 'AgentDev', pmLead: 'Adel Zaalouk', engLead: 'Bill Murdock, Justin Sun' },
+        { name: 'OGX (formerly Llama Stack) core', pmLead: 'Adel Zaalouk', engLead: 'Sebastien Han, Francisco Arceo, Eric Duen' },
+        { name: 'Agentic and AI Tooling Experience', pmLead: 'Jehlum Pandit', engLead: 'Ann Marie Fred, Nick Ommen' },
+        { name: 'PSAP agentic', pmLead: '', engLead: 'Alex Calhoun / Tanya Osokin' },
+        { name: 'Model Context Protocol', pmLead: 'Peter Double', engLead: '' }
+      ]
     },
     {
       name: 'Platform',
-      components: ['MaaS', 'AI Gateway', 'GPUaaS', 'AI Hub', 'Observability', 'AI Safety', 'AI Navigator', 'Feature Store', 'Notebook Server', 'Notebook images and extensions', 'AI Pipelines', 'AI Core Platform', 'MLflow', 'AI Core Dashboard']
+      components: [
+        { name: 'MaaS', pmLead: 'Jonathan Zarecki', engLead: 'Yuan Tang, Lindani Phiri' },
+        { name: 'AI Gateway', pmLead: 'Jonathan Zarecki', engLead: 'Shane Utt' },
+        { name: 'GPUaaS', pmLead: 'Christoph Goern', engLead: 'Luca Burgazzoli' },
+        { name: 'AI Hub', pmLead: 'Adam Bellusci', engLead: 'Chris Hambridge' },
+        { name: 'Observability', pmLead: 'Suhas Kashyap', engLead: 'Arik Hadas' },
+        { name: 'AI Safety', pmLead: 'William Caban', engLead: 'Stuart Battersby/Rob Geada/Rui Vieira' },
+        { name: 'AI Navigator', pmLead: 'Suhas Kashyap', engLead: 'Amit Oren' },
+        { name: 'Feature Store', pmLead: 'Jonathan Zarecki, Kezia Cook', engLead: 'Umberto Manganiello' },
+        { name: 'Notebook Server', pmLead: 'Kezia Cook', engLead: 'Andy Stoneberg' },
+        { name: 'Notebook images and extensions', pmLead: 'Kezia Cook', engLead: 'Nick Ommen' },
+        { name: 'AI Pipelines', pmLead: 'Myriam Fentanes Gutierrez', engLead: 'Edson Tirelli' },
+        { name: 'AI Core Platform', pmLead: 'Myriam Fentanes Gutierrez', engLead: 'Lindani Phiri' },
+        { name: 'MLflow', pmLead: 'Myriam Fentanes Gutierrez', engLead: 'Lindani Phiri' },
+        { name: 'AI Core Dashboard', pmLead: 'Jenny Yi', engLead: 'Eder Ignatowicz' }
+      ]
     }
   ]
 }
@@ -39,10 +86,17 @@ function validatePillarConfig(data) {
     if (!p.name || typeof p.name !== 'string') return 'pillar at index ' + i + ' must have a name string'
     if (!Array.isArray(p.components)) return 'pillar "' + p.name + '" must have a components array'
     for (var j = 0; j < p.components.length; j++) {
-      if (typeof p.components[j] !== 'string') return 'components in pillar "' + p.name + '" must be strings'
+      var c = p.components[j]
+      if (typeof c === 'string') continue
+      if (typeof c === 'object' && c !== null && typeof c.name === 'string') continue
+      return 'components in pillar "' + p.name + '" must be strings or objects with a name'
     }
   }
   return null
+}
+
+function _getComponentName(comp) {
+  return typeof comp === 'string' ? comp : (comp && comp.name) || ''
 }
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [


### PR DESCRIPTION
## Summary

- **PM & Engineering Leads**: Display PM Lead and Engineering Lead per component in the PM Hub table, pre-filled from pillar config data. Leads are editable via the pillar settings panel. Shown with distinct color-coded person icons (violet for PM, sky for Eng).
- **Filter Pane Redesign**: Replace scattered vertical filter dropdowns with a unified horizontal filter panel. Row 1 holds data filters (Pillar, Component, Release). Row 2 adds seven new client-side result filters (Product, Type, Release Type, Status, Blocked, Delivery Owner, PM Owner) that filter already-fetched data without additional API calls.
- **Table simplification**: Filtering now happens upstream in the report view via `clientFilteredGroups`, so the table component no longer needs the `activeFilter` prop. Summary cards are read-only stats.

## Test plan

- [ ] Verify pillar config panel allows editing PM Lead and Eng Lead per component
- [ ] Verify PM/Eng leads display on component group headers with correct icons and colors
- [ ] Verify Row 1 filters (Pillar, Component, Release) still drive backend queries correctly
- [ ] Verify Row 2 filters appear after data loads and filter results client-side
- [ ] Verify "Clear All" resets all filters
- [ ] Verify summary cards show correct counts (read-only, no longer clickable)
- [ ] Run `npx vitest run modules/releases/__tests__/server/pm-hub/` — all 16 tests pass

Made with [Cursor](https://cursor.com)