### PR TITLE
Feat/rfe pipeline friction plan

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -613,6 +613,35 @@ Cached RFE issues fetched from Jira. The module's primary data file.
 - `linkedFeature` is resolved from Jira issue links (type = "Cloners", outward to RHAISTRAT project). Can be `null` if no link exists.
 - `labels` is the raw Jira label array, preserved for reference
 
+## AI Impact — RFE Metrics API Response (`GET /api/modules/ai-impact/rfe-data`)
+
+The `/rfe-data` endpoint returns computed metrics alongside the cached issue list. The `pipelineFriction` object surfaces friction signals from Jira pipeline labels that are already present on every issue.
+
+```json
+{
+  "pipelineFriction": {
+    "needsAttentionPct": 18,
+    "needsAttentionChange": 3,
+    "needsAttentionTrend": "worsening",
+    "feasibilityBlockedPct": 9,
+    "feasibilityBlockedChange": -2,
+    "feasibilityBlockedTrend": "improving"
+  }
+}
+```
+
+**Fields:**
+- `needsAttentionPct`: % of AI-touched RFEs in the selected window with label `rfe-creator-needs-attention`
+- `needsAttentionChange`: percentage-point change vs the prior period (positive = more friction)
+- `needsAttentionTrend`: `"improving"` | `"stable"` | `"worsening"` — based on `trendThresholdPp` config (default 2pp); lower is improving for friction metrics
+- `feasibilityBlockedPct`: % of AI-touched RFEs with `rfe-creator-feasibility-fail` **or** `rfe-creator-feasibility-unknown` (each issue counted once)
+- `feasibilityBlockedChange`: pp change vs prior period
+- `feasibilityBlockedTrend`: same trend classification as above
+
+**Denominator:** AI-touched RFEs only (`aiInvolvement !== 'none'`), filtered by `issue.created` within the time window. Manual RFEs the pipeline never processed are excluded.
+
+**UI:** `needsAttentionPct` / `needsAttentionChange` render as sub-text under the "Created with AI" tile; `feasibilityBlockedPct` / `feasibilityBlockedChange` under "Revised with AI".
+
 ## AI Impact — Assessments (`data/ai-impact/assessments.json`)
 
 Quality assessment data pushed from the rfe-quality-dashboard CI pipeline. Stores the latest assessment and score history for each RFE.

