### PR TITLE
feat(tv-fv-delta): add GA Date, Days to GA, and Planning Freeze columns

### DIFF
--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -327,6 +327,55 @@ describe('buildExport', () => {
     expect(summary.alignment_pct).toBe(50);
   });
 
+  it('includes ga_date and planning_freeze from releaseDates', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const releaseDates = {
+      'rhoai-3.5': { dueDate: '2026-08-20', planningFreezeDate: '2026-06-24' },
+    };
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT', releaseDates);
+    const summary = result.executive_summary[0];
+    expect(summary.ga_date).toBe('2026-08-20');
+    expect(summary.planning_freeze).toBe('2026-06-24');
+  });
+
+  it('sets ga_date and planning_freeze to null when releaseDates is not provided', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const summary = result.executive_summary[0];
+    expect(summary.ga_date).toBeNull();
+    expect(summary.planning_freeze).toBeNull();
+  });
+
+  it('falls back to normVer lookup when release key does not match directly', () => {
+    const classifications = [
+      { release: 'RHOAI-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const releaseDates = {
+      'rhoai-3.5': { dueDate: '2026-08-20', planningFreezeDate: '2026-06-24' },
+    };
+    const result = buildExport(classifications, ['RHOAI-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT', releaseDates);
+    const summary = result.executive_summary[0];
+    expect(summary.ga_date).toBe('2026-08-20');
+    expect(summary.planning_freeze).toBe('2026-06-24');
+  });
+
+  it('handles partial releaseDates (only ga_date, no planning_freeze)', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const releaseDates = {
+      'rhoai-3.5': { dueDate: '2026-08-20' },
+    };
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT', releaseDates);
+    const summary = result.executive_summary[0];
+    expect(summary.ga_date).toBe('2026-08-20');
+    expect(summary.planning_freeze).toBeNull();
+  });
+
   it('generates correct JQL links for tv_only (fixVersion is EMPTY, not OR)', () => {
     const classifications = [
       { release: 'rhoai-3.5', category: 'tv_only', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -65,6 +65,13 @@ const filteredSummary = computed(() => {
 
 const { releaseComponentBreakdown } = useComponentBreakdown(data, releaseData)
 
+/** Compute days until GA from an ISO date string. Returns null if no date. */
+function daysToGa(gaDate) {
+  if (!gaDate) return null
+  const diff = new Date(gaDate + 'T00:00:00Z') - new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z')
+  return Math.ceil(diff / 86400000)
+}
+
 // ---------------------------------------------------------------------------
 // Auto-refresh when selection includes releases not yet in data
 // ---------------------------------------------------------------------------
@@ -170,6 +177,9 @@ onBeforeUnmount(() => {
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">FV-Only</th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Mismatched</th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Alignment</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">GA Date</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to GA</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Planning Freeze</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -218,6 +228,26 @@ onBeforeUnmount(() => {
                     {{ row.alignment_pct }}%
                   </span>
                   <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {{ row.ga_date ? formatDate(row.ga_date) : '—' }}
+                </td>
+                <td class="px-4 py-2 text-right text-xs whitespace-nowrap"
+                  :class="{
+                    'text-gray-400': row._pending || daysToGa(row.ga_date) === null,
+                    'text-green-600 dark:text-green-400': daysToGa(row.ga_date) !== null && daysToGa(row.ga_date) <= 0,
+                    'text-red-600 dark:text-red-400': daysToGa(row.ga_date) > 0 && daysToGa(row.ga_date) <= 30,
+                    'text-yellow-600 dark:text-yellow-400': daysToGa(row.ga_date) > 30 && daysToGa(row.ga_date) <= 60,
+                    'text-gray-500 dark:text-gray-400': daysToGa(row.ga_date) > 60,
+                  }"
+                >
+                  <template v-if="daysToGa(row.ga_date) !== null">
+                    {{ daysToGa(row.ga_date) > 0 ? daysToGa(row.ga_date) + 'd' : 'Released' }}
+                  </template>
+                  <template v-else>&mdash;</template>
+                </td>
+                <td class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {{ row.planning_freeze ? formatDate(row.planning_freeze) : '—' }}
                 </td>
               </tr>
             </tbody>

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -282,7 +282,7 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
     const alignPct = nTotal > 0 ? Math.round(1000 * cats.aligned / nTotal) / 10 : 0
 
     // Look up release dates from Product Pages cache
-    var dates = {}
+    let dates = {}
     if (releaseDates) {
       dates = releaseDates[release] || releaseDates[normVer(release)] || {}
     }
@@ -431,9 +431,9 @@ async function fetchAndClassify(releases, storage, jiraProject) {
   const releaseDates = {}
   const ppCache = storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
   if (ppCache && Array.isArray(ppCache.releases)) {
-    for (var pi = 0; pi < ppCache.releases.length; pi++) {
-      var ppRel = ppCache.releases[pi]
-      var ppKey = (ppRel.releaseNumber || '').toLowerCase()
+    for (let pi = 0; pi < ppCache.releases.length; pi++) {
+      const ppRel = ppCache.releases[pi]
+      const ppKey = (ppRel.releaseNumber || '').toLowerCase()
       if (ppKey) {
         releaseDates[ppKey] = {
           dueDate: ppRel.dueDate || null,

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -263,7 +263,7 @@ function classifyFeatures(features, releases) {
 // Build export payload
 // ---------------------------------------------------------------------------
 
-function buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject) {
+function buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject, releaseDates) {
   const baseJql = 'project = ' + jiraProject + ' AND issuetype = Feature'
 
   const executiveSummary = []
@@ -281,6 +281,12 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
 
     const alignPct = nTotal > 0 ? Math.round(1000 * cats.aligned / nTotal) / 10 : 0
 
+    // Look up release dates from Product Pages cache
+    var dates = {}
+    if (releaseDates) {
+      dates = releaseDates[release] || releaseDates[normVer(release)] || {}
+    }
+
     executiveSummary.push({
       release: release,
       total: nTotal,
@@ -293,7 +299,9 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
       fv_only_jql: jqlUrl(baseJql + ' AND fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is EMPTY'),
       mismatched: cats.mismatched,
       mismatched_jql: jqlUrl(baseJql + ' AND (("Target Version" in (' + quoteRelease(release) + ') AND fixVersion is not EMPTY AND fixVersion not in (' + quoteRelease(release) + ')) OR (fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is not EMPTY AND "Target Version" not in (' + quoteRelease(release) + ')))'),
-      alignment_pct: alignPct
+      alignment_pct: alignPct,
+      ga_date: dates.dueDate || null,
+      planning_freeze: dates.planningFreezeDate || null,
     })
 
     // Per-release feature lists
@@ -419,8 +427,24 @@ async function fetchAndClassify(releases, storage, jiraProject) {
   const classifications = classifyFeatures(features, releases)
   console.log('[releases/tv-fv-delta] Classified ' + classifications.length + ' feature-release pairs')
 
+  // Look up release dates from Product Pages delivery cache
+  const releaseDates = {}
+  const ppCache = storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
+  if (ppCache && Array.isArray(ppCache.releases)) {
+    for (var pi = 0; pi < ppCache.releases.length; pi++) {
+      var ppRel = ppCache.releases[pi]
+      var ppKey = (ppRel.releaseNumber || '').toLowerCase()
+      if (ppKey) {
+        releaseDates[ppKey] = {
+          dueDate: ppRel.dueDate || null,
+          planningFreezeDate: ppRel.planningFreezeDate || null,
+        }
+      }
+    }
+  }
+
   // Build export
-  const result = buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject)
+  const result = buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject, releaseDates)
 
   // Cache
   storage.writeToStorage(CACHE_KEY, result)


### PR DESCRIPTION
## Summary
- Adds **GA Date**, **Days to GA**, and **Planning Freeze** columns to the TV vs FV executive summary table
- Server reads release milestones from the Product Pages delivery cache (`releases/delivery/product-pages-releases-cache.json`)
- Days to GA computed client-side with color-coded urgency: green (released), red (<=30d), yellow (<=60d)
- Graceful fallback: shows `—` when Product Pages data isn't cached yet

## Test plan
- [x] 4 new unit tests covering: with dates, without dates, normVer fallback, partial dates
- [x] All 106 existing pipeline tests pass
- [ ] Visual check on deployed instance with Product Pages cache populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)