### PR TITLE
feat(releases): add Sustaining tab and improve PM Hub table

### DIFF
--- a/modules/releases/client/plan/components/BuFeedbackTable.vue
+++ b/modules/releases/client/plan/components/BuFeedbackTable.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+    <table class="min-w-full text-sm">
+      <thead>
+        <tr class="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+          <th v-for="col in columns" :key="col.key" class="text-left px-3 py-2 font-semibold text-gray-600 dark:text-gray-300 whitespace-nowrap">
+            <div class="space-y-1">
+              <button class="flex items-center gap-1 hover:text-gray-900 dark:hover:text-gray-100" @click="toggleSort(col.key)">
+                {{ col.label }}
+                <span v-if="sortKey === col.key" class="text-xs">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+              </button>
+              <select
+                v-if="col.filterable"
+                v-model="columnFilters[col.key]"
+                class="block w-full text-xs font-normal bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded px-1.5 py-1 text-gray-600 dark:text-gray-300 outline-none focus:ring-1 focus:ring-primary-400"
+              >
+                <option value="">All</option>
+                <option v-for="opt in filterOptions[col.key]" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-if="!sortedIssues.length">
+          <td :colspan="columns.length" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">No issues match the current filters</td>
+        </tr>
+        <tr
+          v-for="issue in sortedIssues"
+          :key="issue.key"
+          class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+        >
+          <td class="px-3 py-2 whitespace-nowrap">
+            <a :href="issue.url" target="_blank" rel="noopener" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">{{ issue.key }}</a>
+          </td>
+          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType }}</td>
+          <td class="px-3 py-2 text-gray-700 dark:text-gray-300 max-w-md truncate" :title="issue.summary">{{ issue.summary }}</td>
+          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.assignee }}</td>
+          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.reporter }}</td>
+          <td class="px-3 py-2 whitespace-nowrap">
+            <span class="inline-flex items-center gap-1">
+              <span :class="priorityDot(issue.priority)" class="w-2.5 h-2.5 rounded-full inline-block" />
+              {{ issue.priority }}
+            </span>
+          </td>
+          <td class="px-3 py-2 whitespace-nowrap">
+            <span
+              class="inline-block px-2 py-0.5 text-xs font-medium rounded-full"
+              :class="statusClasses(issue.statusCategory)"
+            >{{ issue.status }}</span>
+          </td>
+          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.resolution }}</td>
+          <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ formatDate(issue.created) }}</td>
+          <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ formatDate(issue.updated) }}</td>
+          <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.dueDate ? formatDate(issue.dueDate) : 'None' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+var props = defineProps({
+  issues: { type: Array, default: function() { return [] } }
+})
+
+var columns = [
+  { key: 'key', label: 'Key', filterable: false },
+  { key: 'issueType', label: 'Type', filterable: true },
+  { key: 'summary', label: 'Summary', filterable: false },
+  { key: 'assignee', label: 'Assignee', filterable: true },
+  { key: 'reporter', label: 'Reporter', filterable: true },
+  { key: 'priority', label: 'Priority', filterable: true },
+  { key: 'status', label: 'Status', filterable: true },
+  { key: 'resolution', label: 'Resolution', filterable: true },
+  { key: 'created', label: 'Created', filterable: false },
+  { key: 'updated', label: 'Updated', filterable: false },
+  { key: 'dueDate', label: 'Due date', filterable: false }
+]
+
+var columnFilters = ref({
+  issueType: '',
+  assignee: '',
+  reporter: '',
+  priority: '',
+  status: '',
+  resolution: ''
+})
+
+var sortKey = ref('created')
+var sortDir = ref('desc')
+
+var filterOptions = computed(function() {
+  var opts = {}
+    var filterableKeys = ['issueType', 'assignee', 'reporter', 'priority', 'status', 'resolution']
+  for (var ki = 0; ki < filterableKeys.length; ki++) {
+    var key = filterableKeys[ki]
+    var seen = {}
+    var values = []
+    for (var i = 0; i < props.issues.length; i++) {
+      var val = props.issues[i][key] || ''
+      if (val && !seen[val]) {
+        seen[val] = true
+        values.push(val)
+      }
+    }
+    values.sort()
+    opts[key] = values
+  }
+  return opts
+})
+
+var filteredIssues = computed(function() {
+  return props.issues.filter(function(issue) {
+    var keys = Object.keys(columnFilters.value)
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i]
+      var filterVal = columnFilters.value[key]
+      if (filterVal && issue[key] !== filterVal) return false
+    }
+    return true
+  })
+})
+
+var sortedIssues = computed(function() {
+  var arr = filteredIssues.value.slice()
+  var key = sortKey.value
+  var dir = sortDir.value === 'asc' ? 1 : -1
+
+  arr.sort(function(a, b) {
+    var aVal, bVal
+    if (key === 'work') {
+      aVal = a.key || ''
+      bVal = b.key || ''
+    } else {
+      aVal = a[key] || ''
+      bVal = b[key] || ''
+    }
+    if (aVal < bVal) return -1 * dir
+    if (aVal > bVal) return 1 * dir
+    return 0
+  })
+  return arr
+})
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDir.value = key === 'created' || key === 'updated' ? 'desc' : 'asc'
+  }
+}
+
+function priorityDot(priority) {
+  var p = (priority || '').toLowerCase()
+  if (p === 'blocker' || p === 'critical') return 'bg-red-500'
+  if (p === 'major') return 'bg-orange-400'
+  if (p === 'normal' || p === 'minor') return 'bg-yellow-400'
+  if (p === 'trivial') return 'bg-green-400'
+  if (p === 'undefined') return 'bg-gray-300 dark:bg-gray-500'
+  return 'bg-gray-300 dark:bg-gray-500'
+}
+
+function statusClasses(category) {
+  var c = (category || '').toLowerCase()
+  if (c === 'done') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (c === 'in progress') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  var d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+</script>

--- a/modules/releases/client/plan/components/BuFeedbackTable.vue
+++ b/modules/releases/client/plan/components/BuFeedbackTable.vue
@@ -94,7 +94,7 @@ var sortDir = ref('desc')
 
 var filterOptions = computed(function() {
   var opts = {}
-    var filterableKeys = ['issueType', 'assignee', 'reporter', 'priority', 'status', 'resolution']
+  var filterableKeys = ['issueType', 'assignee', 'reporter', 'priority', 'status', 'resolution']
   for (var ki = 0; ki < filterableKeys.length; ki++) {
     var key = filterableKeys[ki]
     var seen = {}
@@ -130,14 +130,8 @@ var sortedIssues = computed(function() {
   var dir = sortDir.value === 'asc' ? 1 : -1
 
   arr.sort(function(a, b) {
-    var aVal, bVal
-    if (key === 'work') {
-      aVal = a.key || ''
-      bVal = b.key || ''
-    } else {
-      aVal = a[key] || ''
-      bVal = b[key] || ''
-    }
+    var aVal = a[key] || ''
+    var bVal = b[key] || ''
     if (aVal < bVal) return -1 * dir
     if (aVal > bVal) return 1 * dir
     return 0

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -132,6 +132,7 @@ var componentGroups = computed(function() {
             assignee: feat.assignee,
             pmOwner: feat.pmOwner,
             products: [],
+            versions: [],
             isRequested: false,
             isCommitted: false
           }
@@ -141,6 +142,9 @@ var componentGroups = computed(function() {
         var product = extractProduct(version)
         if (entry.products.indexOf(product) === -1) {
           entry.products.push(product)
+        }
+        if (entry.versions.indexOf(version) === -1) {
+          entry.versions.push(version)
         }
         if (isReq) entry.isRequested = true
         if (isCom) entry.isCommitted = true
@@ -214,7 +218,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="12" class="px-4 py-3">
+            <td colspan="11" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -274,12 +278,11 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Product</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Version</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Status</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Color Status</th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Fix Version</th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Target Version</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
@@ -312,6 +315,16 @@ defineExpose({ expandAll, collapseAll })
                     :class="productBadgeClass(prod)"
                   >{{ prod }}</span>
                 </div>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <div v-if="feature.versions && feature.versions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
+                  <span
+                    v-for="ver in feature.versions"
+                    :key="ver"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-gray-100 dark:bg-gray-700/60 text-gray-700 dark:text-gray-300"
+                  >{{ ver }}</span>
+                </div>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
                 <div class="flex items-center justify-center gap-1">
@@ -349,26 +362,6 @@ defineExpose({ expandAll, collapseAll })
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
-                <div v-if="feature.fixVersions && feature.fixVersions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
-                  <span
-                    v-for="fv in feature.fixVersions"
-                    :key="fv"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
-                  >{{ fv }}</span>
-                </div>
-                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
-              </td>
-              <td class="px-3 py-2.5 text-center">
-                <div v-if="feature.targetVersions && feature.targetVersions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
-                  <span
-                    v-for="tv in feature.targetVersions"
-                    :key="tv"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300"
-                  >{{ tv }}</span>
-                </div>
-                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
-              </td>
-              <td class="px-3 py-2.5 text-center">
                 <span
                   v-if="feature.isBlocked"
                   class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
@@ -393,7 +386,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="11" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -401,7 +394,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="11" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -196,13 +196,6 @@ function colorStatusRing(colorStatus) {
   return 'ring-gray-200 dark:ring-gray-700'
 }
 
-function productBadgeClass(product) {
-  var p = (product || '').toUpperCase()
-  if (p === 'RHOAI') return 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300'
-  if (p === 'RHELAI') return 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300'
-  if (p === 'RHAII') return 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300'
-  return 'bg-gray-100 dark:bg-gray-700/60 text-gray-600 dark:text-gray-400'
-}
 
 defineExpose({ expandAll, collapseAll })
 </script>
@@ -218,7 +211,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="11" class="px-4 py-3">
+            <td colspan="10" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -277,7 +270,6 @@ defineExpose({ expandAll, collapseAll })
           >
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Product</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Version</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
@@ -305,16 +297,6 @@ defineExpose({ expandAll, collapseAll })
               </td>
               <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
                 {{ feature.summary }}
-              </td>
-              <td class="px-3 py-2.5 text-center">
-                <div class="flex items-center justify-center gap-1 flex-wrap">
-                  <span
-                    v-for="prod in feature.products"
-                    :key="prod"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold"
-                    :class="productBadgeClass(prod)"
-                  >{{ prod }}</span>
-                </div>
               </td>
               <td class="px-3 py-2.5 text-center">
                 <div v-if="feature.versions && feature.versions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
@@ -386,7 +368,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="11" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="10" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -394,7 +376,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="11" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="10" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/views/BuFeedbackView.vue
+++ b/modules/releases/client/plan/views/BuFeedbackView.vue
@@ -2,7 +2,7 @@
   <div class="space-y-4">
     <div class="flex items-center justify-between">
       <div>
-        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">BU (Non-Feature-Asks)</h2>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Sustaining</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Issues labeled <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AIBU_Feedback</code> from Jira, ordered by creation date.
         </p>

--- a/modules/releases/client/plan/views/BuFeedbackView.vue
+++ b/modules/releases/client/plan/views/BuFeedbackView.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <div>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">BU (Non-Feature-Asks)</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Issues labeled <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AIBU_Feedback</code> from Jira, ordered by creation date.
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <span v-if="fetchedAt" class="text-xs text-gray-400 dark:text-gray-500">
+          {{ issues.length }} issue{{ issues.length !== 1 ? 's' : '' }}
+        </span>
+        <button
+          @click="loadData"
+          :disabled="loading"
+          class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
+        >
+          {{ loading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+    </div>
+
+    <div v-if="error" class="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm">
+      {{ error }}
+    </div>
+
+    <div v-if="loading && !issues.length" class="text-sm text-gray-500 dark:text-gray-400">Loading BU feedback issues...</div>
+
+    <div v-if="warning" class="rounded-lg border border-yellow-300 bg-yellow-50 text-yellow-800 px-4 py-3 text-sm">
+      {{ warning }}
+    </div>
+
+    <BuFeedbackTable v-if="issues.length || (!loading && !error)" :issues="issues" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { getApiBase } from '@shared/client/services/api'
+import BuFeedbackTable from '../components/BuFeedbackTable.vue'
+
+var issues = ref([])
+var loading = ref(false)
+var error = ref(null)
+var warning = ref(null)
+var fetchedAt = ref(null)
+
+async function loadData() {
+  loading.value = true
+  error.value = null
+  warning.value = null
+
+  try {
+    var response = await fetch(getApiBase() + '/modules/releases/planning/bu-feedback')
+    if (!response.ok) throw new Error('HTTP ' + response.status)
+    var data = await response.json()
+    issues.value = data.issues || []
+    fetchedAt.value = data.fetchedAt || null
+    if (data.warning) warning.value = data.warning
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadData)
+</script>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -699,15 +699,19 @@ var pillarAllowedComponents = computed(function() {
   return allowed
 })
 
+function normalizeComponentName(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
 function componentMatchesPillar(jiraName) {
   var allowed = pillarAllowedComponents.value
   if (!allowed) return true
-  var lower = jiraName.toLowerCase()
+  if (allowed.has(jiraName.toLowerCase())) return true
+  var normalized = normalizeComponentName(jiraName)
   var iter = allowed.values()
   var next = iter.next()
   while (!next.done) {
-    var entry = next.value
-    if (lower.includes(entry) || entry.includes(lower)) return true
+    if (normalizeComponentName(next.value) === normalized) return true
     next = iter.next()
   }
   return false
@@ -841,15 +845,22 @@ async function fetchComponents() {
   }
 }
 
+function getEffectiveComponents() {
+  if (selectedComponents.value.length > 0) return selectedComponents.value
+  if (pillarAllowedComponents.value) return pillarFilteredComponents.value
+  return []
+}
+
 async function loadData() {
-  if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) return
+  var effectiveComponents = getEffectiveComponents()
+  if (effectiveComponents.length === 0 && selectedVersions.value.length === 0) return
   loadingData.value = true
   dataError.value = null
   hasFetched.value = true
 
   try {
     var params = new URLSearchParams()
-    if (selectedComponents.value.length > 0) params.set('components', selectedComponents.value.join(','))
+    if (effectiveComponents.length > 0) params.set('components', effectiveComponents.join(','))
     if (selectedVersions.value.length > 0) {
       var jiraVersions = resolveJiraVersions(selectedVersions.value)
       params.set('versions', jiraVersions.join(','))
@@ -878,8 +889,9 @@ watch(selectedPillars, function() {
   })
 }, { deep: true })
 
-watch([selectedComponents, selectedVersions], function() {
-  if (selectedComponents.value.length === 0 && selectedVersions.value.length === 0) {
+watch([selectedComponents, selectedVersions, selectedPillars], function() {
+  var effectiveComponents = getEffectiveComponents()
+  if (effectiveComponents.length === 0 && selectedVersions.value.length === 0) {
     groups.value = []
     hasFetched.value = false
     return

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -18,6 +18,7 @@
     <div class="p-6">
       <DashboardView v-if="activeTab === 'outcomes'" />
       <FeatureReadinessView v-else-if="activeTab === 'feature-readiness'" />
+      <BuFeedbackView v-else-if="activeTab === 'bu-feedback'" />
       <PmHubView v-else-if="activeTab === 'pm-hub'" />
     </div>
   </div>
@@ -27,12 +28,14 @@
 import { ref, inject, watch } from 'vue'
 import DashboardView from '../plan/views/DashboardView.vue'
 import FeatureReadinessView from '../plan/views/FeatureReadinessView.vue'
+import BuFeedbackView from '../plan/views/BuFeedbackView.vue'
 import PmHubView from '../plan/views/PmHubView.vue'
 
 const tabs = [
   { id: 'outcomes', label: 'Big Rocks' },
   { id: 'pm-hub', label: 'PM Hub' },
   { id: 'feature-readiness', label: 'Features List (1-n)' },
+  { id: 'bu-feedback', label: 'BU (Non-Feature-Asks)' },
 ]
 
 var moduleNav = inject('moduleNav', null)

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -35,7 +35,7 @@ const tabs = [
   { id: 'outcomes', label: 'Big Rocks' },
   { id: 'pm-hub', label: 'PM Hub' },
   { id: 'feature-readiness', label: 'Features List (1-n)' },
-  { id: 'bu-feedback', label: 'BU (Non-Feature-Asks)' },
+  { id: 'bu-feedback', label: 'Sustaining' },
 ]
 
 var moduleNav = inject('moduleNav', null)

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -486,6 +486,61 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
   })
 
+  /**
+   * @openapi
+   * /api/modules/releases/planning/bu-feedback:
+   *   get:
+   *     summary: List BU non-feature-ask issues from Jira
+   *     tags: [releases-planning]
+   *     security: [{ bearerAuth: [] }]
+   *     description: Queries Jira for issues labeled AIBU_Feedback, ordered by creation date descending.
+   *     responses:
+   *       200:
+   *         description: Array of BU feedback issues
+   *       503:
+   *         description: Jira client not configured
+   */
+  router.get('/bu-feedback', requireAuth, requireScope('releases:read'), async function(req, res) {
+    if (!jiraClient) {
+      return res.json({ issues: [], fetchedAt: new Date().toISOString(), warning: 'Jira not configured' })
+    }
+
+    try {
+      var jql = 'labels = "AIBU_Feedback" ORDER BY createdDate DESC'
+      var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels'
+      var rawIssues = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 100 })
+
+      var issues = []
+      for (var i = 0; i < rawIssues.length; i++) {
+        var raw = rawIssues[i]
+        var f = raw.fields || {}
+        issues.push({
+          key: raw.key,
+          summary: f.summary || '',
+          issueType: f.issuetype ? f.issuetype.name : '',
+          assignee: f.assignee ? f.assignee.displayName : 'Unassigned',
+          reporter: f.reporter ? f.reporter.displayName : '',
+          priority: f.priority ? f.priority.name : '',
+          status: f.status ? f.status.name : '',
+          statusCategory: f.status && f.status.statusCategory ? f.status.statusCategory.name : '',
+          resolution: f.resolution ? f.resolution.name : 'Unresolved',
+          created: f.created || null,
+          updated: f.updated || null,
+          dueDate: f.duedate || null,
+          components: (f.components || []).map(function(c) { return c.name }),
+          fixVersions: (f.fixVersions || []).map(function(v) { return v.name }),
+          labels: f.labels || [],
+          url: 'https://issues.redhat.com/browse/' + raw.key
+        })
+      }
+
+      res.json({ issues: issues, fetchedAt: new Date().toISOString() })
+    } catch (err) {
+      console.error('[releases/planning] BU feedback query failed:', err.message)
+      res.status(500).json({ error: 'Failed to fetch BU feedback issues' })
+    }
+  })
+
   // ─── Cache Invalidation Helper ───
 
   function invalidateCache(version) {


### PR DESCRIPTION
## Summary
- **Sustaining tab**: Add a new "Sustaining" tab to the Plan view that displays Jira issues labeled `AIBU_Feedback`, fetched via a new server endpoint, with a sortable/filterable table (Key, Issue Type, Title, Status, Priority, Labels, Created date)
- **PM Hub table improvements**: Replace the Product, Fix Version, and Target Version columns with a single Version column showing the release version string; fix pillar filter to use normalized component name matching (strips punctuation/casing) so config names like `llm-compressor` correctly match Jira's `LLM Compressor`

## Test plan
- [ ] Select the "Plan" tab and verify the "Sustaining" tab appears and loads issues
- [ ] Verify column sorting and filtering work on the Sustaining table
- [ ] In PM Hub, select a pillar (e.g. Inference) and confirm components with minor name differences (e.g. `llm-compressor` vs `LLM Compressor`) now appear in the dropdown
- [ ] Verify the Version column shows the correct release version (e.g. `rhoai-3.5.EA1`) for each feature row
- [ ] Confirm the removed columns (Product, Fix Version, Target Version) no longer appear


Made with [Cursor](https://cursor.com)