### PR TITLE
fix(deploy): dynamically include all modules in AI Eng images

### DIFF
--- a/deploy/ai-eng.backend.Dockerfile
+++ b/deploy/ai-eng.backend.Dockerfile
@@ -7,16 +7,10 @@ FROM quay.io/org-pulse/org-pulse-core-backend:${CORE_TAG}
 
 USER 0
 
-# Add AI Eng modules
-COPY modules/ai-impact/ ./modules/ai-impact/
-COPY modules/releases/ ./modules/releases/
-COPY modules/upstream-pulse/ ./modules/upstream-pulse/
-COPY modules/product-builds/ ./modules/product-builds/
-COPY modules/system-health/ ./modules/system-health/
+# Add all non-core modules (core image already has team-tracker)
+COPY modules/ ./modules/
 
-# Add AI Eng fixtures (for demo mode)
-COPY fixtures/ai-impact/ ./fixtures/ai-impact/
-COPY fixtures/releases/ ./fixtures/releases/
-COPY fixtures/modules-state.json ./fixtures/modules-state.json
+# Add all non-core fixtures (core image already has core fixtures)
+COPY fixtures/ ./fixtures/
 
 USER 65532

--- a/deploy/ai-eng.frontend.Dockerfile
+++ b/deploy/ai-eng.frontend.Dockerfile
@@ -11,12 +11,8 @@ FROM quay.io/org-pulse/org-pulse-core-frontend-builder:${CORE_TAG} AS build
 # Add platform customizations
 COPY platform/ ./platform/
 
-# Add AI Eng modules
-COPY modules/ai-impact/ ./modules/ai-impact/
-COPY modules/releases/ ./modules/releases/
-COPY modules/upstream-pulse/ ./modules/upstream-pulse/
-COPY modules/product-builds/ ./modules/product-builds/
-COPY modules/system-health/ ./modules/system-health/
+# Add all non-core modules (core builder already has team-tracker)
+COPY modules/ ./modules/
 
 RUN npm run build
 


### PR DESCRIPTION
## Summary

- Replace hardcoded per-module `COPY` lines in `ai-eng.backend.Dockerfile` and `ai-eng.frontend.Dockerfile` with wildcard `COPY modules/ ./modules/` and `COPY fixtures/ ./fixtures/`
- New modules are now automatically included in AI Eng images without needing Dockerfile changes
- Fixes customer-insights module not being picked up in the AI Eng deployment

## Details

The core images already contain `team-tracker` via their own `COPY`. Docker's `COPY` merges into existing directories, so `COPY modules/ ./modules/` adds all non-core modules alongside the existing `team-tracker` — no duplication or overwrite issues.

## Test plan

- [ ] CI build-images workflow builds both AI Eng images successfully
- [ ] Smoke tests pass (app loads with all modules visible)
- [ ] Verify customer-insights module appears in the sidebar in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)