### PR TITLE
feat(autofix): add Last Week activity view with accurate merge date bucketing

### DIFF
--- a/fixtures/ai-impact/autofix-data.json
+++ b/fixtures/ai-impact/autofix-data.json
@@ -18,7 +18,8 @@
         "AI Core Platform Security"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59198",
@@ -36,7 +37,8 @@
         "AI Core Platform"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59193",
@@ -56,7 +58,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-pending"
+      "pipelineState": "triage-pending",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14654",
@@ -74,7 +77,8 @@
         "AI Testing + Workflow Validation"
       ],
       "assignee": "Lance Barto",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59101",
@@ -93,7 +97,8 @@
         "AI Core Platform"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14633",
@@ -109,7 +114,8 @@
       ],
       "components": [],
       "assignee": "Unassigned",
-      "pipelineState": "autofix-pending"
+      "pipelineState": "autofix-pending",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59075",
@@ -128,7 +134,8 @@
         "AI Core Platform"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T17:30:05.162+0000"
     },
     {
       "key": "RHOAIENG-59073",
@@ -148,7 +155,8 @@
         "AI Core Platform"
       ],
       "assignee": "Gowtham Shanmugasundaram",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59067",
@@ -167,7 +175,8 @@
         "Notebooks Images"
       ],
       "assignee": "Vath Sok",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59066",
@@ -185,7 +194,8 @@
         "Notebooks Images"
       ],
       "assignee": "Vath Sok",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59060",
@@ -203,7 +213,8 @@
         "Notebooks Images"
       ],
       "assignee": "Vath Sok",
-      "pipelineState": "triage-not-fixable"
+      "pipelineState": "triage-not-fixable",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14624",
@@ -221,7 +232,8 @@
         "AIPCC Ecosystems"
       ],
       "assignee": "Doug Hellmann",
-      "pipelineState": "autofix-review"
+      "pipelineState": "autofix-review",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-59055",
@@ -239,7 +251,8 @@
         "AI Core Platform"
       ],
       "assignee": "Gowtham Shanmugasundaram",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58992",
@@ -257,7 +270,8 @@
         "AI Core Platform"
       ],
       "assignee": "Davide Bianchi",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58984",
@@ -278,7 +292,8 @@
         "Notebooks Server"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58983",
@@ -297,7 +312,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Christian Vogt",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58940",
@@ -316,7 +332,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Claudia Alphonse",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58933",
@@ -335,7 +352,8 @@
         "AI Core Platform"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58847",
@@ -353,7 +371,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Manaswini Das",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58830",
@@ -371,7 +390,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58829",
@@ -390,7 +410,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14469",
@@ -410,7 +431,8 @@
         "Development Platform"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58758",
@@ -429,7 +451,8 @@
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58747",
@@ -449,7 +472,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58734",
@@ -469,7 +493,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14461",
@@ -488,7 +513,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:05.510+0000"
     },
     {
       "key": "AIPCC-14460",
@@ -507,7 +533,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:05.973+0000"
     },
     {
       "key": "AIPCC-14459",
@@ -526,7 +553,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:06.540+0000"
     },
     {
       "key": "AIPCC-14458",
@@ -545,7 +573,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:07.030+0000"
     },
     {
       "key": "AIPCC-14457",
@@ -564,7 +593,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:07.452+0000"
     },
     {
       "key": "AIPCC-14456",
@@ -583,7 +613,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14455",
@@ -602,7 +633,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:07.890+0000"
     },
     {
       "key": "AIPCC-14454",
@@ -621,7 +653,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Ryan Petrello",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58730",
@@ -640,7 +673,8 @@
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58729",
@@ -659,7 +693,8 @@
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58728",
@@ -678,7 +713,8 @@
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58724",
@@ -698,7 +734,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Moulali Shikalwadi",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58678",
@@ -716,7 +753,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58677",
@@ -734,7 +772,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58676",
@@ -752,7 +791,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58655",
@@ -770,7 +810,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14433",
@@ -789,7 +830,8 @@
         "Development Platform"
       ],
       "assignee": "Sean Johnston",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58577",
@@ -808,7 +850,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58544",
@@ -826,7 +869,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58513",
@@ -844,7 +888,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Claudia Alphonse",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14345",
@@ -862,7 +907,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-researched"
+      "pipelineState": "autofix-researched",
+      "terminalAt": "2026-04-21T14:33:10.934+0000"
     },
     {
       "key": "AIPCC-14342",
@@ -880,7 +926,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "Lance Barto",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T20:13:13.938+0000"
     },
     {
       "key": "AIPCC-14341",
@@ -898,7 +945,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-researched"
+      "pipelineState": "autofix-researched",
+      "terminalAt": "2026-04-21T14:33:11.560+0000"
     },
     {
       "key": "RHOAIENG-58426",
@@ -917,7 +965,8 @@
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58425",
@@ -936,7 +985,8 @@
         "Gen AI Studio"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-not-fixable"
+      "pipelineState": "triage-not-fixable",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58424",
@@ -956,7 +1006,8 @@
         "Gen AI Studio"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-ci-failing"
+      "pipelineState": "autofix-ci-failing",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58423",
@@ -976,7 +1027,8 @@
         "Gen AI Studio"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-ci-failing"
+      "pipelineState": "autofix-ci-failing",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58422",
@@ -996,7 +1048,8 @@
         "Gen AI Studio"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-ci-failing"
+      "pipelineState": "autofix-ci-failing",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58413",
@@ -1015,7 +1068,8 @@
         "Gen AI Studio"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14332",
@@ -1033,7 +1087,8 @@
         "PyTorch"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-not-fixable"
+      "pipelineState": "triage-not-fixable",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58388",
@@ -1053,7 +1108,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58373",
@@ -1071,7 +1127,8 @@
         "AutoRAG"
       ],
       "assignee": "Jakub Walaszczyk",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14329",
