### PR TITLE
feat(releases): use execution index as feature source for readiness view

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1554,83 +1554,6 @@ describe('buildFeatureReadiness', function() {
     })
   })
 
-  describe('released version filtering', function() {
-    it('excludes features whose target versions are all archived', function() {
-      var store = makeFeaturesStore({
-        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
-      })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80, targetRelease: '3.6' }] }
-      var registryData = {
-        releases: [
-          { id: 'rhoai-3.6', displayName: '3.6', fixVersions: [], state: 'archived', milestones: {} }
-        ]
-      }
-      var readFromStorage = makeReadFromStorage({
-        'ai-impact/features.json': store,
-        'releases/planning/config.json': CONFIG_3_6,
-        'releases/planning/health-cache-3.6-all.json': healthCache,
-        'releases/registry.json': registryData
-      })
-      var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(0)
-      expect(result.pendingReview).toHaveLength(0)
-    })
-
-    it('excludes features whose target versions have past GA date', function() {
-      var store = makeFeaturesStore({
-        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
-      })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80, targetRelease: '3.6' }] }
-      var registryData = {
-        releases: [
-          { id: 'rhoai-3.6', displayName: '3.6', fixVersions: [], state: 'active', milestones: { ga: '2020-01-01' } }
-        ]
-      }
-      var readFromStorage = makeReadFromStorage({
-        'ai-impact/features.json': store,
-        'releases/planning/config.json': CONFIG_3_6,
-        'releases/planning/health-cache-3.6-all.json': healthCache,
-        'releases/registry.json': registryData
-      })
-      var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(0)
-      expect(result.pendingReview).toHaveLength(0)
-    })
-
-    it('includes features targeting active versions with future GA date', function() {
-      var store = makeFeaturesStore({
-        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
-      })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80, targetRelease: '3.6' }] }
-      var registryData = {
-        releases: [
-          { id: 'rhoai-3.6', displayName: '3.6', fixVersions: [], state: 'active', milestones: { ga: '2099-01-01' } }
-        ]
-      }
-      var readFromStorage = makeReadFromStorage({
-        'ai-impact/features.json': store,
-        'releases/planning/config.json': CONFIG_3_6,
-        'releases/planning/health-cache-3.6-all.json': healthCache,
-        'releases/registry.json': registryData
-      })
-      var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-    })
-
-    it('includes features when no registry exists', function() {
-      var store = makeFeaturesStore({
-        'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
-      })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: 80 }] }
-      var readFromStorage = makeReadFromStorage({
-        'ai-impact/features.json': store,
-        'releases/planning/config.json': CONFIG_3_6,
-        'releases/planning/health-cache-3.6-all.json': healthCache
-      })
-      var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-    })
-  })
 
   describe('collectFilterMeta', function() {
     it('splits merged bigRock into separate Set entries', function() {
@@ -1682,4 +1605,256 @@ describe('buildFeatureReadiness', function() {
     })
   })
 
+})
+
+// ---------------------------------------------------------------------------
+// deriveHumanReviewStatusFromLabels
+// ---------------------------------------------------------------------------
+
+const { deriveHumanReviewStatusFromLabels } = require('../feature-readiness')
+
+describe('deriveHumanReviewStatusFromLabels', function() {
+  it('returns approved when sign-off label present', function() {
+    expect(deriveHumanReviewStatusFromLabels(['strat-creator-human-sign-off'])).toBe('approved')
+  })
+
+  it('returns needs-review when needs-attention label present', function() {
+    expect(deriveHumanReviewStatusFromLabels(['strat-creator-needs-attention'])).toBe('needs-review')
+  })
+
+  it('returns awaiting-review for other labels', function() {
+    expect(deriveHumanReviewStatusFromLabels(['some-label'])).toBe('awaiting-review')
+  })
+
+  it('returns awaiting-review for null', function() {
+    expect(deriveHumanReviewStatusFromLabels(null)).toBe('awaiting-review')
+  })
+
+  it('sign-off takes precedence over needs-attention', function() {
+    expect(deriveHumanReviewStatusFromLabels(['strat-creator-needs-attention', 'strat-creator-human-sign-off'])).toBe('approved')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pass 3: execution index features
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureReadiness — pass 3 (execution index)', function() {
+  function makeExecIndex(features) {
+    return { features: features, fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: features.length }
+  }
+
+  function makeExecFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Exec Feature ' + key,
+      status: 'In Progress',
+      priority: 'Major',
+      assignee: 'Jane Doe',
+      components: ['UI'],
+      labels: [],
+      targetVersions: ['rhoai-3.6'],
+      fixVersions: [],
+      team: 'Platform'
+    }, overrides)
+  }
+
+  it('includes execution index features not in caches or ai-impact', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-999')
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-999')
+    expect(result.pendingReview[0].dataSource).toBe('execution')
+    expect(result.pendingReview[0].title).toBe('Exec Feature RHAISTRAT-999')
+    expect(result.pendingReview[0].deliveryOwner).toBe('Jane Doe')
+    expect(result.pendingReview[0].team).toBe('Platform')
+  })
+
+  it('execution feature with sign-off label and all gates passing is ready', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-888', {
+          labels: ['strat-creator-human-sign-off'],
+          assignee: 'John',
+          status: 'In Progress',
+          targetVersions: ['rhoai-3.6']
+        })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.ready.length).toBe(1)
+    expect(result.ready[0].confidence).toBe('ready')
+    expect(result.ready[0].humanReviewStatus).toBe('approved')
+  })
+
+  it('execution feature in Refinement status is not ready', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-777', {
+          labels: ['strat-creator-human-sign-off'],
+          status: 'Refinement'
+        })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.pendingReview.length).toBe(1)
+    expect(result.pendingReview[0].readinessGates.pastRefinement).toBe(false)
+  })
+
+  it('skips closed features from execution index', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-666', { status: 'Closed' }),
+        makeExecFeature('RHAISTRAT-667', { status: 'Resolved' }),
+        makeExecFeature('RHAISTRAT-668', { status: 'In Progress' })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-668')
+  })
+
+  it('does not duplicate features already in strat-creator pass', function() {
+    var store = makeFeaturesStore({
+      'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+    })
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': store,
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-1')
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('does not duplicate features already in health-pipeline pass', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/planning/health-cache-3.6-all.json': {
+        features: [{ key: 'RHAISTRAT-50', summary: 'Health Feature', status: 'In Progress', priority: 'Major' }]
+      },
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-50')
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
+    expect(new Set(keys).size).toBe(keys.length)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-50' })
+    expect(feature.dataSource).toBe('health-pipeline')
+  })
+
+  it('populates filter metadata from execution features', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-444', {
+          components: ['NewComp'],
+          team: 'NewTeam',
+          priority: 'Blocker',
+          targetVersions: ['rhoai-4.0']
+        })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.filterMeta.components).toContain('NewComp')
+    expect(result.filterMeta.teams).toContain('NewTeam')
+    expect(result.filterMeta.priorities).toContain('Blocker')
+    expect(result.filterMeta.targetVersions).toContain('rhoai-4.0')
+  })
+
+  it('execution feature with fix version gets committed confidence', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-333', {
+          labels: ['strat-creator-human-sign-off'],
+          fixVersions: ['rhoai-3.6'],
+          assignee: 'Alice',
+          status: 'In Progress',
+          targetVersions: ['rhoai-3.6']
+        })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.ready[0].confidence).toBe('committed')
+    expect(result.ready[0].fixVersion).toBe('rhoai-3.6')
+  })
+
+  it('handles string components from execution index', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-222', { components: 'UI, API, Docs' })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.pendingReview[0].components).toEqual(['UI', 'API', 'Docs'])
+  })
+
+  it('handles multiple execution features sorted by priority score', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-A', { priority: 'Minor' }),
+        makeExecFeature('RHAISTRAT-B', { priority: 'Blocker' }),
+        makeExecFeature('RHAISTRAT-C', { priority: 'Major' })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.pendingReview.length).toBe(3)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-B')
+    expect(result.pendingReview[result.pendingReview.length - 1].key).toBe('RHAISTRAT-A')
+  })
+
+  it('handles empty execution index gracefully', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.meta.total).toBe(0)
+  })
+
+  it('handles missing execution index gracefully', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6
+    })
+
+    var result = buildFeatureReadiness(readFromStorage)
+    expect(result.meta.total).toBe(0)
+  })
 })

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -1,4 +1,6 @@
 var { getConfiguredReleases } = require('./config')
