### PR TITLE
feat(releases): add Priority column to PM Hub release load table

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -111,6 +111,7 @@ function buildComponentGroups(groups) {
             colorStatus: feat.colorStatus,
             statusSummary: feat.statusSummary,
             releaseType: feat.releaseType,
+            priority: feat.priority,
             isBlocked: feat.isBlocked,
             components: feat.components,
             fixVersions: feat.fixVersions || [],
@@ -174,6 +175,7 @@ function makeFeature(overrides) {
     colorStatus: 'Green',
     statusSummary: '<p>On track</p>',
     releaseType: 'Feature',
+    priority: 'Major',
     isBlocked: false,
     components: ['Dashboard'],
     fixVersions: ['rhoai-3.5'],
@@ -521,6 +523,30 @@ describe('buildComponentGroups', function () {
     var result = buildComponentGroups(groups)
     expect(result[0].features[0].fixVersions).toEqual([])
     expect(result[0].features[0].targetVersions).toEqual([])
+  })
+
+  it('preserves priority on features', function () {
+    var feat = makeFeature({ key: 'X-1', priority: 'Critical' })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].priority).toBe('Critical')
+  })
+
+  it('preserves null priority on features', function () {
+    var feat = makeFeature({ key: 'X-1', priority: null })
+    var groups = [makeGroup('rhoai-3.5', 'Dash', [feat])]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].priority).toBeNull()
+  })
+
+  it('preserves priority through deduplication', function () {
+    var feat = makeFeature({ key: 'X-1', priority: 'Blocker' })
+    var groups = [
+      makeGroup('rhoai-3.5', 'Dash', [feat]),
+      makeGroup('rhelai-3.5', 'Dash', [feat])
+    ]
+    var result = buildComponentGroups(groups)
+    expect(result[0].features[0].priority).toBe('Blocker')
   })
 
   it('handles features with multiple fixVersions', function () {

--- a/modules/releases/__tests__/server/execution/feature-tracking.test.js
+++ b/modules/releases/__tests__/server/execution/feature-tracking.test.js
@@ -127,6 +127,45 @@ describe('transformIssue — isBlocked', function () {
   })
 })
 
