### PR TITLE
feat(releases): add Schedule view with milestone countdown table

### DIFF
--- a/fixtures/releases/registry.json
+++ b/fixtures/releases/registry.json
@@ -8,6 +8,7 @@
       "productPagesShortname": "red_hat_openshift_ai",
       "productPagesVersion": "2.14",
       "milestones": {
+        "planningFreeze": "2026-04-15",
         "codeFreeze": "2026-06-01",
         "ea1": "2026-06-15",
         "ga": "2026-07-01"
@@ -24,6 +25,7 @@
       "productPagesShortname": "red_hat_openshift_ai",
       "productPagesVersion": "2.15",
       "milestones": {
+        "planningFreeze": "2026-06-15",
         "codeFreeze": "2026-08-01",
         "ga": "2026-09-01"
       },

--- a/modules/releases/__tests__/client/schedule-view.test.js
+++ b/modules/releases/__tests__/client/schedule-view.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+vi.mock('@shared/client/services/api.js', () => ({
+  apiRequest: vi.fn()
+}))
+
+import { apiRequest } from '@shared/client/services/api.js'
+import ScheduleView from '../../client/views/ScheduleView.vue'
+
+function makeRelease(id, opts = {}) {
+  return {
+    id,
+    displayName: opts.displayName || id.toUpperCase(),
+    state: opts.state || 'active',
+    productPagesShortname: opts.shortname || 'rhoai',
+    milestones: {
+      ga: opts.ga || null,
+      codeFreeze: opts.codeFreeze || null,
+      planningFreeze: opts.planningFreeze || null
+    }
+  }
+}
+
+describe('ScheduleView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders loading state initially', () => {
+    apiRequest.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(ScheduleView)
+    expect(wrapper.text()).toContain('Loading schedule...')
+  })
+
+  it('renders empty state when no releases', async () => {
+    apiRequest.mockResolvedValue({ releases: [] })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('No releases found')
+  })
+
+  it('renders releases table with milestone data', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', {
+          ga: '2026-09-15',
+          codeFreeze: '2026-08-20',
+          planningFreeze: '2026-07-10'
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    expect(wrapper.find('table').exists()).toBe(true)
+    expect(wrapper.text()).toContain('RHOAI-3.5')
+    expect(wrapper.text()).toContain('Sep 15, 2026')
+    expect(wrapper.text()).toContain('Aug 20, 2026')
+    expect(wrapper.text()).toContain('Jul 10, 2026')
+  })
+
+  it('shows em-dash for missing milestone dates', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { ga: '2026-09-15' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    const cells = wrapper.findAll('td')
+    const cellTexts = cells.map(c => c.text())
+    const dashCells = cellTexts.filter(t => t === '—')
+    expect(dashCells.length).toBe(2)
+  })
+
+  it('sorts releases by GA date', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.6', { ga: '2026-12-01' }),
+        makeRelease('rhoai-3.4', { ga: '2026-06-01' }),
+        makeRelease('rhoai-3.5', { ga: '2026-09-15' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows[0].text()).toContain('RHOAI-3.4')
+    expect(rows[1].text()).toContain('RHOAI-3.5')
+    expect(rows[2].text()).toContain('RHOAI-3.6')
+  })
+
+  it('filters by non-active state (only shows active)', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { state: 'active', ga: '2026-09-15' }),
+        makeRelease('rhoai-3.4', { state: 'archived', ga: '2026-06-01' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(1)
+    expect(wrapper.text()).toContain('RHOAI-3.5')
+    expect(wrapper.text()).not.toContain('RHOAI-3.4')
+  })
+
+  it('dims released rows (GA in the past)', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.4', { ga: '2024-01-01' }),
+        makeRelease('rhoai-3.5', { ga: '2028-09-15' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    const rows = wrapper.findAll('tbody tr')
+    const pastRow = rows[0]
+    expect(pastRow.classes()).toContain('opacity-50')
+  })
+
+  it('shows global next milestone banner', async () => {
+    const futureDate = new Date()
+    futureDate.setDate(futureDate.getDate() + 5)
+    const dateStr = futureDate.toISOString().split('T')[0]
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { planningFreeze: dateStr, ga: '2028-12-01' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('RHOAI-3.5')
+    expect(wrapper.text()).toContain('Plan Freeze')
+    expect(wrapper.text()).toContain('5d')
+  })
+
+  it('shows product filter pills when multiple products', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { shortname: 'rhoai', ga: '2026-09-15' }),
+        makeRelease('rhelai-1.0', { shortname: 'rhelai', displayName: 'RHELAI-1.0', ga: '2026-10-01' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('All')
+    expect(wrapper.text()).toContain('rhoai')
+    expect(wrapper.text()).toContain('rhelai')
+  })
+
+  it('filters releases when product pill is clicked', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { shortname: 'rhoai', ga: '2026-09-15' }),
+        makeRelease('rhelai-1.0', { shortname: 'rhelai', displayName: 'RHELAI-1.0', ga: '2026-10-01' })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const rhoaiBtn = buttons.find(b => b.text() === 'rhoai')
+    await rhoaiBtn.trigger('click')
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(1)
+    expect(wrapper.text()).toContain('RHOAI-3.5')
+    expect(wrapper.text()).not.toContain('RHELAI-1.0')
+  })
+
+  it('calls the correct API endpoint', async () => {
+    apiRequest.mockResolvedValue({ releases: [] })
+    mount(ScheduleView)
+    await flushPromises()
+    expect(apiRequest).toHaveBeenCalledWith('/modules/releases/registry')
+  })
+
+  it('shows countdown text for future milestones', async () => {
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateStr = tomorrow.toISOString().split('T')[0]
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { ga: dateStr })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('1d')
+  })
+
+  it('shows "Today" for milestones due today', async () => {
+    const today = new Date()
+    const dateStr = today.toISOString().split('T')[0]
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { ga: dateStr })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Today')
+  })
+
+  it('shows "d ago" for past milestones', async () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 3)
+    const dateStr = past.toISOString().split('T')[0]
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { ga: dateStr })
+      ]
+    })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('3d ago')
+  })
+
+  it('refresh button re-fetches registry', async () => {
+    apiRequest.mockResolvedValue({ releases: [makeRelease('rhoai-3.5', { ga: '2026-09-15' })] })
+    const wrapper = mount(ScheduleView)
+    await flushPromises()
+
+    apiRequest.mockResolvedValue({ releases: [makeRelease('rhoai-3.5', { ga: '2026-09-20' })] })
+    const refreshBtn = wrapper.findAll('button').find(b => b.text() === 'Refresh')
+    await refreshBtn.trigger('click')
+    await flushPromises()
+
+    expect(apiRequest).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('Sep 20, 2026')
+  })
+})

