### PR TITLE
feat(releases): unified readiness gates with 7 definition-quality checks

### DIFF
--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -133,7 +133,7 @@ const releaseOptions = computed(() => {
 
 const headers = [
   { id: 'h-num',        label: '#',               scope: 'col' },
-  { id: 'h-score',      label: 'Score',           scope: 'col' },
+  { id: 'h-score',      label: 'Score',           scope: 'col', hasScoreTooltip: true },
   { id: 'h-readiness',  label: 'Readiness',       scope: 'col', hasTooltip: true },
   { id: 'h-key',        label: 'Key',             scope: 'col' },
   { id: 'h-title',      label: 'Title',           scope: 'col' },
@@ -237,6 +237,31 @@ function formatSyncDate(dateStr) {
                     <div class="flex items-center gap-2">
                       <span class="w-2.5 h-2.5 rounded-full bg-red-500 shrink-0"></span>
                       <span class="text-gray-600 dark:text-gray-300"><strong>Not Ready</strong> — does not pass readiness gates</span>
+                    </div>
+                  </div>
+                </div>
+              </span>
+              <span v-else-if="header.hasScoreTooltip" class="inline-flex items-center gap-1 group relative">
+                {{ header.label }}
+                <span
+                  class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-500 dark:text-gray-300 text-[9px] font-bold leading-none cursor-help"
+                >i</span>
+                <div
+                  class="absolute z-50 top-full mt-1 left-0 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal normal-case tracking-normal hidden group-hover:block"
+                >
+                  <p class="font-semibold text-gray-700 dark:text-gray-200 mb-2">Score Rubric</p>
+                  <div class="space-y-2 text-gray-600 dark:text-gray-300">
+                    <div>
+                      <p class="font-medium text-gray-700 dark:text-gray-200 mb-0.5">When RICE or Rubric present:</p>
+                      <p class="font-mono text-[10px]">RICE/Rubric (30w) + Tier (25w) + Priority (25w) + Target Version (20w)</p>
+                    </div>
+                    <div>
+                      <p class="font-medium text-gray-700 dark:text-gray-200 mb-0.5">When neither present:</p>
+                      <p class="font-mono text-[10px]">Tier (40w) + Priority (35w) + Target Version (25w)</p>
+                    </div>
+                    <div class="pt-1 border-t border-gray-100 dark:border-gray-700">
+                      <p class="font-medium text-gray-700 dark:text-gray-200 mb-0.5">Completeness multiplier:</p>
+                      <p class="font-mono text-[10px]">1 signal = 0.5x &middot; 2 = 0.7x &middot; 3 = 0.85x &middot; 4 = 1.0x</p>
                     </div>
                   </div>
                 </div>

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -31,8 +31,8 @@ import PmHubView from '../plan/views/PmHubView.vue'
 
 const tabs = [
   { id: 'outcomes', label: 'Big Rocks' },
-  { id: 'feature-readiness', label: 'Features List (1-n)' },
   { id: 'pm-hub', label: 'PM Hub' },
+  { id: 'feature-readiness', label: 'Features List (1-n)' },
 ]
 
 var moduleNav = inject('moduleNav', null)

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 const {
-  isHealthFeatureReady,
+  computeReadiness,
   buildFeatureReadiness,
   computeBlockers,
   computeBestAvailableScore,
@@ -668,11 +668,16 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('gate logic — bucket assignment', function() {
-    it('humanReviewStatus approved → goes to approved bucket', function() {
+    it('humanReviewStatus approved with all gates → goes to ready bucket', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
+      var readFromStorage = makeReadFromStorage({
+        ...convertToUnifiedFormat(store),
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache
+      })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(1)
       expect(result.ready[0].key).toBe('RHAISTRAT-1')
@@ -716,8 +721,9 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-      expect(result.pendingReview).toHaveLength(0)
+      var allFeatures = result.pendingReview.concat(result.ready)
+      expect(allFeatures).toHaveLength(1)
+      expect(allFeatures[0].key).toBe('RHAISTRAT-1')
     })
   })
 
@@ -727,12 +733,14 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var candidateCache = {
-        data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, fixVersion: '3.6.0' }] }
+        data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, fixVersion: '3.6.0', targetRelease: 'rhoai-3.6' }] }
       }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
-        'releases/planning/candidates-cache-3.6.json': candidateCache
+        'releases/planning/candidates-cache-3.6.json': candidateCache,
+        'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.ready[0].confidence).toBe('committed')
@@ -742,7 +750,12 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
+      var readFromStorage = makeReadFromStorage({
+        ...convertToUnifiedFormat(store),
+        'releases/planning/config.json': CONFIG_3_6,
+        'releases/planning/health-cache-3.6-all.json': healthCache
+      })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.ready[0].confidence).toBe('ready')
     })
@@ -764,8 +777,9 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].readinessGates).toBeDefined()
-      expect(result.ready[0].readinessGates.noBlockingViolations).toBe(true)
+      var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+      expect(feat.readinessGates).toBeDefined()
+      expect(feat.readinessGates.noBlockingViolations).toBe(true)
     })
 
     it('health-pipeline features have readinessGates with noBlockingViolations', function() {
@@ -782,7 +796,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      var feat = result.ready[0]
+      var feat = result.pendingReview[0]
       expect(feat.readinessGates.noBlockingViolations).toBe(true)
     })
   })
@@ -796,7 +810,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -836,7 +850,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -880,8 +894,10 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].key).toBe('RHAISTRAT-HIGH')
-      expect(result.ready[1].key).toBe('RHAISTRAT-LOW')
+      var all = result.pendingReview.concat(result.ready)
+      var highIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-HIGH' })
+      var lowIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-LOW' })
+      expect(highIdx).toBeLessThan(lowIdx)
     })
 
     it('higher rubric score → higher effectivePriorityScore → appears first', function() {
@@ -891,8 +907,9 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      var highIdx = result.ready.findIndex(function(f) { return f.key === 'RHAISTRAT-HIGHTOTAL' })
-      var lowIdx = result.ready.findIndex(function(f) { return f.key === 'RHAISTRAT-LOWTOTAL' })
+      var all = result.pendingReview.concat(result.ready)
+      var highIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-HIGHTOTAL' })
+      var lowIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-LOWTOTAL' })
       expect(highIdx).toBeLessThan(lowIdx)
     })
   })
@@ -956,10 +973,12 @@ describe('buildFeatureReadiness', function() {
           ]
         }
       }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
-        [candidatesKey]: candidateCache
+        [candidatesKey]: candidateCache,
+        'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
       var f = result.ready[0]
@@ -986,7 +1005,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      var f = result.ready[0]
+      var f = result.pendingReview.concat(result.ready).find(function(feat) { return feat.key === 'RHAISTRAT-1' })
       expect(f.tier).toBeNull()
       expect(f.bigRock).toBeNull()
       expect(f.targetVersions).toEqual([])
