### PR TITLE
fix(releases): RHAISTRAT version name matching + .z phantom row fix

### DIFF
--- a/modules/releases/__tests__/server/registry-version-resolution.test.js
+++ b/modules/releases/__tests__/server/registry-version-resolution.test.js
@@ -49,6 +49,33 @@ describe('normalizeVersionName', () => {
   it('trims whitespace', () => {
     expect(normalizeVersionName('  rhoai-3.5  ')).toBe('rhoai 3 5');
   });
+
+  it('normalizes RHAISTRAT GA format to canonical form', () => {
+    expect(normalizeVersionName('3.5 GA RHOAI RELEASE')).toBe('rhoai 3 5');
+    expect(normalizeVersionName('3.5 GA RHAII RELEASE')).toBe('rhaii 3 5');
+    expect(normalizeVersionName('3.5 GA RHELAI RELEASE')).toBe('rhelai 3 5');
+  });
+
+  it('normalizes RHAISTRAT EA format to canonical form', () => {
+    expect(normalizeVersionName('3.5 EA1 RHOAI RELEASE')).toBe('rhoai 3 5 ea1');
+    expect(normalizeVersionName('3.5 EA2 RHOAI RELEASE')).toBe('rhoai 3 5 ea2');
+    expect(normalizeVersionName('3.5 EA1 RHAII RELEASE')).toBe('rhaii 3 5 ea1');
+  });
+
+  it('RHAISTRAT and RHOAIENG normalize to same form', () => {
+    expect(normalizeVersionName('3.5 GA RHOAI RELEASE')).toBe(normalizeVersionName('rhoai-3.5'));
+    expect(normalizeVersionName('3.5 EA1 RHOAI RELEASE')).toBe(normalizeVersionName('rhoai-3.5.EA1'));
+    expect(normalizeVersionName('3.5 EA2 RHOAI RELEASE')).toBe(normalizeVersionName('rhoai-3.5.EA2'));
+    expect(normalizeVersionName('3.6 EA1 RHOAI RELEASE')).toBe(normalizeVersionName('rhoai-3.6.EA1'));
+    expect(normalizeVersionName('3.5 GA RHAII RELEASE')).toBe(normalizeVersionName('RHAII-3.5'));
+  });
+
+  it('does not rearrange non-RHAISTRAT patterns', () => {
+    // z-stream versions with different format should NOT match
+    expect(normalizeVersionName('RHOAI 3.3.5 GA')).toBe('rhoai 3 3 5 ga');
+    expect(normalizeVersionName('RHAII 3.3.5 Release')).toBe('rhaii 3 3 5 release');
+    expect(normalizeVersionName('rhai-3.5')).toBe('rhai 3 5');
+  });
 });
 
 describe('matchVersionsToReleases', () => {
@@ -167,6 +194,41 @@ describe('matchVersionsToReleases', () => {
     expect(match35.proposedFixVersions).toEqual(['rhoai-3.5']);
     expect(match36.proposedFixVersions).toEqual(['rhoai-3.6']);
   });
+
+  it('matches RHAISTRAT naming to registry releases', () => {
+    const releases = [
+      { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' },
+      { id: 'rhoai-3.5.ea1', displayName: 'rhoai-3.5.EA1', fixVersions: [], state: 'active' }
+    ];
+    const jiraVersions = [
+      { name: '3.5 GA RHOAI RELEASE', id: '1', project: 'RHAISTRAT' },
+      { name: '3.5 EA1 RHOAI RELEASE', id: '2', project: 'RHAISTRAT' }
+    ];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches).toHaveLength(2);
+    expect(result.unmatched).toHaveLength(0);
+
+    const gaMatch = result.matches.find(m => m.releaseId === 'rhoai-3.5');
+    expect(gaMatch.proposedFixVersions).toContain('3.5 GA RHOAI RELEASE');
+
+    const ea1Match = result.matches.find(m => m.releaseId === 'rhoai-3.5.ea1');
+    expect(ea1Match.proposedFixVersions).toContain('3.5 EA1 RHOAI RELEASE');
+  });
+
+  it('matches RHAISTRAT and RHOAIENG versions to the same release', () => {
+    const releases = [
+      { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' }
+    ];
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: '3.5 GA RHOAI RELEASE', id: '2', project: 'RHAISTRAT' }
+    ];
+    const result = matchVersionsToReleases(jiraVersions, releases);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].jiraMatches).toHaveLength(2);
+    expect(result.matches[0].proposedFixVersions).toContain('rhoai-3.5');
+    expect(result.matches[0].proposedFixVersions).toContain('3.5 GA RHOAI RELEASE');
+  });
 });
 
 describe('registry-config', () => {
@@ -245,44 +307,57 @@ describe('autoResolveFixVersions', () => {
     expect(ea1.fixVersions).toContain('rhoai-3.5.EA1');
   });
 
-  it('skips releases that already have fixVersions', async () => {
+  it('adds new versions to releases that already have fixVersions', async () => {
     const jiraVersions = [
       { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
-      { name: 'rhoai-3.6', id: '2', project: 'RHOAIENG' }
+      { name: '3.5 GA RHOAI RELEASE', id: '2', project: 'RHAISTRAT' },
+      { name: 'rhoai-3.6', id: '3', project: 'RHOAIENG' }
     ];
 
     const storage = createMockStorage({
       [REGISTRY_FILE]: {
         schemaVersion: 1,
         releases: [
-          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['already-mapped'], state: 'active' },
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['rhoai-3.5'], state: 'active' },
           { id: 'rhoai-3.6', displayName: 'rhoai-3.6', fixVersions: [], state: 'active' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG', 'RHAISTRAT'] }
+    });
+
+    const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
+    expect(result.status).toBe('ok');
+    expect(result.resolved).toBe(2);
+
+    const registry = storage._store[REGISTRY_FILE];
+    // rhoai-3.5 should now have BOTH the existing and newly-discovered RHAISTRAT version
+    const ga = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(ga.fixVersions).toContain('rhoai-3.5');
+    expect(ga.fixVersions).toContain('3.5 GA RHOAI RELEASE');
+    // rhoai-3.6 should get its version populated
+    expect(registry.releases.find(r => r.id === 'rhoai-3.6').fixVersions).toContain('rhoai-3.6');
+  });
+
+  it('does not duplicate existing fixVersions', async () => {
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['rhoai-3.5'], state: 'active' }
         ]
       },
       [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
     });
 
     const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
-    expect(result.status).toBe('ok');
-    expect(result.resolved).toBe(1);
-
-    const registry = storage._store[REGISTRY_FILE];
-    expect(registry.releases.find(r => r.id === 'rhoai-3.5').fixVersions).toEqual(['already-mapped']);
-    expect(registry.releases.find(r => r.id === 'rhoai-3.6').fixVersions).toContain('rhoai-3.6');
-  });
-
-  it('returns skipped when all releases already have fixVersions', async () => {
-    const storage = createMockStorage({
-      [REGISTRY_FILE]: {
-        schemaVersion: 1,
-        releases: [
-          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['v1'], state: 'active' }
-        ]
-      }
-    });
-
-    const result = await autoResolveFixVersions(storage);
     expect(result.status).toBe('skipped');
+    // fixVersions unchanged — rhoai-3.5 was already present
+    const registry = storage._store[REGISTRY_FILE];
+    expect(registry.releases[0].fixVersions).toEqual(['rhoai-3.5']);
   });
 
   it('returns skipped when Jira returns no versions', async () => {
@@ -388,11 +463,11 @@ describe('migration + auto-resolve pipeline (integration)', () => {
     expect(migrated).toBe(3); // 3 groups merged
     expect(registry.releases).toHaveLength(4); // 7 → 4
 
-    // After migration, the GA entry should have fixVersions from the .z entry
+    // After migration, the GA entry should have fixVersions from the .z entry (minus .z names)
     const gaAfterMigrate = registry.releases.find(r => r.id === 'rhoai-3.5');
     expect(gaAfterMigrate.state).toBe('active');
     expect(gaAfterMigrate.fixVersions).toContain('rhoai-3.5');
-    expect(gaAfterMigrate.fixVersions).toContain('rhoai-3.5.z');
+    expect(gaAfterMigrate.fixVersions).not.toContain('rhoai-3.5.z');
 
     // EA entries should also have fixVersions from their .z counterparts
     const ea1AfterMigrate = registry.releases.find(r => r.id === 'rhoai-3.5.ea1');

--- a/modules/releases/__tests__/server/registry.test.js
+++ b/modules/releases/__tests__/server/registry.test.js
@@ -159,7 +159,7 @@ describe('migrateNormalizedIds', () => {
     expect(registry.releases[0].fixVersions).toEqual(['rhoai-3.5']);
   });
 
-  it('merges .z and clean entries, preserving fixVersions union', () => {
+  it('merges .z and clean entries, preserving fixVersions union (excluding .z)', () => {
     const registry = {
       releases: [
         { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['rhoai-3.5', 'rhoai-3.5.z'], state: 'archived' },
@@ -171,9 +171,9 @@ describe('migrateNormalizedIds', () => {
     expect(registry.releases).toHaveLength(1);
     expect(registry.releases[0].id).toBe('rhoai-3.5');
     expect(registry.releases[0].state).toBe('active');
-    // fixVersions from both entries merged
+    // fixVersions merged but .z-suffixed names stripped
     expect(registry.releases[0].fixVersions).toContain('rhoai-3.5');
-    expect(registry.releases[0].fixVersions).toContain('rhoai-3.5.z');
+    expect(registry.releases[0].fixVersions).not.toContain('rhoai-3.5.z');
   });
 
   it('prefers active entry over archived when merging', () => {
@@ -292,7 +292,7 @@ describe('migrateNormalizedIds', () => {
     const ga = registry.releases.find(r => r.id === 'rhoai-3.5');
     expect(ga).toBeDefined();
     expect(ga.fixVersions).toContain('rhoai-3.5');
-    expect(ga.fixVersions).toContain('rhoai-3.5.z');
+    expect(ga.fixVersions).not.toContain('rhoai-3.5.z');
 
     const rhaii = registry.releases.find(r => r.id === 'rhaii-3.5.ea1');
     expect(rhaii).toBeDefined();

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -944,7 +944,7 @@ function registerRegistryRoutes(router, context) {
     context.registerRefresh('registry-resolve-versions', {
       order: 66,
       timeout: 120000,
-      description: 'Auto-resolves Jira fixVersions for registry releases with empty mappings.',
+      description: 'Auto-resolves Jira fixVersions for active registry releases (additive only).',
       handler: async function() {
         return autoResolveFixVersions(storage);
       }

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -85,7 +85,8 @@ function normalizeRelease(input) {
 /**
  * Normalize a version name for fuzzy matching.
  * Lowercases, strips ".z" suffixes (Product Pages z-stream convention),
- * collapses separators (hyphens, dots) to spaces, and trims.
+ * collapses separators (hyphens, dots) to spaces, and handles the
+ * RHAISTRAT naming convention ("3.5 GA RHOAI RELEASE" → "rhoai 3 5").
  * @param {string} name
  * @returns {string}
  */
@@ -97,7 +98,16 @@ function normalizeVersionName(name) {
   s = s.replace(/[-._]+/g, ' ');
   // Collapse multiple spaces
   s = s.replace(/\s+/g, ' ');
-  return s.trim();
+  s = s.trim();
+  // RHAISTRAT uses "3.5 GA RHOAI RELEASE" / "3.5 EA1 RHOAI RELEASE" format.
+  // Rearrange to canonical "rhoai 3 5" / "rhoai 3 5 ea1" form.
+  var rhaistrat = /^(\d+\s+\d+)\s+(ga|ea\d+)\s+(rhoai|rhaii|rhelai)\s+release$/.exec(s);
+  if (rhaistrat) {
+    s = rhaistrat[2] === 'ga'
+      ? rhaistrat[3] + ' ' + rhaistrat[1]
+      : rhaistrat[3] + ' ' + rhaistrat[1] + ' ' + rhaistrat[2];
+  }
+  return s;
 }
 
 /**
@@ -235,11 +245,15 @@ function migrateNormalizedIds(registry) {
 
     const winner = entries[0];
 
-    // Union all fixVersions from every duplicate
-    const allFvs = new Set(winner.fixVersions || []);
-    for (let i = 1; i < entries.length; i++) {
-      for (const fv of (entries[i].fixVersions || [])) allFvs.add(fv);
-      toRemove.add(entries[i]);
+    // Union all fixVersions from every duplicate, excluding .z-suffixed names.
+    // Z-stream Jira fixVersions (e.g. "rhoai-3.5.z") track patch work and
+    // shouldn't be queried as TV/FV delta releases.
+    const allFvs = new Set();
+    for (let i = 0; i < entries.length; i++) {
+      for (const fv of (entries[i].fixVersions || [])) {
+        if (!/\.z$/i.test(fv)) allFvs.add(fv);
+      }
+      if (i > 0) toRemove.add(entries[i]);
     }
 
     winner.id = normId;
@@ -256,10 +270,10 @@ function migrateNormalizedIds(registry) {
 }
 
 /**
- * Auto-resolve Jira fixVersions for registry releases that have empty mappings.
+ * Auto-resolve Jira fixVersions for registry releases.
  * Uses the existing matchVersionsToReleases fuzzy matcher against all Jira
- * project versions. Only touches releases with empty fixVersions — never
- * overwrites manually-curated mappings.
+ * project versions. Additive only — adds newly-discovered Jira version names
+ * to existing fixVersions but never removes manually-curated mappings.
  *
  * @param {object} storage - Storage module
  * @param {object} [deps] - Optional dependency injection for testing
@@ -271,13 +285,12 @@ async function autoResolveFixVersions(storage, deps) {
   const { readFromStorage, writeToStorage } = storage;
   const registry = readRegistry(readFromStorage);
 
-  // Find active releases with no fixVersions
-  const emptyReleases = registry.releases.filter(function (r) {
-    return r.state === 'active' && (!r.fixVersions || r.fixVersions.length === 0);
+  const activeReleases = registry.releases.filter(function (r) {
+    return r.state === 'active';
   });
 
-  if (emptyReleases.length === 0) {
-    return { status: 'skipped', message: 'All active releases already have fixVersions' };
+  if (activeReleases.length === 0) {
+    return { status: 'skipped', message: 'No active releases in registry' };
   }
 
   const config = loadRegistryConfig(storage);
@@ -296,21 +309,26 @@ async function autoResolveFixVersions(storage, deps) {
   // Run fuzzy matching against ALL active releases (matcher needs full context)
   const result = matchVersionsToReleases(jiraVersions, registry.releases);
 
-  // Apply only to releases that had empty fixVersions
-  const emptyIds = new Set(emptyReleases.map(function (r) { return r.id; }));
   const applied = [];
 
   for (const match of result.matches) {
-    if (!emptyIds.has(match.releaseId)) continue;
     if (!match.proposedFixVersions || match.proposedFixVersions.length === 0) continue;
 
-    // Find the release in the registry and apply
+    // Find the release in the registry
     const release = registry.releases.find(function (r) { return r.id === match.releaseId; });
-    if (!release) continue;
+    if (!release || release.state !== 'active') continue;
 
-    release.fixVersions = match.proposedFixVersions;
+    // Only add new versions not already present (additive only)
+    var currentFvs = release.fixVersions || [];
+    var newVersions = match.proposedFixVersions.filter(function (fv) {
+      return currentFvs.indexOf(fv) === -1;
+    });
+
+    if (newVersions.length === 0) continue;
+
+    release.fixVersions = currentFvs.concat(newVersions);
     release.updatedAt = new Date().toISOString();
-    applied.push({ releaseId: release.id, fixVersions: release.fixVersions });
+    applied.push({ releaseId: release.id, fixVersions: release.fixVersions, added: newVersions });
   }
 
   if (applied.length > 0) {
@@ -320,14 +338,14 @@ async function autoResolveFixVersions(storage, deps) {
       action: 'registry_auto_resolve_versions',
       user: 'system',
       summary: 'Auto-resolved Jira fixVersions for ' + applied.length + ' releases',
-      details: { applied: applied, emptyCount: emptyReleases.length }
+      details: { applied: applied }
     });
   }
 
   return {
-    status: 'ok',
+    status: applied.length > 0 ? 'ok' : 'skipped',
     resolved: applied.length,
-    emptyBefore: emptyReleases.length,
+    message: applied.length > 0 ? undefined : 'No new fixVersions to add',
     applied: applied
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #1111. Production TV/FV Delta page still showed 0% alignment on RHOAI 3.5 rows because:

- **RHAISTRAT naming mismatch**: RHAISTRAT projects use `3.5 GA RHOAI RELEASE` while RHOAIENG uses `rhoai-3.5`. `normalizeVersionName` now detects and rearranges the RHAISTRAT pattern so both conventions resolve to the same canonical form during fuzzy matching.
- **Phantom `.z` rows**: `.z`-suffixed fixVersion names (e.g. `rhoai-3.5.z`) persisted in registry entries after migration, causing the frontend to create `_pending` placeholder rows. `migrateNormalizedIds` now strips `.z` names from the fixVersions union.
- **Auto-resolve too narrow**: `autoResolveFixVersions` only ran on releases with empty fixVersions. Widened to additively discover new Jira versions for ALL active releases (e.g. adding RHAISTRAT versions alongside existing RHOAIENG ones).

## Test plan
- [x] All 230 registry/releases tests pass
- [x] RHAISTRAT normalization tests (GA + EA formats, cross-convention equivalence)
- [x] Updated `.z` stripping assertions in migration tests
- [x] Updated auto-resolve tests (additive for non-empty releases, no duplicates)
- [ ] Deploy and verify TV/FV Delta page shows RHOAI 3.5 with real alignment data

🤖 Generated with [Claude Code](https://claude.com/claude-code)