### PR TITLE
feat(releases): maximize data completeness in feature readiness

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -914,7 +914,9 @@ Derived summary index of all features in the unified feature store. Rebuilt auto
       "architect": "Architect Name",
       "parentKey": "RHAISTRAT-100",
       "colorStatus": "Green",
-      "ownerStatusColor": "Green"
+      "ownerStatusColor": "Green",
+      "team": "Model Serving",
+      "components": ["API", "Dashboard"]
     }
   ]
 }
@@ -924,6 +926,7 @@ Derived summary index of all features in the unified feature store. Rebuilt auto
 - `assignee` is a string in the index (flattened from the detail object shape)
 - `colorStatus` and `ownerStatusColor` are identical (backward compat alias)
 - `pm` is flattened to a string from the detail object shape
+- `team` and `components` are Jira-sourced fields surfaced in the index for filtering
 - Metrics fields (`completionPct`, `epicCount`, etc.) are derived from the detail `metrics` object
 
 ## Releases — Execution Feature Detail (`data/releases/execution/features/{KEY}.json`)

--- a/modules/releases/server/execution/feature-store.js
+++ b/modules/releases/server/execution/feature-store.js
@@ -195,7 +195,9 @@ async function rebuildIndex(storage) {
       parentKey: feature.parentKey || null,
       // Jira-sourced fields for index filtering
       colorStatus: feature.colorStatus || null,
-      ownerStatusColor: feature.colorStatus || null // backward compat alias
+      ownerStatusColor: feature.colorStatus || null, // backward compat alias
+      team: feature.team || null,
+      components: feature.components || []
     };
 
     features.push(indexEntry);

