### PR TITLE
feat(releases): Outcomes Dashboard status, version columns, risk cleanup

### DIFF
--- a/fixtures/releases/planning/health-cache-demo.json
+++ b/fixtures/releases/planning/health-cache-demo.json
@@ -131,11 +131,41 @@
       },
       "planningChecks": {
         "checks": [
-          { "id": "DoR-P1", "label": "Components Set", "passed": true, "severity": "hard-blocker", "detail": "Model Serving" },
-          { "id": "DoR-P2", "label": "Product Manager Assigned", "passed": true, "severity": "hard-blocker", "detail": "Sarah Chen" },
-          { "id": "DoR-P3", "label": "Release Type Set", "passed": true, "severity": "hard-blocker", "detail": "GA" },
-          { "id": "DoR-P4", "label": "Child Epics Created", "passed": true, "severity": "hard-blocker", "detail": "4 epic(s)" },
-          { "id": "DoR-P5", "label": "RFE Linked", "passed": true, "severity": "hard-blocker", "detail": "RHAISTRAT-100" }
+          {
+            "id": "DoR-P1",
+            "label": "Components Set",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "Model Serving"
+          },
+          {
+            "id": "DoR-P2",
+            "label": "Product Manager Assigned",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "Sarah Chen"
+          },
+          {
+            "id": "DoR-P3",
+            "label": "Release Type Set",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "GA"
+          },
+          {
+            "id": "DoR-P4",
+            "label": "Child Epics Created",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "4 epic(s)"
+          },
+          {
+            "id": "DoR-P5",
+            "label": "RFE Linked",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "RHAISTRAT-100"
+          }
         ],
         "passedCount": 5,
         "totalCount": 5,
@@ -169,7 +199,9 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHOAIENG-1002",
@@ -263,7 +295,9 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "targeted"
+      "versionStatus": "targeted",
+      "fixVersions": "",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHOAIENG-1003",
@@ -366,7 +400,9 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5, rhoai-3.5-EA2",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHOAIENG-1004",
@@ -466,7 +502,9 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "targeted"
+      "versionStatus": "targeted",
+      "fixVersions": "",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHOAIENG-1005",
@@ -574,7 +612,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHOAIENG-1006",
@@ -659,18 +699,60 @@
       },
       "planningChecks": {
         "checks": [
-          { "id": "DoR-P1", "label": "Components Set", "passed": true, "severity": "hard-blocker", "detail": "Operator" },
-          { "id": "DoR-P2", "label": "Product Manager Assigned", "passed": true, "severity": "hard-blocker", "detail": "Tom Wilson" },
-          { "id": "DoR-P3", "label": "Release Type Set", "passed": true, "severity": "hard-blocker", "detail": "GA" },
-          { "id": "DoR-P4", "label": "Child Epics Created", "passed": false, "severity": "hard-blocker", "detail": "No child epics linked" },
-          { "id": "DoR-P5", "label": "RFE Linked", "passed": false, "severity": "hard-blocker", "detail": "No source RFE linked" }
+          {
+            "id": "DoR-P1",
+            "label": "Components Set",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "Operator"
+          },
+          {
+            "id": "DoR-P2",
+            "label": "Product Manager Assigned",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "Tom Wilson"
+          },
+          {
+            "id": "DoR-P3",
+            "label": "Release Type Set",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "GA"
+          },
+          {
+            "id": "DoR-P4",
+            "label": "Child Epics Created",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No child epics linked"
+          },
+          {
+            "id": "DoR-P5",
+            "label": "RFE Linked",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No source RFE linked"
+          }
         ],
         "passedCount": 3,
         "totalCount": 5,
         "hasHardBlockers": true,
         "hardBlockersFailed": [
-          { "id": "DoR-P4", "label": "Child Epics Created", "passed": false, "severity": "hard-blocker", "detail": "No child epics linked" },
-          { "id": "DoR-P5", "label": "RFE Linked", "passed": false, "severity": "hard-blocker", "detail": "No source RFE linked" }
+          {
+            "id": "DoR-P4",
+            "label": "Child Epics Created",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No child epics linked"
+          },
+          {
+            "id": "DoR-P5",
+            "label": "RFE Linked",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No source RFE linked"
+          }
         ]
       },
       "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1006",
