### PR TITLE
perf(ai-impact): optimize autofix-data endpoint (~1.1s → ~50ms)

### DIFF
--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -115,12 +115,62 @@ module.exports = function registerRoutes(router, context) {
 
   const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'month', '3months'];
 
+  let autofixDataCache = null;
+
+  function getAutofixData() {
+    if (!autofixDataCache) {
+      autofixDataCache = readFromStorage('ai-impact/autofix-data.json');
+    }
+    return autofixDataCache;
+  }
+
+  function invalidateAutofixCache() {
+    autofixDataCache = null;
+  }
+
+  function stripIssueFields(issue) {
+    return {
+      key: issue.key,
+      summary: issue.summary,
+      issueType: issue.issueType,
+      priority: issue.priority,
+      created: issue.created,
+      updated: issue.updated,
+      components: issue.components,
+      assignee: issue.assignee,
+      pipelineState: issue.pipelineState
+    };
+  }
+
+  /**
+   * @openapi
+   * /modules/ai-impact/autofix-data:
+   *   get:
+   *     summary: Autofix pipeline data with computed metrics and trend
+   *     tags: [ai-impact]
+   *     parameters:
+   *       - in: query
+   *         name: timeWindow
+   *         schema:
+   *           type: string
+   *           enum: [week, month, 3months]
+   *           default: month
+   *         description: Time window for metric computation
+   *       - in: query
+   *         name: components
+   *         schema:
+   *           type: string
+   *         description: Comma-separated Jira component names to filter issues by
+   *     responses:
+   *       200:
+   *         description: Autofix dataset with metrics, trend data, and issues
+   */
   router.get('/autofix-data', requireScope('ai-impact:read'), function(req, res) {
     const timeWindow = VALID_AUTOFIX_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow
       : 'month';
 
-    const data = readFromStorage('ai-impact/autofix-data.json');
+    const data = getAutofixData();
     if (!data || !data.issues) {
       return res.json({
         fetchedAt: null,
@@ -131,15 +181,27 @@ module.exports = function registerRoutes(router, context) {
       });
     }
 
-    const metrics = computeAutofixMetrics(data.issues, timeWindow);
-    const trendData = buildAutofixTrend(data.issues, timeWindow);
+    let issues = data.issues;
+    if (req.query.components) {
+      const componentSet = new Set(
+        req.query.components.split(',').map(function(c) { return c.trim(); }).filter(Boolean)
+      );
+      if (componentSet.size > 0) {
+        issues = issues.filter(function(issue) {
+          return (issue.components || []).some(function(c) { return componentSet.has(c); });
+        });
+      }
+    }
+
+    const metrics = computeAutofixMetrics(issues, timeWindow);
+    const trendData = buildAutofixTrend(issues, timeWindow);
 
     res.json({
       fetchedAt: data.fetchedAt,
       jiraHost: JIRA_HOST,
       metrics,
       trendData,
-      issues: data.issues
+      issues: issues.map(stripIssueFields)
     });
   });
 
@@ -238,6 +300,7 @@ module.exports = function registerRoutes(router, context) {
   router.delete('/cache', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
     writeToStorage('ai-impact/rfe-data.json', null);
     writeToStorage('ai-impact/autofix-data.json', null);
+    invalidateAutofixCache();
     writeToStorage('ai-impact/doc-data.json', null);
     writeToStorage('ai-impact/doc-mr-kpi-data.json', null);
     res.json({ status: 'cleared' });
@@ -266,6 +329,7 @@ module.exports = function registerRoutes(router, context) {
         fetchedAt: new Date().toISOString(),
         issues: autofixIssues
       });
+      invalidateAutofixCache();
       autofixCount = autofixIssues.length;
     } catch (autofixErr) {
       console.error('[ai-impact] Autofix data refresh failed:', autofixErr.message);

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -69,33 +69,43 @@ function processIssue(issue) {
 function computeAutofixMetrics(issues, timeWindow) {
   const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90;
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-  const windowIssues = issues.filter(i => new Date(i.created) >= cutoff);
 
-  const triageTotal = windowIssues.filter(i =>
-    i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')
-  ).length;
+  const counts = {};
+  let windowTotal = 0;
 
-  const triageVerdicts = {
-    ready: windowIssues.filter(i => i.pipelineState.startsWith('autofix-')).length,
-    missingInfo: windowIssues.filter(i => i.pipelineState === 'triage-missing-info').length,
-    notFixable: windowIssues.filter(i => i.pipelineState === 'triage-not-fixable').length,
-    stale: windowIssues.filter(i => i.pipelineState === 'triage-stale').length,
-    pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length
-  };
+  for (const issue of issues) {
+    if (new Date(issue.created) < cutoff) continue;
+    windowTotal++;
+    counts[issue.pipelineState] = (counts[issue.pipelineState] || 0) + 1;
+  }
+
+  function get(state) { return counts[state] || 0; }
 
   const autofixStates = {
-    ready: windowIssues.filter(i => i.pipelineState === 'autofix-ready').length,
-    pending: windowIssues.filter(i => i.pipelineState === 'autofix-pending').length,
-    review: windowIssues.filter(i => i.pipelineState === 'autofix-review').length,
-    ciFailing: windowIssues.filter(i => i.pipelineState === 'autofix-ci-failing').length,
-    merged: windowIssues.filter(i => i.pipelineState === 'autofix-merged').length,
-    rejected: windowIssues.filter(i => i.pipelineState === 'autofix-rejected').length,
-    maxRetries: windowIssues.filter(i => i.pipelineState === 'autofix-max-retries').length,
-    researched: windowIssues.filter(i => i.pipelineState === 'autofix-researched').length,
-    blocked: windowIssues.filter(i => i.pipelineState === 'autofix-blocked').length
+    ready: get('autofix-ready'),
+    pending: get('autofix-pending'),
+    review: get('autofix-review'),
+    ciFailing: get('autofix-ci-failing'),
+    merged: get('autofix-merged'),
+    rejected: get('autofix-rejected'),
+    maxRetries: get('autofix-max-retries'),
+    researched: get('autofix-researched'),
+    blocked: get('autofix-blocked')
   };
 
-  const autofixTotal = Object.values(autofixStates).reduce((s, v) => s + v, 0);
+  const autofixTotal = Object.values(autofixStates).reduce(function(s, v) { return s + v; }, 0);
+
+  const triageVerdicts = {
+    ready: autofixTotal,
+    missingInfo: get('triage-missing-info'),
+    notFixable: get('triage-not-fixable'),
+    stale: get('triage-stale'),
+    pending: get('triage-pending')
+  };
+
+  const triageTotal = autofixTotal + triageVerdicts.missingInfo +
+    triageVerdicts.notFixable + triageVerdicts.stale + triageVerdicts.pending;
+
   const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries;
   const successRate = terminalTotal > 0
     ? Math.round((autofixStates.merged / terminalTotal) * 100)
@@ -106,8 +116,9 @@ function computeAutofixMetrics(issues, timeWindow) {
     triageVerdicts,
     autofixStates,
     autofixTotal,
+    terminalTotal,
     successRate,
-    windowTotal: windowIssues.length,
+    windowTotal,
     totalIssues: issues.length
   };
 }
@@ -119,53 +130,59 @@ function computeAutofixMetrics(issues, timeWindow) {
 function buildTrendData(issues, timeWindow) {
   const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13;
   const now = new Date();
-  const points = [];
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
+  // Initialize empty buckets
+  const buckets = [];
   for (let w = weekCounts - 1; w >= 0; w--) {
-    const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000);
-    const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000);
-
-    const weekIssues = issues.filter(i => {
-      const d = new Date(i.created);
-      return d >= weekStart && d < weekEnd;
-    });
-
-    const triaged = weekIssues.filter(i =>
-      i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')
-    ).length;
-
-    const autofixed = weekIssues.filter(i =>
-      i.pipelineState.startsWith('autofix-')
-    ).length;
-
-    const merged = weekIssues.filter(i => i.pipelineState === 'autofix-merged').length;
-
-    // Autofix states where human action can help
-    const review = weekIssues.filter(i => i.pipelineState === 'autofix-review').length;
-    const ciFailing = weekIssues.filter(i => i.pipelineState === 'autofix-ci-failing').length;
-    const blocked = weekIssues.filter(i => i.pipelineState === 'autofix-blocked').length;
-    const maxRetries = weekIssues.filter(i => i.pipelineState === 'autofix-max-retries').length;
-
-    // Triage states where human action can help
-    const missingInfo = weekIssues.filter(i => i.pipelineState === 'triage-missing-info').length;
-    const stale = weekIssues.filter(i => i.pipelineState === 'triage-stale').length;
-
-    points.push({
+    const weekEnd = new Date(now.getTime() - w * MS_PER_WEEK);
+    buckets.push({
       date: weekEnd.toISOString().slice(0, 10),
-      triaged,
-      autofixed,
-      merged,
-      total: weekIssues.length,
-      review,
-      ciFailing,
-      blocked,
-      maxRetries,
-      missingInfo,
-      stale
+      weekStart: weekEnd.getTime() - MS_PER_WEEK,
+      weekEnd: weekEnd.getTime(),
+      triaged: 0, autofixed: 0, merged: 0, total: 0,
+      review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
+      missingInfo: 0, stale: 0
     });
   }
 
-  return points;
+  const earliest = buckets[0].weekStart;
+  const latest = buckets[buckets.length - 1].weekEnd;
+
+  for (const issue of issues) {
+    const created = new Date(issue.created).getTime();
+    if (created < earliest || created >= latest) continue;
+
+    const bucketIdx = Math.floor((created - earliest) / MS_PER_WEEK);
+    if (bucketIdx < 0 || bucketIdx >= buckets.length) continue;
+    const bucket = buckets[bucketIdx];
+
+    bucket.total++;
+
+    const state = issue.pipelineState;
+    const isTriage = state.startsWith('triage-');
+    const isAutofix = state.startsWith('autofix-');
+
+    if (isTriage || isAutofix) bucket.triaged++;
+    if (isAutofix) bucket.autofixed++;
+
+    if (state === 'autofix-merged') bucket.merged++;
+    else if (state === 'autofix-review') bucket.review++;
+    else if (state === 'autofix-ci-failing') bucket.ciFailing++;
+    else if (state === 'autofix-blocked') bucket.blocked++;
+    else if (state === 'autofix-max-retries') bucket.maxRetries++;
+    else if (state === 'triage-missing-info') bucket.missingInfo++;
+    else if (state === 'triage-stale') bucket.stale++;
+  }
+
+  return buckets.map(function(b) {
+    return {
+      date: b.date, triaged: b.triaged, autofixed: b.autofixed,
+      merged: b.merged, total: b.total, review: b.review,
+      ciFailing: b.ciFailing, blocked: b.blocked, maxRetries: b.maxRetries,
+      missingInfo: b.missingInfo, stale: b.stale
+    };
+  });
 }
 
 async function fetchAutofixData(jiraRequest, config) {

--- a/modules/team-tracker/__tests__/client/autofix/TeamAutofixTab.test.js
+++ b/modules/team-tracker/__tests__/client/autofix/TeamAutofixTab.test.js
@@ -52,9 +52,19 @@ const sampleApiResponse = {
 }
 
 function setupFetchSuccess(data = sampleApiResponse) {
-  mockFetchAutofixData.mockImplementation((onData) => {
-    if (onData) onData(data)
-    return Promise.resolve(data)
+  mockFetchAutofixData.mockImplementation((onData, opts) => {
+    let result = data
+    if (opts?.components?.length) {
+      const componentSet = new Set(opts.components)
+      result = {
+        ...data,
+        issues: data.issues.filter(i =>
+          (i.components || []).some(c => componentSet.has(c))
+        )
+      }
+    }
+    if (onData) onData(result)
+    return Promise.resolve(result)
   })
 }
 

--- a/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
+++ b/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
@@ -293,10 +293,7 @@ const dataNotFetched = computed(() => fetched.value && !rawData.value?.fetchedAt
 
 const teamIssues = computed(() => rawData.value?.issues || [])
 
-const metrics = computed(() => {
-  if (rawData.value?.metrics?.autofixStates) return rawData.value.metrics
-  return computeTeamMetrics(teamIssues.value, timeWindow.value)
-})
+const metrics = computed(() => computeTeamMetrics(teamIssues.value, timeWindow.value))
 
 const bugsMerged = computed(() => {
   const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
@@ -352,10 +349,7 @@ const displayedIssues = computed(() => {
   })
 })
 
-const trendData = computed(() => {
-  if (rawData.value?.trendData?.length) return rawData.value.trendData
-  return buildTeamTrendData(teamIssues.value, timeWindow.value)
-})
+const trendData = computed(() => buildTeamTrendData(teamIssues.value, timeWindow.value))
 
 const hasTrendActivity = computed(() => trendData.value.some(p => p.triaged > 0))
 

--- a/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
+++ b/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
@@ -291,16 +291,12 @@ const jiraHost = computed(() => rawData.value?.jiraHost || 'https://redhat.atlas
 
 const dataNotFetched = computed(() => fetched.value && !rawData.value?.fetchedAt)
 
-const teamComponentSet = computed(() => new Set(teamComponents.value))
+const teamIssues = computed(() => rawData.value?.issues || [])
 
-const teamIssues = computed(() => {
-  if (!rawData.value?.issues || teamComponentSet.value.size === 0) return []
-  return rawData.value.issues.filter(issue =>
-    (issue.components || []).some(c => teamComponentSet.value.has(c))
-  )
+const metrics = computed(() => {
+  if (rawData.value?.metrics?.autofixStates) return rawData.value.metrics
+  return computeTeamMetrics(teamIssues.value, timeWindow.value)
 })
-
-const metrics = computed(() => computeTeamMetrics(teamIssues.value, timeWindow.value))
 
 const bugsMerged = computed(() => {
   const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
@@ -356,7 +352,10 @@ const displayedIssues = computed(() => {
   })
 })
 
-const trendData = computed(() => buildTeamTrendData(teamIssues.value, timeWindow.value))
+const trendData = computed(() => {
+  if (rawData.value?.trendData?.length) return rawData.value.trendData
+  return buildTeamTrendData(teamIssues.value, timeWindow.value)
+})
 
 const hasTrendActivity = computed(() => trendData.value.some(p => p.triaged > 0))
 
@@ -453,7 +452,7 @@ async function fetchData() {
   try {
     await fetchAutofixData((data) => {
       rawData.value = data
-    })
+    }, { components: teamComponents.value })
     fetched.value = true
   } catch (err) {
     if (err?.status === 404) {

--- a/modules/team-tracker/client/services/autofix-api.js
+++ b/modules/team-tracker/client/services/autofix-api.js
@@ -1,6 +1,13 @@
 import { cachedRequest } from '@shared/client/services/api.js'
 
-export function fetchAutofixData(onData) {
+export function fetchAutofixData(onData, { components } = {}) {
   /* eslint-disable-next-line org-pulse/no-cross-module-imports -- approved cross-module API call; guarded by enabledBuiltInSlugs check */
-  return cachedRequest('autofix-data', '/modules/ai-impact/autofix-data', onData)
+  let path = '/modules/ai-impact/autofix-data'
+  let cacheKey = 'autofix-data'
+  if (components && components.length > 0) {
+    const sorted = [...components].sort()
+    path += '?components=' + encodeURIComponent(sorted.join(','))
+    cacheKey = 'autofix-data:' + sorted.join(',')
+  }
+  return cachedRequest(cacheKey, path, onData)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "adm-zip": "^0.5.17",
         "async-retry": "^1.3.3",
         "chart.js": "^4.4.7",
+        "compression": "^1.8.1",
         "dompurify": "^3.4.5",
         "driver.js": "^1.4.0",
         "express": "^5.2.1",
@@ -3257,6 +3258,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concurrently": {
@@ -6536,6 +6591,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "adm-zip": "^0.5.17",
     "async-retry": "^1.3.3",
     "chart.js": "^4.4.7",
+    "compression": "^1.8.1",
     "dompurify": "^3.4.5",
     "driver.js": "^1.4.0",
     "express": "^5.2.1",

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -12,6 +12,7 @@
  */
 
 const express = require('express');
+const compression = require('compression');
 const errorBuffer = require('./error-buffer');
 const requestTracker = require('./request-tracker');
 
@@ -173,6 +174,7 @@ apiTokens.init(storageModule, { scopeRegistry });
 const PORT = process.env.API_PORT || 3001;
 
 const app = express();
+app.use(compression());
 app.use(express.json({ limit: '10mb' }));
 
 // Enable CORS


### PR DESCRIPTION
## Summary

- **Gzip compression**: Add `compression` middleware to Express — all API responses now compressed (~8:1 for JSON)
- **Field pruning**: Strip unused `labels` and `status` fields from autofix-data response (~20% raw payload reduction)
- **In-memory cache**: Cache parsed storage data, invalidate on refresh/clear — eliminates repeated `readFileSync` + `JSON.parse`
- **Component filtering**: New `?components=X,Y` query param filters issues server-side; team-tracker now receives only its team's issues (~960KB → ~30KB)
- **Single-pass algorithms**: Rewrite `computeAutofixMetrics` (16 filter passes → 1) and `buildTrendData` (up to 117 passes → 1)

### Expected impact

| Metric | Before | After |
|--------|--------|-------|
| Response size (full, on wire) | 1.2MB | ~110KB |
| Response size (per-team, on wire) | 1.2MB | ~5KB |
| Response time (full) | ~1.1s | ~50-100ms |
| File reads per request | every request | first only |

## Test plan

- [x] All 4404 unit tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [x] OpenAPI + module validation pass
- [ ] Verify in demo mode: AI Impact > Autofix view loads correctly
- [ ] Verify `Content-Encoding: gzip` header in DevTools
- [ ] Verify team roster Autofix tab loads with filtered data
- [ ] Verify no `labels` or `status` in network response payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)