### PR TITLE
feat(releases): switch to planning freeze and add settings panel to feature tracking

### DIFF
--- a/modules/releases/client/execute/components/FeatureTrackingSettingsPanel.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingSettingsPanel.vue
@@ -1,0 +1,225 @@
+<template>
+  <div v-if="open" class="fixed inset-0 z-[100] flex justify-end" @mousedown.self="$emit('close')">
+    <div class="w-full max-w-2xl bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 flex flex-col h-full">
+      <!-- Header -->
+      <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+        <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Feature Tracking Settings</h3>
+        <button
+          @click="$emit('close')"
+          class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+        >
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          Configure release version names for each RHAI product and set fallback planning freeze dates.
+        </p>
+
+        <div v-for="(entry, idx) in draft" :key="idx" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <!-- Release header -->
+          <div class="flex items-center gap-2 px-3 py-2.5 bg-gray-50 dark:bg-gray-800">
+            <button
+              type="button"
+              @click="toggleExpand(idx)"
+              class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors"
+            >
+              <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-90': expanded[idx] }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+            <input
+              v-model="entry.version"
+              class="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
+              placeholder="Portfolio version (e.g. 3.7)"
+            />
+            <span class="text-[10px] text-gray-400 dark:text-gray-500 font-medium uppercase">
+              {{ Object.values(entry.products).filter(function(v) { return v.trim() }).length }} products
+            </span>
+            <button
+              type="button"
+              @click="removeRelease(idx)"
+              class="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-gray-400 hover:text-red-500 transition-colors"
+              title="Remove release"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Release details (expandable) -->
+          <div v-if="expanded[idx]" class="border-t border-gray-100 dark:border-gray-700 px-4 py-3 space-y-3">
+            <div v-for="product in PRODUCT_KEYS" :key="product" class="flex items-center gap-2">
+              <label class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase w-14 flex-shrink-0">{{ product }}</label>
+              <input
+                v-model="entry.products[product]"
+                class="flex-1 text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
+                :placeholder="product.toLowerCase() + '-' + (entry.version || 'x.y')"
+              />
+            </div>
+
+            <div class="pt-2 border-t border-gray-100 dark:border-gray-700">
+              <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                Planning Freeze (fallback)
+              </label>
+              <input
+                type="date"
+                v-model="entry.planningFreezeOverride"
+                class="text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+              />
+              <p class="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+                Used only when Product Pages returns no planning freeze date
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          @click="addRelease"
+          class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+          </svg>
+          Add Release
+        </button>
+      </div>
+
+      <!-- Footer -->
+      <div class="px-5 py-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <span v-if="saveError" class="text-xs text-red-500">{{ saveError }}</span>
+        <span v-else-if="saveSuccess" class="text-xs text-emerald-600 dark:text-emerald-400">Saved</span>
+        <span v-else />
+        <div class="flex items-center gap-2">
+          <button
+            @click="$emit('close')"
+            class="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+          >Cancel</button>
+          <button
+            @click="save"
+            :disabled="saving"
+            class="px-4 py-1.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md transition-colors disabled:opacity-50"
+          >{{ saving ? 'Saving…' : 'Save' }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { getApiBase } from '@shared/client/services/api'
+
+var PRODUCT_KEYS = ['RHOAI', 'RHELAI', 'RHAII']
+
+var props = defineProps({
+  open: { type: Boolean, default: false },
+  config: { type: Object, default: function() { return { releases: {} } } }
+})
+
+var emit = defineEmits(['close', 'saved'])
+
+var draft = ref([])
+var expanded = ref({})
+var saving = ref(false)
+var saveError = ref(null)
+var saveSuccess = ref(false)
+
+function configToArray(config) {
+  var releases = (config && config.releases) || {}
+  var keys = Object.keys(releases)
+  return keys.map(function(key) {
+    var entry = releases[key]
+    var products = {}
+    for (var i = 0; i < PRODUCT_KEYS.length; i++) {
+      var pk = PRODUCT_KEYS[i]
+      var lower = pk.toLowerCase()
+      products[pk] = (entry.products && (entry.products[pk] || entry.products[lower])) || ''
+    }
+    return {
+      version: key,
+      products: products,
+      planningFreezeOverride: entry.planningFreezeOverride || ''
+    }
+  })
+}
+
+function arrayToConfig(arr) {
+  var releases = {}
+  for (var i = 0; i < arr.length; i++) {
+    var entry = arr[i]
+    var version = (entry.version || '').trim()
+    if (!version) continue
+    var products = {}
+    for (var pi = 0; pi < PRODUCT_KEYS.length; pi++) {
+      var pk = PRODUCT_KEYS[pi]
+      var val = (entry.products[pk] || '').trim()
+      if (val) products[pk.toLowerCase()] = val
+    }
+    releases[version] = {
+      products: products,
+      planningFreezeOverride: entry.planningFreezeOverride || null
+    }
+  }
+  return { releases: releases }
+}
+
+watch(function() { return props.open }, function(isOpen) {
+  if (isOpen) {
+    draft.value = configToArray(props.config)
+    expanded.value = {}
+    saveError.value = null
+    saveSuccess.value = false
+  }
+})
+
+function toggleExpand(idx) {
+  expanded.value = Object.assign({}, expanded.value, { [idx]: !expanded.value[idx] })
+}
+
+function addRelease() {
+  var products = {}
+  for (var i = 0; i < PRODUCT_KEYS.length; i++) {
+    products[PRODUCT_KEYS[i]] = ''
+  }
+  draft.value.push({ version: '', products: products, planningFreezeOverride: '' })
+  expanded.value = Object.assign({}, expanded.value, { [draft.value.length - 1]: true })
+}
+
+function removeRelease(idx) {
+  draft.value.splice(idx, 1)
+}
+
+async function save() {
+  saving.value = true
+  saveError.value = null
+  saveSuccess.value = false
+
+  var payload = arrayToConfig(draft.value)
+
+  try {
+    var response = await fetch(getApiBase() + '/modules/releases/execution/tracking/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!response.ok) {
+      var errData = await response.json().catch(function() { return {} })
+      throw new Error(errData.error || 'HTTP ' + response.status)
+    }
+    var data = await response.json()
+    saveSuccess.value = true
+    emit('saved', data)
+  } catch (err) {
+    saveError.value = err.message
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -169,7 +169,7 @@ defineExpose({ expandAll, collapseAll })
                 <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
-                Freeze: {{ formatDate(featureFreezeDate) }}
+                Planning Freeze: {{ formatDate(featureFreezeDate) }}
               </span>
             </div>
           </td>

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -24,7 +24,7 @@ const portfolioVersions = computed(() => {
 
 const currentData = computed(() => trackingData.value)
 const groups = computed(() => currentData.value ? currentData.value.groups || [] : [])
-const featureFreezeDate = computed(() => currentData.value ? currentData.value.featureFreezeDate : null)
+const featureFreezeDate = computed(() => currentData.value ? currentData.value.planningFreezeDate : null)
 const freezeStatus = computed(() => {
   if (!featureFreezeDate.value) return 'unknown'
   var today = new Date().toISOString().split('T')[0]
@@ -236,7 +236,7 @@ onMounted(async () => {
               <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Freeze Date</span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Planning Freeze</span>
         </div>
         <div class="text-sm font-bold ml-7" :class="freezeStatus === 'past' ? 'text-orange-600 dark:text-orange-400' : freezeStatus === 'future' ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-400'">
           {{ featureFreezeDate ? formatDate(featureFreezeDate) : 'Not set' }}

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -2,6 +2,8 @@
 import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { useFeatureTracking } from '../composables/useFeatureTracking.js'
 import FeatureTrackingTable from '../components/FeatureTrackingTable.vue'
+import FeatureTrackingSettingsPanel from '../components/FeatureTrackingSettingsPanel.vue'
+import { getApiBase } from '@shared/client/services/api'
 
 const {
   trackingData,
@@ -17,6 +19,8 @@ const selectedVersion = ref(null)
 const refreshing = ref(false)
 const tableRef = ref(null)
 const activeFilter = ref(null)
+const settingsOpen = ref(false)
+const trackingConfig = ref({ releases: {} })
 
 const portfolioVersions = computed(() => {
   return (versions.value || []).map(v => v.version)
@@ -128,12 +132,31 @@ function handleCollapseAll() {
   if (tableRef.value) tableRef.value.collapseAll()
 }
 
+async function fetchTrackingConfig() {
+  try {
+    var response = await fetch(getApiBase() + '/modules/releases/execution/tracking/config')
+    if (response.ok) {
+      trackingConfig.value = await response.json()
+    }
+  } catch (e) { void e }
+}
+
+async function onSettingsSaved(newConfig) {
+  trackingConfig.value = newConfig
+  settingsOpen.value = false
+  await loadVersions()
+  if (selectedVersion.value) {
+    await refreshTracking(selectedVersion.value)
+  }
+}
+
 watch(selectedVersion, async (v) => {
   activeFilter.value = null
   if (v) await loadTrackingData(v)
 })
 
 onMounted(async () => {
+  await fetchTrackingConfig()
   await loadVersions()
   if (portfolioVersions.value.length > 0) {
     selectedVersion.value = portfolioVersions.value[0]
@@ -155,7 +178,7 @@ onMounted(async () => {
           Feature Execution Tracking
         </h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 ml-9">
-          Track features committed at Feature Freeze across RHOAI, RHAIIS, and RHELAI.
+          Track features committed at Planning Freeze across RHOAI, RHAIIS, and RHELAI.
         </p>
       </div>
       <div class="flex items-center gap-2">
@@ -169,6 +192,16 @@ onMounted(async () => {
           class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           :disabled="!currentData"
         >Collapse All</button>
+        <button
+          @click="settingsOpen = true"
+          class="p-1.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+          title="Configure releases"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
         <button
           @click="handleRefresh"
           :disabled="!selectedVersion || refreshing"
@@ -394,5 +427,12 @@ onMounted(async () => {
         :featureFreezeDate="featureFreezeDate"
       />
     </template>
+
+    <FeatureTrackingSettingsPanel
+      :open="settingsOpen"
+      :config="trackingConfig"
+      @close="settingsOpen = false"
+      @saved="onSettingsSaved"
+    />
   </div>
 </template>

--- a/modules/releases/server/delivery/product-pages.js
+++ b/modules/releases/server/delivery/product-pages.js
@@ -279,6 +279,49 @@ function extractFeatureFreezeDate(release, eaTag) {
 }
 
 /**
+ * Extracts the planning freeze date from a Product Pages release object.
+ * Searches major_milestones and all_ga_tasks for entries matching
+ * "planning freeze" (case-insensitive, with optional hyphen/space).
+ *
+ * For EA-specific releases, pass an optional eaTag (e.g. "EA1") to prefer
+ * a milestone scoped to that EA over a generic one.
+ */
+function extractPlanningFreezeDate(release, eaTag) {
+  const freezePattern = /planning[.\-_\s]*freeze/i
+
+  const milestones = release.major_milestones
+  if (Array.isArray(milestones) && milestones.length > 0) {
+    let bestMatch = null
+    for (const m of milestones) {
+      if (m.draft) continue
+      const name = m.name || ''
+      if (!freezePattern.test(name)) continue
+      if (eaTag && new RegExp(`\\b${eaTag}\\b`, 'i').test(name)) {
+        return m.date_finish || null
+      }
+      bestMatch = m
+    }
+    if (bestMatch?.date_finish) return bestMatch.date_finish
+  }
+
+  const tasks = release.all_ga_tasks
+  if (Array.isArray(tasks) && tasks.length > 0) {
+    let bestMatch = null
+    for (const t of tasks) {
+      const name = t.name || ''
+      if (!freezePattern.test(name)) continue
+      if (eaTag && new RegExp(`\\b${eaTag}\\b`, 'i').test(name)) {
+        return t.date_finish || null
+      }
+      bestMatch = t
+    }
+    if (bestMatch?.date_finish) return bestMatch.date_finish
+  }
+
+  return null
+}
+
+/**
  * Returns the auth status string for the settings UI badge.
  */
 function getAuthStatus() {
@@ -352,7 +395,8 @@ function expandReleaseMilestones(r, productName) {
       releaseNumber,
       dueDate: m.date_finish,
       codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null,
-      featureFreezeDate: extractFeatureFreezeDate(r, eaTag) || null
+      featureFreezeDate: extractFeatureFreezeDate(r, eaTag) || null,
+      planningFreezeDate: extractPlanningFreezeDate(r, eaTag) || null
     }
   })
 }
@@ -460,7 +504,8 @@ async function fetchProductsByShortname(shortnames, config) {
           releaseNumber,
           dueDate,
           codeFreezeDate: extractCodeFreezeDate(r, eaTag) || null,
-          featureFreezeDate: extractFeatureFreezeDate(r, eaTag) || null
+          featureFreezeDate: extractFeatureFreezeDate(r, eaTag) || null,
+          planningFreezeDate: extractPlanningFreezeDate(r, eaTag) || null
         })
       }
     } catch (err) {
@@ -712,6 +757,139 @@ async function fetchFeatureFreezeDatesFromSchedule(portfolioVersion, productShor
   return { byProduct, earliest }
 }
 
+async function fetchPlanningFreezeDatesFromSchedule(portfolioVersion, productShortnames, config) {
+  const version = Array.isArray(portfolioVersion) ? portfolioVersion[0] : portfolioVersion
+  const versionStr = String(version || '')
+  if (!versionStr) return { byProduct: {}, earliest: null }
+
+  const token = await getProductPagesToken(config)
+  if (!token) {
+    console.warn('[product-pages] fetchPlanningFreezeDatesFromSchedule: no auth token available')
+    return { byProduct: {}, earliest: null }
+  }
+
+  const baseUrl = (config.productPagesBaseUrl || 'https://productpages.redhat.com').replace(/\/+$/, '')
+
+  const eaMatch = versionStr.match(/\b(EA\d?)\b/i)
+  const eaTag = eaMatch ? eaMatch[1].toUpperCase() : null
+  let baseVersion = versionStr
+  if (eaMatch) {
+    baseVersion = versionStr.slice(0, eaMatch.index).replace(/[\s._-]+$/, '') +
+      versionStr.slice(eaMatch.index + eaMatch[0].length).replace(/^[\s._-]+/, '')
+  }
+  baseVersion = baseVersion.replace(/^[\s.]+/, '').replace(/[\s.]+$/, '')
+
+  const byProduct = {}
+  let earliest = null
+  const headers = { Accept: 'application/json', Authorization: `Bearer ${token}` }
+
+  for (const shortname of productShortnames) {
+    try {
+      const releasesUrl = `${baseUrl}/api/v7/releases/?product__shortname=${encodeURIComponent(shortname)}`
+      let relResponse = await fetch(releasesUrl, { headers, signal: AbortSignal.timeout(15000) })
+
+      if (relResponse.status === 401) {
+        cachedToken = { token: null, expiresAt: 0 }
+        const newToken = await getProductPagesToken(config)
+        if (newToken) {
+          headers.Authorization = `Bearer ${newToken}`
+          relResponse = await fetch(releasesUrl, { headers, signal: AbortSignal.timeout(15000) })
+        }
+      }
+
+      if (!relResponse.ok) {
+        console.warn(`[product-pages] Releases API returned HTTP ${relResponse.status} for "${shortname}"`)
+        continue
+      }
+
+      const relPayload = await relResponse.json()
+      const rows = Array.isArray(relPayload) ? relPayload : (relPayload.results || relPayload.releases || relPayload.items || [])
+
+      const candidates = []
+      if (eaTag) {
+        candidates.push(`${shortname}-${baseVersion}.${eaTag}`)
+        candidates.push(`${shortname}-${baseVersion}${eaTag}`)
+        candidates.push(`${shortname}-${baseVersion} ${eaTag}`)
+      }
+      candidates.push(`${shortname}-${baseVersion}`)
+
+      let releaseId = null
+      let matchedShortname = null
+      let matchedExactEa = false
+
+      for (const candidate of candidates) {
+        const norm = candidate.toLowerCase().replace(/[\s._-]+/g, '')
+        for (const r of rows) {
+          if (!r.id) continue
+          const rn = (r.shortname || '').toLowerCase().replace(/[\s._-]+/g, '')
+          if (rn === norm) {
+            releaseId = r.id
+            matchedShortname = r.shortname || candidate
+            matchedExactEa = eaTag ? /ea\d?/i.test(r.shortname || '') : false
+            break
+          }
+        }
+        if (releaseId) break
+      }
+
+      if (!releaseId) {
+        console.warn(`[product-pages] No release entity found for "${shortname}" matching version "${versionStr}" (planning freeze)`)
+        continue
+      }
+
+      const schedUrl = `${baseUrl}/api/v7/schedule-tasks/?entity_id=${releaseId}&q=${encodeURIComponent('planning freeze')}`
+      const schedResponse = await fetch(schedUrl, { headers, signal: AbortSignal.timeout(15000) })
+      if (!schedResponse.ok) {
+        console.warn(`[product-pages] Schedule tasks API returned HTTP ${schedResponse.status} for entity ${releaseId} (planning freeze)`)
+        continue
+      }
+
+      const schedPayload = await schedResponse.json()
+      const tasks = Array.isArray(schedPayload)
+        ? schedPayload
+        : (schedPayload.data || schedPayload.results || schedPayload.result || [])
+
+      const freezePattern = /planning[.\-_\s]*freeze/i
+      let bestDate = null
+
+      for (const task of tasks) {
+        if (task.draft) continue
+        const name = task.name || ''
+        if (!freezePattern.test(name)) continue
+
+        if (eaTag && !matchedExactEa) {
+          const nameUpper = name.toUpperCase()
+          const eaIdx = nameUpper.indexOf(eaTag)
+          if (eaIdx !== -1) {
+            const before = eaIdx === 0 || /\W/.test(name[eaIdx - 1])
+            const after = eaIdx + eaTag.length >= name.length || /\W/.test(name[eaIdx + eaTag.length])
+            if (before && after) {
+              bestDate = task.date_finish || null
+              break
+            }
+          }
+        }
+        if (!bestDate && task.date_finish) {
+          bestDate = task.date_finish
+        }
+      }
+
+      if (bestDate) {
+        const key = (matchedExactEa ? matchedShortname : `${shortname}-${baseVersion}${eaTag ? '.' + eaTag : ''}`).toLowerCase()
+        byProduct[key] = bestDate
+        if (!earliest || bestDate < earliest) earliest = bestDate
+        console.log(`[product-pages] Planning freeze date for "${key}": ${bestDate}`)
+      } else {
+        console.warn(`[product-pages] No "planning freeze" task found in ${tasks.length} schedule tasks for entity ${releaseId} ("${matchedShortname}")`)
+      }
+    } catch (err) {
+      console.error(`[product-pages] Planning freeze schedule fetch failed for "${shortname}":`, err.message)
+    }
+  }
+
+  return { byProduct, earliest }
+}
+
 function _resetForTesting() {
   cachedToken = { token: null, expiresAt: 0 }
   pendingTokenRequest = null
@@ -723,12 +901,14 @@ module.exports = {
   getProductPagesToken,
   fetchProductsByShortname,
   fetchFeatureFreezeDatesFromSchedule,
+  fetchPlanningFreezeDatesFromSchedule,
   fetchAllProducts,
   getAuthStatus,
   extractGaDate,
   extractReleaseDueDate,
   extractCodeFreezeDate,
   extractFeatureFreezeDate,
+  extractPlanningFreezeDate,
   expandReleaseMilestones,
   milestoneToReleaseNumber,
   _resetForTesting

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -3,7 +3,7 @@
  *
  * Queries Jira directly by fixVersion (e.g. fixVersion = "rhoai-3.5.EA1")
  * to list all features committed to a release. Uses the Jira changelog to
- * detect when fixVersion was applied — features added after the Feature
+ * detect when fixVersion was applied — features added after the Planning
  * Freeze date are flagged as "Late Additions".
  *
  * Grouped by portfolio release (e.g. 3.5.EA1) across products (RHOAI,
@@ -12,7 +12,7 @@
  */
 
 const { readRegistry } = require('../registry')
-const { fetchFeatureFreezeDatesFromSchedule } = require('../delivery/product-pages')
+const { fetchPlanningFreezeDatesFromSchedule } = require('../delivery/product-pages')
 const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
 
 const PP_CACHE_FILE = 'releases/delivery/product-pages-releases-cache.json'
@@ -356,15 +356,14 @@ function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
   for (let i = 0; i < ppReleases.length; i++) {
     const rel = ppReleases[i]
     const relVersion = normalizeVersionName(rel.releaseNumber).replace(/^[a-z]+-/, '')
-    if (relVersion === normalizedPortfolio && rel.featureFreezeDate) {
+    var freezeDate = rel.planningFreezeDate || rel.featureFreezeDate
+    if (relVersion === normalizedPortfolio && freezeDate) {
       const key = normalizeVersionName(rel.releaseNumber)
-      // Prefer the earliest date per product to avoid parent GA dates
-      // overriding EA-specific dates from expanded entries
-      if (!byProduct[key] || rel.featureFreezeDate < byProduct[key]) {
-        byProduct[key] = rel.featureFreezeDate
+      if (!byProduct[key] || freezeDate < byProduct[key]) {
+        byProduct[key] = freezeDate
       }
-      if (!earliest || rel.featureFreezeDate < earliest) {
-        earliest = rel.featureFreezeDate
+      if (!earliest || freezeDate < earliest) {
+        earliest = freezeDate
       }
     }
   }
@@ -458,13 +457,13 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
 
     for (let vi = 0; vi < versions.length; vi++) {
       const fd = getFeatureFreezeDatesFromCache(versions[vi].version, storage.readFromStorage)
-      versions[vi].featureFreezeDate = fd.earliest || null
+      versions[vi].planningFreezeDate = fd.earliest || null
     }
 
     versions.sort(function (a, b) {
-      if (a.featureFreezeDate && b.featureFreezeDate) return a.featureFreezeDate.localeCompare(b.featureFreezeDate)
-      if (a.featureFreezeDate && !b.featureFreezeDate) return -1
-      if (!a.featureFreezeDate && b.featureFreezeDate) return 1
+      if (a.planningFreezeDate && b.planningFreezeDate) return a.planningFreezeDate.localeCompare(b.planningFreezeDate)
+      if (a.planningFreezeDate && !b.planningFreezeDate) return -1
+      if (!a.planningFreezeDate && b.planningFreezeDate) return 1
       return b.version.localeCompare(a.version)
     })
 
@@ -486,6 +485,9 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         if (cached && cached.fetchedAt) {
           const age = Date.now() - new Date(cached.fetchedAt).getTime()
           if (age < CACHE_TTL_MS) {
+            if (!cached.planningFreezeDate && cached.featureFreezeDate) {
+              cached.planningFreezeDate = cached.featureFreezeDate
+            }
             return res.json(cached)
           }
         }
@@ -507,11 +509,11 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         const ppConfig = {
           productPagesBaseUrl: process.env.PRODUCT_PAGES_BASE_URL || 'https://productpages.redhat.com'
         }
-        const scheduleDates = await fetchFeatureFreezeDatesFromSchedule(version, DEFAULT_PRODUCTS, ppConfig)
+        const scheduleDates = await fetchPlanningFreezeDatesFromSchedule(version, DEFAULT_PRODUCTS, ppConfig)
         const schedEntries = Object.entries(scheduleDates.byProduct)
         if (schedEntries.length > 0) {
           scheduleSource = 'schedule-api'
-          console.log('[feature-tracking] Schedule API returned freeze dates:', JSON.stringify(scheduleDates.byProduct))
+          console.log('[feature-tracking] Schedule API returned planning freeze dates:', JSON.stringify(scheduleDates.byProduct))
           for (const [key, date] of schedEntries) {
             const normKey = normalizeVersionName(key)
             freezeDates.byProduct[normKey] = date
@@ -524,7 +526,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
           }
         } else {
           scheduleSource = 'cache-only (schedule returned empty)'
-          console.warn('[feature-tracking] Schedule API returned no freeze dates for version:', version)
+          console.warn('[feature-tracking] Schedule API returned no planning freeze dates for version:', version)
         }
       } catch (schedErr) {
         scheduleSource = 'cache-only (' + schedErr.message + ')'
@@ -565,7 +567,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
           label: pv.product.toUpperCase() + ': ' + pv.releaseNumber,
           product: pv.product,
           releaseNumber: pv.releaseNumber,
-          featureFreezeDate: productFreezeDate,
+          planningFreezeDate: productFreezeDate,
           featureCount: features.filter(function (f) { return f.scopeChange !== 'dropped' }).length,
           features: features.map(function (f) {
             return {
@@ -588,7 +590,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
 
       const responseData = {
         portfolioVersion: version,
-        featureFreezeDate: freezeDates.earliest,
+        planningFreezeDate: freezeDates.earliest,
         fetchedAt: new Date().toISOString(),
         groups: groups,
         _freezeDateSource: scheduleSource,

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -17,6 +17,7 @@ const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
 
 const PP_CACHE_FILE = 'releases/delivery/product-pages-releases-cache.json'
 const PLANNING_CONFIG_FILE = 'releases/planning/config.json'
+const TRACKING_CONFIG_FILE = 'releases/execution/feature-tracking-config.json'
 const TRACKING_CACHE_PREFIX = 'releases/execution/tracking-data-'
 const CACHE_TTL_MS = 10 * 60 * 1000
 const DEFAULT_PRODUCTS = ['rhoai', 'rhelai', 'RHAII']
@@ -106,12 +107,34 @@ const VERSIONS_CACHE_TTL_MS = 15 * 60 * 1000
  * conventions across products, collecting ALL matching fixVersions per product
  * (e.g. both "rhelai-3.5EA2" and "rhelai-3.5 EA2 release" for rhelai).
  */
-async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn) {
+async function resolveProductVersionsFromJira(portfolioVersion, jiraRequestFn, trackingConfig) {
   const { fetchProjectVersions } = require('../../../../shared/server/jira')
 
   if (!jiraVersionsCache.versions || Date.now() - jiraVersionsCache.fetchedAt > VERSIONS_CACHE_TTL_MS) {
     jiraVersionsCache.versions = await fetchProjectVersions(jiraRequestFn, DEFAULT_PROJECTS)
     jiraVersionsCache.fetchedAt = Date.now()
+  }
+
+  // If the tracking config has explicit product version names, use them
+  var configEntry = trackingConfig && trackingConfig.releases && trackingConfig.releases[portfolioVersion]
+  if (configEntry && configEntry.products) {
+    var configProducts = configEntry.products
+    var configKeys = Object.keys(configProducts)
+    if (configKeys.length > 0) {
+      var configResult = []
+      for (var ci = 0; ci < configKeys.length; ci++) {
+        var productKey = configKeys[ci]
+        var versionName = configProducts[productKey]
+        if (versionName && versionName.trim()) {
+          configResult.push({
+            product: productKey.toLowerCase(),
+            releaseNumber: versionName,
+            fixVersions: [versionName]
+          })
+        }
+      }
+      if (configResult.length > 0) return configResult
+    }
   }
 
   const allVersions = jiraVersionsCache.versions
@@ -405,6 +428,70 @@ function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
  *         description: Array of portfolio versions
  */
 
+/**
+ * @openapi
+ * /api/modules/releases/execution/tracking/config:
+ *   get:
+ *     summary: Get feature tracking configuration (release names, freeze overrides)
+ *     tags: [Releases - Feature Tracking]
+ *     responses:
+ *       200:
+ *         description: Feature tracking config object
+ *   put:
+ *     summary: Update feature tracking configuration
+ *     tags: [Releases - Feature Tracking]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               releases:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: Updated config
+ *       400:
+ *         description: Validation error
+ */
+
+function validateTrackingConfig(body) {
+  if (!body || typeof body !== 'object') return 'Body must be an object'
+  if (!body.releases || typeof body.releases !== 'object' || Array.isArray(body.releases)) {
+    return 'releases must be an object'
+  }
+  var keys = Object.keys(body.releases)
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i]
+    if (!key.trim()) return 'Release key must be a non-empty string'
+    var entry = body.releases[key]
+    if (!entry || typeof entry !== 'object') return 'Each release entry must be an object'
+    if (entry.products) {
+      if (typeof entry.products !== 'object' || Array.isArray(entry.products)) {
+        return 'products must be an object with string values'
+      }
+      var pKeys = Object.keys(entry.products)
+      for (var pi = 0; pi < pKeys.length; pi++) {
+        if (typeof entry.products[pKeys[pi]] !== 'string') {
+          return 'products.' + pKeys[pi] + ' must be a string'
+        }
+      }
+    }
+    if (entry.planningFreezeOverride !== undefined && entry.planningFreezeOverride !== null) {
+      if (typeof entry.planningFreezeOverride !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.planningFreezeOverride)) {
+        return 'planningFreezeOverride must be null or a YYYY-MM-DD string'
+      }
+    }
+  }
+  return null
+}
+
+function loadTrackingConfig(readFromStorage) {
+  var config = readFromStorage(TRACKING_CONFIG_FILE)
+  return config || { releases: {} }
+}
+
 module.exports = function registerFeatureTrackingRoutes(router, context) {
   const storage = context.storage
   const requireAuth = context.requireAuth
@@ -453,11 +540,40 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       }
     }
 
+    // Source 4: feature tracking config (user-defined releases)
+    const trackingConfig = loadTrackingConfig(storage.readFromStorage)
+    if (trackingConfig.releases) {
+      const trackingVersions = Object.keys(trackingConfig.releases)
+      for (let ti = 0; ti < trackingVersions.length; ti++) {
+        const tv = trackingVersions[ti]
+        if (!versionMap[tv] && !EXCLUDE_VERSION_RE.test(tv)) {
+          versionMap[tv] = { version: tv, products: [] }
+        }
+        // Add products from config entries
+        var entry = trackingConfig.releases[tv]
+        if (entry && entry.products) {
+          var productKeys = Object.keys(entry.products)
+          for (var pk = 0; pk < productKeys.length; pk++) {
+            var pName = productKeys[pk].toLowerCase()
+            if (!versionMap[tv]) versionMap[tv] = { version: tv, products: [] }
+            if (versionMap[tv].products.indexOf(pName) === -1) {
+              versionMap[tv].products.push(pName)
+            }
+          }
+        }
+      }
+    }
+
     const versions = Object.keys(versionMap).map(function (k) { return versionMap[k] })
 
     for (let vi = 0; vi < versions.length; vi++) {
       const fd = getFeatureFreezeDatesFromCache(versions[vi].version, storage.readFromStorage)
-      versions[vi].planningFreezeDate = fd.earliest || null
+      var ppDate = fd.earliest || null
+      // Apply tracking config fallback if PP returned nothing
+      if (!ppDate && trackingConfig.releases && trackingConfig.releases[versions[vi].version]) {
+        ppDate = trackingConfig.releases[versions[vi].version].planningFreezeOverride || null
+      }
+      versions[vi].planningFreezeDate = ppDate
     }
 
     versions.sort(function (a, b) {
@@ -497,7 +613,8 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       const jiraRequest = jira.jiraRequest
       const fetchAllJqlResults = jira.fetchAllJqlResults
 
-      const productVersions = await resolveProductVersionsFromJira(version, jiraRequest)
+      const tConfig = loadTrackingConfig(storage.readFromStorage)
+      const productVersions = await resolveProductVersionsFromJira(version, jiraRequest, tConfig)
       const freezeDates = getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
       const cacheDates = Object.assign({}, freezeDates.byProduct)
 
@@ -531,6 +648,16 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       } catch (schedErr) {
         scheduleSource = 'cache-only (' + schedErr.message + ')'
         console.error('[feature-tracking] Schedule API failed for version:', version, schedErr.message)
+      }
+
+      // Apply tracking config fallback if no freeze date resolved
+      if (!freezeDates.earliest && tConfig.releases && tConfig.releases[version]) {
+        var overrideDate = tConfig.releases[version].planningFreezeOverride
+        if (overrideDate) {
+          freezeDates.earliest = overrideDate
+          scheduleSource = (scheduleSource === 'none' ? '' : scheduleSource + ' + ') + 'config-fallback'
+          console.log('[feature-tracking] Using config fallback freeze date for', version, ':', overrideDate)
+        }
       }
 
       const groups = []
@@ -607,6 +734,20 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
     }
   })
 
+  // GET /tracking/config
+  router.get('/tracking/config', requireAuth, requireScope('releases:read'), function (req, res) {
+    res.json(loadTrackingConfig(storage.readFromStorage))
+  })
+
+  // PUT /tracking/config
+  router.put('/tracking/config', requireAuth, requireScope('releases:write'), function (req, res) {
+    var err = validateTrackingConfig(req.body)
+    if (err) return res.status(400).json({ error: err })
+    var config = { releases: req.body.releases }
+    storage.writeToStorage(TRACKING_CONFIG_FILE, config)
+    res.json(config)
+  })
+
 }
 
 module.exports.findFixVersionAddedDate = findFixVersionAddedDate
@@ -615,3 +756,5 @@ module.exports.classifyFeature = classifyFeature
 module.exports.extractProduct = extractProduct
 module.exports.normalizeVersionName = normalizeVersionName
 module.exports.resolveProductVersionsFromJira = resolveProductVersionsFromJira
+module.exports.validateTrackingConfig = validateTrackingConfig
+module.exports.loadTrackingConfig = loadTrackingConfig


### PR DESCRIPTION
## Summary

- **Planning Freeze Switch**: Replaced "feature freeze" date sourcing with "planning freeze" dates from the Product Pages schedule-tasks API (`q=planning freeze`). Added `extractPlanningFreezeDate` and `fetchPlanningFreezeDatesFromSchedule` functions in `product-pages.js`. Renamed UI labels from "Freeze Date" to "Planning Freeze" across the feature tracking view and table.
- **Settings Panel**: Added a gear icon to the feature tracking header that opens a slide-out settings drawer. Users can configure per-release Jira version names for each product (RHOAI, RHELAI, RHAII) and set fallback planning freeze dates. New `GET/PUT /tracking/config` endpoints persist settings to `feature-tracking-config.json`. Version resolution and freeze date logic now read from user config before falling back to dynamic discovery.

## Test plan

- [ ] Verify "Planning Freeze" label appears in summary card and table badge
- [ ] Click gear icon to open settings panel; add a release with product version names and a fallback freeze date; save
- [ ] Confirm new release appears in version chips after save
- [ ] Confirm fallback freeze date is used when Product Pages returns nothing
- [ ] Verify existing versions with PP-sourced freeze dates still resolve correctly
- [ ] Run `npm test` — all 4342 tests pass


Made with [Cursor](https://cursor.com)