### PR TITLE
docs: update autofix pipeline documentation for recent changes

### DIFF
--- a/AUTOFIX-TAB-PLAN.md
+++ b/AUTOFIX-TAB-PLAN.md
@@ -33,7 +33,7 @@ at `ai-impact/autofix-data.json`. Each issue has:
 
 **Autofix states:** `autofix-ready`, `autofix-pending`, `autofix-review`,
 `autofix-ci-failing`, `autofix-merged`, `autofix-rejected`, `autofix-max-retries`,
-`autofix-researched`, `autofix-blocked`
+`autofix-blocked`
 
 ### Team-to-Component Mapping
 
@@ -183,7 +183,6 @@ issues. Color-coded (colors defined locally in `TeamAutofixTab.vue` — see
 - CI Failing: orange
 - Blocked: yellow
 - Max Retries: red
-- Researched: teal
 
 ### Trend Chart
 

--- a/modules/ai-impact/client/views/AIFactoryGuideView.vue
+++ b/modules/ai-impact/client/views/AIFactoryGuideView.vue
@@ -293,7 +293,7 @@ const autofixSteps = [
   { name: 'Bug Filed', desc: 'A bug is filed in Jira with a repository URL and description of the issue', ai: false },
   { name: 'AI Triage', desc: 'Bot scans new tickets, evaluates if they have enough info for an AI agent to fix, and labels accordingly', ai: true },
   { name: 'Autofix', desc: 'Bot clones the repo, creates a branch, runs Claude Code to analyze and fix the issue, and creates an MR/PR', ai: true },
-  { name: 'Review Iteration', desc: 'Bot addresses review feedback and CI failures on each scheduled cycle (~30 min), pushing fixes and resolving threads (up to 36 iterations)', ai: true },
+  { name: 'Review Iteration', desc: 'Bot addresses review feedback and CI failures on each scheduled cycle (~30 min), pushing fixes and resolving threads (up to 10 iterations)', ai: true },
   { name: 'Human Review', desc: 'Engineers review and merge the MR/PR, or leave feedback for the bot to address on its next iteration', ai: false },
 ]
 
@@ -313,7 +313,7 @@ const autofixPipelineLabels = [
   { name: 'jira-autofix-merged', color: 'green', desc: 'MR/PR has been merged' },
   { name: 'jira-autofix-rejected', color: 'red', desc: 'MR/PR closed without merge' },
   { name: 'jira-autofix-max-retries', color: 'amber', desc: 'Bot hit its iteration limit, needs human takeover' },
-  { name: 'jira-autofix-blocked', color: 'amber', desc: 'Bot needs more information (e.g. missing repo URL)' },
+  { name: 'jira-autofix-blocked', color: 'amber', desc: 'Bot can\'t proceed (e.g., missing repo URL, unfixable CI failure)' },
   { name: 'no-autofix', color: 'gray', desc: 'Permanently excludes this ticket from triage and autofix' },
 ]
 
@@ -1673,7 +1673,7 @@ function labelColorClasses(color) {
             <RefreshCw :size="20" class="text-emerald-600 dark:text-emerald-400 flex-shrink-0 mt-0.5" />
             <div>
               <div class="text-sm font-semibold text-gray-900 dark:text-white">Iteration Loop (~30 min cycles)</div>
-              <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">After creating an MR/PR, the bot checks for unresolved review threads and CI failures on each scheduled cycle. It re-runs Claude Code with the feedback as context, pushes fixes, and resolves addressed threads. Up to 36 iterations, then escalates to human.</div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">After creating an MR/PR, the bot checks for unresolved review threads and CI failures on each scheduled cycle. It re-runs Claude Code with the feedback as context, pushes fixes, and resolves addressed threads. Up to 10 iterations, then escalates to human.</div>
             </div>
           </div>
         </div>
@@ -1727,7 +1727,7 @@ function labelColorClasses(color) {
               <AlertTriangle :size="20" class="text-emerald-600 dark:text-emerald-400 flex-shrink-0 mt-0.5" />
               <div>
                 <div class="text-sm font-semibold text-gray-900 dark:text-white">CI keeps failing</div>
-                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Check whether the failure is in the bot's changes or a pre-existing issue. The bot can only fix failures caused by its own code</div>
+                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Check whether the failure is in the bot's changes or a pre-existing issue. The bot can only fix failures caused by its own code. If the bot determines a CI failure is unfixable (e.g., a pre-existing issue or infrastructure problem), it will block the ticket itself rather than burning iterations</div>
               </div>
             </div>
             <div class="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-700/30 rounded-lg">


### PR DESCRIPTION
## Summary

Update autofix-related documentation to reflect recent pipeline changes:

- **Remove references to `autofix-researched` state** (research mode was removed)
- **Remove associated color mapping** for the researched state  
- **Update iteration limit from 36 to 10** iterations (RHAIFIRST-83)
- **Add ci_blocked behavior explanation** - bot self-blocks on unfixable CI failures
- **Update jira-autofix-blocked label description** to include unfixable CI failures

Based on recent changes in the autofix pipeline where:
- Spike/research mode was removed to simplify the codebase
- Iteration limit was reduced from 36 to 10 iterations
- Bot can now self-block on unfixable CI failures instead of burning iterations

## Files changed

- `AUTOFIX-TAB-PLAN.md` - removed autofix-researched from pipeline states and color mappings
- `modules/ai-impact/client/views/AIFactoryGuideView.vue` - updated iteration limits, added ci_blocked behavior, updated label descriptions

## Test plan

- [x] Documentation renders correctly
- [x] No broken references to removed states
- [x] Iteration limits accurately reflect current pipeline behavior
- [x] CI blocking behavior is clearly explained

🤖 Generated with [Claude Code](https://claude.com/claude-code)