@@ -1089,7 +1146,8 @@
         "Development Platform"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-review"
+      "pipelineState": "autofix-review",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14320",
@@ -1107,7 +1165,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "Anu Oguntayo",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:08.401+0000"
     },
     {
       "key": "RHOAIENG-58326",
@@ -1127,7 +1186,8 @@
         "AI Core Dashboard"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-missing-info"
+      "pipelineState": "triage-missing-info",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14318",
@@ -1145,7 +1205,8 @@
         "PyTorch"
       ],
       "assignee": "Unassigned",
-      "pipelineState": "triage-not-fixable"
+      "pipelineState": "triage-not-fixable",
+      "terminalAt": null
     },
     {
       "key": "RHOAIENG-58288",
@@ -1166,7 +1227,8 @@
         "Notebooks Images"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14272",
@@ -1183,7 +1245,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-ready"
+      "pipelineState": "autofix-ready",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14220",
@@ -1199,7 +1262,8 @@
       ],
       "components": [],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-review"
+      "pipelineState": "autofix-review",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-14216",
@@ -1217,7 +1281,8 @@
         "Wheel Package Index"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:08.929+0000"
     },
     {
       "key": "AIPCC-14188",
@@ -1235,7 +1300,8 @@
         "AIPCC Productization"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:09.420+0000"
     },
     {
       "key": "AIPCC-14074",
@@ -1253,7 +1319,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:09.858+0000"
     },
     {
       "key": "AIPCC-14062",
@@ -1271,7 +1338,8 @@
         "Wheel Package Index"
       ],
       "assignee": "AIPCC JIRABOT",
-      "pipelineState": "autofix-merged"
+      "pipelineState": "autofix-merged",
+      "terminalAt": "2026-04-21T14:33:10.434+0000"
     },
     {
       "key": "AIPCC-14049",
@@ -1290,7 +1358,8 @@
         "Wheel Package Index"
       ],
       "assignee": "Emilien Macchi",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-12897",
@@ -1306,7 +1375,8 @@
       ],
       "components": [],
       "assignee": "Martin Prpic",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     },
     {
       "key": "AIPCC-12895",
@@ -1325,7 +1395,8 @@
         "Accelerator Enablement"
       ],
       "assignee": "Emilien Macchi",
-      "pipelineState": "autofix-blocked"
+      "pipelineState": "autofix-blocked",
+      "terminalAt": null
     }
   ]
 }

--- a/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
+++ b/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
@@ -3,6 +3,8 @@ import { describe, it, expect } from 'vitest'
 const {
   classifyIssue,
   processIssue,
+  extractTerminalAt,
+  getLastWeekBounds,
   computeAutofixMetrics,
   buildTrendData
 } = require('../../server/jira/autofix-fetcher')
