### PR TITLE
fix(releases): use user-entered planning freeze date for late addition detection

### DIFF
--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -652,10 +652,12 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         console.error('[feature-tracking] Schedule API failed for version:', version, schedErr.message)
       }
 
-      // User-entered date takes priority over Product Pages
+      // User-entered date takes priority over Product Pages for ALL products
+      var userFreezeOverride = null
       if (tConfig.releases && tConfig.releases[version]) {
         var overrideDate = tConfig.releases[version].planningFreezeOverride
         if (overrideDate) {
+          userFreezeOverride = overrideDate
           freezeDates.earliest = overrideDate
           scheduleSource = 'user-override' + (scheduleSource !== 'none' ? ' (PP: ' + scheduleSource + ')' : '')
           console.log('[feature-tracking] Using user-entered freeze date for', version, ':', overrideDate)
@@ -668,7 +670,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
 
         let features = await fetchFeaturesByFixVersion(pv.fixVersions, jiraRequest, fetchAllJqlResults)
 
-        const productFreezeDate = freezeDates.byProduct[normalizeVersionName(pv.fixVersions[0])] || null
+        const productFreezeDate = userFreezeOverride || freezeDates.byProduct[normalizeVersionName(pv.fixVersions[0])] || freezeDates.earliest || null
         for (let fi = 0; fi < features.length; fi++) {
           features[fi].scopeChange = classifyFeature(features[fi], productFreezeDate)
         }


### PR DESCRIPTION
## Summary
- **Bug**: Feature Tracking Report showed 0 late additions for 3.5 EA2 despite 3+ features having their FixVersion added after the May 20 planning freeze date.
- **Root cause**: The user-configured `planningFreezeOverride` only set the portfolio-level `freezeDates.earliest` (displayed in the UI summary card), but never populated `freezeDates.byProduct`. The per-product freeze date lookup fell through to `null`, causing `classifyFeature()` to short-circuit and never classify any features as "added."
- **Fix**: When a user override is set, it now takes priority over all per-product dates for classification. Additionally, `freezeDates.earliest` is used as a final fallback when neither the user override nor a per-product date is available.

## Test plan
- [ ] Verify existing unit tests pass (`npm test -- modules/releases/__tests__/server/execution/feature-tracking.test.js`)
- [ ] On local dev, navigate to Feature Tracking → 3.5.EA2 with a planning freeze override of May 20 and confirm Late Added count reflects features added after that date
- [ ] Confirm that clicking Refresh re-fetches and still shows the correct late addition count
- [ ] Verify other versions without a user override still use Product Pages per-product dates correctly


Made with [Cursor](https://cursor.com)