### PR TITLE
fix(deploy): improve cronjob resilience for rollouts and concurrent refreshes

### DIFF
--- a/deploy/openshift/base/cronjob-sync-refresh.yaml
+++ b/deploy/openshift/base/cronjob-sync-refresh.yaml
@@ -50,14 +50,31 @@ spec:
 
                   # Step 1: Trigger unified refresh-all (cadence-aware)
                   echo "=== Triggering unified refresh-all ==="
-                  REFRESH_RESP=$(curl -sf -X POST "$BACKEND/api/admin/refresh-all" \
-                    -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" \
-                    -w "\n%{http_code}" 2>/dev/null) || true
-                  HTTP_CODE=$(echo "$REFRESH_RESP" | tail -1)
-                  BODY=$(echo "$REFRESH_RESP" | sed '$d')
+                  RETRY=0
+                  MAX_RETRIES=3
+                  HTTP_CODE=""
+                  BODY=""
+                  while [ $RETRY -lt $MAX_RETRIES ]; do
+                    REFRESH_RESP=$(curl -sf -X POST "$BACKEND/api/admin/refresh-all" \
+                      -H "$AUTH_HEADER" -H "$PROXY_SECRET_HEADER" \
+                      -w "\n%{http_code}" 2>/dev/null) || true
+                    HTTP_CODE=$(echo "$REFRESH_RESP" | tail -1)
+                    BODY=$(echo "$REFRESH_RESP" | sed '$d')
+                    if [ "$HTTP_CODE" != "000" ]; then
+                      break
+                    fi
+                    RETRY=$((RETRY + 1))
+                    echo "Backend unreachable (attempt $RETRY/$MAX_RETRIES), retrying in 10s..."
+                    sleep 10
+                  done
 
                   if [ "$HTTP_CODE" = "409" ]; then
-                    echo "ERROR: A refresh is already running"
+                    echo "Refresh already running — skipping (not an error)"
+                    echo "=== Sync and refresh completed successfully ==="
+                    exit 0
+                  fi
+                  if [ "$HTTP_CODE" = "000" ]; then
+                    echo "ERROR: Backend unreachable after $MAX_RETRIES attempts (likely during rollout)"
                     exit 1
                   fi
                   if [ "$HTTP_CODE" != "202" ]; then


### PR DESCRIPTION
## Summary

- **Retry on backend unavailability**: When the backend returns HTTP 000 (connection refused during rollouts), the cronjob now retries up to 3 times with 10s backoff instead of failing immediately
- **Treat 409 as success**: When a refresh is already running (HTTP 409), the cronjob now exits cleanly (exit 0) instead of treating it as an error — this is normal cadence-aware behavior

Fixes periodic cronjob failures observed in production caused by backend rollouts and overlapping refresh cycles.

## Test plan

- [ ] Verify kustomize build still passes (CI)
- [ ] Deploy and confirm next cron tick succeeds
- [ ] Verify a rollout during cron window no longer causes a failed job

🤖 Generated with [Claude Code](https://claude.com/claude-code)