### PR TITLE
fix(deploy): remove unused google-sa-key volume from base deployment

### DIFF
--- a/deploy/openshift/base/backend-deployment.yaml
+++ b/deploy/openshift/base/backend-deployment.yaml
@@ -76,9 +76,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
-            - name: google-sa-key
-              mountPath: /etc/secrets
-              readOnly: true
           readinessProbe:
             httpGet:
               path: /healthz
@@ -102,7 +99,3 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: team-tracker-data
-        - name: google-sa-key
-          secret:
-            secretName: google-sa-key
-            optional: true


### PR DESCRIPTION
## Summary

- Removes the `google-sa-key` Secret volume and volumeMount from the base backend deployment
- The volume was declared `optional: true` but isn't needed by any current consumer of this base — the CCS overlay was patching it out, which caused a bug
- All code paths (`google-sheets.js`, `google-docs.js`) fall back gracefully via `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` env var, so overlays that need Google Sheets integration can add the volume via strategic merge patch

## Test plan

- [x] `kustomize build deploy/openshift/base` validates successfully
- [ ] CI passes (kustomize validate for all overlays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)