### PR TITLE
feat(releases): add Schedule widget for home page dashboard

### DIFF
--- a/modules/releases/__tests__/client/schedule-widget.test.js
+++ b/modules/releases/__tests__/client/schedule-widget.test.js
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+vi.mock('@shared/client/services/api.js', () => ({
+  apiRequest: vi.fn()
+}))
+
+vi.mock('@shared/client/composables/useModuleLink.js', () => ({
+  useModuleLink: () => ({
+    navigateTo: vi.fn(),
+    linkTo: vi.fn()
+  })
+}))
+
+import { apiRequest } from '@shared/client/services/api.js'
+import ScheduleWidget from '../../client/widgets/ScheduleWidget.vue'
+
+function makeRelease(id, opts = {}) {
+  return {
+    id,
+    displayName: opts.displayName || id.toUpperCase(),
+    state: opts.state || 'active',
+    productPagesShortname: opts.shortname || 'rhoai',
+    milestones: {
+      ga: opts.ga || null,
+      codeFreeze: opts.codeFreeze || null,
+      planningFreeze: opts.planningFreeze || null
+    }
+  }
+}
+
+function futureDate(daysFromNow) {
+  const d = new Date()
+  d.setDate(d.getDate() + daysFromNow)
+  return d.toISOString().split('T')[0]
+}
+
+describe('ScheduleWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders loading skeleton initially', () => {
+    apiRequest.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(ScheduleWidget)
+    expect(wrapper.findAll('.animate-pulse').length).toBeGreaterThan(0)
+  })
+
+  it('renders empty state when no upcoming milestones', async () => {
+    apiRequest.mockResolvedValue({ releases: [] })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    expect(wrapper.text()).toContain('No upcoming milestones')
+  })
+
+  it('calls the correct API endpoint', async () => {
+    apiRequest.mockResolvedValue({ releases: [] })
+    mount(ScheduleWidget)
+    await flushPromises()
+    expect(apiRequest).toHaveBeenCalledWith('/modules/releases/registry')
+  })
+
+  it('shows upcoming milestones sorted by soonest first', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', {
+          planningFreeze: futureDate(20),
+          codeFreeze: futureDate(40),
+          ga: futureDate(60)
+        }),
+        makeRelease('rhoai-3.4', {
+          planningFreeze: futureDate(5),
+          ga: futureDate(30)
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+
+    const items = wrapper.findAll('[class*="px-5 py-2"]')
+    expect(items.length).toBeGreaterThanOrEqual(2)
+    expect(items[0].text()).toContain('RHOAI-3.4')
+    expect(items[0].text()).toContain('5d')
+  })
+
+  it('only shows active releases', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', { state: 'active', ga: futureDate(30) }),
+        makeRelease('rhoai-3.4', { state: 'archived', ga: futureDate(10) })
+      ]
+    })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    expect(wrapper.text()).toContain('RHOAI-3.5')
+    expect(wrapper.text()).not.toContain('RHOAI-3.4')
+  })
+
+  it('excludes past milestones', async () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 5)
+    const pastStr = past.toISOString().split('T')[0]
+
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.5', {
+          planningFreeze: pastStr,
+          ga: futureDate(30)
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('Plan Freeze')
+    expect(wrapper.text()).toContain('Release')
+  })
+
+  it('limits to 6 milestones maximum', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [
+        makeRelease('rhoai-3.4', {
+          planningFreeze: futureDate(1),
+          codeFreeze: futureDate(10),
+          ga: futureDate(20)
+        }),
+        makeRelease('rhoai-3.5', {
+          planningFreeze: futureDate(25),
+          codeFreeze: futureDate(35),
+          ga: futureDate(45)
+        }),
+        makeRelease('rhoai-3.6', {
+          planningFreeze: futureDate(50),
+          codeFreeze: futureDate(60),
+          ga: futureDate(70)
+        })
+      ]
+    })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+
+    const items = wrapper.findAll('[class*="px-5 py-2"]')
+    expect(items).toHaveLength(6)
+  })
+
+  it('shows "Today" for milestones due today', async () => {
+    const today = new Date().toISOString().split('T')[0]
+    apiRequest.mockResolvedValue({
+      releases: [makeRelease('rhoai-3.5', { ga: today })]
+    })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Today')
+  })
+
+  it('has a "View all" link', async () => {
+    apiRequest.mockResolvedValue({
+      releases: [makeRelease('rhoai-3.5', { ga: futureDate(10) })]
+    })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    const viewAll = wrapper.findAll('button').find(b => b.text() === 'View all')
+    expect(viewAll).toBeTruthy()
+  })
+
+  it('shows error state with retry button', async () => {
+    apiRequest.mockRejectedValue(new Error('Network fail'))
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Network fail')
+    expect(wrapper.text()).toContain('Retry')
+  })
+
+  it('accepts a size prop', () => {
+    apiRequest.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(ScheduleWidget, { props: { size: 'full' } })
+    expect(wrapper.props('size')).toBe('full')
+  })
+
+  it('shows widget title "Release Schedule"', async () => {
+    apiRequest.mockResolvedValue({ releases: [] })
+    const wrapper = mount(ScheduleWidget)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Release Schedule')
+  })
+
+  describe('product filter', () => {
+    function multiProductPayload() {
+      return {
+        releases: [
+          makeRelease('rhoai-3.5', { shortname: 'rhoai', ga: futureDate(30) }),
+          makeRelease('rhelai-1.0', { shortname: 'rhelai', displayName: 'RHELAI-1.0', ga: futureDate(20) }),
+          makeRelease('rhaii-1.0', { shortname: 'RHAII', displayName: 'RHAII-1.0', ga: futureDate(10) })
+        ]
+      }
+    }
+
+    it('shows product dropdown when multiple products exist', async () => {
+      apiRequest.mockResolvedValue(multiProductPayload())
+      const wrapper = mount(ScheduleWidget)
+      await flushPromises()
+      expect(wrapper.find('select').exists()).toBe(true)
+    })
+
+    it('does not show product dropdown with single product', async () => {
+      apiRequest.mockResolvedValue({
+        releases: [
+          makeRelease('rhoai-3.5', { shortname: 'rhoai', ga: futureDate(30) }),
+          makeRelease('rhoai-3.4', { shortname: 'rhoai', ga: futureDate(10) })
+        ]
+      })
+      const wrapper = mount(ScheduleWidget)
+      await flushPromises()
+      expect(wrapper.find('select').exists()).toBe(false)
+    })
+
+    it('defaults to showing all products', async () => {
+      apiRequest.mockResolvedValue(multiProductPayload())
+      const wrapper = mount(ScheduleWidget)
+      await flushPromises()
+      expect(wrapper.text()).toContain('RHOAI-3.5')
+      expect(wrapper.text()).toContain('RHELAI-1.0')
+      expect(wrapper.text()).toContain('RHAII-1.0')
+    })
+
+    it('filters milestones when a product is selected', async () => {
+      apiRequest.mockResolvedValue(multiProductPayload())
+      const wrapper = mount(ScheduleWidget)
+      await flushPromises()
+
+      await wrapper.find('select').setValue('rhoai')
+      expect(wrapper.text()).toContain('RHOAI-3.5')
+      expect(wrapper.text()).not.toContain('RHELAI-1.0')
+      expect(wrapper.text()).not.toContain('RHAII-1.0')
+    })
+
+    it('shows all milestones again when filter is reset', async () => {
+      apiRequest.mockResolvedValue(multiProductPayload())
+      const wrapper = mount(ScheduleWidget)
+      await flushPromises()
+
+      await wrapper.find('select').setValue('rhoai')
+      await wrapper.find('select').setValue('')
+      expect(wrapper.text()).toContain('RHOAI-3.5')
+      expect(wrapper.text()).toContain('RHELAI-1.0')
+    })
+  })
+})

