### PR TITLE
feat(releases): add Feature Pressure report with live Jira queries

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,6 +66,16 @@ jobs:
               - 'modules/releases/client/components/FeatureTable.vue'
               - 'modules/releases/client/components/ClickableCount.vue'
               - 'tests/integration/tv-fv-delta.spec.js'
+            feature-pressure:
+              - 'modules/releases/server/feature-pressure/**'
+              - 'modules/releases/server/index.js'
+              - 'modules/releases/client/views/FeaturePressureView.vue'
+              - 'modules/releases/client/composables/useFeaturePressureData.js'
+              - 'modules/releases/client/composables/useComponentPressure.js'
+              - 'modules/releases/client/components/PressureHeatmap.vue'
+              - 'modules/releases/client/components/MonthlyFlowChart.vue'
+              - 'modules/releases/client/components/ClickableCount.vue'
+              - 'tests/integration/feature-pressure.spec.js'
 
       # For merge_group events, dorny/paths-filter doesn't support this event type.
       # Use git diff directly, mirroring the filter definitions above.
@@ -83,7 +93,7 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          ALL_MODULES='["ai-impact", "system-health", "people-teams", "upstream-pulse", "releases", "tv-fv-delta"]'
+          ALL_MODULES='["ai-impact", "system-health", "people-teams", "upstream-pulse", "releases", "tv-fv-delta", "feature-pressure"]'
 
           # If shared test infrastructure changed, test all modules
           if echo "$CHANGED" | grep -qE '^tests/integration/(constants|helpers)\.js$'; then
@@ -114,6 +124,8 @@ jobs:
             "^(modules/releases/server/(execution|planning)/|modules/releases/client/views/FeatureDetailView\.vue|modules/releases/client/(execute|plan)/|tests/integration/(execution-data|releases)\.spec\.js)"
           check_module "tv-fv-delta" \
             "^(modules/releases/server/(tv-fv-delta/|index\.js)|modules/releases/client/views/TvFvDeltaView\.vue|modules/releases/client/composables/use.*(TvFv|ReleasePicker|ComponentBreakdown)\.js|modules/releases/client/components/(FeatureTable|ClickableCount)\.vue|tests/integration/tv-fv-delta\.spec\.js)"
+          check_module "feature-pressure" \
+            "^(modules/releases/server/(feature-pressure/|index\.js)|modules/releases/client/views/FeaturePressureView\.vue|modules/releases/client/composables/use(FeaturePressureData|ComponentPressure)\.js|modules/releases/client/components/(PressureHeatmap|MonthlyFlowChart|ClickableCount)\.vue|tests/integration/feature-pressure\.spec\.js)"
 
           echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
           echo "Testing modules: $MODULES"
@@ -124,7 +136,7 @@ jobs:
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             MODULES='${{ steps.git-filter.outputs.modules }}'
           elif [ "${{ steps.filter.outputs.shared-test-files }}" == "true" ]; then
-            MODULES='["ai-impact", "system-health", "people-teams", "upstream-pulse", "releases", "tv-fv-delta"]'
+            MODULES='["ai-impact", "system-health", "people-teams", "upstream-pulse", "releases", "tv-fv-delta", "feature-pressure"]'
           else
             # Use the modules that have direct changes
             MODULES='${{ steps.filter.outputs.changes }}'

--- a/modules/releases/__tests__/client/feature-pressure/useComponentPressure.test.js
+++ b/modules/releases/__tests__/client/feature-pressure/useComponentPressure.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useComponentPressure } from '../../../client/composables/useComponentPressure'
+
+function makeData(components) {
+  return ref({
+    component_pressure: components || [
+      { component: 'Alpha', created: 10, resolved: 5, net: 5, open: 8, pressure_ratio: 2.0 },
+      { component: 'Beta', created: 20, resolved: 15, net: 5, open: 12, pressure_ratio: 1.33 },
+      { component: 'Gamma', created: 3, resolved: 3, net: 0, open: 1, pressure_ratio: 1.0 }
+    ]
+  })
+}
+
+describe('useComponentPressure', function () {
+  it('returns all components when no filter', function () {
+    var data = makeData()
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value).toHaveLength(3)
+  })
+
+  it('returns empty array when data is null', function () {
+    var data = ref(null)
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value).toHaveLength(0)
+  })
+
+  it('returns empty array when component_pressure is missing', function () {
+    var data = ref({})
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value).toHaveLength(0)
+  })
+
+  it('filters by component name (case insensitive)', function () {
+    var data = makeData()
+    var search = ref('alp')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value).toHaveLength(1)
+    expect(result.filteredComponents.value[0].component).toBe('Alpha')
+  })
+
+  it('sorts by net descending by default', function () {
+    var data = makeData([
+      { component: 'A', net: 1 },
+      { component: 'B', net: 10 },
+      { component: 'C', net: 5 }
+    ])
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value[0].component).toBe('B')
+    expect(result.filteredComponents.value[1].component).toBe('C')
+    expect(result.filteredComponents.value[2].component).toBe('A')
+  })
+
+  it('sorts ascending when sortAsc is true', function () {
+    var data = makeData([
+      { component: 'A', net: 1 },
+      { component: 'B', net: 10 },
+      { component: 'C', net: 5 }
+    ])
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(true)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value[0].component).toBe('A')
+    expect(result.filteredComponents.value[2].component).toBe('B')
+  })
+
+  it('sorts by component name alphabetically', function () {
+    var data = makeData([
+      { component: 'Zebra', net: 1 },
+      { component: 'Apple', net: 1 },
+      { component: 'Mango', net: 1 }
+    ])
+    var search = ref('')
+    var sortField = ref('component')
+    var sortAsc = ref(true)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value[0].component).toBe('Apple')
+    expect(result.filteredComponents.value[2].component).toBe('Zebra')
+  })
+
+  it('handles Infinity in pressure_ratio during sort', function () {
+    var data = makeData([
+      { component: 'A', pressure_ratio: Infinity },
+      { component: 'B', pressure_ratio: 2.0 },
+      { component: 'C', pressure_ratio: 5.0 }
+    ])
+    var search = ref('')
+    var sortField = ref('pressure_ratio')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value[0].component).toBe('A')
+  })
+
+  it('handles empty component_pressure array', function () {
+    var data = makeData([])
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value).toHaveLength(0)
+  })
+
+  it('is reactive to search changes', function () {
+    var data = makeData()
+    var search = ref('')
+    var sortField = ref('net')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    expect(result.filteredComponents.value).toHaveLength(3)
+    search.value = 'beta'
+    expect(result.filteredComponents.value).toHaveLength(1)
+    expect(result.filteredComponents.value[0].component).toBe('Beta')
+  })
+})

--- a/modules/releases/__tests__/client/feature-pressure/useComponentPressure.test.js
+++ b/modules/releases/__tests__/client/feature-pressure/useComponentPressure.test.js
@@ -115,6 +115,22 @@ describe('useComponentPressure', function () {
     expect(result.filteredComponents.value).toHaveLength(0)
   })
 
