### PR TITLE
fix(releases): default Feature Status to all versions

### DIFF
--- a/modules/releases/client/execute/composables/useHygieneFilters.js
+++ b/modules/releases/client/execute/composables/useHygieneFilters.js
@@ -20,7 +20,8 @@ function persistSavedSets(sets) {
   } catch { /* localStorage unavailable */ }
 }
 
-export function useHygieneFilters(features) {
+export function useHygieneFilters(features, options = {}) {
+  const { productFilter, versionFilter, allVersions } = options
   const selectedTeams = ref([])
   const selectedComponents = ref([])
   const savedSets = ref(loadSavedSets())
@@ -71,7 +72,10 @@ export function useHygieneFilters(features) {
   })
 
   const isFiltered = computed(() => {
-    return selectedTeams.value.length > 0 || selectedComponents.value.length > 0
+    if (selectedTeams.value.length > 0 || selectedComponents.value.length > 0) return true
+    if (productFilter && productFilter.value.length > 0) return true
+    if (versionFilter && versionFilter.value.length > 0) return true
+    return false
   })
 
   function toggleTeam(team) {
@@ -95,6 +99,8 @@ export function useHygieneFilters(features) {
   function clearFilters() {
     selectedTeams.value = []
     selectedComponents.value = []
+    if (productFilter) productFilter.value = []
+    if (versionFilter) versionFilter.value = []
   }
 
   function saveCurrentSet(name) {
@@ -102,11 +108,14 @@ export function useHygieneFilters(features) {
     const trimmed = name.trim()
     if (savedSets.value.some(s => s.name === trimmed)) return false
     if (savedSets.value.length >= MAX_SAVED_SETS) return false
-    savedSets.value.push({
+    const set = {
       name: trimmed,
       teams: [...selectedTeams.value],
       components: [...selectedComponents.value]
-    })
+    }
+    if (productFilter) set.products = [...productFilter.value]
+    if (versionFilter) set.versions = [...versionFilter.value]
+    savedSets.value.push(set)
     persistSavedSets(savedSets.value)
     return true
   }
@@ -115,6 +124,11 @@ export function useHygieneFilters(features) {
     // Intersect with available values for stale detection
     selectedTeams.value = set.teams.filter(t => availableTeams.value.includes(t))
     selectedComponents.value = set.components.filter(c => availableComponents.value.includes(c))
+    if (productFilter && set.products) productFilter.value = [...set.products]
+    if (versionFilter && set.versions && allVersions) {
+      const valid = set.versions.filter(v => allVersions.value.includes(v))
+      if (valid.length > 0) versionFilter.value = valid
+    }
   }
 
   function deleteSet(name) {

--- a/modules/releases/client/execute/views/HygieneView.vue
+++ b/modules/releases/client/execute/views/HygieneView.vue
@@ -62,8 +62,9 @@ async function loadVersions() {
     }
     if (params.version && allVersions.value.includes(params.version)) {
       selectedVersions.value = [params.version]
-    } else if (allVersions.value.length > 0 && selectedVersions.value.length === 0) {
-      selectedVersions.value = [allVersions.value[0]]
+    } else {
+      // No version param and no selection — load all versions
+      loadData([])
     }
   } catch {
     allVersions.value = []
@@ -71,7 +72,8 @@ async function loadVersions() {
 }
 
 async function loadData(versions) {
-  if (!versions || versions.length === 0) return
+  const effective = versions && versions.length > 0 ? versions : allVersions.value
+  if (effective.length === 0) return
   loading.value = true
   error.value = null
 
@@ -81,7 +83,7 @@ async function loadData(versions) {
     let mergedSummary = null
     const execByKey = {}
 
-    await Promise.all(versions.map(async (version) => {
+    await Promise.all(effective.map(async (version) => {
       const rel = registryReleases.value.find(r => r.displayName === version)
       const execVersion = (rel && rel.fixVersions && rel.fixVersions.length > 0)
         ? rel.fixVersions[0]
@@ -185,7 +187,7 @@ const hasData = computed(() => {
 })
 
 watch(selectedVersions, (v) => {
-  if (v.length > 0) loadData(v)
+  loadData(v)
 })
 
 onMounted(() => {
@@ -249,7 +251,11 @@ const {
   loadSet,
   deleteSet,
   setMatchCount
-} = useHygieneFilters(mergedFeatures)
+} = useHygieneFilters(mergedFeatures, {
+  productFilter: selectedProducts,
+  versionFilter: selectedVersions,
+  allVersions
+})
 
 const showSaveInput = ref(false)
 const saveFilterName = ref('')
@@ -306,14 +312,12 @@ const versionOptions = computed(() =>
         @update:modelValue="v => selectedVersions = v"
       />
       <HygieneSelect
-        v-if="availableTeams.length > 0"
         :modelValue="selectedTeams"
         :options="availableTeams"
         placeholder="All Teams"
         @update:modelValue="v => selectedTeams = v"
       />
       <HygieneSelect
-        v-if="availableComponents.length > 0"
         :modelValue="selectedComponents"
         :options="availableComponents"
         placeholder="All Components"


### PR DESCRIPTION
## Summary

- The version picker on the Feature Status (hygiene kanban) tab defaulted to selecting the first version instead of showing all versions
- Now empty selection means "all" — consistent with the product, team, and component filters
- Wires product and version filters into `useHygieneFilters` so "Clear filters" and saved filter sets work across all four filter dimensions

## Changes

- **`HygieneView.vue`**: Remove forced default of first version; `loadData()` resolves empty selection to all versions; watcher triggers on empty selection
- **`useHygieneFilters.js`**: Accept `productFilter`/`versionFilter`/`allVersions` options; `clearFilters()` resets all four dimensions to `[]`; `isFiltered` treats any version/product selection as active; saved sets persist and restore product/version selections

## Test plan

- [ ] Open Feature Status tab — all versions should load (no version chips shown, placeholder says "All Versions")
- [ ] Select a specific version — data filters to that version
- [ ] Clear selection back to empty — shows all versions again
- [ ] Click "Clear filters" after selecting versions/products/teams — all reset to empty (all)
- [ ] Save a filter set with version+product selected, reload, restore it — selections restored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)