### PR TITLE
feat(releases): add Release Performance external report link

### DIFF
--- a/modules/releases/client/reports/ReportsHub.vue
+++ b/modules/releases/client/reports/ReportsHub.vue
@@ -4,12 +4,14 @@
       <p class="text-sm">No reports registered yet.</p>
     </div>
     <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <button
+      <component
+        :is="report.externalUrl ? 'a' : 'button'"
         v-for="report in reports"
         :key="report.id"
+        v-bind="report.externalUrl ? { href: report.externalUrl, target: '_blank', rel: 'noopener noreferrer' } : {}"
         class="group text-left bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 cursor-pointer hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200"
         :aria-label="report.label"
-        @click="$emit('select', report)"
+        @click="!report.externalUrl && $emit('select', report)"
       >
         <div class="flex items-start gap-3">
           <div class="flex-shrink-0 w-8 h-8 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center group-hover:bg-primary-100 dark:group-hover:bg-primary-900/50 transition-colors">
@@ -18,11 +20,16 @@
             </svg>
           </div>
           <div class="min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">{{ report.label }}</h3>
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
+              {{ report.label }}
+              <svg v-if="report.externalUrl" class="inline w-3 h-3 ml-1 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+              </svg>
+            </h3>
             <p class="text-xs text-gray-500 dark:text-gray-400">{{ report.description }}</p>
           </div>
         </div>
-      </button>
+      </component>
     </div>
   </div>
 </template>

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -30,5 +30,11 @@ export const reports = [
     label: 'Feature Pressure',
     description: 'Where feature inflow exceeds capacity to burn down — RHAI-wide pressure by component, with RFE pipeline and risk scorecard.',
     component: defineAsyncComponent(() => import('../views/FeaturePressureView.vue'))
+  },
+  {
+    id: 'release-performance',
+    label: 'Release Performance',
+    description: 'Cross-releases, and competitive comparisons performance dashboard',
+    externalUrl: 'https://aidash.app.intlab.redhat.com/'
   }
 ]


### PR DESCRIPTION
## Summary
Adds a card in Releases > Reports linking to the AI Performance Dashboard at
aidash.app.intlab.redhat.com, opening in a new tab with an external-link indicator icon.

## Test plan
- [ ] Navigate to Releases > Reports in the sidebar
- [ ] Verify the "Release Performance" card appears with external-link icon
- [ ] Click the card and confirm it opens https://aidash.app.intlab.redhat.com/ in a new tab
- [ ] Verify other report cards still navigate internally as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)