@@ -1006,7 +1025,8 @@ describe('buildFeatureReadiness', function() {
         [candidatesKey]: candidateCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].tier).toBe('T2')
+      var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+      expect(feat.tier).toBe('T2')
     })
   })
 
@@ -1020,7 +1040,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
+      expect(result.pendingReview.concat(result.ready)).toHaveLength(1)
     })
 
     it('includes all features when no releases are configured', function() {
@@ -1031,7 +1051,7 @@ describe('buildFeatureReadiness', function() {
         ...convertToUnifiedFormat(store)
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
+      expect(result.pendingReview.concat(result.ready)).toHaveLength(1)
     })
 
     it('falls back to health cache for tier, bigRock, targetVersions, fixVersion when candidates cache is absent', function() {
@@ -1046,6 +1066,7 @@ describe('buildFeatureReadiness', function() {
           targetRelease: 'rhoai-3.6',
           fixVersions: '3.6.0',
           deliveryOwner: 'Jane Smith',
+          pmOwner: 'Jane PM',
           priorityScore: null
         }]
       }
@@ -1071,7 +1092,7 @@ describe('buildFeatureReadiness', function() {
         data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'AI Speed', targetRelease: 'rhoai-3.6-cand', fixVersion: '3.6.0-cand' }] }
       }
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', tier: 'T3', bigRock: 'Platform', targetRelease: 'rhoai-3.6-health', fixVersions: '3.6.0-health', priorityScore: null }]
+        features: [{ key: 'RHAISTRAT-1', tier: 'T3', bigRock: 'Platform', targetRelease: 'rhoai-3.6-health', fixVersions: '3.6.0-health', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1092,7 +1113,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved', components: [] }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', components: 'Serving, Training', priorityScore: null }]
+        features: [{ key: 'RHAISTRAT-1', components: 'Serving, Training', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1112,7 +1133,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 87, priorityBreakdown: { rice: 50, bigRock: 100 } }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 87, priorityBreakdown: { rice: 50, bigRock: 100 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1143,7 +1164,7 @@ describe('buildFeatureReadiness', function() {
         [healthKey]: healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      var f = result.ready[0]
+      var f = result.pendingReview.concat(result.ready).find(function(feat) { return feat.key === 'RHAISTRAT-1' })
       expect(f.priorityScore).toBeNull()
       expect(f.priorityScoreFallback).toBe(true)
       expect(f.effectivePriorityScore).toBeGreaterThan(0)
@@ -1155,7 +1176,7 @@ describe('buildFeatureReadiness', function() {
       })
       var breakdown = { rice: 60, bigRock: 80, priority: 70, complexity: 50 }
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: breakdown }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: breakdown, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1226,7 +1247,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'wrong-owner', priorityScore: null }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'wrong-owner', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
       var hygieneCache = { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Real Team' } } }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1249,7 +1270,7 @@ describe('buildFeatureReadiness', function() {
       })
       var healthCache = {
         features: [
-          { key: 'RHAISTRAT-1', priorityScore: null },
+          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null },
           { key: 'RHAISTRAT-2', priorityScore: null },
           { key: 'RHAISTRAT-3', priorityScore: null }
         ]
@@ -1287,7 +1308,8 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].rubricTotal).toBe(8)
+      var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+      expect(feat.rubricTotal).toBe(8)
     })
 
     it('treats missing score dimensions as 0', function() {
@@ -1299,7 +1321,8 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].rubricTotal).toBe(2)
+      var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+      expect(feat.rubricTotal).toBe(2)
     })
   })
 
@@ -1312,14 +1335,22 @@ describe('buildFeatureReadiness', function() {
       var healthCache = {
         features: [{ key: 'RHAISTRAT-IN', priorityScore: 80 }]
       }
+      var inOnly = convertToUnifiedFormat(store)
+      delete inOnly['releases/execution/features/RHAISTRAT-OUT.json']
+      var idx = inOnly['releases/execution/index.json']
+      if (idx && idx.features) {
+        idx.features = idx.features.filter(function(f) { return f.key !== 'RHAISTRAT-OUT' })
+        idx.featureCount = idx.features.length
+      }
       var readFromStorage = makeReadFromStorage({
-        ...convertToUnifiedFormat(store),
+        ...inOnly,
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-      expect(result.ready[0].key).toBe('RHAISTRAT-IN')
+      var allFeatures = result.pendingReview.concat(result.ready)
+      expect(allFeatures).toHaveLength(1)
+      expect(allFeatures[0].key).toBe('RHAISTRAT-IN')
     })
 
     it('includes all features when no configured releases exist', function() {
@@ -1329,8 +1360,7 @@ describe('buildFeatureReadiness', function() {
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-      expect(result.pendingReview).toHaveLength(1)
+      expect(result.pendingReview.concat(result.ready)).toHaveLength(2)
     })
   })
 
@@ -1344,8 +1374,8 @@ describe('buildFeatureReadiness', function() {
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': config,
-        'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', priorityScore: 80 }] },
-        'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', priorityScore: 60 }] }
+        'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.5', priorityScore: 80 }] },
+        'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', deliveryOwner: 'Bob', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 60 }] }
       })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(2)
