### PR TITLE
fix(releases): include targetVersions in Jira enrichment cycle

### DIFF
--- a/modules/releases/server/execution/feature-store.js
+++ b/modules/releases/server/execution/feature-store.js
@@ -14,9 +14,9 @@ let storeWriteInProgress = false;
 const JIRA_FIELDS = [
   'status', 'statusCategory', 'colorStatus', 'ownerStatusColor',
   'statusSummary', 'assignee', 'pm', 'labels', 'fixVersions',
-  'components', 'priority', 'team', 'releaseType', 'docsRequired',
-  'targetEnd', 'riceScore', 'riceStatus', 'isBlocked', 'linkedRfeKey',
-  'issueLinks', 'epics'
+  'targetVersions', 'components', 'priority', 'team', 'releaseType',
+  'docsRequired', 'targetEnd', 'riceScore', 'riceStatus', 'isBlocked',
+  'linkedRfeKey', 'issueLinks', 'epics'
 ];
 
 // Pipeline-owned fields — pipeline always wins

--- a/modules/releases/server/execution/jira-enrich.js
+++ b/modules/releases/server/execution/jira-enrich.js
@@ -27,6 +27,7 @@ const ENRICH_FIELDS = [
   CUSTOM_FIELDS.docsRequired,
   CUSTOM_FIELDS.targetEnd,
   CUSTOM_FIELDS.productManager,
+  CUSTOM_FIELDS.targetVersion,
   CUSTOM_FIELDS.reach,
   CUSTOM_FIELDS.impact,
   CUSTOM_FIELDS.confidence,
@@ -152,6 +153,15 @@ function transformForEnrichment(rawIssue) {
     }
   }
 
+  // Target versions (customfield_10855) as array of names
+  const targetVersions = [];
+  const tvField = fields[CUSTOM_FIELDS.targetVersion];
+  if (tvField && Array.isArray(tvField)) {
+    for (let i = 0; i < tvField.length; i++) {
+      if (tvField[i].name) targetVersions.push(tvField[i].name);
+    }
+  }
+
   // Labels
   const labels = Array.isArray(fields.labels) ? fields.labels : [];
 
@@ -195,6 +205,7 @@ function transformForEnrichment(rawIssue) {
     team: serializeField(fields[CUSTOM_FIELDS.team]),
     releaseType: serializeField(fields[CUSTOM_FIELDS.releaseType]),
     fixVersions,
+    targetVersions,
     labels,
     components,
     docsRequired: serializeField(fields[CUSTOM_FIELDS.docsRequired]),


### PR DESCRIPTION
## Summary
- **Root cause**: `targetVersions` (Jira `customfield_10855`) was only updated during GitLab CI artifact ingest (12h cadence), not during the 6h Jira enrichment cycle. Features re-targeted in Jira would show stale version data in the Big Rocks planning view.
- **Fix**: Add `targetVersions` to the Jira enrichment query, transform, and merge field list so the 6h enrichment cycle keeps it current.
- **Example**: RHAISTRAT-1552 was re-targeted to `rhoai-3.6.EA1` in Jira but still appeared under the 3.5 release because the cached `targetVersions` was stale.

## Test plan
- [ ] Verify `npm test` passes for execution and planning test suites
- [ ] Deploy to preprod, trigger a Jira enrichment refresh, and confirm features with updated target versions reflect correctly in the Big Rocks display
- [ ] Verify that pipeline ingest still seeds `targetVersions` for new features (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)