### PR TITLE
feat(ai-impact): add external reporter and security review triage labels

### DIFF
--- a/modules/ai-impact/__tests__/client/AutofixContent.test.js
+++ b/modules/ai-impact/__tests__/client/AutofixContent.test.js
@@ -10,7 +10,7 @@ const MOCK_DATA = {
   jiraHost: 'https://redhat.atlassian.net',
   metrics: {
     triageTotal: 10,
-    triageVerdicts: { ready: 6, missingInfo: 2, notFixable: 1, stale: 1, pending: 0 },
+    triageVerdicts: { ready: 6, missingInfo: 2, notFixable: 1, stale: 1, pending: 0, external: 0, securityReview: 0 },
     autofixStates: { ready: 1, pending: 1, review: 1, ciFailing: 0, merged: 2, rejected: 0, maxRetries: 0, researched: 0, blocked: 1 },
     autofixTotal: 6,
     successRate: 100,
@@ -18,8 +18,8 @@ const MOCK_DATA = {
     totalIssues: 10
   },
   trendData: [
-    { date: daysAgo(7).slice(0, 10), triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0 },
-    { date: daysAgo(0).slice(0, 10), triaged: 7, autofixed: 4, merged: 1, total: 7, review: 1, ciFailing: 1, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 1 }
+    { date: daysAgo(7).slice(0, 10), triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0, external: 0, securityReview: 0 },
+    { date: daysAgo(0).slice(0, 10), triaged: 7, autofixed: 4, merged: 1, total: 7, review: 1, ciFailing: 1, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 1, external: 0, securityReview: 0 }
   ],
   componentBreakdown: [
     { component: 'Model Server', triaged: 5, autofixed: 3, done: 1 },
@@ -125,6 +125,16 @@ describe('AutofixContent', () => {
     const rows = findIssueTableRows(wrapper)
     expect(rows).toHaveLength(1)
     expect(rows[0].text()).toContain('AIPCC-100')
+  })
+
+  it('renders new triage states in state filter dropdown', () => {
+    const wrapper = mount(AutofixContent, {
+      props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
+    })
+    const allOptions = wrapper.findAll('option')
+    const optionValues = allOptions.map(o => o.attributes('value'))
+    expect(optionValues).toContain('triage-external')
+    expect(optionValues).toContain('triage-security-review')
   })
 
   it('filters issues by state', async () => {

--- a/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
+++ b/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
@@ -60,6 +60,18 @@ describe('classifyIssue', () => {
     expect(classifyIssue(['jira-triage-pending'])).toBe('triage-pending')
   })
 
+  it('returns triage-external for jira-triage-external', () => {
+    expect(classifyIssue(['jira-triage-external'])).toBe('triage-external')
+  })
+
+  it('returns triage-security-review for jira-triage-security-review', () => {
+    expect(classifyIssue(['jira-triage-security-review'])).toBe('triage-security-review')
+  })
+
+  it('prioritizes triage-security-review over other triage states', () => {
+    expect(classifyIssue(['jira-triage-not-fixable', 'jira-triage-security-review'])).toBe('triage-security-review')
+  })
+
   it('returns unknown when no pipeline labels present', () => {
     expect(classifyIssue(['some-other-label'])).toBe('unknown')
   })
@@ -133,19 +145,23 @@ describe('computeAutofixMetrics', () => {
     { created: recent, pipelineState: 'autofix-rejected', components: ['A'] },
     { created: recent, pipelineState: 'triage-missing-info', components: ['B'] },
     { created: recent, pipelineState: 'triage-not-fixable', components: ['B'] },
+    { created: recent, pipelineState: 'triage-external', components: ['B'] },
+    { created: recent, pipelineState: 'triage-security-review', components: ['B'] },
     { created: old, pipelineState: 'autofix-merged', components: ['A'] }
   ]
 
   it('computes metrics for a week window', () => {
     const m = computeAutofixMetrics(issues, 'week')
-    expect(m.windowTotal).toBe(5)
+    expect(m.windowTotal).toBe(7)
     expect(m.triageVerdicts.ready).toBe(3)
     expect(m.triageVerdicts.missingInfo).toBe(1)
     expect(m.triageVerdicts.notFixable).toBe(1)
+    expect(m.triageVerdicts.external).toBe(1)
+    expect(m.triageVerdicts.securityReview).toBe(1)
     expect(m.autofixStates.merged).toBe(1)
     expect(m.autofixStates.review).toBe(1)
     expect(m.autofixStates.rejected).toBe(1)
-    expect(m.totalIssues).toBe(6)
+    expect(m.totalIssues).toBe(8)
   })
 
   it('computes success rate from terminal states (merged / (merged + rejected + maxRetries))', () => {
@@ -177,6 +193,8 @@ describe('buildTrendData', () => {
     expect(trend[0]).toHaveProperty('maxRetries')
     expect(trend[0]).toHaveProperty('missingInfo')
     expect(trend[0]).toHaveProperty('stale')
+    expect(trend[0]).toHaveProperty('external')
+    expect(trend[0]).toHaveProperty('securityReview')
   })
 
   it('returns 13 points for 3months window', () => {
@@ -195,7 +213,9 @@ describe('buildTrendData', () => {
       { created: recent, pipelineState: 'autofix-max-retries', components: [] },
       { created: recent, pipelineState: 'autofix-merged', components: [] },
       { created: recent, pipelineState: 'triage-missing-info', components: [] },
-      { created: recent, pipelineState: 'triage-stale', components: [] }
+      { created: recent, pipelineState: 'triage-stale', components: [] },
+      { created: recent, pipelineState: 'triage-external', components: [] },
+      { created: recent, pipelineState: 'triage-security-review', components: [] }
     ]
     const trend = buildTrendData(issues, 'week')
     const lastPoint = trend[trend.length - 1]
@@ -206,5 +226,7 @@ describe('buildTrendData', () => {
     expect(lastPoint.merged).toBe(1)
     expect(lastPoint.missingInfo).toBe(1)
     expect(lastPoint.stale).toBe(1)
+    expect(lastPoint.external).toBe(1)
+    expect(lastPoint.securityReview).toBe(1)
   })
 })

--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -118,7 +118,9 @@ const metrics = computed(() => {
     missingInfo: windowIssues.filter(i => i.pipelineState === 'triage-missing-info').length,
     notFixable: windowIssues.filter(i => i.pipelineState === 'triage-not-fixable').length,
     stale: windowIssues.filter(i => i.pipelineState === 'triage-stale').length,
-    pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length
+    pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length,
+    external: windowIssues.filter(i => i.pipelineState === 'triage-external').length,
+    securityReview: windowIssues.filter(i => i.pipelineState === 'triage-security-review').length
   }
 
   const autofixStates = {
@@ -159,9 +161,11 @@ const trendData = computed(() => {
     const maxRetries = weekIssues.filter(i => i.pipelineState === 'autofix-max-retries').length
     const missingInfo = weekIssues.filter(i => i.pipelineState === 'triage-missing-info').length
     const stale = weekIssues.filter(i => i.pipelineState === 'triage-stale').length
+    const external = weekIssues.filter(i => i.pipelineState === 'triage-external').length
+    const securityReview = weekIssues.filter(i => i.pipelineState === 'triage-security-review').length
     points.push({
       date: weekEnd.toISOString().slice(0, 10), triaged, autofixed, merged, total: weekIssues.length,
-      review, ciFailing, blocked, maxRetries, missingInfo, stale
+      review, ciFailing, blocked, maxRetries, missingInfo, stale, external, securityReview
     })
   }
   return points
@@ -173,6 +177,8 @@ const STATE_OPTIONS = [
   { value: 'triage-missing-info', label: 'Missing Info' },
   { value: 'triage-not-fixable', label: 'Not AI-Fixable' },
   { value: 'triage-stale', label: 'Stale' },
+  { value: 'triage-external', label: 'External Reporter' },
+  { value: 'triage-security-review', label: 'Security Review' },
   { value: 'autofix-ready', label: 'Queued for AI' },
   { value: 'autofix-pending', label: 'AI Working' },
   { value: 'autofix-review', label: 'AI Fix Under Review' },
@@ -305,6 +311,8 @@ const triageWaitingData = computed(() => ({
   labels: trendData.value.map(p => p.date),
   datasets: [
     { label: 'Missing Info', data: trendData.value.map(p => p.missingInfo || 0), backgroundColor: 'rgba(245, 158, 11, 0.6)' },
+    { label: 'External Reporter', data: trendData.value.map(p => p.external || 0), backgroundColor: 'rgba(168, 85, 247, 0.6)' },
+    { label: 'Security Review', data: trendData.value.map(p => p.securityReview || 0), backgroundColor: 'rgba(244, 63, 94, 0.6)' },
     { label: 'Stale', data: trendData.value.map(p => p.stale || 0), backgroundColor: 'rgba(156, 163, 175, 0.6)' }
   ]
 }))
@@ -337,6 +345,8 @@ function stateColorClass(state) {
   if (state === 'autofix-blocked' || state === 'triage-missing-info') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
   if (state === 'triage-not-fixable') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
   if (state === 'triage-stale') return 'bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400'
+  if (state === 'triage-external') return 'bg-purple-100 dark:bg-purple-500/20 text-purple-700 dark:text-purple-400'
+  if (state === 'triage-security-review') return 'bg-rose-100 dark:bg-rose-500/20 text-rose-700 dark:text-rose-400'
   return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
 }
 
@@ -352,6 +362,8 @@ const triageSegments = computed(() => {
     { label: 'Ready for AI', count: v.ready || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400', jiraLabels: ['jira-autofix', 'jira-autofix-pending', 'jira-autofix-review', 'jira-autofix-ci-failing', 'jira-autofix-merged', 'jira-autofix-rejected', 'jira-autofix-max-retries', 'jira-autofix-researched', 'jira-autofix-blocked'] },
     { label: 'Missing Info', count: v.missingInfo || 0, color: 'bg-yellow-500', textClass: 'text-yellow-600 dark:text-yellow-400', jiraLabels: ['jira-triage-missing-info'] },
     { label: 'Not AI-Fixable', count: v.notFixable || 0, color: 'bg-red-500', textClass: 'text-red-600 dark:text-red-400', jiraLabels: ['jira-triage-not-fixable'] },
+    { label: 'External Reporter', count: v.external || 0, color: 'bg-purple-500', textClass: 'text-purple-600 dark:text-purple-400', jiraLabels: ['jira-triage-external'] },
+    { label: 'Security Review', count: v.securityReview || 0, color: 'bg-rose-500', textClass: 'text-rose-600 dark:text-rose-400', jiraLabels: ['jira-triage-security-review'] },
     { label: 'Stale', count: v.stale || 0, color: 'bg-gray-400', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-triage-stale'] },
     { label: 'AI Assessing', count: v.pending || 0, color: 'bg-gray-300 dark:bg-gray-600', textClass: 'text-gray-500 dark:text-gray-400', jiraLabels: ['jira-triage-pending'] }
   ].filter(s => s.count > 0)
@@ -429,6 +441,8 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">AI Assessing</td><td class="text-gray-400 py-0.5">Bot is evaluating the ticket</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Missing Info</td><td class="text-gray-400 py-0.5">Ticket incomplete, waiting on reporter</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Not AI-Fixable</td><td class="text-gray-400 py-0.5">Not suitable for automated fixing</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">External Reporter</td><td class="text-gray-400 py-0.5">Non-RH reporter, needs RH engineer approval</td></tr>
+                  <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Security Review</td><td class="text-gray-400 py-0.5">Flagged as security-sensitive, needs human review</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Stale</td><td class="text-gray-400 py-0.5">No response for 14+ days</td></tr>
                   <tr><td colspan="2" class="font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide text-[10px] pb-1 pt-3">Autofix</td></tr>
                   <tr><td class="font-medium pr-4 py-0.5 whitespace-nowrap">Queued for AI</td><td class="text-gray-400 py-0.5">Waiting for bot pickup</td></tr>
@@ -582,16 +596,16 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
               <div class="absolute right-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300 text-left">
                 Issues where human action can help unblock progress. Includes:
                 <div class="mt-1.5 space-y-0.5">
-                  <div><span class="font-medium">Triage:</span> missing info, stale (no response 14+ days)</div>
+                  <div><span class="font-medium">Triage:</span> missing info, external reporter, security review, stale</div>
                   <div><span class="font-medium">Autofix:</span> CI failing, blocked, max retries exhausted</div>
                 </div>
               </div>
             </div>
             <div class="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
-              {{ (metrics.triageVerdicts.missingInfo || 0) + (metrics.triageVerdicts.stale || 0) + (metrics.autofixStates.ciFailing || 0) + (metrics.autofixStates.blocked || 0) + (metrics.autofixStates.maxRetries || 0) }}
+              {{ (metrics.triageVerdicts.missingInfo || 0) + (metrics.triageVerdicts.stale || 0) + (metrics.triageVerdicts.external || 0) + (metrics.triageVerdicts.securityReview || 0) + (metrics.autofixStates.ciFailing || 0) + (metrics.autofixStates.blocked || 0) + (metrics.autofixStates.maxRetries || 0) }}
             </div>
             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 uppercase tracking-wide">Needs Attention</div>
-            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ (metrics.triageVerdicts.missingInfo || 0) + (metrics.triageVerdicts.stale || 0) }} triage · {{ (metrics.autofixStates.ciFailing || 0) + (metrics.autofixStates.blocked || 0) + (metrics.autofixStates.maxRetries || 0) }} autofix</div>
+            <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{{ (metrics.triageVerdicts.missingInfo || 0) + (metrics.triageVerdicts.stale || 0) + (metrics.triageVerdicts.external || 0) + (metrics.triageVerdicts.securityReview || 0) }} triage · {{ (metrics.autofixStates.ciFailing || 0) + (metrics.autofixStates.blocked || 0) + (metrics.autofixStates.maxRetries || 0) }} autofix</div>
           </div>
           <div class="relative bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center">
             <div class="absolute top-2 right-2 group">
@@ -632,6 +646,8 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                       <div class="flex justify-between"><span class="font-medium">Ready for AI</span><span class="text-gray-400">Qualified for autofix</span></div>
                       <div class="flex justify-between"><span class="font-medium">Missing Info</span><span class="text-gray-400">Waiting on reporter</span></div>
                       <div class="flex justify-between"><span class="font-medium">Not AI-Fixable</span><span class="text-gray-400">Not suitable for AI</span></div>
+                      <div class="flex justify-between"><span class="font-medium">External Reporter</span><span class="text-gray-400">Needs RH approval</span></div>
+                      <div class="flex justify-between"><span class="font-medium">Security Review</span><span class="text-gray-400">Needs human review</span></div>
                       <div class="flex justify-between"><span class="font-medium">Stale</span><span class="text-gray-400">No response 14+ days</span></div>
                       <div class="flex justify-between"><span class="font-medium">AI Assessing</span><span class="text-gray-400">Bot is evaluating</span></div>
                     </div>
@@ -746,7 +762,7 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   <div class="absolute left-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
-                    Triage issues where a human can help. Missing Info: reporter hasn't provided details the bot needs. Stale: no response for 14+ days.
+                    Triage issues where a human can help. Missing Info: reporter hasn't provided details. External Reporter: non-RH reporter, needs RH approval. Security Review: flagged as security-sensitive. Stale: no response for 14+ days.
                   </div>
                 </div>
               </div>
@@ -818,6 +834,8 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                       <div class="flex justify-between"><span>AI Assessing</span><span class="text-gray-400">Bot is evaluating</span></div>
                       <div class="flex justify-between"><span>Missing Info</span><span class="text-gray-400">Waiting on reporter</span></div>
                       <div class="flex justify-between"><span>Not AI-Fixable</span><span class="text-gray-400">Not suitable for AI</span></div>
+                      <div class="flex justify-between"><span>External Reporter</span><span class="text-gray-400">Needs RH approval</span></div>
+                      <div class="flex justify-between"><span>Security Review</span><span class="text-gray-400">Needs human review</span></div>
                       <div class="flex justify-between"><span>Stale</span><span class="text-gray-400">No response 14+ days</span></div>
                     </div>
                     <p class="font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide text-[10px]">Autofix</p>

--- a/modules/ai-impact/client/views/AIFactoryGuideView.vue
+++ b/modules/ai-impact/client/views/AIFactoryGuideView.vue
@@ -302,6 +302,7 @@ const autofixTriageLabels = [
   { name: 'jira-triage-missing-info', color: 'amber', desc: 'Ticket needs more information from the reporter' },
   { name: 'jira-triage-not-fixable', color: 'gray', desc: 'Not suitable for automated fixing' },
   { name: 'jira-triage-external', color: 'amber', desc: 'External reporter, needs Red Hat engineer approval' },
+  { name: 'jira-triage-security-review', color: 'rose', desc: 'Flagged as security-sensitive, needs human review' },
   { name: 'jira-triage-stale', color: 'gray', desc: 'No response for 14 days' },
 ]
 
@@ -349,6 +350,7 @@ function labelColorClasses(color) {
     red: 'bg-red-500/15 text-red-600 dark:text-red-400',
     gray: 'bg-gray-500/15 text-gray-600 dark:text-gray-400',
     purple: 'bg-purple-500/15 text-purple-600 dark:text-purple-400',
+    rose: 'bg-rose-500/15 text-rose-600 dark:text-rose-400',
   }
   return map[color] || map.gray
 }

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -6,7 +6,9 @@ const TRIAGE_LABELS = [
   'jira-triage-pending',
   'jira-triage-missing-info',
   'jira-triage-not-fixable',
-  'jira-triage-stale'
+  'jira-triage-stale',
+  'jira-triage-external',
+  'jira-triage-security-review'
 ];
 
 const AUTOFIX_LABELS = [
@@ -38,7 +40,10 @@ function classifyIssue(labels) {
   if (labelSet.has('jira-autofix-review')) return 'autofix-review';
   if (labelSet.has('jira-autofix-pending')) return 'autofix-pending';
   if (labelSet.has('jira-autofix')) return 'autofix-ready';
-  // Triage states
+  // Triage states (security-review first: it's added alongside other verdicts
+  // and should take precedence since it requires human review)
+  if (labelSet.has('jira-triage-security-review')) return 'triage-security-review';
+  if (labelSet.has('jira-triage-external')) return 'triage-external';
   if (labelSet.has('jira-triage-not-fixable')) return 'triage-not-fixable';
   if (labelSet.has('jira-triage-stale')) return 'triage-stale';
   if (labelSet.has('jira-triage-missing-info')) return 'triage-missing-info';
@@ -100,11 +105,14 @@ function computeAutofixMetrics(issues, timeWindow) {
     missingInfo: get('triage-missing-info'),
     notFixable: get('triage-not-fixable'),
     stale: get('triage-stale'),
-    pending: get('triage-pending')
+    pending: get('triage-pending'),
+    external: get('triage-external'),
+    securityReview: get('triage-security-review')
   };
 
   const triageTotal = autofixTotal + triageVerdicts.missingInfo +
-    triageVerdicts.notFixable + triageVerdicts.stale + triageVerdicts.pending;
+    triageVerdicts.notFixable + triageVerdicts.stale + triageVerdicts.pending +
+    triageVerdicts.external + triageVerdicts.securityReview;
 
   const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries;
   const successRate = terminalTotal > 0
@@ -142,7 +150,7 @@ function buildTrendData(issues, timeWindow) {
       weekEnd: weekEnd.getTime(),
       triaged: 0, autofixed: 0, merged: 0, total: 0,
       review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
-      missingInfo: 0, stale: 0
+      missingInfo: 0, stale: 0, external: 0, securityReview: 0
     });
   }
 
@@ -173,6 +181,8 @@ function buildTrendData(issues, timeWindow) {
     else if (state === 'autofix-max-retries') bucket.maxRetries++;
     else if (state === 'triage-missing-info') bucket.missingInfo++;
     else if (state === 'triage-stale') bucket.stale++;
+    else if (state === 'triage-external') bucket.external++;
+    else if (state === 'triage-security-review') bucket.securityReview++;
   }
 
   return buckets.map(function(b) {
@@ -180,7 +190,8 @@ function buildTrendData(issues, timeWindow) {
       date: b.date, triaged: b.triaged, autofixed: b.autofixed,
       merged: b.merged, total: b.total, review: b.review,
       ciFailing: b.ciFailing, blocked: b.blocked, maxRetries: b.maxRetries,
-      missingInfo: b.missingInfo, stale: b.stale
+      missingInfo: b.missingInfo, stale: b.stale,
+      external: b.external, securityReview: b.securityReview
     };
   });
 }

--- a/modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js
+++ b/modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js
@@ -66,6 +66,8 @@ describe('autofix-constants', () => {
       expect(values).toContain('triage-missing-info')
       expect(values).toContain('triage-not-fixable')
       expect(values).toContain('triage-stale')
+      expect(values).toContain('triage-external')
+      expect(values).toContain('triage-security-review')
       expect(values).toContain('autofix-ready')
       expect(values).toContain('autofix-pending')
       expect(values).toContain('autofix-review')

--- a/modules/team-tracker/client/components/autofix/autofix-constants.js
+++ b/modules/team-tracker/client/components/autofix/autofix-constants.js
@@ -10,6 +10,8 @@ export const STATE_OPTIONS = [
   { value: 'triage-missing-info', label: 'Missing Info' },
   { value: 'triage-not-fixable', label: 'Not AI-Fixable' },
   { value: 'triage-stale', label: 'Stale' },
+  { value: 'triage-external', label: 'External Reporter' },
+  { value: 'triage-security-review', label: 'Security Review' },
   { value: 'autofix-ready', label: 'Queued for AI' },
   { value: 'autofix-pending', label: 'AI Working' },
   { value: 'autofix-review', label: 'AI Fix Under Review' },
@@ -47,6 +49,8 @@ export function stateColorClass(state) {
   if (state === 'autofix-blocked' || state === 'triage-missing-info') return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
   if (state === 'triage-not-fixable') return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
   if (state === 'triage-stale') return 'bg-gray-100 dark:bg-gray-600/20 text-gray-600 dark:text-gray-400'
+  if (state === 'triage-external') return 'bg-purple-100 dark:bg-purple-500/20 text-purple-700 dark:text-purple-400'
+  if (state === 'triage-security-review') return 'bg-rose-100 dark:bg-rose-500/20 text-rose-700 dark:text-rose-400'
   return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
 }
 
@@ -68,7 +72,9 @@ export function computeTeamMetrics(issues, timeWindow) {
     missingInfo: windowIssues.filter(i => i.pipelineState === 'triage-missing-info').length,
     notFixable: windowIssues.filter(i => i.pipelineState === 'triage-not-fixable').length,
     stale: windowIssues.filter(i => i.pipelineState === 'triage-stale').length,
-    pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length
+    pending: windowIssues.filter(i => i.pipelineState === 'triage-pending').length,
+    external: windowIssues.filter(i => i.pipelineState === 'triage-external').length,
+    securityReview: windowIssues.filter(i => i.pipelineState === 'triage-security-review').length
   }
 
   const autofixStates = {


### PR DESCRIPTION
## Summary

The autofix pipeline added two triage labels that org-pulse was not tracking, making those tickets invisible to the dashboard:

- **`jira-triage-external`** (External Reporter): Blocks AI analysis for tickets opened by non-`@redhat.com` reporters until a Red Hat engineer reviews and approves (prompt injection mitigation). Shown in purple.
- **`jira-triage-security-review`** (Security Review): Added alongside other triage verdict labels when the bot flags a ticket as security-sensitive. Requires human review regardless of the AI verdict. Shown in rose.

### What changed

**Backend** (`autofix-fetcher.js`):
- Added both labels to `TRIAGE_LABELS` so they're included in the JQL query
- Added classification in `classifyIssue()` with `security-review` taking precedence (since it's added alongside other verdicts)
- Added `external` and `securityReview` fields to metrics and trend data

**Frontend** (`AutofixContent.vue` + `autofix-constants.js`):
- Added to state filter dropdown, color classes, and triage segments
- Updated all 3 tooltip legends (header, triage outcomes, issue table)
- Added to "Waiting on Humans: Triage" stacked bar chart
- Included in "Needs Attention" card count
- Updated client-side metrics/trend recomputation for filtered views
- Updated team-tracker's local copy (hard constraint #1: no cross-module imports)

### Labels not added

- `jira-triage-external-ok`: Transient approval flag, removed by the bot after validation. Too brief to track.
- `no-autofix`: Exclusion/opt-out label, not a pipeline state.

## Test plan

- [x] `npm run lint` passes
- [x] All 30 autofix-related tests pass (27 in `autofix-fetcher.test.js` + 3 in `autofix-constants.test.js`)
- [x] New tests: classify external, classify security-review, security-review priority over other triage states
- [x] Updated existing metrics/trend tests to include new states
- [x] Frontend test: new states appear in dropdown options
- [ ] Visual check: deploy and verify new states render in the Jira AutoFix dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)