+// ─── priority derivation ──────────────────────────────────────────
+
+describe('transformIssue — priority', function () {
+  it('extracts priority name from priority field', function () {
+    var result = transformIssue(makeRawIssue({ priority: { name: 'Major' } }), {})
+    expect(result.priority).toBe('Major')
+  })
+
+  it('returns null when priority field is not set', function () {
+    var result = transformIssue(makeRawIssue(), {})
+    expect(result.priority).toBeNull()
+  })
+
+  it('returns null when priority field is null', function () {
+    var result = transformIssue(makeRawIssue({ priority: null }), {})
+    expect(result.priority).toBeNull()
+  })
+
+  it('extracts Blocker priority', function () {
+    var result = transformIssue(makeRawIssue({ priority: { name: 'Blocker' } }), {})
+    expect(result.priority).toBe('Blocker')
+  })
+
+  it('extracts Critical priority', function () {
+    var result = transformIssue(makeRawIssue({ priority: { name: 'Critical' } }), {})
+    expect(result.priority).toBe('Critical')
+  })
+
+  it('extracts Minor priority', function () {
+    var result = transformIssue(makeRawIssue({ priority: { name: 'Minor' } }), {})
+    expect(result.priority).toBe('Minor')
+  })
+
+  it('extracts Trivial priority', function () {
+    var result = transformIssue(makeRawIssue({ priority: { name: 'Trivial' } }), {})
+    expect(result.priority).toBe('Trivial')
+  })
+})
+
 // ─── pmOwner derivation ────────────────────────────────────────────
 
 describe('transformIssue — pmOwner', function () {

--- a/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
+++ b/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
@@ -15,6 +15,7 @@ describe('buildFeatureObj', function () {
     colorStatus: 'Green',
     statusSummary: '<p>On track</p>',
     releaseType: 'Feature',
+    priority: 'Major',
     isBlocked: false,
     components: ['Inference', 'Serving'],
     fixVersions: ['rhoai-3.5', 'rhoai-3.6'],
@@ -31,6 +32,7 @@ describe('buildFeatureObj', function () {
     expect(result.colorStatus).toBe('Green')
     expect(result.statusSummary).toBe('<p>On track</p>')
     expect(result.releaseType).toBe('Feature')
+    expect(result.priority).toBe('Major')
     expect(result.isBlocked).toBe(false)
     expect(result.components).toEqual(['Inference', 'Serving'])
     expect(result.fixVersions).toEqual(['rhoai-3.5', 'rhoai-3.6'])
@@ -48,6 +50,7 @@ describe('buildFeatureObj', function () {
     expect(result.colorStatus).toBeNull()
     expect(result.statusSummary).toBeNull()
     expect(result.releaseType).toBeNull()
+    expect(result.priority).toBeNull()
     expect(result.isBlocked).toBe(false)
     expect(result.components).toEqual([])
     expect(result.fixVersions).toEqual([])
@@ -83,6 +86,18 @@ describe('buildFeatureObj', function () {
     var input = Object.assign({}, fullInput, { isBlocked: true })
     var result = buildFeatureObj(input, [])
     expect(result.isBlocked).toBe(true)
+  })
+
+  it('passes through priority from input', function () {
+    var input = Object.assign({}, fullInput, { priority: 'Critical' })
+    var result = buildFeatureObj(input, [])
+    expect(result.priority).toBe('Critical')
+  })
+
+  it('defaults priority to null when missing', function () {
+    var input = { key: 'X-3' }
+    var result = buildFeatureObj(input, [])
+    expect(result.priority).toBeNull()
   })
 
   it('does not include extra fields from the input', function () {

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -211,7 +211,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="12" class="px-4 py-3">
+            <td colspan="11" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -270,7 +270,6 @@ defineExpose({ expandAll, collapseAll })
           >
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Version</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Status</th>
@@ -299,16 +298,6 @@ defineExpose({ expandAll, collapseAll })
               </td>
               <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
                 {{ feature.summary }}
-              </td>
-              <td class="px-3 py-2.5 text-center">
-                <div v-if="feature.versions && feature.versions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
-                  <span
-                    v-for="ver in feature.versions"
-                    :key="ver"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-gray-100 dark:bg-gray-700/60 text-gray-700 dark:text-gray-300"
-                  >{{ ver }}</span>
-                </div>
-                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
                 <div class="flex items-center justify-center gap-1">
@@ -390,7 +379,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="11" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -398,7 +387,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="11" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -125,6 +125,7 @@ var componentGroups = computed(function() {
             colorStatus: feat.colorStatus,
             statusSummary: feat.statusSummary,
             releaseType: feat.releaseType,
+            priority: feat.priority,
             isBlocked: feat.isBlocked,
             components: feat.components,
             fixVersions: feat.fixVersions || [],
@@ -211,7 +212,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="11" class="px-4 py-3">
+            <td colspan="12" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -270,6 +271,7 @@ defineExpose({ expandAll, collapseAll })
           >
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Feature</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Priority</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Status</th>
@@ -298,6 +300,19 @@ defineExpose({ expandAll, collapseAll })
               </td>
               <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
                 {{ feature.summary }}
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
+                  v-if="feature.priority"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                  :class="{
+                    'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300': feature.priority === 'Blocker' || feature.priority === 'Critical',
+                    'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300': feature.priority === 'Major',
+                    'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300': feature.priority === 'Normal',
+                    'bg-gray-100 dark:bg-gray-700/60 text-gray-600 dark:text-gray-400': feature.priority === 'Minor' || feature.priority === 'Trivial'
+                  }"
+                >{{ feature.priority }}</span>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
                 <div class="flex items-center justify-center gap-1">
@@ -379,7 +394,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="11" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -387,7 +402,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="11" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -211,7 +211,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="10" class="px-4 py-3">
+            <td colspan="12" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -275,6 +275,8 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Release Type</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Status</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Color Status</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Fix Version</th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Target Version</th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16">Blocked</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Delivery Owner</th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">PM Owner</th>
@@ -344,6 +346,26 @@ defineExpose({ expandAll, collapseAll })
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
+                <div v-if="feature.fixVersions && feature.fixVersions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
+                  <span
+                    v-for="fv in feature.fixVersions"
+                    :key="fv"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
+                  >{{ fv }}</span>
+                </div>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
+                <div v-if="feature.targetVersions && feature.targetVersions.length > 0" class="flex items-center justify-center gap-1 flex-wrap">
+                  <span
+                    v-for="tv in feature.targetVersions"
+                    :key="tv"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300"
+                  >{{ tv }}</span>
+                </div>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
+              </td>
+              <td class="px-3 py-2.5 text-center">
                 <span
                   v-if="feature.isBlocked"
                   class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
@@ -368,7 +390,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="10" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -376,7 +398,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="10" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/server/hygiene/jira-fetch.js
+++ b/modules/releases/server/hygiene/jira-fetch.js
@@ -260,6 +260,9 @@ function transformIssue(rawIssue, rfeMap) {
     }
   }
 
+  // Priority
+  const priority = fields.priority ? fields.priority.name : null
+
   // PM Owner from Product Manager custom field
   const pmOwnerField = fields[CUSTOM_FIELDS.productManager]
   const pmOwner = pmOwnerField ? (pmOwnerField.displayName || null) : null
@@ -286,6 +289,7 @@ function transformIssue(rawIssue, rfeMap) {
     targetEnd: fields[CUSTOM_FIELDS.targetEnd] || null,
     riceStatus: computeRiceStatus(fields),
     riceScore: fields[CUSTOM_FIELDS.riceScore] || null,
+    priority,
     isBlocked,
     pmOwner,
     linkedRfeKey,

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -368,7 +368,7 @@ function formatAvg(value) {
 
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [
-  'summary', 'status', 'issuetype', 'assignee', 'fixVersions', 'versions',
+  'summary', 'status', 'issuetype', 'assignee', 'priority', 'fixVersions', 'versions',
   'components', 'labels', 'issuelinks',
   CUSTOM_FIELDS.team,
   CUSTOM_FIELDS.releaseType,
@@ -386,6 +386,7 @@ function buildFeatureObj(f, targetVersions) {
     colorStatus: f.colorStatus || null,
     statusSummary: f.statusSummary || null,
     releaseType: f.releaseType || null,
+    priority: f.priority || null,
     isBlocked: f.isBlocked || false,
     components: f.components || [],
     fixVersions: f.fixVersions || [],


### PR DESCRIPTION
## Summary
- Adds Priority column to the PM Hub component release load table
- Fetches `priority` field from Jira, extracts via `transformIssue`, passes through `buildFeatureObj`
- Color-coded badges: red (Blocker/Critical), orange (Major), yellow (Normal), gray (Minor/Trivial)

## Test plan
- [ ] Open PM Hub → Component Release Load
- [ ] Verify Priority column appears between Title and Version
- [ ] Confirm color coding matches priority level

🤖 Generated with [Claude Code](https://claude.com/claude-code)