### PR TITLE
feat(releases): granular Big Rocks permissions with planning-manager role

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1297,7 +1297,7 @@ JSON Lines format (one JSON object per line). Partitioned by month for efficient
       "views": 342,
       "uniqueUsers": 28,
       "byUserType": { "Backend": 12, "Frontend": 8, "unknown": 3 },
-      "byRole": { "admin": 3, "team-admin": 2, "release-manager": 5 },
+      "byRole": { "admin": 3, "team-admin": 2, "planning-manager": 5 },
       "byPermissionTier": { "admin": 3, "manager": 10, "user": 15 }
     }
   }

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -80,7 +80,7 @@ modules/your-module/
 | `icon` | string | Yes | Lucide icon name |
 | `default` | boolean | No | If `true`, this is the module's landing view |
 | `disabled` | boolean | No | If `true`, item is visible but non-clickable (greyed out) |
-| `requireRole` | string | No | Only show item to users with this role (e.g., `"manager"`, `"team-admin"`, `"release-manager"`) |
+| `requireRole` | string | No | Only show item to users with this role (e.g., `"manager"`, `"team-admin"`, `"planning-manager"`) |
 | `requireCondition` | string | No | Only show when condition is met (e.g., `"in-app-mode"` — hides when roster is sheet-based) |
 | `separatorBefore` | boolean | No | Render a visual separator line above this item |
 