--- a/docs/plans/rfe-pipeline-friction.md
+++ b/docs/plans/rfe-pipeline-friction.md
@@ -1,0 +1,142 @@
+# RFE Pipeline Friction — Implementation Plan
+
+## Overview
+
+Add two friction metrics to **RFE Review** (AI Impact) for when the rfe-creator automation does not fully succeed. Org Pulse already tracks adoption (AI-created / AI-revised). This adds the complementary “gone wrong” signals using Jira labels already on every cached RFE.
+
+**Naming:** “Friction” not “Health.” Health implies a broad readiness score (like the Component Maturity dashboard). This is specifically **where automation created human overhead** — blocked, flagged, or inconclusive runs.
+
+**Scope:** Two stat tiles below the existing adoption metrics row. No new nav tab. No new Jira fetch. No PM breakdown table. No extra list filters. No new trend charts — use the same prior-period delta pattern as the adoption tiles.
+
+**Questions this answers:**
+- What % of AI-touched RFEs require manual human cleanup?
+- Is that rate getting better or worse over time? (via pp change vs prior period, same as “Created with AI”)
+
+---
+
+## The two panels
+
+| Panel | Label(s) | Metric |
+|-------|----------|--------|
+| **Needs Attention** | `rfe-creator-needs-attention` | % of AI-touched RFEs in the time window with this label |
+| **Feasibility Blocked** | `rfe-creator-feasibility-fail`, `rfe-creator-feasibility-unknown` | % of AI-touched RFEs with **either** label (one combined “feasibility didn’t clear” rate) |
+
+Each tile shows:
+- Current window %
+- Change vs prior period (percentage points), with trend direction where **lower is better**
+
+**Denominator:** RFEs in the window where `aiInvolvement !== 'none'` (pipeline actually ran). Manual RFEs with no AI labels are excluded so rates are not diluted.
+
+**Time window:** Same selector as adoption metrics (`week` / `month` / `3months`), filtered by `issue.created`.
+
+**Out of scope for this change:** `rfe-creator-autofix-rubric-pass`, per-PM breakdown, topic grouping, friction trend charts, list filters, assessment rubric scores (those are a separate signal).
+
+---
+
+## Why these two labels
+
+| Signal | Meaning |
+|--------|---------|
+| `rfe-creator-needs-attention` | Automation ran but could not resolve the RFE — **human must intervene** |
+| `rfe-creator-feasibility-fail` | Pipeline judged the RFE **technically infeasible** |
+| `rfe-creator-feasibility-unknown` | Pipeline **could not determine** feasibility |
+
+Needs-attention = cleanup overhead. Feasibility fail/unknown = pipeline blocked or inconclusive on technical grounds. Together they cover the main “system didn’t work for the user” cases visible in Jira today.
+
+---
+
+## Data flow (unchanged infrastructure)
+
+```
+rfe-fetcher.js  →  labels[] on each issue  →  rfe-data.json
+                                                    ↓
+metrics.js  →  computePipelineFrictionMetrics()  →  API response
+                                                    ↓
+PhaseContent.vue  →  PipelineFrictionRow.vue (2 tiles)
+```
+
+Labels are already stored; `metrics.js` only aggregates `aiInvolvement` today and ignores friction labels.
+
+---
+
+## Implementation
+
+### 1. Server — `modules/ai-impact/server/metrics.js`
+
+Add:
+
+```js
+const FRICTION_LABELS = {
+  needsAttention: 'rfe-creator-needs-attention',
+  feasibilityFail: 'rfe-creator-feasibility-fail',
+  feasibilityUnknown: 'rfe-creator-feasibility-unknown'
+};
+
+function hasFeasibilityBlocked(labels) {
+  const set = new Set(labels || []);
+  return set.has(FRICTION_LABELS.feasibilityFail)
+    || set.has(FRICTION_LABELS.feasibilityUnknown);
+}
+```
+
+Add `computePipelineFrictionMetrics(issues, timeWindow, config)`:
+- Current and prior windows (same cutoffs as `computeMetrics`)
+- Denominator: `aiInvolvement !== 'none'` in each window
+- `needsAttentionPct`, `needsAttentionChange`, `needsAttentionTrend`
+- `feasibilityBlockedPct`, `feasibilityBlockedChange`, `feasibilityBlockedTrend`
+- Trend: lower friction = improving (invert logic vs adoption)
+
+Wire into `computeAllMetrics()`:
+
+```js
+return {
+  metrics: computeMetrics(...),
+  trendData: buildTrendData(...),
+  breakdown: buildBreakdownData(...),
+  pipelineFriction: computePipelineFrictionMetrics(issues, timeWindow, config)
+};
+```
+
+### 2. Tests — `modules/ai-impact/__tests__/server/pipeline-friction.test.js`
+
+- Rates use AI-touched denominator only
+- Feasibility fail + unknown counted once per issue (not double-counted)
+- Prior-period delta and empty window → 0%, not NaN
+- Update `computeAllMetrics` test to expect `pipelineFriction`
+
+### 3. UI — `modules/ai-impact/client/components/PipelineFrictionRow.vue`
+
+- Copy layout from `MetricsRow.vue` — **2 columns**, not 4
+- Section label: **Pipeline Friction**
+- Subtitle: *When automation needs a human*
+- Amber/red styling; down arrow = good for friction metrics
+
+### 4. Wire-up
+
+- `PhaseContent.vue` — render `PipelineFrictionRow` below `MetricsRow`
+- `RFEReviewView.vue` — pass `rfeData.pipelineFriction` (or from `computeAllMetrics` payload)
+
+### 5. Fixtures — `fixtures/ai-impact/rfe-data.json`
+
+Add sample friction labels on a few demo RFEs so local demo mode shows non-zero rates (use **Last 3 Months** if fixture dates are stale).
+
+### 6. Docs — same PR
+
+- `docs/DATA-FORMATS.md` — document `pipelineFriction` object on RFE metrics response
+
+---
+
+## Acceptance criteria
+
+- [ ] RFE Review shows **Pipeline Friction** row with two tiles below adoption metrics
+- [ ] Needs Attention % matches manual count: AI-touched RFEs in window with `rfe-creator-needs-attention`
+- [ ] Feasibility Blocked % matches: AI-touched RFEs with fail **or** unknown label
+- [ ] Both tiles show change vs prior period when time window changes
+- [ ] Demo fixtures include friction labels; rates visible locally
+- [ ] Unit tests pass; lint passes
+
+---
+
+## Open question (resolve before merge)
+
+**Denominator:** AI-touched only (recommended) vs all RFEs in window. AI-touched keeps the rate aligned with “of pipeline runs, how many failed?”

--- a/docs/plans/rfe-pipeline-friction.md
+++ b/docs/plans/rfe-pipeline-friction.md
@@ -6,24 +6,21 @@ Add two friction metrics to **RFE Review** (AI Impact) for when the rfe-creator 
 
 **Naming:** “Friction” not “Health.” Health implies a broad readiness score (like the Component Maturity dashboard). This is specifically **where automation created human overhead** — blocked, flagged, or inconclusive runs.
 
-**Scope:** Two stat tiles below the existing adoption metrics row. No new nav tab. No new Jira fetch. No PM breakdown table. No extra list filters. No new trend charts — use the same prior-period delta pattern as the adoption tiles.
+**Scope:** Embed friction as sub-text inside the existing 4-column adoption metrics row — **no second row, no new cards, no extra vertical space**. No new nav tab. No new Jira fetch. No PM breakdown table. No extra list filters. No new trend charts.
 
 **Questions this answers:**
 - What % of AI-touched RFEs require manual human cleanup?
-- Is that rate getting better or worse over time? (via pp change vs prior period, same as “Created with AI”)
+- Is that rate getting better or worse over time? (via pp change vs prior period)
+- At a glance: “We’re creating a lot with AI — and how much of that needed a human?”
 
 ---
 
-## The two panels
+## The two friction signals
 
-| Panel | Label(s) | Metric |
-|-------|----------|--------|
+| Signal | Label(s) | Metric |
+|--------|----------|--------|
 | **Needs Attention** | `rfe-creator-needs-attention` | % of AI-touched RFEs in the time window with this label |
 | **Feasibility Blocked** | `rfe-creator-feasibility-fail`, `rfe-creator-feasibility-unknown` | % of AI-touched RFEs with **either** label (one combined “feasibility didn’t clear” rate) |