@@ -108,6 +110,7 @@ describe('processIssue', () => {
     expect(result.components).toEqual(['Model Server'])
     expect(result.assignee).toBe('Jane Doe')
     expect(result.pipelineState).toBe('autofix-review')
+    expect(result.terminalAt).toBeNull()
   })
 
   it('handles missing optional fields', () => {
@@ -228,5 +231,146 @@ describe('buildTrendData', () => {
     expect(lastPoint.stale).toBe(1)
     expect(lastPoint.external).toBe(1)
     expect(lastPoint.securityReview).toBe(1)
+  })
+
+  it('returns 4 points for lastWeek window', () => {
+    const trend = buildTrendData([], 'lastWeek')
+    expect(trend).toHaveLength(4)
+  })
+
+  it('uses terminalAt for merged issues in lastWeek window', () => {
+    const { start, end } = getLastWeekBounds()
+    const midLastWeek = new Date(start + (end - start) / 2).toISOString()
+    const threeMonthsAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created: threeMonthsAgo, terminalAt: midLastWeek, pipelineState: 'autofix-merged' },
+      { created: midLastWeek, terminalAt: null, pipelineState: 'autofix-review' }
+    ]
+    const trend = buildTrendData(issues, 'lastWeek')
+    const lastBucket = trend[trend.length - 1]
+    expect(lastBucket.merged).toBe(1)
+    expect(lastBucket.review).toBe(1)
+  })
+
+  it('does not use terminalAt for existing time windows', () => {
+    const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created: old, terminalAt: recent, pipelineState: 'autofix-merged' }
+    ]
+    const trend = buildTrendData(issues, 'week')
+    const lastBucket = trend[trend.length - 1]
+    expect(lastBucket.merged).toBe(0)
+  })
+})
+
+describe('extractTerminalAt', () => {
+  it('returns timestamp when terminal label appears in changelog', () => {
+    const changelog = {
+      histories: [
+        {
+          created: '2026-06-18T15:11:11.202+0000',
+          items: [
+            { field: 'labels', toString: 'jira-autofix jira-autofix-merged' }
+          ]
+        }
+      ]
+    }
+    expect(extractTerminalAt(changelog, 'autofix-merged')).toBe('2026-06-18T15:11:11.202Z')
+  })
+
+  it('returns the latest timestamp when label was added multiple times', () => {
+    const changelog = {
+      histories: [
+        {
+          created: '2026-04-21T17:30:05.162+0000',
+          items: [
+            { field: 'labels', toString: 'jira-autofix jira-autofix-merged' }
+          ]
+        },
+        {
+          created: '2026-06-11T15:05:41.099+0000',
+          items: [
+            { field: 'labels', toString: 'jira-autofix jira-autofix-merged' }
+          ]
+        }
+      ]
+    }
+    expect(extractTerminalAt(changelog, 'autofix-merged')).toBe('2026-06-11T15:05:41.099Z')
+  })
+
+  it('returns null when label is not found in changelog', () => {
+    const changelog = {
+      histories: [
+        {
+          created: '2026-06-18T15:11:11.202+0000',
+          items: [
+            { field: 'labels', toString: 'jira-autofix jira-autofix-review' }
+          ]
+        }
+      ]
+    }
+    expect(extractTerminalAt(changelog, 'autofix-merged')).toBeNull()
+  })
+
+  it('returns null for empty changelog', () => {
+    expect(extractTerminalAt(null, 'autofix-merged')).toBeNull()
+    expect(extractTerminalAt({}, 'autofix-merged')).toBeNull()
+  })
+
+  it('ignores non-label changelog entries', () => {
+    const changelog = {
+      histories: [
+        {
+          created: '2026-06-18T15:11:11.202+0000',
+          items: [
+            { field: 'status', toString: 'Closed' }
+          ]
+        }
+      ]
+    }
+    expect(extractTerminalAt(changelog, 'autofix-merged')).toBeNull()
+  })
+})
+
+describe('computeAutofixMetrics with lastWeek', () => {
+  it('uses terminalAt for terminal issues in lastWeek window', () => {
+    const { start, end } = getLastWeekBounds()
+    const midLastWeek = new Date(start + (end - start) / 2).toISOString()
+    const threeMonthsAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created: threeMonthsAgo, terminalAt: midLastWeek, pipelineState: 'autofix-merged' },
+      { created: midLastWeek, terminalAt: null, pipelineState: 'autofix-review' },
+      { created: threeMonthsAgo, terminalAt: null, pipelineState: 'autofix-merged' }
+    ]
+    const m = computeAutofixMetrics(issues, 'lastWeek')
+    expect(m.autofixStates.merged).toBe(1)
+    expect(m.autofixStates.review).toBe(1)
+    expect(m.windowTotal).toBe(2)
+  })
+
+  it('does not include terminal issues outside lastWeek window', () => {
+    const twoWeeksAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created: twoWeeksAgo, terminalAt: twoWeeksAgo, pipelineState: 'autofix-merged' }
+    ]
+    const m = computeAutofixMetrics(issues, 'lastWeek')
+    expect(m.autofixStates.merged).toBe(0)
+  })
+})
+
+describe('getLastWeekBounds', () => {
+  it('returns Monday-to-Monday boundaries', () => {
+    const { start, end } = getLastWeekBounds()
+    const startDate = new Date(start)
+    const endDate = new Date(end)
+    expect(startDate.getUTCDay()).toBe(1)
+    expect(endDate.getUTCDay()).toBe(1)
+    expect(end - start).toBe(7 * 24 * 60 * 60 * 1000)
+  })
+
+  it('end is before now', () => {
+    const { end } = getLastWeekBounds()
+    expect(end).toBeLessThanOrEqual(Date.now())
   })
 })

--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -55,6 +55,46 @@ const selectedProject = ref('all')
 const selectedIssueType = ref('all')
 const selectedComponent = ref('all')
 
+const TERMINAL_STATES = new Set([
+  'autofix-merged', 'autofix-rejected', 'autofix-max-retries', 'autofix-researched'
+])
+
+function getLastWeekBounds() {
+  const now = new Date()
+  const day = now.getUTCDay()
+  const diffToMonday = day === 0 ? 6 : day - 1
+  const thisMonday = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - diffToMonday
+  ))
+  const lastMonday = new Date(thisMonday.getTime() - 7 * 24 * 60 * 60 * 1000)
+  return { start: lastMonday.getTime(), end: thisMonday.getTime() }
+}
+
+function issueTimestamp(issue, isLastWeek) {
+  if (isLastWeek && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
+    return new Date(issue.terminalAt).getTime()
+  }
+  return new Date(issue.created).getTime()
+}
+
+const SHORT_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+function formatUTCShortDate(d) {
+  return SHORT_MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate()
+}
+
+const windowDateRange = computed(() => {
+  if (props.timeWindow === 'lastWeek') {
+    const { start, end } = getLastWeekBounds()
+    const s = new Date(start)
+    const e = new Date(end - 86400000)
+    return 'Mon ' + formatUTCShortDate(s) + ' – Sun ' + formatUTCShortDate(e)
+  }
+  const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
+  const endDate = new Date()
+  const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  return formatUTCShortDate(startDate) + ' – ' + formatUTCShortDate(endDate)
+})
+
 const jiraHost = computed(() => props.autofixData?.jiraHost || 'https://redhat.atlassian.net')
 const isEmpty = computed(() => !props.autofixData?.fetchedAt)
 
