### PR TITLE
fix(releases): replace individual releases with direct FixVersion inputs in portfolio config

### DIFF
--- a/modules/releases/__tests__/client/deliver/MainView.test.js
+++ b/modules/releases/__tests__/client/deliver/MainView.test.js
@@ -72,7 +72,27 @@ function createMockAnalysisState(overrides = {}) {
   }
 }
 
+function seedPortfolioConfig(releases) {
+  const releaseNumbers = releases.map(function (r) { return r.releaseNumber })
+  while (releaseNumbers.length < 3) releaseNumbers.push('placeholder-' + releaseNumbers.length)
+  const config = {
+    portfolioReleases: [{
+      id: 'pf-test',
+      name: 'Test Portfolio',
+      releases: releaseNumbers.slice(0, 3),
+      codeFreezeDate: null,
+      dueDate: null,
+      enabled: true
+    }]
+  }
+  sessionStorage.setItem('tt_cache:session:risk-dashboard-config:v1', JSON.stringify({
+    data: config,
+    _cachedAt: Date.now()
+  }))
+}
+
 function mountView(releases = [], analysisOverrides = {}) {
+  if (releases.length) seedPortfolioConfig(releases)
   const mockFilter = createMockFilter(releases)
   const mockAnalysis = createMockAnalysisState(analysisOverrides)
   return mount(MainView, {

--- a/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
+++ b/modules/releases/client/deliver/components/RiskDashboardSettingsPanel.vue
@@ -16,110 +16,12 @@
 
       <!-- Body -->
       <div class="flex-1 overflow-y-auto px-5 py-4 space-y-6">
-        <!-- Individual Releases Section -->
-        <div class="space-y-4">
-          <div>
-            <h4 class="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">Individual Releases</h4>
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Manage the releases shown on the Risk Dashboard. Each entry maps a Jira release number
-              to a portfolio name and optional schedule dates that override Product Pages.
-            </p>
-          </div>
-
-          <div v-for="(entry, idx) in draft" :key="idx" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-            <div class="flex items-center gap-2 px-3 py-2.5 bg-gray-50 dark:bg-gray-800">
-              <button
-                type="button"
-                @click="toggleExpand(idx)"
-                class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors"
-              >
-                <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-90': expanded[idx] }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                </svg>
-              </button>
-              <input
-                v-model="entry.releaseNumber"
-                class="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
-                placeholder="Release number (e.g. rhoai-3.7)"
-              />
-              <span
-                v-if="entry.productName"
-                class="text-[10px] text-gray-400 dark:text-gray-500 font-medium uppercase truncate max-w-[100px]"
-              >{{ entry.productName }}</span>
-              <button
-                type="button"
-                @click="removeEntry(idx)"
-                class="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-gray-400 hover:text-red-500 transition-colors"
-                title="Remove release"
-              >
-                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-              </button>
-            </div>
-
-            <div v-if="expanded[idx]" class="border-t border-gray-100 dark:border-gray-700 px-4 py-3 space-y-3">
-              <div>
-                <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                  Portfolio / Product Name
-                </label>
-                <input
-                  v-model="entry.productName"
-                  class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
-                  placeholder="e.g. RHOAI"
-                />
-              </div>
-
-              <div class="grid grid-cols-2 gap-3 pt-2 border-t border-gray-100 dark:border-gray-700">
-                <div>
-                  <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                    Due / GA Date
-                  </label>
-                  <input
-                    type="date"
-                    v-model="entry.dueDate"
-                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
-                  />
-                </div>
-                <div>
-                  <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                    Code Freeze Date
-                  </label>
-                  <input
-                    type="date"
-                    v-model="entry.codeFreezeDate"
-                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
-                  />
-                </div>
-              </div>
-              <p class="text-[10px] text-gray-400 dark:text-gray-500">
-                Dates override Product Pages values when set
-              </p>
-            </div>
-          </div>
-
-          <button
-            type="button"
-            @click="addEntry"
-            class="w-full flex items-center justify-center gap-1.5 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-          >
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-            </svg>
-            Add Release
-          </button>
-        </div>
-
-        <!-- Divider -->
-        <div class="border-t border-gray-200 dark:border-gray-700" />
-
         <!-- Portfolio Releases Section -->
         <div class="space-y-4">
           <div>
             <h4 class="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">Portfolio Releases</h4>
             <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Bundle exactly 3 individual releases into a named portfolio group for the Risk Dashboard.
-              Disabled portfolios hide their constituent releases from the dashboard.
+              Define portfolio release groups with exactly 3 FixVersion identifiers, a shared code freeze date, and GA date.
             </p>
           </div>
 
@@ -169,24 +71,45 @@
 
               <div>
                 <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
-                  Releases (select exactly 3)
+                  FixVersions (exactly 3)
                 </label>
                 <div class="space-y-2">
-                  <select
+                  <input
                     v-for="ri in 3"
                     :key="ri"
                     v-model="pf.releases[ri - 1]"
-                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
-                  >
-                    <option value="">— Select release {{ ri }} —</option>
-                    <option
-                      v-for="rn in availableReleasesForSlot(pi, ri - 1)"
-                      :key="rn"
-                      :value="rn"
-                    >{{ rn }}</option>
-                  </select>
+                    type="text"
+                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400 placeholder-gray-300 dark:placeholder-gray-600"
+                    :placeholder="'FixVersion ' + ri + ' (e.g. rhoai-3.7)'"
+                  />
                 </div>
               </div>
+
+              <div class="grid grid-cols-2 gap-3 pt-2 border-t border-indigo-100 dark:border-indigo-800/50">
+                <div>
+                  <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                    Code Freeze Date
+                  </label>
+                  <input
+                    type="date"
+                    v-model="pf.codeFreezeDate"
+                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">
+                    GA Date
+                  </label>
+                  <input
+                    type="date"
+                    v-model="pf.dueDate"
+                    class="w-full text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+                  />
+                </div>
+              </div>
+              <p class="text-[10px] text-gray-400 dark:text-gray-500">
+                Dates are shared across all releases in this portfolio and override Product Pages values when set.
+              </p>
 
               <div v-if="portfolioValidationError(pf)" class="text-xs text-red-500">
                 {{ portfolioValidationError(pf) }}
@@ -229,7 +152,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, watch } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
 import { useRiskDashboardConfig } from '../composables/useRiskDashboardConfig'
 
@@ -239,8 +162,6 @@ var props = defineProps({
 
 var emit = defineEmits(['close', 'saved'])
 
-var draft = ref([])
-var expanded = ref({})
 var portfolioDraft = ref([])
 var portfolioExpanded = ref({})
 var saving = ref(false)
@@ -249,72 +170,10 @@ var saveSuccess = ref(false)
 
 var { saveConfig } = useRiskDashboardConfig()
 
-function metadataToArray(metadata) {
-  var keys = Object.keys(metadata || {})
-  var entries = []
-  for (var i = 0; i < keys.length; i++) {
-    var releaseNumber = keys[i]
-    var meta = metadata[releaseNumber] || {}
-    entries.push({
-      releaseNumber: releaseNumber,
-      productName: meta.productName || '',
-      dueDate: meta.dueDate || '',
-      codeFreezeDate: meta.codeFreezeDate || ''
-    })
-  }
-  entries.sort(function(a, b) { return a.releaseNumber.localeCompare(b.releaseNumber) })
-  return entries
-}
-
-function arrayToMetadata(arr) {
-  var metadata = {}
-  for (var i = 0; i < arr.length; i++) {
-    var entry = arr[i]
-    var releaseNumber = (entry.releaseNumber || '').trim()
-    if (!releaseNumber) continue
-    metadata[releaseNumber] = {
-      productName: (entry.productName || '').trim() || null,
-      dueDate: entry.dueDate || null,
-      codeFreezeDate: entry.codeFreezeDate || null
-    }
-  }
-  return metadata
-}
-
-var allReleaseNumbers = computed(function () {
-  var numbers = []
-  for (var i = 0; i < draft.value.length; i++) {
-    var rn = (draft.value[i].releaseNumber || '').trim()
-    if (rn) numbers.push(rn)
-  }
-  return numbers
-})
-
-function availableReleasesForSlot(portfolioIdx, slotIdx) {
-  var usedInOtherPortfolios = {}
-  for (var i = 0; i < portfolioDraft.value.length; i++) {
-    if (i === portfolioIdx) continue
-    var releases = portfolioDraft.value[i].releases || []
-    for (var j = 0; j < releases.length; j++) {
-      if (releases[j]) usedInOtherPortfolios[releases[j]] = true
-    }
-  }
-
-  var usedInThisPortfolio = {}
-  var thisReleases = portfolioDraft.value[portfolioIdx].releases || []
-  for (var k = 0; k < thisReleases.length; k++) {
-    if (k !== slotIdx && thisReleases[k]) usedInThisPortfolio[thisReleases[k]] = true
-  }
-
-  return allReleaseNumbers.value.filter(function (rn) {
-    return !usedInOtherPortfolios[rn] && !usedInThisPortfolio[rn]
-  })
-}
-
 function portfolioValidationError(pf) {
   if (!pf.name || !pf.name.trim()) return 'Name is required'
   var filled = pf.releases.filter(function (r) { return r && r.trim() })
-  if (filled.length < 3) return 'Select exactly 3 releases'
+  if (filled.length < 3) return 'Enter exactly 3 FixVersions'
   return null
 }
 
@@ -322,17 +181,6 @@ var nextPortfolioId = 1
 
 function makePortfolioId() {
   return 'pf-' + Date.now() + '-' + (nextPortfolioId++)
-}
-
-async function loadMetadata() {
-  try {
-    var response = await fetch(getApiBase() + '/modules/releases/delivery/releases-metadata')
-    if (!response.ok) throw new Error('HTTP ' + response.status)
-    var data = await response.json()
-    draft.value = metadataToArray(data)
-  } catch {
-    draft.value = []
-  }
 }
 
 async function loadPortfolioConfig() {
@@ -346,6 +194,8 @@ async function loadPortfolioConfig() {
         id: p.id || makePortfolioId(),
         name: p.name || '',
         releases: [p.releases[0] || '', p.releases[1] || '', p.releases[2] || ''],
+        codeFreezeDate: p.codeFreezeDate || '',
+        dueDate: p.dueDate || '',
         enabled: p.enabled !== false
       }
     })
@@ -356,30 +206,15 @@ async function loadPortfolioConfig() {
 
 watch(function() { return props.open }, function(isOpen) {
   if (isOpen) {
-    expanded.value = {}
     portfolioExpanded.value = {}
     saveError.value = null
     saveSuccess.value = false
-    loadMetadata()
     loadPortfolioConfig()
   }
 })
 
-function toggleExpand(idx) {
-  expanded.value = Object.assign({}, expanded.value, { [idx]: !expanded.value[idx] })
-}
-
 function togglePortfolioExpand(idx) {
   portfolioExpanded.value = Object.assign({}, portfolioExpanded.value, { [idx]: !portfolioExpanded.value[idx] })
-}
-
-function addEntry() {
-  draft.value.push({ releaseNumber: '', productName: '', dueDate: '', codeFreezeDate: '' })
-  expanded.value = Object.assign({}, expanded.value, { [draft.value.length - 1]: true })
-}
-
-function removeEntry(idx) {
-  draft.value.splice(idx, 1)
 }
 
 function addPortfolio() {
@@ -387,6 +222,8 @@ function addPortfolio() {
     id: makePortfolioId(),
     name: '',
     releases: ['', '', ''],
+    codeFreezeDate: '',
+    dueDate: '',
     enabled: true
   }
   portfolioDraft.value.push(newPf)
@@ -397,12 +234,28 @@ function removePortfolio(idx) {
   portfolioDraft.value.splice(idx, 1)
 }
 
+function buildMetadataFromPortfolios(portfolios) {
+  var metadata = {}
+  for (var i = 0; i < portfolios.length; i++) {
+    var pf = portfolios[i]
+    for (var j = 0; j < pf.releases.length; j++) {
+      var releaseNumber = (pf.releases[j] || '').trim()
+      if (!releaseNumber) continue
+      metadata[releaseNumber] = {
+        productName: pf.name.trim() || null,
+        dueDate: pf.dueDate || null,
+        codeFreezeDate: pf.codeFreezeDate || null
+      }
+    }
+  }
+  return metadata
+}
+
 async function save() {
   saving.value = true
   saveError.value = null
   saveSuccess.value = false
 
-  var metadataPayload = arrayToMetadata(draft.value)
   var validPortfolios = []
   for (var i = 0; i < portfolioDraft.value.length; i++) {
     var pf = portfolioDraft.value[i]
@@ -416,6 +269,8 @@ async function save() {
       id: pf.id,
       name: pf.name.trim(),
       releases: [pf.releases[0].trim(), pf.releases[1].trim(), pf.releases[2].trim()],
+      codeFreezeDate: pf.codeFreezeDate || null,
+      dueDate: pf.dueDate || null,
       enabled: pf.enabled
     })
   }
@@ -423,6 +278,7 @@ async function save() {
   try {
     await saveConfig({ portfolioReleases: validPortfolios })
 
+    var metadataPayload = buildMetadataFromPortfolios(validPortfolios)
     var metaResponse = await fetch(getApiBase() + '/modules/releases/delivery/releases-metadata', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/modules/releases/client/deliver/views/MainView.vue
+++ b/modules/releases/client/deliver/views/MainView.vue
@@ -216,7 +216,10 @@ const groupedByVersion = computed(() => {
     if (!pfReleases.length) continue
     var pfGroupKey = 'portfolio-' + pf.id
     var pfVersion = pfReleases[0] ? extractVersion(pfReleases[0].releaseNumber) : pf.name
-    groups.push(buildGroupFromReleases(pfGroupKey, pfVersion, pfReleases, pf.name))
+    var pfGroup = buildGroupFromReleases(pfGroupKey, pfVersion, pfReleases, pf.name)
+    if (pf.codeFreezeDate) pfGroup.earliestCodeFreeze = pf.codeFreezeDate
+    if (pf.dueDate) pfGroup.earliestRelease = pf.dueDate
+    groups.push(pfGroup)
   }
 
   groups.sort((a, b) => (a.displayName || a.version).localeCompare(b.displayName || b.version, undefined, { numeric: true }))

--- a/modules/releases/client/deliver/views/MainView.vue
+++ b/modules/releases/client/deliver/views/MainView.vue
@@ -127,6 +127,19 @@ function onSettingsSaved() {
   refreshAnalysis()
 }
 
+// All release numbers configured in any portfolio (enabled or disabled)
+const configuredReleaseNumbers = computed(function () {
+  var configured = {}
+  var portfolios = portfolioReleases.value
+  for (var i = 0; i < portfolios.length; i++) {
+    var releases = portfolios[i].releases || []
+    for (var j = 0; j < releases.length; j++) {
+      if (releases[j]) configured[releases[j]] = true
+    }
+  }
+  return configured
+})
+
 // Build a set of release numbers belonging to disabled portfolios (hidden entirely)
 const hiddenReleaseNumbers = computed(function () {
   var hidden = {}
@@ -164,6 +177,7 @@ const allReleases = computed(() => {
   const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
 
   return releases.filter(r => {
+    if (!configuredReleaseNumbers.value[r.releaseNumber]) return false
     if (hiddenReleaseNumbers.value[r.releaseNumber]) return false
     const due = new Date(`${r.dueDate}T00:00:00Z`)
     if (Number.isNaN(due.getTime())) return true

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -2139,6 +2139,14 @@ module.exports = function registerRoutes(router, context) {
    *                         type: string
    *                       minItems: 3
    *                       maxItems: 3
+   *                     codeFreezeDate:
+   *                       type: string
+   *                       format: date
+   *                       nullable: true
+   *                     dueDate:
+   *                       type: string
+   *                       format: date
+   *                       nullable: true
    *                     enabled:
    *                       type: boolean
    *     responses:
@@ -2167,6 +2175,12 @@ module.exports = function registerRoutes(router, context) {
         }
         if (typeof p.enabled !== 'boolean') {
           return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have a boolean enabled field' })
+        }
+        if (p.codeFreezeDate != null && typeof p.codeFreezeDate !== 'string') {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" codeFreezeDate must be a string or null' })
+        }
+        if (p.dueDate != null && typeof p.dueDate !== 'string') {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" dueDate must be a string or null' })
         }
       }
       writeToStorage('releases/delivery/risk-dashboard-config.json', config)

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -2176,11 +2176,12 @@ module.exports = function registerRoutes(router, context) {
         if (typeof p.enabled !== 'boolean') {
           return res.status(400).json({ error: 'Portfolio "' + p.name + '" must have a boolean enabled field' })
         }
-        if (p.codeFreezeDate != null && typeof p.codeFreezeDate !== 'string') {
-          return res.status(400).json({ error: 'Portfolio "' + p.name + '" codeFreezeDate must be a string or null' })
+        var dateRe = /^\d{4}-\d{2}-\d{2}$/
+        if (p.codeFreezeDate != null && (typeof p.codeFreezeDate !== 'string' || !dateRe.test(p.codeFreezeDate))) {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" codeFreezeDate must be a YYYY-MM-DD string or null' })
         }
-        if (p.dueDate != null && typeof p.dueDate !== 'string') {
-          return res.status(400).json({ error: 'Portfolio "' + p.name + '" dueDate must be a string or null' })
+        if (p.dueDate != null && (typeof p.dueDate !== 'string' || !dateRe.test(p.dueDate))) {
+          return res.status(400).json({ error: 'Portfolio "' + p.name + '" dueDate must be a YYYY-MM-DD string or null' })
         }
       }
       writeToStorage('releases/delivery/risk-dashboard-config.json', config)


### PR DESCRIPTION
## Summary
- Removes the Individual Releases section from the Risk Dashboard settings panel (gear icon) and replaces the portfolio release dropdowns with direct, typeable text input fields for FixVersion.
- Consolidates Code Freeze and GA Date inputs at the portfolio level, since all products in a portfolio share identical dates.
- Filters the Risk Dashboard to only show releases explicitly configured through the settings panel, excluding auto-discovered releases from Jira/Product Pages that aren't part of a portfolio.
- Updates server-side validation and OpenAPI annotations to accept the new `codeFreezeDate` and `dueDate` fields on portfolio objects.

## Test plan
- [ ] Open the Risk Dashboard gear icon and verify the Individual Releases section is gone
- [ ] Add a Portfolio Release with 3 typed FixVersions and shared Code Freeze / GA dates, then save
- [ ] Verify only the configured portfolio releases appear on the dashboard (no stray auto-discovered releases)
- [ ] Toggle a portfolio's enabled switch off and confirm its releases are hidden
- [ ] Confirm dates display correctly on the portfolio group header
- [ ] Verify saving with missing FixVersions or name shows validation errors


Made with [Cursor](https://cursor.com)