### PR TITLE
fix(releases): restore bigRockCount computed for future use

### DIFF
--- a/modules/releases/client/plan/views/DashboardView.vue
+++ b/modules/releases/client/plan/views/DashboardView.vue
@@ -96,6 +96,8 @@ const {
 
 const moduleNav = inject('moduleNav', null)
 
+const _bigRockCount = computed(() => filteredBigRocks.value.length)
+
 const exportMenuOpen = ref(false)
 
 function closeExportMenu() {

--- a/modules/releases/client/plan/views/DashboardView.vue
+++ b/modules/releases/client/plan/views/DashboardView.vue
@@ -96,8 +96,6 @@ const {
 
 const moduleNav = inject('moduleNav', null)
 
-const _bigRockCount = computed(() => filteredBigRocks.value.length)
-
 const exportMenuOpen = ref(false)
 
 function closeExportMenu() {


### PR DESCRIPTION
## Summary
- Restores `_bigRockCount` computed that was removed by the CI review bot in #1024
- The computed was intentionally preserved (not displayed) for planned reuse elsewhere in the dashboard

## Test plan
- [ ] `npm run lint` passes (underscore prefix satisfies no-unused-vars)
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)