### PR TITLE
feat: add June 2026 Jira Autofix enablement materials with date groups

### DIFF
--- a/shared/client/enablement-links.js
+++ b/shared/client/enablement-links.js
@@ -69,10 +69,24 @@ export const enablementCategories = [
     title: 'Jira Autofix',
     section: 'ai-workflows',
     slackChannel: { name: '#wg-rhai-ai-first-code-autofix', url: 'https://app.slack.com/client/E030G10V24F/C0ASJ32PJ0N' },
-    links: [
-      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1b-PZD3OiPAA8LOZ8lWmfcNZBByUa0Nel/view?ts=69e8ff07' },
-      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1_UaHAI65K1P5Y2pAhZ4ie2KY-tHiSrqbnWN0UUqvsYs/edit?slide=id.g3d84ce2c2ca_1_0#slide=id.g3d84ce2c2ca_1_0' },
-      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1O3i5Ijoo3fi-gPHG0e9ON70Nfij2EUdfU18KOrVQADY/edit?tab=t.4ih80ylpl5y1' },
+    linkGroups: [
+      {
+        date: '2026JUN11',
+        links: [
+          { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1B3TYRfH2J8AtMXE4SsNuOl39hu4Z5boY/view' },
+          { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1m0TEwUxyuouEt8MK5F42mXS0PMuYt6IBcM3BKZUcvdU/edit?slide=id.g3dc5b8ade0b_0_14#slide=id.g3dc5b8ade0b_0_14' },
+          { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1Md24Vb77hbz4aP0Cu-RRdArJcfupAxPkcdoPjHfHims/edit?tab=t.xjqu48g1l03j' },
+          { label: 'Enablement Chat', icon: 'MessageSquare', url: 'https://drive.google.com/file/d/1h-CGNO2tSteblI0mls49yXtjiJdShh4g/view' },
+        ],
+      },
+      {
+        date: '2026APR22',
+        links: [
+          { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1b-PZD3OiPAA8LOZ8lWmfcNZBByUa0Nel/view?ts=69e8ff07' },
+          { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1_UaHAI65K1P5Y2pAhZ4ie2KY-tHiSrqbnWN0UUqvsYs/edit?slide=id.g3d84ce2c2ca_1_0#slide=id.g3d84ce2c2ca_1_0' },
+          { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1O3i5Ijoo3fi-gPHG0e9ON70Nfij2EUdfU18KOrVQADY/edit?tab=t.4ih80ylpl5y1' },
+        ],
+      },
     ],
   },
   {

--- a/src/components/AboutView.vue
+++ b/src/components/AboutView.vue
@@ -158,7 +158,28 @@
               {{ cat.slackChannel.name }}
             </a>
           </h3>
-          <div class="flex flex-wrap gap-4">
+          <template v-if="cat.resolvedLinkGroups">
+            <div v-for="group in cat.resolvedLinkGroups" :key="group.date" class="mb-4 last:mb-0">
+              <span class="inline-block mb-2 px-2.5 py-0.5 text-xs font-semibold rounded-full bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300">
+                {{ group.date }}
+              </span>
+              <div class="flex flex-wrap gap-4">
+                <a
+                  v-for="link in group.links"
+                  :key="link.url"
+                  :href="link.url"
+                  target="_blank"
+                  rel="noopener"
+                  class="flex items-center gap-2.5 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all duration-200"
+                >
+                  <component :is="link.icon" :size="18" :stroke-width="1.7" class="flex-shrink-0 text-gray-500 dark:text-gray-400" />
+                  <span>{{ link.label }}</span>
+                  <ExternalLink :size="14" class="flex-shrink-0 text-gray-400 dark:text-gray-500" />
+                </a>
+              </div>
+            </div>
+          </template>
+          <div v-else class="flex flex-wrap gap-4">
             <a
               v-for="link in cat.resolvedLinks"
               :key="link.url"
@@ -521,7 +542,13 @@ const docsSections = enablementSections.map(s => ({
     .filter(c => c.section === s.id)
     .map(c => ({
       ...c,
-      resolvedLinks: c.links.map(l => ({ ...l, icon: resolveIcon(l.icon) })),
+      resolvedLinks: c.links ? c.links.map(l => ({ ...l, icon: resolveIcon(l.icon) })) : null,
+      resolvedLinkGroups: c.linkGroups
+        ? c.linkGroups.map(g => ({
+          ...g,
+          links: g.links.map(l => ({ ...l, icon: resolveIcon(l.icon) })),
+        }))
+        : null,
     })),
 }))
 


### PR DESCRIPTION
Add linkGroups support to enablement categories so links can be grouped by date. The Jira Autofix section now shows two sets of enablement content: 2026JUN11 (4 new links) and 2026APR22 (existing 3 links).

Closes #993

Generated with [Claude Code](https://claude.ai/code)