### PR TITLE
fix(ci): skip Claude review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,11 +37,13 @@ jobs:
   # the synchronize event fires with actor=rhai-org-pulse[bot]. We don't want
   # to re-run the full review (infinite loop), but "Claude Review" is a
   # required check — so we need this no-op job to satisfy the gate.
+  # Dependabot PRs also skip here — they lack repo secrets for Vertex AI auth.
+  # The maintainer reviews them manually.
   autofix-pass:
     name: Claude Review
     if: |
       github.event_name != 'merge_group' &&
-      (github.actor == 'rhai-org-pulse[bot]' || github.actor == 'github-actions[bot]')
+      (github.actor == 'rhai-org-pulse[bot]' || github.actor == 'github-actions[bot]' || github.actor == 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - run: echo "Autofix push by ${{ github.actor }} — review already passed, skipping re-review"
@@ -55,12 +57,14 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]' &&
-       github.actor != 'rhai-org-pulse[bot]') ||
+       github.actor != 'rhai-org-pulse[bot]' &&
+       github.actor != 'dependabot[bot]') ||
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name != github.repository &&
        github.event.pull_request.draft != true &&
        github.actor != 'github-actions[bot]' &&
-       github.actor != 'rhai-org-pulse[bot]') ||
+       github.actor != 'rhai-org-pulse[bot]' &&
+       github.actor != 'dependabot[bot]') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&


### PR DESCRIPTION
## Summary
- Add `dependabot[bot]` to the `autofix-pass` no-op job so the required "Claude Review" check passes
- Exclude `dependabot[bot]` from the `claude-review` job so it doesn't attempt to run (and fail due to missing secrets)
- Dependabot PRs lack access to repo secrets (`APP_ID`, `GCP_SA_KEY`), causing the GitHub App token generation step to fail

## Test plan
- [ ] Verify this PR's own Claude Review check passes (meta-test)
- [ ] Re-run the failed check on #841 after merge to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)