### PR TITLE
feat(releases): add Status, Fix Version, Target Version columns to PM Hub

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -1,0 +1,532 @@
+/**
+ * Tests for ComponentReleaseLoadTable logic.
+ *
+ * Vue component mounting is broken project-wide (vue plugin / vitest compat).
+ * These tests exercise the core data-transformation logic that the component's
+ * computed properties and helper functions rely on, using the same algorithms
+ * inlined from the component source.
+ */
+import { describe, it, expect } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Inline the pure functions from ComponentReleaseLoadTable.vue so we can
+// test them without mounting the component.
+// ---------------------------------------------------------------------------
+
+function extractProduct(versionName) {
+  if (!versionName) return versionName
+  var lower = versionName.toLowerCase()
+  if (lower.startsWith('rhoai')) return 'RHOAI'
+  if (lower.startsWith('rhelai')) return 'RHELAI'
+  if (lower.startsWith('rhaii')) return 'RHAII'
+  return versionName.split('-')[0] || versionName
+}
+
+function colorStatusClass(colorStatus) {
+  var s = (colorStatus || '').toLowerCase()
+  if (s === 'green') return 'bg-emerald-500'
+  if (s === 'yellow') return 'bg-amber-400'
+  if (s === 'red') return 'bg-red-500'
+  return 'bg-gray-300 dark:bg-gray-600'
+}
+
+function colorStatusRing(colorStatus) {
+  var s = (colorStatus || '').toLowerCase()
+  if (s === 'green') return 'ring-emerald-200 dark:ring-emerald-800'
+  if (s === 'yellow') return 'ring-amber-200 dark:ring-amber-800'
+  if (s === 'red') return 'ring-red-200 dark:ring-red-800'
+  return 'ring-gray-200 dark:ring-gray-700'
+}
+
+function productBadgeClass(product) {
+  var p = (product || '').toUpperCase()
+  if (p === 'RHOAI') return 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300'
+  if (p === 'RHELAI') return 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300'
+  if (p === 'RHAII') return 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300'
+  return 'bg-gray-100 dark:bg-gray-700/60 text-gray-600 dark:text-gray-400'
+}
+
+function getLeads(componentName, componentLeads) {
+  var lower = (componentName || '').toLowerCase()
+  if (componentLeads[lower]) return componentLeads[lower]
+  var keys = Object.keys(componentLeads)
+  for (var i = 0; i < keys.length; i++) {
+    if (lower.includes(keys[i]) || keys[i].includes(lower)) return componentLeads[keys[i]]
+  }
+  return null
+}
+
+/**
+ * This is the core algorithm from componentGroups computed property.
+ * It transforms server response groups into component-centric view with
+ * deduplicated features.
+ */
+function buildComponentGroups(groups) {
+  var compMap = {}
+
+  for (var gi = 0; gi < groups.length; gi++) {
+    var group = groups[gi]
+    var version = group.version
+
+    for (var ci = 0; ci < group.components.length; ci++) {
+      var comp = group.components[ci]
+      var cName = comp.component
+
+      if (!compMap[cName]) {
+        compMap[cName] = { component: cName, features: {} }
+      }
+
+      var cg = compMap[cName]
+      var reqList = comp.requestedFeatures || []
+      var comList = comp.committedFeatures || []
+
+      var reqKeys = {}
+      var comKeys = {}
+      for (var ri = 0; ri < reqList.length; ri++) reqKeys[reqList[ri].key] = true
+      for (var cmi = 0; cmi < comList.length; cmi++) comKeys[comList[cmi].key] = true
+
+      var allFeatures = []
+      var seen = {}
+      var lists = [reqList, comList]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!seen[f.key]) {
+            seen[f.key] = true
+            allFeatures.push(f)
+          }
+        }
+      }
+
+      for (var ai = 0; ai < allFeatures.length; ai++) {
+        var feat = allFeatures[ai]
+        var isReq = !!reqKeys[feat.key]
+        var isCom = !!comKeys[feat.key]
+
+        if (!cg.features[feat.key]) {
+          cg.features[feat.key] = {
+            key: feat.key,
+            summary: feat.summary,
+            status: feat.status,
+            colorStatus: feat.colorStatus,
+            statusSummary: feat.statusSummary,
+            releaseType: feat.releaseType,
+            isBlocked: feat.isBlocked,
+            components: feat.components,
+            fixVersions: feat.fixVersions || [],
+            targetVersions: feat.targetVersions || [],
+            assignee: feat.assignee,
+            pmOwner: feat.pmOwner,
+            products: [],
+            isRequested: false,
+            isCommitted: false
+          }
+        }
+
+        var entry = cg.features[feat.key]
+        var product = extractProduct(version)
+        if (entry.products.indexOf(product) === -1) {
+          entry.products.push(product)
+        }
+        if (isReq) entry.isRequested = true
+        if (isCom) entry.isCommitted = true
+      }
+    }
+  }
+
+  var result = []
+  var compNames = Object.keys(compMap).sort()
+  for (var ni = 0; ni < compNames.length; ni++) {
+    var cm = compMap[compNames[ni]]
+    var featureList = Object.values(cm.features)
+    if (featureList.length === 0) continue
+
+    var reqCount = 0
+    var comCount = 0
+    var blkCount = 0
+    for (var fli = 0; fli < featureList.length; fli++) {
+      if (featureList[fli].isRequested) reqCount++
+      if (featureList[fli].isCommitted) comCount++
+      if (featureList[fli].isBlocked) blkCount++
+    }
+
+    result.push({
+      component: cm.component,
+      features: featureList,
+      requestedCount: reqCount,
+      committedCount: comCount,
+      blockedCount: blkCount
+    })
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeFeature(overrides) {
+  return Object.assign({
+    key: 'RHAIENG-1',
+    summary: 'Test feature',
+    status: 'In Progress',
+    colorStatus: 'Green',
+    statusSummary: '<p>On track</p>',
+    releaseType: 'Feature',
+    isBlocked: false,
+    components: ['Dashboard'],
+    fixVersions: ['rhoai-3.5'],
+    targetVersions: ['rhoai-3.5'],
+    assignee: 'Alice',
+    pmOwner: 'Bob'
+  }, overrides)
+}
+
+function makeGroup(version, componentName, features, opts) {
+  var reqFeatures = (opts && opts.committedOnly) ? [] : features
+  var comFeatures = (opts && opts.requestedOnly) ? [] : features
+  return {
+    version: version,
+    components: [{
+      component: componentName,
+      requestedFeatures: reqFeatures,
+      committedFeatures: comFeatures,
+      requestedCount: reqFeatures.length,
+      committedCount: comFeatures.length,
+      blockedCount: features.filter(function (f) { return f.isBlocked }).length
+    }],
+    requestedCount: reqFeatures.length,
+    committedCount: comFeatures.length,
+    blockedCount: features.filter(function (f) { return f.isBlocked }).length
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extractProduct
+// ---------------------------------------------------------------------------
+
+describe('extractProduct', function () {
+  it('detects RHOAI from version name', function () {
+    expect(extractProduct('rhoai-3.5')).toBe('RHOAI')
+  })
+
+  it('detects RHELAI from version name', function () {
+    expect(extractProduct('rhelai-3.5')).toBe('RHELAI')
+  })
+
+  it('detects RHAII from version name', function () {
+    expect(extractProduct('RHAII-3.5')).toBe('RHAII')
+  })
+
+  it('case-insensitive detection', function () {
+    expect(extractProduct('RHOAI-3.5.EA1')).toBe('RHOAI')
+    expect(extractProduct('Rhelai-3.6')).toBe('RHELAI')
+  })
+
+  it('falls back to splitting on dash', function () {
+    expect(extractProduct('custom-3.5')).toBe('custom')
+  })
+
+  it('returns null/undefined for null/undefined input', function () {
+    expect(extractProduct(null)).toBeNull()
+    expect(extractProduct(undefined)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// colorStatusClass
+// ---------------------------------------------------------------------------
+
+describe('colorStatusClass', function () {
+  it('returns emerald for Green', function () {
+    expect(colorStatusClass('Green')).toBe('bg-emerald-500')
+  })
+
+  it('returns amber for Yellow', function () {
+    expect(colorStatusClass('Yellow')).toBe('bg-amber-400')
+  })
+
+  it('returns red for Red', function () {
+    expect(colorStatusClass('Red')).toBe('bg-red-500')
+  })
+
+  it('is case-insensitive', function () {
+    expect(colorStatusClass('green')).toBe('bg-emerald-500')
+    expect(colorStatusClass('RED')).toBe('bg-red-500')
+  })
+
+  it('returns gray for null', function () {
+    expect(colorStatusClass(null)).toBe('bg-gray-300 dark:bg-gray-600')
+  })
+
+  it('returns gray for unknown status', function () {
+    expect(colorStatusClass('Purple')).toBe('bg-gray-300 dark:bg-gray-600')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// colorStatusRing
+// ---------------------------------------------------------------------------
+
+describe('colorStatusRing', function () {
+  it('returns emerald ring for Green', function () {
+    expect(colorStatusRing('Green')).toContain('emerald')
+  })
+
+  it('returns amber ring for Yellow', function () {
+    expect(colorStatusRing('Yellow')).toContain('amber')
+  })
+
+  it('returns red ring for Red', function () {
+    expect(colorStatusRing('Red')).toContain('red')
+  })
+
+  it('returns gray ring for null', function () {
+    expect(colorStatusRing(null)).toContain('gray')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// productBadgeClass
+// ---------------------------------------------------------------------------
+
+describe('productBadgeClass', function () {
+  it('returns indigo for RHOAI', function () {
+    expect(productBadgeClass('RHOAI')).toContain('indigo')
+  })
+
+  it('returns orange for RHELAI', function () {
+    expect(productBadgeClass('RHELAI')).toContain('orange')
+  })
+
+  it('returns teal for RHAII', function () {
+    expect(productBadgeClass('RHAII')).toContain('teal')
+  })
+
+  it('is case-insensitive', function () {
+    expect(productBadgeClass('rhoai')).toContain('indigo')
+  })
+
+  it('returns gray for unknown product', function () {
+    expect(productBadgeClass('Unknown')).toContain('gray')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getLeads
+// ---------------------------------------------------------------------------
+
+describe('getLeads', function () {
+  var leads = {
+    dashboard: { pmLead: 'Alice', engLead: 'Bob' },
+    inference: { pmLead: 'Charlie', engLead: 'Diana' }
+  }
+
+  it('returns exact match (case-insensitive)', function () {
+    expect(getLeads('Dashboard', leads)).toEqual({ pmLead: 'Alice', engLead: 'Bob' })
+  })
+
+  it('returns fuzzy match via includes', function () {
+    expect(getLeads('AI Dashboard Extended', leads)).toEqual({ pmLead: 'Alice', engLead: 'Bob' })
+  })
+
+  it('returns null when no match', function () {
+    expect(getLeads('Unknown Component', leads)).toBeNull()
+  })
+
+  it('handles null component name by fuzzy matching (empty string is substring of any key)', function () {
+    // null → '' → ''.includes('dashboard') is false, but 'dashboard'.includes('') is true
+    // So it returns the first matching entry via the fuzzy loop
+    expect(getLeads(null, leads)).not.toBeNull()
+  })
+
+  it('handles empty leads map', function () {
+    expect(getLeads('Dashboard', {})).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildComponentGroups — core computed property logic
+// ---------------------------------------------------------------------------
+
+describe('buildComponentGroups', function () {
+  it('groups features by component across versions', function () {
+    var groups = [
+      makeGroup('rhoai-3.5', 'Dashboard', [makeFeature({ key: 'X-1' })]),
+      makeGroup('rhoai-3.5', 'Inference', [makeFeature({ key: 'X-2' })])
+    ]
+    var result = buildComponentGroups(groups)
+    expect(result).toHaveLength(2)
+    expect(result[0].component).toBe('Dashboard')
+    expect(result[1].component).toBe('Inference')
+  })
+
+  it('deduplicates features appearing in multiple version groups', function () {
+    var feat = makeFeature({ key: 'RHAIENG-1' })
+    var groups = [
+      makeGroup('rhoai-3.5', 'Dashboard', [feat]),
+      makeGroup('rhoai-3.6', 'Dashboard', [feat])
+    ]
+    var result = buildComponentGroups(groups)
+    expect(result).toHaveLength(1)
+    expect(result[0].features).toHaveLength(1)
+  })
+
+  it('aggregates products from different versions', function () {
+    var feat = makeFeature({ key: 'X-1' })
+    var groups = [
+      makeGroup('rhoai-3.5', 'Dash', [feat]),
+      makeGroup('rhelai-3.5', 'Dash', [feat])
+    ]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].products).toEqual(['RHOAI', 'RHELAI'])
+  })
+
+  it('sets isRequested and isCommitted flags correctly', function () {
+    var feat = makeFeature({ key: 'X-1' })
+    var groups = [{
+      version: 'rhoai-3.5',
+      components: [{
+        component: 'Dash',
+        requestedFeatures: [feat],
+        committedFeatures: [],
+        requestedCount: 1,
+        committedCount: 0,
+        blockedCount: 0
+      }]
+    }]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].isRequested).toBe(true)
+    expect(result[0].features[0].isCommitted).toBe(false)
+  })
+
+  it('counts requested, committed, and blocked correctly', function () {
+    var feats = [
+      makeFeature({ key: 'X-1', isBlocked: false }),
+      makeFeature({ key: 'X-2', isBlocked: true })
+    ]
+    var groups = [makeGroup('rhoai-3.5', 'Dash', feats)]
+    var result = buildComponentGroups(groups)
+    expect(result[0].requestedCount).toBe(2)
+    expect(result[0].committedCount).toBe(2)
+    expect(result[0].blockedCount).toBe(1)
+  })
+
+  it('skips components with no features', function () {
+    var groups = [{
+      version: 'rhoai-3.5',
+      components: [{
+        component: 'Empty',
+        requestedFeatures: [],
+        committedFeatures: [],
+        requestedCount: 0,
+        committedCount: 0,
+        blockedCount: 0
+      }]
+    }]
+    var result = buildComponentGroups(groups)
+    expect(result).toHaveLength(0)
+  })
+
+  it('sorts components alphabetically', function () {
+    var groups = [
+      makeGroup('rhoai-3.5', 'Zebra', [makeFeature({ key: 'Z-1' })]),
+      makeGroup('rhoai-3.5', 'Alpha', [makeFeature({ key: 'A-1' })])
+    ]
+    var result = buildComponentGroups(groups)
+    expect(result[0].component).toBe('Alpha')
+    expect(result[1].component).toBe('Zebra')
+  })
+
+  it('returns empty array for empty input', function () {
+    expect(buildComponentGroups([])).toEqual([])
+  })
+
+  // --- New field preservation tests ---
+
+  it('preserves fixVersions on features', function () {
+    var feat = makeFeature({ key: 'X-1', fixVersions: ['rhoai-3.5', 'rhoai-3.6'] })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].fixVersions).toEqual(['rhoai-3.5', 'rhoai-3.6'])
+  })
+
+  it('preserves targetVersions on features', function () {
+    var feat = makeFeature({ key: 'X-1', targetVersions: ['rhoai-3.5', 'rhelai-3.5'] })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].targetVersions).toEqual(['rhoai-3.5', 'rhelai-3.5'])
+  })
+
+  it('defaults fixVersions to empty array when missing', function () {
+    var feat = makeFeature({ key: 'X-1' })
+    delete feat.fixVersions
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].fixVersions).toEqual([])
+  })
+
+  it('defaults targetVersions to empty array when missing', function () {
+    var feat = makeFeature({ key: 'X-1' })
+    delete feat.targetVersions
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].targetVersions).toEqual([])
+  })
+
+  it('preserves status (Jira workflow status) on features', function () {
+    var feat = makeFeature({ key: 'X-1', status: 'Code Review' })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].status).toBe('Code Review')
+  })
+
+  it('preserves colorStatus on features', function () {
+    var feat = makeFeature({ key: 'X-1', colorStatus: 'Red' })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].colorStatus).toBe('Red')
+  })
+
+  it('preserves all fields through deduplication', function () {
+    var feat = makeFeature({
+      key: 'X-1',
+      status: 'In Progress',
+      colorStatus: 'Yellow',
+      fixVersions: ['rhoai-3.5'],
+      targetVersions: ['rhoai-3.5', 'rhelai-3.5'],
+      releaseType: 'Enhancement',
+      assignee: 'Charlie',
+      pmOwner: 'Diana'
+    })
+    var groups = [
+      makeGroup('rhoai-3.5', 'Dash', [feat]),
+      makeGroup('rhelai-3.5', 'Dash', [feat])
+    ]
+    var result = buildComponentGroups(groups)
+    var f = result[0].features[0]
+    expect(f.status).toBe('In Progress')
+    expect(f.colorStatus).toBe('Yellow')
+    expect(f.fixVersions).toEqual(['rhoai-3.5'])
+    expect(f.targetVersions).toEqual(['rhoai-3.5', 'rhelai-3.5'])
+    expect(f.releaseType).toBe('Enhancement')
+    expect(f.assignee).toBe('Charlie')
+    expect(f.pmOwner).toBe('Diana')
+  })
+
+  it('handles features with empty fixVersions and targetVersions', function () {
+    var feat = makeFeature({ key: 'X-1', fixVersions: [], targetVersions: [] })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].fixVersions).toEqual([])
+    expect(result[0].features[0].targetVersions).toEqual([])
+  })
+
+  it('handles features with multiple fixVersions', function () {
+    var feat = makeFeature({ key: 'X-1', fixVersions: ['rhoai-3.5', 'rhoai-3.6', 'rhelai-3.5'] })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].fixVersions).toHaveLength(3)
+  })
+})

--- a/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
+++ b/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+
+const { buildFeatureObj, extractTargetVersions } = require('../../../server/pm-hub/routes')
+
+// ---------------------------------------------------------------------------
+// buildFeatureObj
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureObj', function () {
+  var fullInput = {
+    key: 'RHAIENG-123',
+    summary: 'Add model serving support',
+    status: 'In Progress',
+    statusCategory: 'In Progress',
+    colorStatus: 'Green',
+    statusSummary: '<p>On track</p>',
+    releaseType: 'Feature',
+    isBlocked: false,
+    components: ['Inference', 'Serving'],
+    fixVersions: ['rhoai-3.5', 'rhoai-3.6'],
+    assignee: 'Alice',
+    pmOwner: 'Bob'
+  }
+
+  it('maps all fields from a fully-populated transformed issue', function () {
+    var result = buildFeatureObj(fullInput, ['rhoai-3.5'])
+    expect(result.key).toBe('RHAIENG-123')
+    expect(result.summary).toBe('Add model serving support')
+    expect(result.status).toBe('In Progress')
+    expect(result.statusCategory).toBe('In Progress')
+    expect(result.colorStatus).toBe('Green')
+    expect(result.statusSummary).toBe('<p>On track</p>')
+    expect(result.releaseType).toBe('Feature')
+    expect(result.isBlocked).toBe(false)
+    expect(result.components).toEqual(['Inference', 'Serving'])
+    expect(result.fixVersions).toEqual(['rhoai-3.5', 'rhoai-3.6'])
+    expect(result.targetVersions).toEqual(['rhoai-3.5'])
+    expect(result.assignee).toBe('Alice')
+    expect(result.pmOwner).toBe('Bob')
+  })
+
+  it('defaults missing fields to null or empty', function () {
+    var result = buildFeatureObj({ key: 'X-1' })
+    expect(result.key).toBe('X-1')
+    expect(result.summary).toBe('')
+    expect(result.status).toBeNull()
+    expect(result.statusCategory).toBeNull()
+    expect(result.colorStatus).toBeNull()
+    expect(result.statusSummary).toBeNull()
+    expect(result.releaseType).toBeNull()
+    expect(result.isBlocked).toBe(false)
+    expect(result.components).toEqual([])
+    expect(result.fixVersions).toEqual([])
+    expect(result.targetVersions).toEqual([])
+    expect(result.assignee).toBeNull()
+    expect(result.pmOwner).toBeNull()
+  })
+
+  it('defaults targetVersions to empty array when not provided', function () {
+    var result = buildFeatureObj(fullInput)
+    expect(result.targetVersions).toEqual([])
+  })
+
+  it('passes through targetVersions array', function () {
+    var tvs = ['rhoai-3.5', 'rhelai-3.5']
+    var result = buildFeatureObj(fullInput, tvs)
+    expect(result.targetVersions).toEqual(['rhoai-3.5', 'rhelai-3.5'])
+  })
+
+  it('includes fixVersions from the transformed issue', function () {
+    var input = Object.assign({}, fullInput, { fixVersions: ['rhoai-3.6'] })
+    var result = buildFeatureObj(input, [])
+    expect(result.fixVersions).toEqual(['rhoai-3.6'])
+  })
+
+  it('defaults fixVersions to empty array when missing', function () {
+    var input = { key: 'X-2', fixVersions: undefined }
+    var result = buildFeatureObj(input, [])
+    expect(result.fixVersions).toEqual([])
+  })
+
+  it('preserves isBlocked true', function () {
+    var input = Object.assign({}, fullInput, { isBlocked: true })
+    var result = buildFeatureObj(input, [])
+    expect(result.isBlocked).toBe(true)
+  })
+
+  it('does not include extra fields from the input', function () {
+    var input = Object.assign({}, fullInput, {
+      team: 'Some Team',
+      linkedRfeKey: 'RHAIRFE-99',
+      violations: ['missing-summary']
+    })
+    var result = buildFeatureObj(input, [])
+    expect(result).not.toHaveProperty('team')
+    expect(result).not.toHaveProperty('linkedRfeKey')
+    expect(result).not.toHaveProperty('violations')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractTargetVersions
+// ---------------------------------------------------------------------------
+
+describe('extractTargetVersions', function () {
+  var TV_FIELD = 'customfield_10855'
+
+  it('extracts target version names from array field', function () {
+    var raw = { fields: { [TV_FIELD]: [{ name: 'rhoai-3.5' }, { name: 'rhelai-3.5' }] } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5', 'rhelai-3.5'])
+  })
+
+  it('extracts from single object (non-array) field', function () {
+    var raw = { fields: { [TV_FIELD]: { name: 'rhoai-3.6' } } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.6'])
+  })
+
+  it('uses value property when name is missing', function () {
+    var raw = { fields: { [TV_FIELD]: [{ value: 'rhoai-3.5' }] } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
+  })
+
+  it('prefers name over value', function () {
+    var raw = { fields: { [TV_FIELD]: [{ name: 'rhoai-3.5', value: 'rhoai-3.5-alt' }] } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
+  })
+
+  it('returns empty array when field is missing', function () {
+    var raw = { fields: {} }
+    expect(extractTargetVersions(raw)).toEqual([])
+  })
+
+  it('returns empty array when fields is missing', function () {
+    var raw = {}
+    expect(extractTargetVersions(raw)).toEqual([])
+  })
+
+  it('returns empty array when field is null', function () {
+    var raw = { fields: { [TV_FIELD]: null } }
+    expect(extractTargetVersions(raw)).toEqual([])
+  })
+
+  it('returns empty array when field is empty array', function () {
+    var raw = { fields: { [TV_FIELD]: [] } }
+    expect(extractTargetVersions(raw)).toEqual([])
+  })
+
+  it('skips entries with null name and value', function () {
+    var raw = { fields: { [TV_FIELD]: [{ name: 'rhoai-3.5' }, null, { name: null }] } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
+  })
+
+  it('trims whitespace from version names', function () {
+    var raw = { fields: { [TV_FIELD]: [{ name: '  rhoai-3.5  ' }] } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
+  })
+
+  it('handles mixed name and value entries', function () {
+    var raw = { fields: { [TV_FIELD]: [
+      { name: 'rhoai-3.5' },
+      { value: 'rhelai-3.5' },
+      { name: 'RHAII-3.5', value: 'ignored' }
+    ] } }
+    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5', 'rhelai-3.5', 'RHAII-3.5'])
+  })
+})

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -127,6 +127,8 @@ var componentGroups = computed(function() {
             releaseType: feat.releaseType,
             isBlocked: feat.isBlocked,
             components: feat.components,
+            fixVersions: feat.fixVersions || [],
+            targetVersions: feat.targetVersions || [],
             assignee: feat.assignee,
             pmOwner: feat.pmOwner,
             products: [],
@@ -212,7 +214,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="9" class="px-4 py-3">
+            <td colspan="12" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -274,7 +276,10 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Product</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Status</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Status</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Color Status</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Fix Version</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Target Version</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
@@ -329,11 +334,38 @@ defineExpose({ expandAll, collapseAll })
               </td>
               <td class="px-3 py-2.5 text-center">
                 <span
+                  v-if="feature.status"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-100 dark:bg-gray-700/60 text-gray-700 dark:text-gray-300"
+                >{{ feature.status }}</span>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
                   v-if="feature.colorStatus"
                   class="inline-block w-3.5 h-3.5 rounded-full ring-2"
                   :class="[colorStatusClass(feature.colorStatus), colorStatusRing(feature.colorStatus)]"
                   :title="feature.colorStatus"
                 />
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <div v-if="feature.fixVersions && feature.fixVersions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
+                  <span
+                    v-for="fv in feature.fixVersions"
+                    :key="fv"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
+                  >{{ fv }}</span>
+                </div>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <div v-if="feature.targetVersions && feature.targetVersions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
+                  <span
+                    v-for="tv in feature.targetVersions"
+                    :key="tv"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300"
+                  >{{ tv }}</span>
+                </div>
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
@@ -361,7 +393,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="9" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -369,7 +401,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="9" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -377,6 +377,36 @@ const FIELDS_TO_FETCH = [
   CUSTOM_FIELDS.productManager
 ].join(',')
 
+function buildFeatureObj(f, targetVersions) {
+  return {
+    key: f.key,
+    summary: f.summary || '',
+    status: f.status || null,
+    statusCategory: f.statusCategory || null,
+    colorStatus: f.colorStatus || null,
+    statusSummary: f.statusSummary || null,
+    releaseType: f.releaseType || null,
+    isBlocked: f.isBlocked || false,
+    components: f.components || [],
+    fixVersions: f.fixVersions || [],
+    targetVersions: targetVersions || [],
+    assignee: f.assignee || null,
+    pmOwner: f.pmOwner || null
+  }
+}
+
+function extractTargetVersions(rawIssue) {
+  var tvField = rawIssue.fields && rawIssue.fields[CUSTOM_FIELDS.targetVersion]
+  if (!tvField) return []
+  var arr = Array.isArray(tvField) ? tvField : [tvField]
+  var result = []
+  for (var i = 0; i < arr.length; i++) {
+    var name = arr[i] && (arr[i].name || arr[i].value)
+    if (name) result.push(String(name).trim())
+  }
+  return result
+}
+
 /**
  * @param {import('express').Router} router
  * @param {{ requireAuth: Function, requireScope: Function, jira: object, storage: object }} context
@@ -625,18 +655,6 @@ module.exports = function registerPmHubRoutes(router, context) {
         committedIssues = await jiraClient.fetchAllJqlResults(compJql, fieldsWithTv, { expand: 'renderedFields' })
       }
 
-      function extractTargetVersions(rawIssue) {
-        var tvField = rawIssue.fields && rawIssue.fields[CUSTOM_FIELDS.targetVersion]
-        if (!tvField) return []
-        var arr = Array.isArray(tvField) ? tvField : [tvField]
-        var result = []
-        for (var i = 0; i < arr.length; i++) {
-          var name = arr[i] && (arr[i].name || arr[i].value)
-          if (name) result.push(String(name).trim())
-        }
-        return result
-      }
-
       var versionGroups = {}
 
       function ensureGroup(vName, cName) {
@@ -656,22 +674,6 @@ module.exports = function registerPmHubRoutes(router, context) {
         return versionGroups[vName].components[cName]
       }
 
-      function buildFeatureObj(f) {
-        return {
-          key: f.key,
-          summary: f.summary || '',
-          status: f.status || null,
-          statusCategory: f.statusCategory || null,
-          colorStatus: f.colorStatus || null,
-          statusSummary: f.statusSummary || null,
-          releaseType: f.releaseType || null,
-          isBlocked: f.isBlocked || false,
-          components: f.components || [],
-          assignee: f.assignee || null,
-          pmOwner: f.pmOwner || null
-        }
-      }
-
       // Process requested issues (Target Version matches)
       for (var ri = 0; ri < requestedIssues.length; ri++) {
         var raw = requestedIssues[ri]
@@ -688,7 +690,7 @@ module.exports = function registerPmHubRoutes(router, context) {
             if (componentNames.length > 0 && componentNames.indexOf(cName) === -1) continue
             var group = ensureGroup(tvName, cName)
             if (!group.requestedFeatures.some(function(e) { return e.key === f.key })) {
-              group.requestedFeatures.push(buildFeatureObj(f))
+              group.requestedFeatures.push(buildFeatureObj(f, tvNames))
               group.requestedCount++
             }
           }
@@ -699,6 +701,7 @@ module.exports = function registerPmHubRoutes(router, context) {
       for (var cii = 0; cii < committedIssues.length; cii++) {
         var rawC = committedIssues[cii]
         var fc = transformIssue(rawC, {})
+        var tvNamesC = extractTargetVersions(rawC)
         var fvList = fc.fixVersions && fc.fixVersions.length > 0 ? fc.fixVersions : ['Unversioned']
         var compListC = fc.components && fc.components.length > 0 ? fc.components : ['No Component']
 
@@ -711,7 +714,7 @@ module.exports = function registerPmHubRoutes(router, context) {
             if (componentNames.length > 0 && componentNames.indexOf(cNameC) === -1) continue
             var groupC = ensureGroup(fvName, cNameC)
             if (!groupC.committedFeatures.some(function(e) { return e.key === fc.key })) {
-              groupC.committedFeatures.push(buildFeatureObj(fc))
+              groupC.committedFeatures.push(buildFeatureObj(fc, tvNamesC))
               groupC.committedCount++
               if (fc.isBlocked) groupC.blockedCount++
             }
@@ -773,3 +776,5 @@ module.exports.validatePillarConfig = validatePillarConfig
 module.exports.PILLAR_CONFIG_FILE = PILLAR_CONFIG_FILE
 module.exports.backfillLeads = backfillLeads
 module.exports.computeVelocity = computeVelocity
+module.exports.buildFeatureObj = buildFeatureObj
+module.exports.extractTargetVersions = extractTargetVersions


### PR DESCRIPTION
## Summary

- Renames existing "Status" column to "Color Status" (the green/yellow/red dot)
- Adds new **Status** column showing the Jira workflow status (New, In Progress, Code Review, etc.)
- Adds **Fix Version** column (emerald badges) and **Target Version** column (blue badges)
- Moves `buildFeatureObj` and `extractTargetVersions` to module scope for testability and exports them
- Passes `fixVersions` and `targetVersions` through the full server→client data pipeline

## Test plan

- [x] 19 new server tests for `buildFeatureObj` and `extractTargetVersions` (all pass)
- [x] 43 new client logic tests for table data transformation, helpers, and field preservation (all pass)
- [x] All 66 existing pm-hub server tests pass (velocity + pillar-config + new)
- [ ] Manual verification via dev server — expand a component group and confirm new columns render
- [ ] Verify color status dot still renders correctly
- [ ] Verify fix version / target version badges show correct data from Jira

🤖 Generated with [Claude Code](https://claude.com/claude-code)