### PR TITLE
fix(health-metrics): show all tracked pages in Site Usage table

### DIFF
--- a/src/__tests__/health-metrics/SiteUsageTab.test.js
+++ b/src/__tests__/health-metrics/SiteUsageTab.test.js
@@ -18,11 +18,17 @@ vi.mock('../../components/health-metrics/useMetricsDashboard.js', () => ({
     loading: ref(false),
     error: ref(null),
     fetchDashboard: vi.fn(),
+    fetchPages: vi.fn(),
     totalViews: ref(1500),
     uniqueUsers: ref(42),
     activePages: ref(8),
     topPages: ref([
       { pageId: 'team-tracker::home', views: 523, uniqueUsers: 34, byUserType: {}, byPermissionTier: {} },
+    ]),
+    allPages: ref([
+      { pageId: 'team-tracker::home', views: 523, uniqueUsers: 34, byUserType: {}, byPermissionTier: {} },
+      { pageId: 'team-tracker::org-dashboard', views: 342, uniqueUsers: 28, byUserType: {}, byPermissionTier: {} },
+      { pageId: 'upstream-pulse::dashboard', views: 45, uniqueUsers: 12, byUserType: {}, byPermissionTier: {} },
     ]),
     userTypes: ref({ Backend: 400, Frontend: 300 }),
     daily: ref({}),
@@ -68,8 +74,9 @@ describe('SiteUsageTab', () => {
     expect(wrapper.text()).toContain('User Type Breakdown');
   });
 
-  it('renders pages table', () => {
+  it('renders pages table with all pages including low-traffic modules', () => {
     expect(wrapper.text()).toContain('All Pages');
     expect(wrapper.text()).toContain('team-tracker / home');
+    expect(wrapper.text()).toContain('upstream-pulse / dashboard');
   });
 });

--- a/src/components/health-metrics/SiteUsageTab.vue
+++ b/src/components/health-metrics/SiteUsageTab.vue
@@ -77,7 +77,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="page in topPages"
+              v-for="page in allPages"
               :key="page.pageId"
               class="border-b border-gray-100 dark:border-gray-700/50"
             >
@@ -104,10 +104,12 @@ const {
   loading,
   error,
   fetchDashboard,
+  fetchPages,
   totalViews,
   uniqueUsers,
   activePages,
   topPages,
+  allPages,
   userTypes,
   daily,
 } = useMetricsDashboard()
@@ -122,11 +124,12 @@ function formatPageId(pageId) {
   return `${mod} / ${view}`
 }
 
-watch([fromDate, toDate], () => {
+function fetchAll() {
   fetchDashboard(fromDate.value, toDate.value)
-})
+  fetchPages({ from: fromDate.value, to: toDate.value, limit: 200 })
+}
 
-onMounted(() => {
-  fetchDashboard(fromDate.value, toDate.value)
-})
+watch([fromDate, toDate], fetchAll)
+
+onMounted(fetchAll)
 </script>

--- a/src/components/health-metrics/useMetricsDashboard.js
+++ b/src/components/health-metrics/useMetricsDashboard.js
@@ -25,6 +25,7 @@ export function useMetricsDashboard() {
   }
 
   async function fetchPages(options = {}) {
+    pagesData.value = null
     try {
       const params = new URLSearchParams()
       if (options.from) params.set('from', options.from)
@@ -33,8 +34,8 @@ export function useMetricsDashboard() {
       if (options.limit) params.set('limit', String(options.limit))
       const qs = params.toString()
       pagesData.value = await apiRequest(`/health-metrics/pages${qs ? '?' + qs : ''}`)
-    } catch (err) {
-      error.value = err.message || 'Failed to load pages data'
+    } catch {
+      pagesData.value = null
     }
   }
 
@@ -67,6 +68,7 @@ export function useMetricsDashboard() {
   const uniqueUsers = computed(() => dashboardData.value?.uniqueUsers || 0)
   const activePages = computed(() => dashboardData.value?.activePages || 0)
   const topPages = computed(() => dashboardData.value?.topPages || [])
+  const allPages = computed(() => pagesData.value?.pages || [])
   const userTypes = computed(() => dashboardData.value?.userTypes || {})
   const daily = computed(() => dashboardData.value?.daily || {})
 
@@ -84,6 +86,7 @@ export function useMetricsDashboard() {
     uniqueUsers,
     activePages,
     topPages,
+    allPages,
     userTypes,
     daily,
   }


### PR DESCRIPTION
## Summary

- The "All Pages" table in Site Usage (`#/about?tab=usage`) was reusing the dashboard's `topPages`, which is hard-capped to 10 results server-side. This hid low-traffic modules like upstream-pulse entirely.
- Wires up the existing `/api/health-metrics/pages` endpoint (supports up to 200 results) so the table genuinely shows all tracked pages.
- Keeps the "Top Pages" bar chart at 10 entries for visual readability.
- Isolates `fetchPages` errors so a pages-only failure doesn't hide the primary dashboard.

## Changes

| File | What changed |
|------|-------------|
| `useMetricsDashboard.js` | Added `allPages` computed; made `fetchPages` fail silently (clears `pagesData` instead of setting shared `error`) |
| `SiteUsageTab.vue` | Calls `fetchPages` alongside `fetchDashboard`; "All Pages" table iterates `allPages` instead of `topPages`; passes `limit: 200` |
| `SiteUsageTab.test.js` | Updated mock with `fetchPages`, `allPages` (includes upstream-pulse sample); assertion verifies low-traffic modules appear |

## Test plan

- [ ] Open `#/about?tab=usage` — verify "All Pages" table now shows all tracked pages (not just top 10)
- [ ] Confirm "Top Pages" chart still shows top 10 only
- [ ] Change date range — verify table updates without stale rows
- [ ] Verify upstream-pulse pages appear in the table when the module is enabled