### PR TITLE
fix(releases): UX improvements on plan features list tab

### DIFF
--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -1,12 +1,17 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, inject } from 'vue'
 import { useFeatureReadiness } from '../composables/useFeatureReadiness'
 import { useReleases } from '../composables/useReleasePlanning'
 import FeatureReadinessFilterBar from '../components/FeatureReadinessFilterBar.vue'
 import FeatureReadinessRow from '@shared/client/components/FeatureReadinessRow.vue'
 import FeatureReadinessDrawer from '@shared/client/components/FeatureReadinessDrawer.vue'
 
+const nav = inject('moduleNav')
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
+
+function navigateToFeature(key) {
+  nav.navigateTo('feature-detail', { key, from: 'plan-features' })
+}
 
 const { pendingReview, ready, filterMeta, meta, loading, error, loadFeatureReadiness } = useFeatureReadiness()
 const { releases, loadReleases } = useReleases()
@@ -103,8 +108,8 @@ const headers = [
   { id: 'h-key',        label: 'Key',             scope: 'col' },
   { id: 'h-title',      label: 'Title',           scope: 'col' },
   { id: 'h-outcome',    label: 'Outcome',         scope: 'col' },
-  { id: 'h-target',     label: 'Target Version',  scope: 'col' },
-  { id: 'h-fixver',     label: 'Fix Version',     scope: 'col' },
+  { id: 'h-target',     label: 'Target Version',  scope: 'col', info: 'The release version that PM is targeting for this feature to be delivered in.' },
+  { id: 'h-fixver',     label: 'Fix Version',     scope: 'col', info: 'The release version that engineering has committed to delivering this feature in.' },
   { id: 'h-comp',       label: 'Components',      scope: 'col' },
   { id: 'h-team',       label: 'Team',            scope: 'col' },
   { id: 'h-rubric',     label: 'Rubric',          scope: 'col' },
@@ -113,8 +118,6 @@ const headers = [
   { id: 'h-priority',   label: 'Priority',        scope: 'col' },
   { id: 'h-attention',  label: '',                scope: 'col' },
 ]
-
-const showLegend = ref(false)
 
 function formatSyncDate(dateStr) {
   if (!dateStr) return '—'
@@ -177,17 +180,13 @@ function formatSyncDate(dateStr) {
               :scope="header.scope"
               class="px-3 py-2.5 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide leading-tight"
             >
-              <span v-if="header.hasTooltip" class="inline-flex items-center gap-1">
+              <span v-if="header.hasTooltip" class="inline-flex items-center gap-1 group relative">
                 {{ header.label }}
-                <button
-                  type="button"
-                  class="relative inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-500 text-[9px] font-bold leading-none cursor-help"
-                  title="Color indicates confidence: Green=Committed, Yellow=Ready, Red=Not Ready"
-                  @click.stop="showLegend = !showLegend"
-                >i</button>
+                <span
+                  class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 text-[9px] font-bold leading-none cursor-help"
+                >i</span>
                 <div
-                  v-if="showLegend"
-                  class="absolute z-50 mt-1 top-8 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal normal-case tracking-normal"
+                  class="absolute z-50 top-full mt-1 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block"
                 >
                   <p class="font-semibold text-gray-700 dark:text-gray-200 mb-1.5">Confidence Legend</p>
                   <div class="space-y-1">
@@ -204,12 +203,16 @@ function formatSyncDate(dateStr) {
                       <span class="text-gray-600 dark:text-gray-300"><strong>Not Ready</strong> — does not pass readiness gates</span>
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    class="mt-2 text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                    @click.stop="showLegend = false"
-                  >Close</button>
                 </div>
+              </span>
+              <span v-else-if="header.info" class="inline-flex items-center gap-1 group relative">
+                {{ header.label }}
+                <span
+                  class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 text-[9px] font-bold leading-none cursor-help"
+                >i</span>
+                <span class="absolute z-50 top-full mt-1 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block">
+                  {{ header.info }}
+                </span>
               </span>
               <span v-else>{{ header.label }}</span>
             </th>
@@ -233,6 +236,7 @@ function formatSyncDate(dateStr) {
             :index="i + 1"
             :jiraBaseUrl="jiraBaseUrl"
             @select="selectedFeature = $event"
+            @navigate="navigateToFeature"
           />
 
           <!-- Empty state -->
@@ -260,5 +264,6 @@ function formatSyncDate(dateStr) {
     :feature="selectedFeature"
     :jiraBaseUrl="jiraBaseUrl"
     @close="selectedFeature = null"
+    @navigate="navigateToFeature"
   />
 </template>

--- a/modules/releases/client/views/FeatureDetailView.vue
+++ b/modules/releases/client/views/FeatureDetailView.vue
@@ -147,6 +147,7 @@ const hasDeliveryInsight = computed(() => {
 const fromRfe = computed(() => nav.params.value.fromRfe)
 const fromFeatureReview = computed(() => nav.params.value.fromFeatureReview)
 const fromPlan = computed(() => nav.params.value.from === 'plan')
+const fromPlanFeatures = computed(() => nav.params.value.from === 'plan-features')
 const fromFeatureStatus = computed(() => nav.params.value.from === 'feature-status')
 const fromHygieneReport = computed(() => nav.params.value.from === 'hygiene-report')
 const fromForYou = computed(() => nav.params.value.from === 'state-of-the-union')
@@ -158,6 +159,8 @@ function goBack() {
     crossNavigate('ai-impact', 'rfe-review', { select: fromRfe.value })
   } else if (fromFeatureReview.value) {
     crossNavigate('ai-impact', 'feature-review')
+  } else if (fromPlanFeatures.value) {
+    nav.navigateTo('plan', { tab: 'feature-readiness' })
   } else if (fromPlan.value) {
     nav.navigateTo('plan')
   } else if (fromHygieneReport.value) {
@@ -362,7 +365,7 @@ onMounted(() => {
       class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white flex items-center gap-1"
       @click="goBack"
     >
-      &larr; {{ fromForYou ? 'Back to State of the Union' : fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : fromPlan ? 'Back to Plan' : fromHygieneReport ? 'Back to Hygiene Report' : fromFeatureStatus ? 'Back to Feature Status' : 'Back to Execute' }}
+      &larr; {{ fromForYou ? 'Back to State of the Union' : fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : fromPlanFeatures ? 'Back to Features List' : fromPlan ? 'Back to Plan' : fromHygieneReport ? 'Back to Hygiene Report' : fromFeatureStatus ? 'Back to Feature Status' : 'Back to Execute' }}
     </button>
 
     <!-- Loading -->

--- a/shared/__tests__/client/FeatureReadinessRow.test.js
+++ b/shared/__tests__/client/FeatureReadinessRow.test.js
@@ -152,11 +152,13 @@ describe('FeatureReadinessRow', () => {
       expect(wrapper.emitted('select')[0][0]).toEqual(feature)
     })
 
-    it('renders Jira link with correct href', () => {
+    it('renders feature key as navigate button with Jira external link', () => {
       const wrapper = mountRow(makeFeature({ key: 'RHAISTRAT-42' }))
-      const link = wrapper.find('a')
-      expect(link.attributes('href')).toBe('https://issues.redhat.com/browse/RHAISTRAT-42')
-      expect(link.text()).toBe('RHAISTRAT-42')
+      const keyButton = wrapper.find('button')
+      expect(keyButton.text()).toBe('RHAISTRAT-42')
+      const jiraLink = wrapper.find('a[href="https://issues.redhat.com/browse/RHAISTRAT-42"]')
+      expect(jiraLink.exists()).toBe(true)
+      expect(jiraLink.attributes('target')).toBe('_blank')
     })
 
     it('shows tilde prefix for fallback priority score', () => {

--- a/shared/client/components/FeatureReadinessDrawer.vue
+++ b/shared/client/components/FeatureReadinessDrawer.vue
@@ -7,7 +7,7 @@ const props = defineProps({
   jiraBaseUrl: { type: String, default: 'https://issues.redhat.com/browse' }
 })
 
-const emit = defineEmits(['close'])
+const emit = defineEmits(['close', 'navigate'])
 
 const open = computed(() => props.feature !== null)
 
@@ -190,13 +190,25 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
         <!-- Header -->
         <div class="px-4 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60 shrink-0">
           <div class="flex items-start gap-2">
-            <a
-              :href="`${jiraBaseUrl}/${feature.key}`"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="font-mono text-xs font-bold text-primary-600 dark:text-blue-400 hover:underline shrink-0 mt-0.5"
-              @click.stop
-            >{{ feature.key }}</a>
+            <span class="inline-flex items-center gap-1 shrink-0 mt-0.5">
+              <button
+                type="button"
+                class="font-mono text-xs font-bold text-primary-600 dark:text-blue-400 hover:underline"
+                @click.stop="emit('navigate', feature.key)"
+              >{{ feature.key }}</button>
+              <a
+                :href="`${jiraBaseUrl}/${feature.key}`"
+                target="_blank"
+                rel="noopener noreferrer"
+                :aria-label="`Open ${feature.key} in Jira`"
+                class="text-gray-400 dark:text-gray-500 hover:text-primary-600 dark:hover:text-blue-400 transition-colors"
+                @click.stop
+              >
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            </span>
             <p class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100 leading-snug">
               {{ feature.title || '—' }}
             </p>

--- a/shared/client/components/FeatureReadinessRow.vue
+++ b/shared/client/components/FeatureReadinessRow.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   index: { type: Number, default: null }
 })
 
-const emit = defineEmits(['select'])
+const emit = defineEmits(['select', 'navigate'])
 
 const isHealthPipeline = computed(() => props.feature.dataSource === 'health-pipeline')
 
@@ -116,14 +116,26 @@ const confidenceTooltip = computed(() => {
 
     <!-- Key -->
     <td class="px-3 py-2.5 whitespace-nowrap">
-      <a
-        :href="`${jiraBaseUrl}/${feature.key}`"
-        target="_blank"
-        rel="noopener noreferrer"
-        :aria-label="`Open Jira issue ${feature.key} in new tab`"
-        class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
-        @click.stop
-      >{{ feature.key }}</a>
+      <span class="inline-flex items-center gap-1">
+        <button
+          type="button"
+          :aria-label="`View feature details for ${feature.key}`"
+          class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
+          @click.stop="emit('navigate', feature.key)"
+        >{{ feature.key }}</button>
+        <a
+          :href="`${jiraBaseUrl}/${feature.key}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          :aria-label="`Open ${feature.key} in Jira`"
+          class="text-gray-400 dark:text-gray-500 hover:text-primary-600 dark:hover:text-blue-400 transition-colors"
+          @click.stop
+        >
+          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
+      </span>
     </td>
 
     <!-- Title -->

--- a/shared/client/components/RubricScoreBadge.vue
+++ b/shared/client/components/RubricScoreBadge.vue
@@ -10,10 +10,10 @@ const props = defineProps({
 })
 
 const DIMENSIONS = [
-  { key: 'feasibility', label: 'F' },
-  { key: 'testability', label: 'T' },
-  { key: 'scope', label: 'S' },
-  { key: 'architecture', label: 'A' }
+  { key: 'feasibility', label: 'Feasibility' },
+  { key: 'testability', label: 'Testability' },
+  { key: 'scope', label: 'Scope' },
+  { key: 'architecture', label: 'Architecture' }
 ]
 
 function scoreClass(score) {


### PR DESCRIPTION
## Summary

Addresses #1001 — four UX improvements to the features list tab on the releases plan page:

- **Info bubbles**: Added hover tooltips on Target Version and Fix Version column headers explaining the difference between them
- **Readiness popover fix**: Fixed confidence legend positioning (was rendering at page top-left) and converted to hover-based display matching the other info bubbles
- **Feature key navigation**: Feature keys now link to the internal feature detail page instead of Jira. A small external-link arrow opens Jira if needed. Same treatment in the readiness drawer. Breadcrumbs return to the Features List tab.
- **Rubric labels**: Expanded single-letter abbreviations (F, T, S, A) to full dimension names (Feasibility, Testability, Scope, Architecture)

Closes #1001

## Test plan

- [ ] Hover over Target Version / Fix Version headers — info bubble appears
- [ ] Hover over Readiness header — confidence legend appears inline below the header
- [ ] Click a feature key in the table — navigates to feature detail page
- [ ] Verify back button on feature detail says "Back to Features List" and returns to the correct tab
- [ ] Verify external Jira arrow icon opens the issue in a new tab
- [ ] Click a feature key in the readiness drawer — same navigation behavior
- [ ] Rubric column shows full dimension names (Feasibility, Testability, Scope, Architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)