@@ -700,7 +782,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "none",
+      "fixVersions": "",
+      "targetRelease": ""
     },
     {
       "key": "RHOAIENG-1007",
@@ -786,20 +870,74 @@
       "rice": null,
       "planningChecks": {
         "checks": [
-          { "id": "DoR-P1", "label": "Components Set", "passed": false, "severity": "hard-blocker", "detail": "No components assigned" },
-          { "id": "DoR-P2", "label": "Product Manager Assigned", "passed": false, "severity": "hard-blocker", "detail": null },
-          { "id": "DoR-P3", "label": "Release Type Set", "passed": true, "severity": "hard-blocker", "detail": "TP" },
-          { "id": "DoR-P4", "label": "Child Epics Created", "passed": false, "severity": "hard-blocker", "detail": "No child epics linked" },
-          { "id": "DoR-P5", "label": "RFE Linked", "passed": false, "severity": "hard-blocker", "detail": "No source RFE linked" }
+          {
+            "id": "DoR-P1",
+            "label": "Components Set",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No components assigned"
+          },
+          {
+            "id": "DoR-P2",
+            "label": "Product Manager Assigned",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": null
+          },
+          {
+            "id": "DoR-P3",
+            "label": "Release Type Set",
+            "passed": true,
+            "severity": "hard-blocker",
+            "detail": "TP"
+          },
+          {
+            "id": "DoR-P4",
+            "label": "Child Epics Created",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No child epics linked"
+          },
+          {
+            "id": "DoR-P5",
+            "label": "RFE Linked",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No source RFE linked"
+          }
         ],
         "passedCount": 1,
         "totalCount": 5,
         "hasHardBlockers": true,
         "hardBlockersFailed": [
-          { "id": "DoR-P1", "label": "Components Set", "passed": false, "severity": "hard-blocker", "detail": "No components assigned" },
-          { "id": "DoR-P2", "label": "Product Manager Assigned", "passed": false, "severity": "hard-blocker", "detail": null },
-          { "id": "DoR-P4", "label": "Child Epics Created", "passed": false, "severity": "hard-blocker", "detail": "No child epics linked" },
-          { "id": "DoR-P5", "label": "RFE Linked", "passed": false, "severity": "hard-blocker", "detail": "No source RFE linked" }
+          {
+            "id": "DoR-P1",
+            "label": "Components Set",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No components assigned"
+          },
+          {
+            "id": "DoR-P2",
+            "label": "Product Manager Assigned",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": null
+          },
+          {
+            "id": "DoR-P4",
+            "label": "Child Epics Created",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No child epics linked"
+          },
+          {
+            "id": "DoR-P5",
+            "label": "RFE Linked",
+            "passed": false,
+            "severity": "hard-blocker",
+            "detail": "No source RFE linked"
+          }
         ]
       },
       "jiraUrl": "https://issues.redhat.com/browse/RHOAIENG-1007",
@@ -829,7 +967,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "targeted"
+      "versionStatus": "targeted",
+      "fixVersions": "",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHOAIENG-1008",
@@ -941,7 +1081,9 @@
       },
       "planningStatus": "ready-for-execution",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHAISTRAT-2001",
@@ -1044,7 +1186,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5-EA1",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHAISTRAT-2006",
@@ -1138,7 +1282,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Initiative",
-      "versionStatus": "targeted"
+      "versionStatus": "targeted",
+      "fixVersions": "",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHAISTRAT-2013",
@@ -1246,7 +1392,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "none"
+      "versionStatus": "none",
+      "fixVersions": "",
+      "targetRelease": ""
     },
     {
       "key": "RHAISTRAT-2030",
@@ -1346,7 +1494,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5",
+      "targetRelease": "rhoai-3.5"
     },
     {
       "key": "RHAISTRAT-2016",
@@ -1452,7 +1602,9 @@
       },
       "planningStatus": "in-planning",
       "issueType": "Feature",