-
-Each tile shows:
-- Current window %
-- Change vs prior period (percentage points), with trend direction where **lower is better**
 
 **Denominator:** RFEs in the window where `aiInvolvement !== 'none'` (pipeline actually ran). Manual RFEs with no AI labels are excluded so rates are not diluted.
 
@@ -45,6 +42,40 @@ Needs-attention = cleanup overhead. Feasibility fail/unknown = pipeline blocked 
 
 ---
 
+## UI — Split-card layout (recommended)
+
+### Problem with a stacked second row
+
+A separate “Pipeline Friction” row below adoption metrics causes:
+1. **Vertical bloat** — users scroll past two card rows before reaching trend charts
+2. **Disconnected context** — “Created with AI 100%” sits far from “Needs Attention 50%”; users must look up and down to connect success vs friction
+
+### Solution: pair friction inside existing adoption cards
+
+Keep the **4-column layout unchanged**. Friction metrics are sub-attributes of AI-touched RFEs, so show them as sub-text inside the adoption cards they relate to:
+
+| Column | Adoption metric | Friction sub-text |
+|--------|-----------------|-------------------|
+| 1 | **Created with AI** (big %) | `{needsAttentionPct}% require attention` (+ change as `pp`) |
+| 2 | **Revised with AI** (count) | `{feasibilityBlockedPct}% feasibility blocked` (+ change as `pp`) |
+| 3 | Total RFEs | *(unchanged)* |
+| 4 | Trend Status | *(unchanged)* |
+
+Example appearance:
+
+```
+Created with AI          Revised with AI
+100%  +5%                12
+33% require attention    25% feasibility blocked
+  +3pp                     -2pp
+```
+
+**Styling:** sub-text uses `text-xs text-gray-500` — informational, not alarming. No warning icons, no amber/red badges. Same neutral tone as “X prev period” on the Revised card.
+
+**Why this works:** zero extra vertical space, success vs friction read in a single glance, no new component file.
+
+---
+
 ## Data flow (unchanged infrastructure)
 
 ```
@@ -52,7 +83,7 @@ rfe-fetcher.js  →  labels[] on each issue  →  rfe-data.json
                                                     ↓
 metrics.js  →  computePipelineFrictionMetrics()  →  API response
                                                     ↓
-PhaseContent.vue  →  PipelineFrictionRow.vue (2 tiles)
+MetricsRow.vue  →  friction sub-text in columns 1 & 2
 ```
 
 Labels are already stored; `metrics.js` only aggregates `aiInvolvement` today and ignores friction labels.
@@ -104,17 +135,21 @@ return {
 - Prior-period delta and empty window → 0%, not NaN
 - Update `computeAllMetrics` test to expect `pipelineFriction`
 
-### 3. UI — `modules/ai-impact/client/components/PipelineFrictionRow.vue`
+### 3. UI — extend `modules/ai-impact/client/components/MetricsRow.vue`
 
-- Copy layout from `MetricsRow.vue` — **2 columns**, not 4
-- Section label: **Pipeline Friction**
-- Subtitle: *When automation needs a human*
-- Amber/red styling; down arrow = good for friction metrics
+- Add optional `pipelineFriction` prop
+- **Column 1 (Created with AI):** below the main stat, add sub-text:
+  - `{needsAttentionPct}% require attention`
+  - `{needsAttentionChange}` formatted as `+Npp` / `-Npp` / `—`
+- **Column 2 (Revised with AI):** below the count, add sub-text:
+  - `{feasibilityBlockedPct}% feasibility blocked`
+  - `{feasibilityBlockedChange}` formatted as `+Npp` / `-Npp` / `—`
+- No new component. No second row.
 
 ### 4. Wire-up
 
-- `PhaseContent.vue` — render `PipelineFrictionRow` below `MetricsRow`
-- `RFEReviewView.vue` — pass `rfeData.pipelineFriction` (or from `computeAllMetrics` payload)
+- `PhaseContent.vue` — pass `pipelineFriction` to `MetricsRow` (not a separate row component)
+- `RFEReviewView.vue` — pass `rfeData.pipelineFriction` through to `PhaseContent`
 
 ### 5. Fixtures — `fixtures/ai-impact/rfe-data.json`
 
@@ -128,15 +163,19 @@ Add sample friction labels on a few demo RFEs so local demo mode shows non-zero 
 
 ## Acceptance criteria
 
-- [ ] RFE Review shows **Pipeline Friction** row with two tiles below adoption metrics
+- [ ] RFE Review keeps a **single** 4-column metrics row (no second friction row)
+- [ ] “Created with AI” card shows needs-attention % and pp change as sub-text
+- [ ] “Revised with AI” card shows feasibility-blocked % and pp change as sub-text
 - [ ] Needs Attention % matches manual count: AI-touched RFEs in window with `rfe-creator-needs-attention`
 - [ ] Feasibility Blocked % matches: AI-touched RFEs with fail **or** unknown label
-- [ ] Both tiles show change vs prior period when time window changes
-- [ ] Demo fixtures include friction labels; rates visible locally
+- [ ] Sub-text updates when time window changes
+- [ ] Demo fixtures include friction labels; sub-text visible locally
 - [ ] Unit tests pass; lint passes
 
 ---
 
-## Open question (resolve before merge)
+## Resolved decisions
 
-**Denominator:** AI-touched only (recommended) vs all RFEs in window. AI-touched keeps the rate aligned with “of pipeline runs, how many failed?”
+**Denominator:** AI-touched only (`aiInvolvement !== 'none'`). Keeps the rate aligned with “of pipeline runs, how many had this outcome?”
+
+**UI layout:** Split-card (friction sub-text inside existing adoption cards), not a stacked second row.

--- a/fixtures/ai-impact/rfe-data.json
+++ b/fixtures/ai-impact/rfe-data.json
@@ -9,7 +9,8 @@
       "created": "2026-03-15T10:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-needs-attention", "customer-request"],
