### PR TITLE
fix(releases): pass planningFreezeDate through all cache paths

### DIFF
--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -264,6 +264,7 @@ async function discoverReleasesFromJira(storage, config) {
       dueDate: meta.dueDate || null,
       codeFreezeDate: meta.codeFreezeDate || null,
       featureFreezeDate: meta.featureFreezeDate || null,
+      planningFreezeDate: meta.planningFreezeDate || null,
       featureCount: featureCounts.get(version) || 0
     })
   }
@@ -323,7 +324,8 @@ async function fetchOpenReleases(storage, config) {
         releaseNumber: r.releaseNumber || r.release_number || r.name || '',
         dueDate: toIsoDate(r.dueDate || r.due_date || r.gaDate || r.ga_date || r.date_finish || r.date_start),
         codeFreezeDate: toIsoDate(r.codeFreezeDate || r.code_freeze_date || r.codeFreeze || r.code_freeze) || null,
-        featureFreezeDate: toIsoDate(r.featureFreezeDate || r.feature_freeze_date || r.featureFreeze || r.feature_freeze) || null
+        featureFreezeDate: toIsoDate(r.featureFreezeDate || r.feature_freeze_date || r.featureFreeze || r.feature_freeze) || null,
+        planningFreezeDate: toIsoDate(r.planningFreezeDate || r.planning_freeze_date || r.planningFreeze || r.planning_freeze) || null
       }))
       .filter(r => r.productName && r.releaseNumber && r.dueDate)
     storage.writeToStorage('releases/delivery/product-pages-releases-cache.json', {


### PR DESCRIPTION
## Summary

- The Product Pages API client (`product-pages.js`) correctly extracts `planningFreezeDate` via `extractPlanningFreezeDate()`, but two cache-write paths were dropping it before it reached the TV vs FV Delta page
- **Jira discovery path** (`discoverReleasesFromJira`) — now includes `planningFreezeDate` from releases metadata
- **Legacy URL path** — now maps `planningFreezeDate` / `planning_freeze_date` variants when writing to the Product Pages cache

This fixes the GA Date, Days to GA, and Planning Freeze columns showing dashes on the TV vs FV Delta page.

## Test plan

- [ ] Trigger a delivery refresh (`Refresh from Jira` on TV vs FV Delta page)
- [ ] Verify Planning Freeze column populates for releases that have planning freeze dates in Product Pages
- [ ] Verify GA Date and Days to GA columns populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)