### PR TITLE
feat(releases): scoring completeness penalty, breakdown UI, dynamic hygiene

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -9,7 +9,8 @@ const {
   computeTargetVersionScore,
   hasBlockingViolations,
   computeConfidence,
-  collectFilterMeta
+  collectFilterMeta,
+  MAX_SIGNALS
 } = require('../feature-readiness')
 
 // ---------------------------------------------------------------------------
@@ -309,56 +310,85 @@ describe('computeConfidence', function() {
 // ---------------------------------------------------------------------------
 
 describe('computeBestAvailableScore', function() {
+  it('returns an object with score, rawScore, signals, and breakdown fields', function() {
+    var result = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T1' })
+    expect(result).toHaveProperty('score')
+    expect(result).toHaveProperty('rawScore')
+    expect(result).toHaveProperty('signals')
+    expect(result).toHaveProperty('signalCount')
+    expect(result).toHaveProperty('maxSignals', MAX_SIGNALS)
+    expect(result).toHaveProperty('completenessMultiplier')
+    expect(result).toHaveProperty('missing')
+    expect(Array.isArray(result.signals)).toBe(true)
+    expect(Array.isArray(result.missing)).toBe(true)
+  })
+
   describe('signals: rubric proxy + priority only (no riceScore, no tier, no target version)', function() {
-    it('Blocker priority + rubricTotal=8 → 100', function() {
-      // (1.0*30 + 1.0*25) / 55 * 100 = 100
-      expect(computeBestAvailableScore({ priority: 'Blocker', rubricTotal: 8 })).toBe(100)
+    it('Blocker priority + rubricTotal=8 rawScore=100, penalized by completeness', function() {
+      var result = computeBestAvailableScore({ priority: 'Blocker', rubricTotal: 8 })
+      expect(result.rawScore).toBe(100)
+      expect(result.signalCount).toBe(2)
+      expect(result.completenessMultiplier).toBe(0.7)
+      expect(result.score).toBe(70)
     })
 
-    it('Normal priority + rubricTotal=4 → 45', function() {
-      // (0.5*30 + 0.4*25) / 55 * 100 = round(45.45) = 45
-      expect(computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4 })).toBe(45)
+    it('Normal priority + rubricTotal=4 rawScore=45, penalized', function() {
+      var result = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4 })
+      expect(result.rawScore).toBe(45)
+      expect(result.signalCount).toBe(2)
+      expect(result.score).toBe(Math.round(45 * 0.7))
     })
 
     it('unknown priority with rubricTotal=0 redistributes to priority only', function() {
-      // hasValueSignal=false, only priority signal: (0.4*35) / 35 * 100 = 40
-      expect(computeBestAvailableScore({ priority: 'Unknown', rubricTotal: 0 })).toBe(40)
+      var result = computeBestAvailableScore({ priority: 'Unknown', rubricTotal: 0 })
+      expect(result.rawScore).toBe(40)
+      expect(result.signalCount).toBe(1)
+      expect(result.completenessMultiplier).toBe(0.5)
+      expect(result.score).toBe(20)
     })
 
     it('missing priority uses 0.4 fallback', function() {
-      expect(computeBestAvailableScore({ rubricTotal: 0 })).toBe(40)
+      var result = computeBestAvailableScore({ rubricTotal: 0 })
+      expect(result.rawScore).toBe(40)
+      expect(result.signalCount).toBe(1)
+      expect(result.score).toBe(20)
     })
 
     it('missing rubricTotal redistributes weights', function() {
-      // hasValueSignal=false, only priority: (1.0*35) / 35 * 100 = 100
-      expect(computeBestAvailableScore({ priority: 'Blocker' })).toBe(100)
+      var result = computeBestAvailableScore({ priority: 'Blocker' })
+      expect(result.rawScore).toBe(100)
+      expect(result.signalCount).toBe(1)
+      expect(result.score).toBe(50)
     })
   })
 
   describe('signals: rubric proxy + priority + tier (no riceScore, no target version)', function() {
-    it('Blocker + rubricTotal=8 + T1 → 100', function() {
-      // hasValueSignal=true, totalWeight = 30 + 25 + 25 = 80
-      // (1.0*30 + 1.0*25 + 1.0*25) / 80 * 100 = 100
-      expect(computeBestAvailableScore({ priority: 'Blocker', rubricTotal: 8, tier: 'T1' })).toBe(100)
+    it('Blocker + rubricTotal=8 + T1 rawScore=100, 3 signals', function() {
+      var result = computeBestAvailableScore({ priority: 'Blocker', rubricTotal: 8, tier: 'T1' })
+      expect(result.rawScore).toBe(100)
+      expect(result.signalCount).toBe(3)
+      expect(result.completenessMultiplier).toBe(0.85)
+      expect(result.score).toBe(85)
     })
 
-    it('Normal + rubricTotal=4 + T2 → 49', function() {
-      // rubricProxy=4/8=0.5, tier=T2=0.6, priority=0.4
-      // (0.5*30 + 0.6*25 + 0.4*25) / 80 * 100
-      // = (15 + 15 + 10) / 80 * 100 = 50
-      expect(computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T2' })).toBe(50)
+    it('Normal + rubricTotal=4 + T2 rawScore=50, 3 signals', function() {
+      var result = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T2' })
+      expect(result.rawScore).toBe(50)
+      expect(result.signalCount).toBe(3)
+      expect(result.score).toBe(Math.round(50 * 0.85))
     })
   })
 
   describe('signals with target version', function() {
-    it('includes target version weight when configured versions provided', function() {
-      // hasValueSignal=true (rubric>0), all signals: rubric(30) + tier(25) + priority(25) + tv(20) = 100
-      // rubric=1.0, tier=T1=1.0, priority=Blocker=1.0, tv=first=1.0
-      var score = computeBestAvailableScore(
+    it('all 4 signals: no completeness penalty', function() {
+      var result = computeBestAvailableScore(
         { priority: 'Blocker', rubricTotal: 8, tier: 'T1', targetVersions: ['3.6'] },
         ['3.6']
       )
-      expect(score).toBe(100)
+      expect(result.signalCount).toBe(4)
+      expect(result.completenessMultiplier).toBe(1.0)
+      expect(result.rawScore).toBe(result.score)
+      expect(result.score).toBe(100)
     })
 
     it('later target version lowers score', function() {
@@ -370,7 +400,7 @@ describe('computeBestAvailableScore', function() {
         { priority: 'Normal', rubricTotal: 4, tier: 'T1', targetVersions: ['3.7'] },
         ['3.5', '3.6', '3.7']
       )
-      expect(first).toBeGreaterThan(last)
+      expect(first.score).toBeGreaterThan(last.score)
     })
 
     it('no target version gives lowest tv score', function() {
@@ -382,7 +412,7 @@ describe('computeBestAvailableScore', function() {
         { priority: 'Normal', rubricTotal: 4, tier: 'T1', targetVersions: [] },
         ['3.6']
       )
-      expect(withTv).toBeGreaterThan(noTv)
+      expect(withTv.score).toBeGreaterThan(noTv.score)
     })
   })
 
@@ -390,30 +420,36 @@ describe('computeBestAvailableScore', function() {
     it('T1 rock priority 1 scores higher than rock priority 8', function() {
       var rock1 = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T1', rockPriority: 1 })
       var rock8 = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T1', rockPriority: 8 })
-      expect(rock1).toBeGreaterThan(rock8)
+      expect(rock1.score).toBeGreaterThan(rock8.score)
     })
 
     it('T2 rockPriority is ignored', function() {
       var rock1 = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T2', rockPriority: 1 })
       var rock8 = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 4, tier: 'T2', rockPriority: 8 })
-      expect(rock1).toBe(rock8)
+      expect(rock1.score).toBe(rock8.score)
     })
   })
 
   describe('signals: no RICE, no rubric (health-pipeline features)', function() {
-    it('T1 + Blocker → high score', function() {
-      var score = computeBestAvailableScore({ priority: 'Blocker', rubricTotal: 0, tier: 'T1' })
-      expect(score).toBeGreaterThanOrEqual(70)
+    it('T1 + Blocker with 2 signals', function() {
+      var result = computeBestAvailableScore({ priority: 'Blocker', rubricTotal: 0, tier: 'T1' })
+      expect(result.signalCount).toBe(2)
+      expect(result.completenessMultiplier).toBe(0.7)
+      expect(result.rawScore).toBe(100)
+      expect(result.score).toBe(70)
     })
 
-    it('no tier → only priority', function() {
-      // (0.4*35) / 35 * 100 = 40
-      expect(computeBestAvailableScore({ priority: 'Normal', rubricTotal: 0 })).toBe(40)
+    it('no tier, only priority = 1 signal', function() {
+      var result = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 0 })
+      expect(result.signalCount).toBe(1)
+      expect(result.completenessMultiplier).toBe(0.5)
+      expect(result.score).toBe(20)
     })
 
-    it('tier + priority, no target version → two signals', function() {
-      var score = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 0, tier: 'T1' })
-      expect(score).toBeGreaterThan(40)
+    it('tier + priority, no target version = 2 signals', function() {
+      var result = computeBestAvailableScore({ priority: 'Normal', rubricTotal: 0, tier: 'T1' })
+      expect(result.signalCount).toBe(2)
+      expect(result.score).toBeGreaterThan(20)
     })
   })
 
@@ -421,7 +457,47 @@ describe('computeBestAvailableScore', function() {
     it('RICE present drops rubric proxy', function() {
       var withRice = computeBestAvailableScore({ priority: 'Blocker', riceScore: 1690, tier: 'T1', rubricTotal: 8 })
       var withoutRice = computeBestAvailableScore({ priority: 'Blocker', riceScore: 1690, tier: 'T1', rubricTotal: 0 })
-      expect(withRice).toBe(withoutRice)
+      expect(withRice.score).toBe(withoutRice.score)
+    })
+  })
+
+  describe('completeness penalty', function() {
+    it('4 signals get no penalty (1.0x)', function() {
+      var result = computeBestAvailableScore(
+        { priority: 'Major', rubricTotal: 6, tier: 'T2', targetVersions: ['3.6'] },
+        ['3.6']
+      )
+      expect(result.signalCount).toBe(4)
+      expect(result.completenessMultiplier).toBe(1.0)
+      expect(result.score).toBe(result.rawScore)
+    })
+
+    it('fewer signals produce lower scores for same raw inputs', function() {
+      var four = computeBestAvailableScore(
+        { priority: 'Major', rubricTotal: 6, tier: 'T2', targetVersions: ['3.6'] },
+        ['3.6']
+      )
+      var two = computeBestAvailableScore(
+        { priority: 'Major', rubricTotal: 6 }
+      )
+      expect(four.score).toBeGreaterThan(two.score)
+    })
+
+    it('missing signals are listed in the missing array', function() {
+      var result = computeBestAvailableScore({ priority: 'Major' })
+      expect(result.missing).toContain('RICE Score')
+      expect(result.missing).toContain('Tier')
+      expect(result.missing).toContain('Target Version')
+    })
+
+    it('signal objects have name, value, weight, and raw', function() {
+      var result = computeBestAvailableScore({ priority: 'Major', rubricTotal: 6, tier: 'T1' })
+      for (var i = 0; i < result.signals.length; i++) {
+        expect(result.signals[i]).toHaveProperty('name')
+        expect(result.signals[i]).toHaveProperty('value')
+        expect(result.signals[i]).toHaveProperty('weight')
+        expect(result.signals[i]).toHaveProperty('raw')
+      }
     })
   })
 })

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -43,25 +43,35 @@ function computeTargetVersionScore(feature, configuredVersions) {
   return 1.0 - (bestIndex / (configuredVersions.length - 1)) * 0.7
 }
 
+var COMPLETENESS_MULTIPLIERS = [0, 0.5, 0.7, 0.85, 1.0]
+var MAX_SIGNALS = 4
+
 function computeBestAvailableScore(feature, configuredVersions) {
   var signals = []
+  var missing = []
   var hasValueSignal = feature.riceScore != null || (feature.rubricTotal || 0) > 0
 
   if (feature.riceScore != null) {
-    signals.push({ value: feature.riceScore / RICE_MAX, weight: 30 })
+    signals.push({ name: "RICE Score", value: feature.riceScore / RICE_MAX, weight: 30, raw: feature.riceScore })
   } else if ((feature.rubricTotal || 0) > 0) {
-    signals.push({ value: feature.rubricTotal / 8, weight: 30 })
+    signals.push({ name: "Rubric", value: feature.rubricTotal / 8, weight: 30, raw: feature.rubricTotal })
+  } else {
+    missing.push("RICE Score")
   }
 
   if (feature.tier != null) {
-    signals.push({ value: computeTierScore(feature), weight: hasValueSignal ? 25 : 40 })
+    signals.push({ name: "Tier", value: computeTierScore(feature), weight: hasValueSignal ? 25 : 40, raw: feature.tier })
+  } else {
+    missing.push("Tier")
   }
 
-  signals.push({ value: PRIORITY_SCORES[feature.priority] || 0.4, weight: hasValueSignal ? 25 : 35 })
+  signals.push({ name: "Priority", value: PRIORITY_SCORES[feature.priority] || 0.4, weight: hasValueSignal ? 25 : 35, raw: feature.priority || "Normal" })
 
   var tvScore = computeTargetVersionScore(feature, configuredVersions)
   if (tvScore != null) {
-    signals.push({ value: tvScore, weight: hasValueSignal ? 20 : 25 })
+    signals.push({ name: "Target Version", value: tvScore, weight: hasValueSignal ? 20 : 25, raw: (feature.targetVersions || []).join(", ") || "none" })
+  } else {
+    missing.push("Target Version")
   }
 
   var totalWeight = 0
@@ -71,7 +81,20 @@ function computeBestAvailableScore(feature, configuredVersions) {
     weightedSum += signals[i].value * signals[i].weight
   }
 
-  return Math.round((weightedSum / totalWeight) * 100)
+  var rawScore = Math.round((weightedSum / totalWeight) * 100)
+  var signalCount = signals.length
+  var completenessMultiplier = COMPLETENESS_MULTIPLIERS[Math.min(signalCount, MAX_SIGNALS)]
+  var score = Math.round(rawScore * completenessMultiplier)
+
+  return {
+    score: score,
+    rawScore: rawScore,
+    signals: signals,
+    signalCount: signalCount,
+    maxSignals: MAX_SIGNALS,
+    completenessMultiplier: completenessMultiplier,
+    missing: missing
+  }
 }
 
 function computeBlockers(feature, productPath) {
@@ -347,12 +370,14 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
     var team = teamIndex.get(key) || (jiraFeatures && jiraFeatures.has(key) ? jiraFeatures.get(key).team : null) || null
 
     var priorityScore = healthData ? (healthData.priorityScore != null ? healthData.priorityScore : null) : null
-    var priorityScoreBreakdown = healthData ? (healthData.priorityBreakdown || healthData.priorityScoreBreakdown || null) : null
-
     var priorityScoreFallback = priorityScore === null
-    var effectivePriorityScore = priorityScore !== null
-      ? priorityScore
-      : computeBestAvailableScore(Object.assign({}, latest, { rubricTotal: rubricTotal, tier: tier, rockPriority: rockPriority, targetVersions: targetVersions }), configuredVersions)
+    var fallbackResult = priorityScoreFallback
+      ? computeBestAvailableScore(Object.assign({}, latest, { rubricTotal: rubricTotal, tier: tier, rockPriority: rockPriority, targetVersions: targetVersions }), configuredVersions)
+      : null
+    var effectivePriorityScore = priorityScoreFallback ? fallbackResult.score : priorityScore
+    var priorityScoreBreakdown = priorityScoreFallback
+      ? fallbackResult
+      : (healthData ? (healthData.priorityBreakdown || healthData.priorityScoreBreakdown || null) : null)
 
     var blockerResult = computeBlockers(Object.assign({}, latest, { rubricTotal: rubricTotal }))
 
@@ -365,6 +390,23 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       : (healthComponents.length > 0 ? healthComponents : jiraComponents)
 
     var violations = hygieneIndex.get(key) || null
+    if (!violations && jiraFeatures && jiraFeatures.has(key)) {
+      try {
+        var jf = jiraFeatures.get(key)
+        violations = evaluateHygiene({
+          key: key, summary: jf.summary || latest.title, status: jf.status || latest.status,
+          issueType: jf.issueType, assignee: jf.assignee, team: team,
+          components: componentsList, fixVersions: jf.fixVersions || [],
+          labels: jf.labels || [], statusSummary: jf.statusSummary || null,
+          colorStatus: jf.colorStatus || null, releaseType: jf.releaseType || null,
+          docsRequired: jf.docsRequired || null, targetEnd: jf.targetEnd || null,
+          riceScore: jf.riceScore || null
+        }, hygieneRulesConfig)
+        if (violations && violations.length === 0) violations = null
+      } catch {
+        // dynamic evaluation failed, leave violations as null
+      }
+    }
     var isApproved = latest.humanReviewStatus === 'approved'
     var blockedByHygiene = hasBlockingViolations(violations)
     var isReady = isApproved && !blockedByHygiene
@@ -449,11 +491,9 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
     var hpTeam = teamIndex.get(ckey) || (jiraFeatures && jiraFeatures.has(ckey) ? jiraFeatures.get(ckey).team : null) || null
 
     var hpPriorityScore = hd.priorityScore != null ? hd.priorityScore : null
-    var hpPriorityBreakdown = hd.priorityBreakdown || null
     var hpFallback = hpPriorityScore === null
-    var hpEffective = hpPriorityScore !== null
-      ? hpPriorityScore
-      : computeBestAvailableScore({
+    var hpFallbackResult = hpFallback
+      ? computeBestAvailableScore({
           tier: hpTier,
           priority: hd.priority,
           riceScore: hd.rice && hd.rice.score != null ? hd.rice.score : null,
@@ -461,8 +501,28 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
           rockPriority: hpRockPriority,
           targetVersions: hpTargetVersions
         }, configuredVersions)
+      : null
+    var hpEffective = hpFallback ? hpFallbackResult.score : hpPriorityScore
+    var hpPriorityBreakdown = hpFallback ? hpFallbackResult : (hd.priorityBreakdown || null)
 
     var hpViolations = hygieneIndex.get(ckey) || null
+    if (!hpViolations && jiraFeatures && jiraFeatures.has(ckey)) {
+      try {
+        var hpJf = jiraFeatures.get(ckey)
+        hpViolations = evaluateHygiene({
+          key: ckey, summary: hpJf.summary || hd.summary, status: hpJf.status || hd.status,
+          issueType: hpJf.issueType, assignee: hpJf.assignee || hd.assignee,
+          team: hpTeam, components: hpComponents, fixVersions: hpJf.fixVersions || [],
+          labels: hpJf.labels || [], statusSummary: hpJf.statusSummary || null,
+          colorStatus: hpJf.colorStatus || null, releaseType: hpJf.releaseType || null,
+          docsRequired: hpJf.docsRequired || null, targetEnd: hpJf.targetEnd || null,
+          riceScore: hpJf.riceScore || null
+        }, hygieneRulesConfig)
+        if (hpViolations && hpViolations.length === 0) hpViolations = null
+      } catch {
+        // dynamic evaluation failed, leave violations as null
+      }
+    }
     var hpGatesReady = isHealthFeatureReady(hd, cd)
     var hpBlockedByHygiene = hasBlockingViolations(hpViolations)
     var hpReady = hpGatesReady && !hpBlockedByHygiene
@@ -590,7 +650,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
 
     var efRiceScore = ef.riceScore != null ? ef.riceScore : (execData && execData.riceScore != null ? execData.riceScore : null)
 
-    var efEffective = computeBestAvailableScore({
+    var efFallbackResult = computeBestAvailableScore({
       tier: efTier,
       priority: ef.priority || null,
       riceScore: efRiceScore,
@@ -598,6 +658,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       rockPriority: efRockPriority,
       targetVersions: efTargetVersions
     }, configuredVersions)
+    var efEffective = efFallbackResult.score
 
     var efBlockedByHygiene = hasBlockingViolations(efViolations)
     var efIsApproved = efHumanReviewStatus === 'approved'
@@ -634,7 +695,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       targetVersions: efTargetVersions,
       fixVersion: efFixVersion,
       priorityScore: null,
-      priorityScoreBreakdown: null,
+      priorityScoreBreakdown: efFallbackResult,
       priorityScoreFallback: true,
       effectivePriorityScore: efEffective,
       blockingDimensions: [],
@@ -694,4 +755,4 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
   return { pendingReview: pendingReview, ready: ready, filterMeta: filterMeta, meta: meta }
 }
 
-module.exports = { buildFeatureReadiness: buildFeatureReadiness, computeBlockers: computeBlockers, computeBestAvailableScore: computeBestAvailableScore, isHealthFeatureReady: isHealthFeatureReady, computeTierScore: computeTierScore, computeTargetVersionScore: computeTargetVersionScore, hasBlockingViolations: hasBlockingViolations, computeConfidence: computeConfidence, collectFilterMeta: collectFilterMeta, deriveHumanReviewStatusFromLabels: deriveHumanReviewStatusFromLabels, BLOCKING_HYGIENE_RULES: BLOCKING_HYGIENE_RULES }
+module.exports = { buildFeatureReadiness: buildFeatureReadiness, computeBlockers: computeBlockers, computeBestAvailableScore: computeBestAvailableScore, isHealthFeatureReady: isHealthFeatureReady, computeTierScore: computeTierScore, computeTargetVersionScore: computeTargetVersionScore, hasBlockingViolations: hasBlockingViolations, computeConfidence: computeConfidence, collectFilterMeta: collectFilterMeta, deriveHumanReviewStatusFromLabels: deriveHumanReviewStatusFromLabels, BLOCKING_HYGIENE_RULES: BLOCKING_HYGIENE_RULES, COMPLETENESS_MULTIPLIERS: COMPLETENESS_MULTIPLIERS, MAX_SIGNALS: MAX_SIGNALS }

--- a/shared/__tests__/client/FeatureReadinessDrawer.test.js
+++ b/shared/__tests__/client/FeatureReadinessDrawer.test.js
@@ -329,4 +329,80 @@ describe('FeatureReadinessDrawer', () => {
       expect(wrapper.text()).toContain('From prioritization pipeline')
     })
   })
+
+  describe('score breakdown section', () => {
+    const breakdown = {
+      score: 62,
+      rawScore: 88,
+      signals: [
+        { name: 'Rubric', value: 0.75, weight: 30, raw: 6 },
+        { name: 'Priority', value: 0.6, weight: 35, raw: 'Major' }
+      ],
+      signalCount: 2,
+      maxSignals: 4,
+      completenessMultiplier: 0.7,
+      missing: ['Tier', 'Target Version']
+    }
+
+    it('shows Score Breakdown header when breakdown is present', () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        priorityScoreFallback: true,
+        priorityScoreBreakdown: breakdown
+      }))
+      expect(wrapper.text()).toContain('Score Breakdown')
+    })
+
+    it('shows signal count badge when completeness < 1', () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        priorityScoreFallback: true,
+        priorityScoreBreakdown: breakdown
+      }))
+      expect(wrapper.text()).toContain('2/4 signals')
+    })
+
+    it('does not render breakdown section when no breakdown', () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        priorityScoreFallback: false,
+        priorityScoreBreakdown: null
+      }))
+      expect(wrapper.text()).not.toContain('Score Breakdown')
+    })
+
+    it('shows signal names when expanded', async () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        priorityScoreFallback: true,
+        priorityScoreBreakdown: breakdown
+      }))
+      const buttons = wrapper.findAll('button')
+      const breakdownBtn = buttons.find(b => b.text().includes('Score Breakdown'))
+      await breakdownBtn.trigger('click')
+      expect(wrapper.text()).toContain('Rubric')
+      expect(wrapper.text()).toContain('Priority')
+    })
+
+    it('shows completeness penalty info when expanded', async () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        priorityScoreFallback: true,
+        priorityScoreBreakdown: breakdown
+      }))
+      const buttons = wrapper.findAll('button')
+      const breakdownBtn = buttons.find(b => b.text().includes('Score Breakdown'))
+      await breakdownBtn.trigger('click')
+      expect(wrapper.text()).toContain('completeness')
+      expect(wrapper.text()).toContain('0.7')
+    })
+
+    it('shows missing signals when expanded', async () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        priorityScoreFallback: true,
+        priorityScoreBreakdown: breakdown
+      }))
+      const buttons = wrapper.findAll('button')
+      const breakdownBtn = buttons.find(b => b.text().includes('Score Breakdown'))
+      await breakdownBtn.trigger('click')
+      expect(wrapper.text()).toContain('Missing')
+      expect(wrapper.text()).toContain('Tier')
+      expect(wrapper.text()).toContain('Target Version')
+    })
+  })
 })