+      "components": ["Platform Core"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "customer-request"],
       "aiInvolvement": "both",
       "linkedFeature": {
         "key": "RHAISTRAT-1168",
@@ -26,7 +27,8 @@
       "created": "2026-03-12T14:30:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
-      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-unknown"],
+      "components": ["Platform Dashboard"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-autofix-rubric-pass", "strat-creator-3.5"],
       "aiInvolvement": "created",
       "linkedFeature": null
     },
@@ -38,7 +40,8 @@
       "created": "2026-03-10T09:15:00Z",
       "creator": "mgarcia",
       "creatorDisplayName": "Maria Garcia",
-      "labels": ["rfe-creator-auto-revised", "strategic"],
+      "components": ["ML Models"],
+      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "tech-reviewed", "strategic"],
       "aiInvolvement": "revised",
       "linkedFeature": {
         "key": "RHAISTRAT-502",
@@ -55,6 +58,7 @@
       "created": "2026-03-08T11:00:00Z",
       "creator": "akim",
       "creatorDisplayName": "Alex Kim",
+      "components": ["Infrastructure Services"],
       "labels": [],
       "aiInvolvement": "none",
       "linkedFeature": null
@@ -67,14 +71,10 @@
       "created": "2026-02-28T16:45:00Z",
       "creator": "lwong",
       "creatorDisplayName": "Lisa Wong",
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised"],
+      "components": ["ML Models"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "rfe-creator-needs-attention"],
       "aiInvolvement": "both",
-      "linkedFeature": {
-        "key": "RHAISTRAT-503",
-        "summary": "Strat: A/B testing for model endpoints",
-        "status": "In Progress",
-        "fixVersions": ["RHOAI 2.16"]
-      }
+      "linkedFeature": null
     },
     {
       "key": "RHAIRFE-1006",
@@ -84,7 +84,8 @@
       "created": "2026-02-20T08:30:00Z",
       "creator": "rpatel",
       "creatorDisplayName": "Raj Patel",
-      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-fail"],
+      "components": ["Data Pipelines"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
       "aiInvolvement": "created",
       "linkedFeature": null
     },
@@ -96,7 +97,8 @@
       "created": "2026-02-15T13:20:00Z",
       "creator": "emiller",
       "creatorDisplayName": "Emily Miller",
-      "labels": ["rfe-creator-auto-revised"],
+      "components": ["Platform Core"],
+      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass"],
       "aiInvolvement": "revised",
       "linkedFeature": null
     },
@@ -108,7 +110,8 @@
       "created": "2026-02-10T10:00:00Z",
       "creator": "dlee",
       "creatorDisplayName": "David Lee",
-      "labels": [],
+      "components": ["Platform Core", "Infrastructure Services"],
+      "labels": ["rfe-creator-autofix-rubric-pass", "tech-reviewed", "strat-creator-3.5"],
       "aiInvolvement": "none",
       "linkedFeature": null
     },
@@ -120,7 +123,8 @@
       "created": "2026-01-25T15:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "innovation"],
+      "components": ["ML Models"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "innovation"],
       "aiInvolvement": "both",
       "linkedFeature": null
     },
@@ -132,6 +136,7 @@
       "created": "2026-01-15T09:45:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
+      "components": ["ML Models", "Platform Core"],
       "labels": [],
       "aiInvolvement": "none",
       "linkedFeature": null

--- a/fixtures/ai-impact/rfe-data.json
+++ b/fixtures/ai-impact/rfe-data.json
@@ -9,8 +9,7 @@
       "created": "2026-03-15T10:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "components": ["Platform Core"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "customer-request"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-needs-attention", "customer-request"],
       "aiInvolvement": "both",
       "linkedFeature": {
         "key": "RHAISTRAT-1168",
@@ -27,8 +26,7 @@
       "created": "2026-03-12T14:30:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
-      "components": ["Platform Dashboard"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-autofix-rubric-pass", "strat-creator-3.5"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-unknown"],
       "aiInvolvement": "created",
       "linkedFeature": null
     },
@@ -40,8 +38,7 @@
       "created": "2026-03-10T09:15:00Z",
       "creator": "mgarcia",
       "creatorDisplayName": "Maria Garcia",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "tech-reviewed", "strategic"],
