### PR TITLE
feat(releases): add portfolio release grouping to Risk Dashboard

### DIFF
--- a/modules/releases/client/deliver/components/ReleaseVersionGroup.vue
+++ b/modules/releases/client/deliver/components/ReleaseVersionGroup.vue
@@ -12,7 +12,7 @@
         <div class="flex items-center gap-2">
           <span
             class="text-lg font-bold tabular-nums text-gray-900 dark:text-gray-100"
-          >RHAI {{ group.version }}</span>
+          >{{ group.displayName || 'RHAI ' + group.version }}</span>
           <span
             class="inline-flex h-3 w-3 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900"
             :class="riskDotClass"

--- a/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
+++ b/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
@@ -139,7 +139,7 @@
               </span>
               <label class="relative inline-flex items-center cursor-pointer" @click.stop>
                 <input type="checkbox" v-model="pf.enabled" class="sr-only peer" />
-                <div class="w-8 h-4.5 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-600 peer-checked:bg-primary-600 transition-colors">
+                <div class="w-8 h-[18px] bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-600 peer-checked:bg-primary-600 transition-colors">
                   <div class="absolute top-[2px] left-[2px] bg-white rounded-full h-3.5 w-3.5 transition-transform peer-checked:translate-x-3.5 shadow" />
                 </div>
               </label>

--- a/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
+++ b/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
@@ -15,96 +15,196 @@
       </div>
 
       <!-- Body -->
-      <div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-        <p class="text-xs text-gray-500 dark:text-gray-400">
-          Manage the releases shown on the Risk Dashboard. Each entry maps a Jira release number
-          to a portfolio name and optional schedule dates that override Product Pages.
-        </p>
-
-        <div v-for="(entry, idx) in draft" :key="idx" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-          <!-- Release header row -->
-          <div class="flex items-center gap-2 px-3 py-2.5 bg-gray-50 dark:bg-gray-800">
-            <button
-              type="button"
-              @click="toggleExpand(idx)"
-              class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors"
-            >
-              <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-90': expanded[idx] }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-            <input
-              v-model="entry.releaseNumber"
-              class="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
-              placeholder="Release number (e.g. rhoai-3.7)"
-            />
-            <span
-              v-if="entry.productName"
-              class="text-[10px] text-gray-400 dark:text-gray-500 font-medium uppercase truncate max-w-[100px]"
-            >{{ entry.productName }}</span>
-            <button
-              type="button"
-              @click="removeEntry(idx)"
-              class="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-gray-400 hover:text-red-500 transition-colors"
-              title="Remove release"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
-          </div>
-
-          <!-- Release details (expandable) -->
-          <div v-if="expanded[idx]" class="border-t border-gray-100 dark:border-gray-700 px-4 py-3 space-y-3">
-            <div>
-              <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                Portfolio / Product Name
-              </label>
-              <input
-                v-model="entry.productName"
-                class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
-                placeholder="e.g. RHOAI"
-              />
-            </div>
-
-            <div class="grid grid-cols-2 gap-3 pt-2 border-t border-gray-100 dark:border-gray-700">
-              <div>
-                <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                  Due / GA Date
-                </label>
-                <input
-                  type="date"
-                  v-model="entry.dueDate"
-                  class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
-                />
-              </div>
-              <div>
-                <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                  Code Freeze Date
-                </label>
-                <input
-                  type="date"
-                  v-model="entry.codeFreezeDate"
-                  class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
-                />
-              </div>
-            </div>
-            <p class="text-[10px] text-gray-400 dark:text-gray-500">
-              Dates override Product Pages values when set
+      <div class="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+        <!-- Individual Releases Section -->
+        <div class="space-y-4">
+          <div>
+            <h4 class="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">Individual Releases</h4>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Manage the releases shown on the Risk Dashboard. Each entry maps a Jira release number
+              to a portfolio name and optional schedule dates that override Product Pages.
             </p>
           </div>
