### PR TITLE
feat(releases): add deep linking for Plan and Deliver sub-tabs

### DIFF
--- a/modules/releases/client/plan/views/PmHubView.vue
+++ b/modules/releases/client/plan/views/PmHubView.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script setup>
-import { ref, defineAsyncComponent } from 'vue'
+import { ref, inject, watch, defineAsyncComponent } from 'vue'
 
 const reports = [
   {
@@ -47,5 +47,29 @@ const reports = [
   }
 ]
 
-const selectedReport = ref(null)
+var moduleNav = inject('moduleNav', null)
+
+function getReportFromParams() {
+  var params = moduleNav && moduleNav.params ? moduleNav.params.value : {}
+  var reportId = params.report
+  if (reportId) return reports.find(function(r) { return r.id === reportId }) || null
+  return null
+}
+
+const selectedReport = ref(getReportFromParams())
+
+watch(selectedReport, function(report) {
+  if (moduleNav && moduleNav.updateParams) {
+    moduleNav.updateParams({ report: report ? report.id : null }, { push: false })
+  }
+})
+
+if (moduleNav && moduleNav.params) {
+  watch(moduleNav.params, function() {
+    var report = getReportFromParams()
+    var currentId = selectedReport.value ? selectedReport.value.id : null
+    var newId = report ? report.id : null
+    if (currentId !== newId) selectedReport.value = report
+  })
+}
 </script>

--- a/modules/releases/client/views/DeliverView.vue
+++ b/modules/releases/client/views/DeliverView.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup>
-import { ref, computed, provide, defineAsyncComponent } from 'vue'
+import { ref, computed, provide, inject, watch, defineAsyncComponent } from 'vue'
 import { useReleaseAnalysis } from '../deliver/composables/useReleaseAnalysis.js'
 import { useReleaseFilter } from '../deliver/composables/useReleaseFilter.js'
 import ReleaseChipBar from '../deliver/components/ReleaseChipBar.vue'
@@ -56,7 +56,30 @@ const tabs = [
   { id: 'post-release-defects', label: 'Post-Release Defects' },
 ]
 
-const activeTab = ref('risk-dashboard')
+var moduleNav = inject('moduleNav', null)
+var validTabIds = tabs.map(function(t) { return t.id })
+
+function getTabFromParams() {
+  var params = moduleNav && moduleNav.params ? moduleNav.params.value : {}
+  var tab = params.tab
+  if (tab && validTabIds.indexOf(tab) !== -1) return tab
+  return 'risk-dashboard'
+}
+
+const activeTab = ref(getTabFromParams())
+
+watch(activeTab, function(tab) {
+  if (moduleNav && moduleNav.updateParams) {
+    moduleNav.updateParams({ tab: tab }, { push: false })
+  }
+})
+
+if (moduleNav && moduleNav.params) {
+  watch(moduleNav.params, function() {
+    var tab = getTabFromParams()
+    if (tab !== activeTab.value) activeTab.value = tab
+  })
+}
 
 const componentMap = {
   'risk-dashboard': RiskDashboard,

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -47,6 +47,12 @@ function getTabFromParams() {
 
 const activeTab = ref(getTabFromParams())
 
+watch(activeTab, function(tab) {
+  if (moduleNav && moduleNav.updateParams) {
+    moduleNav.updateParams({ tab: tab }, { push: false })
+  }
+})
+
 if (moduleNav && moduleNav.params) {
   watch(moduleNav.params, function() {
     var tab = getTabFromParams()


### PR DESCRIPTION
## Summary

- **Plan view**: Switching between Outcomes, Features List, and PM Hub updates the URL with `?tab=<id>`. Loading a URL with that param opens the correct tab.
- **PM Hub view**: Opening a report (e.g. Component Release Load) adds `&report=<id>` to the URL. Clicking "Back to PM Hub" clears it. A URL like `#/releases/plan?tab=pm-hub&report=component-release-load` deep links directly into the report.
- **Deliver view**: Switching between Risk Dashboard, Conforma Insights, and Post-Release Defects updates the URL with `?tab=<id>`.
- All use `replaceState` so tab switches don't pollute browser history.

## Test plan

- [ ] Click each Plan sub-tab — verify URL updates with `?tab=outcomes`, `?tab=feature-readiness`, `?tab=pm-hub`
- [ ] Copy URL with tab param, paste in new browser tab — verify correct tab opens
- [ ] In PM Hub, open a report — verify `&report=component-release-load` appears in URL
- [ ] Click "Back to PM Hub" — verify `report` param is removed from URL
- [ ] Click each Deliver sub-tab — verify URL updates accordingly
- [ ] Verify browser back/forward buttons don't break (replaceState, not pushState)

Made with [Cursor](https://cursor.com)