### PR TITLE
feat(catalyst-showcase): add admin settings tab for sheet ID configuration

### DIFF
--- a/modules/catalyst-showcase/client/components/CatalystShowcaseSettings.vue
+++ b/modules/catalyst-showcase/client/components/CatalystShowcaseSettings.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const config = ref(null)
+const loading = ref(true)
+const saving = ref(false)
+const saveError = ref(null)
+const saveSuccess = ref(false)
+
+async function loadConfig() {
+  loading.value = true
+  try {
+    config.value = await apiRequest('/modules/catalyst-showcase/config')
+  } catch {
+    config.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfig() {
+  saving.value = true
+  saveError.value = null
+  saveSuccess.value = false
+  try {
+    await apiRequest('/modules/catalyst-showcase/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config.value)
+    })
+    saveSuccess.value = true
+    setTimeout(() => { saveSuccess.value = false }, 3000)
+  } catch (e) {
+    saveError.value = e.message
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => {
+  loadConfig()
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div v-if="loading" class="text-gray-500 dark:text-gray-400">Loading configuration...</div>
+
+    <template v-else-if="config">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Google Spreadsheet ID</label>
+        <input
+          v-model="config.sheetId"
+          type="text"
+          placeholder="e.g. 1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+          class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-800 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500"
+        />
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          The ID from the Google Sheets URL. The sheet must be shared with the Google service account.
+        </p>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <button
+          @click="saveConfig"
+          :disabled="saving"
+          class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700 disabled:opacity-50"
+        >
+          {{ saving ? 'Saving...' : 'Save Configuration' }}
+        </button>
+        <span v-if="saveSuccess" class="text-green-600 dark:text-green-400 text-sm">Saved successfully</span>
+        <span v-if="saveError" class="text-red-600 dark:text-red-400 text-sm">{{ saveError }}</span>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/catalyst-showcase/module.json
+++ b/modules/catalyst-showcase/module.json
@@ -8,6 +8,7 @@
   "requires": [],
   "client": {
     "entry": "./client/index.js",
+    "settingsComponent": "./client/components/CatalystShowcaseSettings.vue",
     "navItems": [
       { "id": "catalog", "label": "Catalog", "icon": "LayoutGrid", "default": true }
     ],
@@ -25,12 +26,6 @@
   },
   "secrets": {
     "platform": ["google"],
-    "module": [
-      {
-        "key": "CATALYST_SHOWCASE_SHEET_ID",
-        "description": "Google Spreadsheet ID for the AI catalyst showcase data",
-        "required": false
-      }
-    ]
+    "module": []
   }
 }

--- a/modules/catalyst-showcase/server/config.js
+++ b/modules/catalyst-showcase/server/config.js
@@ -1,0 +1,25 @@
+const CONFIG_KEY = 'catalyst-showcase/config.json';
+
+const DEFAULT_CONFIG = {
+  sheetId: ''
+};
+
+function getConfig(readFromStorage) {
+  const saved = readFromStorage(CONFIG_KEY);
+  return { ...DEFAULT_CONFIG, ...saved };
+}
+
+function saveConfig(writeToStorage, config) {
+  const merged = { ...DEFAULT_CONFIG };
+
+  if (config.sheetId !== undefined) {
+    if (typeof config.sheetId !== 'string') {
+      throw new Error('sheetId must be a string');
+    }
+    merged.sheetId = config.sheetId.trim();
+  }
+
+  writeToStorage(CONFIG_KEY, merged);
+}
+
+module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, CONFIG_KEY };

--- a/modules/catalyst-showcase/server/index.js
+++ b/modules/catalyst-showcase/server/index.js
@@ -1,4 +1,5 @@
 const { getShowcaseData, fetchShowcaseData, clearCache, STORAGE_KEY } = require('./sheets-sync');
+const { getConfig, saveConfig } = require('./config');
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true';
 
@@ -8,14 +9,47 @@ const DEMO_MODE = process.env.DEMO_MODE === 'true';
  */
 module.exports = function registerRoutes(router, context) {
   const { storage, requireAuth, requireAdmin } = context;
-  function getSheetId() {
-    return context.resolveSecret('CATALYST_SHOWCASE_SHEET_ID') || '';
-  }
+  const { readFromStorage, writeToStorage } = storage;
   const keyFile = context.resolveSecret('GOOGLE_SERVICE_ACCOUNT_KEY_FILE') || '/etc/secrets/google-sa-key.json';
 
   function loadDemoData() {
-    return storage.readFromStorage(STORAGE_KEY) || { entries: [], pillars: [], fetchedAt: null };
+    return readFromStorage(STORAGE_KEY) || { entries: [], pillars: [], fetchedAt: null };
   }
+
+  /**
+   * @openapi
+   * /api/modules/catalyst-showcase/config:
+   *   get:
+   *     tags: [Catalyst Showcase]
+   *     summary: Get module configuration (admin)
+   *     responses:
+   *       200:
+   *         description: Current configuration
+   */
+  router.get('/config', requireAdmin, function(req, res) {
+    res.json(getConfig(readFromStorage));
+  });
+
+  /**
+   * @openapi
+   * /api/modules/catalyst-showcase/config:
+   *   post:
+   *     tags: [Catalyst Showcase]
+   *     summary: Update module configuration (admin)
+   *     responses:
+   *       200:
+   *         description: Configuration saved
+   *       400:
+   *         description: Validation error
+   */
+  router.post('/config', requireAdmin, function(req, res) {
+    try {
+      saveConfig(writeToStorage, req.body);
+      res.json({ status: 'saved' });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
 
   /**
    * @openapi
@@ -30,7 +64,7 @@ module.exports = function registerRoutes(router, context) {
   router.get('/entries', requireAuth, async function(req, res) {
     try {
       let data;
-      const sheetId = getSheetId();
+      const sheetId = getConfig(readFromStorage).sheetId;
       if (DEMO_MODE || !sheetId) {
         data = loadDemoData();
       } else {
@@ -74,7 +108,7 @@ module.exports = function registerRoutes(router, context) {
   router.get('/entries/:slug', requireAuth, async function(req, res) {
     try {
       let data;
-      const sheetId = getSheetId();
+      const sheetId = getConfig(readFromStorage).sheetId;
       if (DEMO_MODE || !sheetId) {
         data = loadDemoData();
       } else {
@@ -111,7 +145,7 @@ module.exports = function registerRoutes(router, context) {
    *         description: Refresh result
    */
   router.post('/refresh', requireAdmin, async function(req, res) {
-    const sheetId = getSheetId();
+    const sheetId = getConfig(readFromStorage).sheetId;
     if (DEMO_MODE || !sheetId) {
       return res.json({ status: 'skipped', reason: 'Demo mode or no sheet configured' });
     }
@@ -137,7 +171,7 @@ module.exports = function registerRoutes(router, context) {
       cadence: '1h',
       description: 'Sync AI Catalyst Showcase data from Google Sheets',
       handler: async function() {
-        const sheetId = getSheetId();
+        const sheetId = getConfig(readFromStorage).sheetId;
         if (DEMO_MODE || !sheetId) return;
         clearCache();
         await fetchShowcaseData(sheetId, keyFile, storage);
@@ -156,9 +190,9 @@ module.exports = function registerRoutes(router, context) {
 
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const data = storage.readFromStorage(STORAGE_KEY);
+      const data = readFromStorage(STORAGE_KEY);
       return {
-        sheetConfigured: !!getSheetId(),
+        sheetConfigured: !!getConfig(readFromStorage).sheetId,
         dataExists: !!data,
         entryCount: data?.entries?.length || 0,
         pillarCount: data?.pillars?.length || 0,

--- a/modules/catalyst-showcase/server/index.js
+++ b/modules/catalyst-showcase/server/index.js
@@ -8,7 +8,9 @@ const DEMO_MODE = process.env.DEMO_MODE === 'true';
  */
 module.exports = function registerRoutes(router, context) {
   const { storage, requireAuth, requireAdmin } = context;
-  const sheetId = context.secrets.CATALYST_SHOWCASE_SHEET_ID || '';
+  function getSheetId() {
+    return context.resolveSecret('CATALYST_SHOWCASE_SHEET_ID') || '';
+  }
   const keyFile = context.resolveSecret('GOOGLE_SERVICE_ACCOUNT_KEY_FILE') || '/etc/secrets/google-sa-key.json';
 
   function loadDemoData() {
@@ -28,6 +30,7 @@ module.exports = function registerRoutes(router, context) {
   router.get('/entries', requireAuth, async function(req, res) {
     try {
       let data;
+      const sheetId = getSheetId();
       if (DEMO_MODE || !sheetId) {
         data = loadDemoData();
       } else {
@@ -71,6 +74,7 @@ module.exports = function registerRoutes(router, context) {
   router.get('/entries/:slug', requireAuth, async function(req, res) {
     try {
       let data;
+      const sheetId = getSheetId();
       if (DEMO_MODE || !sheetId) {
         data = loadDemoData();
       } else {
@@ -107,6 +111,7 @@ module.exports = function registerRoutes(router, context) {
    *         description: Refresh result
    */
   router.post('/refresh', requireAdmin, async function(req, res) {
+    const sheetId = getSheetId();
     if (DEMO_MODE || !sheetId) {
       return res.json({ status: 'skipped', reason: 'Demo mode or no sheet configured' });
     }
@@ -132,6 +137,7 @@ module.exports = function registerRoutes(router, context) {
       cadence: '1h',
       description: 'Sync AI Catalyst Showcase data from Google Sheets',
       handler: async function() {
+        const sheetId = getSheetId();
         if (DEMO_MODE || !sheetId) return;
         clearCache();
         await fetchShowcaseData(sheetId, keyFile, storage);
@@ -152,7 +158,7 @@ module.exports = function registerRoutes(router, context) {
     context.registerDiagnostics(async function() {
       const data = storage.readFromStorage(STORAGE_KEY);
       return {
-        sheetConfigured: !!sheetId,
+        sheetConfigured: !!getSheetId(),
         dataExists: !!data,
         entryCount: data?.entries?.length || 0,
         pillarCount: data?.pillars?.length || 0,

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -2342,8 +2342,7 @@ app.post('/api/admin/secrets/update', requireAdmin, requireScope('admin:manage')
       'PRODUCT_BUILDS_API_URL',
       'MODELS_CORP_API_KEY',
       'MODELS_CORP_BASE_URL',
-      'SESSION_SECRET',
-      'CATALYST_SHOWCASE_SHEET_ID'
+      'SESSION_SECRET'
     ];
 
     // Update with new secrets (only allowlisted keys)

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -2342,7 +2342,8 @@ app.post('/api/admin/secrets/update', requireAdmin, requireScope('admin:manage')
       'PRODUCT_BUILDS_API_URL',
       'MODELS_CORP_API_KEY',
       'MODELS_CORP_BASE_URL',
-      'SESSION_SECRET'
+      'SESSION_SECRET',
+      'CATALYST_SHOWCASE_SHEET_ID'
     ];
 
     // Update with new secrets (only allowlisted keys)


### PR DESCRIPTION
## Summary
- Add "AI Catalyst Showcase" settings tab in the admin Settings UI with a Google Spreadsheet ID config field
- Store config in `data/catalyst-showcase/config.json` via new `GET/POST /config` API routes
- Remove `CATALYST_SHOWCASE_SHEET_ID` from secrets declaration — it's a config option, not a secret
- Read `sheetId` from config at request time so changes take effect without server restart

Follow-up to #1087.

## Test plan
- [ ] `npm test` and `npm run lint` pass
- [ ] Settings page shows "AI Catalyst Showcase" tab alongside other module tabs
- [ ] Tab has "Google Spreadsheet ID" input with save button
- [ ] Saving persists to `data/catalyst-showcase/config.json`
- [ ] Secrets tab no longer shows `CATALYST_SHOWCASE_SHEET_ID`
- [ ] Showcase module reads the saved config for sheet sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)