### PR TITLE
feat(releases): direct Jira query as primary feature source for Feature Readiness

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const { fetchFeatures, normalizeIssue, JQL, QUERY_FIELDS } = require('../feature-query')
+const { CUSTOM_FIELDS } = require('../../hygiene/jira-fetch')
+
+describe('feature-query', function() {
+
+  describe('JQL', function() {
+    it('queries RHAISTRAT Features and Initiatives excluding closed statuses', function() {
+      expect(JQL).toContain('project = RHAISTRAT')
+      expect(JQL).toContain('issuetype IN (Feature, Initiative)')
+      expect(JQL).toContain('status NOT IN (Closed, Done, Resolved, Cancelled)')
+    })
+
+    it('does not include a created date filter', function() {
+      expect(JQL).not.toContain('created')
+    })
+  })
+
+  describe('QUERY_FIELDS', function() {
+    it('includes standard Jira fields', function() {
+      expect(QUERY_FIELDS).toContain('summary')
+      expect(QUERY_FIELDS).toContain('status')
+      expect(QUERY_FIELDS).toContain('issuetype')
+      expect(QUERY_FIELDS).toContain('assignee')
+      expect(QUERY_FIELDS).toContain('fixVersions')
+      expect(QUERY_FIELDS).toContain('components')
+      expect(QUERY_FIELDS).toContain('labels')
+      expect(QUERY_FIELDS).toContain('priority')
+    })
+
+    it('includes custom field IDs for team, targetVersion, riceScore', function() {
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.team)
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.targetVersion)
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.riceScore)
+    })
+  })
+
+  describe('normalizeIssue', function() {
+    it('extracts key and summary', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-1', fields: { summary: 'My Feature' } })
+      expect(result.key).toBe('RHAISTRAT-1')
+      expect(result.summary).toBe('My Feature')
+    })
+
+    it('extracts assignee displayName from object', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-2',
+        fields: { assignee: { displayName: 'Jane Doe', emailAddress: 'jane@example.com' } }
+      })
+      expect(result.assignee).toBe('Jane Doe')
+    })
+
+    it('handles assignee as string', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-3', fields: { assignee: 'John' } })
+      expect(result.assignee).toBe('John')
+    })
+
+    it('handles null assignee', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-4', fields: { assignee: null } })
+      expect(result.assignee).toBeNull()
+    })
+
+    it('extracts component names from objects', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-5',
+        fields: { components: [{ name: 'UI' }, { name: 'API' }] }
+      })
+      expect(result.components).toEqual(['UI', 'API'])
+    })
+
+    it('handles missing components', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-6', fields: {} })
+      expect(result.components).toEqual([])
+    })
+
+    it('extracts fixVersion names from objects', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-7',
+        fields: { fixVersions: [{ name: 'rhoai-3.6' }] }
+      })
+      expect(result.fixVersions).toEqual(['rhoai-3.6'])
+    })
+
+    it('extracts status name from object', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-8',
+        fields: { status: { name: 'In Progress' } }
+      })
+      expect(result.status).toBe('In Progress')
+    })
+
+    it('handles status as string', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-9', fields: { status: 'New' } })
+      expect(result.status).toBe('New')
+    })
+
+    it('extracts priority name from object', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-10',
+        fields: { priority: { name: 'Major' } }
+      })
+      expect(result.priority).toBe('Major')
+    })
+
+    it('extracts issueType name from object', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-11',
+        fields: { issuetype: { name: 'Feature' } }
+      })
+      expect(result.issueType).toBe('Feature')
+    })
+
+    it('preserves labels array', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-12',
+        fields: { labels: ['strat-creator-human-sign-off', 'priority-1'] }
+      })
+      expect(result.labels).toEqual(['strat-creator-human-sign-off', 'priority-1'])
+    })
+
+    it('extracts team from custom field', function() {
+      var fields = {}
+      fields[CUSTOM_FIELDS.team] = { value: 'Platform' }
+      var result = normalizeIssue({ key: 'RHAISTRAT-13', fields: fields })
+      expect(result.team).toBe('Platform')
+    })
+
+    it('extracts targetVersion from custom field', function() {
+      var fields = {}
+      fields[CUSTOM_FIELDS.targetVersion] = { name: 'rhoai-3.6' }
+      var result = normalizeIssue({ key: 'RHAISTRAT-14', fields: fields })
+      expect(result.targetVersions).toEqual(['rhoai-3.6'])
+    })
+
+    it('returns empty targetVersions when custom field is null', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-15', fields: {} })
+      expect(result.targetVersions).toEqual([])
+    })
+
+    it('extracts riceScore from custom field', function() {
+      var fields = {}
+      fields[CUSTOM_FIELDS.riceScore] = 42
+      var result = normalizeIssue({ key: 'RHAISTRAT-16', fields: fields })
+      expect(result.riceScore).toBe(42)
+    })
+
+    it('handles completely empty fields', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-17', fields: {} })
+      expect(result.key).toBe('RHAISTRAT-17')
+      expect(result.summary).toBe('')
+      expect(result.status).toBeNull()
+      expect(result.assignee).toBeNull()
+      expect(result.components).toEqual([])
+      expect(result.fixVersions).toEqual([])
+      expect(result.labels).toEqual([])
+      expect(result.targetVersions).toEqual([])
+      expect(result.priority).toBeNull()
+      expect(result.riceScore).toBeNull()
+    })
+
+    it('handles missing fields object', function() {
+      var result = normalizeIssue({ key: 'RHAISTRAT-18' })
+      expect(result.key).toBe('RHAISTRAT-18')
+      expect(result.summary).toBe('')
+    })
+  })
+
+  describe('fetchFeatures', function() {
+    it('returns empty Map when jiraClient is null', async function() {
+      var result = await fetchFeatures(null)
+      expect(result).toBeInstanceOf(Map)
+      expect(result.size).toBe(0)
+    })
+
+    it('returns empty Map when jiraClient has no fetchAllJqlResults', async function() {
+      var result = await fetchFeatures({})
+      expect(result).toBeInstanceOf(Map)
+      expect(result.size).toBe(0)
+    })
+
+    it('calls fetchAllJqlResults with correct JQL and fields', async function() {
+      var mockFetch = vi.fn().mockResolvedValue([])
+      var client = { fetchAllJqlResults: mockFetch }
+
+      await fetchFeatures(client)
+
+      expect(mockFetch).toHaveBeenCalledWith(JQL, QUERY_FIELDS, { maxResults: 100 })
+    })
+
+    it('returns Map keyed by issue key', async function() {
+      var issues = [
+        { key: 'RHAISTRAT-100', fields: { summary: 'Feature A', status: { name: 'In Progress' } } },
+        { key: 'RHAISTRAT-200', fields: { summary: 'Feature B', status: { name: 'New' } } }
+      ]
+      var client = { fetchAllJqlResults: vi.fn().mockResolvedValue(issues) }
+
+      var result = await fetchFeatures(client)
+
+      expect(result.size).toBe(2)
+      expect(result.get('RHAISTRAT-100').summary).toBe('Feature A')
+      expect(result.get('RHAISTRAT-200').summary).toBe('Feature B')
+    })
+
+    it('skips issues without a key', async function() {
+      var issues = [
+        { key: 'RHAISTRAT-100', fields: { summary: 'Valid' } },
+        { key: null, fields: { summary: 'No key' } },
+        { fields: { summary: 'Also no key' } }
+      ]
+      var client = { fetchAllJqlResults: vi.fn().mockResolvedValue(issues) }
+
+      var result = await fetchFeatures(client)
+
+      expect(result.size).toBe(1)
+      expect(result.has('RHAISTRAT-100')).toBe(true)
+    })
+
+    it('normalizes all fields in returned features', async function() {
+      var fields = {
+        summary: 'Test Feature',
+        status: { name: 'In Progress' },
+        issuetype: { name: 'Feature' },
+        assignee: { displayName: 'Alice' },
+        components: [{ name: 'Dashboard' }],
+        fixVersions: [{ name: 'rhoai-3.6' }],
+        labels: ['strat-creator-human-sign-off'],
+        priority: { name: 'Major' }
+      }
+      fields[CUSTOM_FIELDS.team] = { value: 'Platform' }
+      fields[CUSTOM_FIELDS.targetVersion] = { name: 'rhoai-3.6' }
+      fields[CUSTOM_FIELDS.riceScore] = 150
+
+      var client = { fetchAllJqlResults: vi.fn().mockResolvedValue([{ key: 'RHAISTRAT-300', fields: fields }]) }
+
+      var result = await fetchFeatures(client)
+      var feature = result.get('RHAISTRAT-300')
+
+      expect(feature.summary).toBe('Test Feature')
+      expect(feature.status).toBe('In Progress')
+      expect(feature.issueType).toBe('Feature')
+      expect(feature.assignee).toBe('Alice')
+      expect(feature.components).toEqual(['Dashboard'])
+      expect(feature.fixVersions).toEqual(['rhoai-3.6'])
+      expect(feature.labels).toEqual(['strat-creator-human-sign-off'])
+      expect(feature.priority).toBe('Major')
+      expect(feature.team).toBe('Platform')
+      expect(feature.targetVersions).toEqual(['rhoai-3.6'])
+      expect(feature.riceScore).toBe(150)
+    })
+  })
+})

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1858,3 +1858,360 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     expect(result.meta.total).toBe(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Pass 3: Jira features as primary source
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
+  function makeExecIndex(features) {
+    return { features: features, fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: features.length }
+  }
+
+  function makeExecFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Exec Feature ' + key,
+      status: 'In Progress',
+      priority: 'Major',
+      assignee: 'Jane Doe',
+      components: ['UI'],
+      labels: [],
+      targetVersions: ['rhoai-3.6'],
+      fixVersions: [],
+      team: 'Platform'
+    }, overrides)
+  }
+
+  function makeJiraMap(features) {
+    var map = new Map()
+    for (var i = 0; i < features.length; i++) {
+      map.set(features[i].key, features[i])
+    }
+    return map
+  }
+
+  function makeJiraFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Jira Feature ' + key,
+      status: 'In Progress',
+      issueType: 'Feature',
+      assignee: 'Alice',
+      team: 'Platform',
+      components: ['Dashboard'],
+      labels: [],
+      fixVersions: [],
+      targetVersions: ['rhoai-3.6'],
+      priority: 'Major',
+      riceScore: null
+    }, overrides)
+  }
+
+  it('uses jiraFeatures as pass 3 source when provided', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-900')
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-900')
+    expect(result.pendingReview[0].dataSource).toBe('jira')
+    expect(result.pendingReview[0].title).toBe('Jira Feature RHAISTRAT-900')
+  })
+
+  it('falls back to execution index when jiraFeatures is null', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-800')
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, null)
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-800')
+    expect(result.pendingReview[0].dataSource).toBe('execution')
+  })
+
+  it('falls back to execution index when jiraFeatures is empty Map', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-700')
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, new Map())
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-700')
+    expect(result.pendingReview[0].dataSource).toBe('execution')
+  })
+
+  it('does not duplicate features already in strat-creator pass', function() {
+    var store = makeFeaturesStore({
+      'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
+    })
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-1')
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': store,
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('does not duplicate features already in health-pipeline pass', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-50')
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/planning/health-cache-3.6-all.json': {
+        features: [{ key: 'RHAISTRAT-50', summary: 'Health Feature', status: 'In Progress', priority: 'Major' }]
+      },
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
+    expect(new Set(keys).size).toBe(keys.length)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-50' })
+    expect(feature.dataSource).toBe('health-pipeline')
+  })
+
+  it('enriches Jira features with execution index data when available', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-600', { riceScore: null })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-600', { riceScore: 250, blockerCount: 3 })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.meta.total).toBe(1)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-600' })
+    expect(feature.dataSource).toBe('jira')
+    expect(feature.riceScore).toBe(250)
+    expect(feature.readinessGates.notBlocked).toBe(false)
+  })
+
+  it('Jira feature with sign-off and all gates passing is ready', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-500', {
+        labels: ['strat-creator-human-sign-off'],
+        assignee: 'Alice',
+        status: 'In Progress',
+        targetVersions: ['rhoai-3.6']
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.ready.length).toBe(1)
+    expect(result.ready[0].confidence).toBe('ready')
+    expect(result.ready[0].humanReviewStatus).toBe('approved')
+  })
+
+  it('Jira feature with fix version gets committed confidence', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-400', {
+        labels: ['strat-creator-human-sign-off'],
+        fixVersions: ['rhoai-3.6'],
+        assignee: 'Alice',
+        status: 'In Progress',
+        targetVersions: ['rhoai-3.6']
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.ready[0].confidence).toBe('committed')
+    expect(result.ready[0].fixVersion).toBe('rhoai-3.6')
+  })
+
+  it('skips closed Jira features', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-C1', { status: 'Closed' }),
+      makeJiraFeature('RHAISTRAT-C2', { status: 'Resolved' }),
+      makeJiraFeature('RHAISTRAT-C3', { status: 'In Progress' })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-C3')
+  })
+
+  it('Jira feature in Refinement status is not ready', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-REF', {
+        labels: ['strat-creator-human-sign-off'],
+        status: 'Refinement'
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.pendingReview.length).toBe(1)
+    expect(result.pendingReview[0].readinessGates.pastRefinement).toBe(false)
+  })
+
+  it('populates filter metadata from Jira features', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-META', {
+        components: ['NewJiraComp'],
+        team: 'JiraTeam',
+        priority: 'Critical',
+        targetVersions: ['rhoai-4.0']
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.filterMeta.components).toContain('NewJiraComp')
+    expect(result.filterMeta.teams).toContain('JiraTeam')
+    expect(result.filterMeta.priorities).toContain('Critical')
+    expect(result.filterMeta.targetVersions).toContain('rhoai-4.0')
+  })
+
+  it('prefers Jira riceScore over execution index riceScore', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-RICE', { riceScore: 100 })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-RICE', { riceScore: 50 })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-RICE' })
+    expect(feature.riceScore).toBe(100)
+  })
+
+  it('uses execution index riceScore when Jira riceScore is null', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-RICE2', { riceScore: null })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-RICE2', { riceScore: 75 })
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-RICE2' })
+    expect(feature.riceScore).toBe(75)
+  })
+
+  it('includes Jira features not present in execution index', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-JONLY', { summary: 'Jira only feature' })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.meta.total).toBe(1)
+    expect(result.pendingReview[0].title).toBe('Jira only feature')
+  })
+
+  it('handles multiple Jira features sorted by priority score', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-J1', { priority: 'Minor' }),
+      makeJiraFeature('RHAISTRAT-J2', { priority: 'Blocker' }),
+      makeJiraFeature('RHAISTRAT-J3', { priority: 'Major' })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.pendingReview.length).toBe(3)
+    expect(result.pendingReview[0].key).toBe('RHAISTRAT-J2')
+    expect(result.pendingReview[result.pendingReview.length - 1].key).toBe('RHAISTRAT-J1')
+  })
+
+  it('Jira feature without assignee fails ownerAssigned gate', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-NOOWN', {
+        assignee: null,
+        labels: ['strat-creator-human-sign-off']
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.pendingReview.length).toBe(1)
+    expect(result.pendingReview[0].readinessGates.ownerAssigned).toBe(false)
+  })
+
+  it('Jira feature without target version fails hasTargetVersion gate', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-NOTV', {
+        targetVersions: [],
+        labels: ['strat-creator-human-sign-off']
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    expect(result.pendingReview.length).toBe(1)
+    expect(result.pendingReview[0].readinessGates.hasTargetVersion).toBe(false)
+  })
+})

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -1,0 +1,65 @@
+var { CUSTOM_FIELDS, serializeField } = require('../hygiene/jira-fetch')
+
+var QUERY_FIELDS = [
+  'summary', 'status', 'issuetype', 'assignee', 'fixVersions',
+  'components', 'labels', 'priority', 'created', 'updated',
+  CUSTOM_FIELDS.team,
+  CUSTOM_FIELDS.targetVersion,
+  CUSTOM_FIELDS.riceScore
+].join(',')
+
+var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status NOT IN (Closed, Done, Resolved, Cancelled)'
+
+function normalizeIssue(issue) {
+  var fields = issue.fields || {}
+  var assignee = fields.assignee
+    ? (typeof fields.assignee === 'object' ? fields.assignee.displayName || null : fields.assignee)
+    : null
+  var components = Array.isArray(fields.components)
+    ? fields.components.map(function(c) { return c.name || String(c) }).filter(Boolean)
+    : []
+  var fixVersions = Array.isArray(fields.fixVersions)
+    ? fields.fixVersions.map(function(v) { return v.name || String(v) }).filter(Boolean)
+    : []
+  var labels = Array.isArray(fields.labels) ? fields.labels : []
+  var targetVersionRaw = serializeField(fields[CUSTOM_FIELDS.targetVersion])
+  var targetVersions = targetVersionRaw ? [targetVersionRaw] : []
+  var status = fields.status
+    ? (typeof fields.status === 'object' ? fields.status.name || null : fields.status)
+    : null
+  var priority = fields.priority
+    ? (typeof fields.priority === 'object' ? fields.priority.name || null : fields.priority)
+    : null
+  var issueType = fields.issuetype
+    ? (typeof fields.issuetype === 'object' ? fields.issuetype.name || null : fields.issuetype)
+    : null
+
+  return {
+    key: issue.key,
+    summary: fields.summary || '',
+    status: status,
+    issueType: issueType,
+    assignee: assignee,
+    team: serializeField(fields[CUSTOM_FIELDS.team]),
+    components: components,
+    labels: labels,
+    fixVersions: fixVersions,
+    targetVersions: targetVersions,
+    priority: priority,
+    riceScore: fields[CUSTOM_FIELDS.riceScore] || null
+  }
+}
+
+async function fetchFeatures(jiraClient) {
+  if (!jiraClient || !jiraClient.fetchAllJqlResults) return new Map()
+
+  var issues = await jiraClient.fetchAllJqlResults(JQL, QUERY_FIELDS, { maxResults: 100 })
+  var map = new Map()
+  for (var i = 0; i < issues.length; i++) {
+    var normalized = normalizeIssue(issues[i])
+    if (normalized.key) map.set(normalized.key, normalized)
+  }
+  return map
+}
+
+module.exports = { fetchFeatures: fetchFeatures, normalizeIssue: normalizeIssue, JQL: JQL, QUERY_FIELDS: QUERY_FIELDS }

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -151,7 +151,7 @@ function deriveHumanReviewStatusFromLabels(labels) {
   return 'awaiting-review'
 }
 
