### PR TITLE
fix(ci): use Quay-hosted Playwright image to avoid MCR outages

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -173,9 +173,9 @@ Smoke tests verify:
 - Client-side routing functions (hash-based navigation)
 - Basic accessibility (semantic landmarks present)
 
-Playwright runs in a container (`mcr.microsoft.com/playwright:v1.60.0`), so no local browser installation needed. Works on any OS (RHEL/Podman, macOS/Docker, Ubuntu). The Makefile auto-detects the container runtime (prefers Podman on RHEL).
+Playwright runs in a container (`quay.io/browser/playwright-chromium`), so no local browser installation needed. Works on any OS (RHEL/Podman, macOS/Docker, Ubuntu). The Makefile auto-detects the container runtime (prefers Podman on RHEL).
 
-**IMPORTANT:** The Playwright version must match between `package.json` (`@playwright/test`) and `Makefile` (`PLAYWRIGHT_IMAGE`). When updating Playwright, change both files to the same version to prevent browser binary mismatches.
+**IMPORTANT:** The Playwright version must match between `package.json` (`@playwright/test`) and `Makefile` (`PLAYWRIGHT_IMAGE`). When updating Playwright, change both files to the same version to prevent browser binary mismatches. The Quay image uses `playwright-<version>` tags (e.g., `playwright-1.60.0`).
 
 CI workflow (`build-images.yml`):
 1. Builds core images (backend, frontend, frontend-builder, frontend-runtime) with smoke test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CORE_FRONTEND_RUNTIME_IMAGE ?= core-frontend-runtime-smoke-local
 CORE_TAG ?= local
 FRONTEND_CONTAINER := frontend-smoke-local
 BACKEND_CONTAINER := backend-smoke-local
-PLAYWRIGHT_IMAGE := mcr.microsoft.com/playwright:v1.60.0
+PLAYWRIGHT_IMAGE := quay.io/browser/playwright-chromium:playwright-1.60.0
 BACKEND_PORT := 3001
 FRONTEND_PORT := 8080
 WORKSPACE := /workspace
@@ -23,13 +23,15 @@ OS := $(shell uname -s)
 # instead of downloading them at runtime (saves time, ensures consistency)
 COMMON_ENV := \
 	-e HOME=/tmp \
-	-e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+	-e PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright \
 	-e XDG_CACHE_HOME=/tmp/.cache \
 	-e npm_config_cache=/tmp/.npm \
 	-e BASE_URL=http://localhost:$(FRONTEND_PORT)
 
 CONTAINER_FLAGS := --rm -t \
 	--network host \
+	--entrypoint "" \
+	--user 0:0 \
 	-v $(CURDIR):$(WORKSPACE):z \
 	-w $(WORKSPACE)
 


### PR DESCRIPTION
## Summary

- Switch Playwright container image from `mcr.microsoft.com/playwright:v1.60.0` to `quay.io/browser/playwright-chromium:playwright-1.60.0`
- Update `PLAYWRIGHT_BROWSERS_PATH` from `/ms-playwright` to `/root/.cache/ms-playwright` (different install location in the Quay image)
- PR #957 was [removed from the merge queue](https://github.com/red-hat-data-services/rhai-org-pulse/pull/957#event-26577340674) because MCR blocked the image pull with "pull access denied", failing the integration tests. This is a transient MCR rate-limiting/geo-blocking issue that can recur at any time.

## Why this image

The `quay.io/browser` org maintains version-matched Playwright browser images on Quay.io. The `playwright-chromium` variant includes Node.js 20, npm, npx, bash, and pre-installed Chromium — everything our `SETUP_CMD` (`npm ci && npx playwright test`) needs. Verified locally:

- Image pulls successfully
- Chromium launches (v148.0.7778.96)
- `playwright` and `playwright-chromium` packages pre-installed at v1.60.0
- `@playwright/test` is installed by `npm ci` from the mounted workspace (same as before)

## Test plan

- [ ] CI smoke tests pass (uses same `PLAYWRIGHT_IMAGE` + `COMMON_ENV`)
- [ ] CI integration tests pass (the actual failure point from #957)
- [ ] Verify the PR can enter and exit the merge queue successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)