### PR TITLE
feat(releases): add average-per-release summary card to PM Hub

### DIFF
--- a/modules/releases/__tests__/client/plan/summary-stats.test.js
+++ b/modules/releases/__tests__/client/plan/summary-stats.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+
+import { avgPerRelease } from '../../../client/plan/utils/summary-stats'
+
+describe('avgPerRelease', function () {
+  it('returns dash when releaseCount is zero', function () {
+    expect(avgPerRelease(10, 0)).toBe('—')
+  })
+
+  it('returns dash when releaseCount is negative', function () {
+    expect(avgPerRelease(5, -1)).toBe('—')
+  })
+
+  it('returns dash when releaseCount is null', function () {
+    expect(avgPerRelease(5, null)).toBe('—')
+  })
+
+  it('returns dash when releaseCount is undefined', function () {
+    expect(avgPerRelease(5, undefined)).toBe('—')
+  })
+
+  it('returns whole number without decimal when evenly divisible', function () {
+    expect(avgPerRelease(10, 2)).toBe('5')
+  })
+
+  it('rounds to one decimal place', function () {
+    expect(avgPerRelease(10, 3)).toBe('3.3')
+  })
+
+  it('handles single release (identity)', function () {
+    expect(avgPerRelease(7, 1)).toBe('7')
+  })
+
+  it('returns zero string when totalRequested is zero', function () {
+    expect(avgPerRelease(0, 3)).toBe('0')
+  })
+
+  it('handles large numbers', function () {
+    expect(avgPerRelease(1000, 7)).toBe('142.9')
+  })
+})

--- a/modules/releases/client/plan/utils/summary-stats.js
+++ b/modules/releases/client/plan/utils/summary-stats.js
@@ -1,0 +1,14 @@
+/**
+ * Compute the average requested features per release.
+ *
+ * @param {number} totalRequested - Total requested feature count across all releases.
+ * @param {number} releaseCount   - Number of selected portfolio releases.
+ * @returns {string} Formatted average rounded to one decimal place, or '—' when no releases are selected.
+ */
+function avgPerRelease(totalRequested, releaseCount) {
+  if (!releaseCount || releaseCount <= 0) return '—'
+  var avg = totalRequested / releaseCount
+  return avg % 1 === 0 ? String(avg) : avg.toFixed(1)
+}
+
+export { avgPerRelease }

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -248,7 +248,7 @@
     </div>
 
     <!-- Summary cards -->
-    <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+    <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-5 gap-3">
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
@@ -278,6 +278,16 @@
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
         </div>
         <div class="text-2xl font-bold ml-7" :class="totalBlocked > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ totalBlocked }}</div>
+      </div>
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full bg-amber-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
+            <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Avg / Release</span>
+        </div>
+        <div class="text-2xl font-bold text-amber-600 dark:text-amber-400 ml-7">{{ formattedAvgPerRelease }}</div>
       </div>
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />
@@ -338,6 +348,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
 import ComponentReleaseLoadTable from '../components/ComponentReleaseLoadTable.vue'
 import PillarConfigPanel from '../components/PillarConfigPanel.vue'
+import { avgPerRelease } from '../utils/summary-stats.js'
 
 const API_BASE = '/modules/releases/pm-hub'
 
@@ -735,6 +746,10 @@ var totalBlocked = computed(function() {
   var count = 0
   for (var i = 0; i < groups.value.length; i++) count += groups.value[i].blockedCount || 0
   return count
+})
+
+var formattedAvgPerRelease = computed(function() {
+  return avgPerRelease(totalRequested.value, selectedVersions.value.length)
 })
 
 function togglePillar(name) {


### PR DESCRIPTION
## Summary
- Adds an amber "Avg / Release" summary card between Blocked and Releases in the Component Release Load Tracking module (PM Hub tab)
- Calculation: `totalRequested / selectedPortfolioReleases`, rounded to 1 decimal
- Grid updated from 4 to 5 columns
- Includes 9 focused unit tests for the `avgPerRelease` utility function

## Test plan
- [x] `npx vitest run` — all 792 tests pass (39 files)
- [ ] Visual check: navigate to Releases → Plan → PM Hub, select components + releases, verify 5 summary cards render correctly
- [ ] Verify average displays `—` when no releases selected
- [ ] Verify rounding: e.g. 10 requested / 3 releases = 3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)