+      "labels": ["rfe-creator-auto-revised", "strategic"],
       "aiInvolvement": "revised",
       "linkedFeature": {
         "key": "RHAISTRAT-502",
@@ -58,7 +55,6 @@
       "created": "2026-03-08T11:00:00Z",
       "creator": "akim",
       "creatorDisplayName": "Alex Kim",
-      "components": ["Infrastructure Services"],
       "labels": [],
       "aiInvolvement": "none",
       "linkedFeature": null
@@ -71,10 +67,14 @@
       "created": "2026-02-28T16:45:00Z",
       "creator": "lwong",
       "creatorDisplayName": "Lisa Wong",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "rfe-creator-needs-attention"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised"],
       "aiInvolvement": "both",
-      "linkedFeature": null
+      "linkedFeature": {
+        "key": "RHAISTRAT-503",
+        "summary": "Strat: A/B testing for model endpoints",
+        "status": "In Progress",
+        "fixVersions": ["RHOAI 2.16"]
+      }
     },
     {
       "key": "RHAIRFE-1006",
@@ -84,8 +84,7 @@
       "created": "2026-02-20T08:30:00Z",
       "creator": "rpatel",
       "creatorDisplayName": "Raj Patel",
-      "components": ["Data Pipelines"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-fail"],
       "aiInvolvement": "created",
       "linkedFeature": null
     },
@@ -97,8 +96,7 @@
       "created": "2026-02-15T13:20:00Z",
       "creator": "emiller",
       "creatorDisplayName": "Emily Miller",
-      "components": ["Platform Core"],
-      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass"],
+      "labels": ["rfe-creator-auto-revised"],
       "aiInvolvement": "revised",
       "linkedFeature": null
     },
@@ -110,8 +108,7 @@
       "created": "2026-02-10T10:00:00Z",
       "creator": "dlee",
       "creatorDisplayName": "David Lee",
-      "components": ["Platform Core", "Infrastructure Services"],
-      "labels": ["rfe-creator-autofix-rubric-pass", "tech-reviewed", "strat-creator-3.5"],
+      "labels": [],
       "aiInvolvement": "none",
       "linkedFeature": null
     },
@@ -123,8 +120,7 @@
       "created": "2026-01-25T15:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "innovation"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "innovation"],
       "aiInvolvement": "both",
       "linkedFeature": null
     },
@@ -136,7 +132,6 @@
       "created": "2026-01-15T09:45:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
-      "components": ["ML Models", "Platform Core"],
       "labels": [],
       "aiInvolvement": "none",
       "linkedFeature": null

