### PR TITLE
fix(releases): fix JQL reserved word error in Jira enrichment

### DIFF
--- a/modules/releases/server/execution/jira-enrich.js
+++ b/modules/releases/server/execution/jira-enrich.js
@@ -233,7 +233,7 @@ async function enrichFeatures(keys, jiraRequestFn, fetchAllJqlResultsFn) {
     const jql = 'key in (' + batchKeys.map(k => '"' + k + '"').join(', ') + ')';
 
     try {
-      const issues = await fetchAllJqlResultsFn(jiraRequestFn, jql, ENRICH_FIELDS, {
+      const issues = await fetchAllJqlResultsFn(jql, ENRICH_FIELDS, {
         expand: 'renderedFields'
       });
 
@@ -311,7 +311,7 @@ async function fetchSignOffDetails(keys, storage, jiraRequestFn, fetchAllJqlResu
     const jql = 'key in (' + batchKeys.map(function(k) { return '"' + k + '"'; }).join(', ') + ')';
 
     try {
-      const issues = await fetchAllJqlResultsFn(jiraRequestFn, jql, 'labels', {
+      const issues = await fetchAllJqlResultsFn(jql, 'labels', {
         expand: 'changelog'
       });
 
@@ -352,7 +352,7 @@ async function fetchEpicsForFeatures(featureKeys, jiraRequestFn, fetchAllJqlResu
     const fields = 'summary,status,parent,customfield_10014';
 
     try {
-      const children = await fetchAllJqlResultsFn(jiraRequestFn, jql, fields);
+      const children = await fetchAllJqlResultsFn(jql, fields);
 
       for (let i = 0; i < children.length; i++) {
         const child = children[i];
@@ -392,7 +392,7 @@ async function fetchEpicsForFeatures(featureKeys, jiraRequestFn, fetchAllJqlResu
  * @returns {Promise<Array<object>>} Array of enriched feature objects
  */
 async function discoverFeatures(jql, jiraRequestFn, fetchAllJqlResultsFn) {
-  const issues = await fetchAllJqlResultsFn(jiraRequestFn, jql, ENRICH_FIELDS, {
+  const issues = await fetchAllJqlResultsFn(jql, ENRICH_FIELDS, {
     expand: 'renderedFields'
   });
 


### PR DESCRIPTION
## Summary

- The bound `fetchAllJqlResults` from `createJiraClient()` already has the request function baked in, but all call sites in `jira-enrich.js` were passing `jiraRequestFn` as the first argument
- This caused the function object to be stringified as the JQL query, producing `function() {...}` — and `function` is a JQL reserved word, so every batch failed with a 400 error
- Remove the spurious first argument from all 4 call sites

Follow-up to #1033 which enabled Jira enrichment by default — this fixes the enrichment actually working once it runs.

## Test plan

- [x] 133 execution tests pass
- [x] Lint passes
- [ ] CI
- [ ] Verify enrichment runs successfully in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)