+
+          <div v-for="(entry, idx) in draft" :key="idx" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <div class="flex items-center gap-2 px-3 py-2.5 bg-gray-50 dark:bg-gray-800">
+              <button
+                type="button"
+                @click="toggleExpand(idx)"
+                class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors"
+              >
+                <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-90': expanded[idx] }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+              <input
+                v-model="entry.releaseNumber"
+                class="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
+                placeholder="Release number (e.g. rhoai-3.7)"
+              />
+              <span
+                v-if="entry.productName"
+                class="text-[10px] text-gray-400 dark:text-gray-500 font-medium uppercase truncate max-w-[100px]"
+              >{{ entry.productName }}</span>
+              <button
+                type="button"
+                @click="removeEntry(idx)"
+                class="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-gray-400 hover:text-red-500 transition-colors"
+                title="Remove release"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+
+            <div v-if="expanded[idx]" class="border-t border-gray-100 dark:border-gray-700 px-4 py-3 space-y-3">
+              <div>
+                <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                  Portfolio / Product Name
+                </label>
+                <input
+                  v-model="entry.productName"
+                  class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
+                  placeholder="e.g. RHOAI"
+                />
+              </div>
+
+              <div class="grid grid-cols-2 gap-3 pt-2 border-t border-gray-100 dark:border-gray-700">
+                <div>
+                  <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                    Due / GA Date
+                  </label>
+                  <input
+                    type="date"
+                    v-model="entry.dueDate"
+                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                    Code Freeze Date
+                  </label>
+                  <input
+                    type="date"
+                    v-model="entry.codeFreezeDate"
+                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+                  />
+                </div>
+              </div>
+              <p class="text-[10px] text-gray-400 dark:text-gray-500">
+                Dates override Product Pages values when set
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            @click="addEntry"
+            class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            Add Release
+          </button>
         </div>
 
-        <button
-          type="button"
-          @click="addEntry"
-          class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-        >
-          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
-          Add Release
-        </button>
+        <!-- Divider -->
+        <div class="border-t border-gray-200 dark:border-gray-700" />
+
+        <!-- Portfolio Releases Section -->
+        <div class="space-y-4">
+          <div>
+            <h4 class="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">Portfolio Releases</h4>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Bundle exactly 3 individual releases into a named portfolio group for the Risk Dashboard.
+              Disabled portfolios hide their constituent releases from the dashboard.
+            </p>
+          </div>
+
+          <div v-for="(pf, pi) in portfolioDraft" :key="pf.id" class="rounded-lg border border-indigo-200 dark:border-indigo-700/50 overflow-hidden">
+            <div class="flex items-center gap-2 px-3 py-2.5 bg-indigo-50/50 dark:bg-indigo-900/20">
+              <button
+                type="button"
+                @click="togglePortfolioExpand(pi)"
+                class="p-0.5 rounded hover:bg-indigo-100 dark:hover:bg-indigo-800/40 text-gray-400 transition-colors"
+              >
+                <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-90': portfolioExpanded[pi] }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+              <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                {{ pf.name || 'Untitled Portfolio' }}
+              </span>
+              <label class="relative inline-flex items-center cursor-pointer" @click.stop>
+                <input type="checkbox" v-model="pf.enabled" class="sr-only peer" />
+                <div class="w-8 h-4.5 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-600 peer-checked:bg-primary-600 transition-colors">
+                  <div class="absolute top-[2px] left-[2px] bg-white rounded-full h-3.5 w-3.5 transition-transform peer-checked:translate-x-3.5 shadow" />
+                </div>
+              </label>
+              <button
+                type="button"
+                @click="removePortfolio(pi)"
+                class="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-gray-400 hover:text-red-500 transition-colors"
+                title="Remove portfolio"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+
+            <div v-if="portfolioExpanded[pi]" class="border-t border-indigo-100 dark:border-indigo-800/50 px-4 py-3 space-y-3">
+              <div>
+                <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                  Portfolio Name
+                </label>
+                <input
+                  v-model="pf.name"
+                  class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
+                  placeholder="e.g. RHAI 3.5"
+                />
+              </div>
+
+              <div>
+                <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                  Releases (select exactly 3)
+                </label>
+                <div class="space-y-2">
+                  <select
+                    v-for="ri in 3"
+                    :key="ri"
+                    v-model="pf.releases[ri - 1]"
+                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+                  >
+                    <option value="">— Select release {{ ri }} —</option>
+                    <option
+                      v-for="rn in availableReleasesForSlot(pi, ri - 1)"
+                      :key="rn"
+                      :value="rn"
+                    >{{ rn }}</option>
+                  </select>
+                </div>
+              </div>
+
+              <div v-if="portfolioValidationError(pf)" class="text-xs text-red-500">
+                {{ portfolioValidationError(pf) }}
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            @click="addPortfolio"
+            class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 border border-dashed border-indigo-300 dark:border-indigo-600 rounded-lg hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-colors"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            Add Portfolio Release
+          </button>
+        </div>
       </div>
 
       <!-- Footer -->