--- a/shared/__tests__/client/FeatureReadinessRow.test.js
+++ b/shared/__tests__/client/FeatureReadinessRow.test.js
@@ -181,5 +181,44 @@ describe('FeatureReadinessRow', () => {
       const wrapper = mountRow(makeFeature({ needsAttention: true }))
       expect(wrapper.find('[title="Needs attention"]').exists()).toBe(true)
     })
+
+    it('shows score breakdown tooltip when priorityScoreBreakdown is present', () => {
+      const breakdown = {
+        score: 62,
+        rawScore: 88,
+        signals: [
+          { name: 'Rubric', value: 0.75, weight: 30, raw: 6 },
+          { name: 'Priority', value: 0.6, weight: 35, raw: 'Major' }
+        ],
+        signalCount: 2,
+        maxSignals: 4,
+        completenessMultiplier: 0.7,
+        missing: ['Tier', 'Target Version']
+      }
+      const wrapper = mountRow(makeFeature({
+        effectivePriorityScore: 62,
+        priorityScoreFallback: true,
+        priorityScoreBreakdown: breakdown
+      }))
+      const scoreTd = wrapper.findAll('td').at(1)
+      const scoreSpan = scoreTd.find('span')
+      const title = scoreSpan.attributes('title')
+      expect(title).toContain('Score: 62 / 100')
+      expect(title).toContain('Rubric')
+      expect(title).toContain('Priority')
+      expect(title).toContain('0.7')
+      expect(title).toContain('Missing')
+    })
+
+    it('shows simple tooltip when no breakdown available', () => {
+      const wrapper = mountRow(makeFeature({
+        effectivePriorityScore: 72,
+        priorityScoreFallback: false,
+        priorityScoreBreakdown: null
+      }))
+      const scoreTd = wrapper.findAll('td').at(1)
+      const scoreSpan = scoreTd.find('span')
+      expect(scoreSpan.attributes('title')).toBe('Computed priority score')
+    })
   })
 })

