### PR TITLE
fix(releases): remove broken dynamic hygiene eval, add refresh button and Jira links

### DIFF
--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -2,6 +2,8 @@
 import { ref, computed, onMounted, inject } from 'vue'
 import { useFeatureReadiness } from '../composables/useFeatureReadiness'
 import { useReleases } from '../composables/useReleasePlanning'
+import { useRefreshPolling } from '../composables/useRefreshPolling'
+import { apiRequest } from '@shared/client/services/api'
 import FeatureReadinessFilterBar from '../components/FeatureReadinessFilterBar.vue'
 import FeatureReadinessRow from '@shared/client/components/FeatureReadinessRow.vue'
 import FeatureReadinessDrawer from '@shared/client/components/FeatureReadinessDrawer.vue'
@@ -15,6 +17,34 @@ function navigateToFeature(key) {
 
 const { pendingReview, ready, filterMeta, meta, loading, error, loadFeatureReadiness } = useFeatureReadiness()
 const { releases, loadReleases } = useReleases()
+
+const refreshing = ref(false)
+const refreshStatus = ref('')
+
+async function triggerHygieneRefresh() {
+  refreshing.value = true
+  refreshStatus.value = 'Starting hygiene refresh...'
+  try {
+    await apiRequest('/modules/releases/hygiene/refresh-all', { method: 'POST' })
+  } catch {
+    refreshStatus.value = 'Refresh failed'
+    refreshing.value = false
+  }
+}
+
+async function checkRefreshStatus() {
+  var data = await apiRequest('/modules/releases/hygiene/refresh/status')
+  if (data.running) {
+    refreshStatus.value = (data.progress && data.progress.message) || 'Refreshing...'
+  }
+  return data
+}
+
+useRefreshPolling(refreshing, checkRefreshStatus, function() {
+  refreshing.value = false
+  refreshStatus.value = ''
+  loadFeatureReadiness()
+})
 
 onMounted(function() {
   loadFeatureReadiness()
@@ -150,6 +180,12 @@ function formatSyncDate(dateStr) {
         <span>{{ readyCounts.total }} features</span>
         <span class="text-green-600 dark:text-green-400">{{ readyCounts.ready }} ready</span>
         <span class="text-red-600 dark:text-red-400">{{ readyCounts.notReady }} not ready</span>
+        <button
+          @click="triggerHygieneRefresh"
+          :disabled="refreshing"
+          class="ml-2 px-3 py-1 text-xs font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          :title="refreshing ? refreshStatus : 'Refresh hygiene data from Jira'"
+        >{{ refreshing ? 'Refreshing...' : 'Refresh Hygiene' }}</button>
       </div>
     </div>
 

--- a/modules/releases/server/hygiene/hygiene-rules.js
+++ b/modules/releases/server/hygiene/hygiene-rules.js
@@ -337,7 +337,8 @@ function evaluateHygiene(feature, rulesConfig) {
         id: rule.id,
         name: rule.name,
         category: rule.category,
-        message: rule.message(feature)
+        message: rule.message(feature),
+        remediation: rule.remediation
       })
     }
   }

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -2703,10 +2703,10 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
 })
 
 // ---------------------------------------------------------------------------
-// Dynamic hygiene evaluation in pass 3
+// Hygiene violations from cache (hygieneIndex)
 // ---------------------------------------------------------------------------
 