--- a/modules/ai-impact/__tests__/client/AIImpactView.test.js
+++ b/modules/ai-impact/__tests__/client/AIImpactView.test.js
@@ -30,12 +30,22 @@ describe('MetricsRow', () => {
       windowTotal: 20,
       totalRFEs: 62
     }
-    const wrapper = mount(MetricsRow, { props: { metrics } })
+    const pipelineFriction = {
+      needsAttentionPct: 33,
+      needsAttentionChange: 3,
+      feasibilityBlockedPct: 25,
+      feasibilityBlockedChange: -2
+    }
+    const wrapper = mount(MetricsRow, { props: { metrics, pipelineFriction } })
     expect(wrapper.text()).toContain('77%')
     expect(wrapper.text()).toContain('14')
     expect(wrapper.text()).toContain('11 prev period')
     expect(wrapper.text()).toContain('20')
     expect(wrapper.text()).toContain('growing')
+    expect(wrapper.text()).toContain('33% require attention')
+    expect(wrapper.text()).toContain('+3pp')
+    expect(wrapper.text()).toContain('25% feasibility blocked')
+    expect(wrapper.text()).toContain('-2pp')
   })
 
   it('renders nothing when metrics is null', () => {

--- a/modules/ai-impact/__tests__/server/metrics.test.js
+++ b/modules/ai-impact/__tests__/server/metrics.test.js
@@ -298,13 +298,16 @@ describe('buildBreakdownData', () => {
 });
 
 describe('computeAllMetrics', () => {
-  it('returns metrics, trendData, and breakdown', () => {
+  it('returns metrics, trendData, breakdown, and pipelineFriction', () => {
     const issues = [makeIssue(5, 'created')];
     const result = computeAllMetrics(issues, 'month', { trendThresholdPp: 2 });
 
     expect(result).toHaveProperty('metrics');
     expect(result).toHaveProperty('trendData');
     expect(result).toHaveProperty('breakdown');
+    expect(result).toHaveProperty('pipelineFriction');
     expect(result.trendData).toHaveLength(8);
+    expect(result.pipelineFriction).toHaveProperty('needsAttentionPct');
+    expect(result.pipelineFriction).toHaveProperty('feasibilityBlockedPct');
   });
 });

--- a/modules/ai-impact/__tests__/server/pipeline-friction.test.js
+++ b/modules/ai-impact/__tests__/server/pipeline-friction.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { computePipelineFrictionMetrics, FRICTION_LABELS } from '../../server/metrics.js';
+
+function makeIssue(daysAgo, aiInvolvement, labels = []) {
+  const created = new Date();
+  created.setDate(created.getDate() - daysAgo);
+  return {
+    key: `RFE-${Math.random().toString(36).slice(2, 6)}`,
+    summary: 'Test RFE',
+    status: 'New',
+    created: created.toISOString(),
+    aiInvolvement,
+    labels
+  };
+}
+
+const CONFIG = { trendThresholdPp: 2 };
+
+describe('computePipelineFrictionMetrics', () => {
+  it('returns zeros when there are no issues', () => {
+    const result = computePipelineFrictionMetrics([], 'month', CONFIG);
+    expect(result.needsAttentionPct).toBe(0);
+    expect(result.needsAttentionChange).toBe(0);
+    expect(result.needsAttentionTrend).toBe('stable');
+    expect(result.feasibilityBlockedPct).toBe(0);
+    expect(result.feasibilityBlockedChange).toBe(0);
+    expect(result.feasibilityBlockedTrend).toBe('stable');
+  });
+
+  it('returns zeros not NaN when denominator is 0', () => {
+    const issues = [makeIssue(5, 'none', [])];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    expect(result.needsAttentionPct).toBe(0);
+    expect(result.feasibilityBlockedPct).toBe(0);
+  });
+
+  it('excludes non-AI-touched RFEs from denominator', () => {
+    const issues = [
+      makeIssue(5, 'none', [FRICTION_LABELS.needsAttention]),
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    // Denominator = 1 (only the 'created' issue), 1 needs-attention → 100%
+    expect(result.needsAttentionPct).toBe(100);
+  });
+
+  it('computes needs attention percentage correctly', () => {
+    const issues = [
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(5, 'both', []),
+      makeIssue(5, 'revised', []),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    // 2 of 4 AI-touched = 50%
+    expect(result.needsAttentionPct).toBe(50);
+  });
+
+  it('counts feasibility blocked when either fail or unknown label present', () => {
+    const issues = [
+      makeIssue(5, 'created', [FRICTION_LABELS.feasibilityFail]),
+      makeIssue(5, 'created', [FRICTION_LABELS.feasibilityUnknown]),
+      makeIssue(5, 'both', []),
+      makeIssue(5, 'both', []),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    // 2 of 4 = 50%
+    expect(result.feasibilityBlockedPct).toBe(50);
+  });
+
+  it('does not double-count an issue with both feasibility fail and unknown', () => {
+    const issues = [
+      makeIssue(5, 'created', [FRICTION_LABELS.feasibilityFail, FRICTION_LABELS.feasibilityUnknown]),
+      makeIssue(5, 'created', []),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    // 1 of 2 = 50% (not 100%)
+    expect(result.feasibilityBlockedPct).toBe(50);
+  });
+
+  it('computes prior-period delta and trends for needs attention', () => {
+    const issues = [
+      // Current period: 2 of 2 = 100%
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+      // Prior period: 0 of 2 = 0%
+      makeIssue(35, 'created', []),
+      makeIssue(35, 'both', []),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    expect(result.needsAttentionPct).toBe(100);
+    expect(result.needsAttentionChange).toBe(100);
+    expect(result.needsAttentionTrend).toBe('worsening');
+  });
+
+  it('computes improving trend when friction decreases', () => {
+    const issues = [
+      // Current: 0 of 2 = 0%
+      makeIssue(5, 'created', []),
+      makeIssue(5, 'both', []),
+      // Prior: 2 of 2 = 100%
+      makeIssue(35, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(35, 'both', [FRICTION_LABELS.needsAttention]),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    expect(result.needsAttentionTrend).toBe('improving');
+    expect(result.needsAttentionChange).toBe(-100);
+  });
+
+  it('classifies stable when change is within threshold', () => {
+    const issues = [
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(5, 'created', []),
+      makeIssue(35, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(35, 'created', []),
+    ];
+    const result = computePipelineFrictionMetrics(issues, 'month', CONFIG);
+    // Both 50% → change = 0 → stable
+    expect(result.needsAttentionTrend).toBe('stable');
+    expect(result.needsAttentionChange).toBe(0);
+  });
+
+  it('uses configurable threshold', () => {
+    const issues = [
+      makeIssue(5, 'created', [FRICTION_LABELS.needsAttention]),
+      makeIssue(5, 'created', []),
+      makeIssue(35, 'created', []),
+      makeIssue(35, 'created', []),
+    ];
+    // Change = 50 - 0 = 50pp
+    const highThreshold = computePipelineFrictionMetrics(issues, 'month', { trendThresholdPp: 60 });
+    expect(highThreshold.needsAttentionTrend).toBe('stable');
+
+    const lowThreshold = computePipelineFrictionMetrics(issues, 'month', { trendThresholdPp: 2 });
+    expect(lowThreshold.needsAttentionTrend).toBe('worsening');
+  });
+
+  it('handles null config gracefully', () => {
+    const result = computePipelineFrictionMetrics([], 'month', null);
+    expect(result.needsAttentionTrend).toBe('stable');
+  });
+
+  it('works across all time windows', () => {
+    const issues = [makeIssue(3, 'created', [FRICTION_LABELS.needsAttention])];
+    expect(() => computePipelineFrictionMetrics(issues, 'week', CONFIG)).not.toThrow();
+    expect(() => computePipelineFrictionMetrics(issues, 'month', CONFIG)).not.toThrow();
+    expect(() => computePipelineFrictionMetrics(issues, '3months', CONFIG)).not.toThrow();
+  });
+});

--- a/modules/ai-impact/client/components/MetricsRow.vue
+++ b/modules/ai-impact/client/components/MetricsRow.vue
@@ -3,6 +3,10 @@ defineProps({
   metrics: {
     type: Object,
     default: null
+  },
+  pipelineFriction: {
+    type: Object,
+    default: null
   }
 })
 
@@ -15,6 +19,12 @@ function getTrendClass(trend) {
 function formatChange(change) {
   if (change > 0) return `+${change}%`
   return `${change}%`
+}
+
+function formatFrictionChange(change) {
+  if (change > 0) return `+${change}pp`
+  if (change < 0) return `${change}pp`
+  return '—'
 }
 </script>
 
@@ -33,7 +43,6 @@ function formatChange(change) {
         <div class="flex items-baseline gap-2">
           <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.createdPct }}%</span>
           <span class="text-sm flex items-center gap-1" :class="getTrendClass(metrics.trend)">
-            <!-- Trend arrow -->
             <svg v-if="metrics.trend === 'growing'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
             </svg>
@@ -46,6 +55,10 @@ function formatChange(change) {
             {{ formatChange(metrics.createdChange) }}
           </span>
         </div>
+        <p v-if="pipelineFriction" class="text-xs text-gray-400 dark:text-gray-500">
+          {{ pipelineFriction.needsAttentionPct }}% require attention
+          <span class="ml-1">{{ formatFrictionChange(pipelineFriction.needsAttentionChange) }}</span>
+        </p>
       </div>
 
       <!-- Revised with AI -->
@@ -63,6 +76,10 @@ function formatChange(change) {
             {{ metrics.priorRevisedCount }} prev period
           </span>
         </div>
+        <p v-if="pipelineFriction" class="text-xs text-gray-400 dark:text-gray-500">
+          {{ pipelineFriction.feasibilityBlockedPct }}% feasibility blocked
+          <span class="ml-1">{{ formatFrictionChange(pipelineFriction.feasibilityBlockedChange) }}</span>
+        </p>
       </div>
 
       <!-- Total RFEs -->

--- a/modules/ai-impact/client/components/PhaseContent.vue
+++ b/modules/ai-impact/client/components/PhaseContent.vue
@@ -25,7 +25,8 @@ const props = defineProps({
   priorityFilter: { type: String, default: 'all' },
   statusFilter: { type: String, default: 'all' },
   selectedRFE: { type: Object, default: null },
-  rfeToFeature: { type: Object, default: () => ({}) }
+  rfeToFeature: { type: Object, default: () => ({}) },
+  pipelineFriction: { type: Object, default: null }
 })
 
 const emit = defineEmits([
@@ -105,7 +106,7 @@ const isEmpty = computed(() => !props.rfeData?.fetchedAt)
 
       <!-- Data display -->
       <template v-else>
-        <MetricsRow :metrics="metrics" />
+        <MetricsRow :metrics="metrics" :pipelineFriction="pipelineFriction" />
 
         <TrendCharts
           :trendData="trendData"

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -34,6 +34,7 @@ const phase = PHASES.find(p => p.id === 'rfe-review')
 const metrics = computed(() => rfeData.value?.metrics || null)
 const trendData = computed(() => rfeData.value?.trendData || [])
 const breakdown = computed(() => rfeData.value?.breakdown || [])
+const pipelineFriction = computed(() => rfeData.value?.pipelineFriction || null)
 
 const timeWindowCutoff = computed(() => {
   const days = timeWindow.value === 'week' ? 7 : timeWindow.value === '3months' ? 90 : 30
@@ -174,6 +175,7 @@ watch([() => moduleNav.params.value, rfeData], ([params]) => {
       :statusFilter="statusFilter"
       :selectedRFE="selectedRFE"
       :rfeToFeature="rfeToFeature"
+      :pipelineFriction="pipelineFriction"
       @update:timeWindow="timeWindow = $event"
       @update:filter="filter = $event"
       @update:searchQuery="searchQuery = $event"

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -60,6 +60,24 @@ module.exports = function registerRoutes(router, context) {
 
   const VALID_TIME_WINDOWS = ['week', 'month', '3months'];
 
+  /**
+   * @openapi
+   * /modules/ai-impact/rfe-data:
+   *   get:
+   *     summary: RFE data with computed metrics and pipeline friction
+   *     tags: [ai-impact]
+   *     parameters:
+   *       - in: query
+   *         name: timeWindow
+   *         schema:
+   *           type: string
+   *           enum: [week, month, 3months]
+   *           default: month
+   *         description: Time window for metric computation
+   *     responses:
+   *       200:
+   *         description: RFE dataset with metrics, trend data, breakdown, and pipeline friction
+   */
   router.get('/rfe-data', requireScope('ai-impact:read'), function(req, res) {
     const timeWindow = VALID_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow
@@ -73,13 +91,14 @@ module.exports = function registerRoutes(router, context) {
         metrics: { createdPct: 0, createdChange: 0, trend: 'stable', revisedCount: 0, priorRevisedCount: 0, windowTotal: 0, totalRFEs: 0 },
         trendData: [],
         breakdown: [],
+        pipelineFriction: { needsAttentionPct: 0, needsAttentionChange: 0, needsAttentionTrend: 'stable', feasibilityBlockedPct: 0, feasibilityBlockedChange: 0, feasibilityBlockedTrend: 'stable' },
         issues: []
       });
     }
 
     // Compute metrics server-side from cached issues
     const config = getConfig(readFromStorage);
-    const { metrics, trendData, breakdown } = computeAllMetrics(data.issues, timeWindow, config);
+    const { metrics, trendData, breakdown, pipelineFriction } = computeAllMetrics(data.issues, timeWindow, config);
 
     res.json({
       fetchedAt: data.fetchedAt,
@@ -87,6 +106,7 @@ module.exports = function registerRoutes(router, context) {
       metrics,
       trendData,
       breakdown,
+      pipelineFriction,
       issues: data.issues
     });
   });

--- a/modules/ai-impact/server/metrics.js
+++ b/modules/ai-impact/server/metrics.js
@@ -1,3 +1,72 @@
+const FRICTION_LABELS = {
+  needsAttention: 'rfe-creator-needs-attention',
+  feasibilityFail: 'rfe-creator-feasibility-fail',
+  feasibilityUnknown: 'rfe-creator-feasibility-unknown'
+};
+
+/**
+ * Compute pipeline friction metrics for a given time window.
+ *
+ * Denominator is AI-touched RFEs only (aiInvolvement !== 'none').
+ *
+ * @param {Array} issues - Cached RFE issue list
+ * @param {string} timeWindow - 'week' | 'month' | '3months'
+ * @param {object} config - Module config (for trendThresholdPp)
+ */
+function computePipelineFrictionMetrics(issues, timeWindow, config) {
+  const threshold = config?.trendThresholdPp || 2;
+  const now = new Date();
+  const { cutoff, priorCutoff } = getTimeWindowDates(now, timeWindow);
+
+  const currentAI = issues.filter(i =>
+    i.aiInvolvement !== 'none' && new Date(i.created) >= cutoff);
+  const priorAI = issues.filter(i => {
+    const d = new Date(i.created);
+    return i.aiInvolvement !== 'none' && d >= priorCutoff && d < cutoff;
+  });
+
+  function pct(subset, total) {
+    return total > 0 ? Math.round((subset / total) * 100) : 0;
+  }
+
+  function frictionTrend(change) {
+    if (change > threshold) return 'worsening';
+    if (change < -threshold) return 'improving';
+    return 'stable';
+  }
+
+  const currentNeedsAttention = currentAI.filter(i =>
+    (i.labels || []).includes(FRICTION_LABELS.needsAttention)).length;
+  const priorNeedsAttention = priorAI.filter(i =>
+    (i.labels || []).includes(FRICTION_LABELS.needsAttention)).length;
+
+  const needsAttentionPct = pct(currentNeedsAttention, currentAI.length);
+  const priorNeedsAttentionPct = pct(priorNeedsAttention, priorAI.length);
+  const needsAttentionChange = needsAttentionPct - priorNeedsAttentionPct;
+
+  const currentFeasBlocked = currentAI.filter(i => {
+    const labels = new Set(i.labels || []);
+    return labels.has(FRICTION_LABELS.feasibilityFail) || labels.has(FRICTION_LABELS.feasibilityUnknown);
+  }).length;
+  const priorFeasBlocked = priorAI.filter(i => {
+    const labels = new Set(i.labels || []);
+    return labels.has(FRICTION_LABELS.feasibilityFail) || labels.has(FRICTION_LABELS.feasibilityUnknown);
+  }).length;
+
+  const feasibilityBlockedPct = pct(currentFeasBlocked, currentAI.length);
+  const priorFeasibilityBlockedPct = pct(priorFeasBlocked, priorAI.length);
+  const feasibilityBlockedChange = feasibilityBlockedPct - priorFeasibilityBlockedPct;
+
+  return {
+    needsAttentionPct,
+    needsAttentionChange,
+    needsAttentionTrend: frictionTrend(needsAttentionChange),
+    feasibilityBlockedPct,
+    feasibilityBlockedChange,
+    feasibilityBlockedTrend: frictionTrend(feasibilityBlockedChange)
+  };
+}
+
 /**
  * Compute adoption metrics for a given time window.
  *
@@ -8,7 +77,7 @@
  * @param {Array} issues - Cached RFE issue list
  * @param {string} timeWindow - 'week' | 'month' | '3months'
  * @param {object} config - Module config (for trendThresholdPp)
- * @returns {{ metrics, trendData, breakdown }}
+ * @returns {{ metrics, trendData, breakdown, pipelineFriction }}
  */
 function computeAllMetrics(issues, timeWindow, config) {
   const { cutoff } = getTimeWindowDates(new Date(), timeWindow);
@@ -16,7 +85,8 @@ function computeAllMetrics(issues, timeWindow, config) {
   return {
     metrics: computeMetrics(issues, timeWindow, config),
     trendData: buildTrendData(issues, timeWindow),
-    breakdown: buildBreakdownData(windowIssues)
+    breakdown: buildBreakdownData(windowIssues),
+    pipelineFriction: computePipelineFrictionMetrics(issues, timeWindow, config)
   };
 }
 
@@ -119,4 +189,4 @@ function buildBreakdownData(issues) {
   ];
 }
 
-module.exports = { computeAllMetrics, computeMetrics, buildTrendData, buildBreakdownData, getTimeWindowDates };
+module.exports = { computeAllMetrics, computeMetrics, buildTrendData, buildBreakdownData, getTimeWindowDates, computePipelineFrictionMetrics, FRICTION_LABELS };


### PR DESCRIPTION
Add RFE pipeline friction metrics to RFE Review

Org Pulse tracks AI RFE usage but has no signal for frictions along the way. The labels exist are pulled from jira, but this should be shown with the rest of the metrics. 

What's added: Two subtle rates appear as sub-text inside the existing adoption cards — no new layout or data figures.

"Created with AI" → X% require attention (RFEs flagged for human cleanup)
"Revised with AI" → X% feasibility blocked (RFEs the pipeline couldn't clear)
Both show pp change vs the prior period so trend direction is visible at a glance.

Scope: metrics.js aggregation, MetricsRow.vue sub-text, fixtures updated, unit tests added, DATA-FORMATS.md documented. No new Jira fetch, no new component, no new nav.

Submitted by Matthew Chiccino, AI Team PM Intern. My project initiative to surface pipeline friction alongside adoption — making Org Pulse reflect true ADLC efficiency, not just volume.