### PR TITLE
fix(releases): auto-backfill PM/Eng leads into existing pillar config

### DIFF
--- a/modules/releases/__tests__/server/pm-hub/pillar-config.test.js
+++ b/modules/releases/__tests__/server/pm-hub/pillar-config.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-const { validatePillarConfig, DEFAULT_PILLAR_CONFIG } = require('../../../server/pm-hub/routes')
+const { validatePillarConfig, DEFAULT_PILLAR_CONFIG, backfillLeads } = require('../../../server/pm-hub/routes')
 
 describe('validatePillarConfig', function () {
   it('accepts valid config', function () {
@@ -95,5 +95,46 @@ describe('DEFAULT_PILLAR_CONFIG', function () {
 
   it('passes its own validation', function () {
     expect(validatePillarConfig(DEFAULT_PILLAR_CONFIG)).toBe(null)
+  })
+})
+
+describe('backfillLeads', function () {
+  it('converts string components to objects with leads from defaults', function () {
+    var firstName = DEFAULT_PILLAR_CONFIG.pillars[0].components[0].name
+    var config = {
+      pillars: [{ name: DEFAULT_PILLAR_CONFIG.pillars[0].name, components: [firstName] }]
+    }
+    var changed = backfillLeads(config)
+    expect(changed).toBe(true)
+    var comp = config.pillars[0].components[0]
+    expect(comp).toHaveProperty('name', firstName)
+    expect(comp).toHaveProperty('pmLead')
+    expect(comp).toHaveProperty('engLead')
+  })
+
+  it('backfills leads into object components missing them', function () {
+    var firstName = DEFAULT_PILLAR_CONFIG.pillars[0].components[0].name
+    var config = {
+      pillars: [{ name: 'Test', components: [{ name: firstName }] }]
+    }
+    var changed = backfillLeads(config)
+    expect(changed).toBe(true)
+    expect(config.pillars[0].components[0].pmLead).toBeTruthy()
+  })
+
+  it('does not overwrite existing leads', function () {
+    var firstName = DEFAULT_PILLAR_CONFIG.pillars[0].components[0].name
+    var config = {
+      pillars: [{ name: 'Test', components: [{ name: firstName, pmLead: 'Custom PM', engLead: 'Custom Eng' }] }]
+    }
+    var changed = backfillLeads(config)
+    expect(changed).toBe(false)
+    expect(config.pillars[0].components[0].pmLead).toBe('Custom PM')
+  })
+
+  it('returns false when nothing to migrate', function () {
+    var config = JSON.parse(JSON.stringify(DEFAULT_PILLAR_CONFIG))
+    var changed = backfillLeads(config)
+    expect(changed).toBe(false)
   })
 })

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -95,6 +95,47 @@ function validatePillarConfig(data) {
   return null
 }
 
+function _getComponentName(comp) {
+  return typeof comp === 'string' ? comp : (comp && comp.name) || ''
+}
+
+function backfillLeads(config) {
+  var defaultMap = {}
+  for (var di = 0; di < DEFAULT_PILLAR_CONFIG.pillars.length; di++) {
+    var dp = DEFAULT_PILLAR_CONFIG.pillars[di]
+    for (var dci = 0; dci < dp.components.length; dci++) {
+      var dc = dp.components[dci]
+      if (typeof dc === 'object' && dc !== null && dc.name) {
+        defaultMap[dc.name.toLowerCase()] = dc
+      }
+    }
+  }
+
+  var changed = false
+  for (var pi = 0; pi < config.pillars.length; pi++) {
+    var pillar = config.pillars[pi]
+    for (var ci = 0; ci < pillar.components.length; ci++) {
+      var comp = pillar.components[ci]
+      var compName = _getComponentName(comp)
+      if (!compName) continue
+      var defaults = defaultMap[compName.toLowerCase()]
+
+      if (typeof comp === 'string') {
+        var obj = { name: comp }
+        if (defaults) { obj.pmLead = defaults.pmLead || ''; obj.engLead = defaults.engLead || '' }
+        pillar.components[ci] = obj
+        changed = true
+      } else if (typeof comp === 'object' && comp !== null) {
+        if (!comp.pmLead && !comp.engLead && defaults) {
+          comp.pmLead = defaults.pmLead || ''
+          comp.engLead = defaults.engLead || ''
+          changed = true
+        }
+      }
+    }
+  }
+  return changed
+}
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
@@ -242,6 +283,11 @@ module.exports = function registerPmHubRoutes(router, context) {
     if (!config) {
       config = DEFAULT_PILLAR_CONFIG
       storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+    } else {
+      var migrated = backfillLeads(config)
+      if (migrated) {
+        storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+      }
     }
     res.json(config)
   })
@@ -479,3 +525,4 @@ module.exports = function registerPmHubRoutes(router, context) {
 module.exports.DEFAULT_PILLAR_CONFIG = DEFAULT_PILLAR_CONFIG
 module.exports.validatePillarConfig = validatePillarConfig
 module.exports.PILLAR_CONFIG_FILE = PILLAR_CONFIG_FILE
+module.exports.backfillLeads = backfillLeads

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -122,7 +122,8 @@ function backfillLeads(config) {
 
       if (typeof comp === 'string') {
         var obj = { name: comp }
-        if (defaults) { obj.pmLead = defaults.pmLead || ''; obj.engLead = defaults.engLead || '' }
+        obj.pmLead = (defaults && defaults.pmLead) || ''
+        obj.engLead = (defaults && defaults.engLead) || ''
         pillar.components[ci] = obj
         changed = true
       } else if (typeof comp === 'object' && comp !== null) {
@@ -136,6 +137,7 @@ function backfillLeads(config) {
   }
   return changed
 }
+
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',


### PR DESCRIPTION
## Summary

- On prod the pillar config file predates the leads feature and stores components as plain strings without `pmLead`/`engLead` fields, so leads don't appear in the PM Hub table.
- Adds a `backfillLeads` migration that runs automatically on `GET /pillar-config`: converts string component entries to objects and populates missing leads from `DEFAULT_PILLAR_CONFIG`. Existing custom leads are never overwritten.
- Adds 4 unit tests covering the migration (string→object conversion, backfill into empty leads, preservation of custom leads, no-op when already migrated).

## Test plan

- [ ] Run `npx vitest run modules/releases/__tests__/server/pm-hub/` — all 20 tests pass
- [ ] On a fresh deployment with an existing pillar config file (old format), verify PM/Eng leads auto-populate on the PM Hub page without manual intervention
- [ ] Verify editing leads via the pillar settings panel still works after migration

Made with [Cursor](https://cursor.com)