--- a/modules/releases/__tests__/server/registry-sync.test.js
+++ b/modules/releases/__tests__/server/registry-sync.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const registryMod = require('../../server/registry');
+const { runRegistrySync, normalizeRelease, REGISTRY_FILE } = registryMod;
+
+const ppMod = require('../../server/delivery/product-pages');
+const configMod = require('../../server/delivery/config');
+
+function createMockStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    _store: store
+  };
+}
+
+describe('runRegistrySync — planningFreeze', () => {
+  let origFetch, origGetAuth, origGetConfig;
+
+  beforeEach(() => {
+    origFetch = ppMod.fetchProductsByShortname;
+    origGetAuth = ppMod.getAuthStatus;
+    origGetConfig = configMod.getConfig;
+
+    ppMod.getAuthStatus = vi.fn().mockReturnValue('configured');
+    ppMod.fetchProductsByShortname = vi.fn().mockResolvedValue([]);
+    configMod.getConfig = vi.fn().mockReturnValue({
+      productPagesProductShortnames: ['rhoai']
+    });
+  });
+
+  afterEach(() => {
+    ppMod.fetchProductsByShortname = origFetch;
+    ppMod.getAuthStatus = origGetAuth;
+    configMod.getConfig = origGetConfig;
+  });
+
+  it('creates new release with planningFreeze from PP data', async () => {
+    ppMod.fetchProductsByShortname.mockResolvedValue([
+      {
+        releaseNumber: 'RHOAI-3.5',
+        productName: 'RHOAI',
+        dueDate: '2026-09-15',
+        codeFreezeDate: '2026-08-20',
+        planningFreezeDate: '2026-07-10'
+      }
+    ]);
+
+    const storage = createMockStorage();
+    const result = await runRegistrySync(storage, {});
+
+    expect(result.created).toBe(1);
+    const registry = storage._store[REGISTRY_FILE];
+    const release = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(release).toBeDefined();
+    expect(release.milestones.ga).toBe('2026-09-15');
+    expect(release.milestones.codeFreeze).toBe('2026-08-20');
+    expect(release.milestones.planningFreeze).toBe('2026-07-10');
+  });
+
+  it('updates existing release with planningFreeze from PP data', async () => {
+    const existingRelease = normalizeRelease({
+      id: 'rhoai-3.5',
+      displayName: 'RHOAI-3.5',
+      productPagesShortname: 'rhoai',
+      productPagesVersion: 'RHOAI-3.5',
+      milestones: { ga: '2026-09-01', codeFreeze: '2026-08-15', planningFreeze: null },
+      source: 'product-pages',
+      state: 'active'
+    });
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: { schemaVersion: 1, releases: [existingRelease] }
+    });
+
+    ppMod.fetchProductsByShortname.mockResolvedValue([
+      {
+        releaseNumber: 'RHOAI-3.5',
+        productName: 'RHOAI',
+        dueDate: '2026-09-15',
+        codeFreezeDate: '2026-08-20',
+        planningFreezeDate: '2026-07-10'
+      }
+    ]);
+
+    const result = await runRegistrySync(storage, {});
+
+    expect(result.updated).toBe(1);
+    const registry = storage._store[REGISTRY_FILE];
+    const release = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(release.milestones.planningFreeze).toBe('2026-07-10');
+    expect(release.milestones.ga).toBe('2026-09-15');
+    expect(release.milestones.codeFreeze).toBe('2026-08-20');
+  });
+
+  it('preserves existing planningFreeze when PP data is missing it', async () => {
+    const existingRelease = normalizeRelease({
+      id: 'rhoai-3.5',
+      displayName: 'RHOAI-3.5',
+      productPagesShortname: 'rhoai',
+      productPagesVersion: 'RHOAI-3.5',
+      milestones: { ga: '2026-09-01', codeFreeze: '2026-08-15', planningFreeze: '2026-07-01' },
+      source: 'product-pages',
+      state: 'active'
+    });
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: { schemaVersion: 1, releases: [existingRelease] }
+    });
+
+    ppMod.fetchProductsByShortname.mockResolvedValue([
+      {
+        releaseNumber: 'RHOAI-3.5',
+        productName: 'RHOAI',
+        dueDate: '2026-09-15',
+        codeFreezeDate: '2026-08-20',
+        planningFreezeDate: undefined
+      }
+    ]);
+
+    const result = await runRegistrySync(storage, {});
+
+    expect(result.updated).toBe(1);
+    const registry = storage._store[REGISTRY_FILE];
+    const release = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(release.milestones.planningFreeze).toBe('2026-07-01');
+  });
+
+  it('creates release with null planningFreeze when PP data omits it', async () => {
+    ppMod.fetchProductsByShortname.mockResolvedValue([
+      {
+        releaseNumber: 'RHOAI-3.6',
+        productName: 'RHOAI',
+        dueDate: '2026-12-01',
+        codeFreezeDate: '2026-11-15'
+      }
+    ]);
+
+    const storage = createMockStorage();
+    const result = await runRegistrySync(storage, {});
+
+    expect(result.created).toBe(1);
+    const registry = storage._store[REGISTRY_FILE];
+    const release = registry.releases.find(r => r.id === 'rhoai-3.6');
+    expect(release.milestones.planningFreeze).toBeNull();
+  });
+
+  it('skips sync when auth is not configured', async () => {
+    ppMod.getAuthStatus.mockReturnValue('none');
+    const storage = createMockStorage();
+    const result = await runRegistrySync(storage, {});
+    expect(result.status).toBe('skipped');
+    expect(ppMod.fetchProductsByShortname).not.toHaveBeenCalled();
+  });
+
+  it('archives releases no longer discovered from PP', async () => {
+    const existingRelease = normalizeRelease({
+      id: 'rhoai-3.4',
+      displayName: 'RHOAI-3.4',
+      productPagesShortname: 'rhoai',
+      productPagesVersion: 'RHOAI-3.4',
+      milestones: { ga: '2026-06-01', codeFreeze: '2026-05-15', planningFreeze: '2026-04-01' },
+      source: 'product-pages',
+      state: 'active'
+    });
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: { schemaVersion: 1, releases: [existingRelease] }
+    });
+
+    ppMod.fetchProductsByShortname.mockResolvedValue([
+      {
+        releaseNumber: 'RHOAI-3.5',
+        productName: 'RHOAI',
+        dueDate: '2026-09-15',
+        codeFreezeDate: '2026-08-20',
+        planningFreezeDate: '2026-07-10'
+      }
+    ]);
+
+    const result = await runRegistrySync(storage, {});
+
+    expect(result.archived).toBe(1);
+    const registry = storage._store[REGISTRY_FILE];
+    const archived = registry.releases.find(r => r.id === 'rhoai-3.4');
+    expect(archived.state).toBe('archived');
+  });
+
+  it('does not update non-product-pages sourced releases', async () => {
+    const manualRelease = normalizeRelease({
+      id: 'rhoai-3.5',
+      displayName: 'RHOAI-3.5',
+      milestones: { ga: '2026-09-01', codeFreeze: null, planningFreeze: null },
+      source: 'manual',
+      state: 'active'
+    });
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: { schemaVersion: 1, releases: [manualRelease] }
+    });
+
+    ppMod.fetchProductsByShortname.mockResolvedValue([
+      {
+        releaseNumber: 'RHOAI-3.5',
+        productName: 'RHOAI',
+        dueDate: '2026-09-15',
+        codeFreezeDate: '2026-08-20',
+        planningFreezeDate: '2026-07-10'
+      }
+    ]);
+
+    const result = await runRegistrySync(storage, {});
+
+    expect(result.updated).toBe(0);
+    const registry = storage._store[REGISTRY_FILE];
+    const release = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(release.milestones.planningFreeze).toBeNull();
+  });
+});