-describe('buildFeatureReadiness - dynamic hygiene evaluation', function() {
+describe('buildFeatureReadiness - hygiene violations from cache', function() {
   function makeExecIndex(features) {
     return { features: features, fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: features.length }
   }
@@ -2741,32 +2741,7 @@ describe('buildFeatureReadiness - dynamic hygiene evaluation', function() {
     }, overrides)
   }
 
-  it('dynamically evaluates hygiene for Jira pass 3 features not in hygieneIndex', function() {
-    var jiraFeatures = makeJiraMap([
-      makeJiraFeature('RHAISTRAT-DYN1', {
-        status: 'In Progress',
-        assignee: null,
-        team: null
-      })
-    ])
-
-    var readFromStorage = makeReadFromStorage({
-      'ai-impact/features.json': makeFeaturesStore({}),
-      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
-      'releases/execution/index.json': makeExecIndex([])
-    })
-
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
-    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN1' })
-    expect(feature).toBeDefined()
-    expect(feature.violations).not.toBeNull()
-    expect(feature.violations.length).toBeGreaterThan(0)
-    var violationIds = feature.violations.map(function(v) { return v.id })
-    expect(violationIds).toContain('missing-assignee')
-    expect(violationIds).toContain('missing-team')
-  })
-
-  it('does not dynamically evaluate when hygieneIndex already has violations', function() {
+  it('attaches cached violations from hygieneIndex', function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-DYN2', {
         status: 'In Progress',
@@ -2794,7 +2769,28 @@ describe('buildFeatureReadiness - dynamic hygiene evaluation', function() {
     expect(feature.violations).toEqual([{ id: 'cached-violation', name: 'Cached Violation' }])
   })
 
-  it('does not dynamically evaluate for execution index source', function() {
+  it('returns null violations for features not in hygieneIndex', function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-DYN1', {
+        status: 'In Progress',
+        assignee: null,
+        team: null
+      })
+    ])
+
+    var readFromStorage = makeReadFromStorage({
+      'ai-impact/features.json': makeFeaturesStore({}),
+      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
+      'releases/execution/index.json': makeExecIndex([])
+    })
+
+    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN1' })
+    expect(feature).toBeDefined()
+    expect(feature.violations).toBeNull()
+  })
+
+  it('returns null violations for execution index features', function() {
     var readFromStorage = makeReadFromStorage({
       'ai-impact/features.json': makeFeaturesStore({}),
       'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
@@ -2816,29 +2812,5 @@ describe('buildFeatureReadiness - dynamic hygiene evaluation', function() {
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN3' })
     expect(feature).toBeDefined()
     expect(feature.violations).toBeNull()
-  })
-
-  it('detects missing-color-status for In Progress feature without colorStatus', function() {
-    var jiraFeatures = makeJiraMap([
-      makeJiraFeature('RHAISTRAT-DYN4', {
-        status: 'In Progress',
-        assignee: 'Owner',
-        team: 'MyTeam',
-        colorStatus: null
-      })
-    ])
-
-    var readFromStorage = makeReadFromStorage({
-      'ai-impact/features.json': makeFeaturesStore({}),
-      'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
-      'releases/execution/index.json': makeExecIndex([])
-    })
-
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
-    var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN4' })
-    expect(feature).toBeDefined()
-    expect(feature.violations).not.toBeNull()
-    var violationIds = feature.violations.map(function(v) { return v.id })
-    expect(violationIds).toContain('missing-color-status')
   })
 })

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -234,7 +234,6 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
 
   var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
 
-
   for (var cvi = 0; cvi < configuredVersions.length; cvi++) {
     var cv = configuredVersions[cvi]
     if (!versionAliasMap[cv]) {

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -1,8 +1,6 @@
 var { getConfiguredReleases } = require('./config')
 var { loadIndex } = require('./cache-reader')
 var { CLOSED_STATUSES } = require('./constants')
-var { evaluateHygiene } = require('../hygiene/hygiene-rules')
-var { loadConfig: loadHygieneConfig } = require('../hygiene/config')
 var { deriveHumanReviewStatus: sharedDeriveStatus } = require('../execution/ai-review-fields')
 
 var RICE_MAX = 16900 // 13 × 13 × 100 ÷ 1 (theoretical max: max Reach × max Impact × max Confidence ÷ min Effort)
@@ -236,13 +234,6 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
 
   var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
 
-  var hygieneRulesConfig = {}
-  try {
-    var hConfig = loadHygieneConfig({ readFromStorage: readFromStorage })
-    hygieneRulesConfig = hConfig.rules || {}
-  } catch {
-    // hygiene config not available
-  }
 
   for (var cvi = 0; cvi < configuredVersions.length; cvi++) {
     var cv = configuredVersions[cvi]
@@ -390,23 +381,6 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       : (healthComponents.length > 0 ? healthComponents : jiraComponents)
 
     var violations = hygieneIndex.get(key) || null
-    if (!violations && jiraFeatures && jiraFeatures.has(key)) {
-      try {
-        var jf = jiraFeatures.get(key)
-        violations = evaluateHygiene({
-          key: key, summary: jf.summary || latest.title, status: jf.status || latest.status,
-          issueType: jf.issueType, assignee: jf.assignee, team: team,
-          components: componentsList, fixVersions: jf.fixVersions || [],
-          labels: jf.labels || [], statusSummary: jf.statusSummary || null,
-          colorStatus: jf.colorStatus || null, releaseType: jf.releaseType || null,
-          docsRequired: jf.docsRequired || null, targetEnd: jf.targetEnd || null,
-          riceScore: jf.riceScore || null
-        }, hygieneRulesConfig)
-        if (violations && violations.length === 0) violations = null
-      } catch {
-        // dynamic evaluation failed, leave violations as null
-      }
-    }
     var isApproved = latest.humanReviewStatus === 'approved'
     var blockedByHygiene = hasBlockingViolations(violations)
     var isReady = isApproved && !blockedByHygiene
@@ -506,23 +480,6 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
     var hpPriorityBreakdown = hpFallback ? hpFallbackResult : (hd.priorityBreakdown || null)
 
     var hpViolations = hygieneIndex.get(ckey) || null
-    if (!hpViolations && jiraFeatures && jiraFeatures.has(ckey)) {
-      try {
-        var hpJf = jiraFeatures.get(ckey)
-        hpViolations = evaluateHygiene({
-          key: ckey, summary: hpJf.summary || hd.summary, status: hpJf.status || hd.status,
-          issueType: hpJf.issueType, assignee: hpJf.assignee || hd.assignee,
-          team: hpTeam, components: hpComponents, fixVersions: hpJf.fixVersions || [],
-          labels: hpJf.labels || [], statusSummary: hpJf.statusSummary || null,
-          colorStatus: hpJf.colorStatus || null, releaseType: hpJf.releaseType || null,
-          docsRequired: hpJf.docsRequired || null, targetEnd: hpJf.targetEnd || null,
-          riceScore: hpJf.riceScore || null
-        }, hygieneRulesConfig)
-        if (hpViolations && hpViolations.length === 0) hpViolations = null
-      } catch {
-        // dynamic evaluation failed, leave violations as null
-      }
-    }
     var hpGatesReady = isHealthFeatureReady(hd, cd)
     var hpBlockedByHygiene = hasBlockingViolations(hpViolations)
     var hpReady = hpGatesReady && !hpBlockedByHygiene
@@ -618,30 +575,6 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
     var efAssignee = typeof ef.assignee === 'string' ? ef.assignee : (ef.assignee && ef.assignee.displayName ? ef.assignee.displayName : null)
     var efTeam = teamIndex.get(ef.key) || ef.team || null
     var efViolations = hygieneIndex.get(ef.key) || null
-    if (!efViolations && pass3DataSource === 'jira') {
-      try {
-        efViolations = evaluateHygiene({
-          key: ef.key,
-          summary: ef.summary,
-          status: ef.status,
-          issueType: ef.issueType,
-          assignee: efAssignee,
-          team: efTeam,
-          components: efComponents,
-          fixVersions: efFixVersions,
-          labels: efLabels,
-          statusSummary: ef.statusSummary || null,
-          colorStatus: ef.colorStatus || null,
-          releaseType: ef.releaseType || null,
-          docsRequired: ef.docsRequired || null,
-          targetEnd: ef.targetEnd || null,
-          riceScore: ef.riceScore || null
-        }, hygieneRulesConfig)
-        if (efViolations && efViolations.length === 0) efViolations = null
-      } catch {
-        // dynamic evaluation failed, leave as null
-      }
-    }
 
     var efCandidateData = candidateIndex.get(ef.key) || null
     var efTier = efCandidateData && efCandidateData.tier != null ? 'T' + efCandidateData.tier : null

--- a/shared/__tests__/client/FeatureReadinessDrawer.test.js
+++ b/shared/__tests__/client/FeatureReadinessDrawer.test.js
@@ -405,4 +405,27 @@ describe('FeatureReadinessDrawer', () => {
       expect(wrapper.text()).toContain('Target Version')
     })
   })
+
+  describe('Fix in Jira link in hygiene violations', () => {
+    it('renders "Fix in Jira" links when violations exist', () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        key: 'RHAISTRAT-42',
+        violations: [
+          { id: 'missing-assignee', name: 'Missing Assignee', category: 'ownership', message: 'No assignee' }
+        ]
+      }))
+      const links = wrapper.findAll('a').filter(a => a.text().includes('Fix in Jira'))
+      expect(links.length).toBe(1)
+      expect(links[0].attributes('href')).toBe('https://issues.redhat.com/browse/RHAISTRAT-42')
+    })
+
+    it('shows remediation text in hygiene violation cards', () => {
+      const wrapper = mountDrawer(makeStratFeature({
+        violations: [
+          { id: 'missing-assignee', name: 'Missing Assignee', category: 'ownership', message: 'No assignee', remediation: 'Set the Assignee field' }
+        ]
+      }))
+      expect(wrapper.text()).toContain('Set the Assignee field')
+    })
+  })
 })