--- a/modules/releases/client/widgets/ScheduleWidget.vue
+++ b/modules/releases/client/widgets/ScheduleWidget.vue
@@ -1,0 +1,177 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
+
+defineProps({
+  size: { type: String, default: 'half' }
+})
+
+const { navigateTo } = useModuleLink()
+
+const releases = ref([])
+const loading = ref(true)
+const error = ref(null)
+const selectedProduct = ref('')
+
+async function fetchRegistry() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await apiRequest('/modules/releases/registry')
+    releases.value = (data.releases || []).filter(r => r.state === 'active')
+  } catch (e) {
+    error.value = e.message || 'Failed to load'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchRegistry)
+
+function parseDate(val) {
+  if (!val) return null
+  const d = new Date(val)
+  return isNaN(d.getTime()) ? null : d
+}
+
+function todayMidnight() {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function daysFromNow(dateStr) {
+  const d = parseDate(dateStr)
+  if (!d) return null
+  const today = todayMidnight()
+  d.setHours(0, 0, 0, 0)
+  return Math.ceil((d.getTime() - today.getTime()) / 86400000)
+}
+
+function formatShort(dateStr) {
+  const d = parseDate(dateStr)
+  if (!d) return '—'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function getProduct(release) {
+  if (release.productPagesShortname) return release.productPagesShortname
+  const match = release.id.match(/^([a-z]+)-/i)
+  return match ? match[1] : release.id
+}
+
+const products = computed(() => {
+  const set = {}
+  for (const r of releases.value) {
+    set[getProduct(r)] = true
+  }
+  return Object.keys(set).sort()
+})
+
+const filteredReleases = computed(() => {
+  if (!selectedProduct.value) return releases.value
+  return releases.value.filter(r => getProduct(r) === selectedProduct.value)
+})
+
+const milestoneTypes = [
+  { key: 'planningFreeze', label: 'Plan Freeze' },
+  { key: 'codeFreeze', label: 'Code Freeze' },
+  { key: 'ga', label: 'Release' }
+]
+
+const upcomingMilestones = computed(() => {
+  const items = []
+  for (const r of filteredReleases.value) {
+    const ms = r.milestones || {}
+    for (const mt of milestoneTypes) {
+      const days = daysFromNow(ms[mt.key])
+      if (days !== null && days >= 0) {
+        items.push({
+          id: `${r.id}-${mt.key}`,
+          release: r.displayName || r.id,
+          label: mt.label,
+          date: ms[mt.key],
+          days
+        })
+      }
+    }
+  }
+  items.sort((a, b) => a.days - b.days)
+  return items.slice(0, 6)
+})
+
+function daysClass(days) {
+  if (days === 0) return 'text-blue-600 dark:text-blue-400 font-semibold'
+  if (days <= 7) return 'text-blue-600 dark:text-blue-400 font-medium'
+  if (days <= 14) return 'text-blue-500 dark:text-blue-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+function daysLabel(days) {
+  if (days === 0) return 'Today'
+  return days + 'd'
+}
+
+function rowHighlight(days) {
+  if (days <= 7) return 'bg-blue-50/50 dark:bg-blue-900/10'
+  return ''
+}
+</script>
+
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Release Schedule</h3>
+      <button
+        @click="navigateTo('releases', 'schedule')"
+        class="text-xs font-medium text-primary-600 dark:text-primary-400 hover:underline"
+      >View all</button>
+    </div>
+
+    <!-- Product filter -->
+    <div v-if="!loading && !error && products.length > 1" class="mb-3">
+      <select
+        v-model="selectedProduct"
+        class="w-full text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
+      >
+        <option value="">All products</option>
+        <option v-for="p in products" :key="p" :value="p">{{ p }}</option>
+      </select>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="space-y-3">
+      <div v-for="i in 4" :key="i" class="h-10 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="text-sm text-red-600 dark:text-red-400">
+      <p>{{ error }}</p>
+      <button @click="fetchRegistry" class="mt-2 text-primary-600 dark:text-primary-400 hover:underline text-xs font-medium">Retry</button>
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="!upcomingMilestones.length" class="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+      No upcoming milestones
+    </div>
+
+    <!-- Milestone list -->
+    <div v-else class="divide-y divide-gray-100 dark:divide-gray-700/50 -mx-5">
+      <div
+        v-for="m in upcomingMilestones"
+        :key="m.id"
+        class="flex items-center justify-between px-5 py-2.5"
+        :class="rowHighlight(m.days)"
+      >
+        <div class="min-w-0 flex-1">
+          <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ m.release }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400">{{ m.label }} · {{ formatShort(m.date) }}</div>
+        </div>
+        <span class="text-sm tabular-nums ml-3 shrink-0" :class="daysClass(m.days)">
+          {{ daysLabel(m.days) }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -16,6 +16,17 @@
       { "id": "reports", "label": "Reports", "icon": "BarChart3" },
       { "id": "audit", "label": "Audit", "icon": "History" }
     ],
+    "sotuWidgets": [
+      {
+        "id": "schedule",
+        "name": "Release Schedule",
+        "description": "Upcoming release milestones with countdowns",
+        "component": "./client/widgets/ScheduleWidget.vue",
+        "defaultSize": "half",
+        "icon": "CalendarDays",
+        "category": "releases"
+      }
+    ],
     "settingsComponent": "./client/components/ReleasesSettings.vue",
     "hiddenRoutes": {
       "feature-detail": "execute"

--- a/src/components/WidgetPicker.vue
+++ b/src/components/WidgetPicker.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { X, Plus, Check, Box } from 'lucide-vue-next'
 import {
   ClipboardList, Columns, BarChart3, UsersRound, Users, Link2,
-  Sparkles, LayoutDashboard, Search
+  Sparkles, LayoutDashboard, Search, CalendarDays
 } from 'lucide-vue-next'
 
 const props = defineProps({
@@ -15,7 +15,7 @@ const emit = defineEmits(['close', 'toggle'])
 
 const iconMap = {
   ClipboardList, Columns, BarChart3, UsersRound, Users, Link2,
-  Sparkles, LayoutDashboard, Search, Box
+  Sparkles, LayoutDashboard, Search, CalendarDays, Box
 }
 
 function getIcon(iconName) {

--- a/tests/integration/sotu-dashboard.spec.js
+++ b/tests/integration/sotu-dashboard.spec.js
@@ -96,8 +96,8 @@ test.describe('SOTU Widget Dashboard @sotu-dashboard', () => {
     await expect(scheduleWidget).toBeVisible();
     await scheduleWidget.click();
 
-    // Close the picker
-    await page.locator('button:has(svg)').filter({ has: page.locator('[class*="lucide"]') }).first().click();
+    // Close the picker by clicking the backdrop
+    await page.locator('.fixed.inset-0.bg-black').click();
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // Widget should render with its heading

--- a/tests/integration/sotu-dashboard.spec.js
+++ b/tests/integration/sotu-dashboard.spec.js
@@ -82,4 +82,32 @@ test.describe('SOTU Widget Dashboard @sotu-dashboard', () => {
     const hasContent = await pageHasContent(page);
     expect(hasContent).toBe(true);
   });
+
+  test('should add and render Release Schedule widget', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await pageLoadComplete(page);
+
+    // Open widget picker
+    await page.locator('text=Add Widgets').first().click();
+    await expect(page.locator('h2:has-text("Add Widgets")')).toBeVisible({ timeout: DEFAULT_PAGE_WAIT_TIME });
+
+    // Find and toggle the Release Schedule widget
+    const scheduleWidget = page.locator('button', { hasText: 'Release Schedule' });
+    await expect(scheduleWidget).toBeVisible();
+    await scheduleWidget.click();
+
+    // Close the picker
+    await page.locator('button:has(svg)').filter({ has: page.locator('[class*="lucide"]') }).first().click();
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Widget should render with its heading
+    await expect(page.locator('h3:has-text("Release Schedule")')).toBeVisible({ timeout: DEFAULT_PAGE_WAIT_TIME });
+
+    // Should show milestone rows or empty state (not an error)
+    const hasMilestones = await page.locator('text=Plan Freeze').or(page.locator('text=Code Freeze')).or(page.locator('text=Release')).count() > 0;
+    const hasEmpty = await page.locator('text=No upcoming milestones').count() > 0;
+    expect(hasMilestones || hasEmpty).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## What
Adds a Release Schedule widget to the State of the Union dashboard, surfacing upcoming milestones at a glance.

## Why
Based on feedback following the addition of a releases module in https://github.com/red-hat-data-services/rhai-org-pulse/pull/1056: users want release milestone countdowns pinned to the home page without navigating to the Releases module.

## How to verify
1. `npm run dev:full` → navigate to Home
2. Click "Add Widgets" → select "Release Schedule"
3. Widget shows upcoming milestones sorted by soonest, with countdown badges
4. If multiple product streams exist in registry, a filter dropdown appears
5. `npm test` — 17 widget unit tests pass
6. `make test-module MODULE=releases` — integration tests pass

Made with [Cursor](https://cursor.com)