### PR TITLE
fix(ci): fix guard-ai-configs 403 on fork PRs

### DIFF
--- a/.github/workflows/guard-ai-configs.yml
+++ b/.github/workflows/guard-ai-configs.yml
@@ -113,8 +113,11 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
 
+      # On pull_request_review, the status was already set by the earlier
+      # pull_request_target run. Skip to avoid 403 on fork PRs where the
+      # GITHUB_TOKEN lacks statuses:write on the base repo.
       - name: Set status — no sensitive files changed
-        if: steps.check_sensitive_files.outputs.detected != 'true'
+        if: steps.check_sensitive_files.outputs.detected != 'true' && github.event_name != 'pull_request_review'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
@@ -141,9 +144,10 @@ jobs:
             echo "Comment already exists (ID: $COMMENT_EXISTS), skipping duplicate."
           fi
 
-      # Generates "APP_TOKEN" to verify the reviewer belongs to the team of approvers.
-      # Both triggers (pull_request_target and pull_request_review) run in the base
-      # repo context, so secrets are always available.
+      # Generates "APP_TOKEN" to verify the reviewer belongs to the team of
+      # approvers AND to write commit statuses. The GITHUB_TOKEN on
+      # pull_request_review events lacks statuses:write for fork PRs, so the
+      # App token is used for all status writes in the sensitive-files path.
       - name: Generate GitHub App token
         id: app-token
         if: steps.check_sensitive_files.outputs.detected == 'true'
@@ -155,27 +159,24 @@ jobs:
       - name: Check for team approval and set status
         if: steps.check_sensitive_files.outputs.detected == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
           HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
           REPO: ${{ github.repository }}
         run: |
-          if [ -z "$APP_TOKEN" ]; then
+          if [ -z "$GH_TOKEN" ]; then
             echo "::error::App token unavailable — cannot verify team membership."
-            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              -f state=failure \
-              -f context="${STATUS_CONTEXT}" \
-              -f description="App token unavailable — cannot verify approval" || true
             exit 1
           fi
 
-          # Use app token to query team membership (requires org members:read)
+          # App token is used for all calls: team membership, PR reviews, and
+          # commit status writes. This ensures fork PRs work (GITHUB_TOKEN on
+          # pull_request_review lacks statuses:write for forks).
           REVIEWS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json reviews -q '.reviews[] | select(.state=="APPROVED") | .author.login')
 
           ORG=$(echo "${ALLOWED_APPROVER_TEAM}" | cut -d'/' -f1)
           TEAM_SLUG=$(echo "${ALLOWED_APPROVER_TEAM}" | cut -d'/' -f2)
-          TEAM_MEMBERS=$(GH_TOKEN="$APP_TOKEN" gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/members" -q '.[].login')
+          TEAM_MEMBERS=$(gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/members" -q '.[].login')
 
           APPROVED=false
           APPROVER=""


### PR DESCRIPTION
## Summary

- Skip the "no sensitive files" status API call on `pull_request_review` events — it's redundant since `pull_request_target` already set it, and the `GITHUB_TOKEN` on `pull_request_review` lacks `statuses:write` for fork PRs
- Use the GitHub App token for all API calls in the sensitive-files approval path (team membership, PR reviews, and commit status writes), so approval re-evaluation works on fork PRs too

Fixes the failing "Guard AI Configurations" check on #977 (and any other fork PR that triggers a `pull_request_review` event).

## Root cause

`pull_request_target` runs with the base repo's `GITHUB_TOKEN` (full permissions). `pull_request_review` on fork PRs gets a restricted token that can't write commit statuses on the base repo → HTTP 403.

## Test plan

- [ ] Verify CI passes on this PR (the workflow itself runs from main, so the fix won't take effect until merged)
- [ ] After merge, verify the failing check on #977 resolves on the next review event
- [ ] Test a fork PR that touches sensitive files (`.claude/`, `AGENTS.md`) to confirm approval re-evaluation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)