+  it('sorts string "Infinity" values correctly (from JSON round-trip)', function () {
+    var data = makeData([
+      { component: 'Finite', pressure_ratio: 2.5 },
+      { component: 'Infinite', pressure_ratio: 'Infinity' },
+      { component: 'Zero', pressure_ratio: 0 }
+    ])
+    var search = ref('')
+    var sortField = ref('pressure_ratio')
+    var sortAsc = ref(false)
+    var result = useComponentPressure(data, search, sortField, sortAsc)
+    // "Infinity" string should sort as largest value
+    expect(result.filteredComponents.value[0].component).toBe('Infinite')
+    expect(result.filteredComponents.value[1].component).toBe('Finite')
+    expect(result.filteredComponents.value[2].component).toBe('Zero')
+  })
+
   it('is reactive to search changes', function () {
     var data = makeData()
     var search = ref('')

--- a/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
+++ b/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
@@ -18,7 +18,6 @@ const {
   jqlUrl,
   quoteComponent,
   sanitizeInfinity,
-  STATUS_DONE,
   RFE_ACCEPTED,
   RFE_PENDING
 } = require('../../../server/feature-pressure/routes')
@@ -798,11 +797,6 @@ describe('computeScorecard', function () {
 // ---------------------------------------------------------------------------
 
 describe('status constants', function () {
-  it('STATUS_DONE includes expected values', function () {
-    expect(STATUS_DONE).toContain('Release Pending')
-    expect(STATUS_DONE).toContain('Closed')
-  })
-
   it('RFE_ACCEPTED includes all expected values', function () {
     expect(RFE_ACCEPTED).toContain('Approved')
     expect(RFE_ACCEPTED).toContain('In Progress')

--- a/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
+++ b/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 const {
+  normalizeIssue,
   normalizeFeature,
   normalizeRfe,
   toMonth,
@@ -16,6 +17,7 @@ const {
   computeScorecard,
   jqlUrl,
   quoteComponent,
+  sanitizeInfinity,
   STATUS_DONE,
   RFE_ACCEPTED,
   RFE_PENDING
@@ -809,5 +811,87 @@ describe('status constants', function () {
     expect(RFE_PENDING).toContain('Stakeholder review')
     expect(RFE_PENDING).toContain('Stakeholder Feedback')
     expect(RFE_PENDING).toContain('Pending Approval')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// normalizeIssue (shared normaliser)
+// ---------------------------------------------------------------------------
+
+describe('normalizeIssue', function () {
+  it('normalizeFeature and normalizeRfe are aliases for normalizeIssue', function () {
+    expect(normalizeFeature).toBe(normalizeIssue)
+    expect(normalizeRfe).toBe(normalizeIssue)
+  })
+
+  it('returns the same result regardless of which alias is used', function () {
+    var issue = makeIssue({ key: 'TEST-1' })
+    expect(normalizeFeature(issue)).toEqual(normalizeRfe(issue))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sanitizeInfinity
+// ---------------------------------------------------------------------------
+
+describe('sanitizeInfinity', function () {
+  it('replaces Infinity with "Infinity" string in flat objects', function () {
+    var obj = { a: 1, b: Infinity, c: 'hello' }
+    sanitizeInfinity(obj)
+    expect(obj.b).toBe('Infinity')
+    expect(obj.a).toBe(1)
+    expect(obj.c).toBe('hello')
+  })
+
+  it('replaces Infinity in nested objects', function () {
+    var obj = { nested: { val: Infinity } }
+    sanitizeInfinity(obj)
+    expect(obj.nested.val).toBe('Infinity')
+  })
+
+  it('replaces Infinity in arrays', function () {
+    var obj = { arr: [1, Infinity, 3] }
+    sanitizeInfinity(obj)
+    expect(obj.arr).toEqual([1, 'Infinity', 3])
+  })
+
+  it('survives JSON round-trip after sanitisation', function () {
+    var obj = { months_to_clear: Infinity }
+    sanitizeInfinity(obj)
+    var json = JSON.stringify(obj)
+    var parsed = JSON.parse(json)
+    expect(parsed.months_to_clear).toBe('Infinity')
+  })
+
+  it('handles null and non-object inputs gracefully', function () {
+    expect(sanitizeInfinity(null)).toBeNull()
+    expect(sanitizeInfinity(42)).toBe(42)
+    expect(sanitizeInfinity('hello')).toBe('hello')
+  })
+
+  it('handles computeBacklogHalfLife output with stalled components', function () {
+    var pressure = [{ component: 'Stuck', created: 5, resolved: 0, open: 10, net: 5, pressure_ratio: Infinity, open_jql: 'https://test' }]
+    var result = computeBacklogHalfLife(pressure, 12)
+    expect(result[0].months_to_clear).toBe(Infinity)
+
+    sanitizeInfinity(result)
+    expect(result[0].months_to_clear).toBe('Infinity')
+    expect(JSON.parse(JSON.stringify(result))[0].months_to_clear).toBe('Infinity')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// quoteComponent escaping
+// ---------------------------------------------------------------------------
+
+describe('quoteComponent edge cases', function () {
+  it('escapes backslashes before double quotes', function () {
+    var result = quoteComponent('test\\name')
+    expect(result).toBe('"test\\\\name"')
+  })
+
+  it('escapes both backslashes and quotes', function () {
+    var result = quoteComponent('test\\"name')
+    expect(result).toBe('"test\\\\\\"name"')
   })
 })

--- a/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
+++ b/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
@@ -28,37 +28,40 @@ const {
 // ---------------------------------------------------------------------------
 
 function makeIssue(overrides) {
+  var fields = Object.assign({
+    summary: 'Test feature',
+    status: { name: 'In Progress', statusCategory: { name: 'In Progress' } },
+    components: [{ name: 'Dashboard' }],
+    created: '2026-03-15T10:00:00.000Z',
+    resolutiondate: null
+  }, (overrides && overrides.fields) || {})
   return Object.assign({
     key: 'RHAISTRAT-100',
-    fields: Object.assign({
-      summary: 'Test feature',
-      status: { name: 'In Progress' },
-      components: [{ name: 'Dashboard' }],
-      created: '2026-03-15T10:00:00.000Z',
-      resolutiondate: null
-    }, (overrides && overrides.fields) || {})
+    fields: fields
   }, overrides ? { key: overrides.key || 'RHAISTRAT-100' } : {})
 }
 
 function makeRfeIssue(overrides) {
+  var fields = Object.assign({
+    summary: 'Test RFE',
+    status: { name: 'New', statusCategory: { name: 'To Do' } },
+    components: [{ name: 'Serving' }],
+    created: '2026-03-10T10:00:00.000Z',
+    resolutiondate: null
+  }, (overrides && overrides.fields) || {})
   return Object.assign({
     key: 'RHAIRFE-200',
-    fields: Object.assign({
-      summary: 'Test RFE',
-      status: { name: 'New' },
-      components: [{ name: 'Serving' }],
-      created: '2026-03-10T10:00:00.000Z',
-      resolutiondate: null
-    }, (overrides && overrides.fields) || {})
+    fields: fields
   }, overrides ? { key: overrides.key || 'RHAIRFE-200' } : {})
 }
 
-function makeFeature(key, comp, created, resolved, status) {
+function makeFeature(key, comp, created, resolved, status, statusCategory) {
   return {
     key: key,
     url: 'https://redhat.atlassian.net/browse/' + key,
     summary: 'Feature ' + key,
     status: status || 'In Progress',
+    statusCategory: statusCategory || 'In Progress',
     components: Array.isArray(comp) ? comp : [comp],
     created: created,
     resolved: resolved || null
@@ -71,6 +74,7 @@ function makeRfe(key, comp, status, created) {
     url: 'https://redhat.atlassian.net/browse/' + key,
     summary: 'RFE ' + key,
     status: status,
+    statusCategory: 'To Do',
     components: Array.isArray(comp) ? comp : [comp],
     created: created || '2026-03-01T00:00:00.000Z',
     resolved: null
@@ -264,7 +268,7 @@ describe('classifyByMonth', function () {
     var now = new Date()
     var thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1 < 10 ? '0' : '') + (now.getMonth() + 1)
     var features = [
-      makeFeature('F-1', 'A', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+      makeFeature('F-1', 'A', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed', 'Done')
     ]
     var result = classifyByMonth(features, 3)
     var thisRow = result.months.find(function (m) { return m.month === thisMonth })
@@ -277,7 +281,7 @@ describe('classifyByMonth', function () {
     var features = [
       makeFeature('F-1', 'A', now.toISOString(), null),
       makeFeature('F-2', 'A', now.toISOString(), null),
-      makeFeature('F-3', 'A', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+      makeFeature('F-3', 'A', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed', 'Done')
     ]
     var result = classifyByMonth(features, 3)
     var thisRow = result.months.find(function (m) { return m.month === thisMonth })
@@ -330,7 +334,7 @@ describe('computeComponentPressure', function () {
     var now = new Date()
     var features = [
       makeFeature('F-1', 'Dashboard', now.toISOString(), null),
-      makeFeature('F-2', 'Dashboard', now.toISOString(), now.toISOString(), 'Closed'),
+      makeFeature('F-2', 'Dashboard', now.toISOString(), now.toISOString(), 'Closed', 'Done'),
       makeFeature('F-3', 'Serving', now.toISOString(), null)
     ]
     var result = computeComponentPressure(features, 12)
@@ -358,7 +362,7 @@ describe('computeComponentPressure', function () {
     var features = [
       makeFeature('F-1', 'X', now.toISOString(), null),
       makeFeature('F-2', 'X', now.toISOString(), null),
-      makeFeature('F-3', 'X', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+      makeFeature('F-3', 'X', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed', 'Done')
     ]
     var result = computeComponentPressure(features, 12)
     var x = result.find(function (r) { return r.component === 'X' })
@@ -398,7 +402,7 @@ describe('computeComponentPressure', function () {
   it('sorts by net descending', function () {
     var now = new Date()
     var features = [
-      makeFeature('F-1', 'Low', now.toISOString(), now.toISOString(), 'Closed'),
+      makeFeature('F-1', 'Low', now.toISOString(), now.toISOString(), 'Closed', 'Done'),
       makeFeature('F-2', 'High', now.toISOString(), null),
       makeFeature('F-3', 'High', now.toISOString(), null)
     ]
@@ -579,7 +583,7 @@ describe('buildHeatmapMatrix', function () {
     var features = [
       makeFeature('F-1', 'A', now.toISOString(), null),
       makeFeature('F-2', 'A', now.toISOString(), null),
-      makeFeature('F-3', 'A', now.toISOString(), now.toISOString(), 'Closed')
+      makeFeature('F-3', 'A', now.toISOString(), now.toISOString(), 'Closed', 'Done')
     ]
     var result = buildHeatmapMatrix(features, 3)
     var monthIdx = result.months.indexOf(thisMonth)
@@ -641,7 +645,7 @@ describe('computeTrend', function () {
 
     var features = [
       // First half: 1 created, 1 resolved (net 0)
-      makeFeature('F-1', 'A', sixMonthsAgo.toISOString(), sixMonthsAgo.toISOString(), 'Closed'),
+      makeFeature('F-1', 'A', sixMonthsAgo.toISOString(), sixMonthsAgo.toISOString(), 'Closed', 'Done'),
       // Second half: 3 created, 0 resolved (net 3)
       makeFeature('F-2', 'A', now.toISOString(), null),
       makeFeature('F-3', 'A', now.toISOString(), null),
@@ -664,7 +668,7 @@ describe('computeTrend', function () {
       makeFeature('F-2', 'B', nineMonthsAgo.toISOString(), null),
       makeFeature('F-3', 'B', nineMonthsAgo.toISOString(), null),
       // Second half: 0 created, 1 resolved (net -1)
-      makeFeature('F-4', 'B', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+      makeFeature('F-4', 'B', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed', 'Done')
     ]
     var result = computeTrend(features, 12)
     var b = result.find(function (r) { return r.component === 'B' })
@@ -690,7 +694,7 @@ describe('computeTrend', function () {
   it('sorts by delta descending (worst first)', function () {
     var now = new Date()
     var features = [
-      makeFeature('F-1', 'Better', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed'),
+      makeFeature('F-1', 'Better', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed', 'Done'),
       makeFeature('F-2', 'Worse', now.toISOString(), null),
       makeFeature('F-3', 'Worse', now.toISOString(), null)
     ]

--- a/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
+++ b/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
@@ -1,0 +1,813 @@
+import { describe, it, expect } from 'vitest'
+
+const {
+  normalizeFeature,
+  normalizeRfe,
+  toMonth,
+  nextMonth,
+  generateMonthRange,
+  lookbackDate,
+  classifyByMonth,
+  computeComponentPressure,
+  computeRfePipeline,
+  computeBacklogHalfLife,
+  buildHeatmapMatrix,
+  computeTrend,
+  computeScorecard,
+  jqlUrl,
+  quoteComponent,
+  STATUS_DONE,
+  RFE_ACCEPTED,
+  RFE_PENDING
+} = require('../../../server/feature-pressure/routes')
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeIssue(overrides) {
+  return Object.assign({
+    key: 'RHAISTRAT-100',
+    fields: Object.assign({
+      summary: 'Test feature',
+      status: { name: 'In Progress' },
+      components: [{ name: 'Dashboard' }],
+      created: '2026-03-15T10:00:00.000Z',
+      resolutiondate: null
+    }, (overrides && overrides.fields) || {})
+  }, overrides ? { key: overrides.key || 'RHAISTRAT-100' } : {})
+}
+
+function makeRfeIssue(overrides) {
+  return Object.assign({
+    key: 'RHAIRFE-200',
+    fields: Object.assign({
+      summary: 'Test RFE',
+      status: { name: 'New' },
+      components: [{ name: 'Serving' }],
+      created: '2026-03-10T10:00:00.000Z',
+      resolutiondate: null
+    }, (overrides && overrides.fields) || {})
+  }, overrides ? { key: overrides.key || 'RHAIRFE-200' } : {})
+}
+
+function makeFeature(key, comp, created, resolved, status) {
+  return {
+    key: key,
+    url: 'https://redhat.atlassian.net/browse/' + key,
+    summary: 'Feature ' + key,
+    status: status || 'In Progress',
+    components: Array.isArray(comp) ? comp : [comp],
+    created: created,
+    resolved: resolved || null
+  }
+}
+
+function makeRfe(key, comp, status, created) {
+  return {
+    key: key,
+    url: 'https://redhat.atlassian.net/browse/' + key,
+    summary: 'RFE ' + key,
+    status: status,
+    components: Array.isArray(comp) ? comp : [comp],
+    created: created || '2026-03-01T00:00:00.000Z',
+    resolved: null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper tests
+// ---------------------------------------------------------------------------
+
+describe('toMonth', function () {
+  it('extracts YYYY-MM from ISO date string', function () {
+    expect(toMonth('2026-03-15T10:00:00.000Z')).toBe('2026-03')
+  })
+
+  it('pads single-digit months', function () {
+    expect(toMonth('2026-01-05T00:00:00.000Z')).toBe('2026-01')
+  })
+
+  it('returns null for null/undefined/empty', function () {
+    expect(toMonth(null)).toBeNull()
+    expect(toMonth(undefined)).toBeNull()
+    expect(toMonth('')).toBeNull()
+  })
+
+  it('returns null for invalid date strings', function () {
+    expect(toMonth('not-a-date')).toBeNull()
+  })
+})
+
+describe('nextMonth', function () {
+  it('increments month within a year', function () {
+    expect(nextMonth('2026-03')).toBe('2026-04')
+  })
+
+  it('rolls over December to January of next year', function () {
+    expect(nextMonth('2026-12')).toBe('2027-01')
+  })
+
+  it('pads single-digit months', function () {
+    expect(nextMonth('2026-08')).toBe('2026-09')
+    expect(nextMonth('2026-09')).toBe('2026-10')
+  })
+})
+
+describe('generateMonthRange', function () {
+  it('generates correct number of months', function () {
+    var range = generateMonthRange(6)
+    expect(range).toHaveLength(6)
+  })
+
+  it('ends with the current month', function () {
+    var range = generateMonthRange(3)
+    var now = new Date()
+    var m = now.getMonth() + 1
+    var expected = now.getFullYear() + '-' + (m < 10 ? '0' : '') + m
+    expect(range[range.length - 1]).toBe(expected)
+  })
+
+  it('returns months in ascending order', function () {
+    var range = generateMonthRange(6)
+    for (var i = 1; i < range.length; i++) {
+      expect(range[i] > range[i - 1]).toBe(true)
+    }
+  })
+})
+
+describe('lookbackDate', function () {
+  it('returns a date string in YYYY-MM-DD format', function () {
+    var result = lookbackDate(12)
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('jqlUrl', function () {
+  it('encodes JQL into a search URL', function () {
+    var url = jqlUrl('project = TEST')
+    expect(url).toContain('https://redhat.atlassian.net/issues/?jql=')
+    expect(url).toContain(encodeURIComponent('project = TEST'))
+  })
+})
+
+describe('quoteComponent', function () {
+  it('wraps component name in double quotes', function () {
+    expect(quoteComponent('Dashboard')).toBe('"Dashboard"')
+  })
+
+  it('escapes quotes within names', function () {
+    expect(quoteComponent('AI "Core"')).toBe('"AI \\"Core\\""')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// normalizeFeature
+// ---------------------------------------------------------------------------
+
+describe('normalizeFeature', function () {
+  it('extracts key, url, summary, status, components, created, resolved', function () {
+    var result = normalizeFeature(makeIssue())
+    expect(result.key).toBe('RHAISTRAT-100')
+    expect(result.url).toContain('/browse/RHAISTRAT-100')
+    expect(result.summary).toBe('Test feature')
+    expect(result.status).toBe('In Progress')
+    expect(result.components).toEqual(['Dashboard'])
+    expect(result.created).toBe('2026-03-15T10:00:00.000Z')
+    expect(result.resolved).toBeNull()
+  })
+
+  it('truncates long summaries to 120 chars', function () {
+    var result = normalizeFeature(makeIssue({ fields: { summary: 'A'.repeat(200) } }))
+    expect(result.summary.length).toBe(120)
+  })
+
+  it('handles missing components (empty array)', function () {
+    var result = normalizeFeature(makeIssue({ fields: { components: [] } }))
+    expect(result.components).toEqual([])
+  })
+
+  it('handles null components field', function () {
+    var result = normalizeFeature(makeIssue({ fields: { components: null } }))
+    expect(result.components).toEqual([])
+  })
+
+  it('handles missing fields gracefully', function () {
+    var result = normalizeFeature({ key: 'X-1', fields: {} })
+    expect(result.summary).toBe('')
+    expect(result.status).toBe('')
+    expect(result.components).toEqual([])
+    expect(result.created).toBeNull()
+    expect(result.resolved).toBeNull()
+  })
+
+  it('handles completely missing fields object', function () {
+    var result = normalizeFeature({ key: 'X-1' })
+    expect(result.key).toBe('X-1')
+    expect(result.summary).toBe('')
+  })
+
+  it('extracts resolved date when present', function () {
+    var result = normalizeFeature(makeIssue({ fields: { resolutiondate: '2026-04-01T00:00:00.000Z' } }))
+    expect(result.resolved).toBe('2026-04-01T00:00:00.000Z')
+  })
+
+  it('handles multiple components', function () {
+    var result = normalizeFeature(makeIssue({
+      fields: { components: [{ name: 'A' }, { name: 'B' }, { name: 'C' }] }
+    }))
+    expect(result.components).toEqual(['A', 'B', 'C'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// normalizeRfe
+// ---------------------------------------------------------------------------
+
+describe('normalizeRfe', function () {
+  it('extracts key, url, summary, status, components, created', function () {
+    var result = normalizeRfe(makeRfeIssue())
+    expect(result.key).toBe('RHAIRFE-200')
+    expect(result.url).toContain('/browse/RHAIRFE-200')
+    expect(result.summary).toBe('Test RFE')
+    expect(result.status).toBe('New')
+    expect(result.components).toEqual(['Serving'])
+  })
+
+  it('handles missing fields gracefully', function () {
+    var result = normalizeRfe({ key: 'R-1', fields: {} })
+    expect(result.status).toBe('')
+    expect(result.components).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// classifyByMonth
+// ---------------------------------------------------------------------------
+
+describe('classifyByMonth', function () {
+  it('buckets features by created month', function () {
+    var now = new Date()
+    var thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1 < 10 ? '0' : '') + (now.getMonth() + 1)
+    var features = [
+      makeFeature('F-1', 'A', now.toISOString(), null)
+    ]
+    var result = classifyByMonth(features, 3)
+    var thisRow = result.months.find(function (m) { return m.month === thisMonth })
+    expect(thisRow).toBeDefined()
+    expect(thisRow.created).toBe(1)
+  })
+
+  it('buckets features by resolved month', function () {
+    var now = new Date()
+    var thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1 < 10 ? '0' : '') + (now.getMonth() + 1)
+    var features = [
+      makeFeature('F-1', 'A', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+    ]
+    var result = classifyByMonth(features, 3)
+    var thisRow = result.months.find(function (m) { return m.month === thisMonth })
+    expect(thisRow.resolved).toBe(1)
+  })
+
+  it('computes net = created - resolved per month', function () {
+    var now = new Date()
+    var thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1 < 10 ? '0' : '') + (now.getMonth() + 1)
+    var features = [
+      makeFeature('F-1', 'A', now.toISOString(), null),
+      makeFeature('F-2', 'A', now.toISOString(), null),
+      makeFeature('F-3', 'A', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+    ]
+    var result = classifyByMonth(features, 3)
+    var thisRow = result.months.find(function (m) { return m.month === thisMonth })
+    expect(thisRow.net).toBe(1) // 2 created - 1 resolved
+  })
+
+  it('computes cumulative correctly', function () {
+    var result = classifyByMonth([], 3)
+    expect(result.months).toHaveLength(3)
+    // All zero — cumulative stays 0
+    for (var i = 0; i < result.months.length; i++) {
+      expect(result.months[i].cumulative).toBe(0)
+    }
+  })
+
+  it('handles empty input', function () {
+    var result = classifyByMonth([], 6)
+    expect(result.months).toHaveLength(6)
+    result.months.forEach(function (m) {
+      expect(m.created).toBe(0)
+      expect(m.resolved).toBe(0)
+      expect(m.net).toBe(0)
+    })
+  })
+
+  it('ignores features outside the lookback window', function () {
+    var features = [
+      makeFeature('F-old', 'A', '2015-01-01T00:00:00.000Z', null)
+    ]
+    var result = classifyByMonth(features, 3)
+    var total = result.months.reduce(function (sum, m) { return sum + m.created }, 0)
+    expect(total).toBe(0)
+  })
+
+  it('includes JQL URLs for each month', function () {
+    var result = classifyByMonth([], 3)
+    result.months.forEach(function (m) {
+      expect(m.created_jql).toContain('jql=')
+      expect(m.resolved_jql).toContain('jql=')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeComponentPressure
+// ---------------------------------------------------------------------------
+
+describe('computeComponentPressure', function () {
+  it('groups features by component', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', 'Dashboard', now.toISOString(), null),
+      makeFeature('F-2', 'Dashboard', now.toISOString(), now.toISOString(), 'Closed'),
+      makeFeature('F-3', 'Serving', now.toISOString(), null)
+    ]
+    var result = computeComponentPressure(features, 12)
+    expect(result.length).toBe(2)
+    var dashboard = result.find(function (r) { return r.component === 'Dashboard' })
+    expect(dashboard).toBeDefined()
+    expect(dashboard.created).toBe(2)
+    expect(dashboard.resolved).toBe(1)
+  })
+
+  it('handles features with multiple components (counted in each)', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', ['A', 'B'], now.toISOString(), null)
+    ]
+    var result = computeComponentPressure(features, 12)
+    var a = result.find(function (r) { return r.component === 'A' })
+    var b = result.find(function (r) { return r.component === 'B' })
+    expect(a.created).toBe(1)
+    expect(b.created).toBe(1)
+  })
+
+  it('computes pressure_ratio = created / resolved', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', 'X', now.toISOString(), null),
+      makeFeature('F-2', 'X', now.toISOString(), null),
+      makeFeature('F-3', 'X', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+    ]
+    var result = computeComponentPressure(features, 12)
+    var x = result.find(function (r) { return r.component === 'X' })
+    expect(x.pressure_ratio).toBe(2) // 2 created / 1 resolved
+  })
+
+  it('returns Infinity ratio when resolved is zero and created > 0', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', 'X', now.toISOString(), null)
+    ]
+    var result = computeComponentPressure(features, 12)
+    var x = result.find(function (r) { return r.component === 'X' })
+    expect(x.pressure_ratio).toBe(Infinity)
+  })
+
+  it('returns 0 ratio when both created and resolved are zero', function () {
+    // Feature created outside window but still open
+    var features = [
+      makeFeature('F-1', 'X', '2015-01-01T00:00:00.000Z', null)
+    ]
+    var result = computeComponentPressure(features, 12)
+    var x = result.find(function (r) { return r.component === 'X' })
+    expect(x.pressure_ratio).toBe(0)
+    expect(x.open).toBe(1) // still open
+  })
+
+  it('generates correct JQL URLs for each count', function () {
+    var now = new Date()
+    var features = [makeFeature('F-1', 'Dashboard', now.toISOString(), null)]
+    var result = computeComponentPressure(features, 12)
+    var d = result.find(function (r) { return r.component === 'Dashboard' })
+    expect(d.created_jql).toContain('Dashboard')
+    expect(d.open_jql).toContain('statusCategory')
+  })
+
+  it('sorts by net descending', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', 'Low', now.toISOString(), now.toISOString(), 'Closed'),
+      makeFeature('F-2', 'High', now.toISOString(), null),
+      makeFeature('F-3', 'High', now.toISOString(), null)
+    ]
+    var result = computeComponentPressure(features, 12)
+    expect(result[0].component).toBe('High')
+    expect(result[0].net).toBe(2)
+  })
+
+  it('filters out components with zero created and zero open', function () {
+    var features = []
+    var result = computeComponentPressure(features, 12)
+    expect(result).toHaveLength(0)
+  })
+
+  it('uses (No Component) for features without components', function () {
+    var now = new Date()
+    // makeFeature wraps comp as array, so build manually for empty components
+    var feat = {
+      key: 'F-1', url: '', summary: '', status: 'In Progress',
+      components: [], created: now.toISOString(), resolved: null
+    }
+    var result = computeComponentPressure([feat], 12)
+    var noComp = result.find(function (r) { return r.component === '(No Component)' })
+    expect(noComp).toBeDefined()
+    expect(noComp.created).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeRfePipeline
+// ---------------------------------------------------------------------------
+
+describe('computeRfePipeline', function () {
+  it('counts accepted vs pending correctly using STATUS constants', function () {
+    var rfes = [
+      makeRfe('R-1', 'A', 'Approved'),
+      makeRfe('R-2', 'A', 'New'),
+      makeRfe('R-3', 'A', 'Draft'),
+      makeRfe('R-4', 'A', 'In Progress')
+    ]
+    var result = computeRfePipeline(rfes, 12)
+    expect(result.status_breakdown.accepted.count).toBe(2) // Approved, In Progress
+    expect(result.status_breakdown.pending.count).toBe(2) // New, Draft
+  })
+
+  it('handles unknown status as other', function () {
+    var rfes = [makeRfe('R-1', 'A', 'WontDo')]
+    var result = computeRfePipeline(rfes, 12)
+    expect(result.status_breakdown.other.count).toBe(1)
+    expect(result.status_breakdown.accepted.count).toBe(0)
+    expect(result.status_breakdown.pending.count).toBe(0)
+  })
+
+  it('computes monthly arrivals', function () {
+    var now = new Date()
+    var rfes = [
+      makeRfe('R-1', 'A', 'New', now.toISOString()),
+      makeRfe('R-2', 'A', 'New', now.toISOString())
+    ]
+    var result = computeRfePipeline(rfes, 3)
+    var thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1 < 10 ? '0' : '') + (now.getMonth() + 1)
+    var thisRow = result.monthly_arrivals.find(function (m) { return m.month === thisMonth })
+    expect(thisRow.count).toBe(2)
+  })
+
+  it('groups pending by component', function () {
+    var rfes = [
+      makeRfe('R-1', 'Serving', 'New'),
+      makeRfe('R-2', 'Serving', 'Draft'),
+      makeRfe('R-3', 'Training', 'New')
+    ]
+    var result = computeRfePipeline(rfes, 12)
+    var serving = result.per_component_pending.find(function (p) { return p.component === 'Serving' })
+    expect(serving.count).toBe(2)
+    var training = result.per_component_pending.find(function (p) { return p.component === 'Training' })
+    expect(training.count).toBe(1)
+  })
+
+  it('generates JQL URLs for all counts', function () {
+    var rfes = [makeRfe('R-1', 'A', 'New')]
+    var result = computeRfePipeline(rfes, 12)
+    expect(result.status_breakdown.total.jql).toContain('jql=')
+    expect(result.status_breakdown.accepted.jql).toContain('jql=')
+    expect(result.status_breakdown.pending.jql).toContain('jql=')
+  })
+
+  it('handles empty RFE list', function () {
+    var result = computeRfePipeline([], 6)
+    expect(result.status_breakdown.total.count).toBe(0)
+    expect(result.status_breakdown.accepted.count).toBe(0)
+    expect(result.status_breakdown.pending.count).toBe(0)
+    expect(result.per_component_pending).toHaveLength(0)
+  })
+
+  it('sorts per_component_pending by count descending', function () {
+    var rfes = [
+      makeRfe('R-1', 'Low', 'New'),
+      makeRfe('R-2', 'High', 'New'),
+      makeRfe('R-3', 'High', 'Draft'),
+      makeRfe('R-4', 'High', 'Stakeholder review')
+    ]
+    var result = computeRfePipeline(rfes, 12)
+    expect(result.per_component_pending[0].component).toBe('High')
+    expect(result.per_component_pending[0].count).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeBacklogHalfLife
+// ---------------------------------------------------------------------------
+
+describe('computeBacklogHalfLife', function () {
+  it('returns correct months for normal case', function () {
+    var pressure = [
+      { component: 'A', created: 12, resolved: 6, open: 18, net: 6, open_jql: '' }
+    ]
+    var result = computeBacklogHalfLife(pressure, 12)
+    expect(result).toHaveLength(1)
+    // resolved_per_month = 6/12 = 0.5, months_to_clear = 18/0.5 = 36
+    expect(result[0].months_to_clear).toBe(36)
+    expect(result[0].resolved_per_month).toBe(0.5)
+  })
+
+  it('returns Infinity when resolved is zero', function () {
+    var pressure = [
+      { component: 'A', created: 5, resolved: 0, open: 10, net: 5, open_jql: '' }
+    ]
+    var result = computeBacklogHalfLife(pressure, 12)
+    expect(result[0].months_to_clear).toBe(Infinity)
+  })
+
+  it('excludes components with zero open', function () {
+    var pressure = [
+      { component: 'A', created: 5, resolved: 5, open: 0, net: 0, open_jql: '' }
+    ]
+    var result = computeBacklogHalfLife(pressure, 12)
+    expect(result).toHaveLength(0)
+  })
+
+  it('sorts with Infinity first (worst), then descending months', function () {
+    var pressure = [
+      { component: 'Fast', created: 10, resolved: 10, open: 5, net: 0, open_jql: '' },
+      { component: 'Stuck', created: 5, resolved: 0, open: 5, net: 5, open_jql: '' },
+      { component: 'Slow', created: 12, resolved: 2, open: 20, net: 10, open_jql: '' }
+    ]
+    var result = computeBacklogHalfLife(pressure, 12)
+    expect(result[0].component).toBe('Stuck')
+    expect(result[0].months_to_clear).toBe(Infinity)
+    expect(result[1].component).toBe('Slow') // 20 / (2/12) = 120 months
+    expect(result[2].component).toBe('Fast') // 5 / (10/12) = 6 months
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildHeatmapMatrix
+// ---------------------------------------------------------------------------
+
+describe('buildHeatmapMatrix', function () {
+  it('produces correct dimensions (components x months)', function () {
+    var now = new Date()
+    var features = []
+    // Create 4 features in same component to pass >= 3 threshold
+    for (var i = 0; i < 4; i++) {
+      features.push(makeFeature('F-' + i, 'A', now.toISOString(), null))
+    }
+    var result = buildHeatmapMatrix(features, 6)
+    expect(result.months).toHaveLength(6)
+    expect(result.components).toHaveLength(1)
+    expect(result.matrix).toHaveLength(1)
+    expect(result.matrix[0]).toHaveLength(6)
+  })
+
+  it('cell values match created - resolved', function () {
+    var now = new Date()
+    var thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1 < 10 ? '0' : '') + (now.getMonth() + 1)
+    // 3 created this month (including the resolved one), 1 resolved this month
+    // Net = 3 - 1 = 2
+    var features = [
+      makeFeature('F-1', 'A', now.toISOString(), null),
+      makeFeature('F-2', 'A', now.toISOString(), null),
+      makeFeature('F-3', 'A', now.toISOString(), now.toISOString(), 'Closed')
+    ]
+    var result = buildHeatmapMatrix(features, 3)
+    var monthIdx = result.months.indexOf(thisMonth)
+    if (result.components.length > 0) {
+      expect(result.matrix[0][monthIdx]).toBe(2) // 3 created - 1 resolved = 2
+    }
+  })
+
+  it('filters out components with < 3 total activity', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', 'SmallComp', now.toISOString(), null),
+      makeFeature('F-2', 'SmallComp', now.toISOString(), null)
+    ]
+    var result = buildHeatmapMatrix(features, 6)
+    expect(result.components).not.toContain('SmallComp')
+  })
+
+  it('handles empty features list', function () {
+    var result = buildHeatmapMatrix([], 6)
+    expect(result.months).toHaveLength(6)
+    expect(result.components).toHaveLength(0)
+    expect(result.matrix).toHaveLength(0)
+  })
+
+  it('limits to 25 components', function () {
+    var now = new Date()
+    var features = []
+    for (var i = 0; i < 30; i++) {
+      // Each component needs 3+ features
+      for (var j = 0; j < 3; j++) {
+        features.push(makeFeature('F-' + i + '-' + j, 'Comp' + i, now.toISOString(), null))
+      }
+    }
+    var result = buildHeatmapMatrix(features, 6)
+    expect(result.components.length).toBeLessThanOrEqual(25)
+  })
+
+  it('skips features with no components', function () {
+    var now = new Date()
+    var feat = {
+      key: 'F-1', url: '', summary: '', status: 'In Progress',
+      components: [], created: now.toISOString(), resolved: null
+    }
+    var result = buildHeatmapMatrix([feat], 6)
+    expect(result.components).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeTrend
+// ---------------------------------------------------------------------------
+
+describe('computeTrend', function () {
+  it('identifies worsening when second_half_net > first_half_net', function () {
+    var now = new Date()
+    var sixMonthsAgo = new Date(now)
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 9) // in first half of 12mo window
+
+    var features = [
+      // First half: 1 created, 1 resolved (net 0)
+      makeFeature('F-1', 'A', sixMonthsAgo.toISOString(), sixMonthsAgo.toISOString(), 'Closed'),
+      // Second half: 3 created, 0 resolved (net 3)
+      makeFeature('F-2', 'A', now.toISOString(), null),
+      makeFeature('F-3', 'A', now.toISOString(), null),
+      makeFeature('F-4', 'A', now.toISOString(), null)
+    ]
+    var result = computeTrend(features, 12)
+    var a = result.find(function (r) { return r.component === 'A' })
+    expect(a.direction).toBe('worsening')
+    expect(a.delta).toBeGreaterThan(0)
+  })
+
+  it('identifies improving when second_half_net < first_half_net', function () {
+    var now = new Date()
+    var nineMonthsAgo = new Date(now)
+    nineMonthsAgo.setMonth(nineMonthsAgo.getMonth() - 9)
+
+    var features = [
+      // First half: 3 created, 0 resolved (net 3)
+      makeFeature('F-1', 'B', nineMonthsAgo.toISOString(), null),
+      makeFeature('F-2', 'B', nineMonthsAgo.toISOString(), null),
+      makeFeature('F-3', 'B', nineMonthsAgo.toISOString(), null),
+      // Second half: 0 created, 1 resolved (net -1)
+      makeFeature('F-4', 'B', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed')
+    ]
+    var result = computeTrend(features, 12)
+    var b = result.find(function (r) { return r.component === 'B' })
+    expect(b.direction).toBe('improving')
+    expect(b.delta).toBeLessThan(0)
+  })
+
+  it('identifies stable when nets are equal', function () {
+    var now = new Date()
+    var nineMonthsAgo = new Date(now)
+    nineMonthsAgo.setMonth(nineMonthsAgo.getMonth() - 9)
+
+    var features = [
+      makeFeature('F-1', 'C', nineMonthsAgo.toISOString(), null),
+      makeFeature('F-2', 'C', now.toISOString(), null)
+    ]
+    var result = computeTrend(features, 12)
+    var c = result.find(function (r) { return r.component === 'C' })
+    expect(c.direction).toBe('stable')
+    expect(c.delta).toBe(0)
+  })
+
+  it('sorts by delta descending (worst first)', function () {
+    var now = new Date()
+    var features = [
+      makeFeature('F-1', 'Better', '2020-01-01T00:00:00.000Z', now.toISOString(), 'Closed'),
+      makeFeature('F-2', 'Worse', now.toISOString(), null),
+      makeFeature('F-3', 'Worse', now.toISOString(), null)
+    ]
+    var result = computeTrend(features, 12)
+    expect(result[0].component).toBe('Worse')
+  })
+
+  it('handles empty features', function () {
+    var result = computeTrend([], 12)
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeScorecard
+// ---------------------------------------------------------------------------
+
+describe('computeScorecard', function () {
+  it('computes risk score with correct weights', function () {
+    var pressure = [
+      { component: 'A', created: 10, resolved: 5, open: 20, net: 5, pressure_ratio: 2, open_jql: '' }
+    ]
+    var rfePipeline = { per_component_pending: [{ component: 'A', count: 5, jql: '' }] }
+    var halfLife = [{ component: 'A', open: 20, months_to_clear: 24 }]
+    var trend = [{ component: 'A', direction: 'worsening' }]
+
+    var result = computeScorecard(pressure, rfePipeline, halfLife, trend)
+    expect(result).toHaveLength(1)
+    expect(result[0].component).toBe('A')
+    // netScore = min(5/5, 10) = 1, backlogScore = min(20/10, 10) = 2, rfeScore = min(5/5, 10) = 1
+    // risk = 1*0.4 + 2*0.3 + 1*0.3 = 0.4 + 0.6 + 0.3 = 1.3
+    expect(result[0].risk_score).toBe(1.3)
+    expect(result[0].risk_level).toBe('low')
+    expect(result[0].trend).toBe('worsening')
+  })
+
+  it('caps individual scores at 10', function () {
+    var pressure = [
+      { component: 'A', created: 100, resolved: 0, open: 200, net: 100, pressure_ratio: Infinity, open_jql: '' }
+    ]
+    var rfePipeline = { per_component_pending: [{ component: 'A', count: 100, jql: '' }] }
+    var halfLife = [{ component: 'A', open: 200, months_to_clear: Infinity }]
+    var trend = [{ component: 'A', direction: 'worsening' }]
+
+    var result = computeScorecard(pressure, rfePipeline, halfLife, trend)
+    // All capped: net=10, backlog=10, rfe=10 -> 10*0.4 + 10*0.3 + 10*0.3 = 10
+    expect(result[0].risk_score).toBe(10)
+    expect(result[0].risk_level).toBe('critical')
+  })
+
+  it('handles components with no RFE data', function () {
+    var pressure = [
+      { component: 'X', created: 5, resolved: 3, open: 5, net: 2, pressure_ratio: 1.67, open_jql: '' }
+    ]
+    var rfePipeline = { per_component_pending: [] }
+    var halfLife = [{ component: 'X', open: 5, months_to_clear: 10 }]
+    var trend = [{ component: 'X', direction: 'stable' }]
+
+    var result = computeScorecard(pressure, rfePipeline, halfLife, trend)
+    expect(result[0].rfe_pending).toBe(0)
+  })
+
+  it('sorts by risk_score descending', function () {
+    var pressure = [
+      { component: 'Low', created: 1, resolved: 1, open: 1, net: 0, pressure_ratio: 1, open_jql: '' },
+      { component: 'High', created: 50, resolved: 0, open: 100, net: 50, pressure_ratio: Infinity, open_jql: '' }
+    ]
+    var rfePipeline = { per_component_pending: [] }
+    var halfLife = []
+    var trend = []
+
+    var result = computeScorecard(pressure, rfePipeline, halfLife, trend)
+    expect(result[0].component).toBe('High')
+  })
+
+  it('assigns correct risk levels', function () {
+    // Build scenarios for each level
+    var pressure = [
+      { component: 'Critical', created: 100, resolved: 0, open: 200, net: 100, pressure_ratio: Infinity, open_jql: '' },
+      { component: 'High', created: 30, resolved: 5, open: 80, net: 25, pressure_ratio: 6, open_jql: '' },
+      { component: 'Medium', created: 15, resolved: 5, open: 30, net: 10, pressure_ratio: 3, open_jql: '' },
+      { component: 'Low', created: 2, resolved: 2, open: 3, net: 0, pressure_ratio: 1, open_jql: '' }
+    ]
+    var rfePipeline = { per_component_pending: [
+      { component: 'Critical', count: 50, jql: '' },
+      { component: 'High', count: 20, jql: '' }
+    ] }
+    var halfLife = []
+    var trend = []
+
+    var result = computeScorecard(pressure, rfePipeline, halfLife, trend)
+    var critical = result.find(function (r) { return r.component === 'Critical' })
+    var low = result.find(function (r) { return r.component === 'Low' })
+    expect(critical.risk_level).toBe('critical')
+    expect(low.risk_level).toBe('low')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Status constants sanity
+// ---------------------------------------------------------------------------
+
+describe('status constants', function () {
+  it('STATUS_DONE includes expected values', function () {
+    expect(STATUS_DONE).toContain('Release Pending')
+    expect(STATUS_DONE).toContain('Closed')
+  })
+
+  it('RFE_ACCEPTED includes all expected values', function () {
+    expect(RFE_ACCEPTED).toContain('Approved')
+    expect(RFE_ACCEPTED).toContain('In Progress')
+    expect(RFE_ACCEPTED).toContain('Resolved')
+  })
+
+  it('RFE_PENDING includes all expected values', function () {
+    expect(RFE_PENDING).toContain('New')
+    expect(RFE_PENDING).toContain('Draft')
+    expect(RFE_PENDING).toContain('Stakeholder review')
+    expect(RFE_PENDING).toContain('Stakeholder Feedback')
+    expect(RFE_PENDING).toContain('Pending Approval')
+  })
+})

--- a/modules/releases/client/components/MonthlyFlowChart.vue
+++ b/modules/releases/client/components/MonthlyFlowChart.vue
@@ -6,13 +6,11 @@ import {
   CategoryScale,
   LinearScale,
   BarElement,
-  PointElement,
-  LineElement,
   Tooltip,
   Legend,
 } from 'chart.js'
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, Tooltip, Legend)
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
 
 const props = defineProps({
   monthlyFlow: { type: Array, required: true },

--- a/modules/releases/client/components/MonthlyFlowChart.vue
+++ b/modules/releases/client/components/MonthlyFlowChart.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { computed } from 'vue'
+import { Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, Tooltip, Legend)
+
+const props = defineProps({
+  monthlyFlow: { type: Array, required: true },
+})
+
+const chartData = computed(() => ({
+  labels: props.monthlyFlow.map(m => m.month),
+  datasets: [
+    {
+      label: 'Created',
+      data: props.monthlyFlow.map(m => m.created),
+      backgroundColor: 'rgba(239, 68, 68, 0.7)',
+      borderColor: 'rgba(239, 68, 68, 1)',
+      borderWidth: 1,
+    },
+    {
+      label: 'Resolved',
+      data: props.monthlyFlow.map(m => m.resolved),
+      backgroundColor: 'rgba(34, 197, 94, 0.7)',
+      borderColor: 'rgba(34, 197, 94, 1)',
+      borderWidth: 1,
+    },
+  ],
+}))
+
+const chartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { position: 'top' },
+    tooltip: {
+      callbacks: {
+        afterBody(items) {
+          const idx = items[0]?.dataIndex
+          if (idx == null) return ''
+          const row = props.monthlyFlow[idx]
+          return `Net: ${row.net > 0 ? '+' : ''}${row.net}\nCumulative: ${row.cumulative > 0 ? '+' : ''}${row.cumulative}`
+        },
+      },
+    },
+  },
+  scales: {
+    y: {
+      beginAtZero: true,
+      title: { display: true, text: 'Count' },
+    },
+    x: {
+      title: { display: true, text: 'Month' },
+    },
+  },
+}))
+</script>
+
+<template>
+  <div class="w-full" style="height: 320px">
+    <Bar :data="chartData" :options="chartOptions" />
+  </div>
+</template>

--- a/modules/releases/client/components/PressureHeatmap.vue
+++ b/modules/releases/client/components/PressureHeatmap.vue
@@ -1,0 +1,72 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  heatmap: { type: Object, required: true },
+})
+
+/** Map a net-flow value to a CSS background colour (green = burning, red = growing). */
+function cellColor(val) {
+  if (val === 0) return ''
+  const maxAbs = Math.max(
+    ...props.heatmap.matrix.flat().map(v => Math.abs(v)),
+    1
+  )
+  const norm = Math.min(Math.abs(val) / maxAbs, 1)
+  const alpha = Math.round(norm * 60 + 10) // 10–70% opacity
+  if (val > 0) return `rgba(239, 68, 68, ${alpha / 100})`   // red — growing
+  return `rgba(34, 197, 94, ${alpha / 100})`                 // green — burning down
+}
+
+function cellText(val) {
+  return val === 0 ? '' : (val > 0 ? '+' + val : String(val))
+}
+
+const hasData = computed(() =>
+  props.heatmap &&
+  props.heatmap.components &&
+  props.heatmap.components.length > 0
+)
+</script>
+
+<template>
+  <div v-if="hasData" class="overflow-x-auto">
+    <table class="min-w-full text-xs border-collapse">
+      <thead>
+        <tr>
+          <th class="sticky left-0 z-[1] bg-white dark:bg-gray-900 px-2 py-1 text-left font-medium text-gray-500 dark:text-gray-400 border-b border-r dark:border-gray-700">
+            Component
+          </th>
+          <th
+            v-for="month in heatmap.months"
+            :key="month"
+            class="px-2 py-1 text-center font-medium text-gray-500 dark:text-gray-400 border-b dark:border-gray-700 whitespace-nowrap"
+          >
+            {{ month }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(comp, ci) in heatmap.components" :key="comp">
+          <td class="sticky left-0 z-[1] bg-white dark:bg-gray-900 px-2 py-1 text-left font-medium text-gray-700 dark:text-gray-300 border-r dark:border-gray-700 whitespace-nowrap truncate max-w-[180px]" :title="comp">
+            {{ comp }}
+          </td>
+          <td
+            v-for="(val, mi) in heatmap.matrix[ci]"
+            :key="mi"
+            class="px-2 py-1 text-center font-mono border-l dark:border-gray-800"
+            :style="{ backgroundColor: cellColor(val) }"
+            :title="`${comp} / ${heatmap.months[mi]}: net ${val >= 0 ? '+' : ''}${val}`"
+          >
+            <span :class="{ 'text-white': Math.abs(val) > 3, 'text-gray-800 dark:text-gray-200': Math.abs(val) <= 3 }">
+              {{ cellText(val) }}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p v-else class="text-gray-500 dark:text-gray-400 italic text-sm">
+    No heatmap data available (requires components with 3+ features).
+  </p>
+</template>

--- a/modules/releases/client/components/PressureHeatmap.vue
+++ b/modules/releases/client/components/PressureHeatmap.vue
@@ -5,14 +5,15 @@ const props = defineProps({
   heatmap: { type: Object, required: true },
 })
 
+/** Max absolute value across the entire matrix — precomputed once per data change. */
+const maxAbsValue = computed(() =>
+  Math.max(...(props.heatmap.matrix || []).flat().map(v => Math.abs(v)), 1)
+)
+
 /** Map a net-flow value to a CSS background colour (green = burning, red = growing). */
 function cellColor(val) {
   if (val === 0) return ''
-  const maxAbs = Math.max(
-    ...props.heatmap.matrix.flat().map(v => Math.abs(v)),
-    1
-  )
-  const norm = Math.min(Math.abs(val) / maxAbs, 1)
+  const norm = Math.min(Math.abs(val) / maxAbsValue.value, 1)
   const alpha = Math.round(norm * 60 + 10) // 10–70% opacity
   if (val > 0) return `rgba(239, 68, 68, ${alpha / 100})`   // red — growing
   return `rgba(34, 197, 94, ${alpha / 100})`                 // green — burning down

--- a/modules/releases/client/composables/useComponentPressure.js
+++ b/modules/releases/client/composables/useComponentPressure.js
@@ -1,0 +1,46 @@
+import { computed } from 'vue'
+
+/**
+ * Computed filtering and sorting for component pressure data.
+ * @param {import('vue').Ref} data - The full API response ref
+ * @param {import('vue').Ref<string>} searchQuery - Component search filter
+ * @param {import('vue').Ref<string>} sortField - Field to sort by
+ * @param {import('vue').Ref<boolean>} sortAsc - Sort direction
+ */
+export function useComponentPressure(data, searchQuery, sortField, sortAsc) {
+  const filteredComponents = computed(() => {
+    if (!data.value?.component_pressure) return []
+    let list = data.value.component_pressure
+
+    // Filter by search query
+    if (searchQuery.value) {
+      const q = searchQuery.value.toLowerCase()
+      list = list.filter(c => c.component.toLowerCase().includes(q))
+    }
+
+    // Sort
+    const field = sortField.value || 'net'
+    const asc = sortAsc.value
+    list = [...list].sort((a, b) => {
+      let va = a[field]
+      let vb = b[field]
+
+      // Handle string sorting for component name
+      if (field === 'component') {
+        return asc
+          ? String(va).localeCompare(String(vb))
+          : String(vb).localeCompare(String(va))
+      }
+
+      // Handle Infinity
+      if (va === Infinity) va = Number.MAX_SAFE_INTEGER
+      if (vb === Infinity) vb = Number.MAX_SAFE_INTEGER
+
+      return asc ? va - vb : vb - va
+    })
+
+    return list
+  })
+
+  return { filteredComponents }
+}

--- a/modules/releases/client/composables/useComponentPressure.js
+++ b/modules/releases/client/composables/useComponentPressure.js
@@ -32,9 +32,9 @@ export function useComponentPressure(data, searchQuery, sortField, sortAsc) {
           : String(vb).localeCompare(String(va))
       }
 
-      // Handle Infinity
-      if (va === Infinity) va = Number.MAX_SAFE_INTEGER
-      if (vb === Infinity) vb = Number.MAX_SAFE_INTEGER
+      // Handle Infinity (native or string from JSON round-trip)
+      if (va === Infinity || va === 'Infinity') va = Number.MAX_SAFE_INTEGER
+      if (vb === Infinity || vb === 'Infinity') vb = Number.MAX_SAFE_INTEGER
 
       return asc ? va - vb : vb - va
     })

--- a/modules/releases/client/composables/useFeaturePressureData.js
+++ b/modules/releases/client/composables/useFeaturePressureData.js
@@ -24,7 +24,7 @@ export function useFeaturePressureData() {
       if (!_alive) return
 
       if (result._noCache) {
-        loading.value = false
+        // Keep loading = true until data arrives so the template shows the spinner
         refreshing.value = true
         pollRetryCount++
         if (pollRetryCount < MAX_POLL_RETRIES) {

--- a/modules/releases/client/composables/useFeaturePressureData.js
+++ b/modules/releases/client/composables/useFeaturePressureData.js
@@ -1,0 +1,129 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client'
+
+const MAX_POLL_RETRIES = 24 // 24 x 5s = 2 minutes max
+
+/** Feature pressure data fetching, refresh, and polling. */
+export function useFeaturePressureData() {
+  const data = ref(null)
+  const loading = ref(true)
+  const error = ref(null)
+  const refreshing = ref(false)
+  const lookbackMonths = ref(12)
+
+  let pipelinePollTimeout = null
+  let refreshPollInterval = null
+  let pollRetryCount = 0
+  let _alive = true // unmount guard
+
+  async function fetchData() {
+    if (!_alive) return
+    try {
+      const result = await apiRequest('/modules/releases/feature-pressure')
+      if (!_alive) return
+
+      if (result._noCache) {
+        loading.value = false
+        refreshing.value = true
+        pollRetryCount++
+        if (pollRetryCount < MAX_POLL_RETRIES) {
+          if (pipelinePollTimeout) clearTimeout(pipelinePollTimeout)
+          pipelinePollTimeout = setTimeout(fetchData, 5000)
+        } else {
+          error.value = 'Data pipeline is taking too long. Try refreshing manually.'
+          refreshing.value = false
+          loading.value = false
+        }
+        return
+      }
+
+      pollRetryCount = 0
+      error.value = null
+      data.value = result
+      refreshing.value = !!result._refreshing
+      loading.value = false
+
+      if (result.metadata?.lookback_months) {
+        lookbackMonths.value = result.metadata.lookback_months
+      }
+
+      // Poll to detect when background refresh completes
+      if (result._refreshing && !refreshPollInterval) {
+        refreshPollInterval = setInterval(async () => {
+          if (!_alive) { clearInterval(refreshPollInterval); refreshPollInterval = null; return }
+          try {
+            const status = await apiRequest('/modules/releases/feature-pressure/refresh/status')
+            if (!status.running) {
+              clearInterval(refreshPollInterval)
+              refreshPollInterval = null
+              await fetchData()
+            }
+          } catch (e) {
+            console.warn('[useFeaturePressureData] refresh status poll failed:', e.message)
+            clearInterval(refreshPollInterval)
+            refreshPollInterval = null
+            refreshing.value = false
+          }
+        }, 5000)
+      }
+    } catch (e) {
+      if (!_alive) return
+      error.value = e.message
+      loading.value = false
+      refreshing.value = false
+      pollRetryCount = 0
+    }
+  }
+
+  async function triggerRefresh(months) {
+    if (refreshing.value) return
+    refreshing.value = true
+    const lm = months || lookbackMonths.value || 12
+    try {
+      await apiRequest('/modules/releases/feature-pressure/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lookback_months: lm }),
+      })
+      if (refreshPollInterval) { clearInterval(refreshPollInterval); refreshPollInterval = null }
+      refreshPollInterval = setInterval(async () => {
+        if (!_alive) { clearInterval(refreshPollInterval); refreshPollInterval = null; return }
+        try {
+          const status = await apiRequest('/modules/releases/feature-pressure/refresh/status')
+          if (!status.running) {
+            clearInterval(refreshPollInterval)
+            refreshPollInterval = null
+            refreshing.value = false
+            await fetchData()
+          }
+        } catch (e) {
+          console.warn('[useFeaturePressureData] refresh status poll failed:', e.message)
+          clearInterval(refreshPollInterval)
+          refreshPollInterval = null
+          refreshing.value = false
+        }
+      }, 3000)
+    } catch (e) {
+      console.warn('[useFeaturePressureData] triggerRefresh failed:', e.message)
+      refreshing.value = false
+      if (!data.value) error.value = e.message
+    }
+  }
+
+  function cleanup() {
+    _alive = false
+    if (pipelinePollTimeout) clearTimeout(pipelinePollTimeout)
+    if (refreshPollInterval) clearInterval(refreshPollInterval)
+  }
+
+  return {
+    data,
+    loading,
+    error,
+    refreshing,
+    lookbackMonths,
+    fetchData,
+    triggerRefresh,
+    cleanup,
+  }
+}

--- a/modules/releases/client/composables/useFeaturePressureData.js
+++ b/modules/releases/client/composables/useFeaturePressureData.js
@@ -1,6 +1,7 @@
 import { ref, shallowRef } from 'vue'
 import { apiRequest } from '@shared/client'
 
+const POLL_INTERVAL_MS = 5000
 const MAX_POLL_RETRIES = 24 // 24 x 5s = 2 minutes max
 
 /** Feature pressure data fetching, refresh, and polling. */
@@ -28,7 +29,7 @@ export function useFeaturePressureData() {
         pollRetryCount++
         if (pollRetryCount < MAX_POLL_RETRIES) {
           if (pipelinePollTimeout) clearTimeout(pipelinePollTimeout)
-          pipelinePollTimeout = setTimeout(fetchData, 5000)
+          pipelinePollTimeout = setTimeout(fetchData, POLL_INTERVAL_MS)
         } else {
           error.value = 'Data pipeline is taking too long. Try refreshing manually.'
           refreshing.value = false
@@ -64,7 +65,7 @@ export function useFeaturePressureData() {
             refreshPollInterval = null
             refreshing.value = false
           }
-        }, 5000)
+        }, POLL_INTERVAL_MS)
       }
     } catch (e) {
       if (!_alive) return
@@ -76,7 +77,7 @@ export function useFeaturePressureData() {
   }
 
   async function triggerRefresh(months) {
-    if (refreshing.value) return
+    if (!_alive || refreshing.value) return
     refreshing.value = true
     const lm = months || lookbackMonths.value || 12
     try {
@@ -102,7 +103,7 @@ export function useFeaturePressureData() {
           refreshPollInterval = null
           refreshing.value = false
         }
-      }, 3000)
+      }, POLL_INTERVAL_MS)
     } catch (e) {
       console.warn('[useFeaturePressureData] triggerRefresh failed:', e.message)
       refreshing.value = false

--- a/modules/releases/client/composables/useFeaturePressureData.js
+++ b/modules/releases/client/composables/useFeaturePressureData.js
@@ -1,11 +1,11 @@
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { apiRequest } from '@shared/client'
 
 const MAX_POLL_RETRIES = 24 // 24 x 5s = 2 minutes max
 
 /** Feature pressure data fetching, refresh, and polling. */
 export function useFeaturePressureData() {
-  const data = ref(null)
+  const data = shallowRef(null)
   const loading = ref(true)
   const error = ref(null)
   const refreshing = ref(false)

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -24,5 +24,11 @@ export const reports = [
     label: 'TV vs FV Delta',
     description: 'Target Version (PM intent) vs Fix Version (engineering commitment) — alignment, mismatches, and component breakdown.',
     component: defineAsyncComponent(() => import('../views/TvFvDeltaView.vue'))
+  },
+  {
+    id: 'feature-pressure',
+    label: 'Feature Pressure',
+    description: 'Where feature inflow exceeds capacity to burn down — RHAI-wide pressure by component, with RFE pipeline and risk scorecard.',
+    component: defineAsyncComponent(() => import('../views/FeaturePressureView.vue'))
   }
 ]

--- a/modules/releases/client/views/FeaturePressureView.vue
+++ b/modules/releases/client/views/FeaturePressureView.vue
@@ -211,9 +211,9 @@ onBeforeUnmount(() => { cleanup() })
         <div class="mt-2 flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400">
           <span>Burn rate: <strong class="text-gray-700 dark:text-gray-300">{{ summary.monthly_burn_rate }}/mo</strong></span>
           <span>Time to clear: <strong :class="{
-            'text-green-600 dark:text-green-400': summary.months_to_clear < 6,
-            'text-yellow-600 dark:text-yellow-400': summary.months_to_clear >= 6 && summary.months_to_clear < 12,
-            'text-red-600 dark:text-red-400': summary.months_to_clear >= 12,
+            'text-green-600 dark:text-green-400': typeof summary.months_to_clear === 'number' && summary.months_to_clear < 6,
+            'text-yellow-600 dark:text-yellow-400': typeof summary.months_to_clear === 'number' && summary.months_to_clear >= 6 && summary.months_to_clear < 12,
+            'text-red-600 dark:text-red-400': summary.months_to_clear === 'Infinity' || summary.months_to_clear === null || (typeof summary.months_to_clear === 'number' && summary.months_to_clear >= 12),
           }">{{ formatMonths(summary.months_to_clear) }}</strong></span>
           <span>Backlog: <strong :class="{
             'text-red-600 dark:text-red-400': summary.backlog_trend === 'growing',
@@ -338,7 +338,7 @@ onBeforeUnmount(() => { cleanup() })
                   <tr
                     v-for="comp in filteredComponents"
                     :key="comp.component"
-                    class="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                    class="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                   >
                     <td class="px-3 py-2 font-medium text-gray-800 dark:text-gray-200 whitespace-nowrap">{{ comp.component }}</td>
                     <td class="px-3 py-2"><ClickableCount :count="comp.created" :jql="comp.created_jql" /></td>

--- a/modules/releases/client/views/FeaturePressureView.vue
+++ b/modules/releases/client/views/FeaturePressureView.vue
@@ -215,7 +215,11 @@ onBeforeUnmount(() => { cleanup() })
             'text-yellow-600 dark:text-yellow-400': summary.months_to_clear >= 6 && summary.months_to_clear < 12,
             'text-red-600 dark:text-red-400': summary.months_to_clear >= 12,
           }">{{ formatMonths(summary.months_to_clear) }}</strong></span>
-          <span>Backlog: <strong :class="summary.backlog_trend === 'growing' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">{{ summary.backlog_trend }}</strong></span>
+          <span>Backlog: <strong :class="{
+            'text-red-600 dark:text-red-400': summary.backlog_trend === 'growing',
+            'text-green-600 dark:text-green-400': summary.backlog_trend === 'burning down',
+            'text-gray-600 dark:text-gray-400': summary.backlog_trend === 'stable',
+          }">{{ summary.backlog_trend }}</strong></span>
         </div>
 
         <!-- Executive Summary — RFEs (RHAIRFE) -->
@@ -260,7 +264,7 @@ onBeforeUnmount(() => { cleanup() })
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                   +{{ h.net }} net features |
                   {{ h.rfe_pending }} RFEs pending |
-                  <ClickableCount :count="h.open" :jql="h.open_jql" size="xs" /> open
+                  <ClickableCount :count="h.open" :jql="h.open_jql" /> open
                 </div>
               </div>
               <span class="inline-block px-2 py-0.5 rounded text-xs font-medium ml-2 shrink-0" :class="riskColor(h.risk_level)">
@@ -418,7 +422,7 @@ onBeforeUnmount(() => { cleanup() })
               <div class="flex flex-wrap gap-2">
                 <span v-for="c in zeroComponents" :key="c.component"
                   class="inline-flex items-center px-2 py-1 rounded text-xs bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">
-                  {{ c.component }} (<ClickableCount :count="c.open" :jql="c.open_jql" size="xs" /> open)
+                  {{ c.component }} (<ClickableCount :count="c.open" :jql="c.open_jql" /> open)
                 </span>
               </div>
             </div>
@@ -437,7 +441,7 @@ onBeforeUnmount(() => { cleanup() })
                   <tr v-for="c in activeComponents" :key="c.component" class="border-b dark:border-gray-800">
                     <td class="px-3 py-1 text-gray-700 dark:text-gray-300">{{ c.component }}</td>
                     <td class="px-3 py-1"><ClickableCount :count="c.open" :jql="c.open_jql" /></td>
-                    <td class="px-3 py-1">{{ c.resolved_per_month }}</td>
+                    <td class="px-3 py-1">{{ typeof c.resolved_per_month === 'number' ? c.resolved_per_month.toFixed(1) : c.resolved_per_month }}</td>
                     <td class="px-3 py-1 font-semibold" :class="{
                       'text-red-600 dark:text-red-400': c.months_to_clear > 24,
                       'text-yellow-600 dark:text-yellow-400': c.months_to_clear > 12 && c.months_to_clear <= 24,

--- a/modules/releases/client/views/FeaturePressureView.vue
+++ b/modules/releases/client/views/FeaturePressureView.vue
@@ -45,10 +45,10 @@ const scorecard = computed(() => data.value?.scorecard || [])
 const metadata = computed(() => data.value?.metadata || null)
 
 const zeroComponents = computed(() =>
-  backlogHalfLife.value.filter(c => c.months_to_clear === Infinity)
+  backlogHalfLife.value.filter(c => c.months_to_clear === Infinity || c.months_to_clear === 'Infinity' || c.months_to_clear === null)
 )
 const activeComponents = computed(() =>
-  backlogHalfLife.value.filter(c => c.months_to_clear !== Infinity)
+  backlogHalfLife.value.filter(c => c.months_to_clear !== Infinity && c.months_to_clear !== 'Infinity' && c.months_to_clear !== null)
 )
 
 /** Top 5 components by combined demand (feature net + RFE pending) */
@@ -60,13 +60,13 @@ const hotSpots = computed(() => {
 })
 
 function formatRatio(val) {
-  if (val === Infinity || val === 'Infinity') return 'INF'
+  if (val === Infinity || val === 'Infinity' || val === null) return 'INF'
   if (typeof val === 'number') return val.toFixed(2)
   return val
 }
 
 function formatMonths(val) {
-  if (val === Infinity || val === 'Infinity') return 'Never'
+  if (val === Infinity || val === 'Infinity' || val === null) return 'Never'
   if (typeof val === 'number') return val.toFixed(1) + ' mo'
   return val
 }

--- a/modules/releases/client/views/FeaturePressureView.vue
+++ b/modules/releases/client/views/FeaturePressureView.vue
@@ -1,0 +1,531 @@
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import ClickableCount from '../components/ClickableCount.vue'
+import MonthlyFlowChart from '../components/MonthlyFlowChart.vue'
+import PressureHeatmap from '../components/PressureHeatmap.vue'
+import { useFeaturePressureData } from '../composables/useFeaturePressureData'
+import { useComponentPressure } from '../composables/useComponentPressure'
+
+// ---------------------------------------------------------------------------
+// Composables
+// ---------------------------------------------------------------------------
+
+const {
+  data, loading, error, refreshing, lookbackMonths,
+  fetchData, triggerRefresh, cleanup,
+} = useFeaturePressureData()
+
+const searchQuery = ref('')
+const sortField = ref('net')
+const sortAsc = ref(false)
+
+const { filteredComponents } = useComponentPressure(data, searchQuery, sortField, sortAsc)
+
+// ---------------------------------------------------------------------------
+// Lookback options
+// ---------------------------------------------------------------------------
+
+const lookbackOptions = [6, 12, 18, 24]
+
+function changeLookback(months) {
+  lookbackMonths.value = months
+  triggerRefresh(months)
+}
+
+// ---------------------------------------------------------------------------
+// Computed helpers
+// ---------------------------------------------------------------------------
+
+const summary = computed(() => data.value?.executive_summary || null)
+const monthlyFlow = computed(() => data.value?.monthly_flow || [])
+const rfePipeline = computed(() => data.value?.rfe_pipeline || null)
+const backlogHalfLife = computed(() => data.value?.backlog_half_life || [])
+const heatmap = computed(() => data.value?.heatmap || { months: [], components: [], matrix: [] })
+const scorecard = computed(() => data.value?.scorecard || [])
+const metadata = computed(() => data.value?.metadata || null)
+
+const zeroComponents = computed(() =>
+  backlogHalfLife.value.filter(c => c.months_to_clear === Infinity)
+)
+const activeComponents = computed(() =>
+  backlogHalfLife.value.filter(c => c.months_to_clear !== Infinity)
+)
+
+/** Top 5 components by combined demand (feature net + RFE pending) */
+const hotSpots = computed(() => {
+  if (!scorecard.value.length) return []
+  return scorecard.value
+    .filter(s => s.risk_level === 'critical' || s.risk_level === 'high')
+    .slice(0, 5)
+})
+
+function formatRatio(val) {
+  if (val === Infinity || val === 'Infinity') return 'INF'
+  if (typeof val === 'number') return val.toFixed(2)
+  return val
+}
+
+function formatMonths(val) {
+  if (val === Infinity || val === 'Infinity') return 'Never'
+  if (typeof val === 'number') return val.toFixed(1) + ' mo'
+  return val
+}
+
+function riskColor(level) {
+  const colors = {
+    critical: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+    high: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+    medium: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+    low: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  }
+  return colors[level] || ''
+}
+
+function trendArrow(dir) {
+  if (dir === 'worsening') return '\u2191'
+  if (dir === 'improving') return '\u2193'
+  return '\u2192'
+}
+
+function trendColor(dir) {
+  if (dir === 'worsening') return 'text-red-600 dark:text-red-400'
+  if (dir === 'improving') return 'text-green-600 dark:text-green-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+function toggleSort(field) {
+  if (sortField.value === field) {
+    sortAsc.value = !sortAsc.value
+  } else {
+    sortField.value = field
+    sortAsc.value = false
+  }
+}
+
+function sortIcon(field) {
+  if (sortField.value !== field) return ''
+  return sortAsc.value ? '\u25B2' : '\u25BC'
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+onMounted(() => { fetchData() })
+onBeforeUnmount(() => { cleanup() })
+</script>
+
+<template>
+  <div class="max-w-7xl mx-auto px-4 py-6 space-y-8">
+    <!-- Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Feature Pressure</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Where feature inflow exceeds capacity to burn down — RHAI-wide, by component.
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <!-- Lookback selector -->
+        <select
+          :value="lookbackMonths"
+          @change="changeLookback(Number($event.target.value))"
+          class="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+          :disabled="refreshing"
+        >
+          <option v-for="opt in lookbackOptions" :key="opt" :value="opt">{{ opt }} months</option>
+        </select>
+        <!-- Refresh button -->
+        <button
+          @click="triggerRefresh(lookbackMonths)"
+          :disabled="refreshing"
+          class="inline-flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded border transition-colors"
+          :class="refreshing
+            ? 'border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+            : 'border-blue-500 text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20'"
+        >
+          <svg v-if="refreshing" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+          {{ refreshing ? 'Refreshing...' : 'Refresh from Jira' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Metadata -->
+    <p v-if="metadata" class="text-xs text-gray-400 dark:text-gray-500 italic">
+      Data fetched: {{ metadata.data_timestamp?.slice(0, 16).replace('T', ' ') }} UTC |
+      {{ metadata.total_features?.toLocaleString() }} features,
+      {{ metadata.total_rfes?.toLocaleString() }} RFEs |
+      {{ lookbackMonths }}-month lookback
+    </p>
+
+    <!-- Loading / Error -->
+    <div v-if="loading && !data" class="text-center py-12 text-gray-500 dark:text-gray-400">
+      <svg class="animate-spin h-8 w-8 mx-auto mb-3 text-blue-500" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+      Loading feature pressure data from Jira...
+    </div>
+
+    <div v-if="error" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded p-4 text-sm text-red-700 dark:text-red-300">
+      {{ error }}
+    </div>
+
+    <template v-if="data && summary">
+
+      <!-- 1. Executive Summary — Features (RHAISTRAT) -->
+      <section>
+        <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Executive Summary</h2>
+
+        <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Features (RHAISTRAT)</h3>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Total</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.total_features" :jql="summary.total_features_jql" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Open</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.open_features" :jql="summary.open_features_jql" color="red" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Created ({{ lookbackMonths }}mo)</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.created_in_window" :jql="summary.created_in_window_jql" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Resolved ({{ lookbackMonths }}mo)</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.resolved_in_window" :jql="summary.resolved_in_window_jql" color="green" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Net ({{ lookbackMonths }}mo)</div>
+            <div class="mt-1 text-2xl font-bold" :class="summary.net_in_window > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">
+              {{ summary.net_in_window > 0 ? '+' : '' }}{{ summary.net_in_window }}
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-2 flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400">
+          <span>Burn rate: <strong class="text-gray-700 dark:text-gray-300">{{ summary.monthly_burn_rate }}/mo</strong></span>
+          <span>Time to clear: <strong :class="{
+            'text-green-600 dark:text-green-400': summary.months_to_clear < 6,
+            'text-yellow-600 dark:text-yellow-400': summary.months_to_clear >= 6 && summary.months_to_clear < 12,
+            'text-red-600 dark:text-red-400': summary.months_to_clear >= 12,
+          }">{{ formatMonths(summary.months_to_clear) }}</strong></span>
+          <span>Backlog: <strong :class="summary.backlog_trend === 'growing' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">{{ summary.backlog_trend }}</strong></span>
+        </div>
+
+        <!-- Executive Summary — RFEs (RHAIRFE) -->
+        <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">Feature Requests (RHAIRFE)</h3>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Total RFEs</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.total_rfes" :jql="summary.total_rfes_jql" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Pending</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.rfe_pending" :jql="summary.rfe_pending_jql" color="yellow" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Accepted</div>
+            <div class="mt-1 text-2xl font-bold">
+              <ClickableCount :count="summary.rfe_accepted" :jql="summary.rfe_accepted_jql" color="green" />
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">Conversion Rate</div>
+            <div class="mt-1 text-2xl font-bold text-gray-700 dark:text-gray-300">
+              {{ summary.total_rfes > 0 ? Math.round(100 * summary.rfe_accepted / summary.total_rfes) : 0 }}%
+            </div>
+          </div>
+        </div>
+
+        <!-- Hot Spots -->
+        <div v-if="hotSpots.length" class="mt-5">
+          <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Hot Spots — Components Under Most Pressure</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            <div v-for="h in hotSpots" :key="h.component"
+              class="flex items-center justify-between bg-white dark:bg-gray-800 rounded-lg border px-3 py-2"
+              :class="h.risk_level === 'critical' ? 'border-red-300 dark:border-red-800' : 'border-orange-300 dark:border-orange-800'"
+            >
+              <div>
+                <span class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ h.component }}</span>
+                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  +{{ h.net }} net features |
+                  {{ h.rfe_pending }} RFEs pending |
+                  <ClickableCount :count="h.open" :jql="h.open_jql" size="xs" /> open
+                </div>
+              </div>
+              <span class="inline-block px-2 py-0.5 rounded text-xs font-medium ml-2 shrink-0" :class="riskColor(h.risk_level)">
+                {{ h.risk_level }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Trend summary -->
+        <div class="mt-3 flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400">
+          <span>Component trends: <strong class="text-green-600 dark:text-green-400">{{ summary.trend_improving }}</strong> improving, <strong class="text-red-600 dark:text-red-400">{{ summary.trend_worsening }}</strong> worsening, {{ summary.trend_stable }} stable</span>
+        </div>
+      </section>
+
+      <!-- 2. Monthly Flow Chart -->
+      <section>
+        <details open>
+          <summary class="text-lg font-semibold text-gray-800 dark:text-gray-200 cursor-pointer">
+            Monthly Inflow vs Burn
+            <span class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2">
+              {{ lookbackMonths }}-month window
+            </span>
+          </summary>
+          <div class="mt-3 bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-4">
+            <MonthlyFlowChart :monthly-flow="monthlyFlow" />
+          </div>
+        </details>
+      </section>
+
+      <!-- 3. Component Pressure Table (Features) -->
+      <section>
+        <details open>
+          <summary class="text-lg font-semibold text-gray-800 dark:text-gray-200 cursor-pointer">
+            Feature Pressure by Component
+            <span class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2">({{ filteredComponents.length }} components)</span>
+          </summary>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            RHAISTRAT Features created vs resolved in the lookback window. Ratio > 1 means inflow exceeds burn.
+          </p>
+          <div class="mt-3">
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-3 mb-3">
+              <input
+                v-model="searchQuery"
+                type="text"
+                placeholder="Filter components..."
+                class="text-sm border border-gray-300 dark:border-gray-600 rounded px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 w-full sm:w-64"
+              />
+            </div>
+            <div class="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700">
+              <table class="min-w-full text-sm">
+                <thead>
+                  <tr class="border-b dark:border-gray-700">
+                    <th v-for="col in [
+                      { key: 'component', label: 'Component' },
+                      { key: 'created', label: 'Created' },
+                      { key: 'resolved', label: 'Resolved' },
+                      { key: 'net', label: 'Net' },
+                      { key: 'open', label: 'Open' },
+                      { key: 'pressure_ratio', label: 'Ratio' },
+                    ]"
+                      :key="col.key"
+                      class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none whitespace-nowrap"
+                      @click="toggleSort(col.key)"
+                    >
+                      {{ col.label }} {{ sortIcon(col.key) }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="comp in filteredComponents"
+                    :key="comp.component"
+                    class="border-b dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                  >
+                    <td class="px-3 py-2 font-medium text-gray-800 dark:text-gray-200 whitespace-nowrap">{{ comp.component }}</td>
+                    <td class="px-3 py-2"><ClickableCount :count="comp.created" :jql="comp.created_jql" /></td>
+                    <td class="px-3 py-2"><ClickableCount :count="comp.resolved" :jql="comp.resolved_jql" color="green" /></td>
+                    <td class="px-3 py-2 font-semibold" :class="comp.net > 0 ? 'text-red-600 dark:text-red-400' : comp.net < 0 ? 'text-green-600 dark:text-green-400' : ''">
+                      {{ comp.net > 0 ? '+' : '' }}{{ comp.net }}
+                    </td>
+                    <td class="px-3 py-2"><ClickableCount :count="comp.open" :jql="comp.open_jql" color="red" /></td>
+                    <td class="px-3 py-2 font-mono text-xs">{{ formatRatio(comp.pressure_ratio) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <!-- 4. RFE Pipeline -->
+      <section>
+        <details>
+          <summary class="text-lg font-semibold text-gray-800 dark:text-gray-200 cursor-pointer">
+            RFE Pipeline (RHAIRFE)
+            <span class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2">
+              {{ rfePipeline?.status_breakdown?.total?.count || 0 }} total |
+              {{ rfePipeline?.status_breakdown?.pending?.count || 0 }} pending
+            </span>
+          </summary>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Customer and field Feature Requests — pending review, accepted for planning, or other.
+          </p>
+          <div v-if="rfePipeline" class="mt-3 space-y-4">
+            <div class="flex flex-wrap gap-4 text-sm">
+              <div>Total: <ClickableCount :count="rfePipeline.status_breakdown.total.count" :jql="rfePipeline.status_breakdown.total.jql" /></div>
+              <div>Accepted: <ClickableCount :count="rfePipeline.status_breakdown.accepted.count" :jql="rfePipeline.status_breakdown.accepted.jql" color="green" /></div>
+              <div>Pending: <ClickableCount :count="rfePipeline.status_breakdown.pending.count" :jql="rfePipeline.status_breakdown.pending.jql" color="yellow" /></div>
+              <div>Other: <span class="font-semibold">{{ rfePipeline.status_breakdown.other.count }}</span></div>
+            </div>
+            <div v-if="rfePipeline.per_component_pending.length" class="overflow-x-auto">
+              <h3 class="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">Pending RFEs by Component</h3>
+              <table class="min-w-full text-sm">
+                <thead>
+                  <tr class="border-b dark:border-gray-700">
+                    <th class="px-3 py-1 text-left text-gray-500 dark:text-gray-400">Component</th>
+                    <th class="px-3 py-1 text-left text-gray-500 dark:text-gray-400">Pending RFEs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="p in rfePipeline.per_component_pending" :key="p.component" class="border-b dark:border-gray-800">
+                    <td class="px-3 py-1 text-gray-700 dark:text-gray-300">{{ p.component }}</td>
+                    <td class="px-3 py-1"><ClickableCount :count="p.count" :jql="p.jql" color="yellow" /></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <!-- 5. Backlog Burn-Down Estimate -->
+      <section>
+        <details>
+          <summary class="text-lg font-semibold text-gray-800 dark:text-gray-200 cursor-pointer">
+            Backlog Burn-Down Estimate
+            <span class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2">
+              {{ zeroComponents.length }} stalled |
+              {{ activeComponents.length }} active
+            </span>
+          </summary>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            At the current monthly resolution rate, how long to close every open feature per component.
+            "Never" means zero features were resolved in the lookback window.
+          </p>
+          <div class="mt-3 space-y-4">
+            <div v-if="zeroComponents.length">
+              <h3 class="text-sm font-medium text-red-600 dark:text-red-400 mb-2">
+                Stalled — Zero Resolution Rate ({{ zeroComponents.length }} components)
+              </h3>
+              <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                These components have open features but resolved nothing in the {{ lookbackMonths }}-month window.
+              </p>
+              <div class="flex flex-wrap gap-2">
+                <span v-for="c in zeroComponents" :key="c.component"
+                  class="inline-flex items-center px-2 py-1 rounded text-xs bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">
+                  {{ c.component }} (<ClickableCount :count="c.open" :jql="c.open_jql" size="xs" /> open)
+                </span>
+              </div>
+            </div>
+            <div v-if="activeComponents.length">
+              <h3 class="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">Active — Estimated Time to Clear</h3>
+              <table class="min-w-full text-sm">
+                <thead>
+                  <tr class="border-b dark:border-gray-700">
+                    <th class="px-3 py-1 text-left text-gray-500">Component</th>
+                    <th class="px-3 py-1 text-left text-gray-500">Open Features</th>
+                    <th class="px-3 py-1 text-left text-gray-500">Resolved/Mo</th>
+                    <th class="px-3 py-1 text-left text-gray-500">Est. Months to Clear</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="c in activeComponents" :key="c.component" class="border-b dark:border-gray-800">
+                    <td class="px-3 py-1 text-gray-700 dark:text-gray-300">{{ c.component }}</td>
+                    <td class="px-3 py-1"><ClickableCount :count="c.open" :jql="c.open_jql" /></td>
+                    <td class="px-3 py-1">{{ c.resolved_per_month }}</td>
+                    <td class="px-3 py-1 font-semibold" :class="{
+                      'text-red-600 dark:text-red-400': c.months_to_clear > 24,
+                      'text-yellow-600 dark:text-yellow-400': c.months_to_clear > 12 && c.months_to_clear <= 24,
+                      'text-green-600 dark:text-green-400': c.months_to_clear <= 12,
+                    }">{{ formatMonths(c.months_to_clear) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <!-- 6. Heatmap -->
+      <section>
+        <details>
+          <summary class="text-lg font-semibold text-gray-800 dark:text-gray-200 cursor-pointer">
+            Pressure Heatmap
+            <span class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2">
+              component x month net flow
+            </span>
+          </summary>
+          <div class="mt-3 bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 p-3">
+            <PressureHeatmap :heatmap="heatmap" />
+            <p class="text-xs text-gray-400 dark:text-gray-500 mt-2">
+              Red = more created than resolved (growing). Green = burning down.
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <!-- 7. Risk Scorecard -->
+      <section>
+        <details open>
+          <summary class="text-lg font-semibold text-gray-800 dark:text-gray-200 cursor-pointer">
+            Risk Scorecard
+            <span v-if="scorecard.length" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-2">
+              {{ scorecard.filter(s => s.risk_level === 'critical').length }} critical,
+              {{ scorecard.filter(s => s.risk_level === 'high').length }} high
+            </span>
+          </summary>
+          <div class="mt-3">
+            <div class="bg-gray-50 dark:bg-gray-800/50 rounded border border-gray-200 dark:border-gray-700 p-3 mb-3 text-xs text-gray-600 dark:text-gray-400 space-y-1">
+              <p><strong>What this measures:</strong> Which components are most at risk of becoming overwhelmed. Combines three signals — net feature inflow (are features piling up?), open backlog size (how deep is the hole?), and pending RFE demand (how much more is coming from customers?).</p>
+              <p><strong>How to read it:</strong> <span class="text-red-600 dark:text-red-400 font-medium">Critical</span> = immediate leadership attention needed. <span class="text-orange-600 dark:text-orange-400 font-medium">High</span> = at risk without intervention. <span class="text-yellow-600 dark:text-yellow-400 font-medium">Medium</span> = manageable but watch. <span class="text-green-600 dark:text-green-400 font-medium">Low</span> = healthy.</p>
+              <p class="italic">Score = (Net/5, cap 10) x 0.4 + (Open/10, cap 10) x 0.3 + (RFE Pending/5, cap 10) x 0.3</p>
+            </div>
+            <div class="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700">
+              <table class="min-w-full text-sm">
+                <thead>
+                  <tr class="border-b dark:border-gray-700">
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Component</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Risk</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Score</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Net Features</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Open Features</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Pending RFEs</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Burn-Down</th>
+                    <th class="px-3 py-2 text-left text-gray-500 dark:text-gray-400">Trend</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="s in scorecard" :key="s.component" class="border-b dark:border-gray-800">
+                    <td class="px-3 py-2 font-medium text-gray-800 dark:text-gray-200 whitespace-nowrap">{{ s.component }}</td>
+                    <td class="px-3 py-2">
+                      <span class="inline-block px-2 py-0.5 rounded text-xs font-medium" :class="riskColor(s.risk_level)">
+                        {{ s.risk_level }}
+                      </span>
+                    </td>
+                    <td class="px-3 py-2 font-mono">{{ s.risk_score }}</td>
+                    <td class="px-3 py-2" :class="s.net > 0 ? 'text-red-600 dark:text-red-400' : ''">{{ s.net > 0 ? '+' : '' }}{{ s.net }}</td>
+                    <td class="px-3 py-2"><ClickableCount :count="s.open" :jql="s.open_jql" /></td>
+                    <td class="px-3 py-2">
+                      <ClickableCount v-if="s.rfe_pending_jql" :count="s.rfe_pending" :jql="s.rfe_pending_jql" color="yellow" />
+                      <span v-else class="text-gray-500">{{ s.rfe_pending }}</span>
+                    </td>
+                    <td class="px-3 py-2 font-mono text-xs">{{ formatMonths(s.backlog_months) }}</td>
+                    <td class="px-3 py-2">
+                      <span :class="trendColor(s.trend)">{{ trendArrow(s.trend) }} {{ s.trend }}</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+      </section>
+
+    </template>
+  </div>
+</template>

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -9,6 +9,8 @@
  * background refresh with cooldown, polling status endpoint).
  */
 
+// NOTE: uses deprecated jiraRequest/fetchAllJqlResults (process.env auth) to match
+// tv-fv-delta pattern.  Migrate to context.secrets + createJiraClient when tv-fv-delta does.
 const { jiraRequest, JIRA_HOST, fetchAllJqlResults } = require('../../../../shared/server/jira')
 
 const JIRA_BROWSE = JIRA_HOST + '/browse'
@@ -31,7 +33,7 @@ const RFE_FIELDS = 'summary,status,components,created,resolutiondate'
 // Status classification constants
 // ---------------------------------------------------------------------------
 
-const STATUS_DONE = ['Release Pending', 'Closed']
+// Open/done classification uses statusCategory from Jira (not individual status names).
 const RFE_ACCEPTED = ['Approved', 'In Progress', 'Refinement', 'Planning', 'Review', 'Resolved']
 const RFE_PENDING = ['New', 'Draft', 'Stakeholder review', 'Stakeholder Feedback', 'Pending Approval']
 
@@ -396,6 +398,8 @@ function buildHeatmapMatrix(features, lookbackMonths) {
 
   for (var fi = 0; fi < features.length; fi++) {
     var feat = features[fi]
+    // Intentionally skip features with no component — heatmap/trend are per-component views.
+    // "(No Component)" is tracked separately in computeComponentPressure.
     var comps = feat.components.length > 0 ? feat.components : []
     if (comps.length === 0) continue
 
@@ -487,6 +491,7 @@ function computeTrend(features, lookbackMonths) {
 
   for (var fi = 0; fi < features.length; fi++) {
     var feat = features[fi]
+    // Skip unclassified features — trend is per-component only (same as heatmap)
     var comps = feat.components.length > 0 ? feat.components : []
     if (comps.length === 0) continue
 
@@ -899,7 +904,6 @@ module.exports.computeTrend = computeTrend
 module.exports.computeScorecard = computeScorecard
 module.exports.jqlUrl = jqlUrl
 module.exports.quoteComponent = quoteComponent
-module.exports.STATUS_DONE = STATUS_DONE
 module.exports.RFE_ACCEPTED = RFE_ACCEPTED
 module.exports.RFE_PENDING = RFE_PENDING
 module.exports.CACHE_KEY = CACHE_KEY

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -1,0 +1,869 @@
+/**
+ * Feature Pressure — server routes.
+ *
+ * Queries Jira LIVE for RHAISTRAT Features and RHAIRFE RFEs, computes
+ * inflow vs burn analysis RHAI-wide by component.  Every count is backed
+ * by a clickable JQL verification URL.
+ *
+ * Pattern: mirrors tv-fv-delta/routes.js (stale-while-revalidate cache,
+ * background refresh with cooldown, polling status endpoint).
+ */
+
+const { jiraRequest, JIRA_HOST, fetchAllJqlResults } = require('../../../../shared/server/jira')
+
+const JIRA_BROWSE = JIRA_HOST + '/browse'
+const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
+const CACHE_KEY = 'releases/feature-pressure.json'
+const CACHE_MAX_AGE_MS = 60 * 60 * 1000 // 1 hour
+const REFRESH_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
+
+const FEATURE_PROJECT = 'RHAISTRAT'
+const RFE_PROJECT = 'RHAIRFE'
+
+// Fields to fetch from Jira (Jira REST API uses 'resolutiondate', not 'resolved')
+const FEATURE_FIELDS = 'summary,status,components,created,resolutiondate'
+const RFE_FIELDS = 'summary,status,components,created,resolutiondate'
+
+// ---------------------------------------------------------------------------
+// Status classification constants
+// ---------------------------------------------------------------------------
+
+const STATUS_DONE = ['Release Pending', 'Closed']
+const RFE_ACCEPTED = ['Approved', 'In Progress', 'Refinement', 'Planning', 'Review', 'Resolved']
+const RFE_PENDING = ['New', 'Draft', 'Stakeholder review', 'Stakeholder Feedback', 'Pending Approval']
+
+// ---------------------------------------------------------------------------
+// JQL helpers
+// ---------------------------------------------------------------------------
+
+function jqlUrl(jql) {
+  return JIRA_SEARCH + encodeURIComponent(jql)
+}
+
+/** Quote a component name for JQL */
+function quoteComponent(name) {
+  return '"' + name.replace(/"/g, '\\"') + '"'
+}
+
+// ---------------------------------------------------------------------------
+// Issue normalisation
+// ---------------------------------------------------------------------------
+
+function normalizeFeature(issue) {
+  var fields = issue.fields || {}
+
+  var components = []
+  if (Array.isArray(fields.components)) {
+    components = fields.components.map(function (c) { return c.name || '' }).filter(Boolean)
+  }
+
+  var status = ''
+  if (fields.status) {
+    status = fields.status.name || ''
+  }
+
+  return {
+    key: issue.key,
+    url: JIRA_BROWSE + '/' + issue.key,
+    summary: String(fields.summary || '').slice(0, 120),
+    status: status,
+    components: components,
+    created: fields.created || null,
+    resolved: fields.resolutiondate || null
+  }
+}
+
+function normalizeRfe(issue) {
+  var fields = issue.fields || {}
+
+  var components = []
+  if (Array.isArray(fields.components)) {
+    components = fields.components.map(function (c) { return c.name || '' }).filter(Boolean)
+  }
+
+  var status = ''
+  if (fields.status) {
+    status = fields.status.name || ''
+  }
+
+  return {
+    key: issue.key,
+    url: JIRA_BROWSE + '/' + issue.key,
+    summary: String(fields.summary || '').slice(0, 120),
+    status: status,
+    components: components,
+    created: fields.created || null,
+    resolved: fields.resolutiondate || null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers
+// ---------------------------------------------------------------------------
+
+/** Parse ISO date string to YYYY-MM month key */
+function toMonth(dateStr) {
+  if (!dateStr) return null
+  var d = new Date(dateStr)
+  if (isNaN(d.getTime())) return null
+  var m = d.getMonth() + 1
+  return d.getFullYear() + '-' + (m < 10 ? '0' : '') + m
+}
+
+/** Generate array of YYYY-MM strings for the lookback window */
+function generateMonthRange(lookbackMonths) {
+  var months = []
+  var now = new Date()
+  for (var i = lookbackMonths - 1; i >= 0; i--) {
+    var d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    var m = d.getMonth() + 1
+    months.push(d.getFullYear() + '-' + (m < 10 ? '0' : '') + m)
+  }
+  return months
+}
+
+/** Return ISO date string for N months ago */
+function lookbackDate(months) {
+  var d = new Date()
+  d.setMonth(d.getMonth() - months)
+  return d.toISOString().slice(0, 10)
+}
+
+// ---------------------------------------------------------------------------
+// Analysis functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Bucket features by created/resolved month within the lookback window.
+ * Returns { months: [{month, created, resolved, net, cumulative}] }
+ */
+function classifyByMonth(features, lookbackMonths) {
+  var monthRange = generateMonthRange(lookbackMonths)
+  var cutoff = lookbackDate(lookbackMonths)
+
+  var createdMap = {}
+  var resolvedMap = {}
+  for (var i = 0; i < monthRange.length; i++) {
+    createdMap[monthRange[i]] = 0
+    resolvedMap[monthRange[i]] = 0
+  }
+
+  for (var fi = 0; fi < features.length; fi++) {
+    var feat = features[fi]
+    if (feat.created && feat.created >= cutoff) {
+      var cm = toMonth(feat.created)
+      if (cm && createdMap[cm] !== undefined) createdMap[cm]++
+    }
+    if (feat.resolved && feat.resolved >= cutoff) {
+      var rm = toMonth(feat.resolved)
+      if (rm && resolvedMap[rm] !== undefined) resolvedMap[rm]++
+    }
+  }
+
+  var months = []
+  var cumulative = 0
+  for (var mi = 0; mi < monthRange.length; mi++) {
+    var month = monthRange[mi]
+    var created = createdMap[month]
+    var resolved = resolvedMap[month]
+    var net = created - resolved
+    cumulative += net
+    months.push({
+      month: month,
+      created: created,
+      created_jql: jqlUrl('project = ' + FEATURE_PROJECT + ' AND issuetype = Feature AND created >= "' + month + '-01" AND created < "' + nextMonth(month) + '-01"'),
+      resolved: resolved,
+      resolved_jql: jqlUrl('project = ' + FEATURE_PROJECT + ' AND issuetype = Feature AND resolved >= "' + month + '-01" AND resolved < "' + nextMonth(month) + '-01"'),
+      net: net,
+      cumulative: cumulative
+    })
+  }
+
+  return { months: months }
+}
+
+/** Get next month as YYYY-MM */
+function nextMonth(ym) {
+  var parts = ym.split('-')
+  var y = parseInt(parts[0], 10)
+  var m = parseInt(parts[1], 10)
+  m++
+  if (m > 12) { m = 1; y++ }
+  return y + '-' + (m < 10 ? '0' : '') + m
+}
+
+/**
+ * Per-component pressure analysis.
+ * Returns sorted array of { component, created, resolved, open, net, pressure_ratio, ..._jql }
+ */
+function computeComponentPressure(features, lookbackMonths) {
+  var cutoff = lookbackDate(lookbackMonths)
+  var compMap = {} // component -> { created, resolved, open }
+
+  for (var fi = 0; fi < features.length; fi++) {
+    var feat = features[fi]
+    var comps = feat.components.length > 0 ? feat.components : ['(No Component)']
+
+    for (var ci = 0; ci < comps.length; ci++) {
+      var comp = comps[ci]
+      if (!compMap[comp]) {
+        compMap[comp] = { created: 0, resolved: 0, open: 0 }
+      }
+
+      if (feat.created && feat.created >= cutoff) {
+        compMap[comp].created++
+      }
+      if (feat.resolved && feat.resolved >= cutoff) {
+        compMap[comp].resolved++
+      }
+      if (STATUS_DONE.indexOf(feat.status) === -1) {
+        compMap[comp].open++
+      }
+    }
+  }
+
+  var baseJql = 'project = ' + FEATURE_PROJECT + ' AND issuetype = Feature'
+  var result = []
+  var compNames = Object.keys(compMap)
+
+  for (var ni = 0; ni < compNames.length; ni++) {
+    var name = compNames[ni]
+    var data = compMap[name]
+    var net = data.created - data.resolved
+    var ratio = data.resolved > 0 ? Math.round(100 * data.created / data.resolved) / 100 : (data.created > 0 ? Infinity : 0)
+    var compQ = name === '(No Component)' ? '' : ' AND component = ' + quoteComponent(name)
+
+    result.push({
+      component: name,
+      created: data.created,
+      created_jql: jqlUrl(baseJql + compQ + ' AND created >= "' + cutoff + '"'),
+      resolved: data.resolved,
+      resolved_jql: jqlUrl(baseJql + compQ + ' AND resolved >= "' + cutoff + '"'),
+      open: data.open,
+      open_jql: jqlUrl(baseJql + compQ + ' AND statusCategory != Done'),
+      net: net,
+      pressure_ratio: ratio
+    })
+  }
+
+  // Filter to components with activity and sort by net descending
+  result = result.filter(function (r) { return r.created > 0 || r.open > 0 })
+  result.sort(function (a, b) { return b.net - a.net || a.component.localeCompare(b.component) })
+
+  return result
+}
+
+/**
+ * RFE pipeline analysis.
+ * Returns { status_breakdown, monthly_arrivals, per_component_pending }
+ */
+function computeRfePipeline(rfes, lookbackMonths) {
+  var cutoff = lookbackDate(lookbackMonths)
+  var monthRange = generateMonthRange(lookbackMonths)
+
+  // Status breakdown
+  var accepted = 0
+  var pending = 0
+  var other = 0
+  for (var ri = 0; ri < rfes.length; ri++) {
+    var s = rfes[ri].status
+    if (RFE_ACCEPTED.indexOf(s) !== -1) accepted++
+    else if (RFE_PENDING.indexOf(s) !== -1) pending++
+    else other++
+  }
+
+  var baseJql = 'project = ' + RFE_PROJECT + ' AND issuetype = "Feature Request"'
+  var pendingStatusJql = 'status in (New, Draft, "Stakeholder review", "Stakeholder Feedback", "Pending Approval")'
+  var acceptedStatusJql = 'status in (Approved, "In Progress", Refinement, Planning, Review, Resolved)'
+
+  var statusBreakdown = {
+    total: { count: rfes.length, jql: jqlUrl(baseJql) },
+    accepted: { count: accepted, jql: jqlUrl(baseJql + ' AND ' + acceptedStatusJql) },
+    pending: { count: pending, jql: jqlUrl(baseJql + ' AND ' + pendingStatusJql) },
+    other: { count: other }
+  }
+
+  // Monthly arrivals
+  var arrivalMap = {}
+  for (var mi = 0; mi < monthRange.length; mi++) arrivalMap[monthRange[mi]] = 0
+
+  for (var ai = 0; ai < rfes.length; ai++) {
+    if (rfes[ai].created && rfes[ai].created >= cutoff) {
+      var m = toMonth(rfes[ai].created)
+      if (m && arrivalMap[m] !== undefined) arrivalMap[m]++
+    }
+  }
+
+  var monthlyArrivals = []
+  for (var mai = 0; mai < monthRange.length; mai++) {
+    var month = monthRange[mai]
+    monthlyArrivals.push({
+      month: month,
+      count: arrivalMap[month],
+      jql: jqlUrl(baseJql + ' AND created >= "' + month + '-01" AND created < "' + nextMonth(month) + '-01"')
+    })
+  }
+
+  // Per-component pending
+  var compPending = {}
+  for (var pi = 0; pi < rfes.length; pi++) {
+    var rfe = rfes[pi]
+    if (RFE_PENDING.indexOf(rfe.status) === -1) continue
+    var rfeComps = rfe.components.length > 0 ? rfe.components : ['(No Component)']
+    for (var pci = 0; pci < rfeComps.length; pci++) {
+      var c = rfeComps[pci]
+      compPending[c] = (compPending[c] || 0) + 1
+    }
+  }
+
+  var perComponentPending = Object.keys(compPending)
+    .map(function (comp) {
+      var compQ = comp === '(No Component)' ? '' : ' AND component = ' + quoteComponent(comp)
+      return {
+        component: comp,
+        count: compPending[comp],
+        jql: jqlUrl(baseJql + ' AND ' + pendingStatusJql + compQ)
+      }
+    })
+    .sort(function (a, b) { return b.count - a.count })
+
+  return {
+    status_breakdown: statusBreakdown,
+    monthly_arrivals: monthlyArrivals,
+    per_component_pending: perComponentPending
+  }
+}
+
+/**
+ * Backlog half-life per component.
+ * Returns array of { component, open, resolved_per_month, months_to_clear }
+ */
+function computeBacklogHalfLife(componentPressure, lookbackMonths) {
+  return componentPressure
+    .filter(function (c) { return c.open > 0 })
+    .map(function (c) {
+      var resolvedPerMonth = c.resolved / lookbackMonths
+      var monthsToClear = resolvedPerMonth > 0
+        ? Math.round(10 * c.open / resolvedPerMonth) / 10
+        : Infinity
+
+      return {
+        component: c.component,
+        open: c.open,
+        open_jql: c.open_jql,
+        resolved_per_month: Math.round(100 * resolvedPerMonth) / 100,
+        months_to_clear: monthsToClear
+      }
+    })
+    .sort(function (a, b) {
+      // Infinity sorts last among themselves, but before finite values? No — infinity first (worst)
+      if (a.months_to_clear === Infinity && b.months_to_clear === Infinity) return a.component.localeCompare(b.component)
+      if (a.months_to_clear === Infinity) return -1
+      if (b.months_to_clear === Infinity) return 1
+      return b.months_to_clear - a.months_to_clear
+    })
+}
+
+/**
+ * Component x Month heatmap matrix.
+ * Returns { months, components, matrix } where matrix[i][j] = net flow for component i in month j.
+ */
+function buildHeatmapMatrix(features, lookbackMonths) {
+  var monthRange = generateMonthRange(lookbackMonths)
+  var cutoff = lookbackDate(lookbackMonths)
+
+  // Count created and resolved per component per month
+  var compMonthCreated = {} // comp -> { month -> count }
+  var compMonthResolved = {}
+  var activeComps = {}
+
+  for (var fi = 0; fi < features.length; fi++) {
+    var feat = features[fi]
+    var comps = feat.components.length > 0 ? feat.components : []
+    if (comps.length === 0) continue
+
+    for (var ci = 0; ci < comps.length; ci++) {
+      var comp = comps[ci]
+      activeComps[comp] = true
+
+      if (feat.created && feat.created >= cutoff) {
+        var cm = toMonth(feat.created)
+        if (cm) {
+          if (!compMonthCreated[comp]) compMonthCreated[comp] = {}
+          compMonthCreated[comp][cm] = (compMonthCreated[comp][cm] || 0) + 1
+        }
+      }
+      if (feat.resolved && feat.resolved >= cutoff) {
+        var rm = toMonth(feat.resolved)
+        if (rm) {
+          if (!compMonthResolved[comp]) compMonthResolved[comp] = {}
+          compMonthResolved[comp][rm] = (compMonthResolved[comp][rm] || 0) + 1
+        }
+      }
+    }
+  }
+
+  // Filter to components with >= 3 total activity
+  var compNames = Object.keys(activeComps).filter(function (comp) {
+    var total = 0
+    if (compMonthCreated[comp]) {
+      var vals = Object.values(compMonthCreated[comp])
+      for (var v = 0; v < vals.length; v++) total += vals[v]
+    }
+    if (compMonthResolved[comp]) {
+      var rvals = Object.values(compMonthResolved[comp])
+      for (var rv = 0; rv < rvals.length; rv++) total += rvals[rv]
+    }
+    return total >= 3
+  })
+
+  // Sort by total net (worst first)
+  compNames.sort(function (a, b) {
+    var netA = 0
+    var netB = 0
+    for (var mi = 0; mi < monthRange.length; mi++) {
+      var m = monthRange[mi]
+      netA += ((compMonthCreated[a] || {})[m] || 0) - ((compMonthResolved[a] || {})[m] || 0)
+      netB += ((compMonthCreated[b] || {})[m] || 0) - ((compMonthResolved[b] || {})[m] || 0)
+    }
+    return netB - netA
+  })
+
+  // Limit to top 25 for readability
+  compNames = compNames.slice(0, 25)
+
+  // Build matrix
+  var matrix = []
+  for (var cni = 0; cni < compNames.length; cni++) {
+    var row = []
+    for (var mj = 0; mj < monthRange.length; mj++) {
+      var month = monthRange[mj]
+      var created = (compMonthCreated[compNames[cni]] || {})[month] || 0
+      var resolved = (compMonthResolved[compNames[cni]] || {})[month] || 0
+      row.push(created - resolved)
+    }
+    matrix.push(row)
+  }
+
+  return { months: monthRange, components: compNames, matrix: matrix }
+}
+
+/**
+ * Trend analysis — compare first-half vs second-half of lookback window.
+ * Returns array of { component, first_half_net, second_half_net, direction, delta }
+ */
+function computeTrend(features, lookbackMonths) {
+  var monthRange = generateMonthRange(lookbackMonths)
+  var cutoff = lookbackDate(lookbackMonths)
+  var midIdx = Math.floor(monthRange.length / 2)
+  var firstHalfMonths = monthRange.slice(0, midIdx)
+  var secondHalfMonths = monthRange.slice(midIdx)
+
+  var firstHalfSet = {}
+  var secondHalfSet = {}
+  for (var i = 0; i < firstHalfMonths.length; i++) firstHalfSet[firstHalfMonths[i]] = true
+  for (var j = 0; j < secondHalfMonths.length; j++) secondHalfSet[secondHalfMonths[j]] = true
+
+  // Per component: count created/resolved in each half
+  var compData = {} // comp -> { h1_created, h1_resolved, h2_created, h2_resolved }
+  var activeComps = {}
+
+  for (var fi = 0; fi < features.length; fi++) {
+    var feat = features[fi]
+    var comps = feat.components.length > 0 ? feat.components : []
+    if (comps.length === 0) continue
+
+    for (var ci = 0; ci < comps.length; ci++) {
+      var comp = comps[ci]
+      if (!compData[comp]) {
+        compData[comp] = { h1_created: 0, h1_resolved: 0, h2_created: 0, h2_resolved: 0 }
+      }
+
+      if (feat.created && feat.created >= cutoff) {
+        var cm = toMonth(feat.created)
+        if (cm) {
+          activeComps[comp] = true
+          if (firstHalfSet[cm]) compData[comp].h1_created++
+          else if (secondHalfSet[cm]) compData[comp].h2_created++
+        }
+      }
+      if (feat.resolved && feat.resolved >= cutoff) {
+        var rm = toMonth(feat.resolved)
+        if (rm) {
+          activeComps[comp] = true
+          if (firstHalfSet[rm]) compData[comp].h1_resolved++
+          else if (secondHalfSet[rm]) compData[comp].h2_resolved++
+        }
+      }
+    }
+  }
+
+  var result = []
+  var compNames = Object.keys(activeComps)
+
+  for (var ni = 0; ni < compNames.length; ni++) {
+    var name = compNames[ni]
+    var d = compData[name]
+    var h1Net = d.h1_created - d.h1_resolved
+    var h2Net = d.h2_created - d.h2_resolved
+    var delta = h2Net - h1Net
+    var direction = delta > 0 ? 'worsening' : (delta < 0 ? 'improving' : 'stable')
+
+    result.push({
+      component: name,
+      first_half_net: h1Net,
+      second_half_net: h2Net,
+      direction: direction,
+      delta: delta
+    })
+  }
+
+  result.sort(function (a, b) { return b.delta - a.delta || a.component.localeCompare(b.component) })
+  return result
+}
+
+/**
+ * Combined scorecard — composite risk score per component.
+ * Merges feature pressure, RFE demand, backlog half-life, and trend.
+ *
+ * Risk score = (net/5, cap 10) x 0.4 + (open/10, cap 10) x 0.3 + (rfePending/5, cap 10) x 0.3
+ * Risk levels: low (<2.5), medium (2.5-5), high (5-7.5), critical (>7.5)
+ */
+function computeScorecard(componentPressure, rfePipeline, backlogHalfLife, trend) {
+  var rfeMap = {}
+  var pendingList = rfePipeline.per_component_pending
+  for (var pi = 0; pi < pendingList.length; pi++) {
+    rfeMap[pendingList[pi].component] = pendingList[pi].count
+  }
+
+  var halfLifeMap = {}
+  for (var hi = 0; hi < backlogHalfLife.length; hi++) {
+    halfLifeMap[backlogHalfLife[hi].component] = backlogHalfLife[hi].months_to_clear
+  }
+
+  var trendMap = {}
+  for (var ti = 0; ti < trend.length; ti++) {
+    trendMap[trend[ti].component] = trend[ti].direction
+  }
+
+  var scorecard = []
+  for (var ci = 0; ci < componentPressure.length; ci++) {
+    var cp = componentPressure[ci]
+    var rfePending = rfeMap[cp.component] || 0
+    var halfLife = halfLifeMap[cp.component] || 0
+    var trendDir = trendMap[cp.component] || 'stable'
+
+    var netScore = Math.min(Math.max(cp.net, 0) / 5, 10)
+    var backlogScore = Math.min(cp.open / 10, 10)
+    var rfeScore = Math.min(rfePending / 5, 10)
+    var riskScore = Math.round(10 * (netScore * 0.4 + backlogScore * 0.3 + rfeScore * 0.3)) / 10
+
+    var riskLevel = riskScore >= 7.5 ? 'critical'
+      : riskScore >= 5 ? 'high'
+      : riskScore >= 2.5 ? 'medium'
+      : 'low'
+
+    scorecard.push({
+      component: cp.component,
+      risk_score: riskScore,
+      risk_level: riskLevel,
+      created: cp.created,
+      resolved: cp.resolved,
+      net: cp.net,
+      open: cp.open,
+      open_jql: cp.open_jql,
+      pressure_ratio: cp.pressure_ratio,
+      rfe_pending: rfePending,
+      rfe_pending_jql: (pendingList.find(function (p) { return p.component === cp.component }) || {}).jql || '',
+      backlog_months: halfLife,
+      trend: trendDir
+    })
+  }
+
+  scorecard.sort(function (a, b) { return b.risk_score - a.risk_score || a.component.localeCompare(b.component) })
+  return scorecard
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + analyse pipeline
+// ---------------------------------------------------------------------------
+
+async function fetchAndAnalyze(lookbackMonths, storage) {
+  var fetchTimestamp = new Date().toISOString()
+
+  // Fetch features and RFEs in parallel
+  var featureJql = 'project = ' + FEATURE_PROJECT + ' AND issuetype = Feature'
+  var rfeJql = 'project = ' + RFE_PROJECT + ' AND issuetype = "Feature Request"'
+
+  console.log('[releases/feature-pressure] Fetching features: ' + featureJql)
+  console.log('[releases/feature-pressure] Fetching RFEs: ' + rfeJql)
+
+  var results = await Promise.all([
+    fetchAllJqlResults(jiraRequest, featureJql, FEATURE_FIELDS),
+    fetchAllJqlResults(jiraRequest, rfeJql, RFE_FIELDS)
+  ])
+
+  var rawFeatures = results[0]
+  var rawRfes = results[1]
+
+  console.log('[releases/feature-pressure] Fetched ' + rawFeatures.length + ' features and ' + rawRfes.length + ' RFEs')
+
+  // Normalize
+  var features = rawFeatures.map(normalizeFeature)
+  var rfes = rawRfes.map(normalizeRfe)
+
+  // Run all analyses
+  var monthlyFlow = classifyByMonth(features, lookbackMonths)
+  var componentPressure = computeComponentPressure(features, lookbackMonths)
+  var rfePipeline = computeRfePipeline(rfes, lookbackMonths)
+  var backlogHalfLife = computeBacklogHalfLife(componentPressure, lookbackMonths)
+  var heatmap = buildHeatmapMatrix(features, lookbackMonths)
+  var trend = computeTrend(features, lookbackMonths)
+  var scorecard = computeScorecard(componentPressure, rfePipeline, backlogHalfLife, trend)
+
+  // Executive summary
+  var cutoff = lookbackDate(lookbackMonths)
+  var baseJql = 'project = ' + FEATURE_PROJECT + ' AND issuetype = Feature'
+  var rfeBaseJql = 'project = ' + RFE_PROJECT + ' AND issuetype = "Feature Request"'
+  var pendingStatusJql = 'status in (New, Draft, "Stakeholder review", "Stakeholder Feedback", "Pending Approval")'
+  var acceptedStatusJql = 'status in (Approved, "In Progress", Refinement, Planning, Review, Resolved)'
+
+  var totalOpen = features.filter(function (f) { return STATUS_DONE.indexOf(f.status) === -1 }).length
+  var totalCreated = features.filter(function (f) { return f.created && f.created >= cutoff }).length
+  var totalResolved = features.filter(function (f) { return f.resolved && f.resolved >= cutoff }).length
+  var burnRate = Math.round(100 * totalResolved / lookbackMonths) / 100
+  var monthsToClear = burnRate > 0 ? Math.round(10 * totalOpen / burnRate) / 10 : Infinity
+
+  // Trend counts
+  var improving = trend.filter(function (t) { return t.direction === 'improving' }).length
+  var worsening = trend.filter(function (t) { return t.direction === 'worsening' }).length
+  var stable = trend.filter(function (t) { return t.direction === 'stable' }).length
+
+  var result = {
+    metadata: {
+      generated_at: new Date().toISOString(),
+      data_timestamp: fetchTimestamp,
+      lookback_months: lookbackMonths,
+      total_features: features.length,
+      total_rfes: rfes.length
+    },
+    executive_summary: {
+      total_features: features.length,
+      total_features_jql: jqlUrl(baseJql),
+      open_features: totalOpen,
+      open_features_jql: jqlUrl(baseJql + ' AND statusCategory != Done'),
+      created_in_window: totalCreated,
+      created_in_window_jql: jqlUrl(baseJql + ' AND created >= "' + cutoff + '"'),
+      resolved_in_window: totalResolved,
+      resolved_in_window_jql: jqlUrl(baseJql + ' AND resolved >= "' + cutoff + '"'),
+      net_in_window: totalCreated - totalResolved,
+      monthly_burn_rate: burnRate,
+      months_to_clear: monthsToClear,
+      backlog_trend: totalCreated > totalResolved ? 'growing' : 'burning down',
+      total_rfes: rfes.length,
+      total_rfes_jql: jqlUrl(rfeBaseJql),
+      rfe_pending: rfePipeline.status_breakdown.pending.count,
+      rfe_pending_jql: jqlUrl(rfeBaseJql + ' AND ' + pendingStatusJql),
+      rfe_accepted: rfePipeline.status_breakdown.accepted.count,
+      rfe_accepted_jql: jqlUrl(rfeBaseJql + ' AND ' + acceptedStatusJql),
+      trend_improving: improving,
+      trend_worsening: worsening,
+      trend_stable: stable
+    },
+    monthly_flow: monthlyFlow.months,
+    component_pressure: componentPressure,
+    rfe_pipeline: rfePipeline,
+    backlog_half_life: backlogHalfLife,
+    heatmap: heatmap,
+    trend: trend,
+    scorecard: scorecard
+  }
+
+  // Cache
+  storage.writeToStorage(CACHE_KEY, result)
+  console.log('[releases/feature-pressure] Cached analysis (' + features.length + ' features, ' + rfes.length + ' RFEs, ' + componentPressure.length + ' components)')
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+function registerRoutes(router, context) {
+  var storage = context.storage
+  var requireAuth = context.requireAuth
+  var requireScope = context.requireScope
+
+  var refreshState = { running: false, lastResult: null, startedAt: null, completedAt: null }
+
+  function triggerBackgroundRefresh(lookbackMonths, force) {
+    if (refreshState.running) return
+    if (!force && refreshState.completedAt) {
+      var elapsed = Date.now() - new Date(refreshState.completedAt).getTime()
+      if (elapsed < REFRESH_COOLDOWN_MS) return
+    }
+
+    refreshState.running = true
+    refreshState.startedAt = new Date().toISOString()
+
+    console.log('[releases/feature-pressure] Background refresh started (lookback: ' + lookbackMonths + 'mo)')
+    setImmediate(function () {
+      fetchAndAnalyze(lookbackMonths, storage)
+        .then(function (result) {
+          refreshState.running = false
+          refreshState.completedAt = new Date().toISOString()
+          refreshState.lastResult = {
+            status: 'success',
+            message: result.metadata.total_features + ' features, ' + result.metadata.total_rfes + ' RFEs analysed',
+            completedAt: new Date().toISOString()
+          }
+          console.log('[releases/feature-pressure] Background refresh completed')
+        })
+        .catch(function (err) {
+          refreshState.running = false
+          refreshState.completedAt = new Date().toISOString()
+          refreshState.lastResult = {
+            status: 'error',
+            message: err.message,
+            completedAt: new Date().toISOString()
+          }
+          console.error('[releases/feature-pressure] Background refresh failed:', err.message)
+        })
+    })
+  }
+
+  /**
+   * @openapi
+   * /api/modules/releases/feature-pressure:
+   *   get:
+   *     tags: ['Releases']
+   *     summary: Get feature pressure analysis (RHAI-wide)
+   *     description: Returns cached data with stale-while-revalidate. Triggers background refresh if cache is stale.
+   *     responses:
+   *       200:
+   *         description: Feature pressure analysis with per-component breakdowns
+   *       202:
+   *         description: Data pipeline is running for the first time
+   */
+  router.get('/', requireAuth, requireScope('releases:read'), function (req, res) {
+    var data = storage.readFromStorage(CACHE_KEY)
+
+    if (data) {
+      var cachedAt = data.metadata && data.metadata.generated_at
+      if (cachedAt) {
+        var age = Date.now() - new Date(cachedAt).getTime()
+        if (age >= CACHE_MAX_AGE_MS) {
+          var lm = (data.metadata && data.metadata.lookback_months) || 12
+          triggerBackgroundRefresh(lm)
+        }
+      }
+      return res.json({
+        ...data,
+        _refreshing: refreshState.running
+      })
+    }
+
+    // No cache — trigger first fetch
+    triggerBackgroundRefresh(12)
+    res.status(202).json({
+      _refreshing: true,
+      _noCache: true,
+      message: 'Data pipeline is running for the first time. Refresh the page in a few moments.'
+    })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/feature-pressure/refresh:
+   *   post:
+   *     tags: ['Releases']
+   *     summary: Trigger a refresh of feature pressure data from Jira
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               lookback_months:
+   *                 type: integer
+   *                 description: Lookback period in months (1-36, default 12)
+   *     responses:
+   *       200:
+   *         description: Refresh started or already running
+   */
+  router.post('/refresh', requireAuth, requireScope('releases:write'), function (req, res) {
+    if (refreshState.running) {
+      return res.json({ status: 'already_running', startedAt: refreshState.startedAt })
+    }
+
+    var lookbackMonths = 12
+    if (req.body && req.body.lookback_months !== undefined) {
+      var lm = parseInt(req.body.lookback_months, 10)
+      if (isNaN(lm) || lm < 1 || lm > 36) {
+        return res.status(400).json({
+          error: 'Invalid lookback_months: must be an integer between 1 and 36'
+        })
+      }
+      lookbackMonths = lm
+    }
+
+    triggerBackgroundRefresh(lookbackMonths, true)
+    res.json({ status: 'started', lookback_months: lookbackMonths })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/feature-pressure/refresh/status:
+   *   get:
+   *     tags: ['Releases']
+   *     summary: Check status of the feature pressure refresh
+   *     responses:
+   *       200:
+   *         description: Refresh state
+   */
+  router.get('/refresh/status', requireAuth, requireScope('releases:read'), function (req, res) {
+    res.json(refreshState)
+  })
+
+  // Diagnostics hook
+  if (context.registerDiagnostics) {
+    context.registerDiagnostics(async function () {
+      var fp = storage.readFromStorage(CACHE_KEY)
+      return {
+        featurePressure: fp ? {
+          generatedAt: fp.metadata && fp.metadata.generated_at,
+          lookbackMonths: fp.metadata && fp.metadata.lookback_months,
+          totalFeatures: fp.metadata && fp.metadata.total_features,
+          totalRfes: fp.metadata && fp.metadata.total_rfes
+        } : null,
+        refresh: refreshState
+      }
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports (pure functions exported for testing)
+// ---------------------------------------------------------------------------
+
+module.exports = registerRoutes
+module.exports.normalizeFeature = normalizeFeature
+module.exports.normalizeRfe = normalizeRfe
+module.exports.toMonth = toMonth
+module.exports.nextMonth = nextMonth
+module.exports.generateMonthRange = generateMonthRange
+module.exports.lookbackDate = lookbackDate
+module.exports.classifyByMonth = classifyByMonth
+module.exports.computeComponentPressure = computeComponentPressure
+module.exports.computeRfePipeline = computeRfePipeline
+module.exports.computeBacklogHalfLife = computeBacklogHalfLife
+module.exports.buildHeatmapMatrix = buildHeatmapMatrix
+module.exports.computeTrend = computeTrend
+module.exports.computeScorecard = computeScorecard
+module.exports.jqlUrl = jqlUrl
+module.exports.quoteComponent = quoteComponent
+module.exports.STATUS_DONE = STATUS_DONE
+module.exports.RFE_ACCEPTED = RFE_ACCEPTED
+module.exports.RFE_PENDING = RFE_PENDING
+module.exports.CACHE_KEY = CACHE_KEY

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -16,6 +16,9 @@ const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 const CACHE_KEY = 'releases/feature-pressure.json'
 const CACHE_MAX_AGE_MS = 60 * 60 * 1000 // 1 hour
 const REFRESH_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
+const FETCH_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes — abort if Jira fetch hangs
+const HEATMAP_MIN_ACTIVITY = 3 // minimum total created+resolved to appear in heatmap
+const HEATMAP_MAX_COMPONENTS = 25 // cap for readability
 
 const FEATURE_PROJECT = 'RHAISTRAT'
 const RFE_PROJECT = 'RHAIRFE'
@@ -40,16 +43,42 @@ function jqlUrl(jql) {
   return JIRA_SEARCH + encodeURIComponent(jql)
 }
 
-/** Quote a component name for JQL */
+/** Quote a component name for JQL (escape backslashes first, then quotes) */
 function quoteComponent(name) {
-  return '"' + name.replace(/"/g, '\\"') + '"'
+  return '"' + name.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialisation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace Infinity values with the string "Infinity" so JSON.stringify
+ * doesn't silently turn them into null.  Mutates in place.
+ */
+function sanitizeInfinity(obj) {
+  if (obj === null || typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) {
+    for (var i = 0; i < obj.length; i++) {
+      if (obj[i] === Infinity) obj[i] = 'Infinity'
+      else if (typeof obj[i] === 'object' && obj[i] !== null) sanitizeInfinity(obj[i])
+    }
+  } else {
+    var keys = Object.keys(obj)
+    for (var k = 0; k < keys.length; k++) {
+      if (obj[keys[k]] === Infinity) obj[keys[k]] = 'Infinity'
+      else if (typeof obj[keys[k]] === 'object' && obj[keys[k]] !== null) sanitizeInfinity(obj[keys[k]])
+    }
+  }
+  return obj
 }
 
 // ---------------------------------------------------------------------------
 // Issue normalisation
 // ---------------------------------------------------------------------------
 
-function normalizeFeature(issue) {
+/** Shared normaliser for both Features and RFEs (identical field shape). */
+function normalizeIssue(issue) {
   var fields = issue.fields || {}
 
   var components = []
@@ -73,29 +102,9 @@ function normalizeFeature(issue) {
   }
 }
 
-function normalizeRfe(issue) {
-  var fields = issue.fields || {}
-
-  var components = []
-  if (Array.isArray(fields.components)) {
-    components = fields.components.map(function (c) { return c.name || '' }).filter(Boolean)
-  }
-
-  var status = ''
-  if (fields.status) {
-    status = fields.status.name || ''
-  }
-
-  return {
-    key: issue.key,
-    url: JIRA_BROWSE + '/' + issue.key,
-    summary: String(fields.summary || '').slice(0, 120),
-    status: status,
-    components: components,
-    created: fields.created || null,
-    resolved: fields.resolutiondate || null
-  }
-}
+// Backward-compatible aliases
+var normalizeFeature = normalizeIssue
+var normalizeRfe = normalizeIssue
 
 // ---------------------------------------------------------------------------
 // Date helpers
@@ -414,7 +423,7 @@ function buildHeatmapMatrix(features, lookbackMonths) {
       var rvals = Object.values(compMonthResolved[comp])
       for (var rv = 0; rv < rvals.length; rv++) total += rvals[rv]
     }
-    return total >= 3
+    return total >= HEATMAP_MIN_ACTIVITY
   })
 
   // Sort by total net (worst first)
@@ -429,8 +438,8 @@ function buildHeatmapMatrix(features, lookbackMonths) {
     return netB - netA
   })
 
-  // Limit to top 25 for readability
-  compNames = compNames.slice(0, 25)
+  // Limit to top N for readability
+  compNames = compNames.slice(0, HEATMAP_MAX_COMPONENTS)
 
   // Build matrix
   var matrix = []
@@ -524,7 +533,9 @@ function computeTrend(features, lookbackMonths) {
 
 /**
  * Combined scorecard — composite risk score per component.
- * Merges feature pressure, RFE demand, backlog half-life, and trend.
+ * Score is computed from three signals: net feature inflow, open backlog size,
+ * and pending RFE demand.  Backlog half-life and trend are included as display
+ * columns but do not affect the score calculation.
  *
  * Risk score = (net/5, cap 10) x 0.4 + (open/10, cap 10) x 0.3 + (rfePending/5, cap 10) x 0.3
  * Risk levels: low (<2.5), medium (2.5-5), high (5-7.5), critical (>7.5)
@@ -591,16 +602,23 @@ function computeScorecard(componentPressure, rfePipeline, backlogHalfLife, trend
 async function fetchAndAnalyze(lookbackMonths, storage) {
   var fetchTimestamp = new Date().toISOString()
 
-  // Fetch features and RFEs in parallel
+  // Fetch features and RFEs in parallel with timeout guard
   var featureJql = 'project = ' + FEATURE_PROJECT + ' AND issuetype = Feature'
   var rfeJql = 'project = ' + RFE_PROJECT + ' AND issuetype = "Feature Request"'
 
   console.log('[releases/feature-pressure] Fetching features: ' + featureJql)
   console.log('[releases/feature-pressure] Fetching RFEs: ' + rfeJql)
 
-  var results = await Promise.all([
-    fetchAllJqlResults(jiraRequest, featureJql, FEATURE_FIELDS),
-    fetchAllJqlResults(jiraRequest, rfeJql, RFE_FIELDS)
+  var timeout = new Promise(function (_, reject) {
+    setTimeout(function () { reject(new Error('Jira fetch timed out after ' + (FETCH_TIMEOUT_MS / 1000) + 's')) }, FETCH_TIMEOUT_MS)
+  })
+
+  var results = await Promise.race([
+    Promise.all([
+      fetchAllJqlResults(jiraRequest, featureJql, FEATURE_FIELDS),
+      fetchAllJqlResults(jiraRequest, rfeJql, RFE_FIELDS)
+    ]),
+    timeout
   ])
 
   var rawFeatures = results[0]
@@ -678,6 +696,9 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
     trend: trend,
     scorecard: scorecard
   }
+
+  // Sanitise Infinity before caching — JSON.stringify(Infinity) produces null
+  sanitizeInfinity(result)
 
   // Cache
   storage.writeToStorage(CACHE_KEY, result)
@@ -848,6 +869,7 @@ function registerRoutes(router, context) {
 // ---------------------------------------------------------------------------
 
 module.exports = registerRoutes
+module.exports.normalizeIssue = normalizeIssue
 module.exports.normalizeFeature = normalizeFeature
 module.exports.normalizeRfe = normalizeRfe
 module.exports.toMonth = toMonth
@@ -867,3 +889,4 @@ module.exports.STATUS_DONE = STATUS_DONE
 module.exports.RFE_ACCEPTED = RFE_ACCEPTED
 module.exports.RFE_PENDING = RFE_PENDING
 module.exports.CACHE_KEY = CACHE_KEY
+module.exports.sanitizeInfinity = sanitizeInfinity

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -92,8 +92,10 @@ function normalizeIssue(issue) {
   }
 
   var status = ''
+  var statusCategory = ''
   if (fields.status) {
     status = fields.status.name || ''
+    statusCategory = (fields.status.statusCategory && fields.status.statusCategory.name) || ''
   }
 
   return {
@@ -101,6 +103,7 @@ function normalizeIssue(issue) {
     url: JIRA_BROWSE + '/' + issue.key,
     summary: String(fields.summary || '').slice(0, 120),
     status: status,
+    statusCategory: statusCategory,
     components: components,
     created: fields.created || null,
     resolved: fields.resolutiondate || null
@@ -230,7 +233,7 @@ function computeComponentPressure(features, lookbackMonths) {
       if (feat.resolved && feat.resolved >= cutoff) {
         compMap[comp].resolved++
       }
-      if (STATUS_DONE.indexOf(feat.status) === -1) {
+      if (feat.statusCategory !== 'Done') {
         compMap[comp].open++
       }
     }
@@ -657,7 +660,7 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
   var pendingStatusJql = 'status in (New, Draft, "Stakeholder review", "Stakeholder Feedback", "Pending Approval")'
   var acceptedStatusJql = 'status in (Approved, "In Progress", Refinement, Planning, Review, Resolved)'
 
-  var totalOpen = features.filter(function (f) { return STATUS_DONE.indexOf(f.status) === -1 }).length
+  var totalOpen = features.filter(function (f) { return f.statusCategory !== 'Done' }).length
   var totalCreated = features.filter(function (f) { return f.created && f.created >= cutoff }).length
   var totalResolved = features.filter(function (f) { return f.resolved && f.resolved >= cutoff }).length
   var burnRate = Math.round(100 * totalResolved / lookbackMonths) / 100

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -53,20 +53,25 @@ function quoteComponent(name) {
 // ---------------------------------------------------------------------------
 
 /**
- * Replace Infinity values with the string "Infinity" so JSON.stringify
- * doesn't silently turn them into null.  Mutates in place.
+ * Replace non-finite numeric values so JSON.stringify doesn't silently
+ * turn them into null.  Infinity → "Infinity", -Infinity → "-Infinity",
+ * NaN → null.  Mutates in place.
  */
 function sanitizeInfinity(obj) {
   if (obj === null || typeof obj !== 'object') return obj
   if (Array.isArray(obj)) {
     for (var i = 0; i < obj.length; i++) {
       if (obj[i] === Infinity) obj[i] = 'Infinity'
+      else if (obj[i] === -Infinity) obj[i] = '-Infinity'
+      else if (typeof obj[i] === 'number' && isNaN(obj[i])) obj[i] = null
       else if (typeof obj[i] === 'object' && obj[i] !== null) sanitizeInfinity(obj[i])
     }
   } else {
     var keys = Object.keys(obj)
     for (var k = 0; k < keys.length; k++) {
       if (obj[keys[k]] === Infinity) obj[keys[k]] = 'Infinity'
+      else if (obj[keys[k]] === -Infinity) obj[keys[k]] = '-Infinity'
+      else if (typeof obj[keys[k]] === 'number' && isNaN(obj[keys[k]])) obj[keys[k]] = null
       else if (typeof obj[keys[k]] === 'object' && obj[keys[k]] !== null) sanitizeInfinity(obj[keys[k]])
     }
   }
@@ -240,7 +245,7 @@ function computeComponentPressure(features, lookbackMonths) {
     var data = compMap[name]
     var net = data.created - data.resolved
     var ratio = data.resolved > 0 ? Math.round(100 * data.created / data.resolved) / 100 : (data.created > 0 ? Infinity : 0)
-    var compQ = name === '(No Component)' ? '' : ' AND component = ' + quoteComponent(name)
+    var compQ = name === '(No Component)' ? ' AND component is EMPTY' : ' AND component = ' + quoteComponent(name)
 
     result.push({
       component: name,
@@ -327,7 +332,7 @@ function computeRfePipeline(rfes, lookbackMonths) {
 
   var perComponentPending = Object.keys(compPending)
     .map(function (comp) {
-      var compQ = comp === '(No Component)' ? '' : ' AND component = ' + quoteComponent(comp)
+      var compQ = comp === '(No Component)' ? ' AND component is EMPTY' : ' AND component = ' + quoteComponent(comp)
       return {
         component: comp,
         count: compPending[comp],
@@ -561,7 +566,7 @@ function computeScorecard(componentPressure, rfePipeline, backlogHalfLife, trend
   for (var ci = 0; ci < componentPressure.length; ci++) {
     var cp = componentPressure[ci]
     var rfePending = rfeMap[cp.component] || 0
-    var halfLife = halfLifeMap[cp.component] || 0
+    var halfLife = halfLifeMap[cp.component] !== undefined ? halfLifeMap[cp.component] : null
     var trendDir = trendMap[cp.component] || 'stable'
 
     var netScore = Math.min(Math.max(cp.net, 0) / 5, 10)
@@ -609,17 +614,23 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
   console.log('[releases/feature-pressure] Fetching features: ' + featureJql)
   console.log('[releases/feature-pressure] Fetching RFEs: ' + rfeJql)
 
+  var timer
   var timeout = new Promise(function (_, reject) {
-    setTimeout(function () { reject(new Error('Jira fetch timed out after ' + (FETCH_TIMEOUT_MS / 1000) + 's')) }, FETCH_TIMEOUT_MS)
+    timer = setTimeout(function () { reject(new Error('Jira fetch timed out after ' + (FETCH_TIMEOUT_MS / 1000) + 's')) }, FETCH_TIMEOUT_MS)
   })
 
-  var results = await Promise.race([
-    Promise.all([
-      fetchAllJqlResults(jiraRequest, featureJql, FEATURE_FIELDS),
-      fetchAllJqlResults(jiraRequest, rfeJql, RFE_FIELDS)
-    ]),
-    timeout
-  ])
+  var results
+  try {
+    results = await Promise.race([
+      Promise.all([
+        fetchAllJqlResults(jiraRequest, featureJql, FEATURE_FIELDS),
+        fetchAllJqlResults(jiraRequest, rfeJql, RFE_FIELDS)
+      ]),
+      timeout
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
 
   var rawFeatures = results[0]
   var rawRfes = results[1]
@@ -677,7 +688,7 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
       net_in_window: totalCreated - totalResolved,
       monthly_burn_rate: burnRate,
       months_to_clear: monthsToClear,
-      backlog_trend: totalCreated > totalResolved ? 'growing' : 'burning down',
+      backlog_trend: totalCreated > totalResolved ? 'growing' : (totalCreated < totalResolved ? 'burning down' : 'stable'),
       total_rfes: rfes.length,
       total_rfes_jql: jqlUrl(rfeBaseJql),
       rfe_pending: rfePipeline.status_breakdown.pending.count,

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -14,6 +14,7 @@ const registerFeatureTrackingRoutes = require('./execution/feature-tracking-rout
 const registerDeliveryRoutes = require('./delivery/routes');
 const registerHygieneRoutes = require('./hygiene/routes');
 const registerTvFvDeltaRoutes = require('./tv-fv-delta/routes');
+const registerFeaturePressureRoutes = require('./feature-pressure/routes');
 const registerPmHubRoutes = require('./pm-hub/routes');
 const { getAuditLog } = require('./planning/audit-log');
 
@@ -228,6 +229,16 @@ module.exports = function registerRoutes(router, context) {
     registerDiagnostics: context.registerDiagnostics || null
   });
   router.use('/tv-fv-delta', tvFvDeltaRouter);
+
+  // Feature Pressure sub-router (mounted at /api/modules/releases/feature-pressure/)
+  const featurePressureRouter = express.Router();
+  registerFeaturePressureRoutes(featurePressureRouter, {
+    storage,
+    requireAuth,
+    requireScope,
+    registerDiagnostics: context.registerDiagnostics || null
+  });
+  router.use('/feature-pressure', featurePressureRouter);
 
   // PM Hub sub-router (mounted at /api/modules/releases/pm-hub/)
   var pmHubRouter = express.Router();

--- a/tests/integration/feature-pressure.spec.js
+++ b/tests/integration/feature-pressure.spec.js
@@ -258,9 +258,10 @@ test.describe('Feature Pressure - Executive Summary @feature-pressure', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // Check for key values in the split Features / RFEs summary
+    const summarySection = page.locator('section').first();
     await expect(page.locator('text=Features (RHAISTRAT)')).toBeVisible();
     await expect(page.locator('text=Feature Requests (RHAIRFE)')).toBeVisible();
-    await expect(page.locator('text=Open')).toBeVisible();
+    await expect(summarySection.locator('text=Open').first()).toBeVisible();
     await expect(page.locator('text=Burn rate:')).toBeVisible();
     await expect(page.locator('text=Time to clear:')).toBeVisible();
     expect(relevantErrors(page)).toHaveLength(0);
@@ -285,7 +286,7 @@ test.describe('Feature Pressure - Executive Summary @feature-pressure', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    await expect(page.locator('text=growing')).toBeVisible();
+    await expect(page.locator('text=growing').first()).toBeVisible();
     expect(relevantErrors(page)).toHaveLength(0);
   });
 });
@@ -306,9 +307,10 @@ test.describe('Feature Pressure - Component Table @feature-pressure', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     await expect(page.locator('text=Pressure by Component')).toBeVisible();
-    // Table should have rows for fixture components
-    await expect(page.locator('text=AI Core Dashboard')).toBeVisible();
-    await expect(page.locator('text=Documentation')).toBeVisible();
+    // Table should have rows for fixture components — scope to the component table section
+    const pressureSection = page.locator('details:has(summary:has-text("Feature Pressure by Component"))');
+    await expect(pressureSection.locator('text=AI Core Dashboard')).toBeVisible();
+    await expect(pressureSection.locator('text=Documentation')).toBeVisible();
     expect(relevantErrors(page)).toHaveLength(0);
   });
 
@@ -330,13 +332,14 @@ test.describe('Feature Pressure - Component Table @feature-pressure', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    const searchInput = page.locator('input[placeholder*="Filter"]');
+    const pressureSection = page.locator('details:has(summary:has-text("Feature Pressure by Component"))');
+    const searchInput = pressureSection.locator('input[placeholder*="Filter"]');
     await searchInput.fill('UXD');
     await page.waitForTimeout(500);
 
-    await expect(page.locator('td:has-text("UXD")')).toBeVisible();
-    // Other components should be filtered out
-    await expect(page.locator('td:has-text("AI Core Dashboard")')).not.toBeVisible();
+    await expect(pressureSection.locator('td:has-text("UXD")')).toBeVisible();
+    // Other components should be filtered out from the pressure table
+    await expect(pressureSection.locator('td:has-text("AI Core Dashboard")')).not.toBeVisible();
     expect(relevantErrors(page)).toHaveLength(0);
   });
 });

--- a/tests/integration/feature-pressure.spec.js
+++ b/tests/integration/feature-pressure.spec.js
@@ -88,7 +88,7 @@ const FIXTURE_DATA = {
     ]
   },
   backlog_half_life: [
-    { component: 'Stuck', open: 10, open_jql: 'https://test/hl-1', resolved_per_month: 0, months_to_clear: Infinity },
+    { component: 'Stuck', open: 10, open_jql: 'https://test/hl-1', resolved_per_month: 0, months_to_clear: 'Infinity' },
     { component: 'AI Core Dashboard', open: 163, open_jql: 'https://test/hl-2', resolved_per_month: 10.25, months_to_clear: 15.9 }
   ],
   heatmap: {

--- a/tests/integration/feature-pressure.spec.js
+++ b/tests/integration/feature-pressure.spec.js
@@ -1,0 +1,448 @@
+const { test, expect } = require('@playwright/test');
+const { DEFAULT_PAGE_WAIT_TIME } = require('./constants');
+const { setupErrorTracking, logCapturedErrors } = require('./helpers');
+
+/**
+ * Integration tests for Feature Pressure view (Releases module -> Reports hub)
+ *
+ * Tests verify:
+ * - View loads via Reports hub (/#/releases/reports?report=feature-pressure)
+ * - Executive summary cards render with correct data
+ * - Monthly flow chart renders
+ * - Component pressure table renders with sortable columns
+ * - All counts are clickable Jira links
+ * - Lookback period selector works
+ * - Refresh button works
+ * - Empty/loading/error states handled
+ *
+ * Tag: @feature-pressure
+ * Usage: npx playwright test --grep @feature-pressure
+ */
+
+// ---------------------------------------------------------------------------
+// Fixture data for deterministic tests
+// ---------------------------------------------------------------------------
+
+const FIXTURE_DATA = {
+  metadata: {
+    generated_at: '2026-06-09T10:00:00.000Z',
+    data_timestamp: '2026-06-09T09:00:00.000Z',
+    lookback_months: 12,
+    total_features: 1499,
+    total_rfes: 1465
+  },
+  executive_summary: {
+    total_features: 1499,
+    total_features_jql: 'https://redhat.atlassian.net/issues/?jql=test-total',
+    open_features: 658,
+    open_features_jql: 'https://redhat.atlassian.net/issues/?jql=test-open',
+    created_in_window: 1041,
+    created_in_window_jql: 'https://redhat.atlassian.net/issues/?jql=test-created',
+    resolved_in_window: 613,
+    resolved_in_window_jql: 'https://redhat.atlassian.net/issues/?jql=test-resolved',
+    net_in_window: 428,
+    monthly_burn_rate: 51.08,
+    months_to_clear: 12.9,
+    backlog_trend: 'growing',
+    total_rfes: 1465,
+    total_rfes_jql: 'https://redhat.atlassian.net/issues/?jql=test-rfes',
+    rfe_pending: 814,
+    rfe_pending_jql: 'https://redhat.atlassian.net/issues/?jql=test-rfe-pending',
+    rfe_accepted: 635,
+    rfe_accepted_jql: 'https://redhat.atlassian.net/issues/?jql=test-rfe-accepted',
+    trend_improving: 23,
+    trend_worsening: 31,
+    trend_stable: 1
+  },
+  monthly_flow: [
+    { month: '2025-07', created: 41, resolved: 24, net: 17, cumulative: 16, created_jql: 'https://test/c1', resolved_jql: 'https://test/r1' },
+    { month: '2025-08', created: 47, resolved: 26, net: 21, cumulative: 37, created_jql: 'https://test/c2', resolved_jql: 'https://test/r2' },
+    { month: '2025-09', created: 69, resolved: 23, net: 46, cumulative: 83, created_jql: 'https://test/c3', resolved_jql: 'https://test/r3' }
+  ],
+  component_pressure: [
+    {
+      component: 'AI Core Dashboard', created: 215, resolved: 123, net: 92, open: 163, pressure_ratio: 1.75,
+      created_jql: 'https://test/comp-c1', resolved_jql: 'https://test/comp-r1', open_jql: 'https://test/comp-o1'
+    },
+    {
+      component: 'Documentation', created: 202, resolved: 133, net: 69, open: 113, pressure_ratio: 1.52,
+      created_jql: 'https://test/comp-c2', resolved_jql: 'https://test/comp-r2', open_jql: 'https://test/comp-o2'
+    },
+    {
+      component: 'UXD', created: 164, resolved: 96, net: 68, open: 125, pressure_ratio: 1.71,
+      created_jql: 'https://test/comp-c3', resolved_jql: 'https://test/comp-r3', open_jql: 'https://test/comp-o3'
+    }
+  ],
+  rfe_pipeline: {
+    status_breakdown: {
+      total: { count: 1465, jql: 'https://test/rfe-total' },
+      accepted: { count: 635, jql: 'https://test/rfe-accepted' },
+      pending: { count: 814, jql: 'https://test/rfe-pending' },
+      other: { count: 16 }
+    },
+    monthly_arrivals: [
+      { month: '2025-07', count: 80, jql: 'https://test/rfe-m1' }
+    ],
+    per_component_pending: [
+      { component: 'AI Core Dashboard', count: 50, jql: 'https://test/rfe-comp1' }
+    ]
+  },
+  backlog_half_life: [
+    { component: 'Stuck', open: 10, open_jql: 'https://test/hl-1', resolved_per_month: 0, months_to_clear: Infinity },
+    { component: 'AI Core Dashboard', open: 163, open_jql: 'https://test/hl-2', resolved_per_month: 10.25, months_to_clear: 15.9 }
+  ],
+  heatmap: {
+    months: ['2025-07', '2025-08', '2025-09'],
+    components: ['AI Core Dashboard', 'Documentation'],
+    matrix: [[5, 3, -2], [2, -1, 4]]
+  },
+  trend: [
+    { component: 'AI Core Dashboard', first_half_net: 30, second_half_net: 62, direction: 'worsening', delta: 32 },
+    { component: 'UXD', first_half_net: 40, second_half_net: 28, direction: 'improving', delta: -12 }
+  ],
+  scorecard: [
+    {
+      component: 'AI Core Dashboard', risk_score: 8.5, risk_level: 'critical',
+      created: 215, resolved: 123, net: 92, open: 163, pressure_ratio: 1.75,
+      rfe_pending: 50, rfe_pending_jql: 'https://test/sc-rfe1', open_jql: 'https://test/sc-o1',
+      backlog_months: 15.9, trend: 'worsening'
+    },
+    {
+      component: 'Documentation', risk_score: 5.2, risk_level: 'high',
+      created: 202, resolved: 133, net: 69, open: 113, pressure_ratio: 1.52,
+      rfe_pending: 0, rfe_pending_jql: '', open_jql: 'https://test/sc-o2',
+      backlog_months: 10.2, trend: 'worsening'
+    }
+  ]
+};
+
+const RELEASES_MANIFEST = {
+  name: 'Releases',
+  slug: 'releases',
+  defaultEnabled: true,
+  description: 'Unified release lifecycle',
+  icon: 'rocket',
+  order: 10,
+  client: { routes: [] }
+};
+
+const REGISTRY_DATA = { releases: [], versions: [], meta: {} };
+
+// ---------------------------------------------------------------------------
+// Route mocking
+// ---------------------------------------------------------------------------
+
+function relevantErrors(page) {
+  return (page.errors || []).filter(e =>
+    !e.message.includes('favicon') &&
+    !e.message.includes('ResizeObserver') &&
+    !e.message.includes('navigation') &&
+    !e.message.includes('ERR_ABORTED')
+  );
+}
+
+async function mockAllApis(page, fpData) {
+  // Catch-all (lowest priority)
+  await page.route('**/api/**', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+  });
+
+  // Module manifest
+  await page.route('**/api/modules', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ modules: [RELEASES_MANIFEST] })
+    });
+  });
+
+  // Registry
+  await page.route('**/api/modules/releases/registry', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(REGISTRY_DATA) });
+  });
+
+  // Feature pressure endpoint
+  await page.route('**/api/modules/releases/feature-pressure', route => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'started' }) });
+    } else {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fpData || FIXTURE_DATA) });
+    }
+  });
+
+  await page.route('**/api/modules/releases/feature-pressure/refresh', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'started', lookback_months: 12 }) });
+  });
+
+  await page.route('**/api/modules/releases/feature-pressure/refresh/status', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ running: false }) });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Feature Pressure - View Loading @feature-pressure', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should load the view without JavaScript errors', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render the page heading and subtitle', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const heading = page.getByRole('heading', { name: 'Feature Pressure' });
+    await expect(heading).toBeVisible();
+
+    const subtitle = page.locator('text=Where feature inflow exceeds capacity to burn down');
+    await expect(subtitle).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render metadata line with timestamps', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const meta = page.locator('text=1,499 features');
+    await expect(meta).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should call the feature-pressure API endpoint', async ({ page }) => {
+    let apiCalled = false;
+    await page.route('**/api/**', route => {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    });
+    await page.route('**/api/modules/releases/feature-pressure', route => {
+      apiCalled = true;
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(FIXTURE_DATA) });
+    });
+
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    expect(apiCalled).toBe(true);
+  });
+});
+
+test.describe('Feature Pressure - Executive Summary @feature-pressure', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render summary cards', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Check for key values in the split Features / RFEs summary
+    await expect(page.locator('text=Features (RHAISTRAT)')).toBeVisible();
+    await expect(page.locator('text=Feature Requests (RHAIRFE)')).toBeVisible();
+    await expect(page.locator('text=Open')).toBeVisible();
+    await expect(page.locator('text=Burn rate:')).toBeVisible();
+    await expect(page.locator('text=Time to clear:')).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render counts as clickable Jira links', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // ClickableCount renders as <a> with href containing jql
+    const jiraLinks = page.locator('a[href*="jql"]');
+    const count = await jiraLinks.count();
+    expect(count).toBeGreaterThan(0);
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show backlog trend', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('text=growing')).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+test.describe('Feature Pressure - Component Table @feature-pressure', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render component pressure table', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('text=Pressure by Component')).toBeVisible();
+    // Table should have rows for fixture components
+    await expect(page.locator('text=AI Core Dashboard')).toBeVisible();
+    await expect(page.locator('text=Documentation')).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should render column headers', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    for (const col of ['Component', 'Created', 'Resolved', 'Net', 'Open', 'Ratio']) {
+      await expect(page.locator(`th:has-text("${col}")`).first()).toBeVisible();
+    }
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should filter components when typing in search', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const searchInput = page.locator('input[placeholder*="Filter"]');
+    await searchInput.fill('UXD');
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('td:has-text("UXD")')).toBeVisible();
+    // Other components should be filtered out
+    await expect(page.locator('td:has-text("AI Core Dashboard")')).not.toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+test.describe('Feature Pressure - Scorecard @feature-pressure', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should render risk scorecard section', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('text=Risk Scorecard')).toBeVisible();
+    // Should show risk badges
+    await expect(page.locator('text=critical').first()).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+test.describe('Feature Pressure - Refresh @feature-pressure', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should show refresh button', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const refreshBtn = page.locator('button:has-text("Refresh from Jira")');
+    await expect(refreshBtn).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show lookback period selector', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const select = page.locator('select');
+    await expect(select).toBeVisible();
+    // Should have 12 months selected
+    await expect(select).toHaveValue('12');
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should handle 202 pipeline-running gracefully', async ({ page }) => {
+    await page.route('**/api/**', route => {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    });
+    await page.route('**/api/modules/releases/feature-pressure', route => {
+      route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ _refreshing: true, _noCache: true, message: 'Pipeline running' })
+      });
+    });
+
+    setupErrorTracking(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Should not crash
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});
+
+test.describe('Feature Pressure - No Data State @feature-pressure', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should show loading state during first fetch', async ({ page }) => {
+    // Delay the API response
+    await page.route('**/api/**', route => {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    });
+    await page.route('**/api/modules/releases/feature-pressure', async route => {
+      await new Promise(r => setTimeout(r, 2000));
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(FIXTURE_DATA) });
+    });
+
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForTimeout(500);
+
+    // Should show loading indicator
+    const loading = page.locator('text=Loading feature pressure data');
+    await expect(loading).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new **Feature Pressure** report to the Releases module — live Jira queries against RHAISTRAT (Features) and RHAIRFE (Feature Requests)
- Computes inflow vs burn analysis RHAI-wide by component with executive summary, monthly flow chart, component pressure table, RFE pipeline, backlog burn-down estimate, pressure heatmap, and risk scorecard
- Every count is a clickable JQL verification link
- Stale-while-revalidate cache pattern with background refresh and cooldown (mirrors tv-fv-delta)
- Collapsible sections with exec summary always visible
- Hot Spots section highlighting critical/high risk components
- CI integration tests registered in workflow

## Test coverage

- **79 server unit tests** (pipeline.test.js) — all pure analysis functions
- **11 client unit tests** (useComponentPressure.test.js) — filtering, sorting, string Infinity handling
- **15 integration tests** (feature-pressure.spec.js) — Playwright, all sections + edge cases
- ESLint clean, pre-commit hooks pass

## Test plan

- [ ] Verify view loads at `/#/releases/reports?report=feature-pressure`
- [ ] Verify executive summary shows Features (RHAISTRAT) and Feature Requests (RHAIRFE) sections
- [ ] Verify all count values are clickable Jira links
- [ ] Verify monthly flow chart renders
- [ ] Verify component pressure table sorts and filters
- [ ] Verify heatmap renders without z-index overlap
- [ ] Verify risk scorecard shows correct risk levels
- [ ] Verify refresh button triggers background fetch
- [ ] Verify lookback period selector works (6/12/18/24 months)
- [ ] Verify CI integration tests run on PR changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)