### PR TITLE
fix(team-tracker): allow managers to edit boards on team detail page

### DIFF
--- a/modules/team-tracker/client/views/TeamRosterView.vue
+++ b/modules/team-tracker/client/views/TeamRosterView.vue
@@ -610,10 +610,7 @@ const editingBoards = ref(false)
 const editBoardsList = ref([])
 const savingBoards = ref(false)
 
-const canEditBoards = computed(() => {
-  if (!team.value?.teamId) return false
-  return canEditTeam(team.value.teamId)
-})
+const canEditBoards = computed(() => canManageMembers.value)
 
 function startEditingBoards() {
   const boards = teamDetail.value?.boards || []


### PR DESCRIPTION
## Summary

- **Bug:** Managers with purview over a team could not see the board edit button on the team detail page, even though they could already edit boards from the Manager Dashboard and the backend API allows it.
- **Fix:** Align `canEditBoards` with `canManageMembers` (used by Components, PM, Eng Lead on the same page) so managers who manage team members can also edit boards.

## Details

| Surface | Before | After |
|---------|--------|-------|
| Team detail page - board edit | admin/team-admin only | admin/team-admin/manager with purview |
| Team detail page - other fields | admin/team-admin/manager | (unchanged) |
| Manager Dashboard - board drawer | any manager | (unchanged) |
| Backend API (`requireTeamPurview`) | admin/team-admin/manager | (unchanged) |

## Test plan

- [x] TeamRosterView tests pass (7/7)
- [ ] Verify as a manager: board edit pencil icon now visible on team detail page
- [ ] Verify as non-manager non-admin: board edit button still hidden