### PR TITLE
feat: support multiple products in Conforma Insights

### DIFF
--- a/fixtures/releases/delivery/conforma.json
+++ b/fixtures/releases/delivery/conforma.json
@@ -1,7 +1,7 @@
 {
   "fetchedAt": "2026-05-10T06:00:00.000Z",
   "minDate": "2025-05-22",
-  "count": 4,
+  "count": 7,
   "releases": [
     {
       "version": "rhoai-3.4",
@@ -449,6 +449,87 @@
               "comment": "nodejs-18 deprecated image exception for 2.25 z-stream."
             }
           ]
+        }
+      }
+    },
+    {
+      "version": "rhel-ai-3.4",
+      "gaDate": "2026-06-20",
+      "codeFreezeDate": "2026-06-10",
+      "exceptions": {
+        "registry": {
+          "configExcludes": [
+            "cve.cve_blockers",
+            "hermetic_task",
+            "labels.disallowed_inherited_labels",
+            "buildah_build_task.add_capabilities_param",
+            "buildah_build_task.build_task_uses_buildah",
+            "schedule.weekday_restriction"
+          ],
+          "volatileExcludes": [
+            {
+              "value": "rpm_packages.unique_version:ibm-spyre-models",
+              "effectiveUntil": "2026-09-30T00:00:00Z",
+              "references": ["https://issues.redhat.com/browse/RHELAI-1234"],
+              "imageUrl": null,
+              "team": "RHEL AI Platform",
+              "comment": "IBM Spyre model packages require specific version pinning."
+            },
+            {
+              "value": "hermetic_task.hermetic",
+              "effectiveUntil": "2026-08-15T00:00:00Z",
+              "references": ["https://issues.redhat.com/browse/RHELAI-1001"],
+              "imageUrl": "quay.io/rhelai/instructlab-rhel9",
+              "team": "InstructLab",
+              "comment": "InstructLab container has network dependencies during model download."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "version": "rhaii-3.4",
+      "gaDate": "2026-05-30",
+      "codeFreezeDate": "2026-05-20",
+      "exceptions": {
+        "registry": {
+          "configExcludes": [
+            "cve.cve_blockers",
+            "test.test_data_found",
+            "hermetic_task",
+            "buildah_build_task.add_capabilities_param",
+            "schedule.weekday_restriction"
+          ],
+          "volatileExcludes": [
+            {
+              "value": "hermetic_task.hermetic",
+              "effectiveUntil": "2026-07-31T00:00:00Z",
+              "references": ["https://issues.redhat.com/browse/RHAIIS-500"],
+              "imageUrl": "quay.io/rhaii/inference-server-rhel9",
+              "team": "Inference",
+              "comment": "Inference server has network build dependencies for model weights."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "version": "base-images-3.4",
+      "gaDate": "2026-06-01",
+      "codeFreezeDate": "2026-05-22",
+      "exceptions": {
+        "registry": {
+          "configExcludes": [
+            "cve.cve_blockers",
+            "test.test_data_found",
+            "hermetic_task",
+            "buildah_build_task.add_capabilities_param",
+            "schedule.weekday_restriction",
+            "rpm_packages.unique_version:ibm-spyre-firmware",
+            "rpm_packages.unique_version:ibm-spyre-models",
+            "rpm_packages.unique_version:ibm-spyre-runtime"
+          ],
+          "volatileExcludes": []
         }
       }
     }

--- a/modules/releases/__tests__/client/deliver/conforma-constants.test.js
+++ b/modules/releases/__tests__/client/deliver/conforma-constants.test.js
@@ -4,6 +4,9 @@ import {
   targetReleaseBadgeCls,
   targetReleaseLabel,
   extractCategory,
+  policyLabel,
+  policyColor,
+  sortPolicyFiles,
   PERMANENT_TARGET
 } from '../../../client/deliver/constants/conforma.js'
 
@@ -20,20 +23,33 @@ describe('normalizeTargetRelease', () => {
     expect(normalizeTargetRelease('PERMANENT')).toBe(PERMANENT_TARGET)
   })
 
-  it('strips rhoai- prefix and re-adds it', () => {
+  it('preserves product prefix for rhoai', () => {
     expect(normalizeTargetRelease('rhoai-3.5')).toBe('rhoai-3.5')
-    expect(normalizeTargetRelease('3.5')).toBe('rhoai-3.5')
   })
 
-  it('strips v prefix', () => {
-    expect(normalizeTargetRelease('v3.5')).toBe('rhoai-3.5')
+  it('preserves product prefix for rhel-ai', () => {
+    expect(normalizeTargetRelease('rhel-ai-3.4')).toBe('rhel-ai-3.4')
   })
 
-  it('normalizes EA suffixes to .EA format', () => {
+  it('preserves product prefix for base-images', () => {
+    expect(normalizeTargetRelease('base-images-3.4')).toBe('base-images-3.4')
+  })
+
+  it('strips v prefix from bare versions', () => {
+    expect(normalizeTargetRelease('v3.5')).toBe('3.5')
+  })
+
+  it('returns bare version when no product prefix', () => {
+    expect(normalizeTargetRelease('3.5')).toBe('3.5')
+  })
+
+  it('normalizes EA suffixes for rhoai', () => {
     expect(normalizeTargetRelease('rhoai-3.5-ea1')).toBe('rhoai-3.5.EA1')
-    expect(normalizeTargetRelease('3.5-EA1')).toBe('rhoai-3.5.EA1')
-    expect(normalizeTargetRelease('3.5.ea2')).toBe('rhoai-3.5.EA2')
-    expect(normalizeTargetRelease('rhoai-3.5 ea 3')).toBe('rhoai-3.5.EA3')
+    expect(normalizeTargetRelease('rhoai-3.5.ea2')).toBe('rhoai-3.5.EA2')
+  })
+
+  it('normalizes EA suffixes for other products', () => {
+    expect(normalizeTargetRelease('rhel-ai-3.4-ea1')).toBe('rhel-ai-3.4.EA1')
   })
 })
 
@@ -58,8 +74,10 @@ describe('targetReleaseBadgeCls', () => {
 })
 
 describe('targetReleaseLabel', () => {
-  it('strips rhoai- prefix', () => {
+  it('returns version without product prefix', () => {
     expect(targetReleaseLabel('rhoai-3.5')).toBe('3.5')
+    expect(targetReleaseLabel('rhel-ai-3.4')).toBe('3.4')
+    expect(targetReleaseLabel('base-images-3.4')).toBe('3.4')
   })
 
   it('returns Permanent for permanent target', () => {
@@ -85,5 +103,49 @@ describe('extractCategory', () => {
 
   it('returns other for unknown prefix', () => {
     expect(extractCategory('unknown.rule')).toBe('other')
+  })
+})
+
+describe('policyLabel', () => {
+  it('returns known labels', () => {
+    expect(policyLabel('fbc')).toBe('FBC')
+    expect(policyLabel('registry')).toBe('Components')
+  })
+
+  it('title-cases unknown keys', () => {
+    expect(policyLabel('disk-images')).toBe('Disk Images')
+    expect(policyLabel('modelcars')).toBe('Modelcars')
+  })
+})
+
+describe('policyColor', () => {
+  it('returns color for known position', () => {
+    const color = policyColor('fbc', ['fbc', 'registry'])
+    expect(color.bg).toContain('59,130,246')
+  })
+
+  it('returns second color for registry', () => {
+    const color = policyColor('registry', ['fbc', 'registry'])
+    expect(color.bg).toContain('16,185,129')
+  })
+
+  it('returns first color for unknown single-key list', () => {
+    const color = policyColor('registry', ['registry'])
+    expect(color.bg).toContain('59,130,246')
+  })
+})
+
+describe('sortPolicyFiles', () => {
+  it('puts fbc first, registry second', () => {
+    expect(sortPolicyFiles(['registry', 'fbc'])).toEqual(['fbc', 'registry'])
+  })
+
+  it('sorts unknown keys alphabetically after known ones', () => {
+    expect(sortPolicyFiles(['zeta', 'registry', 'alpha', 'fbc']))
+      .toEqual(['fbc', 'registry', 'alpha', 'zeta'])
+  })
+
+  it('handles lists without known keys', () => {
+    expect(sortPolicyFiles(['beta', 'alpha'])).toEqual(['alpha', 'beta'])
   })
 })

--- a/modules/releases/__tests__/client/deliver/release-utils.test.js
+++ b/modules/releases/__tests__/client/deliver/release-utils.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractProduct,
+  extractVersion,
+  normalizeVersionKey,
+  KNOWN_PRODUCTS
+} from '../../../client/deliver/composables/release-utils.js'
+
+describe('KNOWN_PRODUCTS', () => {
+  it('includes all expected products', () => {
+    expect(KNOWN_PRODUCTS).toContain('rhoai')
+    expect(KNOWN_PRODUCTS).toContain('rhel-ai')
+    expect(KNOWN_PRODUCTS).toContain('rhaii')
+    expect(KNOWN_PRODUCTS).toContain('base-images')
+  })
+})
+
+describe('extractProduct', () => {
+  it('returns empty string for falsy input', () => {
+    expect(extractProduct(null)).toBe('')
+    expect(extractProduct('')).toBe('')
+    expect(extractProduct(undefined)).toBe('')
+  })
+
+  it('extracts single-segment products', () => {
+    expect(extractProduct('rhoai-3.4')).toBe('rhoai')
+    expect(extractProduct('rhaii-3.4')).toBe('rhaii')
+  })
+
+  it('extracts multi-dash products', () => {
+    expect(extractProduct('rhel-ai-3.4')).toBe('rhel-ai')
+    expect(extractProduct('base-images-3.4')).toBe('base-images')
+  })
+
+  it('is case-insensitive', () => {
+    expect(extractProduct('RHOAI-3.4')).toBe('rhoai')
+    expect(extractProduct('Rhel-AI-3.4')).toBe('rhel-ai')
+    expect(extractProduct('Base-Images-3.4')).toBe('base-images')
+  })
+
+  it('handles z-stream versions', () => {
+    expect(extractProduct('rhoai-3.3.2')).toBe('rhoai')
+    expect(extractProduct('rhel-ai-3.4.1')).toBe('rhel-ai')
+  })
+
+  it('falls back to regex for unknown products', () => {
+    expect(extractProduct('openshift-4.16')).toBe('openshift')
+    expect(extractProduct('some-product-2.0')).toBe('some-product')
+  })
+
+  it('returns empty for bare versions', () => {
+    expect(extractProduct('3.4')).toBe('')
+    expect(extractProduct('1.0')).toBe('')
+  })
+})
+
+describe('extractVersion', () => {
+  it('returns input for falsy input', () => {
+    expect(extractVersion(null)).toBe('')
+    expect(extractVersion('')).toBe('')
+  })
+
+  it('extracts version from single-segment products', () => {
+    expect(extractVersion('rhoai-3.4')).toBe('3.4')
+    expect(extractVersion('rhaii-3.4')).toBe('3.4')
+  })
+
+  it('extracts version from multi-dash products', () => {
+    expect(extractVersion('rhel-ai-3.4')).toBe('3.4')
+    expect(extractVersion('base-images-3.4')).toBe('3.4')
+  })
+
+  it('preserves z-stream and EA suffixes', () => {
+    expect(extractVersion('rhoai-3.3.2')).toBe('3.3.2')
+    expect(extractVersion('rhoai-3.5-ea1')).toBe('3.5-ea1')
+  })
+
+  it('returns input when no product prefix found', () => {
+    expect(extractVersion('3.4')).toBe('3.4')
+    expect(extractVersion('3.0')).toBe('3.0')
+  })
+})
+
+describe('normalizeVersionKey', () => {
+  it('lowercases and normalizes dots/spaces', () => {
+    expect(normalizeVersionKey('3.4')).toBe('3.4')
+    expect(normalizeVersionKey('3 4')).toBe('3.4')
+    expect(normalizeVersionKey('3..4')).toBe('3.4')
+  })
+})

--- a/modules/releases/client/deliver/components/ConformaAiCategoryChart.vue
+++ b/modules/releases/client/deliver/components/ConformaAiCategoryChart.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { Bar } from 'vue-chartjs'
-import { AI_CATEGORIES, PERMANENT_TARGET, targetReleaseLabel, normalizeTargetRelease } from '../constants/conforma'
+import { AI_CATEGORIES, PERMANENT_TARGET, targetReleaseLabel, normalizeTargetRelease, policyLabel, policyColor, sortPolicyFiles } from '../constants/conforma'
 import ConformaHelpText from './ConformaHelpText.vue'
 
 const props = defineProps({
@@ -10,61 +10,55 @@ const props = defineProps({
   chartKey: { type: Number, default: 0 }
 })
 
+const activePfs = computed(() =>
+  sortPolicyFiles([...new Set(props.exceptions.map(e => e.policyFile).filter(Boolean))])
+)
+
 const categorized = computed(() => {
+  const pfs = activePfs.value
   const cats = {}
   for (const [key, info] of Object.entries(AI_CATEGORIES)) {
-    cats[key] = { ...info, fbc: 0, registry: 0 }
+    const entry = { ...info, total: 0 }
+    for (const pf of pfs) entry[pf] = 0
+    cats[key] = entry
   }
   for (const ex of props.exceptions) {
     if (ex.aiCategory && cats[ex.aiCategory]) {
-      if (ex.policyFile === 'fbc') cats[ex.aiCategory].fbc++
-      else cats[ex.aiCategory].registry++
+      if (ex.policyFile && cats[ex.aiCategory][ex.policyFile] !== undefined) {
+        cats[ex.aiCategory][ex.policyFile]++
+      }
+      cats[ex.aiCategory].total++
     }
   }
   return cats
 })
 
-const resolvedCount = computed(() => {
-  const c = categorized.value.resolved
-  return c ? c.fbc + c.registry : 0
-})
+const resolvedCount = computed(() => categorized.value.resolved?.total || 0)
 
-const componentUpdateCount = computed(() => {
-  const c = categorized.value.component_update
-  return c ? c.fbc + c.registry : 0
-})
+const componentUpdateCount = computed(() => categorized.value.component_update?.total || 0)
 
 const policyMappedCount = computed(() =>
   props.exceptions.filter(e => e.policyMapped === true).length
 )
 
-const permanentCount = computed(() => {
-  const c = categorized.value.partner_permanent
-  return c ? c.fbc + c.registry : 0
-})
+const permanentCount = computed(() => categorized.value.partner_permanent?.total || 0)
 
 const categoryChartData = computed(() => {
   const entries = Object.entries(AI_CATEGORIES)
+  const pfs = activePfs.value
   return {
     labels: entries.map(([, info]) => info.label),
-    datasets: [
-      {
-        label: 'FBC',
-        data: entries.map(([key]) => categorized.value[key]?.fbc || 0),
-        backgroundColor: 'rgba(59,130,246,0.75)',
-        borderColor: 'rgb(59,130,246)',
-        borderWidth: 1,
-        borderRadius: 3
-      },
-      {
-        label: 'Components',
-        data: entries.map(([key]) => categorized.value[key]?.registry || 0),
-        backgroundColor: 'rgba(16,185,129,0.75)',
-        borderColor: 'rgb(16,185,129)',
+    datasets: pfs.map(pf => {
+      const color = policyColor(pf, pfs)
+      return {
+        label: policyLabel(pf),
+        data: entries.map(([key]) => categorized.value[key]?.[pf] || 0),
+        backgroundColor: color.bg,
+        borderColor: color.border,
         borderWidth: 1,
         borderRadius: 3
       }
-    ]
+    })
   }
 })
 

--- a/modules/releases/client/deliver/composables/release-utils.js
+++ b/modules/releases/client/deliver/composables/release-utils.js
@@ -1,13 +1,19 @@
+export const KNOWN_PRODUCTS = ['base-images', 'rhel-ai', 'rhoai', 'rhaii']
+
 export function extractProduct(releaseNumber) {
   const s = (releaseNumber || '').toLowerCase()
-  const dash = s.indexOf('-')
-  return dash > 0 ? s.slice(0, dash) : s
+  for (const p of KNOWN_PRODUCTS) {
+    if (s.startsWith(p + '-') && /\d/.test(s[p.length + 1])) return p
+  }
+  const m = s.match(/^(.+?)-(\d.*)$/)
+  return m ? m[1] : ''
 }
 
 export function extractVersion(releaseNumber) {
   const s = releaseNumber || ''
-  const dash = s.indexOf('-')
-  return dash > 0 ? s.slice(dash + 1) : s
+  const product = extractProduct(s)
+  if (product) return s.slice(product.length + 1)
+  return s
 }
 
 export function normalizeVersionKey(version) {

--- a/modules/releases/client/deliver/constants/conforma.js
+++ b/modules/releases/client/deliver/constants/conforma.js
@@ -1,3 +1,5 @@
+import { extractProduct, extractVersion } from '../composables/release-utils'
+
 // FIPS is first because it is matched by keyword, not by value prefix.
 export const KNOWN_CATEGORIES = [
   'fips', 'hermetic_task', 'test', 'tasks', 'schedule',
@@ -82,6 +84,45 @@ export const AI_CATEGORIES = {
 
 export const PERMANENT_TARGET = 'permanent'
 
+// ─── Policy file display helpers ────────────────────────────────────────────
+
+const POLICY_LABELS = {
+  fbc: 'FBC',
+  registry: 'Components',
+}
+
+const POLICY_COLORS = [
+  { bg: 'rgba(59,130,246,0.75)', border: 'rgb(59,130,246)', badgeCls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300' },
+  { bg: 'rgba(16,185,129,0.75)', border: 'rgb(16,185,129)', badgeCls: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300' },
+  { bg: 'rgba(245,158,11,0.75)', border: 'rgb(245,158,11)', badgeCls: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300' },
+  { bg: 'rgba(139,92,246,0.75)', border: 'rgb(139,92,246)', badgeCls: 'bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300' },
+  { bg: 'rgba(236,72,153,0.75)', border: 'rgb(236,72,153)', badgeCls: 'bg-pink-100 dark:bg-pink-900/40 text-pink-700 dark:text-pink-300' },
+  { bg: 'rgba(100,116,139,0.75)', border: 'rgb(100,116,139)', badgeCls: 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300' }
+]
+
+export function policyLabel(key) {
+  return POLICY_LABELS[key] || key.split(/[-_]/).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+}
+
+export function policyColor(key, orderedKeys) {
+  const idx = orderedKeys.indexOf(key)
+  return POLICY_COLORS[(idx >= 0 ? idx : 0) % POLICY_COLORS.length]
+}
+
+export function sortPolicyFiles(keys) {
+  const order = ['fbc', 'registry']
+  return [...keys].sort((a, b) => {
+    const ai = order.indexOf(a)
+    const bi = order.indexOf(b)
+    if (ai >= 0 && bi >= 0) return ai - bi
+    if (ai >= 0) return -1
+    if (bi >= 0) return 1
+    return a.localeCompare(b)
+  })
+}
+
+// ─── Target release helpers ──────────────────────────────────────────────────
+
 export function targetReleaseBadgeCls(target) {
   if (!target) return ''
   if (target === PERMANENT_TARGET) return 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300'
@@ -92,7 +133,7 @@ export function targetReleaseBadgeCls(target) {
 export function targetReleaseLabel(target) {
   if (!target) return ''
   if (target === PERMANENT_TARGET) return 'Permanent'
-  return target.replace('rhoai-', '')
+  return extractVersion(target) || target
 }
 
 export function normalizeTargetRelease(raw) {
@@ -100,10 +141,11 @@ export function normalizeTargetRelease(raw) {
   const trimmed = raw.trim()
   if (!trimmed) return null
   if (trimmed.toLowerCase().includes('permanent')) return PERMANENT_TARGET
-  let v = trimmed.replace(/^rhoai-/i, '').replace(/^v/i, '')
+  const product = extractProduct(trimmed)
+  let v = product ? extractVersion(trimmed) : trimmed.replace(/^v/i, '')
   v = v.replace(/[\s.-]+[Ee][Aa][\s.-]*(\d+)/, '.EA$1')
   v = v.replace(/^[\s.-]+|[\s.-]+$/g, '')
-  return `rhoai-${v}`
+  return product ? `${product}-${v}` : v
 }
 
 export function extractCategory(value) {

--- a/modules/releases/client/deliver/views/ConformaExceptionsView.vue
+++ b/modules/releases/client/deliver/views/ConformaExceptionsView.vue
@@ -5,7 +5,7 @@
       <div>
         <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Conforma Insights</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-          Policy exceptions approved for each RHOAI release, sourced from Enterprise Contract Policy YAMLs.
+          Policy exceptions approved for each release, sourced from Enterprise Contract Policy YAMLs.
         </p>
       </div>
       <div class="flex flex-col items-end gap-2">
@@ -94,7 +94,7 @@
       </div>
 
       <!-- Summary cards -->
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
         <div
           v-for="card in summaryCards"
           :key="card.label"
@@ -137,7 +137,7 @@
           </div>
           <div class="grid grid-cols-2 gap-4">
             <div>
-              <p class="text-xs text-center text-gray-500 dark:text-gray-400 mb-2">FBC vs Components</p>
+              <p class="text-xs text-center text-gray-500 dark:text-gray-400 mb-2">By Policy File</p>
               <div style="height: 180px; position: relative;">
                 <Doughnut :key="`policy-donut-${chartKey}`" :data="policyFileDonutData" :options="donutOptions" />
               </div>
@@ -240,7 +240,7 @@
                   </div>
                   <div class="flex items-center justify-between pl-0.5">
                     <span class="text-gray-400">
-                      {{ ex.policyFile === 'fbc' ? 'FBC' : 'Components' }}
+                      {{ policyLabel(ex.policyFile) }}
                       &middot; Expires {{ new Date(ex.effectiveUntil).toISOString().slice(0, 10) }}
                       <span
                         :class="ex.daysAfterGa <= 0 ? 'text-red-400' : 'text-amber-400'"
@@ -340,8 +340,7 @@
               class="text-xs rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="">All Policies</option>
-              <option value="fbc">FBC</option>
-              <option value="registry">Components</option>
+              <option v-for="pf in activePolicyFiles" :key="pf" :value="pf">{{ policyLabel(pf) }}</option>
             </select>
 
             <!-- Type filter -->
@@ -451,8 +450,8 @@
                 <td class="px-4 py-3 whitespace-nowrap">
                   <span
                     class="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase"
-                    :class="ex.policyFile === 'fbc' ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300' : 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'"
-                  >{{ ex.policyFile === 'fbc' ? 'FBC' : 'Components' }}</span>
+                    :class="policyBadgeCls(ex.policyFile)"
+                  >{{ policyLabel(ex.policyFile) }}</span>
                 </td>
                 <!-- Type -->
                 <td class="px-4 py-3 whitespace-nowrap">
@@ -668,7 +667,6 @@ import {
   Filler
 } from 'chart.js'
 
-import { useConformaExceptions } from '../composables/useConformaExceptions'
 import { extractProduct, extractVersion, normalizeVersionKey } from '../composables/release-utils'
 import ConformaHelpText from '../components/ConformaHelpText.vue'
 import ConformaAiCategoryChart from '../components/ConformaAiCategoryChart.vue'
@@ -676,7 +674,7 @@ import {
   KNOWN_CATEGORIES, CATEGORY_BADGE, CATEGORY_DOCS,
   AI_CATEGORIES, PERMANENT_TARGET, targetReleaseBadgeCls, targetReleaseLabel,
   normalizeTargetRelease, EXTENSION_JIRA_TEMPLATE_URL, ACTIONABLE_DAYS_THRESHOLD,
-  extractCategory
+  extractCategory, policyLabel, policyColor, sortPolicyFiles
 } from '../constants/conforma'
 
 ChartJS.register(
@@ -709,7 +707,7 @@ const TABLE_COLUMNS = [
 const filter = inject('releaseFilter')
 const moduleNav = inject('moduleNav', null)
 
-const state = useConformaExceptions()
+const state = inject('conformaState')
 const chartKey = ref(0)
 const todayStr = new Date().toLocaleDateString('sv-SE') // YYYY-MM-DD in local time
 
@@ -813,8 +811,8 @@ const flatExceptions = computed(() => {
   const aiMap = aiCategoryMap.value
   const result = []
 
-  for (const policyFile of ['fbc', 'registry']) {
-    const exc = r.exceptions?.[policyFile]
+  for (const policyFile of Object.keys(r.exceptions || {})) {
+    const exc = r.exceptions[policyFile]
     if (!exc) continue
 
     for (const v of exc.configExcludes || []) {
@@ -1032,38 +1030,43 @@ const filteredSortedExceptions = computed(() => {
 
 // ─── Summary cards ──────────────────────────────────────────────────────────
 
+const activePolicyFiles = computed(() => {
+  if (!selectedRelease.value) return []
+  return sortPolicyFiles(Object.keys(selectedRelease.value.exceptions || {}))
+})
+
+const SUMMARY_CARD_STYLES = [
+  { cls: 'border-blue-200 dark:border-blue-700/50 bg-blue-50/60 dark:bg-blue-900/20', labelCls: 'text-blue-600 dark:text-blue-400', valueCls: 'text-blue-700 dark:text-blue-300' },
+  { cls: 'border-emerald-200 dark:border-emerald-700/50 bg-emerald-50/60 dark:bg-emerald-900/20', labelCls: 'text-emerald-600 dark:text-emerald-400', valueCls: 'text-emerald-700 dark:text-emerald-300' },
+  { cls: 'border-violet-200 dark:border-violet-700/50 bg-violet-50/60 dark:bg-violet-900/20', labelCls: 'text-violet-600 dark:text-violet-400', valueCls: 'text-violet-700 dark:text-violet-300' },
+  { cls: 'border-pink-200 dark:border-pink-700/50 bg-pink-50/60 dark:bg-pink-900/20', labelCls: 'text-pink-600 dark:text-pink-400', valueCls: 'text-pink-700 dark:text-pink-300' }
+]
+
 const summaryCards = computed(() => {
   const all = displayExceptions.value
-  const fbc = all.filter(e => e.policyFile === 'fbc').length
-  const registry = all.filter(e => e.policyFile === 'registry').length
   const volatile = all.filter(e => e.type === 'volatile').length
-  return [
+  const cards = [
     {
       label: 'Total Exceptions', value: all.length,
       cls: 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60',
       labelCls: 'text-gray-500 dark:text-gray-400',
       valueCls: 'text-gray-900 dark:text-gray-100'
-    },
-    {
-      label: 'FBC Policy', value: fbc,
-      cls: 'border-blue-200 dark:border-blue-700/50 bg-blue-50/60 dark:bg-blue-900/20',
-      labelCls: 'text-blue-600 dark:text-blue-400',
-      valueCls: 'text-blue-700 dark:text-blue-300'
-    },
-    {
-      label: 'Components Policy', value: registry,
-      cls: 'border-emerald-200 dark:border-emerald-700/50 bg-emerald-50/60 dark:bg-emerald-900/20',
-      labelCls: 'text-emerald-600 dark:text-emerald-400',
-      valueCls: 'text-emerald-700 dark:text-emerald-300'
-    },
-    {
-      label: 'Volatile (Time-bound)', value: volatile,
-      sub: `${all.length - volatile} permanent`,
-      cls: 'border-amber-200 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/20',
-      labelCls: 'text-amber-600 dark:text-amber-400',
-      valueCls: 'text-amber-700 dark:text-amber-300'
     }
   ]
+  for (let i = 0; i < activePolicyFiles.value.length; i++) {
+    const pf = activePolicyFiles.value[i]
+    const count = all.filter(e => e.policyFile === pf).length
+    const style = SUMMARY_CARD_STYLES[i % SUMMARY_CARD_STYLES.length]
+    cards.push({ label: `${policyLabel(pf)} Policy`, value: count, ...style })
+  }
+  cards.push({
+    label: 'Volatile (Time-bound)', value: volatile,
+    sub: `${all.length - volatile} permanent`,
+    cls: 'border-amber-200 dark:border-amber-700/50 bg-amber-50/60 dark:bg-amber-900/20',
+    labelCls: 'text-amber-600 dark:text-amber-400',
+    valueCls: 'text-amber-700 dark:text-amber-300'
+  })
+  return cards
 })
 
 // ─── Category horizontal bar chart ──────────────────────────────────────────
@@ -1071,39 +1074,35 @@ const summaryCards = computed(() => {
 const categoryChartData = computed(() => {
   const all = displayExceptions.value
   if (!all.length) return null
+  const pfs = activePolicyFiles.value
 
-  const fbcCounts = {}
-  const regCounts = {}
-  for (const cat of KNOWN_CATEGORIES) { fbcCounts[cat] = 0; regCounts[cat] = 0 }
-
+  const countsByPf = {}
+  for (const pf of pfs) {
+    countsByPf[pf] = {}
+    for (const cat of KNOWN_CATEGORIES) countsByPf[pf][cat] = 0
+  }
   for (const e of all) {
     const cat = KNOWN_CATEGORIES.includes(e.category) ? e.category : 'other'
-    if (e.policyFile === 'fbc') fbcCounts[cat]++
-    else regCounts[cat]++
+    if (countsByPf[e.policyFile]) countsByPf[e.policyFile][cat]++
   }
 
-  const chartCategories = KNOWN_CATEGORIES.filter(c => (fbcCounts[c] || 0) + (regCounts[c] || 0) > 0)
+  const chartCategories = KNOWN_CATEGORIES.filter(c =>
+    pfs.some(pf => (countsByPf[pf]?.[c] || 0) > 0)
+  )
 
   return {
     labels: chartCategories,
-    datasets: [
-      {
-        label: 'FBC',
-        data: chartCategories.map(c => fbcCounts[c]),
-        backgroundColor: 'rgba(59,130,246,0.75)',
-        borderColor: 'rgb(59,130,246)',
-        borderWidth: 1,
-        borderRadius: 3
-      },
-      {
-        label: 'Components',
-        data: chartCategories.map(c => regCounts[c]),
-        backgroundColor: 'rgba(16,185,129,0.75)',
-        borderColor: 'rgb(16,185,129)',
+    datasets: pfs.map(pf => {
+      const color = policyColor(pf, pfs)
+      return {
+        label: policyLabel(pf),
+        data: chartCategories.map(c => countsByPf[pf]?.[c] || 0),
+        backgroundColor: color.bg,
+        borderColor: color.border,
         borderWidth: 1,
         borderRadius: 3
       }
-    ]
+    })
   }
 })
 
@@ -1184,14 +1183,15 @@ const donutOptions = {
 
 const policyFileDonutData = computed(() => {
   const all = displayExceptions.value
-  const fbc = all.filter(e => e.policyFile === 'fbc').length
-  const reg = all.filter(e => e.policyFile === 'registry').length
+  const pfs = activePolicyFiles.value
+  const counts = pfs.map(pf => all.filter(e => e.policyFile === pf).length)
+  const colors = pfs.map(pf => policyColor(pf, pfs))
   return {
-    labels: ['FBC', 'Components'],
+    labels: pfs.map(pf => policyLabel(pf)),
     datasets: [{
-      data: [fbc, reg],
-      backgroundColor: ['rgba(59,130,246,0.8)', 'rgba(16,185,129,0.8)'],
-      borderColor: ['rgb(59,130,246)', 'rgb(16,185,129)'],
+      data: counts,
+      backgroundColor: colors.map(c => c.bg.replace('0.75', '0.8')),
+      borderColor: colors.map(c => c.border),
       borderWidth: 2
     }]
   }
@@ -1215,62 +1215,60 @@ const typeDonutData = computed(() => {
 // ─── Trend line chart ────────────────────────────────────────────────────────
 
 const trendChartData = computed(() => {
-  const sorted = [...allReleasesRaw.value].sort((a, b) => a.gaDate.localeCompare(b.gaDate))
+  const prods = filter.selectedProducts
+  const sorted = [...allReleasesRaw.value]
+    .filter(r => !prods.size || prods.has(extractProduct(r.version)))
+    .sort((a, b) => a.gaDate.localeCompare(b.gaDate))
   if (sorted.length < 2) return null
 
-  const labels = sorted.map(r => r.version.replace('rhoai-', ''))
-  function countFor(r, filter) {
+  const labels = sorted.map(r => extractVersion(r.version))
+  function countFor(r, filterFn) {
     let all = []
-    for (const pf of ['fbc', 'registry']) {
-      const exc = r.exceptions?.[pf]
+    for (const pf of Object.keys(r.exceptions || {})) {
+      const exc = r.exceptions[pf]
       if (!exc) continue
       for (const v of exc.configExcludes || []) all.push({ type: 'permanent', policyFile: pf, value: v, category: extractCategory(v), team: null })
       for (const ex of exc.volatileExcludes || []) all.push({ type: 'volatile', policyFile: pf, value: ex.value, category: extractCategory(ex.value), team: ex.team || null })
     }
     if (tableFilterTeam.value) all = all.filter(e => e.team === tableFilterTeam.value)
-    return filter ? all.filter(filter).length : all.length
+    return filterFn ? all.filter(filterFn).length : all.length
   }
 
-  return {
-    labels,
-    datasets: [
-      {
-        label: 'Total',
-        data: sorted.map(r => countFor(r)),
-        borderColor: 'rgb(139,92,246)',
-        backgroundColor: 'rgba(139,92,246,0.1)',
-        tension: 0.3, fill: false, pointRadius: 4
-      },
-      {
-        label: 'FIPS',
-        data: sorted.map(r => countFor(r, e => e.category === 'fips')),
-        borderColor: 'rgb(6,182,212)',
-        backgroundColor: 'transparent',
-        tension: 0.3, fill: false, pointRadius: 3, borderDash: [3, 2]
-      },
-      {
-        label: 'FBC',
-        data: sorted.map(r => countFor(r, e => e.policyFile === 'fbc')),
-        borderColor: 'rgb(59,130,246)',
-        backgroundColor: 'transparent',
-        tension: 0.3, fill: false, pointRadius: 3
-      },
-      {
-        label: 'Components',
-        data: sorted.map(r => countFor(r, e => e.policyFile === 'registry')),
-        borderColor: 'rgb(16,185,129)',
-        backgroundColor: 'transparent',
-        tension: 0.3, fill: false, pointRadius: 3
-      },
-      {
-        label: 'Volatile',
-        data: sorted.map(r => countFor(r, e => e.type === 'volatile')),
-        borderColor: 'rgb(245,158,11)',
-        backgroundColor: 'transparent',
-        tension: 0.3, fill: false, pointRadius: 3, borderDash: [4, 3]
-      }
-    ]
+  const trendPfs = sortPolicyFiles([...new Set(sorted.flatMap(r => Object.keys(r.exceptions || {})))])
+  const datasets = [
+    {
+      label: 'Total',
+      data: sorted.map(r => countFor(r)),
+      borderColor: 'rgb(139,92,246)',
+      backgroundColor: 'rgba(139,92,246,0.1)',
+      tension: 0.3, fill: false, pointRadius: 4
+    },
+    {
+      label: 'FIPS',
+      data: sorted.map(r => countFor(r, e => e.category === 'fips')),
+      borderColor: 'rgb(6,182,212)',
+      backgroundColor: 'transparent',
+      tension: 0.3, fill: false, pointRadius: 3, borderDash: [3, 2]
+    }
+  ]
+  for (const pf of trendPfs) {
+    const color = policyColor(pf, trendPfs)
+    datasets.push({
+      label: policyLabel(pf),
+      data: sorted.map(r => countFor(r, e => e.policyFile === pf)),
+      borderColor: color.border,
+      backgroundColor: 'transparent',
+      tension: 0.3, fill: false, pointRadius: 3
+    })
   }
+  datasets.push({
+    label: 'Volatile',
+    data: sorted.map(r => countFor(r, e => e.type === 'volatile')),
+    borderColor: 'rgb(245,158,11)',
+    backgroundColor: 'transparent',
+    tension: 0.3, fill: false, pointRadius: 3, borderDash: [4, 3]
+  })
+  return { labels, datasets }
 })
 
 const trendChartOptions = {
@@ -1472,5 +1470,9 @@ function daysAfterGaCls(days) {
 
 function categoryBadgeCls(cat) {
   return CATEGORY_BADGE[cat] || CATEGORY_BADGE.other
+}
+
+function policyBadgeCls(pf) {
+  return policyColor(pf, activePolicyFiles.value).badgeCls
 }
 </script>

--- a/modules/releases/client/deliver/views/PostReleaseDefectsView.vue
+++ b/modules/releases/client/deliver/views/PostReleaseDefectsView.vue
@@ -128,6 +128,7 @@ import VersionSelector from '../quality-components/VersionSelector.vue';
 import ComponentFilter from '../quality-components/ComponentFilter.vue';
 import CumulativeBugChart from '../quality-components/CumulativeBugChart.vue';
 import { getVersions, getBugData, getComponents, refreshData } from '../quality-services/api';
+import { extractProduct } from '../composables/release-utils';
 
 const { isAdmin } = useAuth();
 
@@ -141,14 +142,11 @@ const loading = ref(true);
 const refreshing = ref(false);
 const error = ref(null);
 
-// Extract unique products from version names (rhoai-3.4 → rhoai)
 const products = computed(() => {
   const productSet = new Set();
   for (const v of versions.value) {
-    const match = v.name.match(/^(rhoai|rhelai|rhaiis|rhaii)/i);
-    if (match) {
-      productSet.add(match[1].toLowerCase());
-    }
+    const p = extractProduct(v.name);
+    if (p) productSet.add(p);
   }
   return Array.from(productSet).sort();
 });

--- a/modules/releases/client/views/DeliverView.vue
+++ b/modules/releases/client/views/DeliverView.vue
@@ -35,6 +35,7 @@
 import { ref, computed, provide, inject, watch, defineAsyncComponent } from 'vue'
 import { useReleaseAnalysis } from '../deliver/composables/useReleaseAnalysis.js'
 import { useReleaseFilter } from '../deliver/composables/useReleaseFilter.js'
+import { useConformaExceptions } from '../deliver/composables/useConformaExceptions.js'
 import ReleaseChipBar from '../deliver/components/ReleaseChipBar.vue'
 
 const RiskDashboard = defineAsyncComponent(() => import('../deliver/views/MainView.vue'))
@@ -42,13 +43,22 @@ const ConformaInsights = defineAsyncComponent(() => import('../deliver/views/Con
 const PostReleaseDefects = defineAsyncComponent(() => import('../deliver/views/PostReleaseDefectsView.vue'))
 
 const { loading, refreshing, error, analysis, refreshAnalysis } = useReleaseAnalysis()
+const conformaState = useConformaExceptions()
 
-const allReleases = computed(() => analysis.value?.releases || [])
+const allReleases = computed(() => {
+  const analysisReleases = analysis.value?.releases || []
+  const seen = new Set(analysisReleases.map(r => r.releaseNumber))
+  const conformaExtras = (conformaState.releases || [])
+    .filter(r => r.version && !seen.has(r.version))
+    .map(r => ({ releaseNumber: r.version }))
+  return [...analysisReleases, ...conformaExtras]
+})
 
 const filter = useReleaseFilter(allReleases)
 
 provide('releaseFilter', filter)
 provide('analysisState', { loading, refreshing, error, analysis, refreshAnalysis })
+provide('conformaState', conformaState)
 
 const tabs = [
   { id: 'risk-dashboard', label: 'Risk Dashboard' },


### PR DESCRIPTION
Generalize the Conforma Insights tab to support RHEL AI, RHAII, and Base Images in addition to RHOAI. Replace all hardcoded fbc/registry assumptions with dynamic policy file handling derived from the data.

- Add KNOWN_PRODUCTS list and fix extractProduct/extractVersion for multi-dash product names (e.g. base-images-3.4, rhel-ai-1.5)
- Add policyLabel/policyColor/sortPolicyFiles helpers for dynamic policy file display in charts, badges, and filters
- Merge conforma releases into DeliverView's allReleases so product filter chips appear in ReleaseChipBar
- Share conformaState via provide/inject to avoid duplicate fetches
- Update fixture data with rhel-ai, rhaii, and base-images releases
- Add release-utils tests, extend conforma-constants tests

AIPCC-17705