### PR TITLE
fix(ai-impact): use Jira label dates for waitDays instead of assessedAt

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -609,6 +609,8 @@ Cached RFE issues fetched from Jira. The module's primary data file.
 - `aiInvolvement` is one of: `"both"`, `"created"`, `"revised"`, `"none"` — derived from exact label matching at fetch time
 - `createdLabelDate`: ISO timestamp of the most recent changelog addition of the created label. Set only when `aiInvolvement` is `"created"` or `"both"`. Falls back to `created` if the label was present since issue creation (no changelog entry). `null` when the created label is not present.
 - `revisedLabelDate`: ISO timestamp of the most recent changelog addition of the revised label. Same logic as `createdLabelDate`. `null` when the revised label is not present.
+- `needsAttentionSince`: ISO timestamp of the most recent changelog addition of `rfe-creator-needs-attention`. Falls back to `created` when the label is present but has no changelog entry. `null` when the label is not currently on the issue. Used by the frontend to calculate how long an item has been in a needs-revision or passed-with-caveats state, independent of pipeline run frequency.
+- `rubricPassSince`: ISO timestamp of the most recent changelog addition of `rfe-creator-autofix-rubric-pass`. Falls back to `created` when the label is present but has no changelog entry. `null` when the label is not currently on the issue. Used by the frontend to calculate how long an item has been in a ready-to-advance or queued-for-pipeline state.
 - `components` is an array of Jira component names (strings). Empty array if the issue has no components.
 - `linkedFeature` is resolved from Jira issue links (type = "Cloners", outward to RHAISTRAT project). Can be `null` if no link exists.
 - `labels` is the raw Jira label array, preserved for reference