@@ -129,8 +229,9 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
+import { useRiskDashboardConfig } from '../composables/useRiskDashboardConfig'
 
 var props = defineProps({
   open: { type: Boolean, default: false }
@@ -140,9 +241,13 @@ var emit = defineEmits(['close', 'saved'])
 
 var draft = ref([])
 var expanded = ref({})
+var portfolioDraft = ref([])
+var portfolioExpanded = ref({})
 var saving = ref(false)
 var saveError = ref(null)
 var saveSuccess = ref(false)
+
+var { saveConfig } = useRiskDashboardConfig()
 
 function metadataToArray(metadata) {
   var keys = Object.keys(metadata || {})
@@ -176,6 +281,49 @@ function arrayToMetadata(arr) {
   return metadata
 }
 
+var allReleaseNumbers = computed(function () {
+  var numbers = []
+  for (var i = 0; i < draft.value.length; i++) {
+    var rn = (draft.value[i].releaseNumber || '').trim()
+    if (rn) numbers.push(rn)
+  }
+  return numbers
+})
+
+function availableReleasesForSlot(portfolioIdx, slotIdx) {
+  var usedInOtherPortfolios = {}
+  for (var i = 0; i < portfolioDraft.value.length; i++) {
+    if (i === portfolioIdx) continue
+    var releases = portfolioDraft.value[i].releases || []
+    for (var j = 0; j < releases.length; j++) {
+      if (releases[j]) usedInOtherPortfolios[releases[j]] = true
+    }
+  }
+
+  var usedInThisPortfolio = {}
+  var thisReleases = portfolioDraft.value[portfolioIdx].releases || []
+  for (var k = 0; k < thisReleases.length; k++) {
+    if (k !== slotIdx && thisReleases[k]) usedInThisPortfolio[thisReleases[k]] = true
+  }
+
+  return allReleaseNumbers.value.filter(function (rn) {
+    return !usedInOtherPortfolios[rn] && !usedInThisPortfolio[rn]
+  })
+}
+
+function portfolioValidationError(pf) {
+  if (!pf.name || !pf.name.trim()) return 'Name is required'
+  var filled = pf.releases.filter(function (r) { return r && r.trim() })
+  if (filled.length < 3) return 'Select exactly 3 releases'
+  return null
+}
+
+var nextPortfolioId = 1
+
+function makePortfolioId() {
+  return 'pf-' + Date.now() + '-' + (nextPortfolioId++)
+}
+
 async function loadMetadata() {
   try {
     var response = await fetch(getApiBase() + '/modules/releases/delivery/releases-metadata')
@@ -187,17 +335,42 @@ async function loadMetadata() {
   }
 }
 
+async function loadPortfolioConfig() {
+  try {
+    var response = await fetch(getApiBase() + '/modules/releases/delivery/risk-dashboard-config')
+    if (!response.ok) throw new Error('HTTP ' + response.status)
+    var data = await response.json()
+    var portfolios = (data && data.portfolioReleases) || []
+    portfolioDraft.value = portfolios.map(function (p) {
+      return {
+        id: p.id || makePortfolioId(),
+        name: p.name || '',
+        releases: [p.releases[0] || '', p.releases[1] || '', p.releases[2] || ''],
+        enabled: p.enabled !== false
+      }
+    })
+  } catch {
+    portfolioDraft.value = []
+  }
+}
+
 watch(function() { return props.open }, function(isOpen) {
   if (isOpen) {
     expanded.value = {}
+    portfolioExpanded.value = {}
     saveError.value = null
     saveSuccess.value = false
     loadMetadata()
+    loadPortfolioConfig()
   }
 })
 
 function toggleExpand(idx) {
   expanded.value = Object.assign({}, expanded.value, { [idx]: !expanded.value[idx] })
+}
+
+function togglePortfolioExpand(idx) {
+  portfolioExpanded.value = Object.assign({}, portfolioExpanded.value, { [idx]: !portfolioExpanded.value[idx] })
 }
 
 function addEntry() {
@@ -209,23 +382,57 @@ function removeEntry(idx) {
   draft.value.splice(idx, 1)
 }
 
+function addPortfolio() {
+  var newPf = {
+    id: makePortfolioId(),
+    name: '',
+    releases: ['', '', ''],
+    enabled: true
+  }
+  portfolioDraft.value.push(newPf)
+  portfolioExpanded.value = Object.assign({}, portfolioExpanded.value, { [portfolioDraft.value.length - 1]: true })
+}
+
+function removePortfolio(idx) {
+  portfolioDraft.value.splice(idx, 1)
+}
+
 async function save() {
   saving.value = true
   saveError.value = null
   saveSuccess.value = false
 
-  var payload = arrayToMetadata(draft.value)
+  var metadataPayload = arrayToMetadata(draft.value)
+  var validPortfolios = []
+  for (var i = 0; i < portfolioDraft.value.length; i++) {
+    var pf = portfolioDraft.value[i]
+    var err = portfolioValidationError(pf)
+    if (err) {
+      saving.value = false
+      saveError.value = 'Portfolio "' + (pf.name || 'Untitled') + '": ' + err
+      return
+    }
+    validPortfolios.push({
+      id: pf.id,
+      name: pf.name.trim(),
+      releases: [pf.releases[0].trim(), pf.releases[1].trim(), pf.releases[2].trim()],
+      enabled: pf.enabled
+    })
+  }
 
   try {
-    var response = await fetch(getApiBase() + '/modules/releases/delivery/releases-metadata', {
+    var metaResponse = await fetch(getApiBase() + '/modules/releases/delivery/releases-metadata', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(metadataPayload)
     })
-    if (!response.ok) {
-      var errData = await response.json().catch(function() { return {} })
-      throw new Error(errData.error || 'HTTP ' + response.status)
+    if (!metaResponse.ok) {
+      var metaErr = await metaResponse.json().catch(function() { return {} })
+      throw new Error(metaErr.error || 'HTTP ' + metaResponse.status)
     }
+
+    await saveConfig({ portfolioReleases: validPortfolios })
+
     saveSuccess.value = true
     emit('saved')
   } catch (err) {

--- a/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
+++ b/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
@@ -421,6 +421,8 @@ async function save() {
   }
 
   try {
+    await saveConfig({ portfolioReleases: validPortfolios })
+
     var metaResponse = await fetch(getApiBase() + '/modules/releases/delivery/releases-metadata', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -430,8 +432,6 @@ async function save() {
       var metaErr = await metaResponse.json().catch(function() { return {} })
       throw new Error(metaErr.error || 'HTTP ' + metaResponse.status)
     }
-
-    await saveConfig({ portfolioReleases: validPortfolios })
 
     saveSuccess.value = true
     emit('saved')

--- a/modules/releases/client/deliver/composables/useRiskDashboardConfig.js
+++ b/modules/releases/client/deliver/composables/useRiskDashboardConfig.js
@@ -1,0 +1,87 @@
+import { ref, computed } from 'vue'
+import { getApiBase, SESSION_CACHE_PREFIX } from '@shared/client/services/api'
+
+const CACHE_KEY = `${SESSION_CACHE_PREFIX}risk-dashboard-config:v1`
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+function readCache() {
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!parsed || Date.now() - parsed._cachedAt > CACHE_TTL_MS) return null
+    return parsed.data
+  } catch {
+    return null
+  }
+}
+
+function writeCache(data) {
+  if (typeof sessionStorage === 'undefined' || !data) return
+  try {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify({ data, _cachedAt: Date.now() }))
+  } catch {
+    // quota or private mode
+  }
+}
+
+function clearCache() {
+  if (typeof sessionStorage === 'undefined') return
+  try { sessionStorage.removeItem(CACHE_KEY) } catch { /* noop */ }
+}
+
+const config = ref(null)
+const loading = ref(false)
+
+async function loadConfig(force) {
+  if (!force) {
+    const cached = readCache()
+    if (cached) {
+      config.value = cached
+      return
+    }
+  }
+
+  loading.value = true
+  try {
+    const response = await fetch(getApiBase() + '/modules/releases/delivery/risk-dashboard-config')
+    if (!response.ok) throw new Error('HTTP ' + response.status)
+    const data = await response.json()
+    config.value = data
+    writeCache(data)
+  } catch {
+    config.value = { portfolioReleases: [] }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfig(data) {
+  const response = await fetch(getApiBase() + '/modules/releases/delivery/risk-dashboard-config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+  if (!response.ok) {
+    const errData = await response.json().catch(function () { return {} })
+    throw new Error(errData.error || 'HTTP ' + response.status)
+  }
+  config.value = data
+  writeCache(data)
+}
+
+const portfolioReleases = computed(function () {
+  return (config.value && config.value.portfolioReleases) || []
+})
+
+export function useRiskDashboardConfig() {
+  return {
+    config,
+    loading,
+    loadConfig,
+    saveConfig,
+    clearCache,
+    portfolioReleases
+  }
+}

--- a/modules/releases/client/deliver/views/MainView.vue
+++ b/modules/releases/client/deliver/views/MainView.vue
@@ -79,7 +79,7 @@
             <div class="space-y-5">
               <ReleaseVersionGroup
                 v-for="group in groupedByVersion"
-                :key="group.version"
+                :key="group.groupKey"
                 :group="group"
                 :mc-inputs-map="mcInputsMap"
                 :get-mc-target="getMcTarget"
@@ -102,8 +102,9 @@
 </template>
 
 <script setup>
-import { ref, computed, reactive, inject } from 'vue'
+import { ref, computed, reactive, inject, onMounted } from 'vue'
 import { extractVersion, normalizeVersionKey } from '../composables/release-utils'
+import { useRiskDashboardConfig } from '../composables/useRiskDashboardConfig'
 import ReleaseVersionGroup from '../components/ReleaseVersionGroup.vue'
 import RiskDashboardSettingsPanel from '../components/RiskDashboardSettingsPanel.vue'
 
@@ -111,31 +112,83 @@ const filter = inject('releaseFilter')
 const analysisState = inject('analysisState')
 const { loading, refreshing, error, analysis, refreshAnalysis } = analysisState
 
+const { loadConfig, portfolioReleases, clearCache: clearDashboardConfigCache } = useRiskDashboardConfig()
+
+onMounted(function () {
+  loadConfig()
+})
+
 const settingsOpen = ref(false)
 
 function onSettingsSaved() {
   settingsOpen.value = false
+  clearDashboardConfigCache()
+  loadConfig(true)
   refreshAnalysis()
 }
+
+// Build a set of release numbers belonging to disabled portfolios (hidden entirely)
+const hiddenReleaseNumbers = computed(function () {
+  var hidden = {}
+  var portfolios = portfolioReleases.value
+  for (var i = 0; i < portfolios.length; i++) {
+    if (!portfolios[i].enabled) {
+      var releases = portfolios[i].releases || []
+      for (var j = 0; j < releases.length; j++) {
+        if (releases[j]) hidden[releases[j]] = true
+      }
+    }
+  }
+  return hidden
+})
+
+// Build a set of release numbers belonging to enabled portfolios (grouped separately)
+const portfolioMemberSet = computed(function () {
+  var members = {}
+  var portfolios = portfolioReleases.value
+  for (var i = 0; i < portfolios.length; i++) {
+    if (portfolios[i].enabled) {
+      var releases = portfolios[i].releases || []
+      for (var j = 0; j < releases.length; j++) {
+        if (releases[j]) members[releases[j]] = true
+      }
+    }
+  }
+  return members
+})
 
 const allReleases = computed(() => {
   const releases = filter.filteredReleases.value
 
-  // Filter to current/future releases only (hide past-due releases like 3.4)
   const now = new Date()
   const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
 
   return releases.filter(r => {
+    if (hiddenReleaseNumbers.value[r.releaseNumber]) return false
     const due = new Date(`${r.dueDate}T00:00:00Z`)
-    if (Number.isNaN(due.getTime())) return true // Keep if no date
-    return due >= today // Hide if due date passed
+    if (Number.isNaN(due.getTime())) return true
+    return due >= today
   })
 })
 
 const groupedByVersion = computed(() => {
+  var members = portfolioMemberSet.value
+  var nonPortfolioReleases = []
+  var portfolioReleasesMap = {}
+
+  for (var ri = 0; ri < allReleases.value.length; ri++) {
+    var r = allReleases.value[ri]
+    if (members[r.releaseNumber]) {
+      portfolioReleasesMap[r.releaseNumber] = r
+    } else {
+      nonPortfolioReleases.push(r)
+    }
+  }
+
+  // Standard version grouping for non-portfolio releases
   const map = new Map()
   const displayVersion = new Map()
-  for (const r of allReleases.value) {
+  for (const r of nonPortfolioReleases) {
     const rawVer = extractVersion(r.releaseNumber)
     const groupKey = normalizeVersionKey(rawVer)
     if (!map.has(groupKey)) {
@@ -147,63 +200,84 @@ const groupedByVersion = computed(() => {
 
   const groups = []
   for (const [groupKey, releases] of map) {
-    const version = displayVersion.get(groupKey)
-    const earliest = releases.reduce((min, r) => {
-      const d = new Date(r.dueDate)
-      return d < min ? d : min
-    }, new Date('9999-12-31'))
-
-    const cfDates = releases.map(r => r.codeFreezeDate).filter(Boolean)
-    const earliestCodeFreeze = cfDates.length
-      ? cfDates.reduce((min, d) => (new Date(d) < new Date(min) ? d : min))
-      : null
-
-    const dueDates = releases.map(r => r.dueDate).filter(Boolean)
-    const earliestRelease = dueDates.length
-      ? dueDates.reduce((min, d) => (new Date(d) < new Date(min) ? d : min))
-      : null
-
-    const products = [...new Set(releases.map(r => {
-      const s = (r.releaseNumber || '').toLowerCase()
-      const dash = s.indexOf('-')
-      return dash > 0 ? s.slice(0, dash) : s
-    }))]
-
-    let risk = 'green'
-    if (releases.some(r => r.risk === 'red')) risk = 'red'
-    else if (releases.some(r => r.risk === 'yellow')) risk = 'yellow'
-
-    const totals = { to_do: 0, doing: 0, done: 0, remaining: 0, total: 0, issues: 0, issues_to_do: 0, issues_doing: 0, issues_done: 0 }
-    for (const r of releases) {
-      const t = r.totals || {}
-      totals.to_do += t.to_do || 0
-      totals.doing += t.doing || 0
-      totals.done += t.done || 0
-      totals.remaining += t.remaining || 0
-      totals.total += t.total || 0
-      totals.issues += t.issues || 0
-      totals.issues_to_do += t.issues_to_do || 0
-      totals.issues_doing += t.issues_doing || 0
-      totals.issues_done += t.issues_done || 0
-    }
-
-    groups.push({
-      version,
-      releases,
-      risk,
-      totals,
-      earliestDue: earliest,
-      earliestCodeFreeze,
-      earliestRelease,
-      productCount: products.length,
-      productNames: products,
-      releaseCount: releases.length
-    })
+    groups.push(buildGroupFromReleases(groupKey, displayVersion.get(groupKey), releases, null))
   }
 
-  groups.sort((a, b) => a.version.localeCompare(b.version, undefined, { numeric: true }))
+  // Portfolio groups from enabled portfolios
+  var portfolios = portfolioReleases.value
+  for (var pi = 0; pi < portfolios.length; pi++) {
+    var pf = portfolios[pi]
+    if (!pf.enabled) continue
+    var pfReleases = []
+    for (var pj = 0; pj < pf.releases.length; pj++) {
+      var releaseObj = portfolioReleasesMap[pf.releases[pj]]
+      if (releaseObj) pfReleases.push(releaseObj)
+    }
+    if (!pfReleases.length) continue
+    var pfGroupKey = 'portfolio-' + pf.id
+    var pfVersion = pfReleases[0] ? extractVersion(pfReleases[0].releaseNumber) : pf.name
+    groups.push(buildGroupFromReleases(pfGroupKey, pfVersion, pfReleases, pf.name))
+  }
+
+  groups.sort((a, b) => (a.displayName || a.version).localeCompare(b.displayName || b.version, undefined, { numeric: true }))
   return groups
 })
+
+function buildGroupFromReleases(groupKey, version, releases, displayName) {
+  const earliest = releases.reduce((min, r) => {
+    const d = new Date(r.dueDate)
+    return d < min ? d : min
+  }, new Date('9999-12-31'))
+
+  const cfDates = releases.map(r => r.codeFreezeDate).filter(Boolean)
+  const earliestCodeFreeze = cfDates.length
+    ? cfDates.reduce((min, d) => (new Date(d) < new Date(min) ? d : min))
+    : null
+
+  const dueDates = releases.map(r => r.dueDate).filter(Boolean)
+  const earliestRelease = dueDates.length
+    ? dueDates.reduce((min, d) => (new Date(d) < new Date(min) ? d : min))
+    : null
+
+  const products = [...new Set(releases.map(r => {
+    const s = (r.releaseNumber || '').toLowerCase()
+    const dash = s.indexOf('-')
+    return dash > 0 ? s.slice(0, dash) : s
+  }))]
+
+  let risk = 'green'
+  if (releases.some(r => r.risk === 'red')) risk = 'red'
+  else if (releases.some(r => r.risk === 'yellow')) risk = 'yellow'
+
+  const totals = { to_do: 0, doing: 0, done: 0, remaining: 0, total: 0, issues: 0, issues_to_do: 0, issues_doing: 0, issues_done: 0 }
+  for (const r of releases) {
+    const t = r.totals || {}
+    totals.to_do += t.to_do || 0
+    totals.doing += t.doing || 0
+    totals.done += t.done || 0
+    totals.remaining += t.remaining || 0
+    totals.total += t.total || 0
+    totals.issues += t.issues || 0
+    totals.issues_to_do += t.issues_to_do || 0
+    totals.issues_doing += t.issues_doing || 0
+    totals.issues_done += t.issues_done || 0
+  }
+
+  return {
+    groupKey,
+    version,
+    displayName: displayName || null,
+    releases,
+    risk,
+    totals,
+    earliestDue: earliest,
+    earliestCodeFreeze,
+    earliestRelease,
+    productCount: products.length,
+    productNames: products,
+    releaseCount: releases.length
+  }
+}
 
 // ── Monte Carlo state ──
 

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -2162,8 +2162,8 @@ module.exports = function registerRoutes(router, context) {
         if (!p.name || typeof p.name !== 'string' || !p.name.trim()) {
           return res.status(400).json({ error: 'Portfolio at index ' + i + ' must have a non-empty name' })
         }
-        if (!Array.isArray(p.releases) || p.releases.length !== 3) {
-          return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have exactly 3 releases' })
+        if (!Array.isArray(p.releases) || p.releases.length !== 3 || p.releases.some(function(r) { return typeof r !== 'string' || !r.trim() })) {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have exactly 3 non-empty release strings' })
         }
         if (typeof p.enabled !== 'boolean') {
           return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have a boolean enabled field' })

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -2089,6 +2089,94 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/risk-dashboard-config:
+   *   get:
+   *     tags: ['Releases: Delivery']
+   *     summary: Get Risk Dashboard configuration
+   *     description: Returns dashboard-scoped settings including portfolio release groupings
+   *     responses:
+   *       200:
+   *         description: Risk dashboard config object
+   */
+  router.get('/risk-dashboard-config', requireAuth, requireScope('releases:read'), function(req, res) {
+    try {
+      const config = readFromStorage('releases/delivery/risk-dashboard-config.json') || { portfolioReleases: [] }
+      res.json(config)
+    } catch (error) {
+      console.error('[releases/delivery] Get risk-dashboard-config error:', error)
+      res.status(500).json({ error: error.message })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/risk-dashboard-config:
+   *   post:
+   *     tags: ['Releases: Delivery']
+   *     summary: Save Risk Dashboard configuration
+   *     description: Stores dashboard-scoped settings including portfolio release groupings
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               portfolioReleases:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   properties:
+   *                     id:
+   *                       type: string
+   *                     name:
+   *                       type: string
+   *                     releases:
+   *                       type: array
+   *                       items:
+   *                         type: string
+   *                       minItems: 3
+   *                       maxItems: 3
+   *                     enabled:
+   *                       type: boolean
+   *     responses:
+   *       200:
+   *         description: Config saved successfully
+   *       400:
+   *         description: Invalid config
+   */
+  router.post('/risk-dashboard-config', requireAdmin, requireScope('releases:write'), function(req, res) {
+    try {
+      const config = req.body
+      if (typeof config !== 'object' || Array.isArray(config)) {
+        return res.status(400).json({ error: 'Config must be an object' })
+      }
+      const portfolios = config.portfolioReleases
+      if (!Array.isArray(portfolios)) {
+        return res.status(400).json({ error: 'portfolioReleases must be an array' })
+      }
+      for (let i = 0; i < portfolios.length; i++) {
+        const p = portfolios[i]
+        if (!p.name || typeof p.name !== 'string' || !p.name.trim()) {
+          return res.status(400).json({ error: 'Portfolio at index ' + i + ' must have a non-empty name' })
+        }
+        if (!Array.isArray(p.releases) || p.releases.length !== 3) {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have exactly 3 releases' })
+        }
+        if (typeof p.enabled !== 'boolean') {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have a boolean enabled field' })
+        }
+      }
+      writeToStorage('releases/delivery/risk-dashboard-config.json', config)
+      res.json({ success: true })
+    } catch (error) {
+      console.error('[releases/delivery] Save risk-dashboard-config error:', error)
+      res.status(500).json({ error: error.message })
+    }
+  })
+
   if (context.registerRefresh) {
     context.registerRefresh('delivery', {
       order: 70,


### PR DESCRIPTION
## Summary
- Adds "Portfolio Release" grouping to the Risk Dashboard settings panel, allowing users to bundle exactly 3 individual releases into a named group with an enable/disable toggle
- Disabled portfolios hide their constituent releases entirely from the Risk Dashboard
- Portfolio groups display with a custom name in the version group header instead of the auto-generated "RHAI X.Y"
- Stored in a separate `risk-dashboard-config.json` (isolated from global release metadata)

### Changes
- **Backend**: New `GET/POST /delivery/risk-dashboard-config` endpoints with validation (name required, exactly 3 releases, boolean enabled)
- **Composable**: `useRiskDashboardConfig.js` with sessionStorage caching (5-min TTL)
- **Settings panel**: Portfolio section with release dropdowns (prevents duplicate selection), enable/disable toggle, and delete
- **MainView**: Portfolio-aware grouping — enabled portfolios are pulled out of standard version groups; disabled portfolios hide their releases
- **ReleaseVersionGroup**: Dynamic header label (`group.displayName || 'RHAI ' + group.version`)

## Test plan
- [ ] Open Risk Dashboard settings (gear icon) — verify both "Individual Releases" and "Portfolio Releases" sections appear
- [ ] Create a portfolio: add a name, select 3 releases from dropdowns, confirm dropdowns prevent selecting the same release twice
- [ ] Save and verify the portfolio appears as a single group on the dashboard with the custom name
- [ ] Toggle the portfolio off, save — verify its 3 releases are hidden from the dashboard
- [ ] Toggle back on — verify the portfolio group reappears
- [ ] Delete a portfolio — verify its releases return to normal version grouping
- [ ] Verify existing non-portfolio releases continue grouping by version as before


Made with [Cursor](https://cursor.com)