### PR TITLE
fix(ci): run Claude review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,8 +55,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]' &&
-       github.actor != 'rhai-org-pulse[bot]' &&
-       github.actor != 'dependabot[bot]') ||
+       github.actor != 'rhai-org-pulse[bot]') ||
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name != github.repository &&
        github.event.pull_request.draft != true &&


### PR DESCRIPTION
Remove the `dependabot[bot]` actor exclusion from the claude-review workflow so dependency update PRs get the same automated review as all other PRs.