--- a/shared/client/components/FeatureReadinessDrawer.vue
+++ b/shared/client/components/FeatureReadinessDrawer.vue
@@ -151,6 +151,13 @@ const violationsList = computed(() => props.feature?.violations || [])
 const violationCount = computed(() => violationsList.value.length)
 
 const hygieneExpanded = ref(true)
+const breakdownExpanded = ref(false)
+
+const scoreBreakdown = computed(() => {
+  const bd = props.feature?.priorityScoreBreakdown
+  if (!bd || !bd.signals) return null
+  return bd
+})
 
 function onKey(e) {
   if (e.key === 'Escape' && open.value) emit('close')
@@ -263,6 +270,53 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
                     ? 'Estimated — no pipeline score yet (tier + priority)'
                     : 'From prioritization pipeline' }}
                 </p>
+              </div>
+            </div>
+          </section>
+
+          <!-- Score Breakdown -->
+          <section v-if="scoreBreakdown" class="px-4 py-4">
+            <button
+              type="button"
+              class="w-full flex items-center justify-between text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-3 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              @click="breakdownExpanded = !breakdownExpanded"
+            >
+              <span class="flex items-center gap-2">
+                Score Breakdown
+                <span
+                  v-if="scoreBreakdown.completenessMultiplier < 1"
+                  class="inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+                >{{ scoreBreakdown.signalCount }}/{{ scoreBreakdown.maxSignals }} signals</span>
+              </span>
+              <svg
+                class="w-3.5 h-3.5 transition-transform"
+                :class="breakdownExpanded ? 'rotate-180' : ''"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            <div v-if="breakdownExpanded" class="space-y-3">
+              <div v-for="signal in scoreBreakdown.signals" :key="signal.name" class="space-y-1">
+                <div class="flex items-center justify-between text-xs">
+                  <span class="text-gray-700 dark:text-gray-300">{{ signal.name }}</span>
+                  <span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ Math.round(signal.value * 100) }}% &times; {{ signal.weight }}w</span>
+                </div>
+                <div class="h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                  <div
+                    class="h-full rounded-full bg-gradient-to-r from-primary-500 to-purple-500 transition-all"
+                    :style="{ width: Math.round(signal.value * 100) + '%' }"
+                  />
+                </div>
+              </div>
+              <div v-if="scoreBreakdown.completenessMultiplier < 1" class="pt-2 border-t border-gray-100 dark:border-gray-800">
+                <p class="text-xs text-amber-600 dark:text-amber-400">
+                  Raw score {{ scoreBreakdown.rawScore }} &times; {{ scoreBreakdown.completenessMultiplier }} completeness
+                  = {{ scoreBreakdown.score }}
+                </p>
+              </div>
+              <div v-if="scoreBreakdown.missing && scoreBreakdown.missing.length > 0" class="text-xs text-gray-400 dark:text-gray-500">
+                Missing: {{ scoreBreakdown.missing.join(', ') }}
               </div>
             </div>
           </section>