-function buildFeatureReadiness(readFromStorage) {
+function buildFeatureReadiness(readFromStorage, jiraFeatures) {
   var raw = readFromStorage('ai-impact/features.json')
   if (!raw || !raw.features) {
     raw = { features: {} }
@@ -456,15 +456,27 @@ function buildFeatureReadiness(readFromStorage) {
     collectFilterMeta(hpFeature, allComponents, allPriorities, allBigRocks, allTargetVersions, allFixVersions, allTeams)
   }
 
-  // Third pass: features from execution index not processed in passes 1 or 2
+  // Third pass: Jira features as primary source, execution index as fallback
   var execIndex = loadIndex(readFromStorage)
+  var execMap = new Map()
   var execFeatures = execIndex.features || []
-  for (var ei = 0; ei < execFeatures.length; ei++) {
-    var ef = execFeatures[ei]
+  for (var emi = 0; emi < execFeatures.length; emi++) {
+    if (execFeatures[emi].key) execMap.set(execFeatures[emi].key, execFeatures[emi])
+  }
+
+  var pass3Source = jiraFeatures && jiraFeatures.size > 0
+    ? Array.from(jiraFeatures.values())
+    : execFeatures
+  var pass3DataSource = jiraFeatures && jiraFeatures.size > 0 ? 'jira' : 'execution'
+
+  for (var ei = 0; ei < pass3Source.length; ei++) {
+    var ef = pass3Source[ei]
     if (!ef.key || processedKeys.has(ef.key)) continue
     if (ef.status && CLOSED_STATUSES.indexOf(ef.status) !== -1) continue
 
     processedKeys.add(ef.key)
+
+    var execData = execMap.get(ef.key) || null
 
     var efLabels = Array.isArray(ef.labels) ? ef.labels : []
     var efHumanReviewStatus = deriveHumanReviewStatusFromLabels(efLabels)
@@ -486,10 +498,12 @@ function buildFeatureReadiness(readFromStorage) {
     var efBigRock = efCandidateData ? efCandidateData.bigRock || null : null
     var efRockPriority = efCandidateData ? efCandidateData.rockPriority || null : null
 
+    var efRiceScore = ef.riceScore != null ? ef.riceScore : (execData && execData.riceScore != null ? execData.riceScore : null)
+
     var efEffective = computeBestAvailableScore({
       tier: efTier,
       priority: ef.priority || null,
-      riceScore: ef.riceScore != null ? ef.riceScore : null,
+      riceScore: efRiceScore,
       rubricTotal: 0,
       rockPriority: efRockPriority,
       targetVersions: efTargetVersions
@@ -500,6 +514,7 @@ function buildFeatureReadiness(readFromStorage) {
     var efHasOwner = !!efAssignee
     var efPastRefinement = !!ef.status && EARLY_STATUSES.indexOf(ef.status) === -1
     var efHasTargetVersion = efTargetVersions.length > 0
+    var efBlockerCount = execData ? (execData.blockerCount || 0) : (ef.blockerCount || 0)
     var efIsReady = efIsApproved && !efBlockedByHygiene && efHasOwner && efPastRefinement && efHasTargetVersion
     var efConfidence = computeConfidence(efIsReady, efFixVersion)
 
@@ -513,7 +528,7 @@ function buildFeatureReadiness(readFromStorage) {
       recommendation: null,
       needsAttention: false,
       humanReviewStatus: efHumanReviewStatus,
-      riceScore: ef.riceScore != null ? ef.riceScore : null,
+      riceScore: efRiceScore,
       rubricTotal: 0,
       scores: {},
       reviewers: {},
@@ -536,11 +551,11 @@ function buildFeatureReadiness(readFromStorage) {
       actionRequired: efHumanReviewStatus !== 'approved'
         ? 'Open the Jira issue and add the strat-creator-human-sign-off label when ready'
         : null,
-      dataSource: 'execution',
+      dataSource: pass3DataSource,
       confidence: efConfidence,
       readinessGates: {
         ownerAssigned: efHasOwner,
-        notBlocked: !(ef.blockerCount > 0),
+        notBlocked: !(efBlockerCount > 0),
         pastRefinement: efPastRefinement,
         hasTargetVersion: efHasTargetVersion,
         noBlockingViolations: !efBlockedByHygiene

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -27,6 +27,7 @@ const { logAudit, getAuditLog, computeFieldDiff } = require('./audit-log')
 const { blockDuringImpersonation } = require('../../../../shared/server/auth')
 const healthRoutes = require('./health/health-routes')
 var { buildFeatureReadiness } = require('./feature-readiness')
+var { fetchFeatures } = require('./feature-query')
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true'
 const DATA_PREFIX = 'releases/planning'
@@ -466,9 +467,18 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       500:
    *         description: Internal error building readiness data
    */
-  router.get('/feature-readiness', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/feature-readiness', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      var result = buildFeatureReadiness(readFromStorage)
+      var jiraFeatures = null
+      if (jiraClient) {
+        try {
+          jiraFeatures = await fetchFeatures(jiraClient)
+          if (jiraFeatures.size === 0) jiraFeatures = null
+        } catch (jiraErr) {
+          console.warn('[releases/planning] Jira feature query failed, falling back to execution index:', jiraErr.message)
+        }
+      }
+      var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
       res.json(result)
     } catch (err) {
       console.error('[releases/planning] Feature readiness build failed:', err.message)


### PR DESCRIPTION
## Summary

- Adds `feature-query.js` that queries Jira for all open RHAISTRAT Features/Initiatives without date restrictions, closing the 160-feature gap (632 shown vs 792 open)
- Pass 3 of `buildFeatureReadiness` now uses Jira as primary source, with execution index enriching blocker counts and RICE scores
- Falls back gracefully to execution-index-only when Jira is unavailable

## Test plan

- 28 new tests for `feature-query.js` (JQL, field normalization, null client handling)
- 17 new tests for Jira-source pass 3 in `feature-readiness.test.js` (deduplication, enrichment, readiness gates, fallback)
- All 186 tests pass (158 feature-readiness + 28 feature-query)