### PR TITLE
fix(releases): PM Hub pillar filter and dropdown fixes

### DIFF
--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -609,12 +609,14 @@ var clientFilteredGroups = computed(function() {
   }).filter(function(g) { return g.components.length > 0 })
 })
 
+var HIDDEN_COMPONENTS = ['lllm-d']
+
 var uniqueComponents = computed(function() {
   var seen = new Set()
   var result = []
   for (var i = 0; i < components.value.length; i++) {
     var name = components.value[i].name
-    if (!seen.has(name)) {
+    if (!seen.has(name) && HIDDEN_COMPONENTS.indexOf(name) === -1) {
       seen.add(name)
       result.push(name)
     }

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -855,11 +855,10 @@ async function loadData() {
 }
 
 watch(selectedPillars, function() {
-  if (selectedPillars.value.length > 0) {
-    selectedComponents.value = pillarFilteredComponents.value.slice()
-  } else {
-    selectedComponents.value = []
-  }
+  var allowed = pillarFilteredComponents.value
+  selectedComponents.value = selectedComponents.value.filter(function(c) {
+    return allowed.indexOf(c) >= 0
+  })
 }, { deep: true })
 
 watch([selectedComponents, selectedVersions], function() {


### PR DESCRIPTION
## Summary

- **Stop auto-selecting components on pillar selection**: Choosing a pillar now only filters the component dropdown to show matching components. Users manually pick which ones they want instead of having all auto-selected.
- **Hide lllm-d typo component**: Filters out the incorrectly named `lllm-d` (triple-L) Jira component from the dropdown until it is cleaned up in Jira.

## Test plan

- [ ] Select a pillar — verify component dropdown is filtered but nothing is auto-selected
- [ ] Verify `lllm-d` (triple-L) no longer appears in the component dropdown
- [ ] Verify `llm-d` (double-L) still appears correctly

Made with [Cursor](https://cursor.com)