### PR TITLE
fix(team-tracker): fix person autocomplete dropdown clipping and LDAP import auth

### DIFF
--- a/modules/team-tracker/__tests__/server/ipa-registry.test.js
+++ b/modules/team-tracker/__tests__/server/ipa-registry.test.js
@@ -7,7 +7,7 @@ import { describe, it, expect } from 'vitest'
  * - associatedTeams on person detail
  * - stats exclude auxiliary from active count
  * - LDAP search route (503 when unavailable, 429 rate limit, demo mode)
- * - LDAP import route (creates auxiliary entry, idempotent, requires team-admin, audit log)
+ * - LDAP import route (creates auxiliary entry, idempotent, requires admin/team-admin/manager, audit log)
  */
 
 const { computeCoverage } = require('../../../../shared/server/roster-sync/lifecycle')

--- a/modules/team-tracker/client/components/PersonAutocomplete.vue
+++ b/modules/team-tracker/client/components/PersonAutocomplete.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, onUnmounted } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 
 const props = defineProps({
@@ -18,7 +18,35 @@ const ldapLoading = ref(false)
 const ldapAvailable = ref(true)
 const ldapError = ref(null)
 let ldapDebounceTimer = null
-let blurTimer = null
+
+const rootEl = ref(null)
+const dropdownEl = ref(null)
+const dropdownStyle = ref({})
+
+function updateDropdownPosition(el) {
+  const target = el || rootEl.value?.querySelector('input')
+  if (!target) return
+  const rect = target.getBoundingClientRect()
+  dropdownStyle.value = {
+    position: 'fixed',
+    top: `${rect.bottom + 4}px`,
+    left: `${rect.left}px`,
+    width: `${rect.width}px`,
+    zIndex: 50
+  }
+}
+
+function onClickOutside(e) {
+  const inRoot = rootEl.value && rootEl.value.contains(e.target)
+  const inDropdown = dropdownEl.value && dropdownEl.value.contains(e.target)
+  if (!inRoot && !inDropdown) {
+    isOpen.value = false
+    initSearchText()
+  }
+}
+
+onMounted(() => document.addEventListener('mousedown', onClickOutside))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onClickOutside))
 
 const filteredPeople = computed(() => {
   if (!searchText.value) return props.people.slice(0, 10)
@@ -48,7 +76,6 @@ initSearchText()
 
 onUnmounted(() => {
   if (ldapDebounceTimer) clearTimeout(ldapDebounceTimer)
-  if (blurTimer) clearTimeout(blurTimer)
 })
 
 // Re-initialize when modelValue changes externally
@@ -92,15 +119,16 @@ function searchLdap(term) {
   }, 300)
 }
 
-function onInput() {
+function onInput(event) {
+  updateDropdownPosition(event.target)
   isOpen.value = true
   highlightedIndex.value = -1
   searchLdap(searchText.value)
 }
 
-function onBlur() {
-  if (blurTimer) clearTimeout(blurTimer)
-  blurTimer = setTimeout(() => { isOpen.value = false }, 200)
+function onFocus(event) {
+  updateDropdownPosition(event.target)
+  isOpen.value = true
 }
 
 async function selectPerson(person) {
@@ -159,7 +187,7 @@ function getOptionIndex(localIdx, isLdap) {
 </script>
 
 <template>
-  <div class="relative">
+  <div ref="rootEl" class="relative">
     <input
       v-model="searchText"
       role="combobox"
@@ -169,14 +197,17 @@ function getOptionIndex(localIdx, isLdap) {
       class="w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm"
       :placeholder="placeholder"
       @input="onInput"
-      @focus="isOpen = true"
-      @blur="onBlur"
+      @focus="onFocus"
+      @click="onFocus"
       @keydown="onKeydown"
     >
+    <Teleport to="body">
     <ul
       v-if="isOpen && (totalOptions > 0 || ldapLoading)"
+      ref="dropdownEl"
       role="listbox"
-      class="absolute z-10 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg max-h-48 overflow-y-auto"
+      :style="dropdownStyle"
+      class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg max-h-48 overflow-y-auto"
     >
       <!-- Local results -->
       <li
@@ -218,6 +249,7 @@ function getOptionIndex(localIdx, isLdap) {
         <div v-if="p.title" class="text-xs text-gray-400 dark:text-gray-500">{{ p.title }}</div>
       </li>
     </ul>
+    </Teleport>
 
     <!-- Import error message -->
     <div v-if="ldapError" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ ldapError }}</div>

--- a/modules/team-tracker/server/routes/ipa-registry.js
+++ b/modules/team-tracker/server/routes/ipa-registry.js
@@ -29,7 +29,6 @@ function loadSyncLog(storage) {
 function registerIpaRegistryRoutes(router, context) {
   var storage = context.storage;
   var requireAdmin = context.requireAdmin;
-  var requireTeamAdmin = context.requireTeamAdmin;
   var requireScope = context.requireScope;
   var DEMO_MODE = process.env.DEMO_MODE === 'true';
 
@@ -660,12 +659,17 @@ function registerIpaRegistryRoutes(router, context) {
    *     responses:
    *       200:
    *         description: Imported person (or existing if already present)
+   *       403:
+   *         description: Requires admin, team-admin, or manager role
    *       404:
    *         description: Person not found in LDAP
    *       503:
    *         description: LDAP not available
    */
-  router.post('/registry/people/ldap-import', requireTeamAdmin, requireScope('team-tracker:write'), function(req, res) {
+  router.post('/registry/people/ldap-import', requireScope('team-tracker:write'), function(req, res) {
+    if (!req.isAdmin && !req.isTeamAdmin && !req.isManager) {
+      return res.status(403).json({ error: 'Requires team-admin, admin, or manager role' });
+    }
     if (DEMO_MODE) {
       return res.status(503).json({ error: 'LDAP not available in demo mode', code: 'LDAP_UNAVAILABLE' });
     }


### PR DESCRIPTION
## Summary

- **Dropdown clipping fix**: `PersonAutocomplete` dropdown was being cut off by `overflow-x-auto` on the team fields table (e.g., My Teams page, Team Detail page). Switched to `<Teleport to="body">` with `position: fixed`, matching the pattern `ConstrainedAutocomplete` already uses.
- **LDAP import auth fix**: The `/registry/people/ldap-import` endpoint required `requireTeamAdmin`, but managers with team purview are allowed to edit team fields (like Product Manager). When a manager selected someone from the "From directory" LDAP results, the import was blocked with a 403. Relaxed auth to also allow managers.

## Test plan

- [ ] As a manager (not admin/team-admin), navigate to a team you manage and edit the Product Manager field
- [ ] Search for someone who appears in the "From directory" (LDAP) section — confirm the import succeeds
- [ ] Verify the autocomplete dropdown is not clipped on the Team Detail page or My Teams page
- [ ] Verify clicking outside the dropdown dismisses it
- [ ] Verify keyboard navigation (arrow keys, Enter, Escape) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)