### PR TITLE
feat(releases): add release family filter, sorting, and target alignment to TV/FV Delta

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -73,49 +73,46 @@ async function mountView() {
 
 // ── Tests ──
 
-describe('TvFvDeltaView product filter', function () {
+describe('TvFvDeltaView release family filter', function () {
   beforeEach(function () {
     mockApiRequest.mockReset()
   })
 
-  it('renders product filter pills', async function () {
+  it('renders release family filter pills', async function () {
     var wrapper = await mountView()
     var buttons = wrapper.findAll('button').filter(function (b) {
       var text = b.text()
-      return text === 'All' || text === 'RHOAI' || text === 'RHELAI'
+      return text === 'All' || text === 'RHOAI 3.6' || text === 'RHOAI 3.5' || text === 'RHELAI 3.2'
     })
-    expect(buttons.length).toBeGreaterThanOrEqual(3)
+    expect(buttons.length).toBeGreaterThanOrEqual(4)
   })
 
-  it('defaults to RHOAI filter', async function () {
+  it('defaults to All — shows all releases', async function () {
     var wrapper = await mountView()
-    var table = findSummaryTable(wrapper)
-    // Summary table should only show rhoai releases by default
-    var rows = table.findAll('tbody tr')
-    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
-    for (var i = 0; i < releaseTexts.length; i++) {
-      expect(releaseTexts[i].toLowerCase()).toContain('rhoai')
-    }
-    // RHELAI-3.2 should NOT be visible
-    var allText = table.find('tbody').text()
-    expect(allText).not.toContain('RHELAI')
-  })
-
-  it('shows all products when "All" is clicked', async function () {
-    var wrapper = await mountView()
-    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
-    await allButton.trigger('click')
-    await flushPromises()
     var table = findSummaryTable(wrapper)
     var allText = table.find('tbody').text()
     expect(allText).toContain('RHELAI')
     expect(allText).toContain('rhoai')
   })
 
-  it('filters to RHELAI when clicked', async function () {
+  it('filters to RHOAI 3.6 family when clicked', async function () {
     var wrapper = await mountView()
-    var rhelaiButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI' })
-    await rhelaiButton.trigger('click')
+    var famButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHOAI 3.6' })
+    await famButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    expect(rows.length).toBe(3) // EA1, EA2, GA
+    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
+    for (var i = 0; i < releaseTexts.length; i++) {
+      expect(releaseTexts[i]).toContain('3.6')
+    }
+  })
+
+  it('filters to RHELAI 3.2 when clicked', async function () {
+    var wrapper = await mountView()
+    var famButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI 3.2' })
+    await famButton.trigger('click')
     await flushPromises()
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
@@ -147,11 +144,14 @@ describe('TvFvDeltaView executive summary sorting', function () {
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
     var releases = rows.map(function (r) { return r.find('td').text().trim() })
-    // rhoai-3.6 family first (EA1, EA2, GA), then 3.5
-    expect(releases[0]).toBe('rhoai-3.6.EA1')
-    expect(releases[1]).toBe('rhoai-3.6.EA2')
-    expect(releases[2]).toBe('rhoai-3.6')
-    expect(releases[3]).toBe('rhoai-3.5')
+    // Default is All — RHELAI first (alpha), then rhoai families
+    expect(releases[0]).toBe('RHELAI-3.2')
+    // rhoai 3.6 family in order, then 3.5
+    var rhoaiReleases = releases.filter(function (r) { return r.toLowerCase().startsWith('rhoai') })
+    expect(rhoaiReleases[0]).toBe('rhoai-3.6.EA1')
+    expect(rhoaiReleases[1]).toBe('rhoai-3.6.EA2')
+    expect(rhoaiReleases[2]).toBe('rhoai-3.6')
+    expect(rhoaiReleases[3]).toBe('rhoai-3.5')
   })
 
   it('clicking Total header sorts by total', async function () {
@@ -213,10 +213,7 @@ describe('TvFvDeltaView target alignment column', function () {
 
   it('shows dash for releases without GA dates', async function () {
     var wrapper = await mountView()
-    // Switch to All to see RHELAI-3.2 which has no ga_date
-    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
-    await allButton.trigger('click')
-    await flushPromises()
+    // Default is All, so RHELAI-3.2 (no ga_date) is already visible
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
     var rhelaiRow = rows.find(function (r) { return r.text().includes('RHELAI') })

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -1,0 +1,245 @@
+/**
+ * View-level tests for TvFvDeltaView — product filter, column sorting,
+ * and target alignment column integration.
+ *
+ * These tests mount the full view with mocked API responses and verify
+ * the template renders the new UI elements correctly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import TvFvDeltaView from '../../../client/views/TvFvDeltaView.vue'
+
+// ── Mock apiRequest ──
+
+var mockApiRequest = vi.fn()
+
+vi.mock('@shared/client', function () {
+  return {
+    apiRequest: function () { return mockApiRequest.apply(null, arguments) },
+  }
+})
+
+// ── Test data ──
+
+function makeTestData() {
+  return {
+    metadata: {
+      generated_at: '2026-06-17T10:00:00Z',
+      data_timestamp: '2026-06-17T09:55:00Z',
+      releases: ['rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6', 'rhoai-3.5', 'RHELAI-3.2'],
+      all_components: ['Dashboard', 'Serving'],
+    },
+    executive_summary: [
+      { release: 'rhoai-3.6.EA1', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
+      { release: 'rhoai-3.6.EA2', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
+      { release: 'rhoai-3.6', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
+      { release: 'rhoai-3.5', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-07-15' },
+      { release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null },
+    ],
+    releases: {
+      'rhoai-3.6.EA1': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'rhoai-3.6.EA2': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'rhoai-3.6': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'rhoai-3.5': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'RHELAI-3.2': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+    },
+  }
+}
+
+async function mountView() {
+  var testData = makeTestData()
+
+  mockApiRequest.mockImplementation(function (url) {
+    if (url.includes('/registry')) return Promise.resolve({ releases: [] })
+    if (url.includes('/versions')) return Promise.resolve({ versions: [] })
+    if (url.includes('/tv-fv-delta')) return Promise.resolve(testData)
+    return Promise.resolve({})
+  })
+
+  var wrapper = mount(TvFvDeltaView, {
+    global: {
+      stubs: {
+        ClickableCount: {
+          template: '<span class="clickable-count">{{ count }}</span>',
+          props: ['count', 'jql', 'color', 'label'],
+        },
+      },
+    },
+  })
+
+  await flushPromises()
+  return wrapper
+}
+
+// ── Tests ──
+
+describe('TvFvDeltaView product filter', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('renders product filter pills', async function () {
+    var wrapper = await mountView()
+    var buttons = wrapper.findAll('button').filter(function (b) {
+      var text = b.text()
+      return text === 'All' || text === 'RHOAI' || text === 'RHELAI'
+    })
+    expect(buttons.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('defaults to RHOAI filter', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    // Summary table should only show rhoai releases by default
+    var rows = table.findAll('tbody tr')
+    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
+    for (var i = 0; i < releaseTexts.length; i++) {
+      expect(releaseTexts[i].toLowerCase()).toContain('rhoai')
+    }
+    // RHELAI-3.2 should NOT be visible
+    var allText = table.find('tbody').text()
+    expect(allText).not.toContain('RHELAI')
+  })
+
+  it('shows all products when "All" is clicked', async function () {
+    var wrapper = await mountView()
+    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
+    await allButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var allText = table.find('tbody').text()
+    expect(allText).toContain('RHELAI')
+    expect(allText).toContain('rhoai')
+  })
+
+  it('filters to RHELAI when clicked', async function () {
+    var wrapper = await mountView()
+    var rhelaiButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI' })
+    await rhelaiButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('RHELAI')
+  })
+})
+
+/** Find the executive summary table (first table in the view) */
+function findSummaryTable(wrapper) {
+  return wrapper.findAll('table')[0]
+}
+
+describe('TvFvDeltaView executive summary sorting', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('renders sortable column headers', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var headers = table.findAll('thead th')
+    // Should have: Release, Total, Aligned, TV-Only, FV-Only, Mismatched, Alignment, Target, GA Date, Days to GA, Planning Freeze
+    expect(headers.length).toBe(11)
+  })
+
+  it('default sort is release family order (EA1 < EA2 < GA)', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    var releases = rows.map(function (r) { return r.find('td').text().trim() })
+    // rhoai-3.6 family first (EA1, EA2, GA), then 3.5
+    expect(releases[0]).toBe('rhoai-3.6.EA1')
+    expect(releases[1]).toBe('rhoai-3.6.EA2')
+    expect(releases[2]).toBe('rhoai-3.6')
+    expect(releases[3]).toBe('rhoai-3.5')
+  })
+
+  it('clicking Total header sorts by total', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var totalHeader = table.findAll('thead th').find(function (th) {
+      return th.text().includes('Total')
+    })
+    await totalHeader.trigger('click')
+    await flushPromises()
+    var rows = table.findAll('tbody tr')
+    var totals = []
+    rows.forEach(function (r) {
+      var cells = r.findAll('td')
+      var countEl = cells[1].find('.clickable-count')
+      if (countEl.exists()) totals.push(parseInt(countEl.text(), 10))
+    })
+    // Ascending order
+    for (var i = 1; i < totals.length; i++) {
+      expect(totals[i]).toBeGreaterThanOrEqual(totals[i - 1])
+    }
+  })
+
+  it('shows sort arrow on active column', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var totalHeader = table.findAll('thead th').find(function (th) {
+      return th.text().includes('Total')
+    })
+    // No arrow initially
+    expect(totalHeader.find('svg').exists()).toBe(false)
+    // Click to sort
+    await totalHeader.trigger('click')
+    await flushPromises()
+    expect(totalHeader.find('svg').exists()).toBe(true)
+  })
+})
+
+describe('TvFvDeltaView target alignment column', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('renders Target column header', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var headers = table.findAll('thead th')
+    var targetHeader = headers.find(function (th) { return th.text().includes('Target') })
+    expect(targetHeader).toBeTruthy()
+  })
+
+  it('shows target percentage with asterisk for releases with GA dates', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var html = table.html()
+    // At least one row should have a target with asterisk
+    expect(html).toMatch(/\d+%\*/)
+  })
+
+  it('shows dash for releases without GA dates', async function () {
+    var wrapper = await mountView()
+    // Switch to All to see RHELAI-3.2 which has no ga_date
+    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
+    await allButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    var rhelaiRow = rows.find(function (r) { return r.text().includes('RHELAI') })
+    expect(rhelaiRow).toBeTruthy()
+    // The target cell (8th column, index 7) should have a dash
+    var cells = rhelaiRow.findAll('td')
+    expect(cells[7].text()).toBe('—')
+  })
+
+  it('colors target red when actual alignment is below target', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    // rhoai-3.5 has alignment_pct: 32.3% and ga_date: 2026-07-15 (~28 days from June 17)
+    // Target for ≤30 days = 100%*, so actual (32.3%) < target (100%) → red
+    var rows = table.findAll('tbody tr')
+    var row35 = rows.find(function (r) { return r.text().includes('rhoai-3.5') && !r.text().includes('EA') })
+    if (row35) {
+      var targetCell = row35.findAll('td')[7]
+      var targetSpan = targetCell.find('span.font-semibold')
+      if (targetSpan.exists()) {
+        var classes = targetSpan.classes()
+        expect(classes.some(function (c) { return c.includes('red') })).toBe(true)
+      }
+    }
+  })
+})

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -8,6 +8,8 @@ import {
   parseReleaseName,
   compareReleases,
   extractProduct,
+  extractFamily,
+  familyLabel,
   productLabel,
   getAlignmentTarget,
   useReleaseFamily,
@@ -198,66 +200,127 @@ function makeSummaryRows() {
   ]
 }
 
+// ═══ extractFamily ═══
+
+describe('extractFamily', function () {
+  it('extracts family from GA version', function () {
+    expect(extractFamily('rhoai-3.6')).toBe('rhoai-3.6')
+  })
+
+  it('extracts family from EA version', function () {
+    expect(extractFamily('rhoai-3.6.EA1')).toBe('rhoai-3.6')
+    expect(extractFamily('rhoai-3.6.EA2')).toBe('rhoai-3.6')
+  })
+
+  it('extracts family case-insensitively', function () {
+    expect(extractFamily('RHELAI-3.2')).toBe('rhelai-3.2')
+  })
+
+  it('falls back to lowercase name for unparseable releases', function () {
+    expect(extractFamily('RHAII-3.2.3')).toBe('rhaii-3.2')
+  })
+})
+
+// ═══ familyLabel ═══
+
+describe('familyLabel', function () {
+  it('formats rhoai family', function () {
+    expect(familyLabel('rhoai-3.6')).toBe('RHOAI 3.6')
+  })
+
+  it('formats rhelai family', function () {
+    expect(familyLabel('rhelai-3.2')).toBe('RHELAI 3.2')
+  })
+
+  it('passes through unknown keys', function () {
+    expect(familyLabel('unknown')).toBe('unknown')
+  })
+})
+
 describe('useReleaseFamily composable', function () {
-  describe('product filtering', function () {
-    it('defaults to rhoai', function () {
+  function makeDataRef() {
+    return ref({ executive_summary: makeSummaryRows() })
+  }
+
+  describe('release family filtering', function () {
+    it('defaults to all', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      expect(rf.selectedProduct.value).toBe('rhoai')
+      var rf = useReleaseFamily(summary, makeDataRef())
+      expect(rf.selectedFamily.value).toBe('all')
     })
 
-    it('filters summary rows by selected product', function () {
+    it('filters to a specific release family', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
 
-      // Default: rhoai only
-      var rhoaiRows = rf.productFilteredSummary.value
-      expect(rhoaiRows.every(function (r) { return extractProduct(r.release) === 'rhoai' })).toBe(true)
-      expect(rhoaiRows.length).toBe(5) // 3.6 EA1/EA2/GA + 3.5 GA/EA1
+      rf.selectedFamily.value = 'rhoai-3.6'
+      var rows = rf.productFilteredSummary.value
+      expect(rows.length).toBe(3) // EA1, EA2, GA
+      expect(rows.every(function (r) { return extractFamily(r.release) === 'rhoai-3.6' })).toBe(true)
     })
 
-    it('shows all products when set to "all"', function () {
+    it('shows all releases when set to "all"', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      rf.selectedProduct.value = 'all'
+      var rf = useReleaseFamily(summary, makeDataRef())
       expect(rf.productFilteredSummary.value.length).toBe(7)
     })
 
-    it('filters to rhelai', function () {
+    it('filters to rhelai family', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      rf.selectedProduct.value = 'rhelai'
+      var rf = useReleaseFamily(summary, makeDataRef())
+      rf.selectedFamily.value = 'rhelai-3.2'
       var rows = rf.productFilteredSummary.value
       expect(rows.length).toBe(1)
       expect(rows[0].release).toBe('RHELAI-3.2')
     })
 
-    it('lists available products sorted', function () {
+    it('discovers families from full data, not just filtered summary', function () {
+      var filteredOnly = ref(makeSummaryRows().filter(function (r) { return extractProduct(r.release) === 'rhoai' }))
+      var fullData = makeDataRef()
+      var rf = useReleaseFamily(filteredOnly, fullData)
+      var familyKeys = rf.availableFamilies.value.map(function (f) { return f.key })
+      expect(familyKeys).toContain('rhoai-3.6')
+      expect(familyKeys).toContain('rhoai-3.5')
+      expect(familyKeys).toContain('rhelai-3.2')
+    })
+
+    it('lists families with display labels', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      // rhaii comes from RHAII-3.2.3 — but extractProduct returns 'rhaii'
-      expect(rf.availableProducts.value).toContain('rhoai')
-      expect(rf.availableProducts.value).toContain('rhelai')
-      expect(rf.availableProducts.value).toContain('rhaii')
+      var rf = useReleaseFamily(summary, makeDataRef())
+      var labels = rf.availableFamilies.value.map(function (f) { return f.label })
+      expect(labels).toContain('RHOAI 3.6')
+      expect(labels).toContain('RHOAI 3.5')
+      expect(labels).toContain('RHELAI 3.2')
     })
   })
 
   describe('sorting', function () {
-    it('default sort is release family order', function () {
+    it('default sort is release family order (all products)', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       var sorted = rf.sortedSummary.value
       var names = sorted.map(function (r) { return r.release })
-      // Within rhoai: 3.6 family (EA1, EA2, GA) then 3.5 family (EA1, GA)
+      // Default is "all", so all products show — rhelai first (alpha), then rhaii (unparseable, last), then rhoai
+      expect(names[0]).toBe('RHELAI-3.2')
+      // rhoai 3.6 family then 3.5 family
+      expect(names.indexOf('rhoai-3.6.EA1')).toBeLessThan(names.indexOf('rhoai-3.6'))
+      expect(names.indexOf('rhoai-3.6')).toBeLessThan(names.indexOf('rhoai-3.5'))
+    })
+
+    it('sorts within filtered family', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary, makeDataRef())
+      rf.selectedFamily.value = 'rhoai-3.6'
+      var sorted = rf.sortedSummary.value
+      var names = sorted.map(function (r) { return r.release })
       expect(names).toEqual([
         'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
-        'rhoai-3.5.EA1', 'rhoai-3.5',
       ])
     })
 
     it('toggleSort cycles asc → desc → clear', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
 
       rf.toggleSummarySort('total')
       expect(rf.sortColumn.value).toBe('total')
@@ -273,7 +336,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sorts by total ascending', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('total')
       var totals = rf.sortedSummary.value.map(function (r) { return r.total })
       for (var i = 1; i < totals.length; i++) {
@@ -283,7 +346,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sorts by total descending', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('total')
       rf.toggleSummarySort('total')
       var totals = rf.sortedSummary.value.map(function (r) { return r.total })
@@ -294,7 +357,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sorts by alignment_pct', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('alignment_pct')
       var pcts = rf.sortedSummary.value.map(function (r) { return r.alignment_pct })
       for (var i = 1; i < pcts.length; i++) {
@@ -304,7 +367,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sortIcon returns correct state', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       expect(rf.summarySortIcon('total')).toBe('none')
       rf.toggleSummarySort('total')
       expect(rf.summarySortIcon('total')).toBe('asc')
@@ -315,7 +378,7 @@ describe('useReleaseFamily composable', function () {
 
     it('switching columns resets direction to asc', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('total')
       rf.toggleSummarySort('total') // desc
       rf.toggleSummarySort('aligned') // switch column

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -1,0 +1,326 @@
+/**
+ * Tests for useReleaseFamily composable — release name parsing, product
+ * filtering, release family sorting, and target alignment thresholds.
+ */
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import {
+  parseReleaseName,
+  compareReleases,
+  extractProduct,
+  productLabel,
+  getAlignmentTarget,
+  useReleaseFamily,
+} from '../../../client/composables/useReleaseFamily'
+
+// ═══ parseReleaseName ═══
+
+describe('parseReleaseName', function () {
+  it('parses rhoai GA version', function () {
+    var r = parseReleaseName('rhoai-3.5')
+    expect(r).toEqual({
+      product: 'rhoai', major: 3, minor: 5,
+      milestone: 'GA', milestoneOrder: 99, raw: 'rhoai-3.5',
+    })
+  })
+
+  it('parses rhoai EA1 version', function () {
+    var r = parseReleaseName('rhoai-3.6.EA1')
+    expect(r).toEqual({
+      product: 'rhoai', major: 3, minor: 6,
+      milestone: 'EA1', milestoneOrder: 1, raw: 'rhoai-3.6.EA1',
+    })
+  })
+
+  it('parses rhoai EA2 version', function () {
+    var r = parseReleaseName('rhoai-3.6.EA2')
+    expect(r).toEqual({
+      product: 'rhoai', major: 3, minor: 6,
+      milestone: 'EA2', milestoneOrder: 2, raw: 'rhoai-3.6.EA2',
+    })
+  })
+
+  it('parses RHELAI version (case-insensitive)', function () {
+    var r = parseReleaseName('RHELAI-3.2')
+    expect(r).toEqual({
+      product: 'rhelai', major: 3, minor: 2,
+      milestone: 'GA', milestoneOrder: 99, raw: 'RHELAI-3.2',
+    })
+  })
+
+  it('returns null for z-stream-like RHAII versions', function () {
+    // RHAII-3.2.3 has ".3" not ".EA<N>", so it doesn't match the pattern
+    expect(parseReleaseName('RHAII-3.2.3')).toBeNull()
+  })
+
+  it('returns null for unrecognised names', function () {
+    expect(parseReleaseName('openshift-4.15')).toBeNull()
+    expect(parseReleaseName('')).toBeNull()
+    expect(parseReleaseName('random-text')).toBeNull()
+  })
+
+  it('handles underscore and space separators', function () {
+    var r = parseReleaseName('rhoai_3.5')
+    expect(r).not.toBeNull()
+    expect(r.product).toBe('rhoai')
+    expect(r.major).toBe(3)
+    expect(r.minor).toBe(5)
+  })
+})
+
+// ═══ extractProduct ═══
+
+describe('extractProduct', function () {
+  it('extracts rhoai', function () {
+    expect(extractProduct('rhoai-3.5')).toBe('rhoai')
+    expect(extractProduct('rhoai-3.6.EA1')).toBe('rhoai')
+  })
+
+  it('extracts rhelai (case-insensitive)', function () {
+    expect(extractProduct('RHELAI-3.2')).toBe('rhelai')
+  })
+
+  it('extracts rhaii', function () {
+    expect(extractProduct('RHAII-3.2.3')).toBe('rhaii')
+  })
+
+  it('returns null for unknown products', function () {
+    expect(extractProduct('openshift-4.15')).toBeNull()
+    expect(extractProduct('')).toBeNull()
+  })
+})
+
+// ═══ productLabel ═══
+
+describe('productLabel', function () {
+  it('returns uppercase labels', function () {
+    expect(productLabel('rhoai')).toBe('RHOAI')
+    expect(productLabel('rhelai')).toBe('RHELAI')
+    expect(productLabel('rhaii')).toBe('RHAII')
+  })
+
+  it('passes through unknown products', function () {
+    expect(productLabel('foo')).toBe('foo')
+  })
+})
+
+// ═══ compareReleases ═══
+
+describe('compareReleases', function () {
+  it('sorts EA1 before EA2 before GA within same version', function () {
+    var names = ['rhoai-3.6', 'rhoai-3.6.EA2', 'rhoai-3.6.EA1']
+    var sorted = names.slice().sort(compareReleases)
+    expect(sorted).toEqual(['rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6'])
+  })
+
+  it('sorts newer minor versions first (descending)', function () {
+    var names = ['rhoai-3.4', 'rhoai-3.6', 'rhoai-3.5']
+    var sorted = names.slice().sort(compareReleases)
+    expect(sorted).toEqual(['rhoai-3.6', 'rhoai-3.5', 'rhoai-3.4'])
+  })
+
+  it('sorts by product alphabetically', function () {
+    var names = ['rhoai-3.5', 'RHELAI-3.2', 'RHAII-3.2.3']
+    var sorted = names.slice().sort(compareReleases)
+    // rhaii < rhelai < rhoai alphabetically
+    // But RHAII-3.2.3 won't parse (z-stream), so it sorts last
+    expect(sorted[sorted.length - 1]).toBe('RHAII-3.2.3')
+  })
+
+  it('puts unparseable names last, sorted alphabetically', function () {
+    var names = ['rhoai-3.5', 'unknown-1.0', 'rhoai-3.6']
+    var sorted = names.slice().sort(compareReleases)
+    expect(sorted).toEqual(['rhoai-3.6', 'rhoai-3.5', 'unknown-1.0'])
+  })
+
+  it('handles full multi-product multi-milestone sort', function () {
+    var names = [
+      'rhoai-3.5', 'rhoai-3.5.EA1', 'rhoai-3.5.EA2',
+      'rhoai-3.6', 'rhoai-3.6.EA1', 'rhoai-3.6.EA2',
+      'RHELAI-3.2',
+    ]
+    var sorted = names.slice().sort(compareReleases)
+    // rhelai first (alphabetically), then rhoai 3.6 family, then 3.5 family
+    expect(sorted).toEqual([
+      'RHELAI-3.2',
+      'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
+      'rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5',
+    ])
+  })
+})
+
+// ═══ getAlignmentTarget ═══
+
+describe('getAlignmentTarget', function () {
+  it('returns 100%* for ≤30 days', function () {
+    expect(getAlignmentTarget(30)).toEqual({ target: 100, label: '100%*', maxDays: 30 })
+    expect(getAlignmentTarget(1)).toEqual({ target: 100, label: '100%*', maxDays: 30 })
+  })
+
+  it('returns 100%* for released (≤0 days)', function () {
+    expect(getAlignmentTarget(0)).toEqual({ target: 100, label: '100%*' })
+    expect(getAlignmentTarget(-5)).toEqual({ target: 100, label: '100%*' })
+  })
+
+  it('returns 95%* for 31-60 days', function () {
+    expect(getAlignmentTarget(31)).toEqual({ target: 95, label: '95%*', maxDays: 60 })
+    expect(getAlignmentTarget(60)).toEqual({ target: 95, label: '95%*', maxDays: 60 })
+  })
+
+  it('returns 90%* for 61-90 days', function () {
+    expect(getAlignmentTarget(61)).toEqual({ target: 90, label: '90%*', maxDays: 90 })
+    expect(getAlignmentTarget(90)).toEqual({ target: 90, label: '90%*', maxDays: 90 })
+  })
+
+  it('returns null for >90 days', function () {
+    expect(getAlignmentTarget(91)).toBeNull()
+    expect(getAlignmentTarget(180)).toBeNull()
+    expect(getAlignmentTarget(365)).toBeNull()
+  })
+
+  it('returns null for null/undefined input', function () {
+    expect(getAlignmentTarget(null)).toBeNull()
+    expect(getAlignmentTarget(undefined)).toBeNull()
+  })
+})
+
+// ═══ useReleaseFamily composable ═══
+
+function makeSummaryRows() {
+  return [
+    { release: 'rhoai-3.6.EA1', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
+    { release: 'rhoai-3.6.EA2', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
+    { release: 'rhoai-3.6', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
+    { release: 'rhoai-3.5', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-08-20' },
+    { release: 'rhoai-3.5.EA1', total: 24, aligned: 14, tv_only: 5, fv_only: 3, mismatched: 2, alignment_pct: 58.3, ga_date: null },
+    { release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null },
+    { release: 'RHAII-3.2.3', total: 3, aligned: 2, tv_only: 1, fv_only: 0, mismatched: 0, alignment_pct: 66.7, ga_date: null },
+  ]
+}
+
+describe('useReleaseFamily composable', function () {
+  describe('product filtering', function () {
+    it('defaults to rhoai', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      expect(rf.selectedProduct.value).toBe('rhoai')
+    })
+
+    it('filters summary rows by selected product', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+
+      // Default: rhoai only
+      var rhoaiRows = rf.productFilteredSummary.value
+      expect(rhoaiRows.every(function (r) { return extractProduct(r.release) === 'rhoai' })).toBe(true)
+      expect(rhoaiRows.length).toBe(5) // 3.6 EA1/EA2/GA + 3.5 GA/EA1
+    })
+
+    it('shows all products when set to "all"', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.selectedProduct.value = 'all'
+      expect(rf.productFilteredSummary.value.length).toBe(7)
+    })
+
+    it('filters to rhelai', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.selectedProduct.value = 'rhelai'
+      var rows = rf.productFilteredSummary.value
+      expect(rows.length).toBe(1)
+      expect(rows[0].release).toBe('RHELAI-3.2')
+    })
+
+    it('lists available products sorted', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      // rhaii comes from RHAII-3.2.3 — but extractProduct returns 'rhaii'
+      expect(rf.availableProducts.value).toContain('rhoai')
+      expect(rf.availableProducts.value).toContain('rhelai')
+      expect(rf.availableProducts.value).toContain('rhaii')
+    })
+  })
+
+  describe('sorting', function () {
+    it('default sort is release family order', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      var sorted = rf.sortedSummary.value
+      var names = sorted.map(function (r) { return r.release })
+      // Within rhoai: 3.6 family (EA1, EA2, GA) then 3.5 family (EA1, GA)
+      expect(names).toEqual([
+        'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
+        'rhoai-3.5.EA1', 'rhoai-3.5',
+      ])
+    })
+
+    it('toggleSort cycles asc → desc → clear', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+
+      rf.toggleSummarySort('total')
+      expect(rf.sortColumn.value).toBe('total')
+      expect(rf.sortDirection.value).toBe('asc')
+
+      rf.toggleSummarySort('total')
+      expect(rf.sortDirection.value).toBe('desc')
+
+      rf.toggleSummarySort('total')
+      expect(rf.sortColumn.value).toBeNull()
+      expect(rf.sortDirection.value).toBe('asc')
+    })
+
+    it('sorts by total ascending', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('total')
+      var totals = rf.sortedSummary.value.map(function (r) { return r.total })
+      for (var i = 1; i < totals.length; i++) {
+        expect(totals[i]).toBeGreaterThanOrEqual(totals[i - 1])
+      }
+    })
+
+    it('sorts by total descending', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('total')
+      rf.toggleSummarySort('total')
+      var totals = rf.sortedSummary.value.map(function (r) { return r.total })
+      for (var i = 1; i < totals.length; i++) {
+        expect(totals[i]).toBeLessThanOrEqual(totals[i - 1])
+      }
+    })
+
+    it('sorts by alignment_pct', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('alignment_pct')
+      var pcts = rf.sortedSummary.value.map(function (r) { return r.alignment_pct })
+      for (var i = 1; i < pcts.length; i++) {
+        expect(pcts[i]).toBeGreaterThanOrEqual(pcts[i - 1])
+      }
+    })
+
+    it('sortIcon returns correct state', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      expect(rf.summarySortIcon('total')).toBe('none')
+      rf.toggleSummarySort('total')
+      expect(rf.summarySortIcon('total')).toBe('asc')
+      expect(rf.summarySortIcon('aligned')).toBe('none')
+      rf.toggleSummarySort('total')
+      expect(rf.summarySortIcon('total')).toBe('desc')
+    })
+
+    it('switching columns resets direction to asc', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('total')
+      rf.toggleSummarySort('total') // desc
+      rf.toggleSummarySort('aligned') // switch column
+      expect(rf.sortColumn.value).toBe('aligned')
+      expect(rf.sortDirection.value).toBe('asc')
+    })
+  })
+})

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -1,0 +1,207 @@
+import { ref, computed } from 'vue'
+
+// ═══ RELEASE NAME PARSING ═══
+
+var RELEASE_PATTERN = /^(rhoai|rhelai|rhaii)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
+
+/**
+ * Parse a release name into structured parts.
+ * e.g. "rhoai-3.6.EA1" → { product: "rhoai", major: 3, minor: 6, milestone: "EA1", milestoneOrder: 1 }
+ * e.g. "rhoai-3.5"     → { product: "rhoai", major: 3, minor: 5, milestone: "GA",  milestoneOrder: 99 }
+ */
+function parseReleaseName(name) {
+  var m = RELEASE_PATTERN.exec(name)
+  if (!m) return null
+  var eaNum = m[4] ? parseInt(m[4], 10) : 0
+  return {
+    product: m[1].toLowerCase(),
+    major: parseInt(m[2], 10),
+    minor: parseInt(m[3], 10),
+    milestone: eaNum ? 'EA' + eaNum : 'GA',
+    milestoneOrder: eaNum || 99,
+    raw: name,
+  }
+}
+
+/**
+ * Compare two release names for sorting.
+ * Order: product alpha → major desc → minor desc → milestone asc (EA1 < EA2 < GA).
+ */
+function compareReleases(a, b) {
+  var pa = parseReleaseName(a)
+  var pb = parseReleaseName(b)
+  // Unparseable releases sort last, alphabetically
+  if (!pa && !pb) return a.localeCompare(b)
+  if (!pa) return 1
+  if (!pb) return -1
+
+  // Product alphabetical (rhelai < rhaii < rhoai)
+  if (pa.product !== pb.product) return pa.product.localeCompare(pb.product)
+  // Major descending (3.6 before 3.5)
+  if (pa.major !== pb.major) return pb.major - pa.major
+  // Minor descending
+  if (pa.minor !== pb.minor) return pb.minor - pa.minor
+  // Milestone ascending (EA1 before EA2 before GA)
+  return pa.milestoneOrder - pb.milestoneOrder
+}
+
+/**
+ * Extract the product prefix from a release name.
+ * Returns lowercase: "rhoai", "rhelai", "rhaii", or null.
+ */
+function extractProduct(name) {
+  var m = /^(rhoai|rhelai|rhaii)/i.exec(name)
+  return m ? m[1].toLowerCase() : null
+}
+
+/**
+ * Get display label for a product.
+ */
+var PRODUCT_LABELS = { rhoai: 'RHOAI', rhelai: 'RHELAI', rhaii: 'RHAII' }
+
+function productLabel(product) {
+  return PRODUCT_LABELS[product] || product
+}
+
+// ═══ TARGET ALIGNMENT THRESHOLDS ═══
+
+var ALIGNMENT_TARGETS = [
+  { maxDays: 30, target: 100, label: '100%*' },
+  { maxDays: 60, target: 95, label: '95%*' },
+  { maxDays: 90, target: 90, label: '90%*' },
+]
+
+/**
+ * Get the target alignment percentage for a given number of days to GA.
+ * Returns { target, label } or null if no target applies (>90 days out).
+ */
+function getAlignmentTarget(daysToGa) {
+  if (daysToGa === null || daysToGa === undefined) return null
+  if (daysToGa <= 0) return { target: 100, label: '100%*' }
+  for (var i = 0; i < ALIGNMENT_TARGETS.length; i++) {
+    if (daysToGa <= ALIGNMENT_TARGETS[i].maxDays) return ALIGNMENT_TARGETS[i]
+  }
+  return null
+}
+
+// ═══ COMPOSABLE ═══
+
+/**
+ * Composable for product filtering and release family sorting on the executive summary.
+ */
+export function useReleaseFamily(filteredSummary) {
+  var selectedProduct = ref('rhoai')
+
+  /** Unique products found in the summary rows */
+  var availableProducts = computed(function () {
+    var seen = {}
+    var result = []
+    var rows = filteredSummary.value || []
+    for (var i = 0; i < rows.length; i++) {
+      var p = extractProduct(rows[i].release)
+      if (p && !seen[p]) {
+        seen[p] = true
+        result.push(p)
+      }
+    }
+    return result.sort()
+  })
+
+  /** Summary rows filtered by selected product */
+  var productFilteredSummary = computed(function () {
+    var rows = filteredSummary.value || []
+    if (selectedProduct.value === 'all') return rows
+    return rows.filter(function (row) {
+      return extractProduct(row.release) === selectedProduct.value
+    })
+  })
+
+  // ── Sort state ──
+
+  var sortColumn = ref(null) // null = release family default
+  var sortDirection = ref('asc')
+
+  function toggleSummarySort(column) {
+    if (sortColumn.value === column) {
+      if (sortDirection.value === 'asc') {
+        sortDirection.value = 'desc'
+      } else {
+        // Clear sort → back to release family default
+        sortColumn.value = null
+        sortDirection.value = 'asc'
+      }
+    } else {
+      sortColumn.value = column
+      sortDirection.value = 'asc'
+    }
+  }
+
+  function summarySortIcon(column) {
+    if (sortColumn.value !== column) return 'none'
+    return sortDirection.value
+  }
+
+  /** Sorted + filtered summary rows */
+  var sortedSummary = computed(function () {
+    var rows = productFilteredSummary.value.slice()
+
+    if (!sortColumn.value) {
+      // Default: release family order
+      rows.sort(function (a, b) { return compareReleases(a.release, b.release) })
+      return rows
+    }
+
+    var col = sortColumn.value
+    var dir = sortDirection.value === 'asc' ? 1 : -1
+
+    rows.sort(function (a, b) {
+      var va, vb
+      if (col === 'release') {
+        return compareReleases(a.release, b.release) * dir
+      }
+      if (col === 'alignment_pct' || col === 'total' || col === 'aligned' ||
+          col === 'tv_only' || col === 'fv_only' || col === 'mismatched') {
+        va = a[col] ?? 0
+        vb = b[col] ?? 0
+        return (va - vb) * dir
+      }
+      if (col === 'ga_date' || col === 'planning_freeze') {
+        va = a[col] || ''
+        vb = b[col] || ''
+        return va.localeCompare(vb) * dir
+      }
+      va = a[col] ?? ''
+      vb = b[col] ?? ''
+      return String(va).localeCompare(String(vb)) * dir
+    })
+
+    return rows
+  })
+
+  return {
+    selectedProduct,
+    availableProducts,
+    productFilteredSummary,
+    sortColumn,
+    sortDirection,
+    toggleSummarySort,
+    summarySortIcon,
+    sortedSummary,
+    // Expose utilities for testing
+    parseReleaseName,
+    compareReleases,
+    extractProduct,
+    productLabel,
+    getAlignmentTarget,
+  }
+}
+
+// Named exports for direct use / testing
+export {
+  parseReleaseName,
+  compareReleases,
+  extractProduct,
+  productLabel,
+  getAlignmentTarget,
+  ALIGNMENT_TARGETS,
+}

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -35,7 +35,7 @@ function compareReleases(a, b) {
   if (!pa) return 1
   if (!pb) return -1
 
-  // Product alphabetical (rhelai < rhaii < rhoai)
+  // Product alphabetical (rhaii < rhelai < rhoai)
   if (pa.product !== pb.product) return pa.product.localeCompare(pb.product)
   // Major descending (3.6 before 3.5)
   if (pa.major !== pb.major) return pb.major - pa.major

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -87,32 +87,62 @@ function getAlignmentTarget(daysToGa) {
 // ═══ COMPOSABLE ═══
 
 /**
- * Composable for product filtering and release family sorting on the executive summary.
+ * Extract the release family key from a release name.
+ * e.g. "rhoai-3.6.EA1" → "rhoai-3.6", "RHELAI-3.2" → "rhelai-3.2"
+ * Returns lowercase key for comparison, or the raw name if unparseable.
  */
-export function useReleaseFamily(filteredSummary) {
-  var selectedProduct = ref('rhoai')
+function extractFamily(name) {
+  var parsed = parseReleaseName(name)
+  if (parsed) return parsed.product + '-' + parsed.major + '.' + parsed.minor
+  // Fallback: try to extract product-major.minor pattern directly
+  var m = /^(rhoai|rhelai|rhaii)[- _](\d+\.\d+)/i.exec(name)
+  if (m) return m[1].toLowerCase() + '-' + m[2]
+  return name.toLowerCase()
+}
 
-  /** Unique products found in the summary rows */
-  var availableProducts = computed(function () {
+/**
+ * Get display label for a release family.
+ * e.g. "rhoai-3.6" → "RHOAI 3.6"
+ */
+function familyLabel(familyKey) {
+  var m = /^(rhoai|rhelai|rhaii)-(.+)$/.exec(familyKey)
+  if (m) return PRODUCT_LABELS[m[1]] + ' ' + m[2]
+  return familyKey
+}
+
+/**
+ * Composable for product filtering and release family sorting on the executive summary.
+ *
+ * @param {Ref} filteredSummary — version-picker-filtered summary rows
+ * @param {Ref} data — full API response (used to discover all available families)
+ */
+export function useReleaseFamily(filteredSummary, data) {
+  var selectedFamily = ref('all')
+
+  /** Unique release families found across ALL data */
+  var availableFamilies = computed(function () {
     var seen = {}
-    var result = []
-    var rows = filteredSummary.value || []
+    var families = []
+    var rows = (data && data.value && data.value.executive_summary) || []
+    if (!rows.length) rows = filteredSummary.value || []
     for (var i = 0; i < rows.length; i++) {
-      var p = extractProduct(rows[i].release)
-      if (p && !seen[p]) {
-        seen[p] = true
-        result.push(p)
+      var fam = extractFamily(rows[i].release)
+      if (!seen[fam]) {
+        seen[fam] = true
+        families.push({ key: fam, label: familyLabel(fam) })
       }
     }
-    return result.sort()
+    // Sort by parsed version (newer first), same as compareReleases
+    families.sort(function (a, b) { return compareReleases(a.key, b.key) })
+    return families
   })
 
-  /** Summary rows filtered by selected product */
+  /** Summary rows filtered by selected release family */
   var productFilteredSummary = computed(function () {
     var rows = filteredSummary.value || []
-    if (selectedProduct.value === 'all') return rows
+    if (selectedFamily.value === 'all') return rows
     return rows.filter(function (row) {
-      return extractProduct(row.release) === selectedProduct.value
+      return extractFamily(row.release) === selectedFamily.value
     })
   })
 
@@ -179,8 +209,8 @@ export function useReleaseFamily(filteredSummary) {
   })
 
   return {
-    selectedProduct,
-    availableProducts,
+    selectedFamily,
+    availableFamilies,
     productFilteredSummary,
     sortColumn,
     sortDirection,
@@ -191,6 +221,8 @@ export function useReleaseFamily(filteredSummary) {
     parseReleaseName,
     compareReleases,
     extractProduct,
+    extractFamily,
+    familyLabel,
     productLabel,
     getAlignmentTarget,
   }
@@ -201,6 +233,8 @@ export {
   parseReleaseName,
   compareReleases,
   extractProduct,
+  extractFamily,
+  familyLabel,
   productLabel,
   getAlignmentTarget,
   ALIGNMENT_TARGETS,

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -5,7 +5,7 @@ import FeatureTable from '../components/FeatureTable.vue'
 import { useReleasePicker } from '../composables/useReleasePicker'
 import { useComponentBreakdown } from '../composables/useComponentBreakdown'
 import { useTvFvData } from '../composables/useTvFvData'
-import { useReleaseFamily, getAlignmentTarget, productLabel } from '../composables/useReleaseFamily'
+import { useReleaseFamily, getAlignmentTarget } from '../composables/useReleaseFamily'
 
 const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
 
@@ -69,10 +69,10 @@ const filteredSummary = computed(() => {
 // ---------------------------------------------------------------------------
 
 const {
-  selectedProduct, availableProducts,
+  selectedFamily, availableFamilies,
   toggleSummarySort, summarySortIcon,
   sortedSummary,
-} = useReleaseFamily(filteredSummary)
+} = useReleaseFamily(filteredSummary, data)
 
 /** Compute target alignment for a row based on days to GA */
 function targetForRow(row) {
@@ -178,24 +178,24 @@ onBeforeUnmount(() => {
         <span class="italic">Counts reflect data at fetch time; live Jira may differ</span>
       </div>
 
-      <!-- Product Filter -->
-      <div class="flex items-center gap-1.5 mb-4">
+      <!-- Release Family Filter -->
+      <div class="flex items-center gap-1.5 mb-4 flex-wrap">
         <button
           class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
-          :class="selectedProduct === 'all'
+          :class="selectedFamily === 'all'
             ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
             : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
-          @click="selectedProduct = 'all'"
+          @click="selectedFamily = 'all'"
         >All</button>
         <button
-          v-for="prod in availableProducts"
-          :key="prod"
+          v-for="fam in availableFamilies"
+          :key="fam.key"
           class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
-          :class="selectedProduct === prod
+          :class="selectedFamily === fam.key
             ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
             : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
-          @click="selectedProduct = prod"
-        >{{ productLabel(prod) }}</button>
+          @click="selectedFamily = fam.key"
+        >{{ fam.label }}</button>
       </div>
 
       <!-- Executive Summary -->

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -5,6 +5,7 @@ import FeatureTable from '../components/FeatureTable.vue'
 import { useReleasePicker } from '../composables/useReleasePicker'
 import { useComponentBreakdown } from '../composables/useComponentBreakdown'
 import { useTvFvData } from '../composables/useTvFvData'
+import { useReleaseFamily, getAlignmentTarget, productLabel } from '../composables/useReleaseFamily'
 
 const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
 
@@ -62,6 +63,22 @@ const filteredSummary = computed(() => {
   }
   return rows
 })
+
+// ---------------------------------------------------------------------------
+// Product filter + release family sorting
+// ---------------------------------------------------------------------------
+
+const {
+  selectedProduct, availableProducts,
+  toggleSummarySort, summarySortIcon,
+  sortedSummary,
+} = useReleaseFamily(filteredSummary)
+
+/** Compute target alignment for a row based on days to GA */
+function targetForRow(row) {
+  var d = daysToGa(row.ga_date)
+  return getAlignmentTarget(d)
+}
 
 const { releaseComponentBreakdown } = useComponentBreakdown(data, releaseData)
 
@@ -161,6 +178,26 @@ onBeforeUnmount(() => {
         <span class="italic">Counts reflect data at fetch time; live Jira may differ</span>
       </div>
 
+      <!-- Product Filter -->
+      <div class="flex items-center gap-1.5 mb-4">
+        <button
+          class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+          :class="selectedProduct === 'all'
+            ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
+          @click="selectedProduct = 'all'"
+        >All</button>
+        <button
+          v-for="prod in availableProducts"
+          :key="prod"
+          class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+          :class="selectedProduct === prod
+            ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
+          @click="selectedProduct = prod"
+        >{{ productLabel(prod) }}</button>
+      </div>
+
       <!-- Executive Summary -->
       <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-6">
         <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
@@ -170,21 +207,40 @@ onBeforeUnmount(() => {
           <table class="min-w-full text-sm">
             <thead>
               <tr class="bg-gray-50 dark:bg-gray-800/50">
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Release</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Total</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Aligned</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">TV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">FV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Mismatched</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Alignment</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">GA Date</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('release')">
+                  <span class="inline-flex items-center gap-1">Release<svg v-if="summarySortIcon('release') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('release') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('total')">
+                  <span class="inline-flex items-center gap-1 justify-end">Total<svg v-if="summarySortIcon('total') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('total') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned')">
+                  <span class="inline-flex items-center gap-1 justify-end">Aligned<svg v-if="summarySortIcon('aligned') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('tv_only')">
+                  <span class="inline-flex items-center gap-1 justify-end">TV-Only<svg v-if="summarySortIcon('tv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('tv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('fv_only')">
+                  <span class="inline-flex items-center gap-1 justify-end">FV-Only<svg v-if="summarySortIcon('fv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('fv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('mismatched')">
+                  <span class="inline-flex items-center gap-1 justify-end">Mismatched<svg v-if="summarySortIcon('mismatched') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('mismatched') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('alignment_pct')">
+                  <span class="inline-flex items-center gap-1 justify-end">Alignment<svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Target</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('ga_date')">
+                  <span class="inline-flex items-center gap-1">GA Date<svg v-if="summarySortIcon('ga_date') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('ga_date') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to GA</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Planning Freeze</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('planning_freeze')">
+                  <span class="inline-flex items-center gap-1">Planning Freeze<svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
               <tr
-                v-for="row in filteredSummary"
+                v-for="row in sortedSummary"
                 :key="row.release"
                 class="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer"
                 :class="{ 'bg-blue-50/50 dark:bg-blue-900/10': row.release === selectedRelease }"
@@ -227,6 +283,19 @@ onBeforeUnmount(() => {
                   >
                     {{ row.alignment_pct }}%
                   </span>
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right text-xs whitespace-nowrap">
+                  <template v-if="!row._pending && targetForRow(row)">
+                    <span
+                      class="font-semibold"
+                      :class="{
+                        'text-red-600 dark:text-red-400': row.alignment_pct < targetForRow(row).target,
+                        'text-green-600 dark:text-green-400': row.alignment_pct >= targetForRow(row).target,
+                      }"
+                      :title="'Target: ' + targetForRow(row).label + ' (based on ' + daysToGa(row.ga_date) + ' days to GA)'"
+                    >{{ targetForRow(row).label }}</span>
+                  </template>
                   <span v-else class="text-gray-400">&mdash;</span>
                 </td>
                 <td class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">


### PR DESCRIPTION
## Summary

- **Release family filter**: Filter pills (All, RHOAI 3.6, RHOAI 3.5, RHELAI 3.2, etc.) that group EA1/EA2/GA milestones together. Families are discovered from the full dataset, not just filtered view.
- **Column sorting**: All executive summary columns are sortable with asc → desc → clear cycling. Default sort follows release family order (product alpha → version desc → milestone asc: EA1 < EA2 < GA).
- **Target alignment column**: Shows target alignment % based on days-to-GA thresholds (≤30d→100%*, ≤60d→95%*, ≤90d→90%*). Color-coded red/green vs actual alignment. Asterisk denotes unconfirmed targets. Shows dash for releases without GA dates.

New composable `useReleaseFamily` with full test coverage (57 tests): release name parsing, family extraction, product identification, version comparison/sorting, and target alignment thresholds.

Also triggers a frontend image rebuild (CI path-based detection), which will fix the PM Hub sorting that wasn't deployed due to identical git trees on the previous squash-merge.

## Test plan

- [x] 45 unit tests for `useReleaseFamily` composable (parsing, sorting, filtering, targets)
- [x] 12 view-level tests for `TvFvDeltaView` (filter pills, sorting, target column rendering)
- [x] ESLint clean
- [ ] Visual verification on deployed instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)