### PR TITLE
fix(ci): add --repo flag to gh pr commands in guard-ai-configs

### DIFF
--- a/.github/workflows/guard-ai-configs.yml
+++ b/.github/workflows/guard-ai-configs.yml
@@ -129,13 +129,14 @@ jobs:
         if: steps.check_sensitive_files.outputs.detected == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
           MODIFIED_FILES_LIST: ${{ steps.check_sensitive_files.outputs.modified_files }}
         run: |
-          COMMENT_EXISTS=$(gh pr view "$PR_NUMBER" --json comments -q '.comments[] | select(.author.login=="github-actions") | select(.body | contains("AI Configuration Guard")) | .id' | head -1)
+          COMMENT_EXISTS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json comments -q '.comments[] | select(.author.login=="github-actions") | select(.body | contains("AI Configuration Guard")) | .id' | head -1)
           if [ -z "$COMMENT_EXISTS" ]; then
             COMMENT_BODY=$(printf "**AI Configuration Guard**\n\nThis PR modifies sensitive AI configuration files or workflows that require approval from a member of: **@%s**\n\nThe following sensitive files were detected:\n%s\nAn approval from an authorized team member is required before this PR can be merged." "${ALLOWED_APPROVER_TEAM}" "${MODIFIED_FILES_LIST}")
-            gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
           else
             echo "Comment already exists (ID: $COMMENT_EXISTS), skipping duplicate."
           fi
@@ -170,7 +171,7 @@ jobs:
           fi
 
           # Use app token to query team membership (requires org members:read)
-          REVIEWS=$(gh pr view "$PR_NUMBER" --json reviews -q '.reviews[] | select(.state=="APPROVED") | .author.login')
+          REVIEWS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json reviews -q '.reviews[] | select(.state=="APPROVED") | .author.login')
 
           ORG=$(echo "${ALLOWED_APPROVER_TEAM}" | cut -d'/' -f1)
           TEAM_SLUG=$(echo "${ALLOWED_APPROVER_TEAM}" | cut -d'/' -f2)


### PR DESCRIPTION
## Summary

- Adds `--repo "$REPO"` to all three `gh pr view`/`gh pr comment` calls in `guard-ai-configs.yml`
- Adds missing `REPO` env var to the "Post PR comment" step

The workflow intentionally skips `actions/checkout` (security posture for `pull_request_target` — never executes PR code). But `gh pr view` and `gh pr comment` need either a git repo context or an explicit `--repo` flag to know which repository to query. Without it, they fail with `fatal: not a git repository`.

This was a latent bug — it only fires when a PR touches sensitive files (`AGENTS.md`, `.claude/`, etc.), which is why it wasn't caught before. Exposed by #981 (Vite upgrade) which updates `AGENTS.md`.

## Test plan

- [x] Can't test in a PR (workflow runs from main branch, per its design)
- [x] Verified the fix by inspecting the three `gh pr` call sites — all now have `--repo "$REPO"`
- [x] Will validate once merged by re-running the guard check on #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)