--- a/modules/releases/client/index.js
+++ b/modules/releases/client/index.js
@@ -2,6 +2,7 @@ import { defineAsyncComponent } from 'vue'
 
 export const routes = {
   'registry': defineAsyncComponent(() => import('./views/RegistryView.vue')),
+  'schedule': defineAsyncComponent(() => import('./views/ScheduleView.vue')),
   'plan': defineAsyncComponent(() => import('./views/PlanView.vue')),
   'execute': defineAsyncComponent(() => import('./views/ExecuteView.vue')),
   'feature-detail': defineAsyncComponent(() => import('./views/FeatureDetailView.vue')),

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -1,0 +1,322 @@
+<template>
+  <div class="max-w-5xl mx-auto py-6 px-4">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Release Schedule</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Milestone dates sourced from
+          <a href="https://productpages.redhat.com" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-primary-400 hover:underline">Product Pages</a>
+        </p>
+      </div>
+      <button
+        @click="fetchRegistry"
+        :disabled="loading"
+        class="px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 transition-colors"
+      >
+        {{ loading ? 'Loading...' : 'Refresh' }}
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading && !releases.length" class="text-center py-12 text-sm text-gray-500 dark:text-gray-400">
+      Loading schedule...
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="error"
+      class="text-center py-16 bg-white dark:bg-gray-800 rounded-lg border border-red-200 dark:border-red-700/50"
+    >
+      <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">Failed to load schedule</h3>
+      <p class="text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+      <button
+        @click="fetchRegistry"
+        class="mt-4 px-4 py-2 text-sm font-medium text-primary-600 dark:text-primary-400 hover:underline"
+      >Try again</button>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="!allSortedReleases.length"
+      class="text-center py-16 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+    >
+      <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">No releases found</h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        Run a registry sync from Product Pages to populate release milestones.
+      </p>
+    </div>
+
+    <template v-else>
+      <!-- Next milestone banner -->
+      <div
+        v-if="globalNextMilestone"
+        class="mb-5 rounded-lg border px-4 py-3 flex items-center justify-between"
+        :class="globalNextMilestone.days <= 7
+          ? 'border-blue-200 dark:border-blue-700/50 bg-blue-50/80 dark:bg-blue-900/20'
+          : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50'"
+      >
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-flex h-2.5 w-2.5 rounded-full shrink-0"
+            :class="globalNextMilestone.days <= 7
+              ? 'bg-blue-500 animate-pulse'
+              : 'bg-gray-400 dark:bg-gray-500'"
+          ></span>
+          <span class="text-sm text-gray-900 dark:text-gray-100">
+            <span class="font-medium">{{ globalNextMilestone.releaseName }}</span>
+            <span class="text-gray-500 dark:text-gray-400"> · {{ globalNextMilestone.label }}</span>
+          </span>
+        </div>
+        <span
+          class="text-sm font-semibold tabular-nums"
+          :class="globalNextMilestone.days <= 7
+            ? 'text-blue-600 dark:text-blue-400'
+            : 'text-gray-600 dark:text-gray-300'"
+        >
+          {{ globalNextMilestone.days === 0 ? 'Today' : globalNextMilestone.days + 'd' }}
+        </span>
+      </div>
+
+      <!-- Product filter -->
+      <div v-if="products.length > 1" class="flex flex-wrap gap-2 mb-5">
+        <button
+          @click="selectedProduct = null"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+          :class="!selectedProduct
+            ? 'bg-primary-600 text-white border-primary-600'
+            : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+        >All</button>
+        <button
+          v-for="p in products"
+          :key="p"
+          @click="selectedProduct = p"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+          :class="selectedProduct === p
+            ? 'bg-primary-600 text-white border-primary-600'
+            : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+        >{{ p }}</button>
+      </div>
+
+      <!-- Releases table -->
+      <div class="bg-white dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/50">
+                <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
+                <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Plan Freeze</th>
+                <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Code Freeze</th>
+                <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="r in allSortedReleases"
+                :key="r.id"
+                class="border-b border-gray-100 dark:border-gray-800 last:border-0 transition-colors"
+                :class="isReleased(r) ? 'opacity-50' : nextMilestoneUrgencyRow(r)"
+              >
+                <td class="px-4 py-3">
+                  <span class="font-semibold text-gray-900 dark:text-gray-100">{{ r.displayName || r.id }}</span>
+                </td>
+                <td class="px-4 py-3">
+                  <MilestoneCell :date="r.milestones?.planningFreeze" :muted="isReleased(r)" />
+                </td>
+                <td class="px-4 py-3">
+                  <MilestoneCell :date="r.milestones?.codeFreeze" :muted="isReleased(r)" />
+                </td>
+                <td class="px-4 py-3">
+                  <MilestoneCell :date="r.milestones?.ga" :muted="isReleased(r)" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, h } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+// ── Data ──
+
+const releases = ref([])
+const loading = ref(true)
+const error = ref(null)
+const selectedProduct = ref(null)
+
+async function fetchRegistry() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await apiRequest('/modules/releases/registry')
+    releases.value = (data.releases || []).filter(function (r) { return r.state === 'active' })
+  } catch (e) {
+    error.value = e.message || 'Failed to load schedule data'
+    console.error('[schedule] Failed to fetch registry:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchRegistry)
+
+// ── Helpers ──
+
+function parseDate(val) {
+  if (!val) return null
+  const d = new Date(val)
+  return isNaN(d.getTime()) ? null : d
+}
+
+function todayMidnight() {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function daysFromNow(dateStr) {
+  const d = parseDate(dateStr)
+  if (!d) return null
+  const today = todayMidnight()
+  d.setHours(0, 0, 0, 0)
+  return Math.ceil((d.getTime() - today.getTime()) / 86400000)
+}
+
+function formatShort(dateStr) {
+  const d = parseDate(dateStr)
+  if (!d) return '—'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function getProduct(release) {
+  if (release.productPagesShortname) return release.productPagesShortname
+  const match = release.id.match(/^([a-z]+)-/)
+  return match ? match[1] : release.id
+}
+
+function getGaDate(release) {
+  return release.milestones?.ga || null
+}
+
+function nextMilestone(release) {
+  const ms = release.milestones || {}
+  const milestones = [
+    { key: 'planningFreeze', label: 'Plan Freeze', date: ms.planningFreeze },
+    { key: 'codeFreeze', label: 'Code Freeze', date: ms.codeFreeze },
+    { key: 'ga', label: 'Release Date', date: ms.ga }
+  ]
+  for (let i = 0; i < milestones.length; i++) {
+    const days = daysFromNow(milestones[i].date)
+    if (days !== null && days >= 0) {
+      return { label: milestones[i].label, type: milestones[i].key, days }
+    }
+  }
+  return null
+}
+
+// ── Computed ──
+
+const products = computed(() => {
+  const set = {}
+  for (let i = 0; i < releases.value.length; i++) {
+    set[getProduct(releases.value[i])] = true
+  }
+  return Object.keys(set).sort()
+})
+
+const filteredReleases = computed(() => {
+  if (!selectedProduct.value) return releases.value
+  return releases.value.filter(r => getProduct(r) === selectedProduct.value)
+})
+
+const allSortedReleases = computed(() => {
+  return filteredReleases.value.slice().sort((a, b) => {
+    const da = parseDate(getGaDate(a))
+    const db = parseDate(getGaDate(b))
+    if (!da && !db) return 0
+    if (!da) return 1
+    if (!db) return -1
+    return da.getTime() - db.getTime()
+  })
+})
+
+const globalNextMilestone = computed(() => {
+  let best = null
+  for (let i = 0; i < allSortedReleases.value.length; i++) {
+    const r = allSortedReleases.value[i]
+    const nm = nextMilestone(r)
+    if (nm && (best === null || nm.days < best.days)) {
+      best = { releaseName: r.displayName || r.id, label: nm.label, type: nm.type, days: nm.days }
+    }
+  }
+  return best
+})
+
+function isReleased(release) {
+  const ga = getGaDate(release)
+  if (!ga) return false
+  const days = daysFromNow(ga)
+  return days !== null && days < 0
+}
+
+function nextMilestoneUrgencyRow(release) {
+  const nm = nextMilestone(release)
+  if (!nm) return ''
+  if (nm.days <= 7) return 'bg-blue-50/50 dark:bg-blue-900/10'
+  return ''
+}
+
+// ── Inline sub-components ──
+
+const MilestoneCell = {
+  props: {
+    date: { type: String, default: null },
+    muted: { type: Boolean, default: false }
+  },
+  setup(props) {
+    return () => {
+      if (!props.date) {
+        return h('span', { class: 'text-gray-300 dark:text-gray-600' }, '—')
+      }
+      const days = daysFromNow(props.date)
+      const dateLabel = formatShort(props.date)
+
+      const dateClass = props.muted
+        ? 'text-gray-500 dark:text-gray-400'
+        : 'text-gray-900 dark:text-gray-100'
+
+      let countdownEl = null
+      if (days !== null) {
+        let countdownClass = 'text-[11px] tabular-nums '
+        if (props.muted || days < 0) {
+          countdownClass += 'text-gray-400 dark:text-gray-500'
+        } else if (days === 0) {
+          countdownClass += 'font-semibold text-blue-600 dark:text-blue-400'
+        } else if (days <= 7) {
+          countdownClass += 'font-medium text-blue-600 dark:text-blue-400'
+        } else if (days <= 14) {
+          countdownClass += 'text-blue-500 dark:text-blue-400'
+        } else {
+          countdownClass += 'text-gray-400 dark:text-gray-500'
+        }
+
+        let countdownText
+        if (days < 0) countdownText = Math.abs(days) + 'd ago'
+        else if (days === 0) countdownText = 'Today'
+        else countdownText = days + 'd'
+
+        countdownEl = h('span', { class: countdownClass }, countdownText)
+      }
+
+      return h('div', { class: 'flex flex-col' }, [
+        h('span', { class: 'text-sm tabular-nums ' + dateClass }, dateLabel),
+        countdownEl
+      ])
+    }
+  }
+}
+</script>

--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -9,6 +9,7 @@
     "entry": "./client/index.js",
     "navItems": [
       { "id": "registry", "label": "Manage", "icon": "Database", "requireRole": "planning-manager" },
+      { "id": "schedule", "label": "Schedule", "icon": "CalendarDays" },
       { "id": "plan", "label": "Plan", "icon": "ClipboardList", "default": true },
       { "id": "execute", "label": "Execute", "icon": "GitBranch" },
       { "id": "deliver", "label": "Deliver", "icon": "Rocket" },

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -236,7 +236,8 @@ async function runRegistrySync(storage, options) {
       displayName: stripZStream(releaseNumber),
       productName: ppRelease.productName,
       dueDate: ppRelease.dueDate,
-      codeFreezeDate: ppRelease.codeFreezeDate
+      codeFreezeDate: ppRelease.codeFreezeDate,
+      planningFreezeDate: ppRelease.planningFreezeDate
     });
 
     const existing = existingById.get(id);
@@ -251,7 +252,8 @@ async function runRegistrySync(storage, options) {
         existing.milestones = {
           ...(existing.milestones || {}),
           ga: ppRelease.dueDate || existing.milestones?.ga || null,
-          codeFreeze: ppRelease.codeFreezeDate || existing.milestones?.codeFreeze || null
+          codeFreeze: ppRelease.codeFreezeDate || existing.milestones?.codeFreeze || null,
+          planningFreeze: ppRelease.planningFreezeDate || existing.milestones?.planningFreeze || null
         };
         existing.updatedAt = new Date().toISOString();
         updated++;
@@ -264,7 +266,8 @@ async function runRegistrySync(storage, options) {
         productPagesVersion: releaseNumber,
         milestones: {
           ga: ppRelease.dueDate || null,
-          codeFreeze: ppRelease.codeFreezeDate || null
+          codeFreeze: ppRelease.codeFreezeDate || null,
+          planningFreeze: ppRelease.planningFreezeDate || null
         },
         source: 'product-pages',
         state: 'active'

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -269,6 +269,7 @@ import {
   Database,
   History,
   Hospital,
+  CalendarDays,
   LayoutDashboard,
   Rocket,
   UserCircle
@@ -319,6 +320,7 @@ const ICON_MAP = {
   History,
   Hospital,
   'hospital': Hospital,
+  CalendarDays,
   LayoutDashboard,
   Rocket,
   UserCircle,

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -177,6 +177,10 @@ test.describe('Releases Views @releases', () => {
   test('should load Audit view', async ({ page }) => {
     await testView(page, 'audit', 'Audit');
   });
+
+  test('should load Schedule view', async ({ page }) => {
+    await testView(page, 'schedule', 'Schedule');
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

Adds a **Schedule** nav item to the Releases module — a cross-release milestone countdown table that shows Planning Freeze, Code Freeze, and Release Date for all active releases.

- Syncs `planningFreeze` from Product Pages alongside existing `ga` and `codeFreeze` milestones in `runRegistrySync`
- Reads from the existing registry API (no new backend routes)
- Registers `CalendarDays` icon in AppSidebar for nav resolution
- Adds `planningFreeze` to demo fixture data

## Test plan

- [x] Unit tests: 15 client tests (ScheduleView rendering, filtering, sorting, error state, countdown logic)
- [x] Unit tests: 7 server tests (planningFreeze sync — create, update, preserve, null, skip, archive, source-guard)
- [x] Integration test: Schedule view loads with content in demo mode
- [x] `npm test` — 4654 tests passing
- [x] `npm run lint` — clean