### PR TITLE
fix(git-sync): reconcile remote URL before fetch

### DIFF
--- a/server/modules/git-sync.js
+++ b/server/modules/git-sync.js
@@ -76,6 +76,15 @@ async function syncModule(storage, mod) {
 
     try {
       if (isExisting) {
+        // Reconcile remote URL if the configured gitUrl has changed since the initial clone
+        const currentUrl = await execGit(
+          ['remote', 'get-url', 'origin'], { cwd: moduleDir, env }, mod.gitToken
+        ).then(s => s.trim());
+        if (currentUrl !== mod.gitUrl) {
+          console.log(`[module-sync] ${mod.slug}: updating origin remote from ${currentUrl} to ${mod.gitUrl}`);
+          await execGit(['remote', 'set-url', 'origin', mod.gitUrl], { cwd: moduleDir, env }, mod.gitToken);
+        }
+
         // Fetch and reset
         await execGit(['fetch', 'origin', branch], { cwd: moduleDir, env }, mod.gitToken);
         await execGit(['reset', '--hard', `origin/${branch}`], { cwd: moduleDir, env }, mod.gitToken);


### PR DESCRIPTION
## Summary

- When an admin updates a git-static module's `gitUrl` via Settings, the config file was updated but the cloned repo on disk kept the old `origin` remote. Subsequent syncs silently fetched from the stale URL and reported success.
- Adds a `git remote get-url origin` check before each fetch. If the current remote doesn't match the configured `gitUrl`, updates it with `git remote set-url` before proceeding.

**Root cause:** discovered when the Customer Insights module on the `team-tracker` instance was stuck on a month-old commit — the team had moved their repo from `gitlab.cee.redhat.com` to `gitlab.com` and updated the config, but the cloned copy kept fetching from the old internal URL.

## Test plan

- [x] Existing `git-sync.test.js` tests pass (12/12)
- [x] ESLint clean
- [ ] Manual verification: update a module's `gitUrl` in Settings, trigger sync, confirm it fetches from the new URL