### PR TITLE
fix(team-tracker): preserve boards on empty structure teams

### DIFF
--- a/modules/team-tracker/__tests__/server/org-teams.test.js
+++ b/modules/team-tracker/__tests__/server/org-teams.test.js
@@ -238,6 +238,82 @@ describe('buildEnrichedTeams board cascade', () => {
     expect(team.components).toEqual(['Legacy Comp'])
   })
 
+  it('preserves structure boards on empty teams (no members in _teamGrouping)', () => {
+    // Simulates a team that exists in team-data/teams.json with boards,
+    // but has zero people with matching _teamGrouping (e.g. after a rename).
+    // The "empty structure team" code path must carry boards forward.
+    const storageData = {
+      ...buildRegistryAndConfig('org1', 'Org One', ['OtherTeam']),
+      'org-roster/teams-metadata.json': { teams: [], boardNames: {} },
+      'org-roster/components.json': { components: {} },
+      'team-data/teams.json': {
+        teams: {
+          team_ft: {
+            id: 'team_ft',
+            name: 'Fine Tuning',
+            orgKey: 'org1',
+            metadata: {},
+            boards: [
+              { url: 'https://jira.example.com/boards/100', name: 'FT Board', boardId: 100 }
+            ]
+          }
+        }
+      },
+      'audit-log.json': { entries: [] }
+    }
+
+    const storage = makeStorage(storageData)
+    const handlers = setupRoutes(storage)
+    const res = mockRes()
+
+    handlers['GET /org-teams']({ query: {} }, res)
+
+    expect(res._status).toBe(200)
+    const team = res._body.teams.find(t => t.name === 'Fine Tuning')
+    expect(team).toBeDefined()
+    expect(team.structureId).toBe('team_ft')
+    expect(team.memberCount).toBe(0)
+    expect(team.boards).toHaveLength(1)
+    expect(team.boards[0].url).toBe('https://jira.example.com/boards/100')
+    expect(team.boards[0].name).toBe('FT Board')
+    expect(team.boards[0].boardId).toBe(100)
+    expect(team.boardUrls).toEqual(['https://jira.example.com/boards/100'])
+  })
+
+  it('backfills boardId on empty structure teams with legacy board entries', () => {
+    const storageData = {
+      ...buildRegistryAndConfig('org1', 'Org One', ['OtherTeam']),
+      'org-roster/teams-metadata.json': { teams: [], boardNames: {} },
+      'org-roster/components.json': { components: {} },
+      'team-data/teams.json': {
+        teams: {
+          team_legacy: {
+            id: 'team_legacy',
+            name: 'Legacy Team',
+            orgKey: 'org1',
+            metadata: {},
+            boards: [
+              { url: 'https://jira.example.com/boards/42', name: 'Old Board' }
+            ]
+          }
+        }
+      },
+      'audit-log.json': { entries: [] }
+    }
+
+    const storage = makeStorage(storageData)
+    const handlers = setupRoutes(storage)
+    const res = mockRes()
+
+    handlers['GET /org-teams']({ query: {} }, res)
+
+    expect(res._status).toBe(200)
+    const team = res._body.teams.find(t => t.name === 'Legacy Team')
+    expect(team).toBeDefined()
+    expect(team.boards).toHaveLength(1)
+    expect(team.boards[0].boardId).toBe(42)
+  })
+
   it('handles missing boards array on structure team gracefully', () => {
     const storageData = {
       ...buildRegistryAndConfig('org1', 'Org One', ['Platform']),

--- a/modules/team-tracker/server/routes/org-teams.js
+++ b/modules/team-tracker/server/routes/org-teams.js
@@ -185,7 +185,10 @@ module.exports = function registerOrgTeamsRoutes(router, context) {
       const emptyTeamComponents = componentFieldId && structure.metadata?.[componentFieldId]
         ? [].concat(structure.metadata[componentFieldId])
         : [];
-      teams.push({ org, name, boardUrls: [], boards: [], engLeads: [], productManagers: [], headcount: {}, components: emptyTeamComponents, memberCount: 0, jiraFilter: null, structureId: structure.id, metadata: structure.metadata || {} });
+      const structureBoards = Array.isArray(structure.boards)
+        ? structure.boards.map(b => b.boardId != null ? b : { ...b, boardId: teamStore.extractBoardId(b.url) })
+        : [];
+      teams.push({ org, name, boardUrls: structureBoards.map(b => b.url), boards: structureBoards, engLeads: [], productManagers: [], headcount: {}, components: emptyTeamComponents, memberCount: 0, jiraFilter: null, structureId: structure.id, metadata: structure.metadata || {} });
     }
 
     // Find people with no team assignment


### PR DESCRIPTION
## Summary

- **Bug:** Teams with a `_teamGrouping` mismatch (e.g. "Fine Tuning" was renamed from "Kubeflow Training" in the team store, but members still have `_teamGrouping: "Kubeflow Training"`) are added via the "empty structure team" code path in `buildEnrichedTeams()`, which hardcoded `boards: []`. This silently dropped any boards saved in `team-data/teams.json`, making the Edit Boards UI appear empty even after a successful save.
- **Fix:** Use `structure.boards` (with `boardId` backfill) instead of `[]`, matching the enrichment logic already applied to teams discovered via `_teamGrouping` (lines 160-163).
- **Tests:** Added 2 test cases covering the empty structure team path — one for boards with `boardId`, one for legacy boards that need backfill.

## Root cause

`buildEnrichedTeams()` discovers teams from people's `_teamGrouping` values. When a team exists in `team-data/teams.json` but no person has a matching `_teamGrouping`, the team is treated as an "empty structure team" and pushed with hardcoded `boards: []`, ignoring the structure's actual boards. This affected the Fine Tuning team on prod (`ambient-code--team-tracker`), which had 4 members via `teamIds` but 0 via `_teamGrouping` (members still had `_teamGrouping: "Kubeflow Training"` from before the rename).

## Test plan

- [x] All 7 org-teams tests pass (5 existing + 2 new)
- [ ] Verify on prod that Fine Tuning team shows its saved board after deploy
- [ ] Verify Tangerine team (which uses `_teamGrouping` path) is unaffected