@@ -165,9 +205,23 @@ const metrics = computed(() => {
   if (!hasActiveFilter.value) return props.autofixData.metrics
 
   const issues = projectFilteredIssues.value
-  const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  const windowIssues = issues.filter(i => new Date(i.created) >= cutoff)
+  const isLastWeek = props.timeWindow === 'lastWeek'
+  let windowStart, windowEnd
+
+  if (isLastWeek) {
+    const bounds = getLastWeekBounds()
+    windowStart = bounds.start
+    windowEnd = bounds.end
+  } else {
+    const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
+    windowEnd = Date.now()
+    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
+  }
+
+  const windowIssues = issues.filter(i => {
+    const ts = issueTimestamp(i, isLastWeek)
+    return ts >= windowStart && ts < windowEnd
+  })
 
   const triageTotal = windowIssues.filter(i =>
     i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')
@@ -205,13 +259,24 @@ const trendData = computed(() => {
   if (!hasActiveFilter.value) return props.autofixData?.trendData || []
 
   const issues = projectFilteredIssues.value
-  const weekCounts = props.timeWindow === 'week' ? 4 : props.timeWindow === 'month' ? 8 : 13
-  const now = new Date()
+  const isLW = props.timeWindow === 'lastWeek'
+  const weekCounts = (props.timeWindow === 'week' || isLW) ? 4 : props.timeWindow === 'month' ? 8 : 13
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
+  let anchor
+  if (isLW) {
+    const { end: thisMonday } = getLastWeekBounds()
+    anchor = thisMonday
+  } else {
+    anchor = Date.now()
+  }
   const points = []
   for (let w = weekCounts - 1; w >= 0; w--) {
-    const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000)
-    const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000)
-    const weekIssues = issues.filter(i => { const d = new Date(i.created); return d >= weekStart && d < weekEnd })
+    const weekEnd = new Date(anchor - w * MS_PER_WEEK)
+    const weekStart = new Date(weekEnd.getTime() - MS_PER_WEEK)
+    const weekIssues = issues.filter(i => {
+      const ts = issueTimestamp(i, isLW)
+      return ts >= weekStart.getTime() && ts < weekEnd.getTime()
+    })
     const triaged = weekIssues.filter(i => i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')).length
     const autofixed = weekIssues.filter(i => i.pipelineState.startsWith('autofix-')).length
     const merged = weekIssues.filter(i => i.pipelineState === 'autofix-merged').length
@@ -254,9 +319,23 @@ const stateFilterOptions = STATE_OPTIONS.filter(o => o.value !== 'all')
 
 const timeFilteredIssues = computed(() => {
   if (!projectFilteredIssues.value.length) return []
-  const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  return projectFilteredIssues.value.filter(i => new Date(i.created) >= cutoff)
+  const isLastWeek = props.timeWindow === 'lastWeek'
+  let windowStart, windowEnd
+
+  if (isLastWeek) {
+    const bounds = getLastWeekBounds()
+    windowStart = bounds.start
+    windowEnd = bounds.end
+  } else {
+    const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
+    windowEnd = Date.now()
+    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
+  }
+
+  return projectFilteredIssues.value.filter(i => {
+    const ts = issueTimestamp(i, isLastWeek)
+    return ts >= windowStart && ts < windowEnd
+  })
 })
 
 const filteredIssues = computed(() => {
@@ -454,6 +533,28 @@ const autofixSegmentTotal = computed(() => autofixSegments.value.reduce((s, v) =
 
 function buildJiraLabelUrl(jiraLabels, excludeLabels) {
   const host = jiraHost.value
+
+  if (props.timeWindow === 'lastWeek') {
+    const isTerminalLabel = jiraLabels.some(l =>
+      l === 'jira-autofix-merged' || l === 'jira-autofix-rejected' ||
+      l === 'jira-autofix-max-retries' || l === 'jira-autofix-researched'
+    )
+    if (isTerminalLabel) {
+      const matchingStates = new Set()
+      for (const l of jiraLabels) {
+        const state = l.replace('jira-', '')
+        if (TERMINAL_STATES.has(state)) matchingStates.add(state)
+      }
+      const keys = timeFilteredIssues.value
+        .filter(i => matchingStates.has(i.pipelineState))
+        .map(i => i.key)
+      if (keys.length > 0) {
+        const jql = `key IN (${keys.map(k => `"${k}"`).join(', ')}) ORDER BY updated DESC`
+        return `${host}/issues/?jql=${encodeURIComponent(jql)}`
+      }
+    }
+  }
+
   const labels = jiraLabels.map(l => `"${l}"`).join(', ')
   let jql = `labels IN (${labels})`
   if (excludeLabels && excludeLabels.length > 0) {
@@ -472,15 +573,22 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
   if (selectedComponent.value !== 'all') {
     jql += ` AND component = "${selectedComponent.value}"`
   }
-  const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-  const windowCutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  const earliestIssue = projectFilteredIssues.value.length > 0
-    ? projectFilteredIssues.value.reduce((min, i) => i.created < min ? i.created : min, projectFilteredIssues.value[0].created)
-    : null
-  const dataCutoff = earliestIssue ? new Date(earliestIssue) : null
-  const cutoff = dataCutoff && dataCutoff > windowCutoff ? dataCutoff : windowCutoff
-  jql += ` AND created >= "${cutoff.toISOString().slice(0, 10)}"`
-  jql += ' ORDER BY created DESC'
+  if (props.timeWindow === 'lastWeek') {
+    const { start, end } = getLastWeekBounds()
+    jql += ` AND created >= "${new Date(start).toISOString().slice(0, 10)}"`
+    jql += ` AND created < "${new Date(end).toISOString().slice(0, 10)}"`
+    jql += ' ORDER BY created DESC'
+  } else {
+    const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
+    const windowCutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    const earliestIssue = projectFilteredIssues.value.length > 0
+      ? projectFilteredIssues.value.reduce((min, i) => i.created < min ? i.created : min, projectFilteredIssues.value[0].created)
+      : null
+    const dataCutoff = earliestIssue ? new Date(earliestIssue) : null
+    const cutoff = dataCutoff && dataCutoff > windowCutoff ? dataCutoff : windowCutoff
+    jql += ` AND created >= "${cutoff.toISOString().slice(0, 10)}"`
+    jql += ' ORDER BY created DESC'
+  }
   return `${host}/issues/?jql=${encodeURIComponent(jql)}`
 }
 </script>
@@ -558,11 +666,20 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
           class="border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300"
         >
           <option value="week">This Week</option>
+          <option value="lastWeek">Last Week</option>
           <option value="month">This Month</option>
           <option value="3months">Last 3 Months</option>
         </select>
       </div>
     </header>
+
+    <!-- Date range banner -->
+    <div class="bg-indigo-50 dark:bg-indigo-900/20 border-b border-indigo-100 dark:border-indigo-800/30 px-6 py-2 text-xs text-indigo-700 dark:text-indigo-300 flex items-center gap-1.5">
+      <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+      </svg>
+      <span>{{ windowDateRange }}</span>
+    </div>
 
     <!-- Content -->
     <div class="flex-1 overflow-auto">

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -113,7 +113,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── Autofix data ───
 
-  const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'month', '3months'];
+  const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'lastWeek', 'month', '3months'];
 
   let autofixDataCache = null;
 
@@ -137,6 +137,7 @@ module.exports = function registerRoutes(router, context) {
       priority: issue.priority,
       created: issue.created,
       updated: issue.updated,
+      terminalAt: issue.terminalAt || null,
       components: issue.components,
       assignee: issue.assignee,
       pipelineState: issue.pipelineState
@@ -154,9 +155,9 @@ module.exports = function registerRoutes(router, context) {
    *         name: timeWindow
    *         schema:
    *           type: string
-   *           enum: [week, month, 3months]
+   *           enum: [week, lastWeek, month, 3months]
    *           default: month
-   *         description: Time window for metric computation
+   *         description: Time window for metric computation. lastWeek uses calendar week (Mon-Sun) with terminalAt for resolved issues.
    *       - in: query
    *         name: components
    *         schema:

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -85,7 +85,7 @@ function processIssue(issue) {
 
 function extractTerminalAt(changelog, pipelineState) {
   if (!changelog || !changelog.histories) return null;
-  const targetLabel = 'jira-' + pipelineState.replace('-', '-');
+  const targetLabel = 'jira-' + pipelineState;
   let latest = null;
   for (const history of changelog.histories) {
     for (const item of history.items) {
@@ -201,34 +201,19 @@ function buildTrendData(issues, timeWindow) {
   const weekCounts = (timeWindow === 'week' || isLastWeek) ? 4 : timeWindow === 'month' ? 8 : 13;
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
-  const buckets = [];
+  const anchor = isLastWeek ? getLastWeekBounds().end : Date.now();
 
-  if (isLastWeek) {
-    const { end: thisMonday } = getLastWeekBounds();
-    for (let w = weekCounts - 1; w >= 0; w--) {
-      const weekEnd = new Date(thisMonday - w * MS_PER_WEEK);
-      buckets.push({
-        date: weekEnd.toISOString().slice(0, 10),
-        weekStart: weekEnd.getTime() - MS_PER_WEEK,
-        weekEnd: weekEnd.getTime(),
-        triaged: 0, autofixed: 0, merged: 0, total: 0,
-        review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
-        missingInfo: 0, stale: 0, external: 0, securityReview: 0
-      });
-    }
-  } else {
-    const now = new Date();
-    for (let w = weekCounts - 1; w >= 0; w--) {
-      const weekEnd = new Date(now.getTime() - w * MS_PER_WEEK);
-      buckets.push({
-        date: weekEnd.toISOString().slice(0, 10),
-        weekStart: weekEnd.getTime() - MS_PER_WEEK,
-        weekEnd: weekEnd.getTime(),
-        triaged: 0, autofixed: 0, merged: 0, total: 0,
-        review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
-        missingInfo: 0, stale: 0, external: 0, securityReview: 0
-      });
-    }
+  const buckets = [];
+  for (let w = weekCounts - 1; w >= 0; w--) {
+    const weekEnd = new Date(anchor - w * MS_PER_WEEK);
+    buckets.push({
+      date: weekEnd.toISOString().slice(0, 10),
+      weekStart: weekEnd.getTime() - MS_PER_WEEK,
+      weekEnd: weekEnd.getTime(),
+      triaged: 0, autofixed: 0, merged: 0, total: 0,
+      review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
+      missingInfo: 0, stale: 0, external: 0, securityReview: 0
+    });
   }
 
   const earliest = buckets[0].weekStart;

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -1,6 +1,17 @@
 const { fetchAllJqlResults } = require('../../../../shared/server/jira');
 const { validateJqlSafeString } = require('../config');
 
+const TERMINAL_LABELS = [
+  'jira-autofix-merged',
+  'jira-autofix-rejected',
+  'jira-autofix-max-retries',
+  'jira-autofix-researched'
+];
+
+const TERMINAL_STATES = new Set([
+  'autofix-merged', 'autofix-rejected', 'autofix-max-retries', 'autofix-researched'
+]);
+
 // All labels from the jira-autofix triage + autofix pipelines
 const TRIAGE_LABELS = [
   'jira-triage-pending',
@@ -64,6 +75,7 @@ function processIssue(issue) {
     priority: issue.fields.priority?.name || 'None',
     created: issue.fields.created,
     updated: issue.fields.updated,
+    terminalAt: null,
     labels,
     components,
     assignee: issue.fields.assignee?.displayName || null,
@@ -71,15 +83,62 @@ function processIssue(issue) {
   };
 }
 
+function extractTerminalAt(changelog, pipelineState) {
+  if (!changelog || !changelog.histories) return null;
+  const targetLabel = 'jira-' + pipelineState.replace('-', '-');
+  let latest = null;
+  for (const history of changelog.histories) {
+    for (const item of history.items) {
+      if (item.field !== 'labels') continue;
+      const after = item.toString || '';
+      if (after.includes(targetLabel)) {
+        const ts = new Date(history.created).getTime();
+        if (latest === null || ts > latest) latest = ts;
+      }
+    }
+  }
+  return latest ? new Date(latest).toISOString() : null;
+}
+
+function getLastWeekBounds() {
+  const now = new Date();
+  const day = now.getUTCDay();
+  const diffToMonday = day === 0 ? 6 : day - 1;
+  const thisMonday = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - diffToMonday
+  ));
+  const lastMonday = new Date(thisMonday.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return { start: lastMonday.getTime(), end: thisMonday.getTime() };
+}
+
+function issueInWindow(issue, windowStart, windowEnd, isLastWeek) {
+  if (isLastWeek && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
+    const t = new Date(issue.terminalAt).getTime();
+    return t >= windowStart && t < windowEnd;
+  }
+  const c = new Date(issue.created).getTime();
+  return c >= windowStart && c < windowEnd;
+}
+
 function computeAutofixMetrics(issues, timeWindow) {
-  const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90;
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const isLastWeek = timeWindow === 'lastWeek';
+  let windowStart, windowEnd;
+
+  if (isLastWeek) {
+    const bounds = getLastWeekBounds();
+    windowStart = bounds.start;
+    windowEnd = bounds.end;
+  } else {
+    const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90;
+    windowEnd = Date.now();
+    windowStart = windowEnd - days * 24 * 60 * 60 * 1000;
+  }
 
   const counts = {};
   let windowTotal = 0;
 
   for (const issue of issues) {
-    if (new Date(issue.created) < cutoff) continue;
+    if (!issueInWindow(issue, windowStart, windowEnd, isLastWeek)) continue;
     windowTotal++;
     counts[issue.pipelineState] = (counts[issue.pipelineState] || 0) + 1;
   }
@@ -135,39 +194,61 @@ function computeAutofixMetrics(issues, timeWindow) {
 // created 3 weeks ago that later moved to autofix-merged appears as "merged"
 // in the week it was created, not when it was merged. This is a known
 // limitation — Jira labels don't carry timestamps for state transitions.
+// The 'lastWeek' time window mitigates this for terminal states by using
+// terminalAt (from the Jira changelog) instead of created.
 function buildTrendData(issues, timeWindow) {
-  const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13;
-  const now = new Date();
+  const isLastWeek = timeWindow === 'lastWeek';
+  const weekCounts = (timeWindow === 'week' || isLastWeek) ? 4 : timeWindow === 'month' ? 8 : 13;
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
-  // Initialize empty buckets
   const buckets = [];
-  for (let w = weekCounts - 1; w >= 0; w--) {
-    const weekEnd = new Date(now.getTime() - w * MS_PER_WEEK);
-    buckets.push({
-      date: weekEnd.toISOString().slice(0, 10),
-      weekStart: weekEnd.getTime() - MS_PER_WEEK,
-      weekEnd: weekEnd.getTime(),
-      triaged: 0, autofixed: 0, merged: 0, total: 0,
-      review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
-      missingInfo: 0, stale: 0, external: 0, securityReview: 0
-    });
+
+  if (isLastWeek) {
+    const { end: thisMonday } = getLastWeekBounds();
+    for (let w = weekCounts - 1; w >= 0; w--) {
+      const weekEnd = new Date(thisMonday - w * MS_PER_WEEK);
+      buckets.push({
+        date: weekEnd.toISOString().slice(0, 10),
+        weekStart: weekEnd.getTime() - MS_PER_WEEK,
+        weekEnd: weekEnd.getTime(),
+        triaged: 0, autofixed: 0, merged: 0, total: 0,
+        review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
+        missingInfo: 0, stale: 0, external: 0, securityReview: 0
+      });
+    }
+  } else {
+    const now = new Date();
+    for (let w = weekCounts - 1; w >= 0; w--) {
+      const weekEnd = new Date(now.getTime() - w * MS_PER_WEEK);
+      buckets.push({
+        date: weekEnd.toISOString().slice(0, 10),
+        weekStart: weekEnd.getTime() - MS_PER_WEEK,
+        weekEnd: weekEnd.getTime(),
+        triaged: 0, autofixed: 0, merged: 0, total: 0,
+        review: 0, ciFailing: 0, blocked: 0, maxRetries: 0,
+        missingInfo: 0, stale: 0, external: 0, securityReview: 0
+      });
+    }
   }
 
   const earliest = buckets[0].weekStart;
   const latest = buckets[buckets.length - 1].weekEnd;
 
   for (const issue of issues) {
-    const created = new Date(issue.created).getTime();
-    if (created < earliest || created >= latest) continue;
+    const state = issue.pipelineState;
+    const useTerminalAt = isLastWeek && TERMINAL_STATES.has(state) && issue.terminalAt;
+    const ts = useTerminalAt
+      ? new Date(issue.terminalAt).getTime()
+      : new Date(issue.created).getTime();
 
-    const bucketIdx = Math.floor((created - earliest) / MS_PER_WEEK);
+    if (ts < earliest || ts >= latest) continue;
+
+    const bucketIdx = Math.floor((ts - earliest) / MS_PER_WEEK);
     if (bucketIdx < 0 || bucketIdx >= buckets.length) continue;
     const bucket = buckets[bucketIdx];
 
     bucket.total++;
 
-    const state = issue.pipelineState;
     const isTriage = state.startsWith('triage-');
     const isAutofix = state.startsWith('autofix-');
 
@@ -218,16 +299,40 @@ async function fetchAutofixData(jiraRequest, config) {
   const fields = 'summary,status,issuetype,priority,created,updated,labels,components,assignee';
   const rawIssues = await fetchAllJqlResults(jiraRequest, jql, fields);
 
-  return rawIssues.map(processIssue);
+  const processed = rawIssues.map(processIssue);
+
+  const terminalIssues = processed.filter(i => TERMINAL_STATES.has(i.pipelineState));
+  const BATCH = 10;
+  for (let i = 0; i < terminalIssues.length; i += BATCH) {
+    const batch = terminalIssues.slice(i, i + BATCH);
+    const results = await Promise.allSettled(batch.map(function(issue) {
+      return jiraRequest(
+        '/rest/api/3/issue/' + encodeURIComponent(issue.key) + '?expand=changelog&fields=labels'
+      ).then(function(detail) {
+        issue.terminalAt = extractTerminalAt(detail.changelog, issue.pipelineState);
+      });
+    }));
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        console.error('[autofix] changelog fetch failed:', r.reason?.message || r.reason);
+      }
+    }
+  }
+
+  return processed;
 }
 
 module.exports = {
   fetchAutofixData,
   processIssue,
   classifyIssue,
+  extractTerminalAt,
+  getLastWeekBounds,
   computeAutofixMetrics,
   buildTrendData,
   ALL_PIPELINE_LABELS,
   TRIAGE_LABELS,
-  AUTOFIX_LABELS
+  AUTOFIX_LABELS,
+  TERMINAL_LABELS,
+  TERMINAL_STATES
 };

--- a/modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js
+++ b/modules/team-tracker/__tests__/client/autofix/autofix-constants.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { computeTeamMetrics, buildTeamTrendData, STATE_OPTIONS } from '../../../client/components/autofix/autofix-constants.js'
+import { computeTeamMetrics, buildTeamTrendData, STATE_OPTIONS, getLastWeekBounds } from '../../../client/components/autofix/autofix-constants.js'
 
 describe('autofix-constants', () => {
   beforeEach(() => {
@@ -55,6 +55,28 @@ describe('autofix-constants', () => {
         expect(point).toHaveProperty('merged')
         expect(point).toHaveProperty('review')
       }
+    })
+  })
+
+  describe('computeTeamMetrics with lastWeek', () => {
+    it('uses terminalAt for terminal issues in lastWeek window', () => {
+      const { start, end } = getLastWeekBounds()
+      const midLastWeek = new Date(start + (end - start) / 2).toISOString()
+      const issues = [
+        { key: 'A-1', created: '2026-01-01', terminalAt: midLastWeek, pipelineState: 'autofix-merged', issueType: 'Bug' },
+        { key: 'A-2', created: midLastWeek, terminalAt: null, pipelineState: 'autofix-review', issueType: 'Bug' }
+      ]
+      const result = computeTeamMetrics(issues, 'lastWeek')
+      expect(result.autofixStates.merged).toBe(1)
+      expect(result.autofixStates.review).toBe(1)
+      expect(result.windowTotal).toBe(2)
+    })
+  })
+
+  describe('buildTeamTrendData with lastWeek', () => {
+    it('returns 4 weekly buckets for lastWeek', () => {
+      const result = buildTeamTrendData([], 'lastWeek')
+      expect(result).toHaveLength(4)
     })
   })
 

--- a/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
+++ b/modules/team-tracker/client/components/autofix/TeamAutofixTab.vue
@@ -267,7 +267,9 @@ import {
   stateLabel,
   stateColorClass,
   computeTeamMetrics,
-  buildTeamTrendData
+  buildTeamTrendData,
+  getLastWeekBounds,
+  issueTimestamp
 } from './autofix-constants.js'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, BarController, Filler, Tooltip, Legend)
@@ -313,6 +315,7 @@ const searchQuery = ref('')
 const stateFilterOptions = STATE_OPTIONS.filter(o => o.value !== 'all')
 const timeWindows = [
   { value: 'week', label: 'Week' },
+  { value: 'lastWeek', label: 'Last Week' },
   { value: 'month', label: 'Month' },
   { value: '3months', label: '3 Months' }
 ]
@@ -348,10 +351,21 @@ const statusFilterLabel = computed(() => {
 const metrics = computed(() => computeTeamMetrics(teamIssues.value, timeWindow.value))
 
 const bugsMerged = computed(() => {
-  const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  return teamIssues.value.filter(i =>
-    new Date(i.created) >= cutoff &&
+  const isLW = timeWindow.value === 'lastWeek'
+  let windowStart, windowEnd
+  if (isLW) {
+    const bounds = getLastWeekBounds()
+    windowStart = bounds.start
+    windowEnd = bounds.end
+  } else {
+    const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
+    windowEnd = Date.now()
+    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
+  }
+  return teamIssues.value.filter(i => {
+    const ts = issueTimestamp(i, isLW)
+    return ts >= windowStart && ts < windowEnd
+  }).filter(i =>
     i.pipelineState === 'autofix-merged' &&
     i.issueType === 'Bug'
   ).length
@@ -384,9 +398,21 @@ const pipelineSegments = computed(() => {
 })
 
 const timeFilteredIssues = computed(() => {
-  const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  return teamIssues.value.filter(i => new Date(i.created) >= cutoff)
+  const isLW = timeWindow.value === 'lastWeek'
+  let windowStart, windowEnd
+  if (isLW) {
+    const bounds = getLastWeekBounds()
+    windowStart = bounds.start
+    windowEnd = bounds.end
+  } else {
+    const days = timeWindow.value === 'week' ? 7 : timeWindow.value === 'month' ? 30 : 90
+    windowEnd = Date.now()
+    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
+  }
+  return teamIssues.value.filter(i => {
+    const ts = issueTimestamp(i, isLW)
+    return ts >= windowStart && ts < windowEnd
+  })
 })
 
 const displayedIssues = computed(() => {

--- a/modules/team-tracker/client/components/autofix/autofix-constants.js
+++ b/modules/team-tracker/client/components/autofix/autofix-constants.js
@@ -54,14 +54,50 @@ export function stateColorClass(state) {
   return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
 }
 
+export const TERMINAL_STATES = new Set([
+  'autofix-merged', 'autofix-rejected', 'autofix-max-retries', 'autofix-researched'
+])
+
+export function getLastWeekBounds() {
+  const now = new Date()
+  const day = now.getUTCDay()
+  const diffToMonday = day === 0 ? 6 : day - 1
+  const thisMonday = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - diffToMonday
+  ))
+  const lastMonday = new Date(thisMonday.getTime() - 7 * 24 * 60 * 60 * 1000)
+  return { start: lastMonday.getTime(), end: thisMonday.getTime() }
+}
+
+export function issueTimestamp(issue, isLastWeek) {
+  if (isLastWeek && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
+    return new Date(issue.terminalAt).getTime()
+  }
+  return new Date(issue.created).getTime()
+}
+
 /**
  * Compute autofix metrics for a set of team-filtered issues.
  * Mirrors computeAutofixMetrics() from ai-impact autofix-fetcher.js.
  */
 export function computeTeamMetrics(issues, timeWindow) {
-  const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  const windowIssues = issues.filter(i => new Date(i.created) >= cutoff)
+  const isLastWeek = timeWindow === 'lastWeek'
+  let windowStart, windowEnd
+
+  if (isLastWeek) {
+    const bounds = getLastWeekBounds()
+    windowStart = bounds.start
+    windowEnd = bounds.end
+  } else {
+    const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90
+    windowEnd = Date.now()
+    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
+  }
+
+  const windowIssues = issues.filter(i => {
+    const ts = issueTimestamp(i, isLastWeek)
+    return ts >= windowStart && ts < windowEnd
+  })
 
   const triageTotal = windowIssues.filter(i =>
     i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')
@@ -109,15 +145,23 @@ export function computeTeamMetrics(issues, timeWindow) {
  * Mirrors buildTrendData() from ai-impact autofix-fetcher.js.
  */
 export function buildTeamTrendData(issues, timeWindow) {
-  const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13
-  const now = new Date()
+  const isLW = timeWindow === 'lastWeek'
+  const weekCounts = (timeWindow === 'week' || isLW) ? 4 : timeWindow === 'month' ? 8 : 13
+  const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
+  let anchor
+  if (isLW) {
+    const { end: thisMonday } = getLastWeekBounds()
+    anchor = thisMonday
+  } else {
+    anchor = Date.now()
+  }
   const points = []
   for (let w = weekCounts - 1; w >= 0; w--) {
-    const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000)
-    const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000)
+    const weekEnd = new Date(anchor - w * MS_PER_WEEK)
+    const weekStart = new Date(weekEnd.getTime() - MS_PER_WEEK)
     const weekIssues = issues.filter(i => {
-      const d = new Date(i.created)
-      return d >= weekStart && d < weekEnd
+      const ts = issueTimestamp(i, isLW)
+      return ts >= weekStart.getTime() && ts < weekEnd.getTime()
     })
     const triaged = weekIssues.filter(i => i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')).length
     const autofixed = weekIssues.filter(i => i.pipelineState.startsWith('autofix-')).length


### PR DESCRIPTION
## Summary

- Adds a **"Last Week"** time window to the Jira AutoFix dashboard that shows the previous completed calendar week (Mon-Sun)
- Terminal-state issues (merged, rejected, max-retries, researched) are bucketed by when they reached that state (`terminalAt` from Jira changelog), not by creation date
- All existing time windows (This Week, This Month, Last 3 Months) remain completely unchanged

## Problem

The dashboard bucketed all issues by creation date. When a stakeholder asked "how many fixes merged last week?", issues created weeks ago but merged during that week were invisible — attributed to their creation week instead. A direct Jira query showed 10 issues had their autofix MR merged during the week of Jun 13-19, but the dashboard showed only 2-4.

## Changes

**Server (`autofix-fetcher.js`, `index.js`):**
- New `terminalAt` field extracted from Jira changelog during refresh (~150-200 extra API calls per refresh for terminal-state issues, batched 10 at a time)
- `extractTerminalAt()` finds the most recent changelog entry where the terminal label was added
- `computeAutofixMetrics` and `buildTrendData` support `lastWeek` with calendar-week boundaries
- `lastWeek` added to valid time windows and OpenAPI annotation

**Client (`AutofixContent.vue`, `autofix-constants.js`, `TeamAutofixTab.vue`):**
- "Last Week" option in time window dropdowns
- Client-side metric/trend recomputation handles `lastWeek` with same terminal-date logic
- Exact-key JQL links for terminal-state counts (no date-approximation mismatch)
- Date range banner below page header showing the active window (e.g., "Mon Jun 15 – Sun Jun 21")

**Tests:**
- `extractTerminalAt` tests (label found, multiple additions, not found, empty changelog)
- `getLastWeekBounds` tests (Monday boundaries, duration)
- `computeAutofixMetrics` and `buildTrendData` with `lastWeek` window
- Team-tracker `computeTeamMetrics` and `buildTeamTrendData` with `lastWeek`
- Verified existing time window tests pass unchanged

**Fixtures:**
- `terminalAt` field added to terminal-state issues in `autofix-data.json`

## Known limitation

The "Ready for AI" count in the Triage Outcomes panel includes terminal autofix issues bucketed by `terminalAt`. The JQL link for this row uses `created`-based filtering, so clicking it may show a slightly different count (off by the number of terminal issues created outside the window but resolved within it). All other clickable counts match exactly.

## Test plan

- [x] `npm test` — 4875 tests pass
- [x] `npm run lint` — clean
- [x] `npm run validate:modules` — pass
- [x] `npm run validate:openapi` — pass
- [ ] Visual check: select "Last Week" on the Jira AutoFix page, verify merged count reflects actual merge dates
- [ ] Visual check: click "AI Fix Merged" count, verify Jira shows the exact matching issues
- [ ] Visual check: date range banner shows correct Mon-Sun range
- [ ] Verify "This Week" / "This Month" / "Last 3 Months" are unchanged