--- a/shared/__tests__/client/HygieneViolations.test.js
+++ b/shared/__tests__/client/HygieneViolations.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import HygieneViolations from '../../client/components/HygieneViolations.vue'
+
+function mountViolations(props = {}) {
+  return mount(HygieneViolations, { props })
+}
+
+describe('HygieneViolations', () => {
+  describe('all clear state', () => {
+    it('shows "All checks passing" when violations is empty', () => {
+      const wrapper = mountViolations({ violations: [] })
+      expect(wrapper.text()).toContain('All checks passing')
+    })
+
+    it('shows "All checks passing" when violations is default (empty)', () => {
+      const wrapper = mountViolations()
+      expect(wrapper.text()).toContain('All checks passing')
+    })
+  })
+
+  describe('violation rendering', () => {
+    const violations = [
+      { id: 'missing-assignee', name: 'Missing Assignee', category: 'ownership', message: 'No assignee set' },
+      { id: 'stale-status', name: 'Stale Status', category: 'timeliness', message: 'Status unchanged for 30+ days' }
+    ]
+
+    it('renders violation names', () => {
+      const wrapper = mountViolations({ violations })
+      expect(wrapper.text()).toContain('Missing Assignee')
+      expect(wrapper.text()).toContain('Stale Status')
+    })
+
+    it('renders violation messages', () => {
+      const wrapper = mountViolations({ violations })
+      expect(wrapper.text()).toContain('No assignee set')
+      expect(wrapper.text()).toContain('Status unchanged for 30+ days')
+    })
+
+    it('groups violations by category', () => {
+      const wrapper = mountViolations({ violations })
+      expect(wrapper.text()).toContain('Ownership')
+      expect(wrapper.text()).toContain('Timeliness')
+    })
+  })
+
+  describe('remediation text', () => {
+    it('shows remediation text when present', () => {
+      const violations = [
+        { id: 'missing-assignee', name: 'Missing Assignee', category: 'ownership', message: 'No assignee', remediation: 'Set the Assignee field in Jira' }
+      ]
+      const wrapper = mountViolations({ violations })
+      expect(wrapper.text()).toContain('Set the Assignee field in Jira')
+    })
+
+    it('does not render remediation paragraph when remediation is absent', () => {
+      const violations = [
+        { id: 'missing-assignee', name: 'Missing Assignee', category: 'ownership', message: 'No assignee' }
+      ]
+      const wrapper = mountViolations({ violations })
+      const italicPs = wrapper.findAll('p').filter(p => p.classes().includes('italic'))
+      expect(italicPs.length).toBe(0)
+    })
+  })
+
+  describe('Fix in Jira link', () => {
+    const violations = [
+      { id: 'missing-assignee', name: 'Missing Assignee', category: 'ownership', message: 'No assignee' }
+    ]
+
+    it('renders "Fix in Jira" link when featureKey is provided', () => {
+      const wrapper = mountViolations({ violations, featureKey: 'RHAISTRAT-100' })
+      const link = wrapper.find('a')
+      expect(link.exists()).toBe(true)
+      expect(link.text()).toContain('Fix in Jira')
+      expect(link.attributes('href')).toBe('https://issues.redhat.com/browse/RHAISTRAT-100')
+      expect(link.attributes('target')).toBe('_blank')
+    })
+
+    it('uses custom jiraBaseUrl when provided', () => {
+      const wrapper = mountViolations({
+        violations,
+        featureKey: 'RHAISTRAT-100',
+        jiraBaseUrl: 'https://custom.jira.com/browse'
+      })
+      const link = wrapper.find('a')
+      expect(link.attributes('href')).toBe('https://custom.jira.com/browse/RHAISTRAT-100')
+    })
+
+    it('does not render "Fix in Jira" link when featureKey is null', () => {
+      const wrapper = mountViolations({ violations, featureKey: null })
+      const links = wrapper.findAll('a')
+      expect(links.length).toBe(0)
+    })
+
+    it('does not render "Fix in Jira" link when featureKey is not provided', () => {
+      const wrapper = mountViolations({ violations })
+      const links = wrapper.findAll('a')
+      expect(links.length).toBe(0)
+    })
+
+    it('sets accessible aria-label on Fix in Jira link', () => {
+      const wrapper = mountViolations({ violations, featureKey: 'RHAISTRAT-100' })
+      const link = wrapper.find('a')
+      expect(link.attributes('aria-label')).toBe('Fix Missing Assignee in Jira')
+    })
+  })
+})

