### PR TITLE
fix(releases): prevent table and score tooltip overflow clipping

### DIFF
--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -161,7 +161,7 @@ function formatSyncDate(dateStr) {
 </script>
 
 <template>
-  <div class="space-y-0">
+  <div class="space-y-0 overflow-hidden">
 
     <!-- Release selector + summary bar -->
     <div class="flex items-center justify-between px-4 py-2 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">

--- a/shared/client/components/FeatureReadinessRow.vue
+++ b/shared/client/components/FeatureReadinessRow.vue
@@ -92,7 +92,7 @@ const confidenceTooltip = computed(() => {
         >{{ priorityDisplay }}</span>
         <div
           v-if="scoreBreakdown"
-          class="absolute z-50 top-full mt-1 left-1/2 -translate-x-1/2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal hidden group-hover:block"
+          class="absolute z-50 top-full mt-1 left-0 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs text-left font-normal hidden group-hover:block"
         >
           <p class="font-semibold text-gray-700 dark:text-gray-200 mb-1.5">
             Score: {{ scoreBreakdown.score }} / 100


### PR DESCRIPTION
## Summary

- Add `overflow-hidden` to FeatureReadinessView root container so the inner `overflow-x-auto` table produces a horizontal scrollbar instead of pushing content off-screen at narrower viewport widths (~80%+)
- Anchor the score breakdown tooltip to `left-0` instead of `left-1/2 -translate-x-1/2`, preventing the left side from being clipped when the Score column is near the left edge

## Test plan

- Resize browser to ~80% width and confirm the table shows a horizontal scrollbar instead of clipping the right-side columns
- Hover over the Score column and confirm the tooltip opens fully visible, anchored to the left edge of the cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)