### PR TITLE
fix(releases): always compute score breakdown so popover renders for all features

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1170,13 +1170,12 @@ describe('buildFeatureReadiness', function() {
       expect(f.effectivePriorityScore).toBeGreaterThan(0)
     })
 
-    it('health cache with priorityBreakdown is reflected in priorityScoreBreakdown', function() {
+    it('priorityScoreBreakdown always has signals array for popover rendering', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var breakdown = { rice: 60, bigRock: 80, priority: 70, complexity: 50 }
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: breakdown, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6' }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: { rice: 60 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1184,7 +1183,11 @@ describe('buildFeatureReadiness', function() {
         [healthKey]: healthCache
       })
       var result = buildFeatureReadiness(readFromStorage)
-      expect(result.ready[0].priorityScoreBreakdown).toEqual(breakdown)
+      var bd = result.ready[0].priorityScoreBreakdown
+      expect(bd.signals).toBeDefined()
+      expect(bd.signals.length).toBeGreaterThan(0)
+      expect(bd.score).toBeGreaterThan(0)
+      expect(result.ready[0].effectivePriorityScore).toBe(70)
     })
   })
 

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -375,13 +375,9 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
 
     var priorityScore = healthData ? (healthData.priorityScore != null ? healthData.priorityScore : null) : null
     var priorityScoreFallback = priorityScore === null
-    var fallbackResult = priorityScoreFallback
-      ? computeBestAvailableScore(Object.assign({}, latest, { rubricTotal: rubricTotal, tier: tier, rockPriority: rockPriority, targetVersions: targetVersions }), configuredVersions)
-      : null
-    var effectivePriorityScore = priorityScoreFallback ? fallbackResult.score : priorityScore
-    var priorityScoreBreakdown = priorityScoreFallback
-      ? fallbackResult
-      : (healthData ? (healthData.priorityBreakdown || healthData.priorityScoreBreakdown || null) : null)
+    var computedBreakdown = computeBestAvailableScore(Object.assign({}, latest, { rubricTotal: rubricTotal, tier: tier, rockPriority: rockPriority, targetVersions: targetVersions }), configuredVersions)
+    var effectivePriorityScore = priorityScoreFallback ? computedBreakdown.score : priorityScore
+    var priorityScoreBreakdown = computedBreakdown
 
     var blockerResult = computeBlockers(Object.assign({}, latest, { rubricTotal: rubricTotal }))
 
@@ -484,18 +480,16 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
 
     var hpPriorityScore = hd.priorityScore != null ? hd.priorityScore : null
     var hpFallback = hpPriorityScore === null
-    var hpFallbackResult = hpFallback
-      ? computeBestAvailableScore({
-          tier: hpTier,
-          priority: hd.priority,
-          riceScore: hd.rice && hd.rice.score != null ? hd.rice.score : null,
-          rubricTotal: 0,
-          rockPriority: hpRockPriority,
-          targetVersions: hpTargetVersions
-        }, configuredVersions)
-      : null
-    var hpEffective = hpFallback ? hpFallbackResult.score : hpPriorityScore
-    var hpPriorityBreakdown = hpFallback ? hpFallbackResult : (hd.priorityBreakdown || null)
+    var hpComputedBreakdown = computeBestAvailableScore({
+        tier: hpTier,
+        priority: hd.priority,
+        riceScore: hd.rice && hd.rice.score != null ? hd.rice.score : null,
+        rubricTotal: 0,
+        rockPriority: hpRockPriority,
+        targetVersions: hpTargetVersions
+      }, configuredVersions)
+    var hpEffective = hpFallback ? hpComputedBreakdown.score : hpPriorityScore
+    var hpPriorityBreakdown = hpComputedBreakdown
 
     var hpViolations = hygieneIndex.get(ckey) || null
     var hpReadinessResult = computeReadiness({


### PR DESCRIPTION
## Summary

- Score popover on the Features List showed only a `?` cursor instead of the per-feature breakdown because passes 1 and 2 only computed the breakdown via `computeBestAvailableScore` when the health pipeline didn't provide a `priorityScore`
- When health data had a score, the breakdown fell back to `healthData.priorityBreakdown` which lacks the `signals` array the frontend popover requires
- Now all passes always compute the breakdown, ensuring every feature row has a working score popover with signal details, weights, and completeness info

## Test plan

- [x] All 177 existing tests pass
- [x] Updated test verifies `priorityScoreBreakdown` always has `signals` array even when health pipeline provides a `priorityScore`