--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -250,3 +250,121 @@ describe('feature-query', function() {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// Expanded custom fields (statusSummary, colorStatus, releaseType, docsRequired, targetEnd)
+// ---------------------------------------------------------------------------
+
+describe('expanded custom fields', function() {
+
+  describe('QUERY_FIELDS', function() {
+    it('includes statusSummary, colorStatus, releaseType, docsRequired, targetEnd custom field IDs', function() {
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.statusSummary)
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.colorStatus)
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.releaseType)
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.docsRequired)
+      expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.targetEnd)
+    })
+  })
+
+  describe('normalizeIssue - new fields', function() {
+    it('extracts statusSummary from custom field', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-NF1',
+        fields: {
+          [CUSTOM_FIELDS.statusSummary]: 'On track for GA'
+        }
+      })
+      expect(result.statusSummary).toBe('On track for GA')
+    })
+
+    it('extracts colorStatus from object custom field', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-NF2',
+        fields: {
+          [CUSTOM_FIELDS.colorStatus]: { value: 'Green' }
+        }
+      })
+      expect(result.colorStatus).toBe('Green')
+    })
+
+    it('extracts releaseType from object custom field', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-NF3',
+        fields: {
+          [CUSTOM_FIELDS.releaseType]: { value: 'GA' }
+        }
+      })
+      expect(result.releaseType).toBe('GA')
+    })
+
+    it('extracts docsRequired from object custom field', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-NF4',
+        fields: {
+          [CUSTOM_FIELDS.docsRequired]: { value: 'Yes' }
+        }
+      })
+      expect(result.docsRequired).toBe('Yes')
+    })
+
+    it('extracts targetEnd date string', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-NF5',
+        fields: {
+          [CUSTOM_FIELDS.targetEnd]: '2026-09-15'
+        }
+      })
+      expect(result.targetEnd).toBe('2026-09-15')
+    })
+
+    it('returns null for missing new fields', function() {
+      var result = normalizeIssue({
+        key: 'RHAISTRAT-NF6',
+        fields: {}
+      })
+      expect(result.statusSummary).toBeNull()
+      expect(result.colorStatus).toBeNull()
+      expect(result.releaseType).toBeNull()
+      expect(result.docsRequired).toBeNull()
+      expect(result.targetEnd).toBeNull()
+    })
+
+    it('fetchFeatures includes new fields in returned map entries', async function() {
+      var mockClient = {
+        fetchAllJqlResults: vi.fn().mockResolvedValue([
+          {
+            key: 'RHAISTRAT-NF7',
+            fields: {
+              summary: 'Full Feature',
+              status: { name: 'In Progress' },
+              issuetype: { name: 'Feature' },
+              assignee: { displayName: 'Dev' },
+              fixVersions: [{ name: 'rhoai-3.6' }],
+              components: [{ name: 'API' }],
+              labels: [],
+              priority: { name: 'Major' },
+              [CUSTOM_FIELDS.team]: { value: 'MyTeam' },
+              [CUSTOM_FIELDS.targetVersion]: { value: 'rhoai-3.6' },
+              [CUSTOM_FIELDS.riceScore]: 200,
+              [CUSTOM_FIELDS.statusSummary]: 'Looking good',
+              [CUSTOM_FIELDS.colorStatus]: { value: 'Green' },
+              [CUSTOM_FIELDS.releaseType]: { value: 'GA' },
+              [CUSTOM_FIELDS.docsRequired]: { value: 'Yes' },
+              [CUSTOM_FIELDS.targetEnd]: '2026-10-01'
+            }
+          }
+        ])
+      }
+
+      var result = await fetchFeatures(mockClient)
+      expect(result.size).toBe(1)
+      var feature = result.get('RHAISTRAT-NF7')
+      expect(feature.statusSummary).toBe('Looking good')
+      expect(feature.colorStatus).toBe('Green')
+      expect(feature.releaseType).toBe('GA')
+      expect(feature.docsRequired).toBe('Yes')
+      expect(feature.targetEnd).toBe('2026-10-01')
+    })
+  })
+})

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -2018,8 +2018,14 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       makeJiraFeature('RHAISTRAT-500', {
         labels: ['strat-creator-human-sign-off'],
         assignee: 'Alice',
+        team: 'MyTeam',
         status: 'In Progress',
-        targetVersions: ['rhoai-3.6']
+        targetVersions: ['rhoai-3.6'],
+        fixVersions: ['rhoai-3.6'],
+        colorStatus: 'Green',
+        releaseType: 'GA',
+        docsRequired: 'Yes',
+        targetEnd: '2026-09-15'
       })
     ])
     var readFromStorage = makeReadFromStorage({
@@ -2030,7 +2036,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
 
     var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.ready.length).toBe(1)
-    expect(result.ready[0].confidence).toBe('ready')
+    expect(result.ready[0].confidence).toBe('committed')
     expect(result.ready[0].humanReviewStatus).toBe('approved')
   })
 