@@ -1364,9 +1394,10 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/candidates-cache-3.6.json': { data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 2, bigRock: 'Second' }] } }
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-      expect(result.ready[0].tier).toBe('T1')
-      expect(result.ready[0].bigRock).toBe('First')
+      var allFeatures = result.pendingReview.concat(result.ready)
+      expect(allFeatures).toHaveLength(1)
+      expect(allFeatures[0].tier).toBe('T1')
+      expect(allFeatures[0].bigRock).toBe('First')
     })
 
     it('meta.versions reflects all configured release versions', function() {
@@ -1384,54 +1415,92 @@ describe('buildFeatureReadiness', function() {
   })
 
   // -------------------------------------------------------------------------
-  // isHealthFeatureReady
+  // computeReadiness
   // -------------------------------------------------------------------------
 
-  describe('isHealthFeatureReady', function() {
-    it('returns true when all four gates pass', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 0, status: 'In Progress', targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(true)
+  describe('computeReadiness', function() {
+    function readyFeature(overrides) {
+      return Object.assign({
+        humanReviewStatus: 'approved',
+        rubricTotal: 4,
+        pmOwner: 'Jane',
+        deliveryOwner: 'Alice',
+        status: 'In Progress',
+        targetVersions: ['rhoai-3.6'],
+        violations: null
+      }, overrides)
+    }
+
+    it('returns isReady=true when all seven gates pass', function() {
+      var result = computeReadiness(readyFeature())
+      expect(result.isReady).toBe(true)
+      expect(result.gates.isApproved).toBe(true)
+      expect(result.gates.hasRubric).toBe(true)
+      expect(result.gates.pmAssigned).toBe(true)
+      expect(result.gates.deliveryOwnerAssigned).toBe(true)
+      expect(result.gates.pastRefinement).toBe(true)
+      expect(result.gates.hasTargetVersion).toBe(true)
+      expect(result.gates.noBlockingViolations).toBe(true)
     })
 
-    it('returns false when owner is missing', function() {
-      var hd = { deliveryOwner: null, assignee: null, blockerCount: 0, status: 'In Progress', targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(false)
+    it('returns isReady=false when not approved', function() {
+      var result = computeReadiness(readyFeature({ humanReviewStatus: 'awaiting-review' }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.isApproved).toBe(false)
     })
 
-    it('returns true when assignee is set but deliveryOwner is not', function() {
-      var hd = { deliveryOwner: null, assignee: 'Bob', blockerCount: 0, status: 'In Progress', targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(true)
+    it('returns isReady=false when rubricTotal is 0', function() {
+      var result = computeReadiness(readyFeature({ rubricTotal: 0 }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.hasRubric).toBe(false)
     })
 
-    it('returns false when there are blockers', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 2, status: 'In Progress', targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(false)
+    it('returns isReady=false when pmOwner is null', function() {
+      var result = computeReadiness(readyFeature({ pmOwner: null }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.pmAssigned).toBe(false)
     })
 
-    it('returns false when status is New', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 0, status: 'New', targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(false)
+    it('returns isReady=false when deliveryOwner is null', function() {
+      var result = computeReadiness(readyFeature({ deliveryOwner: null }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.deliveryOwnerAssigned).toBe(false)
     })
 
-    it('returns false when status is Refinement', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 0, status: 'Refinement', targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(false)
+    it('returns isReady=false when status is New', function() {
+      var result = computeReadiness(readyFeature({ status: 'New' }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.pastRefinement).toBe(false)
     })
 
-    it('returns false when status is null', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 0, status: null, targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, null)).toBe(false)
+    it('returns isReady=false when status is Refinement', function() {
+      var result = computeReadiness(readyFeature({ status: 'Refinement' }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.pastRefinement).toBe(false)
     })
 
-    it('returns false when no target version', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 0, status: 'In Progress', targetRelease: null }
-      expect(isHealthFeatureReady(hd, null)).toBe(false)
+    it('returns isReady=false when status is null', function() {
+      var result = computeReadiness(readyFeature({ status: null }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.pastRefinement).toBe(false)
     })
 
-    it('uses candidate targetRelease when health data lacks it', function() {
-      var hd = { deliveryOwner: 'Alice', blockerCount: 0, status: 'In Progress', targetRelease: null }
-      var cd = { targetRelease: 'rhoai-3.6' }
-      expect(isHealthFeatureReady(hd, cd)).toBe(true)
+    it('returns isReady=false when targetVersions is empty', function() {
+      var result = computeReadiness(readyFeature({ targetVersions: [] }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.hasTargetVersion).toBe(false)
+    })
+
+    it('returns isReady=false when blocking violations exist', function() {
+      var result = computeReadiness(readyFeature({ violations: [{ id: 'missing-fix-version' }] }))
+      expect(result.isReady).toBe(false)
+      expect(result.gates.noBlockingViolations).toBe(false)
+    })
+
+    it('non-blocking violations do not fail the gate', function() {
+      var result = computeReadiness(readyFeature({ violations: [{ id: 'stale-status-summary' }] }))
+      expect(result.isReady).toBe(true)
+      expect(result.gates.noBlockingViolations).toBe(true)
     })
   })
 
@@ -1459,7 +1528,7 @@ describe('buildFeatureReadiness', function() {
       expect(feat.rubricTotal).toBe(0)
     })
 
-    it('health-pipeline feature with all gates passing goes to ready', function() {
+    it('health-pipeline feature always goes to pendingReview (no approval/rubric)', function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -1473,8 +1542,8 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-      expect(result.ready[0].key).toBe('AIPCC-200')
+      expect(result.pendingReview).toHaveLength(1)
+      expect(result.pendingReview[0].key).toBe('AIPCC-200')
     })
 
     it('health-pipeline feature missing owner goes to pendingReview', function() {
@@ -1500,7 +1569,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 70 }]
+        features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70 }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1549,7 +1618,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      var feat = result.ready[0]
+      var feat = result.pendingReview[0]
       expect(feat.effectivePriorityScore).toBe(85)
       expect(feat.priorityScoreFallback).toBe(false)
     })
@@ -1573,7 +1642,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/candidates-cache-3.6.json': candidateCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      var feat = result.ready[0]
+      var feat = result.pendingReview[0]
       expect(feat.priorityScoreFallback).toBe(true)
       expect(feat.effectivePriorityScore).toBeGreaterThan(0)
     })
@@ -1593,8 +1662,9 @@ describe('buildFeatureReadiness', function() {
       })
       var result = buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview[0]
-      expect(feat.readinessGates.ownerAssigned).toBe(true)
-      expect(feat.readinessGates.notBlocked).toBe(false)
+      expect(feat.readinessGates.isApproved).toBe(false)
+      expect(feat.readinessGates.hasRubric).toBe(false)
+      expect(feat.readinessGates.deliveryOwnerAssigned).toBe(true)
       expect(feat.readinessGates.pastRefinement).toBe(false)
       expect(feat.readinessGates.hasTargetVersion).toBe(false)
       expect(feat.readinessGates.noBlockingViolations).toBe(true)
@@ -1612,8 +1682,8 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready).toHaveLength(1)
-      expect(result.ready[0].key).toBe('AIPCC-900')
+      expect(result.pendingReview).toHaveLength(1)
+      expect(result.pendingReview[0].key).toBe('AIPCC-900')
     })
 
     it('meta counts include health-pipeline features', function() {
@@ -1622,7 +1692,7 @@ describe('buildFeatureReadiness', function() {
       })
       var healthCache = {
         features: [
-          { key: 'RHAISTRAT-1', priorityScore: 70 },
+          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70 },
           { key: 'AIPCC-1000', summary: 'AIPCC Ready', status: 'In Progress', priority: 'Major', deliveryOwner: 'Alice', blockerCount: 0, targetRelease: 'rhoai-3.6' }
         ]
       }
@@ -1633,7 +1703,7 @@ describe('buildFeatureReadiness', function() {
       })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.meta.total).toBe(2)
-      expect(result.meta.readyCount).toBe(2)
+      expect(result.meta.readyCount).toBe(1)
     })
   })
 
@@ -1646,7 +1716,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
       var registryData = {
         releases: [
           { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: ['RHOAI-3.6'], state: 'active', milestones: {} }
@@ -1695,7 +1765,7 @@ describe('buildFeatureReadiness', function() {
       })
       var directViolations = [{ id: 'stale-status-summary', name: 'Direct', category: 'timeliness', message: 'Direct' }]
       var aliasViolations = [{ id: 'missing-assignee', name: 'Alias', category: 'ownership', message: 'Alias' }]
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', priorityScore: null }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null }] }
       var registryData = {
         releases: [
           { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: [], state: 'active', milestones: {} }
@@ -1710,7 +1780,8 @@ describe('buildFeatureReadiness', function() {
         'releases/hygiene/features-RHOAI 3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'A', violations: aliasViolations } } }
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].violations).toEqual(directViolations)
+      var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+      expect(feat.violations).toEqual(directViolations)
     })
   })
 
@@ -1731,8 +1802,9 @@ describe('buildFeatureReadiness', function() {
         'releases/hygiene/features-3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', violations: violations } } }
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].team).toBe('Alpha')
-      expect(result.ready[0].violations).toEqual(violations)
+      var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
+      expect(feat.team).toBe('Alpha')
+      expect(feat.violations).toEqual(violations)
     })
   })
 
@@ -1859,7 +1931,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     expect(result.pendingReview[0].team).toBe('Platform')
   })
 
-  it('execution feature with sign-off label and all gates passing is ready', function() {
+  it('execution feature with sign-off but no rubric goes to pendingReview', function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -1874,9 +1946,11 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     })
 
     var result = buildFeatureReadiness(readFromStorage)
-    expect(result.ready.length).toBe(1)
-    expect(result.ready[0].confidence).toBe('ready')
-    expect(result.ready[0].humanReviewStatus).toBe('approved')
+    expect(result.pendingReview.length).toBe(1)
+    expect(result.pendingReview[0].confidence).toBe('not-ready')
+    expect(result.pendingReview[0].humanReviewStatus).toBe('approved')
+    expect(result.pendingReview[0].readinessGates.isApproved).toBe(true)
+    expect(result.pendingReview[0].readinessGates.hasRubric).toBe(false)
   })
 
   it('execution feature in Refinement status is not ready', function() {
@@ -1969,7 +2043,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     expect(result.filterMeta.targetVersions).toContain('rhoai-4.0')
   })
 
-  it('execution feature with fix version gets committed confidence', function() {
+  it('execution feature with fix version still goes to pendingReview (no rubric)', function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -1985,8 +2059,8 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     })
 
     var result = buildFeatureReadiness(readFromStorage)
-    expect(result.ready[0].confidence).toBe('committed')
-    expect(result.ready[0].fixVersion).toBe('rhoai-3.6')
+    expect(result.pendingReview[0].confidence).toBe('not-ready')
+    expect(result.pendingReview[0].fixVersion).toBe('rhoai-3.6')
   })
 
   it('handles string components from execution index', function() {
@@ -2192,10 +2266,10 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-600' })
     expect(feature.dataSource).toBe('jira')
     expect(feature.riceScore).toBe(250)
-    expect(feature.readinessGates.notBlocked).toBe(false)
+    expect(feature.readinessGates.hasRubric).toBe(false)
   })
 
-  it('Jira feature with sign-off and all gates passing is ready', function() {
+  it('Jira feature with sign-off but no rubric goes to pendingReview', function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-500', {
         labels: ['strat-creator-human-sign-off'],
@@ -2217,12 +2291,14 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     })
 
     var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
-    expect(result.ready.length).toBe(1)
-    expect(result.ready[0].confidence).toBe('committed')
-    expect(result.ready[0].humanReviewStatus).toBe('approved')
+    expect(result.pendingReview.length).toBe(1)
+    expect(result.pendingReview[0].confidence).toBe('not-ready')
+    expect(result.pendingReview[0].humanReviewStatus).toBe('approved')
+    expect(result.pendingReview[0].readinessGates.isApproved).toBe(true)
+    expect(result.pendingReview[0].readinessGates.hasRubric).toBe(false)
   })
 