--- a/shared/client/components/FeatureReadinessRow.vue
+++ b/shared/client/components/FeatureReadinessRow.vue
@@ -36,6 +36,25 @@ const priorityDisplay = computed(() => {
   return props.feature.priorityScoreFallback ? `~${score}` : String(score)
 })
 
+const scoreTooltip = computed(() => {
+  const bd = props.feature.priorityScoreBreakdown
+  if (!bd || !bd.signals) {
+    return props.feature.priorityScoreFallback ? 'Estimated score (fallback)' : 'Computed priority score'
+  }
+  const lines = [`Score: ${bd.score} / 100`]
+  for (const s of bd.signals) {
+    const pct = Math.round(s.value * 100)
+    lines.push(`${s.name}: ${pct}% × ${s.weight}w`)
+  }
+  if (bd.completenessMultiplier < 1) {
+    lines.push(`Raw: ${bd.rawScore} × ${bd.completenessMultiplier} (${bd.signalCount}/${bd.maxSignals} signals)`)
+  }
+  if (bd.missing && bd.missing.length > 0) {
+    lines.push(`Missing: ${bd.missing.join(', ')}`)
+  }
+  return lines.join('\n')
+})
+
 const confidenceClass = computed(() => {
   switch (props.feature.confidence) {
     case 'committed': return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
@@ -82,7 +101,7 @@ const confidenceTooltip = computed(() => {
         :class="feature.priorityScoreFallback
           ? 'text-amber-600 dark:text-amber-400'
           : 'text-gray-800 dark:text-gray-200'"
-        :title="feature.priorityScoreFallback ? 'Estimated score (fallback)' : 'Computed priority score'"
+        :title="scoreTooltip"
       >{{ priorityDisplay }}</span>
     </td>
 


### PR DESCRIPTION
## Summary

- **Completeness penalty**: `computeBestAvailableScore` now applies a multiplier based on signal count (1 signal = 0.5x, 2 = 0.7x, 3 = 0.85x, 4 = 1.0x). Features with sparse data no longer get inflated scores that over-prioritize them in the list.
- **Score breakdown**: `computeBestAvailableScore` returns a breakdown object with signal details, weights, raw values, and missing signal names. The Score cell shows a detailed tooltip on hover, and the detail drawer has a new collapsible "Score Breakdown" section showing signals, completeness penalty, and missing data.
- **Dynamic hygiene eval for passes 1 and 2**: When a feature isn't found in the hygiene cache, passes 1 and 2 now dynamically evaluate hygiene rules using `evaluateHygiene()`, matching the fallback already present in pass 3. This fixes the "All clear" display for features that weren't in any hygiene cache file.

## Test plan

- 176 backend tests passing (`feature-readiness.test.js`) — includes 5 new tests for completeness penalty and breakdown return structure
- 19 component tests passing (`FeatureReadinessRow.test.js`) — includes 2 new tests for score tooltip with/without breakdown
- 41 component tests passing (`FeatureReadinessDrawer.test.js`) — includes 6 new tests for breakdown section rendering
- Full suite: 2169 tests passing, lint clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>