@@ -2213,5 +2219,444 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].readinessGates.hasTargetVersion).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// All-hygiene-files loading via listStorageFiles
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureReadiness - all-hygiene-files loading', function() {
+  function makeExecIndex(features) {
+    return { features: features, fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: features.length }
+  }
+
+  function makeExecFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Exec Feature ' + key,
+      status: 'In Progress',
+      priority: 'Major',
+      assignee: 'Jane Doe',
+      components: ['UI'],
+      labels: [],
+      targetVersions: ['rhoai-3.6'],
+      fixVersions: [],
+      team: 'Platform'
+    }, overrides)
+  }
+
+  function makeJiraMap(features) {
+    var map = new Map()
+    for (var i = 0; i < features.length; i++) {
+      map.set(features[i].key, features[i])
+    }
+    return map
+  }
+
+  function makeJiraFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Jira Feature ' + key,
+      status: 'In Progress',
+      issueType: 'Feature',
+      assignee: 'Alice',
+      team: 'Platform',
+      components: ['Dashboard'],
+      labels: [],
+      fixVersions: [],
+      targetVersions: ['rhoai-3.6'],
+      priority: 'Major',
+      riceScore: null
+    }, overrides)
+  }
+
+  it('loads team and violations from non-configured hygiene files via listStorageFiles', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-500', { team: null })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([]),
+      'releases/hygiene/features-rhoai-3.7.json': {
+        features: {
+          'RHAISTRAT-500': {
+            team: 'Llama Stack Core',
+            violations: [{ id: 'missing-fix-version', name: 'Missing Fix Version' }]
+          }
+        }
+      }
+    })
+
+    var listStorageFiles = function(dir) {
+      if (dir === 'releases/hygiene') return ['features-rhoai-3.7.json']
+      return []
+    }
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-500' })
+    expect(feature).toBeDefined()
+    expect(feature.team).toBe('Llama Stack Core')
+    expect(feature.violations).toEqual([{ id: 'missing-fix-version', name: 'Missing Fix Version' }])
+  })
+
+  it('does not overwrite team from configured version with non-configured version data', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-600', { team: null })
+      ]),
+      'releases/hygiene/features-3.6.json': {
+        features: {
+          'RHAISTRAT-600': { team: 'RHOAI Dashboard', violations: [] }
+        }
+      },
+      'releases/hygiene/features-rhoai-3.7.json': {
+        features: {
+          'RHAISTRAT-600': { team: 'Llama Stack Core', violations: [{ id: 'test' }] }
+        }
+      }
+    })
+
+    var listStorageFiles = function(dir) {
+      if (dir === 'releases/hygiene') return ['features-3.6.json', 'features-rhoai-3.7.json']
+      return []
+    }
+
+    var result = buildFeatureReadiness(readFromStorage, null, listStorageFiles)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-600' })
+    expect(feature).toBeDefined()
+    expect(feature.team).toBe('RHOAI Dashboard')
+  })
+
+  it('works without listStorageFiles (backward compatible)', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-700')
+      ])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, null)
+    expect(result.pendingReview.concat(result.ready).length).toBeGreaterThan(0)
+  })
+
+  it('handles listStorageFiles throwing an error gracefully', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([
+        makeExecFeature('RHAISTRAT-800')
+      ])
+    })
+
+    var listStorageFiles = function() {
+      throw new Error('directory not found')
+    }
+
+    var result = buildFeatureReadiness(readFromStorage, null, listStorageFiles)
+    expect(result.pendingReview.concat(result.ready).length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Jira data fallback for passes 1 and 2
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
+  function makeJiraMap(features) {
+    var map = new Map()
+    for (var i = 0; i < features.length; i++) {
+      map.set(features[i].key, features[i])
+    }
+    return map
+  }
+
+  function makeJiraFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Jira Feature ' + key,
+      status: 'In Progress',
+      issueType: 'Feature',
+      assignee: 'JiraAssignee',
+      team: 'JiraTeam',
+      components: ['JiraComp'],
+      labels: [],
+      fixVersions: [],
+      targetVersions: ['rhoai-3.6'],
+      priority: 'Major',
+      riceScore: null
+    }, overrides)
+  }
+
+  it('pass 1: uses Jira team when teamIndex has no entry', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-1', { team: 'JiraTeamFallback' })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({
+        'RHAISTRAT-1': {
+          latest: makeLatest({ key: 'RHAISTRAT-1', humanReviewStatus: 'approved' })
+        }
+      }),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/planning/candidates-cache-3.6.json': {
+        data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'Rock' }] }
+      },
+      'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+    expect(feature).toBeDefined()
+    expect(feature.team).toBe('JiraTeamFallback')
+  })
+
+  it('pass 1: uses Jira components when strat-creator and health-cache are empty', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-1', { components: ['CompFromJira'] })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({
+        'RHAISTRAT-1': {
+          latest: makeLatest({ key: 'RHAISTRAT-1', components: [] })
+        }
+      }),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/planning/candidates-cache-3.6.json': {
+        data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'Rock' }] }
+      },
+      'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+    expect(feature).toBeDefined()
+    expect(feature.components).toEqual(['CompFromJira'])
+  })
+
+  it('pass 1: uses Jira assignee as deliveryOwner when healthData has none', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-1', { assignee: 'JiraOwner' })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({
+        'RHAISTRAT-1': {
+          latest: makeLatest({ key: 'RHAISTRAT-1' })
+        }
+      }),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/planning/candidates-cache-3.6.json': {
+        data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'Rock' }] }
+      },
+      'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+    expect(feature).toBeDefined()
+    expect(feature.deliveryOwner).toBe('JiraOwner')
+  })
+
+  it('pass 2: uses Jira team when teamIndex has no entry', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-HP1', { team: 'JiraTeamHP' })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/planning/health-cache-3.6-all.json': {
+        features: [{
+          key: 'RHAISTRAT-HP1',
+          summary: 'Health Feature',
+          status: 'In Progress',
+          priority: 'Major',
+          components: '',
+          assignee: 'Owner'
+        }]
+      },
+      'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-HP1' })
+    expect(feature).toBeDefined()
+    expect(feature.team).toBe('JiraTeamHP')
+  })
+
+  it('pass 2: uses Jira components when health-cache components are empty', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-HP2', { components: ['JiraCompHP'] })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/planning/health-cache-3.6-all.json': {
+        features: [{
+          key: 'RHAISTRAT-HP2',
+          summary: 'Health Feature',
+          status: 'In Progress',
+          priority: 'Major',
+          components: '',
+          assignee: 'Owner'
+        }]
+      },
+      'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-HP2' })
+    expect(feature).toBeDefined()
+    expect(feature.components).toEqual(['JiraCompHP'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dynamic hygiene evaluation in pass 3
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureReadiness - dynamic hygiene evaluation', function() {
+  function makeExecIndex(features) {
+    return { features: features, fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: features.length }
+  }
+
+  function makeJiraMap(features) {
+    var map = new Map()
+    for (var i = 0; i < features.length; i++) {
+      map.set(features[i].key, features[i])
+    }
+    return map
+  }
+
+  function makeJiraFeature(key, overrides) {
+    return Object.assign({
+      key: key,
+      summary: 'Jira Feature ' + key,
+      status: 'In Progress',
+      issueType: 'Feature',
+      assignee: null,
+      team: null,
+      components: [],
+      labels: [],
+      fixVersions: [],
+      targetVersions: ['rhoai-3.6'],
+      priority: 'Major',
+      riceScore: null,
+      statusSummary: null,
+      colorStatus: null,
+      releaseType: null,
+      docsRequired: null,
+      targetEnd: null
+    }, overrides)
+  }
+
+  it('dynamically evaluates hygiene for Jira pass 3 features not in hygieneIndex', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-DYN1', {
+        status: 'In Progress',
+        assignee: null,
+        team: null
+      })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN1' })
+    expect(feature).toBeDefined()
+    expect(feature.violations).not.toBeNull()
+    expect(feature.violations.length).toBeGreaterThan(0)
+    var violationIds = feature.violations.map(function(v) { return v.id })
+    expect(violationIds).toContain('missing-assignee')
+    expect(violationIds).toContain('missing-team')
+  })
+
+  it('does not dynamically evaluate when hygieneIndex already has violations', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-DYN2', {
+        status: 'In Progress',
+        assignee: null
+      })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([]),
+      'releases/hygiene/features-3.6.json': {
+        features: {
+          'RHAISTRAT-DYN2': {
+            team: 'CachedTeam',
+            violations: [{ id: 'cached-violation', name: 'Cached Violation' }]
+          }
+        }
+      }
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN2' })
+    expect(feature).toBeDefined()
+    expect(feature.violations).toEqual([{ id: 'cached-violation', name: 'Cached Violation' }])
+  })
+
+  it('does not dynamically evaluate for execution index source', function() {
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([{
+        key: 'RHAISTRAT-DYN3',
+        summary: 'Exec Feature',
+        status: 'In Progress',
+        priority: 'Major',
+        assignee: null,
+        components: [],
+        labels: [],
+        targetVersions: ['rhoai-3.6'],
+        fixVersions: [],
+        team: null
+      }])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, null)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN3' })
+    expect(feature).toBeDefined()
+    expect(feature.violations).toBeNull()
+  })
+
+  it('detects missing-color-status for In Progress feature without colorStatus', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-DYN4', {
+        status: 'In Progress',
+        assignee: 'Owner',
+        team: 'MyTeam',
+        colorStatus: null
+      })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN4' })
+    expect(feature).toBeDefined()
+    expect(feature.violations).not.toBeNull()
+    var violationIds = feature.violations.map(function(v) { return v.id })
+    expect(violationIds).toContain('missing-color-status')
   })
 })

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -5,7 +5,12 @@ var QUERY_FIELDS = [
   'components', 'labels', 'priority', 'created', 'updated',
   CUSTOM_FIELDS.team,
   CUSTOM_FIELDS.targetVersion,
-  CUSTOM_FIELDS.riceScore
+  CUSTOM_FIELDS.riceScore,
+  CUSTOM_FIELDS.statusSummary,
+  CUSTOM_FIELDS.colorStatus,
+  CUSTOM_FIELDS.releaseType,
+  CUSTOM_FIELDS.docsRequired,
+  CUSTOM_FIELDS.targetEnd
 ].join(',')
 
 var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status NOT IN (Closed, Done, Resolved, Cancelled)'
