### PR TITLE
fix(releases): prioritize user-entered planning freeze dates over Product Pages

### DIFF
--- a/modules/releases/client/execute/components/FeatureTrackingSettingsPanel.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingSettingsPanel.vue
@@ -65,7 +65,7 @@
 
             <div class="pt-2 border-t border-gray-100 dark:border-gray-700">
               <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                Planning Freeze (fallback)
+                Planning Freeze Date
               </label>
               <input
                 type="date"
@@ -73,7 +73,7 @@
                 class="text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
               />
               <p class="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
-                Used only when Product Pages returns no planning freeze date
+                Overrides the date from Product Pages when set
               </p>
             </div>
           </div>

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -567,13 +567,15 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
     const versions = Object.keys(versionMap).map(function (k) { return versionMap[k] })
 
     for (let vi = 0; vi < versions.length; vi++) {
-      const fd = getFeatureFreezeDatesFromCache(versions[vi].version, storage.readFromStorage)
-      var ppDate = fd.earliest || null
-      // Apply tracking config fallback if PP returned nothing
-      if (!ppDate && trackingConfig.releases && trackingConfig.releases[versions[vi].version]) {
-        ppDate = trackingConfig.releases[versions[vi].version].planningFreezeOverride || null
+      var vKey = versions[vi].version
+      // User-entered date takes priority over Product Pages
+      var userDate = (trackingConfig.releases && trackingConfig.releases[vKey] && trackingConfig.releases[vKey].planningFreezeOverride) || null
+      if (userDate) {
+        versions[vi].planningFreezeDate = userDate
+      } else {
+        const fd = getFeatureFreezeDatesFromCache(vKey, storage.readFromStorage)
+        versions[vi].planningFreezeDate = fd.earliest || null
       }
-      versions[vi].planningFreezeDate = ppDate
     }
 
     versions.sort(function (a, b) {
@@ -650,13 +652,13 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         console.error('[feature-tracking] Schedule API failed for version:', version, schedErr.message)
       }
 
-      // Apply tracking config fallback if no freeze date resolved
-      if (!freezeDates.earliest && tConfig.releases && tConfig.releases[version]) {
+      // User-entered date takes priority over Product Pages
+      if (tConfig.releases && tConfig.releases[version]) {
         var overrideDate = tConfig.releases[version].planningFreezeOverride
         if (overrideDate) {
           freezeDates.earliest = overrideDate
-          scheduleSource = (scheduleSource === 'none' ? '' : scheduleSource + ' + ') + 'config-fallback'
-          console.log('[feature-tracking] Using config fallback freeze date for', version, ':', overrideDate)
+          scheduleSource = 'user-override' + (scheduleSource !== 'none' ? ' (PP: ' + scheduleSource + ')' : '')
+          console.log('[feature-tracking] Using user-entered freeze date for', version, ':', overrideDate)
         }
       }
 


### PR DESCRIPTION
## Summary

- User-entered `planningFreezeOverride` now takes **priority** over dates from the Product Pages API, allowing users to correct inaccurate dates in real time via the settings panel
- Updated the settings panel label from "Planning Freeze (fallback)" to "Planning Freeze Date" with helper text "Overrides the date from Product Pages when set"

## Test plan

- [ ] Open Feature Tracking settings, add a planning freeze date for a release, save
- [ ] Verify the entered date appears in the Planning Freeze card (even if Product Pages has a different date)
- [ ] Remove the user-entered date and verify the Product Pages date is used again
- [ ] Run `npm test` — all tests pass


Made with [Cursor](https://cursor.com)