-  it('Jira feature with fix version gets committed confidence', function() {
+  it('Jira feature with fix version still goes to pendingReview (no rubric)', function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-400', {
         labels: ['strat-creator-human-sign-off'],
@@ -2239,8 +2315,8 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     })
 
     var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
-    expect(result.ready[0].confidence).toBe('committed')
-    expect(result.ready[0].fixVersion).toBe('rhoai-3.6')
+    expect(result.pendingReview[0].confidence).toBe('not-ready')
+    expect(result.pendingReview[0].fixVersion).toBe('rhoai-3.6')
   })
 
   it('skips closed Jira features', function() {
@@ -2367,7 +2443,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     expect(result.pendingReview[result.pendingReview.length - 1].key).toBe('RHAISTRAT-J1')
   })
 
-  it('Jira feature without assignee fails ownerAssigned gate', function() {
+  it('Jira feature without assignee fails deliveryOwnerAssigned gate', function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-NOOWN', {
         assignee: null,
@@ -2382,7 +2458,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
 
     var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(1)
-    expect(result.pendingReview[0].readinessGates.ownerAssigned).toBe(false)
+    expect(result.pendingReview[0].readinessGates.deliveryOwnerAssigned).toBe(false)
   })
 
   it('Jira feature without target version fails hasTargetVersion gate', function() {

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -10,7 +10,8 @@ var QUERY_FIELDS = [
   CUSTOM_FIELDS.colorStatus,
   CUSTOM_FIELDS.releaseType,
   CUSTOM_FIELDS.docsRequired,
-  CUSTOM_FIELDS.targetEnd
+  CUSTOM_FIELDS.targetEnd,
+  CUSTOM_FIELDS.productManager
 ].join(',')
 
 var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status NOT IN (Closed, Done, Resolved, Cancelled)'
@@ -39,6 +40,11 @@ function normalizeIssue(issue) {
     ? (typeof fields.issuetype === 'object' ? fields.issuetype.name || null : fields.issuetype)
     : null
 
+  var pmOwnerField = fields[CUSTOM_FIELDS.productManager]
+  var pmOwner = pmOwnerField
+    ? (typeof pmOwnerField === 'object' ? pmOwnerField.displayName || null : pmOwnerField)
+    : null
+
   return {
     key: issue.key,
     summary: fields.summary || '',
@@ -56,7 +62,8 @@ function normalizeIssue(issue) {
     colorStatus: serializeField(fields[CUSTOM_FIELDS.colorStatus]),
     releaseType: serializeField(fields[CUSTOM_FIELDS.releaseType]),
     docsRequired: serializeField(fields[CUSTOM_FIELDS.docsRequired]),
-    targetEnd: serializeField(fields[CUSTOM_FIELDS.targetEnd])
+    targetEnd: serializeField(fields[CUSTOM_FIELDS.targetEnd]),
+    pmOwner: pmOwner
   }
 }
 

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -123,15 +123,29 @@ function computeBlockers(feature, productPath) {
   return { blockingDimensions: blockingDimensions, actionRequired: actionRequired }
 }
 
-function isHealthFeatureReady(hd, cd) {
-  var hasOwner = !!(hd.deliveryOwner || hd.assignee)
-  var notBlocked = !(hd.blockerCount > 0)
-  var pastRefinement = !!hd.status && EARLY_STATUSES.indexOf(hd.status) === -1
-  var hasTargetVersion = !!(
-    (hd.targetRelease && hd.targetRelease.length > 0) ||
-    (cd && cd.targetRelease)
-  )
-  return hasOwner && notBlocked && pastRefinement && hasTargetVersion
+function computeReadiness(feature) {
+  var isApproved = feature.humanReviewStatus === 'approved'
+  var hasRubric = (feature.rubricTotal || 0) > 0
+  var hasPM = !!feature.pmOwner
+  var hasDeliveryOwner = !!feature.deliveryOwner
+  var pastRefinement = !!feature.status && EARLY_STATUSES.indexOf(feature.status) === -1
+  var hasTargetVersion = (feature.targetVersions || []).length > 0
+  var noBlockingViolations = !hasBlockingViolations(feature.violations)
+
+  var gates = {
+    isApproved: isApproved,
+    hasRubric: hasRubric,
+    pmAssigned: hasPM,
+    deliveryOwnerAssigned: hasDeliveryOwner,
+    pastRefinement: pastRefinement,
+    hasTargetVersion: hasTargetVersion,
+    noBlockingViolations: noBlockingViolations
+  }
+
+  var isReady = isApproved && hasRubric && hasPM && hasDeliveryOwner
+    && pastRefinement && hasTargetVersion && noBlockingViolations
+
+  return { isReady: isReady, gates: gates }
 }
 
 function hasBlockingViolations(violations) {
@@ -380,18 +394,22 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       : (healthComponents.length > 0 ? healthComponents : jiraComponents)
 
     var violations = hygieneIndex.get(key) || null
-    var isApproved = latest.humanReviewStatus === 'approved'
-    var blockedByHygiene = hasBlockingViolations(violations)
-    var isReady = isApproved && !blockedByHygiene
-    var confidence = computeConfidence(isReady, fixVersion)
+    var pmOwner = (healthData ? healthData.pmOwner || null : null)
+      || (jiraFeatures && jiraFeatures.has(key) ? jiraFeatures.get(key).pmOwner : null)
+      || null
 
-    var readinessGates = {
-      ownerAssigned: !!(deliveryOwner || (healthData && healthData.assignee) || latest.approvedBy),
-      notBlocked: blockerResult.blockingDimensions.length === 0,
-      pastRefinement: !!latest.status && EARLY_STATUSES.indexOf(latest.status) === -1,
-      hasTargetVersion: targetVersions.length > 0,
-      noBlockingViolations: !blockedByHygiene
-    }
+    var readinessResult = computeReadiness({
+      humanReviewStatus: latest.humanReviewStatus,
+      rubricTotal: rubricTotal,
+      pmOwner: pmOwner,
+      deliveryOwner: deliveryOwner,
+      status: latest.status,
+      targetVersions: targetVersions,
+      violations: violations
+    })
+    var isReady = readinessResult.isReady
+    var confidence = computeConfidence(isReady, fixVersion)
+    var readinessGates = readinessResult.gates
 
     var feature = {
       key: key,
@@ -409,6 +427,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       reviewers: latest.reviewers || {},
       components: componentsList,
       deliveryOwner: deliveryOwner,
+      pmOwner: pmOwner,
       team: team,
       reviewedAt: latest.reviewedAt,
       approvedBy: latest.approvedBy || null,
@@ -479,9 +498,16 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
     var hpPriorityBreakdown = hpFallback ? hpFallbackResult : (hd.priorityBreakdown || null)
 
     var hpViolations = hygieneIndex.get(ckey) || null
-    var hpGatesReady = isHealthFeatureReady(hd, cd)
-    var hpBlockedByHygiene = hasBlockingViolations(hpViolations)
-    var hpReady = hpGatesReady && !hpBlockedByHygiene
+    var hpReadinessResult = computeReadiness({
+      humanReviewStatus: null,
+      rubricTotal: 0,
+      pmOwner: hd.pmOwner || null,
+      deliveryOwner: hd.deliveryOwner || hd.assignee || null,
+      status: hd.status,
+      targetVersions: hpTargetVersions,
+      violations: hpViolations
+    })
+    var hpReady = hpReadinessResult.isReady
     var hpConfidence = computeConfidence(hpReady, hpFixVersion)
 
     var hpFeature = {
@@ -500,6 +526,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       reviewers: {},
       components: hpComponents,
       deliveryOwner: hd.deliveryOwner || null,
+      pmOwner: hd.pmOwner || null,
       team: hpTeam,
       reviewedAt: null,
       approvedBy: null,
@@ -517,16 +544,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       actionRequired: null,
       dataSource: 'health-pipeline',
       confidence: hpConfidence,
-      readinessGates: {
-        ownerAssigned: !!(hd.deliveryOwner || hd.assignee),
-        notBlocked: !(hd.blockerCount > 0),
-        pastRefinement: !!hd.status && EARLY_STATUSES.indexOf(hd.status) === -1,
-        hasTargetVersion: !!(
-          (hd.targetRelease && hd.targetRelease.length > 0) ||
-          (cd && cd.targetRelease)
-        ),
-        noBlockingViolations: !hpBlockedByHygiene
-      },
+      readinessGates: hpReadinessResult.gates,
       violations: hpViolations
     }
 
@@ -592,13 +610,19 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
     }, configuredVersions)
     var efEffective = efFallbackResult.score
 
-    var efBlockedByHygiene = hasBlockingViolations(efViolations)
-    var efIsApproved = efHumanReviewStatus === 'approved'
-    var efHasOwner = !!efAssignee
-    var efPastRefinement = !!ef.status && EARLY_STATUSES.indexOf(ef.status) === -1
-    var efHasTargetVersion = efTargetVersions.length > 0
-    var efBlockerCount = execData ? (execData.blockerCount || 0) : (ef.blockerCount || 0)
-    var efIsReady = efIsApproved && !efBlockedByHygiene && efHasOwner && efPastRefinement && efHasTargetVersion
+    var efPmOwner = (jiraFeatures && jiraFeatures.has(ef.key))
+      ? jiraFeatures.get(ef.key).pmOwner || null : null
+
+    var efReadinessResult = computeReadiness({
+      humanReviewStatus: efHumanReviewStatus,
+      rubricTotal: 0,
+      pmOwner: efPmOwner,
+      deliveryOwner: efAssignee,
+      status: ef.status,
+      targetVersions: efTargetVersions,
+      violations: efViolations
+    })
+    var efIsReady = efReadinessResult.isReady
     var efConfidence = computeConfidence(efIsReady, efFixVersion)
 
     var efFeature = {
@@ -617,6 +641,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
       reviewers: {},
       components: efComponents,
       deliveryOwner: efAssignee,
+      pmOwner: efPmOwner,
       team: efTeam,
       reviewedAt: null,
       approvedBy: null,
@@ -636,13 +661,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
         : null,
       dataSource: pass3DataSource,
       confidence: efConfidence,
-      readinessGates: {
-        ownerAssigned: efHasOwner,
-        notBlocked: !(efBlockerCount > 0),
-        pastRefinement: efPastRefinement,
-        hasTargetVersion: efHasTargetVersion,
-        noBlockingViolations: !efBlockedByHygiene
-      },
+      readinessGates: efReadinessResult.gates,
       violations: efViolations
     }
 
@@ -687,4 +706,4 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
   return { pendingReview: pendingReview, ready: ready, filterMeta: filterMeta, meta: meta }
 }
 
-module.exports = { buildFeatureReadiness: buildFeatureReadiness, computeBlockers: computeBlockers, computeBestAvailableScore: computeBestAvailableScore, isHealthFeatureReady: isHealthFeatureReady, computeTierScore: computeTierScore, computeTargetVersionScore: computeTargetVersionScore, hasBlockingViolations: hasBlockingViolations, computeConfidence: computeConfidence, collectFilterMeta: collectFilterMeta, deriveHumanReviewStatusFromLabels: deriveHumanReviewStatusFromLabels, BLOCKING_HYGIENE_RULES: BLOCKING_HYGIENE_RULES, COMPLETENESS_MULTIPLIERS: COMPLETENESS_MULTIPLIERS, MAX_SIGNALS: MAX_SIGNALS }
+module.exports = { buildFeatureReadiness: buildFeatureReadiness, computeBlockers: computeBlockers, computeBestAvailableScore: computeBestAvailableScore, computeReadiness: computeReadiness, computeTierScore: computeTierScore, computeTargetVersionScore: computeTargetVersionScore, hasBlockingViolations: hasBlockingViolations, computeConfidence: computeConfidence, collectFilterMeta: collectFilterMeta, deriveHumanReviewStatusFromLabels: deriveHumanReviewStatusFromLabels, BLOCKING_HYGIENE_RULES: BLOCKING_HYGIENE_RULES, COMPLETENESS_MULTIPLIERS: COMPLETENESS_MULTIPLIERS, MAX_SIGNALS: MAX_SIGNALS }

--- a/shared/__tests__/client/FeatureReadinessDrawer.test.js
+++ b/shared/__tests__/client/FeatureReadinessDrawer.test.js
@@ -27,8 +27,10 @@ function makeStratFeature(overrides = {}) {
     dataSource: 'strat-creator',
     confidence: 'committed',
     readinessGates: {
-      ownerAssigned: true,
-      notBlocked: true,
+      isApproved: true,
+      hasRubric: true,
+      pmAssigned: true,
+      deliveryOwnerAssigned: true,
       pastRefinement: true,
       hasTargetVersion: true,
       noBlockingViolations: true
@@ -60,11 +62,14 @@ function makeHealthFeature(overrides = {}) {
     blockingDimensions: [],
     actionRequired: null,
     deliveryOwner: 'Jane Smith',
+    pmOwner: 'Product PM',
     dataSource: 'health-pipeline',
     confidence: 'ready',
     readinessGates: {
-      ownerAssigned: true,
-      notBlocked: true,
+      isApproved: true,
+      hasRubric: true,
+      pmAssigned: true,
+      deliveryOwnerAssigned: true,
       pastRefinement: true,
       hasTargetVersion: true,
       noBlockingViolations: true
@@ -181,10 +186,12 @@ describe('FeatureReadinessDrawer', () => {
       expect(headerDiv.text()).not.toContain('Awaiting Sign-off')
     })
 
-    it('does not show rubric section', () => {
+    it('does not show rubric scoring section with dimension bars', () => {
       const wrapper = mountDrawer(makeHealthFeature())
-      expect(wrapper.text()).not.toContain('Rubric')
       expect(wrapper.text()).not.toContain('feasibility')
+      expect(wrapper.text()).not.toContain('testability')
+      expect(wrapper.text()).not.toContain('scope')
+      expect(wrapper.text()).not.toContain('architecture')
     })
 
     it('shows delivery owner in details section', () => {
@@ -215,23 +222,25 @@ describe('FeatureReadinessDrawer', () => {
       expect(wrapper.text()).toContain('Readiness Gates')
     })
 
-    it('shows all five readiness gate labels', () => {
+    it('shows all seven readiness gate labels', () => {
       const wrapper = mountDrawer(makeHealthFeature())
-      expect(wrapper.text()).toContain('Owner assigned')
-      expect(wrapper.text()).toContain('No blockers')
-      expect(wrapper.text()).toContain('Status beyond Refinement')
-      expect(wrapper.text()).toContain('Target version assigned')
-      expect(wrapper.text()).toContain('No blocking hygiene violations')
+      expect(wrapper.text()).toContain('Approved')
+      expect(wrapper.text()).toContain('Rubric')
+      expect(wrapper.text()).toContain('Product Manager')
+      expect(wrapper.text()).toContain('Delivery Owner')
+      expect(wrapper.text()).toContain('Status')
+      expect(wrapper.text()).toContain('Target Version')
+      expect(wrapper.text()).toContain('Hygiene')
     })
 
     it('shows filled circle for passing gates and empty circle for failing gates', () => {
       const wrapper = mountDrawer(makeHealthFeature({
-        readinessGates: { ownerAssigned: true, notBlocked: false, pastRefinement: true, hasTargetVersion: false, noBlockingViolations: true }
+        readinessGates: { isApproved: true, hasRubric: false, pmAssigned: true, deliveryOwnerAssigned: false, pastRefinement: true, hasTargetVersion: false, noBlockingViolations: true }
       }))
       const gateSection = wrapper.findAll('section').find(s => s.text().includes('Readiness Gates'))
       const gateItems = gateSection.findAll('.flex.items-center.gap-2')
       const indicators = gateItems.map(item => item.findAll('span')[0].text())
-      expect(indicators).toEqual(['●', '○', '●', '○', '●'])
+      expect(indicators).toEqual(['●', '○', '●', '○', '●', '○', '●'])
     })
 
     it('shows green class for passing gates', () => {
@@ -243,7 +252,7 @@ describe('FeatureReadinessDrawer', () => {
 
     it('shows red class for failing gates', () => {
       const wrapper = mountDrawer(makeHealthFeature({
-        readinessGates: { ownerAssigned: false, notBlocked: true, pastRefinement: true, hasTargetVersion: true, noBlockingViolations: true }
+        readinessGates: { isApproved: false, hasRubric: true, pmAssigned: true, deliveryOwnerAssigned: true, pastRefinement: true, hasTargetVersion: true, noBlockingViolations: true }
       }))
       const gateSection = wrapper.findAll('section').find(s => s.text().includes('Readiness Gates'))
       const firstIndicator = gateSection.findAll('.flex.items-center.gap-2')[0].findAll('span')[0]

--- a/shared/__tests__/client/FeatureReadinessRow.test.js
+++ b/shared/__tests__/client/FeatureReadinessRow.test.js
@@ -24,8 +24,10 @@ function makeFeature(overrides = {}) {
     dataSource: 'strat-creator',
     confidence: 'committed',
     readinessGates: {
-      ownerAssigned: true,
-      notBlocked: true,
+      isApproved: true,
+      hasRubric: true,
+      pmAssigned: true,
+      deliveryOwnerAssigned: true,
       pastRefinement: true,
       hasTargetVersion: true,
       noBlockingViolations: true
@@ -45,8 +47,10 @@ function makeHealthFeature(overrides = {}) {
     reviewers: {},
     confidence: 'ready',
     readinessGates: {
-      ownerAssigned: true,
-      notBlocked: true,
+      isApproved: true,
+      hasRubric: true,
+      pmAssigned: true,
+      deliveryOwnerAssigned: true,
       pastRefinement: true,
       hasTargetVersion: true,
       noBlockingViolations: true
@@ -184,7 +188,7 @@ describe('FeatureReadinessRow', () => {
       expect(wrapper.find('[title="Needs attention"]').exists()).toBe(true)
     })
 
-    it('shows score breakdown tooltip when priorityScoreBreakdown is present', () => {
+    it('shows score breakdown popover when priorityScoreBreakdown is present', () => {
       const breakdown = {
         score: 62,
         rawScore: 88,
@@ -203,24 +207,23 @@ describe('FeatureReadinessRow', () => {
         priorityScoreBreakdown: breakdown
       }))
       const scoreTd = wrapper.findAll('td').at(1)
-      const scoreSpan = scoreTd.find('span')
-      const title = scoreSpan.attributes('title')
-      expect(title).toContain('Score: 62 / 100')
-      expect(title).toContain('Rubric')
-      expect(title).toContain('Priority')
-      expect(title).toContain('0.7')
-      expect(title).toContain('Missing')
+      const popover = scoreTd.find('div.absolute')
+      expect(popover.exists()).toBe(true)
+      expect(popover.text()).toContain('Score: 62 / 100')
+      expect(popover.text()).toContain('Rubric')
+      expect(popover.text()).toContain('Priority')
+      expect(popover.text()).toContain('0.7')
+      expect(popover.text()).toContain('Missing')
     })
 
-    it('shows simple tooltip when no breakdown available', () => {
+    it('does not show popover when no breakdown available', () => {
       const wrapper = mountRow(makeFeature({
         effectivePriorityScore: 72,
         priorityScoreFallback: false,
         priorityScoreBreakdown: null
       }))
       const scoreTd = wrapper.findAll('td').at(1)
-      const scoreSpan = scoreTd.find('span')
-      expect(scoreSpan.attributes('title')).toBe('Computed priority score')
+      expect(scoreTd.find('div.absolute').exists()).toBe(false)
     })
   })
 })

--- a/shared/client/components/FeatureReadinessDrawer.vue
+++ b/shared/client/components/FeatureReadinessDrawer.vue
@@ -338,36 +338,53 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
             <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-3">Readiness Gates</p>
             <div class="space-y-2">
               <div class="flex items-center gap-2 text-xs">
-                <span :class="readinessGates.ownerAssigned ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
-                  {{ readinessGates.ownerAssigned ? '●' : '○' }}
+                <span :class="readinessGates.isApproved ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
+                  {{ readinessGates.isApproved ? '●' : '○' }}
                 </span>
-                <span class="text-gray-700 dark:text-gray-300">Owner assigned</span>
-                <span v-if="feature.deliveryOwner" class="text-gray-400 dark:text-gray-500 ml-auto">{{ feature.deliveryOwner }}</span>
+                <span class="text-gray-700 dark:text-gray-300">Approved</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ readinessGates.isApproved ? 'Approved' : 'Awaiting sign-off' }}</span>
               </div>
               <div class="flex items-center gap-2 text-xs">
-                <span :class="readinessGates.notBlocked ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
-                  {{ readinessGates.notBlocked ? '●' : '○' }}
+                <span :class="readinessGates.hasRubric ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
+                  {{ readinessGates.hasRubric ? '●' : '○' }}
                 </span>
-                <span class="text-gray-700 dark:text-gray-300">No blockers</span>
+                <span class="text-gray-700 dark:text-gray-300">Rubric</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ readinessGates.hasRubric ? rubricTotal + '/8' : 'Not scored' }}</span>
+              </div>
+              <div class="flex items-center gap-2 text-xs">
+                <span :class="readinessGates.pmAssigned ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
+                  {{ readinessGates.pmAssigned ? '●' : '○' }}
+                </span>
+                <span class="text-gray-700 dark:text-gray-300">Product Manager</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ feature.pmOwner || 'Missing' }}</span>
+              </div>
+              <div class="flex items-center gap-2 text-xs">
+                <span :class="readinessGates.deliveryOwnerAssigned ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
+                  {{ readinessGates.deliveryOwnerAssigned ? '●' : '○' }}
+                </span>
+                <span class="text-gray-700 dark:text-gray-300">Delivery Owner</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ feature.deliveryOwner || 'Missing' }}</span>
               </div>
               <div class="flex items-center gap-2 text-xs">
                 <span :class="readinessGates.pastRefinement ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
                   {{ readinessGates.pastRefinement ? '●' : '○' }}
                 </span>
-                <span class="text-gray-700 dark:text-gray-300">Status beyond Refinement</span>
-                <span v-if="feature.status" class="text-gray-400 dark:text-gray-500 ml-auto">{{ feature.status }}</span>
+                <span class="text-gray-700 dark:text-gray-300">Status</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ feature.status || 'Unknown' }}</span>
               </div>
               <div class="flex items-center gap-2 text-xs">
                 <span :class="readinessGates.hasTargetVersion ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
                   {{ readinessGates.hasTargetVersion ? '●' : '○' }}
                 </span>
-                <span class="text-gray-700 dark:text-gray-300">Target version assigned</span>
+                <span class="text-gray-700 dark:text-gray-300">Target Version</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ (feature.targetVersions || []).length ? feature.targetVersions.join(', ') : 'Missing' }}</span>
               </div>
               <div class="flex items-center gap-2 text-xs">
                 <span :class="readinessGates.noBlockingViolations ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">
                   {{ readinessGates.noBlockingViolations ? '●' : '○' }}
                 </span>
-                <span class="text-gray-700 dark:text-gray-300">No blocking hygiene violations</span>
+                <span class="text-gray-700 dark:text-gray-300">Hygiene</span>
+                <span class="text-gray-400 dark:text-gray-500 ml-auto">{{ readinessGates.noBlockingViolations ? 'All clear' : violationCount + ' violations' }}</span>
               </div>
             </div>
           </section>
@@ -520,6 +537,11 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
 
               <dt class="text-gray-400 dark:text-gray-500">Team</dt>
               <dd class="text-gray-700 dark:text-gray-300">{{ feature.team || '—' }}</dd>
+
+              <template v-if="feature.pmOwner">
+                <dt class="text-gray-400 dark:text-gray-500">Product Manager</dt>
+                <dd class="text-gray-700 dark:text-gray-300">{{ feature.pmOwner }}</dd>
+              </template>
 
               <template v-if="feature.deliveryOwner">
                 <dt class="text-gray-400 dark:text-gray-500">Delivery Owner</dt>

--- a/shared/client/components/FeatureReadinessRow.vue
+++ b/shared/client/components/FeatureReadinessRow.vue
@@ -36,23 +36,10 @@ const priorityDisplay = computed(() => {
   return props.feature.priorityScoreFallback ? `~${score}` : String(score)
 })
 
-const scoreTooltip = computed(() => {
+const scoreBreakdown = computed(() => {
   const bd = props.feature.priorityScoreBreakdown
-  if (!bd || !bd.signals) {
-    return props.feature.priorityScoreFallback ? 'Estimated score (fallback)' : 'Computed priority score'
-  }
-  const lines = [`Score: ${bd.score} / 100`]
-  for (const s of bd.signals) {
-    const pct = Math.round(s.value * 100)
-    lines.push(`${s.name}: ${pct}% × ${s.weight}w`)
-  }
-  if (bd.completenessMultiplier < 1) {
-    lines.push(`Raw: ${bd.rawScore} × ${bd.completenessMultiplier} (${bd.signalCount}/${bd.maxSignals} signals)`)
-  }
-  if (bd.missing && bd.missing.length > 0) {
-    lines.push(`Missing: ${bd.missing.join(', ')}`)
-  }
-  return lines.join('\n')
+  if (!bd || !bd.signals) return null
+  return bd
 })
 
 const confidenceClass = computed(() => {
@@ -96,13 +83,34 @@ const confidenceTooltip = computed(() => {
 
     <!-- Score -->
     <td class="px-3 py-2.5 whitespace-nowrap text-center">
-      <span
-        class="text-xs font-semibold tabular-nums"
-        :class="feature.priorityScoreFallback
-          ? 'text-amber-600 dark:text-amber-400'
-          : 'text-gray-800 dark:text-gray-200'"
-        :title="scoreTooltip"
-      >{{ priorityDisplay }}</span>
+      <span class="relative group inline-flex items-center">
+        <span
+          class="text-xs font-semibold tabular-nums cursor-help"
+          :class="feature.priorityScoreFallback
+            ? 'text-amber-600 dark:text-amber-400'
+            : 'text-gray-800 dark:text-gray-200'"
+        >{{ priorityDisplay }}</span>
+        <div
+          v-if="scoreBreakdown"
+          class="absolute z-50 top-full mt-1 left-1/2 -translate-x-1/2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal hidden group-hover:block"
+        >
+          <p class="font-semibold text-gray-700 dark:text-gray-200 mb-1.5">
+            Score: {{ scoreBreakdown.score }} / 100
+          </p>
+          <div class="space-y-1">
+            <div v-for="signal in scoreBreakdown.signals" :key="signal.name" class="flex items-center justify-between">
+              <span class="text-gray-600 dark:text-gray-300">{{ signal.name }}</span>
+              <span class="text-gray-400 dark:text-gray-500 tabular-nums">{{ Math.round(signal.value * 100) }}% &times; {{ signal.weight }}w</span>
+            </div>
+          </div>
+          <div v-if="scoreBreakdown.completenessMultiplier < 1" class="mt-1.5 pt-1.5 border-t border-gray-100 dark:border-gray-700 text-gray-400 dark:text-gray-500">
+            Raw {{ scoreBreakdown.rawScore }} &times; {{ scoreBreakdown.completenessMultiplier }} ({{ scoreBreakdown.signalCount }}/{{ scoreBreakdown.maxSignals }} signals)
+          </div>
+          <div v-if="scoreBreakdown.missing && scoreBreakdown.missing.length" class="mt-1 text-gray-400 dark:text-gray-500">
+            Missing: {{ scoreBreakdown.missing.join(', ') }}
+          </div>
+        </div>
+      </span>
     </td>
 
     <!-- Readiness (confidence-colored) -->


### PR DESCRIPTION
## Summary

- **Unified readiness gates**: Replaces three inconsistent readiness calculations (strat-creator, health-pipeline, Jira/execution) with a single `computeReadiness` function using 7 definition-quality gates: human approval, rubric scored, PM assigned, delivery owner assigned, past refinement, target version, and no blocking hygiene violations
- **PM owner gate**: Adds `pmOwner` from Jira `customfield_10469` as a readiness requirement — features without a PM are not ready for commitment
- **Styled score popovers**: Replaces native browser `title` tooltips with styled CSS popovers showing the scoring rubric formula on the column header and per-feature signal breakdowns on each score cell
- **Drawer gate display**: Updates the feature drawer to show all 7 unified gates with contextual detail (PM name, rubric score, status text, violation count)
- **Tab reorder**: Planning tabs changed from Big Rocks → Features List → PM Hub to Big Rocks → PM Hub → Features List

## Key behavior changes

| Before | After |
|--------|-------|
| Features with approval + no rubric could be "Ready" | `hasRubric` gate requires rubric > 0 |
| No PM requirement | `pmAssigned` gate requires PM owner |
| Health-pipeline features could be "Ready" | Always "Not Ready" (no approval/rubric) |
| Execution/Jira-only features could be "Ready" | Always "Not Ready" (no rubric scores) |
| 3 different readiness gate sets | 1 unified set across all passes |

## Files changed

| File | Change |
|------|--------|
| `feature-query.js` | Add `productManager` to query fields, extract `pmOwner` |
| `feature-readiness.js` | Add `computeReadiness`, refactor 3 passes, remove `isHealthFeatureReady` |
| `FeatureReadinessView.vue` | Score column header tooltip with scoring rubric formula |
| `FeatureReadinessRow.vue` | Styled CSS popover replacing native title tooltip |
| `FeatureReadinessDrawer.vue` | 7 unified gates display with contextual detail |
| `PlanView.vue` | Tab reorder |
| `feature-readiness.test.js` | `computeReadiness` unit tests, updated gate assertions |

## Test plan

- [x] All 177 tests pass (`npx vitest run modules/releases/server/planning/__tests__/feature-readiness.test.js`)
- [x] Syntax checks pass for all modified JS files
- [x] `computeReadiness` unit tests cover all 7 gates individually
- [x] Updated assertions for health-pipeline features (always Not Ready)
- [x] Updated assertions for execution/Jira features (always Not Ready without rubric)