--- a/shared/client/components/FeatureReadinessDrawer.vue
+++ b/shared/client/components/FeatureReadinessDrawer.vue
@@ -399,7 +399,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               </svg>
             </button>
             <div v-if="hygieneExpanded">
-              <HygieneViolations :violations="violationsList" />
+              <HygieneViolations :violations="violationsList" :feature-key="feature?.key" :jira-base-url="jiraBaseUrl" />
             </div>
           </section>
 

--- a/shared/client/components/HygieneViolations.vue
+++ b/shared/client/components/HygieneViolations.vue
@@ -4,6 +4,13 @@ import { computed } from 'vue'
 const props = defineProps({
   violations: { type: Array, default: () => [] },
   loading: { type: Boolean, default: false },
+  featureKey: { type: String, default: null },
+  jiraBaseUrl: { type: String, default: 'https://issues.redhat.com/browse' }
+})
+
+const jiraUrl = computed(() => {
+  if (!props.featureKey) return null
+  return `${props.jiraBaseUrl}/${props.featureKey}`
 })
 
 const CATEGORY_COLORS = {
@@ -94,8 +101,19 @@ const grouped = computed(() => {
               class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
               :class="categoryBadgeClass(group.category)"
             >{{ categoryLabel(group.category) }}</span>
+            <a
+              v-if="jiraUrl"
+              :href="jiraUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ml-auto inline-flex items-center gap-1 text-[11px] font-medium text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300 hover:underline transition-colors shrink-0"
+              :aria-label="'Fix ' + v.name + ' in Jira'"
+            >Fix in Jira
+              <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+            </a>
           </div>
           <p class="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">{{ v.message }}</p>
+          <p v-if="v.remediation" class="text-xs text-gray-500 dark:text-gray-500 leading-relaxed mt-1 italic">{{ v.remediation }}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Fix hygiene violations showing "All clear"**: Removed the broken dynamic `evaluateHygiene` calls from feature-readiness.js — they were gated on `jiraFeatures.has(key)` which fails for non-RHAISTRAT features and when the Jira query returns no data. Feature readiness now relies exclusively on the authoritative hygiene cache files produced by the hygiene refresh pipeline.
- **Add "Refresh Hygiene" button**: Users can trigger a hygiene refresh directly from the Feature Readiness view for near-real-time feedback after fixing violations in Jira. Uses existing `POST /hygiene/refresh-all` endpoint and `useRefreshPolling` composable.
- **Add "Fix in Jira" links**: Each violation card in the drawer now links directly to the Jira issue, with remediation text explaining what field to update.

## Changes

| File | Change |
|------|--------|
| `feature-readiness.js` | Remove dynamic eval blocks + unused imports |
| `hygiene-rules.js` | Add `remediation` field to violation output |
| `HygieneViolations.vue` | Add featureKey/jiraBaseUrl props, "Fix in Jira" link, remediation text |
| `FeatureReadinessDrawer.vue` | Pass featureKey and jiraBaseUrl to HygieneViolations |
| `FeatureReadinessView.vue` | Add refresh button + polling |
| `feature-readiness.test.js` | Replace dynamic eval tests with cache-based violation tests |
| `HygieneViolations.test.js` | New: component tests for Fix in Jira link and remediation |
| `FeatureReadinessDrawer.test.js` | Add tests for Fix in Jira link rendering in drawer |

## Test plan

- `npx vitest run modules/releases/server/planning/__tests__/feature-readiness.test.js` — 175 tests pass
- New HygieneViolations component tests cover Fix in Jira link rendering, remediation text, and accessibility
- Updated FeatureReadinessDrawer tests verify new props pass through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)