--- a/fixtures/ai-impact/rfe-data.json
+++ b/fixtures/ai-impact/rfe-data.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-03-28T12:00:00Z",
+  "fetchedAt": "2026-06-11T12:00:00Z",
   "issues": [
     {
       "key": "RHAIRFE-1001",
@@ -12,6 +12,8 @@
       "components": ["Platform Core"],
       "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "customer-request"],
       "aiInvolvement": "both",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
       "linkedFeature": {
         "key": "RHAISTRAT-1168",
         "summary": "GPU-as-a-Service Observability Dashboard",
@@ -30,6 +32,8 @@
       "components": ["Platform Dashboard"],
       "labels": ["rfe-creator-auto-created", "rfe-creator-autofix-rubric-pass", "strat-creator-3.5"],
       "aiInvolvement": "created",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-03-25T14:00:00Z",
       "linkedFeature": null
     },
     {
@@ -43,6 +47,8 @@
       "components": ["ML Models"],
       "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "tech-reviewed", "strategic"],
       "aiInvolvement": "revised",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-03-18T10:30:00Z",
       "linkedFeature": {
         "key": "RHAISTRAT-502",
         "summary": "Strat: LLM fine-tuning capability",
@@ -61,6 +67,8 @@
       "components": ["Infrastructure Services"],
       "labels": [],
       "aiInvolvement": "none",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
       "linkedFeature": null
     },
     {
@@ -74,6 +82,8 @@
       "components": ["ML Models"],
       "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "rfe-creator-needs-attention"],
       "aiInvolvement": "both",
+      "needsAttentionSince": "2026-03-14T10:00:00Z",
+      "rubricPassSince": "2026-03-10T08:00:00Z",
       "linkedFeature": null
     },
     {
@@ -87,6 +97,8 @@
       "components": ["Data Pipelines"],
       "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
       "aiInvolvement": "created",
+      "needsAttentionSince": "2026-04-15T09:00:00Z",
+      "rubricPassSince": null,
       "linkedFeature": null
     },
     {
@@ -100,6 +112,8 @@
       "components": ["Platform Core"],
       "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass"],
       "aiInvolvement": "revised",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-04-10T11:00:00Z",
       "linkedFeature": null
     },
     {
@@ -113,6 +127,8 @@
       "components": ["Platform Core", "Infrastructure Services"],
       "labels": ["rfe-creator-autofix-rubric-pass", "tech-reviewed", "strat-creator-3.5"],
       "aiInvolvement": "none",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-04-01T08:30:00Z",
       "linkedFeature": null
     },
     {
@@ -126,6 +142,8 @@
       "components": ["ML Models"],
       "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "innovation"],
       "aiInvolvement": "both",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-04-20T09:00:00Z",
       "linkedFeature": null
     },
     {
@@ -139,6 +157,173 @@
       "components": ["ML Models", "Platform Core"],
       "labels": [],
       "aiInvolvement": "none",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1016",
+      "summary": "Enable custom metrics collection for deployed model endpoints",
+      "status": "New",
+      "priority": "Medium",
+      "created": "2026-01-18T10:30:00Z",
+      "creator": "bsanders",
+      "creatorDisplayName": "Ben Sanders",
+      "components": ["Platform Dashboard"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-fail"],
+      "aiInvolvement": "created",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1017",
+      "summary": "Implement batch inference scheduling with priority queues",
+      "status": "In Review",
+      "priority": "High",
+      "created": "2026-02-03T14:00:00Z",
+      "creator": "lchang",
+      "creatorDisplayName": "Lin Chang",
+      "components": ["ML Models"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-needs-attention"],
+      "aiInvolvement": "both",
+      "needsAttentionSince": "2026-05-01T11:00:00Z",
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1018",
+      "summary": "Add support for neuromorphic hardware accelerators in serving runtime",
+      "status": "New",
+      "priority": "Low",
+      "created": "2026-02-25T09:00:00Z",
+      "creator": "nthomas",
+      "creatorDisplayName": "Nina Thomas",
+      "components": ["Infrastructure Services"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-unknown"],
+      "aiInvolvement": "created",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1024",
+      "summary": "Expose per-request latency percentiles in model serving metrics",
+      "status": "New",
+      "priority": "Medium",
+      "created": "2026-01-28T11:00:00Z",
+      "creator": "dlee",
+      "creatorDisplayName": "David Lee",
+      "components": ["Platform Dashboard"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
+      "aiInvolvement": "created",
+      "needsAttentionSince": "2026-05-28T09:30:00Z",
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1025",
+      "summary": "Add experiment comparison view for hyperparameter tuning runs",
+      "status": "New",
+      "priority": "High",
+      "created": "2026-02-12T13:30:00Z",
+      "creator": "lchang",
+      "creatorDisplayName": "Lin Chang",
+      "components": ["ML Models", "Platform Dashboard"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-needs-attention"],
+      "aiInvolvement": "both",
+      "needsAttentionSince": "2026-06-05T08:00:00Z",
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1026",
+      "summary": "Cross-cluster model weight synchronization for geo-distributed serving",
+      "status": "New",
+      "priority": "Critical",
+      "created": "2026-03-05T09:45:00Z",
+      "creator": "akim",
+      "creatorDisplayName": "Alex Kim",
+      "components": ["Platform Core"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-feasibility-fail"],
+      "aiInvolvement": "both",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1019",
+      "summary": "Automated model drift detection with configurable alert thresholds",
+      "status": "New",
+      "priority": "High",
+      "created": "2026-03-20T11:15:00Z",
+      "creator": "rpatel",
+      "creatorDisplayName": "Raj Patel",
+      "components": ["Platform Dashboard", "ML Models"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
+      "aiInvolvement": "created",
+      "needsAttentionSince": "2026-05-20T14:00:00Z",
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1020",
+      "summary": "Real-time feature store integration with sub-millisecond retrieval latency",
+      "status": "New",
+      "priority": "Critical",
+      "created": "2026-04-08T13:45:00Z",
+      "creator": "emiller",
+      "creatorDisplayName": "Emily Miller",
+      "components": ["Data Pipelines"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-feasibility-fail"],
+      "aiInvolvement": "both",
+      "needsAttentionSince": null,
+      "rubricPassSince": null,
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1021",
+      "summary": "Improve pipeline step caching for faster iterative reruns",
+      "status": "In Review",
+      "priority": "Medium",
+      "created": "2026-04-25T10:00:00Z",
+      "creator": "schen",
+      "creatorDisplayName": "Sarah Chen",
+      "components": ["Data Pipelines"],
+      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "tech-reviewed"],
+      "aiInvolvement": "revised",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-05-10T10:00:00Z",
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1022",
+      "summary": "Multi-cluster model serving with automatic traffic failover",
+      "status": "In Progress",
+      "priority": "High",
+      "created": "2026-05-18T09:30:00Z",
+      "creator": "jpark",
+      "creatorDisplayName": "James Park",
+      "components": ["Platform Core"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "strat-creator-3.5"],
+      "aiInvolvement": "both",
+      "needsAttentionSince": null,
+      "rubricPassSince": "2026-06-01T09:00:00Z",
+      "linkedFeature": null
+    },
+    {
+      "key": "RHAIRFE-1023",
+      "summary": "Integrate compliance audit logging for regulated ML workloads",
+      "status": "In Review",
+      "priority": "High",
+      "created": "2026-06-04T14:00:00Z",
+      "creator": "mgarcia",
+      "creatorDisplayName": "Maria Garcia",
+      "components": ["Platform Core", "Infrastructure Services"],
+      "labels": ["rfe-creator-auto-created", "rfe-creator-autofix-rubric-pass", "rfe-creator-needs-attention"],
+      "aiInvolvement": "created",
+      "needsAttentionSince": "2026-06-09T10:00:00Z",
+      "rubricPassSince": "2026-06-08T09:00:00Z",
       "linkedFeature": null
     }
   ]

--- a/modules/ai-impact/__tests__/client/useForYou.test.js
+++ b/modules/ai-impact/__tests__/client/useForYou.test.js
@@ -1,5 +1,33 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { ref } from 'vue'
+
+vi.mock('@shared/client/composables/useAuth.js', () => ({
+  useAuth: () => ({ user: ref({ email: 'test@redhat.com' }), isManager: ref(false), isAdmin: ref(false) })
+}))
+vi.mock('@shared/client/composables/useRoster.js', () => ({
+  useRoster: () => ({ rosterData: ref(null), loading: ref(false), loadRoster: vi.fn() })
+}))
+vi.mock('@shared/client/composables/useFieldDefinitions.js', () => ({
+  useFieldDefinitions: () => ({ definitions: ref(null), fetchDefinitions: vi.fn() })
+}))
+vi.mock('../../client/composables/useAIImpact.js', () => ({
+  useAIImpact: () => ({ rfeData: ref(null), loading: ref(false) })
+}))
+vi.mock('../../client/composables/useFeatures.js', () => ({
+  useFeatures: () => ({ features: ref({}), featureLoading: ref(false), loadFeatures: vi.fn() })
+}))
+vi.mock('../../client/composables/useAssessments.js', () => ({
+  useAssessments: () => ({ assessments: ref({}), assessmentLoading: ref(false), loadAssessments: vi.fn() })
+}))
+vi.mock('../../client/composables/useForYouPreferences.js', () => ({
+  useForYouPreferences: () => ({
+    mode: ref('auto'), manualComponents: ref([]), wizardSeen: ref(true),
+    activeTab: ref('actions'), setMode: vi.fn(), setManualComponents: vi.fn(),
+    markWizardSeen: vi.fn(), setActiveTab: vi.fn(), resetPreferences: vi.fn()
+  }),
+  sanitizeComponents: (c) => c
+}))
+
 import {
   classifyRfe,
   classifyFeature,
@@ -103,15 +131,23 @@ describe('classifyFeature', () => {
 })
 
 describe('computeWaitDays', () => {
-  it('computes days from assessedAt for RFE needs-revision state', () => {
+  it('uses needsAttentionSince for RFE needs-revision state', () => {
     const now = Date.now()
     const fiveDaysAgo = new Date(now - 5 * 86400000).toISOString()
-    const item = { assessedAt: fiveDaysAgo, created: '2020-01-01T00:00:00Z' }
+    const item = { needsAttentionSince: fiveDaysAgo, created: '2020-01-01T00:00:00Z' }
     const state = { id: 'needs-revision' }
     expect(computeWaitDays(item, state, 'rfe')).toBe(5)
   })
 
-  it('falls back to created for RFE needs-revision when no assessedAt', () => {
+  it('uses needsAttentionSince for RFE passed-with-caveats state', () => {
+    const now = Date.now()
+    const eightDaysAgo = new Date(now - 8 * 86400000).toISOString()
+    const item = { needsAttentionSince: eightDaysAgo, created: '2020-01-01T00:00:00Z' }
+    const state = { id: 'passed-with-caveats' }
+    expect(computeWaitDays(item, state, 'rfe')).toBe(8)
+  })
+
+  it('falls back to created for RFE needs-revision when no needsAttentionSince', () => {
     const now = Date.now()
     const tenDaysAgo = new Date(now - 10 * 86400000).toISOString()
     const item = { created: tenDaysAgo }
@@ -119,12 +155,45 @@ describe('computeWaitDays', () => {
     expect(computeWaitDays(item, state, 'rfe')).toBe(10)
   })
 
-  it('uses created for RFE queued-for-pipeline state', () => {
+  it('assessedAt alone does not drive waitDays for needs-revision', () => {
+    const now = Date.now()
+    const twoDaysAgo = new Date(now - 2 * 86400000).toISOString()
+    const thirtyDaysAgo = new Date(now - 30 * 86400000).toISOString()
+    const item = { assessedAt: twoDaysAgo, needsAttentionSince: thirtyDaysAgo, created: '2020-01-01T00:00:00Z' }
+    const state = { id: 'needs-revision' }
+    expect(computeWaitDays(item, state, 'rfe')).toBe(30)
+  })
+
+  it('uses rubricPassSince for RFE ready-to-advance state', () => {
     const now = Date.now()
     const threeDaysAgo = new Date(now - 3 * 86400000).toISOString()
-    const item = { created: threeDaysAgo, assessedAt: '2020-01-01T00:00:00Z' }
+    const item = { rubricPassSince: threeDaysAgo, created: '2020-01-01T00:00:00Z' }
+    const state = { id: 'ready-to-advance' }
+    expect(computeWaitDays(item, state, 'rfe')).toBe(3)
+  })
+
+  it('uses rubricPassSince for RFE queued-for-pipeline state', () => {
+    const now = Date.now()
+    const threeDaysAgo = new Date(now - 3 * 86400000).toISOString()
+    const item = { rubricPassSince: threeDaysAgo, created: '2020-01-01T00:00:00Z' }
     const state = { id: 'queued-for-pipeline' }
     expect(computeWaitDays(item, state, 'rfe')).toBe(3)
+  })
+
+  it('falls back to created for RFE queued-for-pipeline when no rubricPassSince', () => {
+    const now = Date.now()
+    const threeDaysAgo = new Date(now - 3 * 86400000).toISOString()
+    const item = { created: threeDaysAgo }
+    const state = { id: 'queued-for-pipeline' }
+    expect(computeWaitDays(item, state, 'rfe')).toBe(3)
+  })
+
+  it('uses created for RFE not-assessed state', () => {
+    const now = Date.now()
+    const sixDaysAgo = new Date(now - 6 * 86400000).toISOString()
+    const item = { created: sixDaysAgo }
+    const state = { id: 'not-assessed' }
+    expect(computeWaitDays(item, state, 'rfe')).toBe(6)
   })
 
   it('uses reviewedAt for features', () => {

--- a/modules/ai-impact/client/composables/useForYou.js
+++ b/modules/ai-impact/client/composables/useForYou.js
@@ -57,8 +57,10 @@ function classifyFeature(feature) {
 function computeWaitDays(item, state, type) {
   let dateStr
   if (type === 'rfe') {
-    if (['needs-revision', 'passed-with-caveats', 'ready-to-advance'].includes(state.id)) {
-      dateStr = item.assessedAt || item.created
+    if (state.id === 'needs-revision' || state.id === 'passed-with-caveats') {
+      dateStr = item.needsAttentionSince || item.created
+    } else if (state.id === 'ready-to-advance' || state.id === 'queued-for-pipeline') {
+      dateStr = item.rubricPassSince || item.created
     } else {
       dateStr = item.created
     }
@@ -180,11 +182,7 @@ export function useForYou(rosterDataArg, userArg, rfeDataArg, featuresArg, asses
       const state = classifyRfe(rfe)
       if (!state) continue
       const assessment = assessments.value?.[rfe.key]
-      const waitDays = computeWaitDays(
-        { ...rfe, assessedAt: assessment?.assessedAt },
-        state,
-        'rfe'
-      )
+      const waitDays = computeWaitDays(rfe, state, 'rfe')
       items.push({
         type: 'rfe',
         key: rfe.key,

--- a/modules/ai-impact/server/jira/rfe-fetcher.js
+++ b/modules/ai-impact/server/jira/rfe-fetcher.js
@@ -20,6 +20,9 @@ function extractLabelDate(changelog, targetLabel) {
   return latestDate;
 }
 
+const NEEDS_ATTENTION_LABEL = 'rfe-creator-needs-attention';
+const RUBRIC_PASS_LABEL = 'rfe-creator-autofix-rubric-pass';
+
 function processIssue(issue, config) {
   const {
     createdLabel,
@@ -45,6 +48,15 @@ function processIssue(issue, config) {
       || issue.fields.created;
   }
 
+  // Record when state-signaling labels were first applied so the frontend can
+  // show true "stuck since" ages rather than the pipeline's last-run timestamp.
+  const needsAttentionSince = labels.includes(NEEDS_ATTENTION_LABEL)
+    ? (extractLabelDate(issue.changelog, NEEDS_ATTENTION_LABEL) || issue.fields.created)
+    : null;
+  const rubricPassSince = labels.includes(RUBRIC_PASS_LABEL)
+    ? (extractLabelDate(issue.changelog, RUBRIC_PASS_LABEL) || issue.fields.created)
+    : null;
+
   return {
     key: issue.key,
     summary: issue.fields.summary,
@@ -58,6 +70,8 @@ function processIssue(issue, config) {
     aiInvolvement,
     createdLabelDate,
     revisedLabelDate,
+    needsAttentionSince,
+    rubricPassSince,
     linkedFeature: null,
     _rawIssueLinks: issue.fields.issuelinks || []
   };


### PR DESCRIPTION
computeWaitDays previously used assessedAt (the pipeline's last-run timestamp) as the reference date for actionable RFE states. In production the pipeline stamps all items with the same timestamp on each run, making every card show the same age.

- rfe-fetcher.js: extract needsAttentionSince and rubricPassSince from Jira changelog using the existing extractLabelDate helper
- useForYou.js: use needsAttentionSince for needs-revision/caveats states and rubricPassSince for ready-to-advance/queued states
- Update unit tests to cover new label-date behaviour
- Add new fields to rfe-data.json fixture with varied dates
- Document new fields in DATA-FORMATS.md