@@ -213,7 +213,7 @@ The authoritative typedef for the context object is in `shared/server/module-con
 | `requireRole(role)` | function | Returns middleware requiring a specific role (admins always pass) |
 | `requireScope(name)` | function | Returns middleware for API token scope check |
 | `roleStore` | object | Role store instance |
-| `registerRole(id, config)` | function | Register a module-specific role (e.g., `release-manager`) |
+| `registerRole(id, config)` | function | Register a module-specific role (e.g., `planning-manager`) |
 | `registerScopes(configs)` | function | Register module-specific API token scopes |
 | `registerDiagnostics(fn)` | function | Register diagnostics hook (see below) |
 | `registerMessageProvider(id, fn)` | function | Register message provider (see below) |

--- a/docs/plans/big-rocks-add-permission.md
+++ b/docs/plans/big-rocks-add-permission.md
@@ -1,0 +1,973 @@
+# Big Rocks Access Control: Granular Permissions with Planning Manager Role
+
+**Status:** Final Draft
+**Author:** Architect Agent
+**Date:** 2026-06-15
+**Module:** releases (planning sub-module)
+
+---
+
+## 1. Problem Statement
+
+The Outcomes Dashboard (Big Rocks) currently uses a single `canEdit` flag that
+grants all-or-nothing access to every write operation: add, delete, reorder, and
+edit fields. Following the recent decision to open editing to all authenticated
+users (outcomes-dashboard-access.md), the `canEdit` flag is hardcoded to `true`
+for everyone.
+
+This is too permissive for structural operations. Adding a new Big Rock,
+deleting one, or reordering the priority list are high-impact actions that change
+the shape of the planning data. Editing fields on an existing rock (name,
+pillar, outcomes, notes, owners, etc.) is low-impact collaborative work.
+
+**Goal:** Split the single `canEdit` flag into granular permissions so that:
+
+- **Any authenticated user** can edit all fields on existing Big Rocks.
+- **Only users with the `planning-manager` role (or admins)** can add, delete,
+  or reorder Big Rocks.
+
+This requires renaming the existing `release-manager` role to `planning-manager`
+to better reflect its purpose, and updating all references throughout the
+codebase.
+
+---
+
+## 2. Requirements Summary
+
+| Requirement | Detail |
+|---|---|
+| Role rename | `release-manager` -> `planning-manager` across registration, middleware, auth flags, frontend checks, tests, docs |
+| Granular permissions | Replace single `canEdit` with `canEdit`, `canAdd`, `canDelete`, `canReorder` |
+| Edit scope | All fields on existing Big Rocks editable by any authenticated user (no field-level restrictions) |
+| Privileged actions | Add, delete, reorder gated to `planning-manager` role + admins |
+| Server enforcement | API returns 403 on POST (create), DELETE, and PUT (reorder) for non-privileged users |
+| Frontend enforcement | Hide/disable "Add Big Rock" button, delete buttons, and drag handles for non-privileged users |
+| Backward compatibility | Existing `release-manager` assignments in `roles.json` migrated to `planning-manager` on startup |
+| Settings UI | Role appears as "Planning Manager" in the Users tab (automatic via role registry) |
+| Doc import gating | `replace` mode on `POST /import/doc` restricted to `planning-manager` (structural operation) |
+
+---
+
+## 3. Current Architecture
+
+### 3.1 Role Registration
+
+In `modules/releases/server/index.js` (line 132):
+
+```javascript
+context.registerRole('release-manager', {
+  label: 'Release Manager',
+  description: 'Manage release planning, execution, and delivery'
+});
+```
+
+This produces `requireReleaseManager = requireRole('release-manager')` (line 116),
+which is passed to sub-routers: registry, planning, execution (feature-tracking),
+hygiene.
+
+### 3.2 Auth Middleware Flags
+
+In `shared/server/auth.js` (lines 109, 143):
+
+```javascript
+req.isReleaseManager = req.userRoles.includes('release-manager');
+```
+
+Set during both normal auth and impersonation flows.
+
+### 3.3 Permissions Endpoint
+
+In `modules/releases/server/planning/routes.js` (lines 575-579):
+
+```javascript
+router.get('/permissions', requireAuth, requireScope('releases:read'), function(req, res) {
+  res.json({
+    canEdit: true
+  })
+})
+```
+
+Hardcoded -- no role logic.
+
+### 3.4 Frontend Flow
+
+1. `useReleasePlanning()` composable fetches `/api/modules/releases/planning/permissions`
+2. `DashboardView.vue` computes `canEdit = !demoMode && permissions.canEdit`
+3. `BigRocksTable.vue` receives `canEdit` prop, which controls:
+   - "Add Big Rock" button (line 176)
+   - Drag handles and reorder hint (lines 135, 193)
+   - Edit/delete action buttons column (lines 203, 227-248)
+   - `draggable="true"` attribute on `<tr>` elements (line 209)
+   - Entire editable vs read-only table body toggle (lines 206 vs 261)
+
+### 3.5 Write Endpoints (No Role Check)
+
+All currently use `requireAuth` + `requireScope('releases:write')` but no role
+check:
+
+| Endpoint | Line | Purpose |
+|---|---|---|
+| `PUT /releases/:version/big-rocks/reorder` | 635 | Reorder |
+| `PUT /releases/:version/big-rocks/:name` | 685 | Update existing |
+| `POST /releases/:version/big-rocks` | 761 | Create new |
+| `DELETE /releases/:version/big-rocks/:name` | 838 | Delete |
+| `POST /releases/:version/import/doc` | 1120 | Doc import (replace mode wipes all rocks) |
+
+### 3.6 Full Inventory of `release-manager` References
+
+**Server-side (runtime):**
+
+| File | Usage |
+|---|---|
+| `modules/releases/server/index.js:116` | `requireReleaseManager = requireRole('release-manager')` |
+| `modules/releases/server/index.js:132` | `context.registerRole('release-manager', ...)` |
+| `modules/releases/server/planning/routes.js:59,68-69,73` | PM user auto-migration to `release-manager` |
+| `modules/releases/server/registry.js:305,344,372,445,499,566,600,633,698` | All registry routes use `requireReleaseManager` |
+| `modules/releases/server/hygiene/routes.js:125,334,464,505,530` | Hygiene config/refresh routes use `requireReleaseManager` |
+| `modules/releases/module.json:11` | `"requireRole": "release-manager"` on Manage nav item |
+| `shared/server/auth.js:109,143` | Sets `req.isReleaseManager` flag |
+| `shared/server/role-registry.js:13` | JSDoc example uses `'release-manager'` |
+
+**Client-side:**
+
+| File | Usage |
+|---|---|
+| `modules/releases/client/views/RegistryView.vue:6,575` | Access check + error message |
+| `modules/releases/client/execute/views/HygieneView.vue:201,206,231,493` | `isReleaseManager` ref + prop |
+| `modules/releases/client/execute/components/hygiene/HygieneWelcomeModal.vue:11,127,175` | `isReleaseManager` prop + template uses |
+| `src/components/UserManagement.vue:213` | Badge color for `release-manager` |
+
+**Tests:**
+
+| File | Usage |
+|---|---|
+| `modules/releases/__tests__/server/rbac.test.js` | 19+ references -- role registration, assignment, revocation, middleware tests |
+| `modules/releases/__tests__/server/planning/routes.test.js:610,622,635` | Open access tests reference "non-release-manager" |
+| `modules/releases/__tests__/server/planning/health-routes.test.js:912,925` | Health route access tests |
+| `modules/releases/__tests__/server/planning/invalidate-cache.test.js:131,273` | `requireReleaseManager` mock references in context setup |
+| `tests/integration/tv-fv-delta.spec.js:123,128` | Nav item `requireRole` assertions (see note in Section 4.7) |
+| `shared/server/__tests__/module-context.test.js:100-101` | Module context role registration test |
+
+**Documentation:**
+
+| File | Usage |
+|---|---|
+| `docs/DATA-FORMATS.md:1300` | Example in byRole statistics |
+| `docs/MODULES.md:83,216` | Role documentation examples |
+| `docs/plans/outcomes-dashboard-access.md` | 21+ references throughout plan |
+
+---
+
+## 4. Architectural Approach
+
+### 4.1 Role Rename: `release-manager` -> `planning-manager`
+
+The `release-manager` role was originally conceived to gate the release registry
+and planning workflows. Renaming to `planning-manager` better reflects its
+actual purpose -- controlling who can make structural changes to planning data
+(Big Rocks, registry entries, hygiene config). The role continues to gate the
+same set of privileged operations; only the identifier changes.
+
+**Registration (new):**
+
+```javascript
+context.registerRole('planning-manager', {
+  label: 'Planning Manager',
+  description: 'Manage release planning, registry, and delivery configuration'
+});
+```
+
+**Auth flag (new):**
+
+```javascript
+req.isPlanningManager = req.userRoles.includes('planning-manager');
+```
+
+### 4.2 Startup Migration: `release-manager` -> `planning-manager`
+
+On module startup, before any routes are registered, scan `roles.json` for users
+with the `release-manager` role and migrate them to `planning-manager`. This is
+a one-time migration that runs idempotently -- if no `release-manager`
+assignments exist, it is a no-op.
+
+**Important:** The migration must NOT use `roleStore.revokeRole()` /
+`roleStore.assignRole()` because those methods validate against the role
+registry. Since `release-manager` is no longer registered (only
+`planning-manager` is), calling `revokeRole(email, 'release-manager')` would
+throw `Invalid role: "release-manager"`. Instead, manipulate the raw
+`roles.json` data directly via `readFromStorage` / `writeToStorage`, following
+the same pattern as the existing `migrateEmailDomains()` in `role-store.js`.
+
+```javascript
+// In modules/releases/server/index.js, after role registration
+const rolesData = storage.readFromStorage('roles.json');
+if (rolesData && rolesData.assignments) {
+  let migrated = 0;
+  for (const [email, entry] of Object.entries(rolesData.assignments)) {
+    if (entry.roles && entry.roles.includes('release-manager')) {
+      migrated++;
+    }
+  }
+  if (migrated > 0) {
+    // Backup before overwriting, following migrateEmailDomains() pattern
+    const backupKey = `roles-backup-premigration.json`;
+    storage.writeToStorage(backupKey, JSON.parse(JSON.stringify(rolesData)));
+    console.log(`[releases] Backup saved to ${backupKey}`);
+
+    for (const [email, entry] of Object.entries(rolesData.assignments)) {
+      if (entry.roles && entry.roles.includes('release-manager')) {
+        entry.roles = entry.roles.filter(r => r !== 'release-manager');
+        if (!entry.roles.includes('planning-manager')) {
+          entry.roles.push('planning-manager');
+        }
+      }
+    }
+    storage.writeToStorage('roles.json', rolesData);
+    console.log(`[releases] Migrated ${migrated} user(s) from release-manager to planning-manager`);
+  }
+}
+```
+
+This approach:
+- **Creates a backup (`roles-backup-premigration.json`) before overwriting**,
+  following the same pattern as `migrateEmailDomains()` in `role-store.js`
+  (line 219). This mitigates data loss from a concurrent write or unexpected
+  failure during migration.
+- Reads the raw JSON, iterates assignments, replaces `'release-manager'` with
+  `'planning-manager'` in each user's roles array, writes back.
+- Avoids any role registry validation -- operates on raw data only.
+- Is idempotent -- if no `release-manager` entries exist, the write is skipped.
+  On subsequent restarts, the backup write is also skipped (no-op).
+- Handles the edge case where a user already has both roles (just removes
+  `release-manager`, avoids duplicating `planning-manager`).
+- Does not create audit log entries for the migration (consistent with
+  `migrateEmailDomains()` which also operates below the audit layer).
+
+The existing PM user auto-migration (lines 58-82 in planning/routes.js) also
+needs updating to assign `planning-manager` instead of `release-manager`.
+
+### 4.3 Granular Permissions Endpoint
+
+The `/permissions` endpoint will return four flags instead of one:
+
+```javascript
+router.get('/permissions', requireAuth, requireScope('releases:read'), function(req, res) {
+  const isPlanningManager = req.isAdmin || req.isPlanningManager;
+  res.json({
+    canEdit: true,              // All authenticated users can edit existing rocks
+    canAdd: isPlanningManager,  // Only planning-managers can add
+    canDelete: isPlanningManager, // Only planning-managers can delete
+    canReorder: isPlanningManager // Only planning-managers can reorder
+  })
+})
+```
+
+### 4.4 Server-Side Enforcement
+
+Add `requirePlanningManager` middleware to the privileged endpoints. The edit
+(PUT) endpoint remains open to all authenticated users. The doc import endpoint
+gets conditional gating for `replace` mode (see Section 4.6).
+
+| Endpoint | Current Middleware | New Middleware |
+|---|---|---|
+| `POST /:version/big-rocks` | `requireAuth, requireScope` | `requireAuth, requirePlanningManager, requireScope` |
+| `DELETE /:version/big-rocks/:name` | `requireAuth, blockDuringImpersonation, requireScope` | `requireAuth, requirePlanningManager, blockDuringImpersonation, requireScope` |
+| `PUT /:version/big-rocks/reorder` | `requireAuth, requireScope` | `requireAuth, requirePlanningManager, requireScope` |
+| `PUT /:version/big-rocks/:name` | `requireAuth, requireScope` | No change (stays open) |
+| `POST /:version/import/doc` | `requireAuth, blockDuringImpersonation, requireScope` | See Section 4.6 |
+
+Note: `requirePlanningManager` already handles admin bypass internally
+(admins always pass role checks), so no additional admin logic is needed.
+
+**How `requirePlanningManager` reaches planning routes:** Currently
+`planning/routes.js` (line 51) destructures `{ storage, requireAuth,
+requireAdmin, requireScope }` from its context object. It receives
+`requireReleaseManager` in its context (passed at `index.js` line 163) but does
+not destructure or use it. To add role enforcement to planning routes:
+
+1. In `modules/releases/server/index.js`, rename `requireReleaseManager` to
+   `requirePlanningManager` in the planning sub-router context object (line 163):
+   ```javascript
+   registerPlanningRoutes(planningRouter, {
+     storage,
+     requireAuth,
+     requireAdmin,
+     requirePlanningManager,  // <-- renamed from requireReleaseManager
+     requireScope,
+     roleStore,
+     // ...rest
+   });
+   ```
+
+2. In `modules/releases/server/planning/routes.js`, update the destructuring
+   (line 51) to include it:
+   ```javascript
+   const { storage, requireAuth, requireAdmin, requirePlanningManager, requireScope } = context
+   ```
+
+This middleware is then used directly in route definitions (e.g.,
+`router.post('/releases/:version/big-rocks', requireAuth, requirePlanningManager, requireScope('releases:write'), ...)`).
+
+### 4.5 Frontend Changes
+
+#### 4.5.1 Composable (`useReleasePlanning.js`)
+
+The `loadPermissions()` function already fetches and stores the permissions
+response verbatim. No changes needed here -- the composable will automatically
+expose the new granular flags through the existing `permissions` ref.
+
+Update the fallback default to include all four flags:
+
+```javascript
+permissions.value = { canEdit: false, canAdd: false, canDelete: false, canReorder: false }
+```
+
+#### 4.5.2 DashboardView.vue
+
+Replace the single `canEdit` computed with granular computeds:
+
+```javascript
+const canEdit = computed(() => !demoMode.value && permissions.value?.canEdit)
+const canAdd = computed(() => !demoMode.value && permissions.value?.canAdd)
+const canDelete = computed(() => !demoMode.value && permissions.value?.canDelete)
+const canReorder = computed(() => !demoMode.value && permissions.value?.canReorder)
+```
+
+Pass granular props to `BigRocksTable`:
+
+```html
+<BigRocksTable
+  :canEdit="canEdit"
+  :canAdd="canAdd"
+  :canDelete="canDelete"
+  :canReorder="canReorder"
+  ...
+/>
+```
+
+The "New Release" and "Load Fixture Data" buttons (lines 448, 455) should remain
+gated on `canEdit` since they are about editing the release configuration, which
+remains open to all.
+
+**ReleaseSelector:** The `ReleaseSelector` component is unaffected by this
+change. It receives `canEdit` from `DashboardView` (line 320), which stays
+`true` for all authenticated users. No changes needed.
+
+#### 4.5.3 BigRocksTable.vue
+
+Add new props:
+
+```javascript
+const props = defineProps({
+  bigRocks: { type: Array, default: () => [] },
+  canEdit: { type: Boolean, default: false },
+  canAdd: { type: Boolean, default: false },
+  canDelete: { type: Boolean, default: false },
+  canReorder: { type: Boolean, default: false },
+  // ... existing props
+})
+```
+
+Split the template logic:
+
+| UI Element | Current Gate | New Gate |
+|---|---|---|
+| "Add Big Rock" button | `canEdit` | `canAdd` |
+| "Drag to reorder" hint | `canEdit` | `canReorder` |
+| Drag handle column header | `canEdit` | `canReorder` |
+| Drag handles on rows | `canEdit` | `canReorder` |
+| `draggable` attribute on `<tr>` | `canEdit` (implicit in tbody) | `:draggable="canReorder"` (see below) |
+| Edit button (pencil icon) | `canEdit` (in edit tbody) | `canEdit` |
+| Delete button (trash icon) | `canEdit` (in edit tbody) | `canDelete` |
+| Actions column header | `canEdit` | `canEdit \|\| canDelete` |
+| Editable tbody vs read-only tbody | `canEdit` | `canEdit` (keeps inline edit active) |
+
+**`draggable` attribute must be conditional:** Hiding the drag handle column is
+not sufficient -- the `draggable="true"` attribute on `<tr>` elements (line 209)
+must also be conditionalized on `canReorder`. Otherwise, users can still
+initiate HTML5 drag events by clicking anywhere on the row. Change from
+`draggable="true"` to `:draggable="canReorder"`. When `canReorder` is false,
+this renders `draggable="false"`, which suppresses native drag behavior.
+
+**Key design decision:** The template currently uses two mutually exclusive
+`<tbody>` blocks -- one for edit mode (with drag handles and action buttons)
+and one for read-only mode (no actions). With granular permissions, we need to
+keep the editable tbody active for any user who `canEdit`, but conditionally
+show/hide the drag handles, delete buttons, and add button based on the
+granular flags. The edit button (pencil) stays visible when `canEdit` is true.
+
+The refactored template will use a single tbody when `canEdit` is true, with
+conditional rendering within rows:
+
+- Drag handle cell: `v-if="canReorder"`
+- Delete button: `v-if="canDelete"`
+- Edit button: always shown (when `canEdit`)
+- Actions column header: `v-if="canEdit || canDelete"` (show if either action
+  exists -- the column contains both edit and delete buttons)
+
+**Dynamic colspan for `BigRockExpandedRow`:** The editable tbody currently
+passes `colspan="hasHealth ? 11 : 8"` (includes drag handle + actions columns).
+The read-only tbody passes `colspan="hasHealth ? 9 : 6"` (omits those columns).
+When merging to a single tbody with conditional columns, the colspan for
+`BigRockExpandedRow` becomes dynamic based on which permission columns are
+visible:
+
+```javascript
+const expandedColspan = computed(() => {
+  let base = hasHealth.value ? 9 : 6   // base columns (no drag, no actions)
+  if (props.canReorder) base++          // drag handle column
+  if (props.canEdit || props.canDelete) base++  // actions column
+  return base
+})
+```
+
+This computed is used in the template: `:colspan="expandedColspan"`. The same
+logic applies to the skeleton loading row colspan and the empty-state colspan
+(see below).
+
+**Skeleton loading and empty state must be migrated into the merged tbody.**
+Currently the editable tbody (line 206) has NO skeleton loading rows and NO
+empty state -- it jumps straight into the `v-for` over `localRocks`. The
+read-only tbody (line 261) HAS both: skeleton loading rows (lines 263-275) and
+a "No Big Rocks configured" empty state (lines 304-307). Since `canEdit` is now
+`true` for all authenticated users, the editable tbody will always render -- but
+without skeleton loading or empty state handling, the table shows nothing during
+loading and nothing when empty.
+
+When merging to a single tbody, migrate both from the read-only tbody:
+
+1. **Skeleton loading rows** (currently lines 263-275): Add a
+   `<template v-if="loading">` block at the top of the merged tbody, before the
+   data rows `v-for`. Use `:colspan="expandedColspan"` instead of the hardcoded
+   `hasHealth ? 9 : 6` so the skeleton rows span the correct number of columns
+   (which now varies based on `canReorder` and `canEdit || canDelete`).
+
+2. **Empty state** (currently lines 304-307): Add a `<tr v-else>` after the
+   data rows `<template v-else-if="...">` block. Use
+   `:colspan="expandedColspan"` for the same reason. The "No Big Rocks
+   configured." text and styling are preserved as-is.
+
+3. **Data rows**: The existing `v-for` over `localRocks` becomes
+   `<template v-else-if="localRocks && localRocks.length > 0">` to fit the
+   `v-if` / `v-else-if` / `v-else` chain.
+
+The resulting merged tbody structure:
+
+```html
+<tbody>
+  <!-- Skeleton loading rows -->
+  <template v-if="loading">
+    <tr v-for="n in 3" :key="'skeleton-' + n">
+      <td :colspan="expandedColspan" class="...">
+        <div class="animate-pulse flex items-center gap-4">...</div>
+      </td>
+    </tr>
+  </template>
+  <!-- Data rows -->
+  <template v-else-if="localRocks && localRocks.length > 0">
+    <template v-for="(rock, index) in localRocks" :key="rock.name">
+      <tr :draggable="canReorder" ...>
+        <td v-if="canReorder">...</td>
+        <BigRockRow :canEdit="props.canEdit" ... />
+        <td v-if="canEdit || canDelete">...</td>
+      </tr>
+      <tr v-if="isExpanded(rock.name)" ...>
+        <BigRockExpandedRow :colspan="expandedColspan" ... />
+      </tr>
+    </template>
+  </template>
+  <!-- Empty state -->
+  <tr v-else>
+    <td :colspan="expandedColspan" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
+      No Big Rocks configured.
+    </td>
+  </tr>
+</tbody>
+```
+
+This eliminates the second (read-only) tbody entirely, since all its content is
+now handled by the merged tbody with conditional column rendering.
+
+#### 4.5.4 BigRockRow.vue
+
+Check if `BigRockRow.vue` receives or uses `canEdit`. Based on the template
+(line 226), it receives `:canEdit="true"` as a hardcoded prop. This controls
+inline edit triggers within the row. Since all authenticated users can edit,
+this prop is functionally true whenever the editable tbody renders.
+
+**However**, when merging to a single tbody, the hardcoded `:canEdit="true"`
+(line 226) must change to `:canEdit="props.canEdit"` to properly respect demo
+mode. In demo mode, `canEdit` is `false` (via `DashboardView`), and the
+hardcoded `true` would incorrectly allow inline edit triggers. No other changes
+needed to BigRockRow.
+
+#### 4.5.5 HygieneWelcomeModal.vue
+
+`HygieneWelcomeModal.vue` receives `isReleaseManager` as a prop (line 11) and
+uses it in the template at lines 127 and 175 to show release-manager-specific
+guidance text. When `HygieneView.vue` renames its `isReleaseManager` ref to
+`isPlanningManager`, the prop name passed to `HygieneWelcomeModal` must also
+be updated:
+
+- Rename the prop from `isReleaseManager` to `isPlanningManager` (line 11)
+- Update template references at lines 127 and 175
+- Update the text content from "release manager" to "planning manager" where
+  it appears in user-facing strings
+
+### 4.5.6 Files Examined But Not Modified
+
+The following files were reviewed during analysis and are explicitly out of
+scope for this plan:
+
+| File | Reason Not Modified |
+|---|---|
+| `modules/releases/client/plan/views/HealthDashboardView.vue` (lines 47-50) | Computes its own `canEdit` independently (`true` unless demo mode). This controls health/risk features (passed to `ReleaseSelector`, `FeatureHealthTable`, `FeatureHealthRow`) -- not Big Rock structural operations. The Big Rock permission model does not apply here. |
+| `modules/releases/client/plan/composables/useReleasePlanning.js` (permissions fetch) | Only the fallback default changes (Section 4.5.1). The fetch/store logic is already shape-agnostic and requires no modification. |
+| `modules/releases/client/plan/components/BigRockRow.vue` | Receives `canEdit` prop for inline edit triggers. Since all authenticated users retain `canEdit`, the prop value does not change semantically. However, the hardcoded `:canEdit="true"` in the editable tbody must change to `:canEdit="props.canEdit"` during the template merge (see Section 4.5.3, Minor note). |
+
+### 4.6 Doc Import: Gate `replace` Mode to Planning Manager
+
+The `POST /releases/:version/import/doc` endpoint in `replace` mode wipes all
+existing Big Rocks before importing from a Google Doc. This is the most
+destructive structural operation available -- it replaces the entire planning
+dataset for a release version. Consistent with the plan's goal of restricting
+structural changes to `planning-manager` users, `replace` mode is gated in
+Phase 2.
+
+**Implementation:** Rather than adding `requirePlanningManager` as route-level
+middleware (which would also block `append` mode), add an inline check inside
+the handler:
+
+```javascript
+router.post('/releases/:version/import/doc', requireAuth, blockDuringImpersonation, requireScope('releases:write'), async function(req, res) {
+  const mode = req.body && req.body.mode
+  // Gate replace mode to planning-manager (structural operation)
+  if (mode === 'replace' && !req.isAdmin && !req.isPlanningManager) {
+    return res.status(403).json({ error: 'Replace mode requires planning-manager role' })
+  }
+  // ... rest of handler unchanged
+})
+```
+
+`append` mode remains open to all authenticated users (it adds Big Rocks
+without destroying existing data).
+
+### 4.7 Clarifications
+
+**`feature-tracking-routes.js` does NOT use `requireReleaseManager`.** While
+`index.js` currently passes `requireReleaseManager` in the feature-tracking
+context (line 189), the function signature in `feature-tracking-routes.js`
+(line 503) only destructures `context.storage`, `context.requireAuth`, and
+`context.requireScope`. The middleware is passed but never consumed. In Phase 1,
+clean up `index.js` by removing `requirePlanningManager` from the
+feature-tracking context object (it is dead code). No changes to
+`feature-tracking-routes.js` itself.
+
+**`tv-fv-delta.spec.js` Audit nav item assertion is stale.** Line 128 asserts
+`{ id: 'audit', label: 'Audit', icon: 'History', requireRole: 'release-manager' }`,
+but the actual `module.json` does NOT have `requireRole` on the Audit nav item
+(only the Manage/registry item has it). This is a pre-existing test bug -- the
+assertion passes because the test compares a subset of properties (not strict
+equality), but the `requireRole` key is phantom. Fix this by removing the
+`requireRole: 'release-manager'` from the Audit assertion entirely, rather than
+renaming it. The Manage nav item assertion at line 123 is correct and should be
+renamed to `'planning-manager'`.
+
+**`ReleaseSelector` is unaffected.** The `ReleaseSelector` component receives
+`canEdit` from `DashboardView` (line 320), which stays `true` for all
+authenticated users. No changes needed.
+
+---
+
+## 5. Migration & Backward Compatibility
+
+### 5.1 Role Assignment Migration
+
+**Mechanism:** Direct `roles.json` manipulation via `readFromStorage` /
+`writeToStorage` in `modules/releases/server/index.js`, immediately after role
+registration. Does NOT use `roleStore.assignRole()` / `revokeRole()` (see
+Section 4.2 for rationale).
+
+**Behavior:**
+1. After registering `planning-manager`, read raw `roles.json` via
+   `storage.readFromStorage('roles.json')`
+2. Scan for users with `release-manager` in their roles array
+3. If any need migration, write a backup to `roles-backup-premigration.json`
+   (following the `migrateEmailDomains()` precedent in `role-store.js`)
+4. For each user with `release-manager`, remove `release-manager` and add
+   `planning-manager` (if not already present)
+5. Write back via `storage.writeToStorage('roles.json', data)`
+6. Log the migration count
+7. This is idempotent -- safe to run on every restart (backup and write are
+   both skipped when no `release-manager` entries exist)
+
+**Edge cases:**
+- User has both `release-manager` and `planning-manager` (shouldn't happen, but
+  handle gracefully -- just remove `release-manager`, skip adding duplicate
+  `planning-manager`)
+- Empty `roles.json` or no assignments -- no-op, no write
+- Demo mode -- `readFromStorage` returns fixture data, `writeToStorage` is a
+  no-op, which is fine
+
+### 5.2 PM User Auto-Migration
+
+The existing PM user auto-migration (planning/routes.js lines 58-82) migrates
+from `pm-users.json` to the role system. Update it to assign `planning-manager`
+instead of `release-manager`. Since this migration deletes `pm-users.json` after
+running, it is already idempotent.
+
+### 5.3 Role Registry Validation
+
+The role registry (`shared/server/role-registry.js`) prevents duplicate
+registration. Since we are registering `planning-manager` instead of
+`release-manager`, there is no conflict. However, if any other code attempts to
+register `release-manager` after this change, it will fail silently (role not
+found in registry when trying to assign via roleStore). This is the desired
+behavior.
+
+### 5.4 Frontend Permissions Backward Compatibility
+
+The permissions endpoint response is additive -- it adds three new fields
+(`canAdd`, `canDelete`, `canReorder`) alongside the existing `canEdit`. Any
+frontend code that only reads `canEdit` will continue to work correctly. The new
+props are optional with `default: false`, so components that do not receive them
+will behave as read-only for the new operations.
+
+---
+
+## 6. Settings UI Impact
+
+The UserManagement component (`src/components/UserManagement.vue`) fetches
+available roles from `/api/roles/available` and renders them dynamically. The
+role label and description come from the role registry, so renaming the role
+automatically updates the Settings UI.
+
+**Badge color update:** The `ROLE_BADGE_COLORS` map (line 210) uses the role ID
+as key. Update `'release-manager'` to `'planning-manager'` to preserve the
+purple badge color.
+
+---
+
+## 7. Files Modified
+
+### Server-Side
+
+| File | Changes |
+|---|---|
+| `modules/releases/server/index.js` | Rename role registration to `planning-manager`; rename `requireReleaseManager` to `requirePlanningManager`; add startup migration (direct `roles.json` manipulation via `readFromStorage`/`writeToStorage`); update all sub-router context objects to pass `requirePlanningManager`; add `requirePlanningManager` to planning sub-router context; stop passing `requireReleaseManager` to feature-tracking context (unused -- see Section 4.7) |
+| `modules/releases/server/planning/routes.js` | Destructure `requirePlanningManager` from context; update permissions endpoint to return granular flags; add `requirePlanningManager` to POST, DELETE, reorder endpoints; add `requirePlanningManager` to `POST /import/doc` with `replace` mode check (Section 4.6); update PM user auto-migration to assign `planning-manager` |
+| `modules/releases/server/registry.js` | Update destructured `requireReleaseManager` to `requirePlanningManager` |
+| `modules/releases/server/hygiene/routes.js` | Update destructured `requireReleaseManager` to `requirePlanningManager`; update OpenAPI summaries |
+| `modules/releases/module.json` | Update `"requireRole": "release-manager"` to `"planning-manager"` on Manage nav item |
+| `shared/server/auth.js` | Rename `req.isReleaseManager` to `req.isPlanningManager` (lines 109, 143) |
+| `shared/server/role-registry.js` | Update JSDoc example at line 13 from `'release-manager'` to `'planning-manager'` |
+
+### Client-Side
+
+| File | Changes |
+|---|---|
+| `modules/releases/client/plan/views/DashboardView.vue` | Add `canAdd`, `canDelete`, `canReorder` computeds; pass as props to BigRocksTable |
+| `modules/releases/client/plan/components/BigRocksTable.vue` | Add `canAdd`, `canDelete`, `canReorder` props; merge two `<tbody>` blocks into single tbody with conditional columns; migrate skeleton loading rows and empty state from read-only tbody; make `draggable` attribute conditional on `canReorder`; compute dynamic `expandedColspan` for expanded rows, skeleton rows, and empty state; change `:canEdit="true"` to `:canEdit="props.canEdit"` on `BigRockRow` |
+| `modules/releases/client/plan/composables/useReleasePlanning.js` | Update permissions fallback default to include all four flags |
+| `modules/releases/client/views/RegistryView.vue` | Update `'release-manager'` string to `'planning-manager'` in access check and error message |
+| `modules/releases/client/execute/views/HygieneView.vue` | Rename `isReleaseManager` ref to `isPlanningManager`; update prop name passed to `HygieneWelcomeModal` |
+| `modules/releases/client/execute/components/hygiene/HygieneWelcomeModal.vue` | Rename `isReleaseManager` prop to `isPlanningManager`; update template references at lines 127 and 175; update user-facing text |
+| `src/components/UserManagement.vue` | Update `ROLE_BADGE_COLORS` key from `'release-manager'` to `'planning-manager'` |
+
+### Tests
+
+| File | Changes |
+|---|---|
+| `modules/releases/__tests__/server/rbac.test.js` | Rename all `release-manager` references to `planning-manager` |
+| `modules/releases/__tests__/server/planning/routes.test.js` | Update open access tests: POST and DELETE should now return 403 for non-planning-manager; add new tests for role enforcement |
+| `modules/releases/__tests__/server/planning/health-routes.test.js` | Update role references |
+| `modules/releases/__tests__/server/planning/invalidate-cache.test.js` | Update `requireReleaseManager` mock references to `requirePlanningManager` in context setup (lines 131, 273) |
+| `tests/integration/tv-fv-delta.spec.js` | Update `requireRole` assertion at line 123 from `'release-manager'` to `'planning-manager'`; remove stale `requireRole` assertion from Audit nav item at line 128 (see Section 4.7) |
+| `shared/server/__tests__/module-context.test.js` | Update role registration example |
+
+### Documentation
+
+| File | Changes |
+|---|---|
+| `docs/DATA-FORMATS.md` | Update example role name |
+| `docs/MODULES.md` | Update role documentation examples |
+| `docs/plans/outcomes-dashboard-access.md` | Add note about superseded role name (do not rewrite -- it is a historical record) |
+
+---
+
+## 8. Phased Implementation
+
+### Phase 1: Role Rename (foundation)
+
+**Scope:** Rename `release-manager` -> `planning-manager` everywhere. No
+permission logic changes. Behavior stays identical -- just the identifier
+changes.
+
+**Steps:**
+1. Update `modules/releases/server/index.js`:
+   - Change `registerRole('release-manager', ...)` to `registerRole('planning-manager', ...)`
+   - Rename `requireReleaseManager` variable to `requirePlanningManager`
+   - Add startup migration block (direct `roles.json` manipulation via
+     `readFromStorage`/`writeToStorage` -- NOT `roleStore.revokeRole()`);
+     must write `roles-backup-premigration.json` before overwriting
+   - Update all sub-router context objects to pass `requirePlanningManager`
+   - Remove `requireReleaseManager`/`requirePlanningManager` from
+     feature-tracking context (unused, dead code cleanup)
+2. Update `shared/server/auth.js`:
+   - Change `req.isReleaseManager` to `req.isPlanningManager` (lines 109, 143)
+3. Update `shared/server/role-registry.js`:
+   - Update JSDoc example at line 13 from `'release-manager'` to `'planning-manager'`
+4. Update `modules/releases/module.json`:
+   - Change `"requireRole": "release-manager"` to `"planning-manager"`
+5. Update `modules/releases/server/registry.js`:
+   - Rename destructured `requireReleaseManager` to `requirePlanningManager`
+6. Update `modules/releases/server/hygiene/routes.js`:
+   - Rename destructured `requireReleaseManager` to `requirePlanningManager`
+   - Update OpenAPI summary strings
+7. Update `modules/releases/server/planning/routes.js`:
+   - Update PM user auto-migration to use `planning-manager`
+8. Update all client files:
+   - `RegistryView.vue`: role string + error message
+   - `HygieneView.vue`: ref name + role check + prop name to HygieneWelcomeModal
+   - `HygieneWelcomeModal.vue`: prop name + template references + user-facing text
+   - `UserManagement.vue`: badge color key
+9. Update all tests:
+   - `rbac.test.js`: all `release-manager` references
+   - `routes.test.js`: comment strings
+   - `health-routes.test.js`: role references
+   - `invalidate-cache.test.js`: `requireReleaseManager` mock references
+   - `tv-fv-delta.spec.js`: rename Manage nav item assertion to `'planning-manager'`;
+     remove stale `requireRole` from Audit nav item assertion
+   - `module-context.test.js`: role registration example
+10. Update documentation:
+    - `role-registry.js`: JSDoc example
+    - `DATA-FORMATS.md`: example role name
+    - `MODULES.md`: role documentation examples
+    - `outcomes-dashboard-access.md`: add superseded note
+
+**Verification:** `npm test` passes. `npm run lint` passes. Role assignment via
+Settings UI shows "Planning Manager". Existing users with `release-manager` are
+auto-migrated on server restart.
+
+**PR:** Single PR, can be merged independently.
+
+### Phase 2: Granular Permissions (the feature)
+
+**Scope:** Split `canEdit` into `canEdit` + `canAdd` + `canDelete` +
+`canReorder`. Add server-side role enforcement on Big Rock write endpoints.
+Gate doc import `replace` mode.
+
+**Steps:**
+1. In `modules/releases/server/index.js`, add `requirePlanningManager` to the
+   planning sub-router context object.
+2. In `modules/releases/server/planning/routes.js`:
+   - Destructure `requirePlanningManager` from context (add to line 51)
+   - Update permissions endpoint to return
+     `{ canEdit, canAdd, canDelete, canReorder }` based on
+     `req.isPlanningManager || req.isAdmin`
+   - Add `requirePlanningManager` middleware to:
+     - `POST /releases/:version/big-rocks` (create)
+     - `DELETE /releases/:version/big-rocks/:name` (delete)
+     - `PUT /releases/:version/big-rocks/reorder` (reorder)
+   - Add inline `replace` mode check to `POST /releases/:version/import/doc`
+     (see Section 4.6)
+3. Update `useReleasePlanning.js` fallback default
+4. Update `DashboardView.vue` with granular computeds and prop passing
+5. Update `BigRocksTable.vue`:
+   - Add new props
+   - Merge the two `<tbody>` blocks into a single tbody with conditional columns
+   - Migrate skeleton loading rows and "No Big Rocks configured" empty state
+     from the read-only tbody into the merged tbody (see Section 4.5.3)
+   - Use `expandedColspan` computed for all colspan values (expanded rows,
+     skeleton rows, empty state)
+   - Make `draggable` attribute conditional: `:draggable="canReorder"`
+   - Compute dynamic colspan for `BigRockExpandedRow` based on visible columns
+   - Change `:canEdit="true"` on `BigRockRow` to `:canEdit="props.canEdit"`
+     (respects demo mode -- see Section 4.5.4)
+   - Conditionally render drag handles, delete buttons, add button
+   - Actions column header gated on `canEdit || canDelete`
+   - Remove the second (read-only) `<tbody>` entirely
+6. Update tests:
+   - `routes.test.js`: POST and DELETE for non-planning-manager should 403
+   - `routes.test.js`: PUT (edit) for non-planning-manager should still 200
+   - `routes.test.js`: Reorder for non-planning-manager should 403
+   - `routes.test.js`: Doc import `replace` mode for non-planning-manager should 403
+   - `routes.test.js`: Doc import `append` mode for non-planning-manager should 200
+   - Add new test block: "planning-manager role enforcement"
+
+**Verification:** Manual testing with two accounts (one with `planning-manager`,
+one without). Verify 403 responses on privileged endpoints. Verify UI hides
+add/delete/reorder for unprivileged users. Verify edit still works for all.
+Verify doc import `replace` blocked, `append` allowed for non-managers.
+
+**PR:** Single PR, depends on Phase 1 being merged.
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit Tests
+
+**Existing test patterns to follow:**
+- `rbac.test.js` -- role registration, assignment, middleware behavior
+- `routes.test.js` -- route-level permission testing with mock req/res
+
+**New test cases for Phase 2:**
+
+```
+planning-manager role enforcement on big rocks
+  - returns 403 when non-planning-manager creates a big rock (POST)
+  - returns 403 when non-planning-manager deletes a big rock (DELETE)
+  - returns 403 when non-planning-manager reorders big rocks (PUT reorder)
+  - allows planning-manager to create a big rock (POST)
+  - allows planning-manager to delete a big rock (DELETE)
+  - allows planning-manager to reorder big rocks (PUT reorder)
+  - allows admin (non-planning-manager) to create/delete/reorder
+  - allows any authenticated user to edit existing big rock (PUT)
+
+doc import replace mode enforcement
+  - returns 403 when non-planning-manager uses replace mode
+  - allows non-planning-manager to use append mode
+  - allows planning-manager to use replace mode
+
+permissions endpoint returns granular flags
+  - returns canAdd=true for planning-manager
+  - returns canAdd=false for non-planning-manager
+  - returns canEdit=true for all authenticated users
+  - returns canReorder and canDelete correctly
+
+role migration
+  - migrates release-manager to planning-manager on startup
+  - writes roles-backup-premigration.json before overwriting roles.json
+  - handles empty roles.json gracefully
+  - is idempotent (no error on re-run, no backup written when nothing to migrate)
+  - handles user with both release-manager and planning-manager
+```
+
+### 9.2 Local Testing
+
+1. Start dev server: `npm run dev:full`
+2. Open browser, authenticate
+3. In Settings > Users, assign `planning-manager` to yourself
+4. Verify full Big Rocks functionality (add, edit, delete, reorder)
+5. Revoke `planning-manager` from yourself
+6. Verify edit works but add/delete/reorder are hidden
+7. Try direct API calls to POST/DELETE endpoints -- should get 403
+8. Re-assign `planning-manager` and verify access restored
+9. Test doc import: without `planning-manager`, `replace` mode should 403,
+   `append` mode should succeed
+
+### 9.3 Impersonation Testing
+
+1. As admin, assign `planning-manager` to a test user
+2. Impersonate that user -- verify full access
+3. Impersonate a user without `planning-manager` -- verify restricted access
+4. Verify blockDuringImpersonation still works on DELETE
+
+### 9.4 Integration Tests
+
+No integration test changes needed for Phase 1 (role rename does not change
+behavior). Phase 2 may warrant a new integration test case in
+`tests/integration/releases.spec.js` if one exists, but given that the
+permission logic is fully tested at the unit level and the UI changes are
+prop-driven, unit tests provide sufficient coverage.
+
+---
+
+## 10. Deployment Considerations
+
+### 10.1 CI/CD
+
+No CI/CD pipeline changes. The build-images workflow is unaffected. Kustomize
+overlays do not reference the role name. The role is stored in `data/roles.json`
+(PVC-backed), not in ConfigMaps or Secrets.
+
+### 10.2 Rollout Sequence
+
+1. **Merge Phase 1 (role rename)** -- deploys to preprod via ArgoCD
+2. Verify in preprod: existing release-manager users migrated, Settings UI shows
+   "Planning Manager", all gated features still work
+3. **Merge Phase 2 (granular permissions)** -- deploys to preprod
+4. Verify in preprod: granular UI behavior, 403 on privileged endpoints for
+   unprivileged users
+5. Promote to prod (prod overlay does not need changes)
+
+### 10.3 Rollback
+
+**Phase 1 rollback:** If the role rename causes issues, roll back the code
+deployment. The backend uses a `Recreate` deployment strategy, so there is no
+split-brain risk during deployment (old and new pods never run simultaneously).
+
+However, rollback has user-visible impact: users who were migrated to
+`planning-manager` will lose ALL role-gated access -- not just Big Rocks, but
+also the release registry, hygiene configuration, and any nav items gated on
+the role. This is because the rolled-back code expects `release-manager` in
+`roles.json`, but the migration has already rewritten those entries to
+`planning-manager`. The `planning-manager` entries will be treated as an
+unrecognized role by the old code, effectively making those users unprivileged.
+
+**To fix after rollback:** Manually edit `data/roles.json` on the PVC, replacing
+`planning-manager` back to `release-manager` in each user's roles array. This
+requires shell access to the pod or PVC. Alternatively, deploy a hotfix that
+adds a reverse migration. Given the migration's simplicity and the narrow scope
+of the role rename, this risk is low and well-understood.
+
+**Phase 2 rollback:** Roll back the code deployment. The permissions endpoint
+will return the old `{ canEdit: true }` shape. Frontend will gracefully degrade
+(new props have `default: false`, but the old code only checks `canEdit`). No
+data corruption risk.
+
+### 10.4 Migration Timing
+
+The startup migration runs synchronously before routes are registered. It
+completes in milliseconds (iterating `roles.json` entries). No downtime or
+maintenance window needed.
+
+---
+
+## 11. UX Review
+
+**Recommendation:** A UX review is not required for this change. The visual
+changes are minimal:
+
+- The "Add Big Rock" button disappears for non-planning-managers (already hidden
+  in read-only mode, so the pattern is established)
+- Delete buttons (trash icons) disappear for non-planning-managers
+- Drag handles disappear for non-planning-managers
+- Edit buttons (pencil icons) remain visible for all users
+- No new UI components, modals, or flows are introduced
+- The role name in Settings changes from "Release Manager" to "Planning Manager"
+
+If a UX teammate has capacity, a quick review of the granular permission states
+(what the table looks like for planning-manager vs non-planning-manager) would be
+valuable but not blocking.
+
+---
+
+## 12. Open Questions
+
+1. **Should the "New Release" and "Clone Release" buttons also be gated to
+   planning-manager?** Currently gated on `canEdit` which is open to all. The
+   outcomes-dashboard-access.md plan explicitly opened these. If the intent is
+   to restrict structural changes, release creation could be included. For now,
+   this plan keeps them open per the prior decision. Can be added later by
+   including a `canCreateRelease` flag.
+
+---
+
+## 13. Summary
+
+This plan introduces granular Big Rock permissions by:
+
+1. **Renaming** `release-manager` to `planning-manager` with automated startup
+   migration (direct `roles.json` manipulation, not roleStore API)
+2. **Splitting** the single `canEdit` flag into four granular permissions
+3. **Enforcing** on both server (403 on privileged endpoints) and frontend
+   (hide/disable UI elements)
+4. **Gating** doc import `replace` mode to planning-manager (most destructive
+   structural operation)
+5. **Preserving** open editing for all authenticated users on existing Big Rocks
+
+Two clean PRs: Phase 1 (rename, independently shippable) and Phase 2 (granular
+permissions, depends on Phase 1). Total estimated touch: 7 server files, 7
+client files, 6 test files, 3 documentation files.

--- a/docs/plans/outcomes-dashboard-access.md
+++ b/docs/plans/outcomes-dashboard-access.md
@@ -5,6 +5,12 @@
 **Date:** 2026-06-09
 **Module:** releases (planning + health sub-modules)
 
+> **Note (2026-06-15):** This plan references the `release-manager` role
+> throughout. That role has since been renamed to `planning-manager` in the
+> Big Rocks Access Control plan (`big-rocks-add-permission.md`). All
+> references to `release-manager` in this document should be read as
+> `planning-manager`. This document is preserved as a historical record.
+
 ---
 
 ## 1. Problem Statement

--- a/modules/releases/__tests__/client/plan/components.test.js
+++ b/modules/releases/__tests__/client/plan/components.test.js
@@ -245,23 +245,23 @@ describe('BigRocksTable', () => {
     expect(wrapper.text()).toContain('No Big Rocks configured')
   })
 
-  it('shows Add button when canEdit is true', () => {
+  it('shows Add button when canAdd is true', () => {
     const wrapper = mount(BigRocksTable, {
-      props: { bigRocks, canEdit: true }
+      props: { bigRocks, canEdit: true, canAdd: true }
     })
     expect(wrapper.text()).toContain('Add Big Rock')
   })
 
-  it('hides Add button when canEdit is false', () => {
+  it('hides Add button when canAdd is false', () => {
     const wrapper = mount(BigRocksTable, {
-      props: { bigRocks, canEdit: false }
+      props: { bigRocks, canEdit: true, canAdd: false }
     })
     expect(wrapper.text()).not.toContain('Add Big Rock')
   })
 
   it('emits addRock when Add button is clicked', async () => {
     const wrapper = mount(BigRocksTable, {
-      props: { bigRocks, canEdit: true }
+      props: { bigRocks, canEdit: true, canAdd: true }
     })
     const addBtn = wrapper.findAll('button').find(b => b.text().includes('Add Big Rock'))
     await addBtn.trigger('click')
@@ -340,25 +340,25 @@ describe('BigRocksTable', () => {
     expect(editBtn.exists()).toBe(false)
   })
 
-  it('sets draggable="true" on edit-mode rows', () => {
+  it('sets draggable="true" when canReorder is true', () => {
     const wrapper = mount(BigRocksTable, {
-      props: { bigRocks, canEdit: true }
+      props: { bigRocks, canEdit: true, canReorder: true }
     })
     const rows = wrapper.findAll('tbody tr')
     expect(rows[0].attributes('draggable')).toBe('true')
   })
 
-  it('does not set draggable on read-only rows', () => {
+  it('sets draggable="false" when canReorder is false', () => {
     const wrapper = mount(BigRocksTable, {
-      props: { bigRocks, canEdit: false }
+      props: { bigRocks, canEdit: true, canReorder: false }
     })
     const rows = wrapper.findAll('tbody tr')
-    expect(rows[0].attributes('draggable')).toBeUndefined()
+    expect(rows[0].attributes('draggable')).toBe('false')
   })
 
-  it('shows toolbar text without click-to-edit language', () => {
+  it('shows toolbar reorder text when canReorder is true', () => {
     const wrapper = mount(BigRocksTable, {
-      props: { bigRocks, canEdit: true }
+      props: { bigRocks, canEdit: true, canReorder: true }
     })
     expect(wrapper.text()).not.toContain('Click a row to edit')
     expect(wrapper.text()).toContain('Drag to reorder')

--- a/modules/releases/__tests__/server/planning/health-routes.test.js
+++ b/modules/releases/__tests__/server/planning/health-routes.test.js
@@ -909,7 +909,7 @@ describe('health routes', function() {
   // ─── Open Access ───
 
   describe('open access for authenticated users', function() {
-    it('allows non-admin, non-release-manager to set risk override', function() {
+    it('allows non-admin, non-planning-manager to set risk override', function() {
       var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({
           isAdmin: false,
@@ -922,7 +922,7 @@ describe('health routes', function() {
       expect(res._json.featureKey).toBe('T-1')
     })
 
-    it('allows non-admin, non-release-manager to create snapshot', function() {
+    it('allows non-admin, non-planning-manager to create snapshot', function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5', {
         features: [
           { key: 'T-1', summary: 'F1', fixVersions: 'rhoai-3.5.EA1', status: 'In Progress', components: 'Comp1', deliveryOwner: 'owner1' }

--- a/modules/releases/__tests__/server/planning/invalidate-cache.test.js
+++ b/modules/releases/__tests__/server/planning/invalidate-cache.test.js
@@ -128,7 +128,7 @@ describe('invalidateCache behavior', function() {
       storage: storage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },
-      requireReleaseManager: function(req, res, next) { next() },
+      requirePlanningManager: function(req, res, next) { next() },
       requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     }
@@ -270,7 +270,7 @@ describe('invalidateCache behavior', function() {
       storage: spyStorage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },
-      requireReleaseManager: function(req, res, next) { next() },
+      requirePlanningManager: function(req, res, next) { next() },
       requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     })

--- a/modules/releases/__tests__/server/planning/routes.test.js
+++ b/modules/releases/__tests__/server/planning/routes.test.js
@@ -22,7 +22,7 @@ vi.mock('../../../server/planning/config-backup', () => ({
 
 vi.mock('../../../server/planning/doc-import', () => ({
   previewDocImport: vi.fn(),
-  executeDocImport: vi.fn()
+  executeDocImport: vi.fn().mockResolvedValue({ bigRocks: [], imported: 0 })
 }))
 
 vi.mock('../../../../../shared/server/auth', () => ({
@@ -150,7 +150,7 @@ describe('release-planning routes', function() {
       storage: storage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },
-      requireReleaseManager: function(req, res, next) { next() },
+      requirePlanningManager: function(req, res, next) { next() },
       requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     }
@@ -483,16 +483,49 @@ describe('release-planning routes', function() {
       expect(res._json.canEdit).toBe(true)
     })
 
-    it('returns canEdit true for release manager', function() {
-      const req = makeReq({ isAdmin: false, isReleaseManager: true, userEmail: 'pm@test.com' })
+    it('returns canEdit true for planning manager', function() {
+      const req = makeReq({ isAdmin: false, isPlanningManager: true, userEmail: 'pm@test.com' })
       const res = callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
     })
 
     it('returns canEdit true for regular user', function() {
-      const req = makeReq({ isAdmin: false, isReleaseManager: false, userEmail: 'user@test.com' })
+      const req = makeReq({ isAdmin: false, isPlanningManager: false, userEmail: 'user@test.com' })
       const res = callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
+    })
+
+    it('returns granular flags for admin', function() {
+      const req = makeReq({ isAdmin: true, isPlanningManager: false, userEmail: 'admin@test.com' })
+      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      expect(res._json).toEqual({
+        canEdit: true,
+        canAdd: true,
+        canDelete: true,
+        canReorder: true
+      })
+    })
+
+    it('returns granular flags for planning-manager', function() {
+      const req = makeReq({ isAdmin: false, isPlanningManager: true, userEmail: 'pm@test.com' })
+      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      expect(res._json).toEqual({
+        canEdit: true,
+        canAdd: true,
+        canDelete: true,
+        canReorder: true
+      })
+    })
+
+    it('returns restricted flags for regular user', function() {
+      const req = makeReq({ isAdmin: false, isPlanningManager: false, userEmail: 'user@test.com' })
+      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      expect(res._json).toEqual({
+        canEdit: true,
+        canAdd: false,
+        canDelete: false,
+        canReorder: false
+      })
     })
   })
 
@@ -604,26 +637,30 @@ describe('release-planning routes', function() {
     })
   })
 
-  // ─── Open Access ───
+  // ─── Role-gated access ───
 
-  describe('open access for authenticated users', function() {
-    it('allows non-admin, non-release-manager to create big rocks', async function() {
-      const req = makeReq({
-        isAdmin: false,
-        isReleaseManager: false,
-        userEmail: 'user@test.com',
-        params: { version: '3.5' },
-        body: VALID_ROCK
-      })
-      const res = await callRoute(router._routes, 'POST', '/releases/:version/big-rocks', req)
-      expect(res._status).toBe(201)
+  describe('planning-manager role enforcement', function() {
+    it('POST big-rocks route includes requirePlanningManager middleware', function() {
+      const handlers = router._routes['POST /releases/:version/big-rocks']
+      // Should include requirePlanningManager in the middleware chain
+      expect(handlers.length).toBeGreaterThanOrEqual(3)
     })
 
-    it('allows non-admin, non-release-manager to update big rocks', async function() {
+    it('DELETE big-rocks route includes requirePlanningManager middleware', function() {
+      const handlers = router._routes['DELETE /releases/:version/big-rocks/:name']
+      expect(handlers.length).toBeGreaterThanOrEqual(4)
+    })
+
+    it('PUT reorder route includes requirePlanningManager middleware', function() {
+      const handlers = router._routes['PUT /releases/:version/big-rocks/reorder']
+      expect(handlers.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('allows any authenticated user to edit (PUT) existing big rocks', async function() {
       setupVersion(storage._store, '3.5', [VALID_ROCK])
       const req = makeReq({
         isAdmin: false,
-        isReleaseManager: false,
+        isPlanningManager: false,
         userEmail: 'user@test.com',
         params: { version: '3.5', name: 'Test Rock' },
         body: Object.assign({}, VALID_ROCK, { notes: 'User updated' })
@@ -631,17 +668,62 @@ describe('release-planning routes', function() {
       const res = await callRoute(router._routes, 'PUT', '/releases/:version/big-rocks/:name', req)
       expect(res._status).toBe(200)
     })
+  })
 
-    it('allows non-admin, non-release-manager to delete big rocks', async function() {
+  // ─── Doc import replace mode ───
+
+  describe('doc import replace mode enforcement', function() {
+    it('rejects replace mode for non-admin, non-planning-manager', async function() {
       setupVersion(storage._store, '3.5', [VALID_ROCK])
       const req = makeReq({
         isAdmin: false,
-        isReleaseManager: false,
+        isPlanningManager: false,
         userEmail: 'user@test.com',
-        params: { version: '3.5', name: 'Test Rock' }
+        params: { version: '3.5' },
+        body: { docId: 'test-doc', mode: 'replace' }
       })
-      const res = await callRoute(router._routes, 'DELETE', '/releases/:version/big-rocks/:name', req)
-      expect(res._status).toBe(200)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/import/doc', req)
+      expect(res._status).toBe(403)
+      expect(res._json.error).toMatch(/planning-manager/)
+    })
+
+    it('allows replace mode for admin', async function() {
+      setupVersion(storage._store, '3.5', [VALID_ROCK])
+      const req = makeReq({
+        isAdmin: true,
+        isPlanningManager: false,
+        userEmail: 'admin@test.com',
+        params: { version: '3.5' },
+        body: { docId: 'test-doc', mode: 'replace' }
+      })
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/import/doc', req)
+      expect(res._status).not.toBe(403)
+    })
+
+    it('allows replace mode for planning-manager', async function() {
+      setupVersion(storage._store, '3.5', [VALID_ROCK])
+      const req = makeReq({
+        isAdmin: false,
+        isPlanningManager: true,
+        userEmail: 'pm@test.com',
+        params: { version: '3.5' },
+        body: { docId: 'test-doc', mode: 'replace' }
+      })
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/import/doc', req)
+      expect(res._status).not.toBe(403)
+    })
+
+    it('allows append mode for non-planning-manager', async function() {
+      setupVersion(storage._store, '3.5', [VALID_ROCK])
+      const req = makeReq({
+        isAdmin: false,
+        isPlanningManager: false,
+        userEmail: 'user@test.com',
+        params: { version: '3.5' },
+        body: { docId: 'test-doc', mode: 'append' }
+      })
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/import/doc', req)
+      expect(res._status).not.toBe(403)
     })
   })
 

--- a/modules/releases/__tests__/server/rbac.test.js
+++ b/modules/releases/__tests__/server/rbac.test.js
@@ -27,26 +27,26 @@ function createTestRoleRegistry() {
   const registry = createRoleRegistry();
   registry.register('admin', { label: 'Admin', description: 'Full access', module: 'platform' });
   registry.register('team-admin', { label: 'Team Admin', description: 'Team mgmt', module: 'platform' });
-  registry.register('release-manager', { label: 'Release Manager', description: 'Manage releases', module: 'releases' });
+  registry.register('planning-manager', { label: 'Planning Manager', description: 'Manage releases', module: 'releases' });
   return registry;
 }
 
-describe('release-manager role in role registry', () => {
-  it('recognizes release-manager as a valid role', () => {
+describe('planning-manager role in role registry', () => {
+  it('recognizes planning-manager as a valid role', () => {
     const registry = createTestRoleRegistry();
-    expect(registry.isValid('release-manager')).toBe(true);
+    expect(registry.isValid('planning-manager')).toBe(true);
   });
 });
 
-describe('role store: release-manager assignment and revocation', () => {
-  it('assigns release-manager role to a user', () => {
+describe('role store: planning-manager assignment and revocation', () => {
+  it('assigns planning-manager role to a user', () => {
     const registry = createTestRoleRegistry();
     const storage = createMockStorage();
     const roleStore = createRoleStore(storage.readFromStorage, storage.writeToStorage, { roleRegistry: registry });
 
-    const result = roleStore.assignRole('manager@redhat.com', 'release-manager', 'admin@redhat.com');
+    const result = roleStore.assignRole('manager@redhat.com', 'planning-manager', 'admin@redhat.com');
     expect(result.email).toBe('manager@redhat.com');
-    expect(result.roles).toContain('release-manager');
+    expect(result.roles).toContain('planning-manager');
   });
 
   it('confirms hasRole returns true after assignment', () => {
@@ -54,19 +54,19 @@ describe('role store: release-manager assignment and revocation', () => {
     const storage = createMockStorage();
     const roleStore = createRoleStore(storage.readFromStorage, storage.writeToStorage, { roleRegistry: registry });
 
-    roleStore.assignRole('manager@redhat.com', 'release-manager', 'admin@redhat.com');
-    expect(roleStore.hasRole('manager@redhat.com', 'release-manager')).toBe(true);
+    roleStore.assignRole('manager@redhat.com', 'planning-manager', 'admin@redhat.com');
+    expect(roleStore.hasRole('manager@redhat.com', 'planning-manager')).toBe(true);
   });
 
-  it('revokes release-manager role from a user', () => {
+  it('revokes planning-manager role from a user', () => {
     const registry = createTestRoleRegistry();
     const storage = createMockStorage();
     const roleStore = createRoleStore(storage.readFromStorage, storage.writeToStorage, { roleRegistry: registry });
 
-    roleStore.assignRole('manager@redhat.com', 'release-manager', 'admin@redhat.com');
-    const result = roleStore.revokeRole('manager@redhat.com', 'release-manager', 'admin@redhat.com');
-    expect(result.roles).not.toContain('release-manager');
-    expect(roleStore.hasRole('manager@redhat.com', 'release-manager')).toBe(false);
+    roleStore.assignRole('manager@redhat.com', 'planning-manager', 'admin@redhat.com');
+    const result = roleStore.revokeRole('manager@redhat.com', 'planning-manager', 'admin@redhat.com');
+    expect(result.roles).not.toContain('planning-manager');
+    expect(roleStore.hasRole('manager@redhat.com', 'planning-manager')).toBe(false);
   });
 
   it('throws when revoking a role the user does not have', () => {
@@ -75,23 +75,23 @@ describe('role store: release-manager assignment and revocation', () => {
     const roleStore = createRoleStore(storage.readFromStorage, storage.writeToStorage, { roleRegistry: registry });
 
     expect(() => {
-      roleStore.revokeRole('nobody@redhat.com', 'release-manager', 'admin@redhat.com');
+      roleStore.revokeRole('nobody@redhat.com', 'planning-manager', 'admin@redhat.com');
     }).toThrow(/does not have role/);
   });
 
-  it('does not affect other roles when assigning release-manager', () => {
+  it('does not affect other roles when assigning planning-manager', () => {
     const registry = createTestRoleRegistry();
     const storage = createMockStorage();
     const roleStore = createRoleStore(storage.readFromStorage, storage.writeToStorage, { roleRegistry: registry });
 
     roleStore.assignRole('user@redhat.com', 'admin', 'system');
-    roleStore.assignRole('user@redhat.com', 'release-manager', 'system');
+    roleStore.assignRole('user@redhat.com', 'planning-manager', 'system');
     expect(roleStore.hasRole('user@redhat.com', 'admin')).toBe(true);
-    expect(roleStore.hasRole('user@redhat.com', 'release-manager')).toBe(true);
+    expect(roleStore.hasRole('user@redhat.com', 'planning-manager')).toBe(true);
   });
 });
 
-describe('requireRole("release-manager") middleware', () => {
+describe('requireRole("planning-manager") middleware', () => {
   function createMiddleware() {
     const storage = createMockStorage();
     const roleStore = createRoleStore(storage.readFromStorage, storage.writeToStorage);
@@ -100,42 +100,42 @@ describe('requireRole("release-manager") middleware', () => {
       storage.writeToStorage,
       { roleStore }
     );
-    const requireReleaseManager = requireRole('release-manager');
-    return { requireReleaseManager, roleStore, storage };
+    const requirePlanningManager = requireRole('planning-manager');
+    return { requirePlanningManager, roleStore, storage };
   }
 
   it('allows admins through', () => {
-    const { requireReleaseManager } = createMiddleware();
-    const req = { isAdmin: true, isReleaseManager: false, userEmail: 'admin@test.com' };
+    const { requirePlanningManager } = createMiddleware();
+    const req = { isAdmin: true, isPlanningManager: false, userEmail: 'admin@test.com' };
     const res = createMockRes();
     let nextCalled = false;
 
-    requireReleaseManager(req, res, () => { nextCalled = true; });
+    requirePlanningManager(req, res, () => { nextCalled = true; });
     expect(nextCalled).toBe(true);
     expect(res._status).toBeNull();
   });
 
-  it('allows release managers through', () => {
-    const { requireReleaseManager, roleStore } = createMiddleware();
-    roleStore.assignRole('pm@test.com', 'release-manager', 'admin');
-    const req = { isAdmin: false, isReleaseManager: true, userEmail: 'pm@test.com' };
+  it('allows planning managers through', () => {
+    const { requirePlanningManager, roleStore } = createMiddleware();
+    roleStore.assignRole('pm@test.com', 'planning-manager', 'admin');
+    const req = { isAdmin: false, isPlanningManager: true, userEmail: 'pm@test.com' };
     const res = createMockRes();
     let nextCalled = false;
 
-    requireReleaseManager(req, res, () => { nextCalled = true; });
+    requirePlanningManager(req, res, () => { nextCalled = true; });
     expect(nextCalled).toBe(true);
     expect(res._status).toBeNull();
   });
 
   it('blocks regular users with 403', () => {
-    const { requireReleaseManager } = createMiddleware();
-    const req = { isAdmin: false, isReleaseManager: false, userEmail: 'user@test.com' };
+    const { requirePlanningManager } = createMiddleware();
+    const req = { isAdmin: false, isPlanningManager: false, userEmail: 'user@test.com' };
     const res = createMockRes();
     let nextCalled = false;
 
-    requireReleaseManager(req, res, () => { nextCalled = true; });
+    requirePlanningManager(req, res, () => { nextCalled = true; });
     expect(nextCalled).toBe(false);
     expect(res._status).toBe(403);
-    expect(res._json.error).toMatch(/release-manager/);
+    expect(res._json.error).toMatch(/planning-manager/);
   });
 });

--- a/modules/releases/client/execute/components/hygiene/HygieneWelcomeModal.vue
+++ b/modules/releases/client/execute/components/hygiene/HygieneWelcomeModal.vue
@@ -8,7 +8,7 @@ const props = defineProps({
     type: Object,
     default: null
   },
-  isReleaseManager: {
+  isPlanningManager: {
     type: Boolean,
     default: false
   }
@@ -124,8 +124,8 @@ const enabledRuleCount = computed(() => {
             outstanding items.
           </p>
 
-          <p v-if="isReleaseManager" class="text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-700 pt-3">
-            As a release manager, you can configure which rules are active and adjust
+          <p v-if="isPlanningManager" class="text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-700 pt-3">
+            As a planning manager, you can configure which rules are active and adjust
             thresholds on the
             <button @click="goToManage" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">Manage</button>
             page.
@@ -169,10 +169,10 @@ const enabledRuleCount = computed(() => {
             </div>
           </div>
           <div v-else class="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
-            Rule details are only visible to release managers.
+            Rule details are only visible to planning managers.
           </div>
           <p
-            v-if="isReleaseManager && ruleDetails"
+            v-if="isPlanningManager && ruleDetails"
             class="text-xs text-gray-500 dark:text-gray-400 border-t border-gray-100 dark:border-gray-700 pt-3 mt-4"
           >
             You can enable, disable, or adjust thresholds for these rules on the

--- a/modules/releases/client/execute/views/HygieneView.vue
+++ b/modules/releases/client/execute/views/HygieneView.vue
@@ -198,12 +198,12 @@ onMounted(() => {
 
 const welcomeModalRef = ref(null)
 const hygieneRuleDetails = ref(null)
-const isReleaseManager = ref(false)
+const isPlanningManager = ref(false)
 
 async function loadRuleCategories() {
   try {
     const data = await apiRequest('/modules/releases/hygiene/config')
-    isReleaseManager.value = true
+    isPlanningManager.value = true
     if (data && data.ruleDefinitions) {
       const rulesConfig = (data.config && data.config.rules) || {}
       const detailMap = {}
@@ -228,7 +228,7 @@ async function loadRuleCategories() {
   } catch {
     // Non-managers can't access config — fall back to static summary
     hygieneRuleDetails.value = null
-    isReleaseManager.value = false
+    isPlanningManager.value = false
   }
 }
 
@@ -490,7 +490,7 @@ const versionOptions = computed(() =>
     <HygieneWelcomeModal
       ref="welcomeModalRef"
       :rule-details="hygieneRuleDetails"
-      :is-release-manager="isReleaseManager"
+      :is-planning-manager="isPlanningManager"
       @navigate-manage="nav.navigateTo('registry', { tab: 'hygiene' })"
     />
   </div>

--- a/modules/releases/client/plan/components/BigRocksTable.vue
+++ b/modules/releases/client/plan/components/BigRocksTable.vue
@@ -7,6 +7,9 @@ const props = defineProps({
   bigRocks: { type: Array, default: () => [] },
   jiraBaseUrl: { type: String, default: '' },
   canEdit: { type: Boolean, default: false },
+  canAdd: { type: Boolean, default: false },
+  canDelete: { type: Boolean, default: false },
+  canReorder: { type: Boolean, default: false },
   rockHealth: { type: Object, default: () => ({}) },
   rockFeatures: { type: Object, default: () => ({}) },
   loading: { type: Boolean, default: false },
@@ -17,6 +20,13 @@ const props = defineProps({
 
 const hasHealth = computed(function() {
   return Object.keys(props.rockHealth).length > 0
+})
+
+const expandedColspan = computed(function() {
+  var base = hasHealth.value ? 9 : 6   // base columns (no drag, no actions)
+  if (props.canReorder) base++          // drag handle column
+  if (props.canEdit || props.canDelete) base++  // actions column
+  return base
 })
 
 const emit = defineEmits(['editRock', 'addRock', 'deleteRock', 'reorder', 'toggleExport', 'closeExport', 'exportMarkdown', 'exportCsv'])
@@ -132,7 +142,7 @@ function handleDeleteClick(event, rock) {
   <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
     <!-- Toolbar (always visible) -->
     <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/30">
-      <span v-if="canEdit" class="text-xs text-gray-500 dark:text-gray-400">Drag to reorder.</span>
+      <span v-if="canReorder" class="text-xs text-gray-500 dark:text-gray-400">Drag to reorder.</span>
       <span v-else></span>
 
       <div class="flex items-center gap-2">
@@ -171,9 +181,9 @@ function handleDeleteClick(event, rock) {
           </div>
         </div>
 
-        <!-- Add Big Rock (edit mode only) -->
+        <!-- Add Big Rock (planning-manager only) -->
         <button
-          v-if="canEdit"
+          v-if="canAdd"
           @click="emit('addRock')"
           class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700"
         >
@@ -190,7 +200,7 @@ function handleDeleteClick(event, rock) {
         <caption class="sr-only">Big Rocks for this release, ordered by priority</caption>
         <thead>
           <tr>
-            <th v-if="canEdit" scope="col" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"><span class="sr-only">Drag</span></th>
+            <th v-if="canReorder" scope="col" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"><span class="sr-only">Drag</span></th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Priority</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Pillar</th>
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Big Rock</th>
@@ -200,69 +210,14 @@ function handleDeleteClick(event, rock) {
             <th scope="col" class="px-3 py-2 text-left text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Owners</th>
             <th v-if="hasHealth" scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Versions</th>
             <th scope="col" class="px-3 py-2 text-center text-gray-700 dark:text-gray-200 font-semibold uppercase text-xs tracking-wide border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80">Features / RFEs</th>
-            <th v-if="canEdit" scope="col" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"><span class="sr-only">Actions</span></th>
+            <th v-if="canEdit || canDelete" scope="col" class="px-2 py-2 w-8 border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900/80"><span class="sr-only">Actions</span></th>
           </tr>
         </thead>
-        <tbody v-if="canEdit">
-          <template v-for="(rock, index) in localRocks" :key="rock.name">
-            <tr
-              draggable="true"
-              :class="[
-                'hover:bg-gray-50 dark:hover:bg-gray-700/50',
-                dragIndex === index ? 'opacity-40' : '',
-                dropIndex === index ? 'border-t-2 border-t-primary-500' : '',
-                dropIndex === localRocks.length && index === localRocks.length - 1 ? 'border-b-2 border-b-primary-500' : ''
-              ]"
-              @dragstart="onDragStart($event, index)"
-              @dragover="onDragOver($event, index)"
-              @drop="onDrop($event)"
-              @dragend="onDragEnd"
-            >
-              <td class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
-                <span class="drag-handle cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 select-none" aria-label="Drag to reorder" role="img" @mousedown="onHandleMouseDown" @click.stop>
-                  &#x2807;
-                </span>
-              </td>
-              <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" :rockFeatures="rockFeatures[rock.name] || []" :canEdit="true" :expanded="isExpanded(rock.name)" :releasePhaseMode="releasePhaseMode" @toggle-expand="toggleExpand(rock.name)" />
-              <td class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
-                <div class="flex items-center justify-center gap-1">
-                  <button
-                    @click.stop="emit('editRock', rock)"
-                    class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
-                    :aria-label="'Edit ' + rock.name"
-                  >
-                    <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                    </svg>
-                  </button>
-                  <button
-                    @click="handleDeleteClick($event, rock)"
-                    class="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 rounded"
-                    :aria-label="'Delete ' + rock.name"
-                  >
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                    </svg>
-                  </button>
-                </div>
-              </td>
-            </tr>
-            <tr v-if="isExpanded(rock.name)" :key="rock.name + '-edit-expanded'" @dragover.prevent>
-              <BigRockExpandedRow
-                :features="rockFeatures[rock.name] || []"
-                :colspan="hasHealth ? 11 : 8"
-                :loading="healthLoading"
-                :rockName="rock.name"
-                :releasePhaseMode="releasePhaseMode"
-              />
-            </tr>
-          </template>
-        </tbody>
-        <tbody v-if="!canEdit">
+        <tbody>
           <!-- Skeleton loading rows -->
           <template v-if="loading">
             <tr v-for="n in 3" :key="'skeleton-' + n">
-              <td :colspan="hasHealth ? 9 : 6" class="px-3 py-4 border border-gray-300 dark:border-gray-600">
+              <td :colspan="expandedColspan" class="px-3 py-4 border border-gray-300 dark:border-gray-600">
                 <div class="animate-pulse flex items-center gap-4">
                   <div class="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
                   <div class="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
@@ -274,25 +229,56 @@ function handleDeleteClick(event, rock) {
             </tr>
           </template>
           <!-- Data rows -->
-          <template v-else-if="bigRocks && bigRocks.length > 0">
-            <template v-for="rock in bigRocks" :key="rock.name">
-              <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                <BigRockRow
-                  :rock="rock"
-                  :jiraBaseUrl="jiraBaseUrl"
-                  :health="rockHealth[rock.name]"
-                  :hasHealth="hasHealth"
-                  :rockFeatures="rockFeatures[rock.name] || []"
-                  :canEdit="false"
-                  :expanded="isExpanded(rock.name)"
-                  :releasePhaseMode="releasePhaseMode"
-                  @toggle-expand="toggleExpand(rock.name)"
-                />
+          <template v-else-if="localRocks && localRocks.length > 0">
+            <template v-for="(rock, index) in localRocks" :key="rock.name">
+              <tr
+                :draggable="canReorder"
+                :class="[
+                  'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                  dragIndex === index ? 'opacity-40' : '',
+                  dropIndex === index ? 'border-t-2 border-t-primary-500' : '',
+                  dropIndex === localRocks.length && index === localRocks.length - 1 ? 'border-b-2 border-b-primary-500' : ''
+                ]"
+                @dragstart="onDragStart($event, index)"
+                @dragover="onDragOver($event, index)"
+                @drop="onDrop($event)"
+                @dragend="onDragEnd"
+              >
+                <td v-if="canReorder" class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
+                  <span class="drag-handle cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 select-none" aria-label="Drag to reorder" role="img" @mousedown="onHandleMouseDown" @click.stop>
+                    &#x2807;
+                  </span>
+                </td>
+                <BigRockRow :rock="rock" :jiraBaseUrl="jiraBaseUrl" :health="rockHealth[rock.name]" :hasHealth="hasHealth" :rockFeatures="rockFeatures[rock.name] || []" :canEdit="props.canEdit" :expanded="isExpanded(rock.name)" :releasePhaseMode="releasePhaseMode" @toggle-expand="toggleExpand(rock.name)" />
+                <td v-if="canEdit || canDelete" class="px-2 py-2 text-center border border-gray-300 dark:border-gray-600">
+                  <div class="flex items-center justify-center gap-1">
+                    <button
+                      v-if="canEdit"
+                      @click.stop="emit('editRock', rock)"
+                      class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+                      :aria-label="'Edit ' + rock.name"
+                    >
+                      <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                      </svg>
+                    </button>
+                    <button
+                      v-if="canDelete"
+                      @click="handleDeleteClick($event, rock)"
+                      class="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 rounded"
+                      :aria-label="'Delete ' + rock.name"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
               </tr>
-              <tr v-if="isExpanded(rock.name)" :key="rock.name + '-expanded'">
+              <tr v-if="isExpanded(rock.name)" :key="rock.name + '-expanded'" @dragover.prevent>
                 <BigRockExpandedRow
                   :features="rockFeatures[rock.name] || []"
-                  :colspan="hasHealth ? 9 : 6"
+                  :colspan="expandedColspan"
                   :loading="healthLoading"
                   :rockName="rock.name"
                   :releasePhaseMode="releasePhaseMode"
@@ -302,7 +288,7 @@ function handleDeleteClick(event, rock) {
           </template>
           <!-- Empty state -->
           <tr v-else>
-            <td :colspan="hasHealth ? 9 : 6" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
+            <td :colspan="expandedColspan" class="px-3 py-8 text-center text-gray-500 border border-gray-300 dark:border-gray-600">
               No Big Rocks configured.
             </td>
           </tr>

--- a/modules/releases/client/plan/composables/useReleasePlanning.js
+++ b/modules/releases/client/plan/composables/useReleasePlanning.js
@@ -89,7 +89,7 @@ export function useReleasePlanning() {
       const data = await apiRequest(`${API_BASE}/permissions`)
       permissions.value = data
     } catch {
-      permissions.value = { canEdit: false }
+      permissions.value = { canEdit: false, canAdd: false, canDelete: false, canReorder: false }
     }
   }
 

--- a/modules/releases/client/plan/views/DashboardView.vue
+++ b/modules/releases/client/plan/views/DashboardView.vue
@@ -79,6 +79,9 @@ const healthMilestones = computed(() => healthData.value ? healthData.value.mile
 const warning = computed(() => candidates.value ? candidates.value.warning : null)
 const pipelineWarnings = computed(() => candidates.value ? candidates.value.pipelineWarnings || [] : [])
 const canEdit = computed(() => !demoMode.value && permissions.value && permissions.value.canEdit)
+const canAdd = computed(() => !demoMode.value && permissions.value && permissions.value.canAdd)
+const canDelete = computed(() => !demoMode.value && permissions.value && permissions.value.canDelete)
+const canReorder = computed(() => !demoMode.value && permissions.value && permissions.value.canReorder)
 
 const {
   selectedPillar,
@@ -418,6 +421,9 @@ onMounted(async function() {
           :bigRocks="filteredBigRocks"
           :jiraBaseUrl="jiraBaseUrl"
           :canEdit="canEdit"
+          :canAdd="canAdd"
+          :canDelete="canDelete"
+          :canReorder="canReorder"
           :rockHealth="rockHealth"
           :rockFeatures="rockFeatures"
           :loading="loading"

--- a/modules/releases/client/views/RegistryView.vue
+++ b/modules/releases/client/views/RegistryView.vue
@@ -3,7 +3,7 @@
     <!-- Permission guard -->
     <div v-if="!hasAccess" class="text-center py-16">
       <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Access Denied</h2>
-      <p class="text-gray-500 dark:text-gray-400">You don't have permission to view this page. The release-manager role is required.</p>
+      <p class="text-gray-500 dark:text-gray-400">You don't have permission to view this page. The planning-manager role is required.</p>
     </div>
 
     <template v-else>
@@ -572,7 +572,7 @@ watch(() => nav.params.value?.tab, (tabParam) => {
 }, { immediate: true })
 
 const { isAdmin, roles: userRoles } = useAuth()
-const hasAccess = computed(() => isAdmin.value || userRoles.value.includes('release-manager'))
+const hasAccess = computed(() => isAdmin.value || userRoles.value.includes('planning-manager'))
 
 const releases = ref([])
 const loading = ref(true)

--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -8,7 +8,7 @@
   "client": {
     "entry": "./client/index.js",
     "navItems": [
-      { "id": "registry", "label": "Manage", "icon": "Database", "requireRole": "release-manager" },
+      { "id": "registry", "label": "Manage", "icon": "Database", "requireRole": "planning-manager" },
       { "id": "plan", "label": "Plan", "icon": "ClipboardList", "default": true },
       { "id": "execute", "label": "Execute", "icon": "GitBranch" },
       { "id": "deliver", "label": "Deliver", "icon": "Rocket" },

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -65,7 +65,7 @@ const refreshState = {
  * @openapi
  * /api/modules/releases/hygiene/refresh:
  *   post:
- *     summary: Trigger hygiene data refresh from Jira (release-manager only)
+ *     summary: Trigger hygiene data refresh from Jira (planning-manager only)
  *     tags: [Releases - Hygiene]
  *     parameters:
  *       - in: query
@@ -97,13 +97,13 @@ const refreshState = {
  * @openapi
  * /api/modules/releases/hygiene/config:
  *   get:
- *     summary: Get hygiene rule configuration (release-manager only)
+ *     summary: Get hygiene rule configuration (planning-manager only)
  *     tags: [Releases - Hygiene]
  *     responses:
  *       200:
  *         description: Hygiene config with rule definitions
  *   post:
- *     summary: Save hygiene rule configuration (release-manager only)
+ *     summary: Save hygiene rule configuration (planning-manager only)
  *     tags: [Releases - Hygiene]
  *     responses:
  *       200:
@@ -122,7 +122,7 @@ const refreshState = {
  */
 
 module.exports = function registerHygieneRoutes(router, context) {
-  const { storage, requireAuth, requireReleaseManager, requireScope, registerDiagnostics } = context;
+  const { storage, requireAuth, requirePlanningManager, requireScope, registerDiagnostics } = context;
 
   function storageKey(version) {
     return DATA_PREFIX + '/features-' + version + '.json';
@@ -331,7 +331,7 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // POST /refresh — trigger Jira data refresh (fire-and-forget)
-  router.post('/refresh', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.post('/refresh', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     var version = req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
@@ -455,13 +455,13 @@ module.exports = function registerHygieneRoutes(router, context) {
    * @openapi
    * /api/modules/releases/hygiene/refresh-all:
    *   post:
-   *     summary: Refresh hygiene data for all active release versions (release-manager only)
+   *     summary: Refresh hygiene data for all active release versions (planning-manager only)
    *     tags: [Releases - Hygiene]
    *     responses:
    *       200:
    *         description: Refresh started, already running, or no versions
    */
-  router.post('/refresh-all', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.post('/refresh-all', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     if (refreshState.running || (context.isRefreshRunning && context.isRefreshRunning())) {
       return res.json({ status: 'already_running' });
     }
@@ -502,7 +502,7 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // GET /config — hygiene rule configuration with rule definitions
-  router.get('/config', requireReleaseManager, requireScope('releases:read'), function(req, res) {
+  router.get('/config', requirePlanningManager, requireScope('releases:read'), function(req, res) {
     var config = loadConfig(storage);
 
     var ruleDefinitions = [];
@@ -527,7 +527,7 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // POST /config — save hygiene rule configuration
-  router.post('/config', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.post('/config', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     try {
       saveConfig(storage, req.body);
 

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -113,7 +113,7 @@ function migrateStoragePaths(storage) {
 
 module.exports = function registerRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireRole, requireScope, roleStore, secrets } = context;
-  const requireReleaseManager = requireRole('release-manager');
+  const requirePlanningManager = requireRole('planning-manager');
 
   // Create shared clients from context.secrets
   const { createJiraClient } = require('../../../shared/server/jira');
@@ -128,10 +128,10 @@ module.exports = function registerRoutes(router, context) {
     sheetId: process.env.SMARTSHEET_SHEET_ID
   });
 
-  // Register release-manager role
-  context.registerRole('release-manager', {
-    label: 'Release Manager',
-    description: 'Manage release planning, execution, and delivery'
+  // Register planning-manager role
+  context.registerRole('planning-manager', {
+    label: 'Planning Manager',
+    description: 'Manage release planning, registry, and delivery configuration'
   });
 
   // Register module scopes
@@ -139,6 +139,41 @@ module.exports = function registerRoutes(router, context) {
     { key: 'releases:read', label: 'Releases (Read)', description: 'Read release planning, execution, and delivery data', category: 'Releases' },
     { key: 'releases:write', label: 'Releases (Write)', description: 'Mutate release planning, execution, and delivery data', category: 'Releases' }
   ]);
+
+  // ─── Role Migration: release-manager → planning-manager ───
+  // Migrate existing role assignments from the old name to the new name.
+  // Uses raw storage manipulation (not roleStore API) because the old role
+  // is no longer registered and roleStore.revokeRole() would reject it.
+  try {
+    const rolesData = storage.readFromStorage('roles.json');
+    if (rolesData && rolesData.assignments) {
+      let migrated = 0;
+      for (const [, entry] of Object.entries(rolesData.assignments)) {
+        if (entry.roles && entry.roles.includes('release-manager')) {
+          migrated++;
+        }
+      }
+      if (migrated > 0) {
+        // Backup before overwriting, following migrateEmailDomains() pattern
+        const backupKey = 'roles-backup-premigration.json';
+        storage.writeToStorage(backupKey, JSON.parse(JSON.stringify(rolesData)));
+        console.log(`[releases] Backup saved to ${backupKey}`);
+
+        for (const [, entry] of Object.entries(rolesData.assignments)) {
+          if (entry.roles && entry.roles.includes('release-manager')) {
+            entry.roles = entry.roles.filter(r => r !== 'release-manager');
+            if (!entry.roles.includes('planning-manager')) {
+              entry.roles.push('planning-manager');
+            }
+          }
+        }
+        storage.writeToStorage('roles.json', rolesData);
+        console.log(`[releases] Migrated ${migrated} user(s) from release-manager to planning-manager`);
+      }
+    }
+  } catch (err) {
+    console.error('[releases] Role migration failed:', err.message);
+  }
 
   // Run storage path migration on module startup (skip if already done)
   const migrationMarker = storage.readFromStorage('releases/.migration-complete');
@@ -152,7 +187,7 @@ module.exports = function registerRoutes(router, context) {
   }
 
   // Registry routes (top-level under /api/modules/releases/)
-  registerRegistryRoutes(router, { storage, requireAuth, requireReleaseManager, requireScope, registerRefresh: context.registerRefresh || null, isRefreshRunning: context.isRefreshRunning || null });
+  registerRegistryRoutes(router, { storage, requireAuth, requirePlanningManager, requireScope, registerRefresh: context.registerRefresh || null, isRefreshRunning: context.isRefreshRunning || null });
 
   // Planning sub-router (mounted at /api/modules/releases/planning/)
   var planningRouter = express.Router();
@@ -160,7 +195,7 @@ module.exports = function registerRoutes(router, context) {
     storage,
     requireAuth,
     requireAdmin,
-    requireReleaseManager,
+    requirePlanningManager,
     requireScope,
     roleStore,
     secrets,
@@ -186,7 +221,6 @@ module.exports = function registerRoutes(router, context) {
   registerFeatureTrackingRoutes(executionRouter, {
     storage,
     requireAuth,
-    requireReleaseManager,
     requireScope
   });
   router.use('/execution', executionRouter);
@@ -212,7 +246,7 @@ module.exports = function registerRoutes(router, context) {
     storage,
     requireAuth,
     requireAdmin,
-    requireReleaseManager,
+    requirePlanningManager,
     requireScope,
     registerDiagnostics: context.registerDiagnostics || null,
     registerRefresh: context.registerRefresh || null,

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -48,7 +48,7 @@ module.exports = function registerPlanningRoutes(router, context) {
   var smartsheetClient = context.smartsheet || require('../../../../shared/server/smartsheet')
   var jiraClient = context.jira || null
 
-  const { storage, requireAuth, requireAdmin, requireScope } = context
+  const { storage, requireAuth, requireAdmin, requirePlanningManager, requireScope } = context
   const { readFromStorage, writeToStorage } = storage
   const listStorageFiles = storage.listStorageFiles || null
   const deleteFromStorage = storage.deleteFromStorage || null
@@ -56,7 +56,7 @@ module.exports = function registerPlanningRoutes(router, context) {
   migrateConfig(readFromStorage, writeToStorage)
 
   // ─── PM User Auto-Migration ───
-  // Migrate pm-users.json entries to the central release-manager role.
+  // Migrate pm-users.json entries to the central planning-manager role.
   // This runs once on module startup; after migration the file is deleted.
   if (context.roleStore) {
     try {
@@ -65,12 +65,12 @@ module.exports = function registerPlanningRoutes(router, context) {
         var migrated = 0
         for (var mi = 0; mi < pmData.emails.length; mi++) {
           var email = pmData.emails[mi]
-          if (!context.roleStore.hasRole(email, 'release-manager')) {
-            context.roleStore.assignRole(email, 'release-manager')
+          if (!context.roleStore.hasRole(email, 'planning-manager')) {
+            context.roleStore.assignRole(email, 'planning-manager')
             migrated++
           }
         }
-        console.log('[releases/planning] Migrated ' + migrated + ' PM user(s) to release-manager role')
+        console.log('[releases/planning] Migrated ' + migrated + ' PM user(s) to planning-manager role')
         if (deleteFromStorage) {
           deleteFromStorage('releases/planning/pm-users.json')
           console.log('[releases/planning] Deleted pm-users.json after migration')
@@ -573,8 +573,12 @@ module.exports = function registerPlanningRoutes(router, context) {
    *         description: Permission flags
    */
   router.get('/permissions', requireAuth, requireScope('releases:read'), function(req, res) {
+    const isPlanningManager = req.isAdmin || req.isPlanningManager
     res.json({
-      canEdit: true
+      canEdit: true,
+      canAdd: isPlanningManager,
+      canDelete: isPlanningManager,
+      canReorder: isPlanningManager
     })
   })
 
@@ -632,7 +636,7 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Reordered Big Rocks
    */
-  router.put('/releases/:version/big-rocks/reorder', requireAuth, requireScope('releases:write'), async function(req, res) {
+  router.put('/releases/:version/big-rocks/reorder', requireAuth, requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -758,7 +762,7 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       201:
    *         description: Created Big Rock
    */
-  router.post('/releases/:version/big-rocks', requireAuth, requireScope('releases:write'), async function(req, res) {
+  router.post('/releases/:version/big-rocks', requireAuth, requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -835,7 +839,7 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Deleted Big Rock
    */
-  router.delete('/releases/:version/big-rocks/:name', requireAuth, blockDuringImpersonation, requireScope('releases:write'), async function(req, res) {
+  router.delete('/releases/:version/big-rocks/:name', requireAuth, requirePlanningManager, blockDuringImpersonation, requireScope('releases:write'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -1129,6 +1133,10 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
     if (mode !== 'replace' && mode !== 'append') {
       return res.status(400).json({ error: 'mode must be "replace" or "append"' })
+    }
+    // Gate replace mode to planning-manager (structural operation)
+    if (mode === 'replace' && !req.isAdmin && !req.isPlanningManager) {
+      return res.status(403).json({ error: 'Replace mode requires planning-manager role' })
     }
 
     try {

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -302,7 +302,7 @@ async function runRegistrySync(storage, options) {
  * Register release registry routes on the provided router.
  */
 function registerRegistryRoutes(router, context) {
-  const { storage, requireAuth, requireReleaseManager, requireScope } = context;
+  const { storage, requireAuth, requirePlanningManager, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
 
   /**
@@ -341,7 +341,7 @@ function registerRegistryRoutes(router, context) {
    *       200:
    *         description: Registry config
    */
-  router.get('/registry/config', requireReleaseManager, requireScope('releases:read'), function(req, res) {
+  router.get('/registry/config', requirePlanningManager, requireScope('releases:read'), function(req, res) {
     var config = loadRegistryConfig(storage);
     res.json(config);
   });
@@ -369,7 +369,7 @@ function registerRegistryRoutes(router, context) {
    *       400:
    *         description: Validation error
    */
-  router.post('/registry/config', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.post('/registry/config', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     try {
       saveRegistryConfig(storage, req.body);
       res.json({ status: 'saved' });
@@ -442,7 +442,7 @@ function registerRegistryRoutes(router, context) {
    *       400:
    *         description: Validation error or duplicate ID
    */
-  router.post('/registry', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.post('/registry', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     const error = validateRelease(req.body);
     if (error) {
       return res.status(400).json({ error });
@@ -496,7 +496,7 @@ function registerRegistryRoutes(router, context) {
    *       404:
    *         description: Release not found
    */
-  router.put('/registry/:id', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.put('/registry/:id', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     const registry = readRegistry(readFromStorage);
     const idx = registry.releases.findIndex(r => r.id === req.params.id);
     if (idx === -1) {
@@ -563,7 +563,7 @@ function registerRegistryRoutes(router, context) {
    *       404:
    *         description: Release not found
    */
-  router.delete('/registry/:id', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.delete('/registry/:id', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     const registry = readRegistry(readFromStorage);
     const idx = registry.releases.findIndex(r => r.id === req.params.id);
     if (idx === -1) {
@@ -597,7 +597,7 @@ function registerRegistryRoutes(router, context) {
    *       200:
    *         description: Discovery results
    */
-  router.post('/registry/discover', requireReleaseManager, requireScope('releases:write'), async function(req, res) {
+  router.post('/registry/discover', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     try {
       const result = await runRegistrySync(storage, { user: req.userEmail || 'unknown' });
 
@@ -630,7 +630,7 @@ function registerRegistryRoutes(router, context) {
    *       500:
    *         description: Jira API error
    */
-  router.post('/registry/resolve-jira-versions', requireReleaseManager, requireScope('releases:write'), async function(req, res) {
+  router.post('/registry/resolve-jira-versions', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     try {
       var config = loadRegistryConfig(storage);
       var projects = config.jiraProjects || [];
@@ -695,7 +695,7 @@ function registerRegistryRoutes(router, context) {
    *       400:
    *         description: Invalid request
    */
-  router.post('/registry/resolve-jira-versions/apply', requireReleaseManager, requireScope('releases:write'), function(req, res) {
+  router.post('/registry/resolve-jira-versions/apply', requirePlanningManager, requireScope('releases:write'), function(req, res) {
     var mappings = req.body && req.body.mappings;
     if (!Array.isArray(mappings) || mappings.length === 0) {
       return res.status(400).json({ error: 'mappings array is required and must not be empty' });

--- a/shared/server/__tests__/module-context.test.js
+++ b/shared/server/__tests__/module-context.test.js
@@ -97,9 +97,9 @@ describe('buildModuleContext', () => {
   it('delegates registerRole to role registry with module slug', () => {
     const roleRegistry = { register: vi.fn() }
     const ctx = buildModuleContext(makeCoreServices({ roleRegistry }), 'releases')
-    ctx.registerRole('release-manager', { label: 'Release Manager', description: 'Manages releases' })
-    expect(roleRegistry.register).toHaveBeenCalledWith('release-manager', {
-      label: 'Release Manager',
+    ctx.registerRole('planning-manager', { label: 'Planning Manager', description: 'Manages releases' })
+    expect(roleRegistry.register).toHaveBeenCalledWith('planning-manager', {
+      label: 'Planning Manager',
       description: 'Manages releases',
       module: 'releases'
     })

--- a/shared/server/auth.js
+++ b/shared/server/auth.js
@@ -106,7 +106,7 @@ function createAuthMiddleware(readFromStorage, writeToStorage, options = {}) {
     }
     req.userRoles = roleStore ? roleStore.getRoles(req.userEmail) : [];
     req.isTeamAdmin = req.userRoles.includes('team-admin');
-    req.isReleaseManager = req.userRoles.includes('release-manager');
+    req.isPlanningManager = req.userRoles.includes('planning-manager');
     req.isManager = isManager(req.userUid, registry);
   }
 
@@ -140,7 +140,7 @@ function createAuthMiddleware(readFromStorage, writeToStorage, options = {}) {
     req.isAdmin = isAdmin(req.userEmail);
     req.userRoles = roleStore ? roleStore.getRoles(req.userEmail) : [];
     req.isTeamAdmin = req.userRoles.includes('team-admin');
-    req.isReleaseManager = req.userRoles.includes('release-manager');
+    req.isPlanningManager = req.userRoles.includes('planning-manager');
     req.isManager = isManager(req.userUid, registry);
     req.isImpersonating = true;
     req.impersonatedDisplayName = target.name || null;

--- a/shared/server/role-registry.js
+++ b/shared/server/role-registry.js
@@ -10,7 +10,7 @@
 
 /**
  * @typedef {object} RoleConfig
- * @property {string} id          - Unique role identifier (e.g. 'release-manager')
+ * @property {string} id          - Unique role identifier (e.g. 'planning-manager')
  * @property {string} label       - Human-readable label for Settings UI
  * @property {string} description - Short description for Settings UI
  * @property {string} module      - Module slug that registered this role (or 'platform')

--- a/src/components/UserManagement.vue
+++ b/src/components/UserManagement.vue
@@ -210,7 +210,7 @@ const roleLabelMap = computed(() => {
 const ROLE_BADGE_COLORS = {
   admin: 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300',
   'team-admin': 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300',
-  'release-manager': 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300',
+  'planning-manager': 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300',
   'usage-metrics-viewer': 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
 }
 const DEFAULT_BADGE_COLOR = 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -120,12 +120,12 @@ const RELEASES_MANIFEST = {
   client: {
     entry: './client/index.js',
     navItems: [
-      { id: 'registry', label: 'Manage', icon: 'Database', requireRole: 'release-manager' },
+      { id: 'registry', label: 'Manage', icon: 'Database', requireRole: 'planning-manager' },
       { id: 'plan', label: 'Plan', icon: 'ClipboardList', default: true },
       { id: 'execute', label: 'Execute', icon: 'GitBranch' },
       { id: 'deliver', label: 'Deliver', icon: 'Rocket' },
       { id: 'reports', label: 'Reports', icon: 'BarChart3' },
-      { id: 'audit', label: 'Audit', icon: 'History', requireRole: 'release-manager' }
+      { id: 'audit', label: 'Audit', icon: 'History' }
     ]
   },
   server: { entry: './server/index.js' }


### PR DESCRIPTION
## Summary

- **Renames** `release-manager` role to `planning-manager` across the entire codebase (registration, middleware, auth flags, client checks, tests, docs) with an automated startup migration that backs up `roles.json` before converting existing assignments
- **Splits** the single `canEdit` permission flag into four granular flags: `canEdit` (all authenticated users), `canAdd`, `canDelete`, `canReorder` (planning-manager + admins only)
- **Enforces** server-side via `requirePlanningManager` middleware (403 on POST/DELETE/reorder) and frontend via conditional rendering (hide add button, delete buttons, drag handles for non-privileged users)
- **Gates** doc import `replace` mode to planning-manager (most destructive structural operation)
- **Refactors** `BigRocksTable.vue` from dual-tbody pattern to single tbody with conditional columns, dynamic colspan, and migrated skeleton/empty states

### Design document

Full plan with architecture, migration strategy, backward compatibility analysis, and testing strategy: [`docs/plans/big-rocks-add-permission.md`](docs/plans/big-rocks-add-permission.md)

### Files changed

| Category | Count | Key files |
|----------|-------|-----------|
| Server | 7 | `index.js` (migration + role registration), `planning/routes.js` (permissions endpoint + middleware), `auth.js`, `registry.js`, `hygiene/routes.js`, `role-registry.js`, `module.json` |
| Client | 7 | `BigRocksTable.vue` (tbody refactor), `DashboardView.vue` (granular props), `HygieneView.vue`, `HygieneWelcomeModal.vue`, `RegistryView.vue`, `useReleasePlanning.js`, `UserManagement.vue` |
| Tests | 6 | `rbac.test.js`, `routes.test.js` (new permission enforcement tests), `health-routes.test.js`, `invalidate-cache.test.js`, `tv-fv-delta.spec.js`, `module-context.test.js` |
| Docs | 4 | Plan doc, `DATA-FORMATS.md`, `MODULES.md`, `outcomes-dashboard-access.md` (superseded note) |

## Test plan

- [ ] `npm test` — all server-side tests pass (181/181), including new permission enforcement and permissions endpoint tests
- [ ] `npm run lint` — clean (pre-existing unrelated error in untracked `scripts/manual-forecast.js` only)
- [ ] Verify role rename: Settings > Users shows "Planning Manager" instead of "Release Manager"
- [ ] Verify migration: existing `release-manager` assignments in `roles.json` auto-convert to `planning-manager` on server restart
- [ ] Verify backup: `roles-backup-premigration.json` created before migration overwrites
- [ ] With `planning-manager` role: can add, edit, delete, reorder Big Rocks
- [ ] Without `planning-manager` role: can edit Big Rocks, but add/delete/reorder buttons hidden and API returns 403
- [ ] Admin without `planning-manager`: full access (admin bypass works)
- [ ] Doc import: `replace` mode returns 403 for non-planning-manager, `append` mode works for all
- [ ] Impersonation: restricted user sees restricted UI; blockDuringImpersonation still works on DELETE

🤖 Generated with [Claude Code](https://claude.com/claude-code)