### PR TITLE
fix(releases): enable Jira enrichment by default and fix handler visibility

### DIFF
--- a/modules/releases/client/execute/components/ExecutionSettings.vue
+++ b/modules/releases/client/execute/components/ExecutionSettings.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 
 const config = ref(null)
@@ -60,6 +60,30 @@ async function saveConfig() {
   }
 }
 
+function formatAge(timestamp) {
+  if (!timestamp) return 'unknown'
+  const ms = Date.now() - new Date(timestamp).getTime()
+  const hours = Math.floor(ms / (1000 * 60 * 60))
+  if (hours < 1) return 'just now'
+  if (hours < 24) return hours + 'h ago'
+  const days = Math.floor(hours / 24)
+  return days === 1 ? '1 day ago' : days + ' days ago'
+}
+
+const jiraEnrichmentStatusClass = computed(() => {
+  const je = statusData.value?.jiraEnrichment
+  if (!je) return ''
+  if (!je.jiraConfigured || je.stale || je.warning) return 'bg-yellow-50 dark:bg-yellow-900/20'
+  return 'bg-green-50 dark:bg-green-900/20'
+})
+
+const jiraEnrichmentTextClass = computed(() => {
+  const je = statusData.value?.jiraEnrichment
+  if (!je) return ''
+  if (!je.jiraConfigured || je.stale || je.warning) return 'text-yellow-700 dark:text-yellow-300'
+  return 'text-green-700 dark:text-green-300'
+})
+
 onMounted(() => {
   loadConfig()
   loadStatus()
@@ -87,6 +111,27 @@ onMounted(() => {
       <div v-if="statusData?.staleWarning" class="rounded-md p-3 bg-yellow-50 dark:bg-yellow-900/20">
         <p class="text-sm text-yellow-700 dark:text-yellow-300">
           Data is stale ({{ statusData.dataAge }} old). Last fetch status: {{ statusData.lastFetch?.status || 'unknown' }}
+        </p>
+      </div>
+
+      <!-- Jira Enrichment Status -->
+      <div v-if="statusData?.jiraEnrichment" class="rounded-md p-3" :class="jiraEnrichmentStatusClass">
+        <p class="text-sm font-medium" :class="jiraEnrichmentTextClass">Jira Enrichment</p>
+        <p class="text-sm mt-1" :class="jiraEnrichmentTextClass">
+          <template v-if="!statusData.jiraEnrichment.jiraConfigured">
+            Jira client not configured — feature status, assignees, and fields cannot be synced from Jira.
+          </template>
+          <template v-else-if="statusData.jiraEnrichment.warning">
+            {{ statusData.jiraEnrichment.warning }}.
+            Feature statuses may be outdated.
+          </template>
+          <template v-else-if="statusData.jiraEnrichment.lastSync">
+            Last synced {{ formatAge(statusData.jiraEnrichment.lastSync.timestamp) }},
+            {{ statusData.jiraEnrichment.lastSync.enrichedCount }} features updated.
+          </template>
+          <template v-else>
+            Enabled but has not run yet.
+          </template>
         </p>
       </div>
 

--- a/modules/releases/server/execution/routes.js
+++ b/modules/releases/server/execution/routes.js
@@ -317,6 +317,32 @@ module.exports = function registerExecutionRoutes(router, context) {
       result.nextScheduledFetch = nextFetch.toISOString();
     }
 
+    // Jira enrichment status
+    const jiraEnrichConfig = config.jiraEnrichment || {};
+    const lastEnrichment = readDataFile('last-enrichment.json');
+    result.jiraEnrichment = {
+      enabled: jiraEnrichConfig.enabled !== false,
+      jiraConfigured: !!jira,
+      lastSync: lastEnrichment || null
+    };
+    // Warn if Jira enrichment hasn't run in >24h (2x the default 6h cadence)
+    if (result.jiraEnrichment.enabled && jira) {
+      const enrichTs = lastEnrichment?.timestamp ? new Date(lastEnrichment.timestamp).getTime() : 0;
+      const enrichAgeMs = enrichTs ? Date.now() - enrichTs : Infinity;
+      const enrichAgeHours = enrichAgeMs / (1000 * 60 * 60);
+      if (enrichAgeHours > 24) {
+        result.jiraEnrichment.stale = true;
+        if (enrichTs === 0) {
+          result.jiraEnrichment.warning = 'Jira enrichment has never run';
+        } else {
+          const ageDays = Math.floor(enrichAgeHours / 24);
+          result.jiraEnrichment.warning = 'Last Jira sync was ' + (ageDays === 1 ? '1 day' : ageDays + ' days') + ' ago';
+        }
+      }
+    } else if (!jira) {
+      result.jiraEnrichment.warning = 'Jira client not configured — enrichment cannot run';
+    }
+
     res.json(result);
   });
 
@@ -516,13 +542,23 @@ module.exports = function registerExecutionRoutes(router, context) {
     context.registerDiagnostics(async function() {
       const index = readDataFile('index.json');
       const lastFetch = readDataFile('last-fetch.json');
+      const lastEnrichment = readDataFile('last-enrichment.json');
+      const config = loadConfig(storage);
+      const jiraEnrichConfig = config.jiraEnrichment || {};
       return {
         dataAvailable: !!index,
         featureCount: index?.featureCount || 0,
         fetchedAt: index?.fetchedAt || null,
         schemaVersion: index?.schemaVersion || null,
         lastFetchStatus: lastFetch?.status || null,
-        configured: loadConfig(storage).enabled && !!getToken()
+        configured: config.enabled && !!getToken(),
+        jiraEnrichment: {
+          enabled: jiraEnrichConfig.enabled !== false,
+          jiraConfigured: !!jira,
+          lastSyncStatus: lastEnrichment?.status || null,
+          lastSyncTimestamp: lastEnrichment?.timestamp || null,
+          enrichedCount: lastEnrichment?.enrichedCount || 0
+        }
       };
     });
   }
@@ -567,8 +603,9 @@ module.exports = function registerExecutionRoutes(router, context) {
       const enrichmentHandler = async function() {
         const config = loadConfig(storage);
         const jiraEnrichConfig = config.jiraEnrichment || {};
-        if (!jiraEnrichConfig.enabled) {
-          return { status: 'skipped', message: 'Jira enrichment disabled' };
+        // Default to enabled — Jira enrichment should run unless explicitly disabled
+        if (jiraEnrichConfig.enabled === false) {
+          return { status: 'skipped', message: 'Jira enrichment disabled in config (jiraEnrichment.enabled = false)' };
         }
 
         const result = await syncAllFeatures(storage, jira.jiraRequest, jira.fetchAllJqlResults);

--- a/shared/server/refresh-registry.js
+++ b/shared/server/refresh-registry.js
@@ -468,6 +468,20 @@ function createRefreshRegistry(storage) {
         }
         handlers[id] = enriched
       }
+      // Include registered handlers that weren't in the last run (newly added)
+      for (var [newId, newConfig] of entries) {
+        if (!handlers[newId]) {
+          var { cadenceStr: newCadenceStr } = getEffectiveCadence(newId, newConfig)
+          handlers[newId] = {
+            state: 'pending',
+            order: newConfig.order,
+            cadence: newCadenceStr,
+            baseCadence: newConfig.cadence || DEFAULT_CADENCE,
+            cadenceOverride: cadenceOverrides[newId] || null,
+            description: newConfig.description || null
+          }
+        }
+      }
       return {
         running: false,
         completedAt: lastRun.completedAt,


### PR DESCRIPTION
## Summary

- **Jira enrichment was silently disabled**: The enrichment handler checked `if (!jiraEnrichConfig.enabled)` which evaluated falsy when the config key was absent (the default). Changed to `if (jiraEnrichConfig.enabled === false)` so it runs by default when Jira credentials are configured.
- **Newly registered refresh handlers were invisible**: `getStatus()` in the refresh registry only iterated `lastRun.progress` (persisted from previous runs), silently dropping any handler registered after the last run. Added a second pass to include new handlers with `state: 'pending'`. This is a general bug affecting any new handler in any module.
- **Added Jira enrichment status to the UI**: The `/status` endpoint, diagnostics, and Execution Settings page now surface enrichment health — stale warnings, last sync time, and whether Jira is configured.

### Root cause

RHAISTRAT-1685 was moved from New → In Progress on June 5th in Jira, but the app still showed "New" because Jira enrichment (built in PR #881) was never actually running — the `enabled` flag defaulted to falsy, and the handler didn't appear in the admin UI due to the registry bug, so there was no way to notice.

## Test plan

- [x] All 133 execution tests pass
- [x] All 68 refresh-registry tests pass
- [x] Lint passes
- [x] Local dev server confirms `releases:jira-enrichment` now appears in `/api/admin/refresh-cadence` with `state: 'pending'`
- [x] `/api/modules/releases/execution/status` returns `jiraEnrichment` section with staleness warning
- [ ] CI (smoke + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)