### PR TITLE
fix(releases): show Jira status in Status column, constrain Team width

### DIFF
--- a/shared/__tests__/client/FeatureReadinessRow.test.js
+++ b/shared/__tests__/client/FeatureReadinessRow.test.js
@@ -75,9 +75,9 @@ describe('FeatureReadinessRow', () => {
       expect(wrapper.find('.italic').exists()).toBe(false)
     })
 
-    it('shows humanReviewStatus badge in status column', () => {
-      const wrapper = mountRow(makeFeature({ humanReviewStatus: 'approved' }))
-      expect(wrapper.text()).toContain('Approved')
+    it('shows Jira status in status column', () => {
+      const wrapper = mountRow(makeFeature({ status: 'In Progress' }))
+      expect(wrapper.text()).toContain('In Progress')
     })
 
     it('shows recommendation label', () => {
@@ -85,14 +85,14 @@ describe('FeatureReadinessRow', () => {
       expect(wrapper.text()).toContain('Approve')
     })
 
-    it('shows Awaiting Sign-off for awaiting-review status', () => {
-      const wrapper = mountRow(makeFeature({ humanReviewStatus: 'awaiting-review' }))
-      expect(wrapper.text()).toContain('Awaiting Sign-off')
+    it('shows Refinement status', () => {
+      const wrapper = mountRow(makeFeature({ status: 'Refinement' }))
+      expect(wrapper.text()).toContain('Refinement')
     })
 
-    it('shows Flagged for needs-review status', () => {
-      const wrapper = mountRow(makeFeature({ humanReviewStatus: 'needs-review' }))
-      expect(wrapper.text()).toContain('Flagged')
+    it('shows dash for missing status', () => {
+      const wrapper = mountRow(makeFeature({ status: null }))
+      expect(wrapper.text()).toContain('—')
     })
   })
 

--- a/shared/client/components/FeatureReadinessRow.vue
+++ b/shared/client/components/FeatureReadinessRow.vue
@@ -163,7 +163,7 @@ const confidenceTooltip = computed(() => {
 
     <!-- Team -->
     <td class="px-3 py-2.5 whitespace-nowrap max-w-[10rem]">
-      <span class="text-xs text-gray-700 dark:text-gray-300 block truncate" :title="feature.team || ''">{{ feature.team || '—' }}</span>
+      <span class="text-xs text-gray-700 dark:text-gray-300 block truncate" :title="feature.team || undefined">{{ feature.team || '—' }}</span>
     </td>
 
     <!-- Rubric (compact dots) -->

--- a/shared/client/components/FeatureReadinessRow.vue
+++ b/shared/client/components/FeatureReadinessRow.vue
@@ -30,24 +30,6 @@ function recommendationLabel(rec) {
   }
 }
 
-function reviewStatusClass(status) {
-  switch (status) {
-    case 'approved':        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
-    case 'needs-review':    return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
-    case 'awaiting-review': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200'
-    default:                return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
-  }
-}
-
-function reviewStatusLabel(status) {
-  switch (status) {
-    case 'approved':        return 'Approved'
-    case 'needs-review':    return 'Flagged'
-    case 'awaiting-review': return 'Awaiting Sign-off'
-    default:                return 'Awaiting Sign-off'
-  }
-}
-
 const priorityDisplay = computed(() => {
   const score = props.feature.effectivePriorityScore
   if (score == null) return '—'
@@ -180,8 +162,8 @@ const confidenceTooltip = computed(() => {
     </td>
 
     <!-- Team -->
-    <td class="px-3 py-2.5 whitespace-nowrap">
-      <span class="text-xs text-gray-700 dark:text-gray-300">{{ feature.team || '—' }}</span>
+    <td class="px-3 py-2.5 whitespace-nowrap max-w-[10rem]">
+      <span class="text-xs text-gray-700 dark:text-gray-300 block truncate" :title="feature.team || ''">{{ feature.team || '—' }}</span>
     </td>
 
     <!-- Rubric (compact dots) -->
@@ -198,20 +180,9 @@ const confidenceTooltip = computed(() => {
       >{{ recommendationLabel(feature.recommendation) }}</span>
     </td>
 
-    <!-- Status -->
+    <!-- Status (Jira workflow status) -->
     <td class="px-3 py-2.5 whitespace-nowrap">
-      <template v-if="isHealthPipeline">
-        <span
-          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-          :class="confidenceClass"
-        >{{ confidenceLabel }}</span>
-      </template>
-      <template v-else>
-        <span
-          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-          :class="reviewStatusClass(feature.humanReviewStatus)"
-        >{{ reviewStatusLabel(feature.humanReviewStatus) }}</span>
-      </template>
+      <span class="text-xs text-gray-700 dark:text-gray-300">{{ feature.status || '—' }}</span>
     </td>
 
     <!-- Priority -->


### PR DESCRIPTION
## Summary

- **Status column**: Was redundantly showing readiness/review badges (Approved/Awaiting Sign-off/Flagged or Ready/Not Ready) already displayed in the Readiness column. Now shows the Jira workflow status (New, Refinement, In Progress, etc.) which is more useful for triage.
- **Team column**: Added `max-w-[10rem]` with `truncate` and hover tooltip so long team names like "RHOAI Model Server and Serving Metrics" don't stretch the table.
- Removed unused `reviewStatusClass` and `reviewStatusLabel` functions from FeatureReadinessRow.

## Test plan

- 17 FeatureReadinessRow component tests passing (3 updated for new Status column behavior)