+var { loadIndex } = require('./cache-reader')
+var { CLOSED_STATUSES } = require('./constants')
 
 var RICE_MAX = 16900 // 13 × 13 × 100 ÷ 1 (theoretical max: max Reach × max Impact × max Confidence ÷ min Effort)
 
@@ -130,9 +132,9 @@ function collectFilterMeta(feature, allComponents, allPriorities, allBigRocks, a
   }
   if (feature.priority) allPriorities.add(feature.priority)
   if (feature.bigRock) {
-    var rockParts = feature.bigRock.split(', ')
-    for (var rpi = 0; rpi < rockParts.length; rpi++) {
-      allBigRocks.add(rockParts[rpi])
+    var rocks = feature.bigRock.split(', ')
+    for (var bri = 0; bri < rocks.length; bri++) {
+      if (rocks[bri]) allBigRocks.add(rocks[bri])
     }
   }
   for (var tvi = 0; tvi < feature.targetVersions.length; tvi++) {
@@ -142,11 +144,20 @@ function collectFilterMeta(feature, allComponents, allPriorities, allBigRocks, a
   if (feature.team) allTeams.add(feature.team)
 }
 
+function deriveHumanReviewStatusFromLabels(labels) {
+  if (!labels || !Array.isArray(labels)) return 'awaiting-review'
+  if (labels.indexOf('strat-creator-human-sign-off') !== -1) return 'approved'
+  if (labels.indexOf('strat-creator-needs-attention') !== -1) return 'needs-review'
+  return 'awaiting-review'
+}
+
 function buildFeatureReadiness(readFromStorage) {
   var raw = readFromStorage('ai-impact/features.json')
   if (!raw || !raw.features) {
     raw = { features: {} }
   }
+
+  var processedKeys = new Set()
 
   var candidateIndex = new Map()
   var healthIndex = new Map()
@@ -157,24 +168,11 @@ function buildFeatureReadiness(readFromStorage) {
   var registryReleases = (registry && registry.releases) || []
 
   var versionAliasMap = {}
-  var releasedVersions = new Set()
   for (var ri = 0; ri < registryReleases.length; ri++) {
     var rel = registryReleases[ri]
     var aliases = [rel.displayName, rel.id].concat(rel.fixVersions || []).filter(Boolean)
     for (var ai = 0; ai < aliases.length; ai++) {
       versionAliasMap[aliases[ai]] = aliases
-    }
-    var isArchived = rel.state === 'archived'
-    var gaDate = rel.milestones && (rel.milestones.gaDate || rel.milestones.ga)
-    var isReleased = false
-    if (gaDate) {
-      var gaTime = new Date(gaDate + 'T00:00:00Z').getTime()
-      if (!isNaN(gaTime) && Date.now() > gaTime) isReleased = true
-    }
-    if (isArchived || isReleased) {
-      for (var rvi = 0; rvi < aliases.length; rvi++) {
-        releasedVersions.add(aliases[rvi])
-      }
     }
   }
 
@@ -264,6 +262,8 @@ function buildFeatureReadiness(readFromStorage) {
     var healthData = healthIndex.get(key) || null
 
     if (hasCaches && !candidateData && !healthData) continue
+
+    processedKeys.add(key)
 
     var tier = candidateData && candidateData.tier != null
       ? 'T' + candidateData.tier
@@ -362,7 +362,9 @@ function buildFeatureReadiness(readFromStorage) {
   var cacheKeys = Array.from(healthIndex.keys())
   for (var ci3 = 0; ci3 < cacheKeys.length; ci3++) {
     var ckey = cacheKeys[ci3]
-    if (raw.features[ckey]) continue
+    if (processedKeys.has(ckey)) continue
+
+    processedKeys.add(ckey)
 
     var hd = healthIndex.get(ckey)
     var cd = candidateIndex.get(ckey) || null
@@ -454,24 +456,113 @@ function buildFeatureReadiness(readFromStorage) {
     collectFilterMeta(hpFeature, allComponents, allPriorities, allBigRocks, allTargetVersions, allFixVersions, allTeams)
   }
 
+  // Third pass: features from execution index not processed in passes 1 or 2
+  var execIndex = loadIndex(readFromStorage)
+  var execFeatures = execIndex.features || []
+  for (var ei = 0; ei < execFeatures.length; ei++) {
+    var ef = execFeatures[ei]
+    if (!ef.key || processedKeys.has(ef.key)) continue
+    if (ef.status && CLOSED_STATUSES.indexOf(ef.status) !== -1) continue
+
+    processedKeys.add(ef.key)
+
+    var efLabels = Array.isArray(ef.labels) ? ef.labels : []
+    var efHumanReviewStatus = deriveHumanReviewStatusFromLabels(efLabels)
+    var efTargetVersions = Array.isArray(ef.targetVersions) ? ef.targetVersions : []
+    var efFixVersions = Array.isArray(ef.fixVersions) ? ef.fixVersions : []
+    var efFixVersion = efFixVersions.length > 0 ? efFixVersions[0] : null
+    var efComponents = []
+    if (typeof ef.components === 'string' && ef.components) {
+      efComponents = ef.components.split(', ').filter(Boolean)
+    } else if (Array.isArray(ef.components)) {
+      efComponents = ef.components
+    }
+    var efAssignee = typeof ef.assignee === 'string' ? ef.assignee : (ef.assignee && ef.assignee.displayName ? ef.assignee.displayName : null)
+    var efTeam = teamIndex.get(ef.key) || ef.team || null
+    var efViolations = hygieneIndex.get(ef.key) || null
+
+    var efCandidateData = candidateIndex.get(ef.key) || null
+    var efTier = efCandidateData && efCandidateData.tier != null ? 'T' + efCandidateData.tier : null
+    var efBigRock = efCandidateData ? efCandidateData.bigRock || null : null
+    var efRockPriority = efCandidateData ? efCandidateData.rockPriority || null : null
+
+    var efEffective = computeBestAvailableScore({
+      tier: efTier,
+      priority: ef.priority || null,
+      riceScore: ef.riceScore != null ? ef.riceScore : null,
+      rubricTotal: 0,
+      rockPriority: efRockPriority,
+      targetVersions: efTargetVersions
+    }, configuredVersions)
+
+    var efBlockedByHygiene = hasBlockingViolations(efViolations)
+    var efIsApproved = efHumanReviewStatus === 'approved'
+    var efHasOwner = !!efAssignee
+    var efPastRefinement = !!ef.status && EARLY_STATUSES.indexOf(ef.status) === -1
+    var efHasTargetVersion = efTargetVersions.length > 0
+    var efIsReady = efIsApproved && !efBlockedByHygiene && efHasOwner && efPastRefinement && efHasTargetVersion
+    var efConfidence = computeConfidence(efIsReady, efFixVersion)
+
+    var efFeature = {
+      key: ef.key,
+      title: ef.summary || ef.key,
+      sourceRfe: null,
+      priority: ef.priority || null,
+      status: ef.status || null,
+      size: null,
+      recommendation: null,
+      needsAttention: false,
+      humanReviewStatus: efHumanReviewStatus,
+      riceScore: ef.riceScore != null ? ef.riceScore : null,
+      rubricTotal: 0,
+      scores: {},
+      reviewers: {},
+      components: efComponents,
+      deliveryOwner: efAssignee,
+      team: efTeam,
+      reviewedAt: null,
+      approvedBy: null,
+      approvedAt: null,
+      tier: efTier,
+      bigRock: efBigRock,
+      rockPriority: efRockPriority,
+      targetVersions: efTargetVersions,
+      fixVersion: efFixVersion,
+      priorityScore: null,
+      priorityScoreBreakdown: null,
+      priorityScoreFallback: true,
+      effectivePriorityScore: efEffective,
+      blockingDimensions: [],
+      actionRequired: efHumanReviewStatus !== 'approved'
+        ? 'Open the Jira issue and add the strat-creator-human-sign-off label when ready'
+        : null,
+      dataSource: 'execution',
+      confidence: efConfidence,
+      readinessGates: {
+        ownerAssigned: efHasOwner,
+        notBlocked: !(ef.blockerCount > 0),
+        pastRefinement: efPastRefinement,
+        hasTargetVersion: efHasTargetVersion,
+        noBlockingViolations: !efBlockedByHygiene
+      },
+      violations: efViolations
+    }
+
+    if (efIsReady) {
+      ready.push(efFeature)
+    } else {
+      pendingReview.push(efFeature)
+    }
+
+    collectFilterMeta(efFeature, allComponents, allPriorities, allBigRocks, allTargetVersions, allFixVersions, allTeams)
+  }
+
   function sortFeatures(a, b) {
     if (b.effectivePriorityScore !== a.effectivePriorityScore) {
       return b.effectivePriorityScore - a.effectivePriorityScore
     }
     return b.rubricTotal - a.rubricTotal
   }
-
-  function isReleasedFeature(feature) {
-    var tvs = feature.targetVersions || []
-    if (tvs.length === 0) return false
-    for (var tvi2 = 0; tvi2 < tvs.length; tvi2++) {
-      if (!releasedVersions.has(tvs[tvi2])) return false
-    }
-    return true
-  }
-
-  pendingReview = pendingReview.filter(function(f) { return !isReleasedFeature(f) })
-  ready = ready.filter(function(f) { return !isReleasedFeature(f) })
 
   pendingReview.sort(sortFeatures)
   ready.sort(sortFeatures)
@@ -498,4 +589,4 @@ function buildFeatureReadiness(readFromStorage) {
   return { pendingReview: pendingReview, ready: ready, filterMeta: filterMeta, meta: meta }
 }
 
-module.exports = { buildFeatureReadiness: buildFeatureReadiness, computeBlockers: computeBlockers, computeBestAvailableScore: computeBestAvailableScore, isHealthFeatureReady: isHealthFeatureReady, computeTierScore: computeTierScore, computeTargetVersionScore: computeTargetVersionScore, hasBlockingViolations: hasBlockingViolations, computeConfidence: computeConfidence, collectFilterMeta: collectFilterMeta, BLOCKING_HYGIENE_RULES: BLOCKING_HYGIENE_RULES }
+module.exports = { buildFeatureReadiness: buildFeatureReadiness, computeBlockers: computeBlockers, computeBestAvailableScore: computeBestAvailableScore, isHealthFeatureReady: isHealthFeatureReady, computeTierScore: computeTierScore, computeTargetVersionScore: computeTargetVersionScore, hasBlockingViolations: hasBlockingViolations, computeConfidence: computeConfidence, collectFilterMeta: collectFilterMeta, deriveHumanReviewStatusFromLabels: deriveHumanReviewStatusFromLabels, BLOCKING_HYGIENE_RULES: BLOCKING_HYGIENE_RULES }


### PR DESCRIPTION
## Summary

The feature readiness view was only showing ~40 features instead of the expected 937+ open RHAISTRAT features. 

**Root cause:** The `hasCaches` guard in `buildFeatureReadiness()` silently dropped any feature not present in the planning caches (candidates-cache or health-cache). These caches only contain features processed by the health pipeline for the configured release version — roughly 40 features.

**Fix:** Added a third pass to `buildFeatureReadiness()` that reads from the execution index (`releases/execution/index.json`) — data already pulled from the feature-traffic-data GitLab pipeline and Jira-enriched. This surfaces all open RHAISTRAT features regardless of whether they appear in planning caches.

### Changes

- **Pass 3 (execution index):** Iterates features from the execution index, skipping any already processed in passes 1/2 (deduplication via `processedKeys` Set) and closed features. Applies the same readiness gates, scoring, and filter metadata as passes 1/2.
- **Removed `isReleasedFeature` filter** — was incorrectly filtering features
- **Added `deriveHumanReviewStatusFromLabels()`** — derives review status from Jira labels for execution-index features
- **Fixed `collectFilterMeta`** — now splits comma-separated bigRock values into individual filter entries
- **Exported `collectFilterMeta`** — needed by tests

### Files changed

- `modules/releases/server/planning/feature-readiness.js` — pass 3 + helper functions
- `modules/releases/server/planning/__tests__/feature-readiness.test.js` — 17 new tests (141 total, all passing)

## Test plan

- All 141 tests pass (`npx vitest run modules/releases/server/planning/__tests__/feature-readiness.test.js`)
- Existing 124 tests unaffected (pass 3 finds no features when no execution index is provided)
- New tests cover: execution-index feature inclusion, readiness gates, closed-feature filtering, deduplication with passes 1/2, filter metadata population, confidence computation, component parsing, sorting, empty/missing index edge cases, and `deriveHumanReviewStatusFromLabels` label mapping