-      "versionStatus": "committed"
+      "versionStatus": "committed",
+      "fixVersions": "rhoai-3.5-EA1",
+      "targetRelease": "rhoai-3.5"
     }
   ],
   "enrichmentStatus": {

--- a/modules/releases/__tests__/client/plan/big-rock-row.test.js
+++ b/modules/releases/__tests__/client/plan/big-rock-row.test.js
@@ -53,10 +53,10 @@ function mountRow(props) {
 
 describe('BigRockRow', function() {
   describe('column structure', function() {
-    it('renders 7 td elements when health is shown', function() {
+    it('renders 8 td elements when health is shown', function() {
       var wrapper = mountRow()
       var tds = wrapper.findAll('td')
-      expect(tds.length).toBe(7)
+      expect(tds.length).toBe(8)
     })
 
     it('renders 6 td elements when health is not shown', function() {

--- a/modules/releases/__tests__/client/plan/health-components.test.js
+++ b/modules/releases/__tests__/client/plan/health-components.test.js
@@ -469,11 +469,10 @@ describe('BigRockExpandedRow', function() {
     expect(featureLinks[0].attributes('target')).toBe('_blank')
   })
 
-  it('shows risk flag categories or -- for no flags', function() {
+  it('shows risk-colored dots but not risk flag text (risk column removed)', function() {
     var wrapper = mountExpanded({ features: sampleFeatures })
-    expect(wrapper.text()).toContain('--')
-    expect(wrapper.text()).toContain('VELOCITY_LAG')
-    expect(wrapper.text()).toContain('BLOCKED, MILESTONE_MISS')
+    expect(wrapper.text()).not.toContain('VELOCITY_LAG')
+    expect(wrapper.text()).not.toContain('BLOCKED, MILESTONE_MISS')
   })
 
   it('shows override indicator (M) when feature has override', function() {
@@ -497,9 +496,9 @@ describe('BigRockExpandedRow', function() {
     expect(td.attributes('colspan')).toBe('8')
   })
 
-  it('has 4 column headers in the inner table', function() {
+  it('has 6 column headers in the inner table', function() {
     var wrapper = mountExpanded({ features: sampleFeatures })
     var headers = wrapper.findAll('th')
-    expect(headers.length).toBe(4)
+    expect(headers.length).toBe(6)
   })
 })

--- a/modules/releases/__tests__/client/plan/planning-gate-status.test.js
+++ b/modules/releases/__tests__/client/plan/planning-gate-status.test.js
@@ -85,7 +85,7 @@ describe('PlanningGateStatus', function() {
     var wrapper = mount(PlanningGateStatus, {
       props: { dor: makeDor(), dod: null, planningStatus: 'in-planning' }
     })
-    expect(wrapper.text()).toContain('Planning Status')
+    expect(wrapper.text()).toContain('Status')
   })
 
   // ─── DoR Blockers ───
@@ -237,7 +237,7 @@ describe('PlanningGateStatus', function() {
     var wrapper = mount(PlanningGateStatus, {
       props: { dor: null, dod: makeDod(), planningStatus: 'in-planning' }
     })
-    expect(wrapper.text()).toContain('Planning Status')
+    expect(wrapper.text()).toContain('Status')
     expect(wrapper.text()).not.toContain('Definition of Ready')
   })
 

--- a/modules/releases/__tests__/client/plan/use-health-aggregation.test.js
+++ b/modules/releases/__tests__/client/plan/use-health-aggregation.test.js
@@ -258,6 +258,11 @@ describe('useHealthAggregation', function() {
       expect(rf[0].jiraUrl).toBe('https://issues.redhat.com/browse/FEAT-1')
       expect(rf[0].override).toBe(null)
       expect(rf[0].status).toBe('In Progress')
+      expect(rf[0].fixVersions).toBe('')
+      expect(rf[0].targetRelease).toBe('')
+      expect(rf[0].versionStatus).toBe('none')
+      expect(rf[0].completionPct).toBe(0)
+      expect(rf[0].planningChecks).toBe(null)
 
       expect(rf[1].key).toBe('FEAT-2')
       expect(rf[1].level).toBe('red')
@@ -271,6 +276,11 @@ describe('useHealthAggregation', function() {
       expect(rf[1].jiraUrl).toBe('https://issues.redhat.com/browse/FEAT-2')
       expect(rf[1].override).toBe(null)
       expect(rf[1].status).toBe('In Progress')
+      expect(rf[1].fixVersions).toBe('')
+      expect(rf[1].targetRelease).toBe('')
+      expect(rf[1].versionStatus).toBe('none')
+      expect(rf[1].completionPct).toBe(0)
+      expect(rf[1].planningChecks).toBe(null)
     })
 
     it('defaults to green when feature has no health data', function() {
@@ -322,6 +332,11 @@ describe('useHealthAggregation', function() {
       expect(unknown.jiraUrl).toBe('')
       expect(unknown.override).toBe(null)
       expect(unknown.status).toBe('')
+      expect(unknown.fixVersions).toBe('')
+      expect(unknown.targetRelease).toBe('')
+      expect(unknown.versionStatus).toBe('none')
+      expect(unknown.completionPct).toBe(0)
+      expect(unknown.planningChecks).toBe(null)
     })
 
     it('splits merged bigRock names into separate entries', function() {

--- a/modules/releases/client/plan/components/BigRockExpandedRow.vue
+++ b/modules/releases/client/plan/components/BigRockExpandedRow.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import StatusInfoPopover from './StatusInfoPopover.vue'
 
 var props = defineProps({
   features: { type: Array, default: () => [] },
@@ -36,6 +37,12 @@ function truncate(text, max) {
   return text.length > max ? text.slice(0, max) + '...' : text
 }
 
+function completionBarColor(pct) {
+  if (pct >= 80) return 'bg-green-500'
+  if (pct >= 50) return 'bg-yellow-500'
+  return 'bg-red-500'
+}
+
 </script>
 
 <template>
@@ -61,9 +68,13 @@ function truncate(text, max) {
           <tr>
             <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Feature</th>
             <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Summary</th>
-            <th v-if="isPlanningMode" class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Planning Status</th>
-            <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Risk Flags</th>
+            <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">
+              Status
+              <StatusInfoPopover />
+            </th>
             <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Owner</th>
+            <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Target</th>
+            <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Fix Version</th>
           </tr>
         </thead>
         <tbody>
@@ -96,21 +107,51 @@ function truncate(text, max) {
             <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300 max-w-[250px]">
               <span :title="f.summary">{{ truncate(f.summary, 60) }}</span>
             </td>
-            <td v-if="isPlanningMode" class="px-2 py-1.5">
-              <span
-                v-if="f.planningStatus"
-                class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                :class="PLANNING_STATUS_CLASSES[f.planningStatus] || ''"
-              >{{ PLANNING_STATUS_LABELS[f.planningStatus] || f.planningStatus }}</span>
-              <span v-if="f.planningChecks" class="ml-1 text-[10px] text-gray-500 dark:text-gray-400">
-                {{ f.planningChecks.passedCount }}/{{ f.planningChecks.totalCount }}
-              </span>
-            </td>
-            <td class="px-2 py-1.5 text-gray-600 dark:text-gray-400">
-              {{ f.flagCategories && f.flagCategories.length > 0 ? f.flagCategories.join(', ') : '--' }}
+            <td class="px-2 py-1.5">
+              <!-- Planning mode: existing badge -->
+              <template v-if="isPlanningMode">
+                <span
+                  v-if="f.planningStatus"
+                  class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                  :class="PLANNING_STATUS_CLASSES[f.planningStatus] || ''"
+                >{{ PLANNING_STATUS_LABELS[f.planningStatus] || f.planningStatus }}</span>
+                <span v-if="f.planningChecks" class="ml-1 text-[10px] text-gray-500 dark:text-gray-400">
+                  {{ f.planningChecks.passedCount }}/{{ f.planningChecks.totalCount }}
+                </span>
+              </template>
+              <!-- Execution mode: completion bar -->
+              <template v-else>
+                <div class="inline-flex items-center gap-1.5">
+                  <div class="w-12 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                    <div class="h-full rounded-full" :style="{ width: f.completionPct + '%' }" :class="completionBarColor(f.completionPct)" />
+                  </div>
+                  <span class="text-[10px] font-semibold">{{ f.completionPct }}%</span>
+                </div>
+              </template>
             </td>
             <td class="px-2 py-1.5 text-gray-600 dark:text-gray-400">
               {{ f.deliveryOwner || '-' }}
+            </td>
+            <td class="px-2 py-1.5">
+              <span v-if="f.targetRelease" class="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300">
+                {{ f.targetRelease }}
+              </span>
+              <span v-else class="text-gray-400 text-[10px]">--</span>
+            </td>
+            <td class="px-2 py-1.5">
+              <div v-if="f.fixVersions" class="flex flex-wrap gap-0.5">
+                <span
+                  v-for="fv in f.fixVersions.split(', ').filter(Boolean)"
+                  :key="fv"
+                  class="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300"
+                >{{ fv }}</span>
+              </div>
+              <span v-else class="inline-flex items-center gap-0.5 text-amber-500 dark:text-amber-400 text-[10px]">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                --
+              </span>
             </td>
           </tr>
         </tbody>

--- a/modules/releases/client/plan/components/BigRockRow.vue
+++ b/modules/releases/client/plan/components/BigRockRow.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import VersionSummaryPopover from './VersionSummaryPopover.vue'
 
 const props = defineProps({
   rock: { type: Object, required: true },
@@ -154,6 +155,17 @@ function handleBadgeKeydown(event) {
       <span class="text-[10px] font-medium text-gray-500 dark:text-gray-400">Eng. Lead</span>
       <span class="text-xs text-gray-700 dark:text-gray-300 ml-1">{{ rock.architect || '-' }}</span>
     </div>
+  </td>
+  <td v-if="hasHealth" class="px-3 py-2 border border-gray-300 dark:border-gray-600">
+    <VersionSummaryPopover
+      v-if="health"
+      :versionedCount="health.versionedCount || 0"
+      :missingVersionCount="health.missingVersionCount || 0"
+      :committedCount="health.committedCount || 0"
+      :targetedCount="health.targetedCount || 0"
+      :distinctVersions="health.distinctVersions || []"
+    />
+    <span v-else class="text-gray-400 dark:text-gray-600 text-xs">-</span>
   </td>
   <td class="px-3 py-2 text-center border border-gray-300 dark:border-gray-600">
     <span class="font-semibold text-gray-700 dark:text-gray-300">{{ rock.featureCount }}</span>

--- a/modules/releases/client/plan/components/BigRocksTable.vue
+++ b/modules/releases/client/plan/components/BigRocksTable.vue
@@ -155,6 +155,7 @@ function handleDeleteClick(event, rock) {
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Outcome(s)</th>
             <th v-if="hasHealth" scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Health</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Owners</th>
+            <th v-if="hasHealth" scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Versions</th>
             <th scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Features / RFEs</th>
             <th v-if="canEdit" scope="col" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"><span class="sr-only">Actions</span></th>
           </tr>
@@ -206,7 +207,7 @@ function handleDeleteClick(event, rock) {
             <tr v-if="isExpanded(rock.name)" :key="rock.name + '-edit-expanded'" @dragover.prevent>
               <BigRockExpandedRow
                 :features="rockFeatures[rock.name] || []"
-                :colspan="hasHealth ? 9 : 8"
+                :colspan="hasHealth ? 10 : 8"
                 :loading="healthLoading"
                 :rockName="rock.name"
                 :releasePhaseMode="releasePhaseMode"
@@ -218,7 +219,7 @@ function handleDeleteClick(event, rock) {
           <!-- Skeleton loading rows -->
           <template v-if="loading">
             <tr v-for="n in 3" :key="'skeleton-' + n">
-              <td :colspan="hasHealth ? 7 : 6" class="px-3 py-4 border border-gray-300 dark:border-gray-600">
+              <td :colspan="hasHealth ? 8 : 6" class="px-3 py-4 border border-gray-300 dark:border-gray-600">
                 <div class="animate-pulse flex items-center gap-4">
                   <div class="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
                   <div class="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
@@ -248,7 +249,7 @@ function handleDeleteClick(event, rock) {
               <tr v-if="isExpanded(rock.name)" :key="rock.name + '-expanded'">
                 <BigRockExpandedRow
                   :features="rockFeatures[rock.name] || []"
-                  :colspan="hasHealth ? 7 : 6"
+                  :colspan="hasHealth ? 8 : 6"
                   :loading="healthLoading"
                   :rockName="rock.name"
                   :releasePhaseMode="releasePhaseMode"
@@ -258,7 +259,7 @@ function handleDeleteClick(event, rock) {
           </template>
           <!-- Empty state -->
           <tr v-else>
-            <td :colspan="hasHealth ? 7 : 6" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
+            <td :colspan="hasHealth ? 8 : 6" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
               No Big Rocks configured.
             </td>
           </tr>

--- a/modules/releases/client/plan/components/PlanningGateStatus.vue
+++ b/modules/releases/client/plan/components/PlanningGateStatus.vue
@@ -83,7 +83,7 @@ function stratBadgeLabel(detail) {
 <template>
   <div class="space-y-3">
     <div class="flex items-center justify-between">
-      <span class="text-xs font-semibold text-gray-500 dark:text-gray-400">Planning Status</span>
+      <span class="text-xs font-semibold text-gray-500 dark:text-gray-400">Status</span>
       <span
         v-if="planningStatus"
         class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"

--- a/modules/releases/client/plan/components/StatusInfoPopover.vue
+++ b/modules/releases/client/plan/components/StatusInfoPopover.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { usePopover } from '../composables/usePopover'
+
+var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismiss, onKeyDown } = usePopover()
+</script>
+
+<template>
+  <span
+    class="relative inline-flex ml-1 align-middle"
+    :data-popover-trigger="popoverId"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    @click.stop="onClick"
+    @keydown="onKeyDown"
+    :aria-expanded="isVisible"
+    tabindex="0"
+    role="button"
+    aria-label="Status info"
+  >
+    <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+
+    <div
+      v-if="isVisible"
+      :data-popover-id="popoverId"
+      role="dialog"
+      aria-live="polite"
+      class="absolute z-50 left-0 top-full mt-1 w-72 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
+      <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+        <span class="font-semibold text-gray-900 dark:text-gray-100">Status Info</span>
+        <button
+          v-if="isPinned"
+          @click.stop="dismiss"
+          class="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+          aria-label="Close popover"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <div class="px-3 py-2 text-gray-700 dark:text-gray-300 space-y-2">
+        <p>Status reflects feature readiness against planning gates.</p>
+        <div>
+          <div class="font-semibold text-gray-900 dark:text-gray-100 mb-1">Statuses:</div>
+          <ul class="space-y-0.5 pl-2">
+            <li><span class="font-medium text-red-600 dark:text-red-400">Not Ready</span> -- DoR not passed</li>
+            <li><span class="font-medium text-yellow-600 dark:text-yellow-400">In Planning</span> -- DoR passed, DoD not passed</li>
+            <li><span class="font-medium text-green-600 dark:text-green-400">Ready</span> -- Both DoR and DoD passed</li>
+          </ul>
+        </div>
+        <p class="text-gray-500 dark:text-gray-400">Specific checks (e.g., RICE Score, Strategy Sign-off) vary by release configuration. Post-freeze, status shows completion % from child epics/stories.</p>
+      </div>
+    </div>
+  </span>
+</template>

--- a/modules/releases/client/plan/components/VersionSummaryPopover.vue
+++ b/modules/releases/client/plan/components/VersionSummaryPopover.vue
@@ -23,6 +23,7 @@ var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismi
     :aria-expanded="isVisible"
     tabindex="0"
     role="button"
+    aria-label="Version summary"
   >
     <span class="text-xs cursor-pointer" :class="missingVersionCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-700 dark:text-gray-300'">
       {{ versionedCount }} versioned<span v-if="missingVersionCount > 0">, {{ missingVersionCount }} missing</span>

--- a/modules/releases/client/plan/components/VersionSummaryPopover.vue
+++ b/modules/releases/client/plan/components/VersionSummaryPopover.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { usePopover } from '../composables/usePopover'
+
+defineProps({
+  versionedCount: { type: Number, default: 0 },
+  missingVersionCount: { type: Number, default: 0 },
+  committedCount: { type: Number, default: 0 },
+  targetedCount: { type: Number, default: 0 },
+  distinctVersions: { type: Array, default: () => [] }
+})
+
+var { isVisible, isPinned, popoverId, onMouseEnter, onMouseLeave, onClick, dismiss, onKeyDown } = usePopover()
+</script>
+
+<template>
+  <span
+    class="relative inline-flex"
+    :data-popover-trigger="popoverId"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    @click.stop="onClick"
+    @keydown="onKeyDown"
+    :aria-expanded="isVisible"
+    tabindex="0"
+    role="button"
+  >
+    <span class="text-xs cursor-pointer" :class="missingVersionCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-700 dark:text-gray-300'">
+      {{ versionedCount }} versioned<span v-if="missingVersionCount > 0">, {{ missingVersionCount }} missing</span>
+    </span>
+
+    <div
+      v-if="isVisible"
+      :data-popover-id="popoverId"
+      role="dialog"
+      aria-live="polite"
+      class="absolute z-50 left-0 top-full mt-1 w-72 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 text-xs"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
+      <!-- Header -->
+      <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+        <span class="font-semibold text-gray-900 dark:text-gray-100">Version Summary</span>
+        <button
+          v-if="isPinned"
+          @click.stop="dismiss"
+          class="p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+          aria-label="Close popover"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="px-3 py-2 space-y-2">
+        <!-- Distinct version badges -->
+        <div v-if="distinctVersions.length > 0">
+          <div class="text-gray-500 dark:text-gray-400 mb-1">Fix Versions:</div>
+          <div class="flex flex-wrap gap-1">
+            <span
+              v-for="v in distinctVersions"
+              :key="v"
+              class="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300"
+            >{{ v }}</span>
+          </div>
+        </div>
+
+        <!-- Warning count -->
+        <div v-if="missingVersionCount > 0" class="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+          <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {{ missingVersionCount }} feature{{ missingVersionCount !== 1 ? 's' : '' }} missing version assignment
+        </div>
+
+        <!-- Breakdown -->
+        <div class="text-gray-600 dark:text-gray-400 border-t border-gray-100 dark:border-gray-700 pt-2">
+          {{ committedCount }} committed, {{ targetedCount }} targeted<span v-if="missingVersionCount > 0">, {{ missingVersionCount }} unversioned</span>
+        </div>
+      </div>
+    </div>
+  </span>
+</template>

--- a/modules/releases/client/plan/composables/useHealthAggregation.js
+++ b/modules/releases/client/plan/composables/useHealthAggregation.js
@@ -105,7 +105,7 @@ export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
       for (var ri = 0; ri < rockNames.length; ri++) {
         var rockName = rockNames[ri]
         if (!result[rockName]) {
-          result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0, dorPassedCount: 0, dodPassedCount: 0, planningReady: 0, planningTotal: 0, planningBlockers: 0 }
+          result[rockName] = { worstLevel: 'green', totalFlags: 0, featureCount: 0, dorPassedCount: 0, dodPassedCount: 0, planningReady: 0, planningTotal: 0, planningBlockers: 0, versionedCount: 0, missingVersionCount: 0, committedCount: 0, targetedCount: 0, distinctVersions: new Set() }
         }
         result[rockName].featureCount++
         result[rockName].totalFlags += (h.risk.score || 0)
@@ -124,7 +124,27 @@ export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
             result[rockName].planningBlockers++
           }
         }
+        // Version aggregation
+        var vs = h.versionStatus || 'none'
+        if (vs === 'committed' || vs === 'targeted') {
+          result[rockName].versionedCount++
+          if (vs === 'committed') result[rockName].committedCount++
+          else result[rockName].targetedCount++
+        } else {
+          result[rockName].missingVersionCount++
+        }
+        if (h.fixVersions) {
+          var fvParts = typeof h.fixVersions === 'string' ? h.fixVersions.split(', ') : []
+          for (var fvi = 0; fvi < fvParts.length; fvi++) {
+            if (fvParts[fvi]) result[rockName].distinctVersions.add(fvParts[fvi])
+          }
+        }
       }
+    }
+    // Convert Sets to arrays before returning
+    var resultKeys = Object.keys(result)
+    for (var rni = 0; rni < resultKeys.length; rni++) {
+      result[resultKeys[rni]].distinctVersions = Array.from(result[resultKeys[rni]].distinctVersions)
     }
     return result
   })
@@ -159,7 +179,12 @@ export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
           deliveryOwner: h ? (h.deliveryOwner || '') : '',
           jiraUrl: h ? (h.jiraUrl || '') : '',
           override: h && h.risk ? (h.risk.override || null) : null,
-          status: h ? (h.status || '') : ''
+          status: h ? (h.status || '') : '',
+          fixVersions: h ? (h.fixVersions || '') : '',
+          targetRelease: h ? (h.targetRelease || '') : '',
+          versionStatus: h ? (h.versionStatus || 'none') : 'none',
+          completionPct: h ? (h.completionPct || 0) : 0,
+          planningChecks: h && h.planningChecks ? h.planningChecks : null
         })
       }
     }

--- a/modules/releases/client/plan/utils/health-export.js
+++ b/modules/releases/client/plan/utils/health-export.js
@@ -198,7 +198,7 @@ export function exportHealthCsv({ version, phase, features }) {
 
   // Header row
   rows.push([
-    'Feature', 'Summary', 'Status', 'Risk', 'Planning Status', 'Priority Score',
+    'Feature', 'Summary', 'Status', 'Risk', 'Gate Status', 'Priority Score',
     'RICE Score', 'Big Rock', 'Component', 'PM', 'Delivery Owner',
     'Fix Version', 'Target Release', 'Completion %', 'Blockers', 'Risk Flags'
   ])

--- a/modules/releases/server/planning/health/health-pipeline.js
+++ b/modules/releases/server/planning/health/health-pipeline.js
@@ -642,6 +642,9 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
       if (execFeature && execFeature.epicCount) {
         features[fi].epicCount = execFeature.epicCount
       }
+      if (execFeature && typeof execFeature.completionPct === 'number') {
+        features[fi].completionPct = execFeature.completionPct
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **Rename "Planning Status" to "Status"** with info icon popover explaining the DoR/DoD gate system
- **Add Target Version and Fix Version columns** to expanded feature rows (badges/chips, warning indicator for missing versions)
- **Add version summary popover** to Big Rock summary rows (compact inline text + click-to-expand breakdown)
- **Remove Risk Flags column** from Outcomes Dashboard (risk engine kept running for Health Dashboard)
- **Add post-freeze completion % bars** — Status column switches from DoR/DoD badges to completion percentage after GA Code Freeze
- **Fix `planningChecks` pass-through bug** — gate pass count ("3/5") was silently broken in expanded rows
- **Fix `completionPct` enrichment** — 1-line server fix to populate from execution index

Also includes the multi-rock health display fix from the branch's first commit.

## Test plan

- [x] All 1,880 releases module tests pass
- [x] Lint clean on all modified files
- [x] Demo mode verified with updated fixtures
- [ ] Verify column order (Owners before Versions) in demo mode
- [ ] Verify expanded row shows Target/Fix Version badges
- [ ] Verify info icon popover on Status header
- [ ] Verify Risk Flags column is removed from expanded rows
- [ ] Test dark mode for new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)