@@ -46,7 +51,12 @@ function normalizeIssue(issue) {
     fixVersions: fixVersions,
     targetVersions: targetVersions,
     priority: priority,
-    riceScore: fields[CUSTOM_FIELDS.riceScore] || null
+    riceScore: fields[CUSTOM_FIELDS.riceScore] || null,
+    statusSummary: serializeField(fields[CUSTOM_FIELDS.statusSummary]),
+    colorStatus: serializeField(fields[CUSTOM_FIELDS.colorStatus]),
+    releaseType: serializeField(fields[CUSTOM_FIELDS.releaseType]),
+    docsRequired: serializeField(fields[CUSTOM_FIELDS.docsRequired]),
+    targetEnd: serializeField(fields[CUSTOM_FIELDS.targetEnd])
   }
 }
 

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -247,11 +247,12 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
   }
 
   if (listStorageFiles) {
-    try {
-      var hygieneFiles = listStorageFiles('releases/hygiene')
-      for (var hfi = 0; hfi < hygieneFiles.length; hfi++) {
-        var hfMatch = hygieneFiles[hfi].match(/^features-(.+)\.json$/)
-        if (!hfMatch) continue
+    var hygieneFiles = []
+    try { hygieneFiles = listStorageFiles('releases/hygiene') } catch { /* directory may not exist */ }
+    for (var hfi = 0; hfi < hygieneFiles.length; hfi++) {
+      var hfMatch = hygieneFiles[hfi].match(/^features-(.+)\.json$/)
+      if (!hfMatch) continue
+      try {
         var hfData = readFromStorage('releases/hygiene/' + hygieneFiles[hfi])
         if (!hfData || !hfData.features) continue
         var hfKeys = Object.keys(hfData.features)
@@ -261,9 +262,9 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
           if (!teamIndex.has(hfKeys[hfki]) && hfFeat.team) teamIndex.set(hfKeys[hfki], hfFeat.team)
           if (!hygieneIndex.has(hfKeys[hfki]) && hfFeat.violations) hygieneIndex.set(hfKeys[hfki], hfFeat.violations)
         }
+      } catch {
+        console.warn('[releases/planning] Failed to load hygiene file:', hygieneFiles[hfi])
       }
-    } catch {
-      // listStorageFiles may fail if directory doesn't exist
     }
   }
 

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -1,6 +1,8 @@
 var { getConfiguredReleases } = require('./config')
 var { loadIndex } = require('./cache-reader')
 var { CLOSED_STATUSES } = require('./constants')
+var { evaluateHygiene } = require('../hygiene/hygiene-rules')
+var { loadConfig: loadHygieneConfig } = require('../hygiene/config')
 
 var RICE_MAX = 16900 // 13 × 13 × 100 ÷ 1 (theoretical max: max Reach × max Impact × max Confidence ÷ min Effort)
 
@@ -151,7 +153,7 @@ function deriveHumanReviewStatusFromLabels(labels) {
   return 'awaiting-review'
 }
 
-function buildFeatureReadiness(readFromStorage, jiraFeatures) {
+function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) {
   var raw = readFromStorage('ai-impact/features.json')
   if (!raw || !raw.features) {
     raw = { features: {} }
@@ -177,6 +179,14 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures) {
   }
 
   var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
+
+  var hygieneRulesConfig = {}
+  try {
+    var hConfig = loadHygieneConfig({ readFromStorage: readFromStorage })
+    hygieneRulesConfig = hConfig.rules || {}
+  } catch {
+    // hygiene config not available
+  }
 
   for (var cvi = 0; cvi < configuredVersions.length; cvi++) {
     var cv = configuredVersions[cvi]
@@ -236,6 +246,27 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures) {
     }
   }
 
+  if (listStorageFiles) {
+    try {
+      var hygieneFiles = listStorageFiles('releases/hygiene')
+      for (var hfi = 0; hfi < hygieneFiles.length; hfi++) {
+        var hfMatch = hygieneFiles[hfi].match(/^features-(.+)\.json$/)
+        if (!hfMatch) continue
+        var hfData = readFromStorage('releases/hygiene/' + hygieneFiles[hfi])
+        if (!hfData || !hfData.features) continue
+        var hfKeys = Object.keys(hfData.features)
+        for (var hfki = 0; hfki < hfKeys.length; hfki++) {
+          var hfFeat = hfData.features[hfKeys[hfki]]
+          if (!hfFeat) continue
+          if (!teamIndex.has(hfKeys[hfki]) && hfFeat.team) teamIndex.set(hfKeys[hfki], hfFeat.team)
+          if (!hygieneIndex.has(hfKeys[hfki]) && hfFeat.violations) hygieneIndex.set(hfKeys[hfki], hfFeat.violations)
+        }
+      }
+    } catch {
+      // listStorageFiles may fail if directory doesn't exist
+    }
+  }
+
   var hasCaches = candidateIndex.size > 0 || healthIndex.size > 0
 
   var pendingReview = []
@@ -278,8 +309,8 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures) {
     var fixVersion = candidateData
       ? candidateData.fixVersion || null
       : (healthData ? healthData.fixVersions || null : null)
-    var deliveryOwner = healthData ? healthData.deliveryOwner || null : null
-    var team = teamIndex.get(key) || null
+    var deliveryOwner = (healthData ? healthData.deliveryOwner || null : null) || (jiraFeatures && jiraFeatures.has(key) ? jiraFeatures.get(key).assignee : null) || null
+    var team = teamIndex.get(key) || (jiraFeatures && jiraFeatures.has(key) ? jiraFeatures.get(key).team : null) || null
 
     var priorityScore = healthData ? (healthData.priorityScore != null ? healthData.priorityScore : null) : null
     var priorityScoreBreakdown = healthData ? (healthData.priorityBreakdown || healthData.priorityScoreBreakdown || null) : null
@@ -294,9 +325,10 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures) {
     var healthComponents = healthData && healthData.components
       ? healthData.components.split(', ').filter(Boolean)
       : []
+    var jiraComponents = jiraFeatures && jiraFeatures.has(key) ? jiraFeatures.get(key).components || [] : []
     var componentsList = (latest.components && latest.components.length > 0)
       ? latest.components
-      : healthComponents
+      : (healthComponents.length > 0 ? healthComponents : jiraComponents)
 
     var violations = hygieneIndex.get(key) || null
     var isApproved = latest.humanReviewStatus === 'approved'
@@ -376,10 +408,11 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures) {
       ? [cd.targetRelease]
       : (hd.targetRelease ? [hd.targetRelease] : [])
     var hpFixVersion = cd ? cd.fixVersion || null : (hd.fixVersions || null)
+    var hpJiraComponents = jiraFeatures && jiraFeatures.has(ckey) ? jiraFeatures.get(ckey).components || [] : []
     var hpComponents = hd.components
       ? hd.components.split(', ').filter(Boolean)
-      : []
-    var hpTeam = teamIndex.get(ckey) || null
+      : hpJiraComponents
+    var hpTeam = teamIndex.get(ckey) || (jiraFeatures && jiraFeatures.has(ckey) ? jiraFeatures.get(ckey).team : null) || null
 
     var hpPriorityScore = hd.priorityScore != null ? hd.priorityScore : null
     var hpPriorityBreakdown = hd.priorityBreakdown || null
@@ -492,6 +525,30 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures) {
     var efAssignee = typeof ef.assignee === 'string' ? ef.assignee : (ef.assignee && ef.assignee.displayName ? ef.assignee.displayName : null)
     var efTeam = teamIndex.get(ef.key) || ef.team || null
     var efViolations = hygieneIndex.get(ef.key) || null
+    if (!efViolations && pass3DataSource === 'jira') {
+      try {
+        efViolations = evaluateHygiene({
+          key: ef.key,
+          summary: ef.summary,
+          status: ef.status,
+          issueType: ef.issueType,
+          assignee: efAssignee,
+          team: efTeam,
+          components: efComponents,
+          fixVersions: efFixVersions,
+          labels: efLabels,
+          statusSummary: ef.statusSummary || null,
+          colorStatus: ef.colorStatus || null,
+          releaseType: ef.releaseType || null,
+          docsRequired: ef.docsRequired || null,
+          targetEnd: ef.targetEnd || null,
+          riceScore: ef.riceScore || null
+        }, hygieneRulesConfig)
+        if (efViolations && efViolations.length === 0) efViolations = null
+      } catch {
+        // dynamic evaluation failed, leave as null
+      }
+    }
 
     var efCandidateData = candidateIndex.get(ef.key) || null
     var efTier = efCandidateData && efCandidateData.tier != null ? 'T' + efCandidateData.tier : null

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -478,7 +478,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           console.warn('[releases/planning] Jira feature query failed, falling back to execution index:', jiraErr.message)
         }
       }
-      var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+      var result = buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles)
       res.json(result)
     } catch (err) {
       console.error('[releases/planning] Feature readiness build failed:', err.message)


### PR DESCRIPTION
## Summary

- Loads team and violations from ALL hygiene files (not just admin-configured versions), fixing the root cause of the teams filter showing only 8 of 33 teams
- Expands Jira query with 5 additional custom fields (statusSummary, colorStatus, releaseType, docsRequired, targetEnd) to enable dynamic hygiene evaluation
- Adds dynamic hygiene rule evaluation for pass 3 Jira features that have no cached hygiene data — features outside configured versions now get real violation data instead of "All clear"
- Uses Jira data as enrichment fallback for team, components, and deliveryOwner in passes 1 and 2
- Adds team and components to execution index summary entries as a safety net

## Test plan

- 171 feature-readiness tests passing (13 new tests for hygiene file loading, Jira fallbacks, dynamic eval)
- 36 feature-query tests passing (8 new tests for expanded custom fields)
- 2053 total releases module tests passing, zero regressions