### PR TITLE
feat(ai-assistant): AI chat module with OpenCode backend

### DIFF
--- a/modules/ai-assistant/client/components/ChatMessage.vue
+++ b/modules/ai-assistant/client/components/ChatMessage.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="flex gap-3" :class="isUser ? 'justify-end' : 'justify-start'">
+    <div
+      class="max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed"
+      :class="isUser
+        ? 'bg-blue-600 text-white rounded-br-md'
+        : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-bl-md'"
+    >
+      <div v-if="isUser" class="whitespace-pre-wrap">{{ content }}</div>
+      <div
+        v-else
+        class="prose prose-sm dark:prose-invert max-w-none [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_code]:text-xs [&_pre]:text-xs"
+        v-html="renderedHtml"
+      />
+      <div v-if="streaming" class="mt-1">
+        <span class="inline-block w-1.5 h-4 bg-current opacity-60 animate-pulse" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { Marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+const md = new Marked({ breaks: true, gfm: true })
+
+const props = defineProps({
+  content: { type: String, default: '' },
+  role: { type: String, required: true },
+  streaming: { type: Boolean, default: false }
+})
+
+const isUser = computed(() => props.role === 'user')
+
+const renderedHtml = computed(() => {
+  if (!props.content) return ''
+  return DOMPurify.sanitize(md.parse(props.content))
+})
+</script>

--- a/modules/ai-assistant/client/components/ChatWidget.vue
+++ b/modules/ai-assistant/client/components/ChatWidget.vue
@@ -88,7 +88,6 @@
 <script setup>
 import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { BotMessageSquare, X, SendHorizonal } from 'lucide-vue-next'
-import { fetchEventSource } from '@microsoft/fetch-event-source'
 import ChatMessage from './ChatMessage.vue'
 
 const STORAGE_KEY = 'ai-assistant-conversation'
@@ -197,54 +196,37 @@ async function handleSubmit() {
   const assistantIdx = messages.value.length - 1
 
   isStreaming.value = true
-  const ctrl = new AbortController()
 
   try {
-    await fetchEventSource('/api/modules/ai-assistant/chat', {
+    const response = await fetch('/api/modules/ai-assistant/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         message: text,
         sessionId: sessionId.value,
         context: getPageContext()
-      }),
-      signal: ctrl.signal,
-      openWhenHidden: true,
-
-      onopen(response) {
-        if (!response.ok) {
-          throw new Error(`Server returned ${response.status}`)
-        }
-      },
-
-      onmessage(ev) {
-        if (ev.event === 'session') {
-          const data = JSON.parse(ev.data)
-          sessionId.value = data.sessionId
-          sessionStorage.setItem(SESSION_KEY, data.sessionId)
-        } else if (ev.event === 'delta') {
-          const data = JSON.parse(ev.data)
-          messages.value[assistantIdx].content += data.text
-        } else if (ev.event === 'done') {
-          messages.value[assistantIdx].streaming = false
-        } else if (ev.event === 'error') {
-          const data = JSON.parse(ev.data)
-          messages.value[assistantIdx].content += `\n\n*Error: ${data.error}*`
-          messages.value[assistantIdx].streaming = false
-        }
-      },
-
-      onerror(err) {
-        messages.value[assistantIdx].content += '\n\n*Connection lost. Please try again.*'
-        messages.value[assistantIdx].streaming = false
-        throw err // stop retrying
-      }
+      })
     })
-  } catch {
-    // fetchEventSource throws on abort or onerror rethrow — already handled above
-    if (messages.value[assistantIdx]?.streaming) {
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: `Server returned ${response.status}` }))
+      messages.value[assistantIdx].content = `*Error: ${err.error || 'Unknown error'}*`
       messages.value[assistantIdx].streaming = false
+      return
     }
+
+    const data = await response.json()
+
+    if (data.sessionId) {
+      sessionId.value = data.sessionId
+      sessionStorage.setItem(SESSION_KEY, data.sessionId)
+    }
+
+    messages.value[assistantIdx].content = data.text || '(No response)'
+    messages.value[assistantIdx].streaming = false
+  } catch {
+    messages.value[assistantIdx].content += '\n\n*Connection lost. Please try again.*'
+    messages.value[assistantIdx].streaming = false
   } finally {
     isStreaming.value = false
   }

--- a/modules/ai-assistant/client/components/ChatWidget.vue
+++ b/modules/ai-assistant/client/components/ChatWidget.vue
@@ -1,0 +1,273 @@
+<template>
+  <!-- FAB button -->
+  <button
+    v-if="!isOpen"
+    @click="isOpen = true"
+    class="fixed bottom-6 right-6 z-60 w-14 h-14 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center"
+    title="Open AI Assistant"
+  >
+    <BotMessageSquare :size="24" />
+  </button>
+
+  <!-- Chat drawer -->
+  <Teleport to="body">
+    <Transition name="chat-drawer">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 sm:inset-auto sm:bottom-6 sm:right-6 sm:w-[420px] sm:h-[600px] sm:max-h-[80vh] z-60 flex flex-col bg-white dark:bg-gray-800 sm:rounded-2xl sm:shadow-2xl sm:border sm:border-gray-200 dark:sm:border-gray-700"
+      >
+        <!-- Header -->
+        <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 sm:rounded-t-2xl">
+          <div class="flex items-center gap-2">
+            <BotMessageSquare :size="18" class="text-blue-600 dark:text-blue-400" />
+            <span class="font-semibold text-sm text-gray-900 dark:text-gray-100">AI Assistant</span>
+          </div>
+          <button
+            @click="isOpen = false"
+            class="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors"
+            title="Close (Esc)"
+          >
+            <X :size="18" />
+          </button>
+        </div>
+
+        <!-- Messages -->
+        <div ref="messagesContainer" class="flex-1 overflow-y-auto p-4 space-y-4">
+          <div v-if="messages.length === 0" class="flex flex-col items-center justify-center h-full text-center px-4">
+            <BotMessageSquare :size="40" class="text-gray-300 dark:text-gray-600 mb-3" />
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Ask me anything about your org data.</p>
+            <div class="flex flex-wrap justify-center gap-2">
+              <button
+                v-for="chip in suggestions"
+                :key="chip"
+                @click="sendFromChip(chip)"
+                class="px-3 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-full border border-blue-200 dark:border-blue-800 transition-colors"
+              >
+                {{ chip }}
+              </button>
+            </div>
+          </div>
+
+          <ChatMessage
+            v-for="(msg, i) in messages"
+            :key="i"
+            :role="msg.role"
+            :content="msg.content"
+            :streaming="msg.streaming"
+          />
+        </div>
+
+        <!-- Input -->
+        <div class="border-t border-gray-200 dark:border-gray-700 p-3">
+          <form @submit.prevent="handleSubmit" class="flex items-end gap-2">
+            <textarea
+              ref="inputEl"
+              v-model="inputText"
+              @keydown.enter.exact.prevent="handleSubmit"
+              @keydown.esc="isOpen = false"
+              placeholder="Ask a question..."
+              rows="1"
+              :disabled="isStreaming"
+              class="flex-1 resize-none rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 max-h-32 overflow-y-auto"
+              @input="autoResize"
+            />
+            <button
+              type="submit"
+              :disabled="!inputText.trim() || isStreaming"
+              class="p-2.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white rounded-xl transition-colors disabled:cursor-not-allowed"
+            >
+              <SendHorizonal :size="18" />
+            </button>
+          </form>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { BotMessageSquare, X, SendHorizonal } from 'lucide-vue-next'
+import { fetchEventSource } from '@microsoft/fetch-event-source'
+import ChatMessage from './ChatMessage.vue'
+
+const STORAGE_KEY = 'ai-assistant-conversation'
+const SESSION_KEY = 'ai-assistant-session-id'
+
+const isOpen = ref(false)
+const inputText = ref('')
+const isStreaming = ref(false)
+const messages = ref([])
+const sessionId = ref(null)
+const messagesContainer = ref(null)
+const inputEl = ref(null)
+
+const suggestions = [
+  'Team velocity this sprint?',
+  'Who has the most open issues?',
+  'Show release readiness',
+  'Summarize recent activity'
+]
+
+// Restore from sessionStorage
+onMounted(() => {
+  try {
+    const saved = sessionStorage.getItem(STORAGE_KEY)
+    if (saved) messages.value = JSON.parse(saved)
+    const savedSession = sessionStorage.getItem(SESSION_KEY)
+    if (savedSession) sessionId.value = savedSession
+  } catch { /* ignore corrupt data */ }
+})
+
+// Persist on change
+watch(messages, (val) => {
+  try {
+    // Strip streaming flag before saving
+    const clean = val.map(m => ({ role: m.role, content: m.content }))
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(clean))
+  } catch { /* quota exceeded — ignore */ }
+}, { deep: true })
+
+// Scroll to bottom on new messages
+watch(messages, () => {
+  nextTick(() => {
+    if (messagesContainer.value) {
+      messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
+    }
+  })
+}, { deep: true })
+
+// Focus input when opened
+watch(isOpen, (open) => {
+  if (open) {
+    nextTick(() => inputEl.value?.focus())
+  }
+})
+
+// Esc key handler (global)
+function onKeyDown(e) {
+  if (e.key === 'Escape' && isOpen.value) {
+    isOpen.value = false
+  }
+}
+onMounted(() => document.addEventListener('keydown', onKeyDown))
+onUnmounted(() => document.removeEventListener('keydown', onKeyDown))
+
+function getPageContext() {
+  const hash = window.location.hash || '#/'
+  const raw = hash.slice(2)
+  const [pathPart] = raw.split('?')
+  const parts = pathPart.split('/').filter(Boolean)
+  const params = {}
+  const queryPart = raw.split('?')[1]
+  if (queryPart) {
+    for (const pair of queryPart.split('&')) {
+      const [k, v] = pair.split('=').map(decodeURIComponent)
+      if (k) params[k] = v || ''
+    }
+  }
+  return {
+    module: parts[0] || 'home',
+    view: parts[1] || null,
+    params
+  }
+}
+
+function autoResize(e) {
+  const el = e.target
+  el.style.height = 'auto'
+  el.style.height = Math.min(el.scrollHeight, 128) + 'px'
+}
+
+function sendFromChip(text) {
+  inputText.value = text
+  handleSubmit()
+}
+
+async function handleSubmit() {
+  const text = inputText.value.trim()
+  if (!text || isStreaming.value) return
+
+  inputText.value = ''
+  // Reset textarea height
+  if (inputEl.value) inputEl.value.style.height = 'auto'
+
+  messages.value.push({ role: 'user', content: text })
+  messages.value.push({ role: 'assistant', content: '', streaming: true })
+  const assistantIdx = messages.value.length - 1
+
+  isStreaming.value = true
+  const ctrl = new AbortController()
+
+  try {
+    await fetchEventSource('/api/modules/ai-assistant/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: text,
+        sessionId: sessionId.value,
+        context: getPageContext()
+      }),
+      signal: ctrl.signal,
+      openWhenHidden: true,
+
+      onopen(response) {
+        if (!response.ok) {
+          throw new Error(`Server returned ${response.status}`)
+        }
+      },
+
+      onmessage(ev) {
+        if (ev.event === 'session') {
+          const data = JSON.parse(ev.data)
+          sessionId.value = data.sessionId
+          sessionStorage.setItem(SESSION_KEY, data.sessionId)
+        } else if (ev.event === 'delta') {
+          const data = JSON.parse(ev.data)
+          messages.value[assistantIdx].content += data.text
+        } else if (ev.event === 'done') {
+          messages.value[assistantIdx].streaming = false
+        } else if (ev.event === 'error') {
+          const data = JSON.parse(ev.data)
+          messages.value[assistantIdx].content += `\n\n*Error: ${data.error}*`
+          messages.value[assistantIdx].streaming = false
+        }
+      },
+
+      onerror(err) {
+        messages.value[assistantIdx].content += '\n\n*Connection lost. Please try again.*'
+        messages.value[assistantIdx].streaming = false
+        throw err // stop retrying
+      }
+    })
+  } catch {
+    // fetchEventSource throws on abort or onerror rethrow — already handled above
+    if (messages.value[assistantIdx]?.streaming) {
+      messages.value[assistantIdx].streaming = false
+    }
+  } finally {
+    isStreaming.value = false
+  }
+}
+</script>
+
+<style scoped>
+.chat-drawer-enter-active,
+.chat-drawer-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.chat-drawer-enter-from,
+.chat-drawer-leave-to {
+  opacity: 0;
+  transform: translateY(16px) scale(0.97);
+}
+
+/* Mobile: slide up from bottom */
+@media (max-width: 639px) {
+  .chat-drawer-enter-from,
+  .chat-drawer-leave-to {
+    transform: translateY(100%);
+  }
+}
+</style>

--- a/modules/ai-assistant/client/index.js
+++ b/modules/ai-assistant/client/index.js
@@ -1,0 +1,2 @@
+// AI Assistant has no routable views — it renders as a shell-level widget.
+export const routes = {}

--- a/modules/ai-assistant/module.json
+++ b/modules/ai-assistant/module.json
@@ -1,0 +1,29 @@
+{
+  "name": "AI Assistant",
+  "slug": "ai-assistant",
+  "description": "AI-powered chat assistant for exploring org data",
+  "icon": "bot",
+  "order": 99,
+  "defaultEnabled": false,
+  "requires": [],
+  "client": {
+    "entry": "./client/index.js"
+  },
+  "server": {
+    "entry": "./server/index.js"
+  },
+  "secrets": {
+    "module": [
+      {
+        "key": "OPENCODE_URL",
+        "description": "Base URL for the OpenCode agent service",
+        "required": true
+      },
+      {
+        "key": "OPENCODE_PASSWORD",
+        "description": "Password for OpenCode authentication",
+        "required": true
+      }
+    ]
+  }
+}

--- a/modules/ai-assistant/server/index.js
+++ b/modules/ai-assistant/server/index.js
@@ -1,0 +1,117 @@
+const { createSession, sendMessage } = require('./opencode-client')
+
+const RATE_LIMIT_MAX = 20
+const RATE_LIMIT_WINDOW_MS = 60_000
+const rateCounts = new Map()
+
+function isRateLimited(email) {
+  const now = Date.now()
+  const entry = rateCounts.get(email)
+  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    rateCounts.set(email, { windowStart: now, count: 1 })
+    return false
+  }
+  entry.count++
+  return entry.count > RATE_LIMIT_MAX
+}
+
+function buildSystemPrompt(context) {
+  if (!context) return ''
+  const parts = ['You are an AI assistant embedded in Org Pulse, an internal org-health dashboard.']
+  if (context.module) parts.push(`The user is currently viewing the "${context.module}" module.`)
+  if (context.view) parts.push(`They are on the "${context.view}" view.`)
+  if (context.params && Object.keys(context.params).length > 0) {
+    parts.push(`Page parameters: ${JSON.stringify(context.params)}`)
+  }
+  parts.push('Answer concisely. Use markdown for formatting. If you don\'t know something, say so.')
+  return parts.join(' ')
+}
+
+module.exports = function registerRoutes(router, context) {
+  const { requireScope } = context
+
+  context.registerScopes([
+    { key: 'ai-assistant:use', label: 'Use', description: 'Send messages to the AI assistant', category: 'AI Assistant' }
+  ])
+
+  const openCodeUrl = context.resolveSecret('OPENCODE_URL')
+
+  if (context.registerDiagnostics) {
+    context.registerDiagnostics(async function () {
+      return {
+        configured: !!openCodeUrl,
+        openCodeUrl: openCodeUrl ? openCodeUrl.replace(/\/\/.*@/, '//***@') : null
+      }
+    })
+  }
+
+  router.post('/chat', requireScope('ai-assistant:use'), async function (req, res) {
+    const baseUrl = context.resolveSecret('OPENCODE_URL')
+    if (!baseUrl) {
+      return res.status(503).json({ error: 'AI assistant is not configured (OPENCODE_URL missing)' })
+    }
+
+    if (isRateLimited(req.userEmail)) {
+      return res.status(429).json({ error: 'Rate limit exceeded. Try again in a minute.' })
+    }
+
+    const { message, sessionId: existingSessionId, context: pageContext } = req.body
+    if (!message || typeof message !== 'string') {
+      return res.status(400).json({ error: 'message is required' })
+    }
+    if (message.length > 4000) {
+      return res.status(400).json({ error: 'message too long (max 4000 characters)' })
+    }
+
+    // Set up SSE
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no'
+    })
+
+    let aborted = false
+    req.on('close', () => { aborted = true })
+
+    try {
+      // Create or reuse session
+      let sessionId = existingSessionId
+      if (!sessionId) {
+        sessionId = await createSession(baseUrl)
+        res.write(`event: session\ndata: ${JSON.stringify({ sessionId })}\n\n`)
+      }
+
+      // Prepend page context to the user message
+      const systemPrompt = buildSystemPrompt(pageContext)
+      const fullMessage = systemPrompt
+        ? `[System context: ${systemPrompt}]\n\n${message}`
+        : message
+
+      await sendMessage(baseUrl, sessionId, fullMessage, function (event) {
+        if (aborted) return
+
+        // Forward text content events to the client
+        if (event.type === 'message.part.text.delta' || event.type === 'text_delta') {
+          res.write(`event: delta\ndata: ${JSON.stringify({ text: event.properties?.text || event.text || '' })}\n\n`)
+        } else if (event.type === 'message.complete' || event.type === 'message_stop') {
+          res.write(`event: done\ndata: ${JSON.stringify({ sessionId })}\n\n`)
+        } else if (event.type === 'error') {
+          res.write(`event: error\ndata: ${JSON.stringify({ error: event.properties?.message || 'Unknown error' })}\n\n`)
+        }
+      })
+
+      // Ensure done is sent even if no explicit complete event
+      if (!aborted) {
+        res.write(`event: done\ndata: ${JSON.stringify({ sessionId })}\n\n`)
+        res.end()
+      }
+    } catch (err) {
+      console.error('[ai-assistant] Chat error:', err.message)
+      if (!aborted) {
+        res.write(`event: error\ndata: ${JSON.stringify({ error: 'Failed to get response from AI assistant' })}\n\n`)
+        res.end()
+      }
+    }
+  })
+}

--- a/modules/ai-assistant/server/index.js
+++ b/modules/ai-assistant/server/index.js
@@ -63,23 +63,11 @@ module.exports = function registerRoutes(router, context) {
       return res.status(400).json({ error: 'message too long (max 4000 characters)' })
     }
 
-    // Set up SSE
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
-      'X-Accel-Buffering': 'no'
-    })
-
-    let aborted = false
-    req.on('close', () => { aborted = true })
-
     try {
       // Create or reuse session
       let sessionId = existingSessionId
       if (!sessionId) {
         sessionId = await createSession(baseUrl)
-        res.write(`event: session\ndata: ${JSON.stringify({ sessionId })}\n\n`)
       }
 
       // Prepend page context to the user message
@@ -88,30 +76,12 @@ module.exports = function registerRoutes(router, context) {
         ? `[System context: ${systemPrompt}]\n\n${message}`
         : message
 
-      await sendMessage(baseUrl, sessionId, fullMessage, function (event) {
-        if (aborted) return
+      const responseText = await sendMessage(baseUrl, sessionId, fullMessage)
 
-        // Forward text content events to the client
-        if (event.type === 'message.part.text.delta' || event.type === 'text_delta') {
-          res.write(`event: delta\ndata: ${JSON.stringify({ text: event.properties?.text || event.text || '' })}\n\n`)
-        } else if (event.type === 'message.complete' || event.type === 'message_stop') {
-          res.write(`event: done\ndata: ${JSON.stringify({ sessionId })}\n\n`)
-        } else if (event.type === 'error') {
-          res.write(`event: error\ndata: ${JSON.stringify({ error: event.properties?.message || 'Unknown error' })}\n\n`)
-        }
-      })
-
-      // Ensure done is sent even if no explicit complete event
-      if (!aborted) {
-        res.write(`event: done\ndata: ${JSON.stringify({ sessionId })}\n\n`)
-        res.end()
-      }
+      res.json({ sessionId, text: responseText })
     } catch (err) {
       console.error('[ai-assistant] Chat error:', err.message)
-      if (!aborted) {
-        res.write(`event: error\ndata: ${JSON.stringify({ error: 'Failed to get response from AI assistant' })}\n\n`)
-        res.end()
-      }
+      res.status(500).json({ error: 'Failed to get response from AI assistant' })
     }
   })
 }

--- a/modules/ai-assistant/server/opencode-client.js
+++ b/modules/ai-assistant/server/opencode-client.js
@@ -1,54 +1,59 @@
-const { createOpencodeClient } = require('@opencode-ai/sdk')
-
-let _client = null
+// @opencode-ai/sdk is ESM-only — use dynamic import() from CJS
+let _clientPromise = null
 
 function getClient(baseUrl) {
-  if (!_client) {
-    _client = createOpencodeClient({ baseUrl })
+  if (!_clientPromise) {
+    _clientPromise = import('@opencode-ai/sdk').then(({ createOpencodeClient }) =>
+      createOpencodeClient({ baseUrl })
+    )
   }
-  return _client
+  return _clientPromise
 }
 
 /**
  * Create a new OpenCode session and return its ID.
  */
 async function createSession(baseUrl) {
-  const client = getClient(baseUrl)
-  const session = await client.session.create()
-  return session.id
+  const client = await getClient(baseUrl)
+  const result = await client.session.create()
+  return result.data.id
 }
 
 /**
- * Send a message to an OpenCode session and stream back events.
+ * Send a message and wait for the complete response.
+ *
+ * Uses the blocking prompt endpoint which returns the assistant reply inline.
  *
  * @param {string} baseUrl - OpenCode server URL
  * @param {string} sessionId - Session ID
  * @param {string} message - User message text
- * @param {(event: object) => void} onEvent - Called for each SSE event
- * @returns {Promise<void>} Resolves when the stream ends
+ * @returns {Promise<string>} The assistant's response text
  */
-async function sendMessage(baseUrl, sessionId, message, onEvent) {
-  const client = getClient(baseUrl)
+async function sendMessage(baseUrl, sessionId, message) {
+  const client = await getClient(baseUrl)
 
-  // Send prompt (non-blocking — the response streams via events)
-  const stream = await client.session.prompt({
+  // prompt() is blocking — waits for the full response and returns it inline
+  const result = await client.session.prompt({
     path: { id: sessionId },
     body: {
       parts: [{ type: 'text', text: message }]
     }
   })
 
-  // Iterate the SSE stream
-  for await (const event of stream) {
-    onEvent(event)
-  }
+  // Extract text from response parts
+  const parts = result.data?.parts || []
+  const text = parts
+    .filter(p => p.type === 'text')
+    .map(p => p.text)
+    .join('')
+  return text || '(No response)'
 }
 
 /**
  * Reset the cached client (useful if config changes at runtime).
  */
 function resetClient() {
-  _client = null
+  _clientPromise = null
 }
 
 module.exports = { createSession, sendMessage, resetClient }

--- a/modules/ai-assistant/server/opencode-client.js
+++ b/modules/ai-assistant/server/opencode-client.js
@@ -1,0 +1,54 @@
+const { createOpencodeClient } = require('@opencode-ai/sdk')
+
+let _client = null
+
+function getClient(baseUrl) {
+  if (!_client) {
+    _client = createOpencodeClient({ baseUrl })
+  }
+  return _client
+}
+
+/**
+ * Create a new OpenCode session and return its ID.
+ */
+async function createSession(baseUrl) {
+  const client = getClient(baseUrl)
+  const session = await client.session.create()
+  return session.id
+}
+
+/**
+ * Send a message to an OpenCode session and stream back events.
+ *
+ * @param {string} baseUrl - OpenCode server URL
+ * @param {string} sessionId - Session ID
+ * @param {string} message - User message text
+ * @param {(event: object) => void} onEvent - Called for each SSE event
+ * @returns {Promise<void>} Resolves when the stream ends
+ */
+async function sendMessage(baseUrl, sessionId, message, onEvent) {
+  const client = getClient(baseUrl)
+
+  // Send prompt (non-blocking — the response streams via events)
+  const stream = await client.session.prompt({
+    path: { id: sessionId },
+    body: {
+      parts: [{ type: 'text', text: message }]
+    }
+  })
+
+  // Iterate the SSE stream
+  for await (const event of stream) {
+    onEvent(event)
+  }
+}
+
+/**
+ * Reset the cached client (useful if config changes at runtime).
+ */
+function resetClient() {
+  _client = null
+}
+
+module.exports = { createSession, sendMessage, resetClient }

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -73,49 +73,46 @@ async function mountView() {
 
 // ── Tests ──
 
-describe('TvFvDeltaView product filter', function () {
+describe('TvFvDeltaView release family filter', function () {
   beforeEach(function () {
     mockApiRequest.mockReset()
   })
 
-  it('renders product filter pills', async function () {
+  it('renders release family filter pills', async function () {
     var wrapper = await mountView()
     var buttons = wrapper.findAll('button').filter(function (b) {
       var text = b.text()
-      return text === 'All' || text === 'RHOAI' || text === 'RHELAI'
+      return text === 'All' || text === 'RHOAI 3.6' || text === 'RHOAI 3.5' || text === 'RHELAI 3.2'
     })
-    expect(buttons.length).toBeGreaterThanOrEqual(3)
+    expect(buttons.length).toBeGreaterThanOrEqual(4)
   })
 
-  it('defaults to RHOAI filter', async function () {
+  it('defaults to All — shows all releases', async function () {
     var wrapper = await mountView()
-    var table = findSummaryTable(wrapper)
-    // Summary table should only show rhoai releases by default
-    var rows = table.findAll('tbody tr')
-    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
-    for (var i = 0; i < releaseTexts.length; i++) {
-      expect(releaseTexts[i].toLowerCase()).toContain('rhoai')
-    }
-    // RHELAI-3.2 should NOT be visible
-    var allText = table.find('tbody').text()
-    expect(allText).not.toContain('RHELAI')
-  })
-
-  it('shows all products when "All" is clicked', async function () {
-    var wrapper = await mountView()
-    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
-    await allButton.trigger('click')
-    await flushPromises()
     var table = findSummaryTable(wrapper)
     var allText = table.find('tbody').text()
     expect(allText).toContain('RHELAI')
     expect(allText).toContain('rhoai')
   })
 
-  it('filters to RHELAI when clicked', async function () {
+  it('filters to RHOAI 3.6 family when clicked', async function () {
     var wrapper = await mountView()
-    var rhelaiButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI' })
-    await rhelaiButton.trigger('click')
+    var famButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHOAI 3.6' })
+    await famButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    expect(rows.length).toBe(3) // EA1, EA2, GA
+    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
+    for (var i = 0; i < releaseTexts.length; i++) {
+      expect(releaseTexts[i]).toContain('3.6')
+    }
+  })
+
+  it('filters to RHELAI 3.2 when clicked', async function () {
+    var wrapper = await mountView()
+    var famButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI 3.2' })
+    await famButton.trigger('click')
     await flushPromises()
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
@@ -147,11 +144,14 @@ describe('TvFvDeltaView executive summary sorting', function () {
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
     var releases = rows.map(function (r) { return r.find('td').text().trim() })
-    // rhoai-3.6 family first (EA1, EA2, GA), then 3.5
-    expect(releases[0]).toBe('rhoai-3.6.EA1')
-    expect(releases[1]).toBe('rhoai-3.6.EA2')
-    expect(releases[2]).toBe('rhoai-3.6')
-    expect(releases[3]).toBe('rhoai-3.5')
+    // Default is All — RHELAI first (alpha), then rhoai families
+    expect(releases[0]).toBe('RHELAI-3.2')
+    // rhoai 3.6 family in order, then 3.5
+    var rhoaiReleases = releases.filter(function (r) { return r.toLowerCase().startsWith('rhoai') })
+    expect(rhoaiReleases[0]).toBe('rhoai-3.6.EA1')
+    expect(rhoaiReleases[1]).toBe('rhoai-3.6.EA2')
+    expect(rhoaiReleases[2]).toBe('rhoai-3.6')
+    expect(rhoaiReleases[3]).toBe('rhoai-3.5')
   })
 
   it('clicking Total header sorts by total', async function () {
@@ -213,10 +213,7 @@ describe('TvFvDeltaView target alignment column', function () {
 
   it('shows dash for releases without GA dates', async function () {
     var wrapper = await mountView()
-    // Switch to All to see RHELAI-3.2 which has no ga_date
-    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
-    await allButton.trigger('click')
-    await flushPromises()
+    // Default is All, so RHELAI-3.2 (no ga_date) is already visible
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
     var rhelaiRow = rows.find(function (r) { return r.text().includes('RHELAI') })

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -1,0 +1,245 @@
+/**
+ * View-level tests for TvFvDeltaView — product filter, column sorting,
+ * and target alignment column integration.
+ *
+ * These tests mount the full view with mocked API responses and verify
+ * the template renders the new UI elements correctly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import TvFvDeltaView from '../../../client/views/TvFvDeltaView.vue'
+
+// ── Mock apiRequest ──
+
+var mockApiRequest = vi.fn()
+
+vi.mock('@shared/client', function () {
+  return {
+    apiRequest: function () { return mockApiRequest.apply(null, arguments) },
+  }
+})
+
+// ── Test data ──
+
+function makeTestData() {
+  return {
+    metadata: {
+      generated_at: '2026-06-17T10:00:00Z',
+      data_timestamp: '2026-06-17T09:55:00Z',
+      releases: ['rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6', 'rhoai-3.5', 'RHELAI-3.2'],
+      all_components: ['Dashboard', 'Serving'],
+    },
+    executive_summary: [
+      { release: 'rhoai-3.6.EA1', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
+      { release: 'rhoai-3.6.EA2', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
+      { release: 'rhoai-3.6', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
+      { release: 'rhoai-3.5', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-07-15' },
+      { release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null },
+    ],
+    releases: {
+      'rhoai-3.6.EA1': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'rhoai-3.6.EA2': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'rhoai-3.6': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'rhoai-3.5': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+      'RHELAI-3.2': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
+    },
+  }
+}
+
+async function mountView() {
+  var testData = makeTestData()
+
+  mockApiRequest.mockImplementation(function (url) {
+    if (url.includes('/registry')) return Promise.resolve({ releases: [] })
+    if (url.includes('/versions')) return Promise.resolve({ versions: [] })
+    if (url.includes('/tv-fv-delta')) return Promise.resolve(testData)
+    return Promise.resolve({})
+  })
+
+  var wrapper = mount(TvFvDeltaView, {
+    global: {
+      stubs: {
+        ClickableCount: {
+          template: '<span class="clickable-count">{{ count }}</span>',
+          props: ['count', 'jql', 'color', 'label'],
+        },
+      },
+    },
+  })
+
+  await flushPromises()
+  return wrapper
+}
+
+// ── Tests ──
+
+describe('TvFvDeltaView product filter', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('renders product filter pills', async function () {
+    var wrapper = await mountView()
+    var buttons = wrapper.findAll('button').filter(function (b) {
+      var text = b.text()
+      return text === 'All' || text === 'RHOAI' || text === 'RHELAI'
+    })
+    expect(buttons.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('defaults to RHOAI filter', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    // Summary table should only show rhoai releases by default
+    var rows = table.findAll('tbody tr')
+    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
+    for (var i = 0; i < releaseTexts.length; i++) {
+      expect(releaseTexts[i].toLowerCase()).toContain('rhoai')
+    }
+    // RHELAI-3.2 should NOT be visible
+    var allText = table.find('tbody').text()
+    expect(allText).not.toContain('RHELAI')
+  })
+
+  it('shows all products when "All" is clicked', async function () {
+    var wrapper = await mountView()
+    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
+    await allButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var allText = table.find('tbody').text()
+    expect(allText).toContain('RHELAI')
+    expect(allText).toContain('rhoai')
+  })
+
+  it('filters to RHELAI when clicked', async function () {
+    var wrapper = await mountView()
+    var rhelaiButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI' })
+    await rhelaiButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('RHELAI')
+  })
+})
+
+/** Find the executive summary table (first table in the view) */
+function findSummaryTable(wrapper) {
+  return wrapper.findAll('table')[0]
+}
+
+describe('TvFvDeltaView executive summary sorting', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('renders sortable column headers', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var headers = table.findAll('thead th')
+    // Should have: Release, Total, Aligned, TV-Only, FV-Only, Mismatched, Alignment, Target, GA Date, Days to GA, Planning Freeze
+    expect(headers.length).toBe(11)
+  })
+
+  it('default sort is release family order (EA1 < EA2 < GA)', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    var releases = rows.map(function (r) { return r.find('td').text().trim() })
+    // rhoai-3.6 family first (EA1, EA2, GA), then 3.5
+    expect(releases[0]).toBe('rhoai-3.6.EA1')
+    expect(releases[1]).toBe('rhoai-3.6.EA2')
+    expect(releases[2]).toBe('rhoai-3.6')
+    expect(releases[3]).toBe('rhoai-3.5')
+  })
+
+  it('clicking Total header sorts by total', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var totalHeader = table.findAll('thead th').find(function (th) {
+      return th.text().includes('Total')
+    })
+    await totalHeader.trigger('click')
+    await flushPromises()
+    var rows = table.findAll('tbody tr')
+    var totals = []
+    rows.forEach(function (r) {
+      var cells = r.findAll('td')
+      var countEl = cells[1].find('.clickable-count')
+      if (countEl.exists()) totals.push(parseInt(countEl.text(), 10))
+    })
+    // Ascending order
+    for (var i = 1; i < totals.length; i++) {
+      expect(totals[i]).toBeGreaterThanOrEqual(totals[i - 1])
+    }
+  })
+
+  it('shows sort arrow on active column', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var totalHeader = table.findAll('thead th').find(function (th) {
+      return th.text().includes('Total')
+    })
+    // No arrow initially
+    expect(totalHeader.find('svg').exists()).toBe(false)
+    // Click to sort
+    await totalHeader.trigger('click')
+    await flushPromises()
+    expect(totalHeader.find('svg').exists()).toBe(true)
+  })
+})
+
+describe('TvFvDeltaView target alignment column', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('renders Target column header', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var headers = table.findAll('thead th')
+    var targetHeader = headers.find(function (th) { return th.text().includes('Target') })
+    expect(targetHeader).toBeTruthy()
+  })
+
+  it('shows target percentage with asterisk for releases with GA dates', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    var html = table.html()
+    // At least one row should have a target with asterisk
+    expect(html).toMatch(/\d+%\*/)
+  })
+
+  it('shows dash for releases without GA dates', async function () {
+    var wrapper = await mountView()
+    // Switch to All to see RHELAI-3.2 which has no ga_date
+    var allButton = wrapper.findAll('button').find(function (b) { return b.text() === 'All' })
+    await allButton.trigger('click')
+    await flushPromises()
+    var table = findSummaryTable(wrapper)
+    var rows = table.findAll('tbody tr')
+    var rhelaiRow = rows.find(function (r) { return r.text().includes('RHELAI') })
+    expect(rhelaiRow).toBeTruthy()
+    // The target cell (8th column, index 7) should have a dash
+    var cells = rhelaiRow.findAll('td')
+    expect(cells[7].text()).toBe('—')
+  })
+
+  it('colors target red when actual alignment is below target', async function () {
+    var wrapper = await mountView()
+    var table = findSummaryTable(wrapper)
+    // rhoai-3.5 has alignment_pct: 32.3% and ga_date: 2026-07-15 (~28 days from June 17)
+    // Target for ≤30 days = 100%*, so actual (32.3%) < target (100%) → red
+    var rows = table.findAll('tbody tr')
+    var row35 = rows.find(function (r) { return r.text().includes('rhoai-3.5') && !r.text().includes('EA') })
+    if (row35) {
+      var targetCell = row35.findAll('td')[7]
+      var targetSpan = targetCell.find('span.font-semibold')
+      if (targetSpan.exists()) {
+        var classes = targetSpan.classes()
+        expect(classes.some(function (c) { return c.includes('red') })).toBe(true)
+      }
+    }
+  })
+})

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -160,8 +160,8 @@ describe('getAlignmentTarget', function () {
   })
 
   it('returns 100%* for released (≤0 days)', function () {
-    expect(getAlignmentTarget(0)).toEqual({ target: 100, label: '100%*' })
-    expect(getAlignmentTarget(-5)).toEqual({ target: 100, label: '100%*' })
+    expect(getAlignmentTarget(0)).toEqual({ target: 100, label: '100%*', maxDays: 0 })
+    expect(getAlignmentTarget(-5)).toEqual({ target: 100, label: '100%*', maxDays: 0 })
   })
 
   it('returns 95%* for 31-60 days', function () {

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -163,7 +163,6 @@ describe('getAlignmentTarget', function () {
     expect(getAlignmentTarget(0)).toEqual({ target: 100, label: '100%*', maxDays: 0 })
     expect(getAlignmentTarget(-5)).toEqual({ target: 100, label: '100%*', maxDays: 0 })
   })
-  })
 
   it('returns 95%* for 31-60 days', function () {
     expect(getAlignmentTarget(31)).toEqual({ target: 95, label: '95%*', maxDays: 60 })

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -8,6 +8,8 @@ import {
   parseReleaseName,
   compareReleases,
   extractProduct,
+  extractFamily,
+  familyLabel,
   productLabel,
   getAlignmentTarget,
   useReleaseFamily,
@@ -198,66 +200,127 @@ function makeSummaryRows() {
   ]
 }
 
+// ═══ extractFamily ═══
+
+describe('extractFamily', function () {
+  it('extracts family from GA version', function () {
+    expect(extractFamily('rhoai-3.6')).toBe('rhoai-3.6')
+  })
+
+  it('extracts family from EA version', function () {
+    expect(extractFamily('rhoai-3.6.EA1')).toBe('rhoai-3.6')
+    expect(extractFamily('rhoai-3.6.EA2')).toBe('rhoai-3.6')
+  })
+
+  it('extracts family case-insensitively', function () {
+    expect(extractFamily('RHELAI-3.2')).toBe('rhelai-3.2')
+  })
+
+  it('falls back to lowercase name for unparseable releases', function () {
+    expect(extractFamily('RHAII-3.2.3')).toBe('rhaii-3.2')
+  })
+})
+
+// ═══ familyLabel ═══
+
+describe('familyLabel', function () {
+  it('formats rhoai family', function () {
+    expect(familyLabel('rhoai-3.6')).toBe('RHOAI 3.6')
+  })
+
+  it('formats rhelai family', function () {
+    expect(familyLabel('rhelai-3.2')).toBe('RHELAI 3.2')
+  })
+
+  it('passes through unknown keys', function () {
+    expect(familyLabel('unknown')).toBe('unknown')
+  })
+})
+
 describe('useReleaseFamily composable', function () {
-  describe('product filtering', function () {
-    it('defaults to rhoai', function () {
+  function makeDataRef() {
+    return ref({ executive_summary: makeSummaryRows() })
+  }
+
+  describe('release family filtering', function () {
+    it('defaults to all', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      expect(rf.selectedProduct.value).toBe('rhoai')
+      var rf = useReleaseFamily(summary, makeDataRef())
+      expect(rf.selectedFamily.value).toBe('all')
     })
 
-    it('filters summary rows by selected product', function () {
+    it('filters to a specific release family', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
 
-      // Default: rhoai only
-      var rhoaiRows = rf.productFilteredSummary.value
-      expect(rhoaiRows.every(function (r) { return extractProduct(r.release) === 'rhoai' })).toBe(true)
-      expect(rhoaiRows.length).toBe(5) // 3.6 EA1/EA2/GA + 3.5 GA/EA1
+      rf.selectedFamily.value = 'rhoai-3.6'
+      var rows = rf.productFilteredSummary.value
+      expect(rows.length).toBe(3) // EA1, EA2, GA
+      expect(rows.every(function (r) { return extractFamily(r.release) === 'rhoai-3.6' })).toBe(true)
     })
 
-    it('shows all products when set to "all"', function () {
+    it('shows all releases when set to "all"', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      rf.selectedProduct.value = 'all'
+      var rf = useReleaseFamily(summary, makeDataRef())
       expect(rf.productFilteredSummary.value.length).toBe(7)
     })
 
-    it('filters to rhelai', function () {
+    it('filters to rhelai family', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      rf.selectedProduct.value = 'rhelai'
+      var rf = useReleaseFamily(summary, makeDataRef())
+      rf.selectedFamily.value = 'rhelai-3.2'
       var rows = rf.productFilteredSummary.value
       expect(rows.length).toBe(1)
       expect(rows[0].release).toBe('RHELAI-3.2')
     })
 
-    it('lists available products sorted', function () {
+    it('discovers families from full data, not just filtered summary', function () {
+      var filteredOnly = ref(makeSummaryRows().filter(function (r) { return extractProduct(r.release) === 'rhoai' }))
+      var fullData = makeDataRef()
+      var rf = useReleaseFamily(filteredOnly, fullData)
+      var familyKeys = rf.availableFamilies.value.map(function (f) { return f.key })
+      expect(familyKeys).toContain('rhoai-3.6')
+      expect(familyKeys).toContain('rhoai-3.5')
+      expect(familyKeys).toContain('rhelai-3.2')
+    })
+
+    it('lists families with display labels', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
-      // rhaii comes from RHAII-3.2.3 — but extractProduct returns 'rhaii'
-      expect(rf.availableProducts.value).toContain('rhoai')
-      expect(rf.availableProducts.value).toContain('rhelai')
-      expect(rf.availableProducts.value).toContain('rhaii')
+      var rf = useReleaseFamily(summary, makeDataRef())
+      var labels = rf.availableFamilies.value.map(function (f) { return f.label })
+      expect(labels).toContain('RHOAI 3.6')
+      expect(labels).toContain('RHOAI 3.5')
+      expect(labels).toContain('RHELAI 3.2')
     })
   })
 
   describe('sorting', function () {
-    it('default sort is release family order', function () {
+    it('default sort is release family order (all products)', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       var sorted = rf.sortedSummary.value
       var names = sorted.map(function (r) { return r.release })
-      // Within rhoai: 3.6 family (EA1, EA2, GA) then 3.5 family (EA1, GA)
+      // Default is "all", so all products show — rhelai first (alpha), then rhaii (unparseable, last), then rhoai
+      expect(names[0]).toBe('RHELAI-3.2')
+      // rhoai 3.6 family then 3.5 family
+      expect(names.indexOf('rhoai-3.6.EA1')).toBeLessThan(names.indexOf('rhoai-3.6'))
+      expect(names.indexOf('rhoai-3.6')).toBeLessThan(names.indexOf('rhoai-3.5'))
+    })
+
+    it('sorts within filtered family', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary, makeDataRef())
+      rf.selectedFamily.value = 'rhoai-3.6'
+      var sorted = rf.sortedSummary.value
+      var names = sorted.map(function (r) { return r.release })
       expect(names).toEqual([
         'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
-        'rhoai-3.5.EA1', 'rhoai-3.5',
       ])
     })
 
     it('toggleSort cycles asc → desc → clear', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
 
       rf.toggleSummarySort('total')
       expect(rf.sortColumn.value).toBe('total')
@@ -273,7 +336,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sorts by total ascending', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('total')
       var totals = rf.sortedSummary.value.map(function (r) { return r.total })
       for (var i = 1; i < totals.length; i++) {
@@ -283,7 +346,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sorts by total descending', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('total')
       rf.toggleSummarySort('total')
       var totals = rf.sortedSummary.value.map(function (r) { return r.total })
@@ -294,7 +357,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sorts by alignment_pct', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('alignment_pct')
       var pcts = rf.sortedSummary.value.map(function (r) { return r.alignment_pct })
       for (var i = 1; i < pcts.length; i++) {
@@ -304,7 +367,7 @@ describe('useReleaseFamily composable', function () {
 
     it('sortIcon returns correct state', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       expect(rf.summarySortIcon('total')).toBe('none')
       rf.toggleSummarySort('total')
       expect(rf.summarySortIcon('total')).toBe('asc')
@@ -315,7 +378,7 @@ describe('useReleaseFamily composable', function () {
 
     it('switching columns resets direction to asc', function () {
       var summary = ref(makeSummaryRows())
-      var rf = useReleaseFamily(summary)
+      var rf = useReleaseFamily(summary, makeDataRef())
       rf.toggleSummarySort('total')
       rf.toggleSummarySort('total') // desc
       rf.toggleSummarySort('aligned') // switch column

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -163,6 +163,7 @@ describe('getAlignmentTarget', function () {
     expect(getAlignmentTarget(0)).toEqual({ target: 100, label: '100%*', maxDays: 0 })
     expect(getAlignmentTarget(-5)).toEqual({ target: 100, label: '100%*', maxDays: 0 })
   })
+  })
 
   it('returns 95%* for 31-60 days', function () {
     expect(getAlignmentTarget(31)).toEqual({ target: 95, label: '95%*', maxDays: 60 })

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -1,0 +1,326 @@
+/**
+ * Tests for useReleaseFamily composable — release name parsing, product
+ * filtering, release family sorting, and target alignment thresholds.
+ */
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import {
+  parseReleaseName,
+  compareReleases,
+  extractProduct,
+  productLabel,
+  getAlignmentTarget,
+  useReleaseFamily,
+} from '../../../client/composables/useReleaseFamily'
+
+// ═══ parseReleaseName ═══
+
+describe('parseReleaseName', function () {
+  it('parses rhoai GA version', function () {
+    var r = parseReleaseName('rhoai-3.5')
+    expect(r).toEqual({
+      product: 'rhoai', major: 3, minor: 5,
+      milestone: 'GA', milestoneOrder: 99, raw: 'rhoai-3.5',
+    })
+  })
+
+  it('parses rhoai EA1 version', function () {
+    var r = parseReleaseName('rhoai-3.6.EA1')
+    expect(r).toEqual({
+      product: 'rhoai', major: 3, minor: 6,
+      milestone: 'EA1', milestoneOrder: 1, raw: 'rhoai-3.6.EA1',
+    })
+  })
+
+  it('parses rhoai EA2 version', function () {
+    var r = parseReleaseName('rhoai-3.6.EA2')
+    expect(r).toEqual({
+      product: 'rhoai', major: 3, minor: 6,
+      milestone: 'EA2', milestoneOrder: 2, raw: 'rhoai-3.6.EA2',
+    })
+  })
+
+  it('parses RHELAI version (case-insensitive)', function () {
+    var r = parseReleaseName('RHELAI-3.2')
+    expect(r).toEqual({
+      product: 'rhelai', major: 3, minor: 2,
+      milestone: 'GA', milestoneOrder: 99, raw: 'RHELAI-3.2',
+    })
+  })
+
+  it('returns null for z-stream-like RHAII versions', function () {
+    // RHAII-3.2.3 has ".3" not ".EA<N>", so it doesn't match the pattern
+    expect(parseReleaseName('RHAII-3.2.3')).toBeNull()
+  })
+
+  it('returns null for unrecognised names', function () {
+    expect(parseReleaseName('openshift-4.15')).toBeNull()
+    expect(parseReleaseName('')).toBeNull()
+    expect(parseReleaseName('random-text')).toBeNull()
+  })
+
+  it('handles underscore and space separators', function () {
+    var r = parseReleaseName('rhoai_3.5')
+    expect(r).not.toBeNull()
+    expect(r.product).toBe('rhoai')
+    expect(r.major).toBe(3)
+    expect(r.minor).toBe(5)
+  })
+})
+
+// ═══ extractProduct ═══
+
+describe('extractProduct', function () {
+  it('extracts rhoai', function () {
+    expect(extractProduct('rhoai-3.5')).toBe('rhoai')
+    expect(extractProduct('rhoai-3.6.EA1')).toBe('rhoai')
+  })
+
+  it('extracts rhelai (case-insensitive)', function () {
+    expect(extractProduct('RHELAI-3.2')).toBe('rhelai')
+  })
+
+  it('extracts rhaii', function () {
+    expect(extractProduct('RHAII-3.2.3')).toBe('rhaii')
+  })
+
+  it('returns null for unknown products', function () {
+    expect(extractProduct('openshift-4.15')).toBeNull()
+    expect(extractProduct('')).toBeNull()
+  })
+})
+
+// ═══ productLabel ═══
+
+describe('productLabel', function () {
+  it('returns uppercase labels', function () {
+    expect(productLabel('rhoai')).toBe('RHOAI')
+    expect(productLabel('rhelai')).toBe('RHELAI')
+    expect(productLabel('rhaii')).toBe('RHAII')
+  })
+
+  it('passes through unknown products', function () {
+    expect(productLabel('foo')).toBe('foo')
+  })
+})
+
+// ═══ compareReleases ═══
+
+describe('compareReleases', function () {
+  it('sorts EA1 before EA2 before GA within same version', function () {
+    var names = ['rhoai-3.6', 'rhoai-3.6.EA2', 'rhoai-3.6.EA1']
+    var sorted = names.slice().sort(compareReleases)
+    expect(sorted).toEqual(['rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6'])
+  })
+
+  it('sorts newer minor versions first (descending)', function () {
+    var names = ['rhoai-3.4', 'rhoai-3.6', 'rhoai-3.5']
+    var sorted = names.slice().sort(compareReleases)
+    expect(sorted).toEqual(['rhoai-3.6', 'rhoai-3.5', 'rhoai-3.4'])
+  })
+
+  it('sorts by product alphabetically', function () {
+    var names = ['rhoai-3.5', 'RHELAI-3.2', 'RHAII-3.2.3']
+    var sorted = names.slice().sort(compareReleases)
+    // rhaii < rhelai < rhoai alphabetically
+    // But RHAII-3.2.3 won't parse (z-stream), so it sorts last
+    expect(sorted[sorted.length - 1]).toBe('RHAII-3.2.3')
+  })
+
+  it('puts unparseable names last, sorted alphabetically', function () {
+    var names = ['rhoai-3.5', 'unknown-1.0', 'rhoai-3.6']
+    var sorted = names.slice().sort(compareReleases)
+    expect(sorted).toEqual(['rhoai-3.6', 'rhoai-3.5', 'unknown-1.0'])
+  })
+
+  it('handles full multi-product multi-milestone sort', function () {
+    var names = [
+      'rhoai-3.5', 'rhoai-3.5.EA1', 'rhoai-3.5.EA2',
+      'rhoai-3.6', 'rhoai-3.6.EA1', 'rhoai-3.6.EA2',
+      'RHELAI-3.2',
+    ]
+    var sorted = names.slice().sort(compareReleases)
+    // rhelai first (alphabetically), then rhoai 3.6 family, then 3.5 family
+    expect(sorted).toEqual([
+      'RHELAI-3.2',
+      'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
+      'rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5',
+    ])
+  })
+})
+
+// ═══ getAlignmentTarget ═══
+
+describe('getAlignmentTarget', function () {
+  it('returns 100%* for ≤30 days', function () {
+    expect(getAlignmentTarget(30)).toEqual({ target: 100, label: '100%*', maxDays: 30 })
+    expect(getAlignmentTarget(1)).toEqual({ target: 100, label: '100%*', maxDays: 30 })
+  })
+
+  it('returns 100%* for released (≤0 days)', function () {
+    expect(getAlignmentTarget(0)).toEqual({ target: 100, label: '100%*' })
+    expect(getAlignmentTarget(-5)).toEqual({ target: 100, label: '100%*' })
+  })
+
+  it('returns 95%* for 31-60 days', function () {
+    expect(getAlignmentTarget(31)).toEqual({ target: 95, label: '95%*', maxDays: 60 })
+    expect(getAlignmentTarget(60)).toEqual({ target: 95, label: '95%*', maxDays: 60 })
+  })
+
+  it('returns 90%* for 61-90 days', function () {
+    expect(getAlignmentTarget(61)).toEqual({ target: 90, label: '90%*', maxDays: 90 })
+    expect(getAlignmentTarget(90)).toEqual({ target: 90, label: '90%*', maxDays: 90 })
+  })
+
+  it('returns null for >90 days', function () {
+    expect(getAlignmentTarget(91)).toBeNull()
+    expect(getAlignmentTarget(180)).toBeNull()
+    expect(getAlignmentTarget(365)).toBeNull()
+  })
+
+  it('returns null for null/undefined input', function () {
+    expect(getAlignmentTarget(null)).toBeNull()
+    expect(getAlignmentTarget(undefined)).toBeNull()
+  })
+})
+
+// ═══ useReleaseFamily composable ═══
+
+function makeSummaryRows() {
+  return [
+    { release: 'rhoai-3.6.EA1', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
+    { release: 'rhoai-3.6.EA2', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
+    { release: 'rhoai-3.6', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
+    { release: 'rhoai-3.5', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-08-20' },
+    { release: 'rhoai-3.5.EA1', total: 24, aligned: 14, tv_only: 5, fv_only: 3, mismatched: 2, alignment_pct: 58.3, ga_date: null },
+    { release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null },
+    { release: 'RHAII-3.2.3', total: 3, aligned: 2, tv_only: 1, fv_only: 0, mismatched: 0, alignment_pct: 66.7, ga_date: null },
+  ]
+}
+
+describe('useReleaseFamily composable', function () {
+  describe('product filtering', function () {
+    it('defaults to rhoai', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      expect(rf.selectedProduct.value).toBe('rhoai')
+    })
+
+    it('filters summary rows by selected product', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+
+      // Default: rhoai only
+      var rhoaiRows = rf.productFilteredSummary.value
+      expect(rhoaiRows.every(function (r) { return extractProduct(r.release) === 'rhoai' })).toBe(true)
+      expect(rhoaiRows.length).toBe(5) // 3.6 EA1/EA2/GA + 3.5 GA/EA1
+    })
+
+    it('shows all products when set to "all"', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.selectedProduct.value = 'all'
+      expect(rf.productFilteredSummary.value.length).toBe(7)
+    })
+
+    it('filters to rhelai', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.selectedProduct.value = 'rhelai'
+      var rows = rf.productFilteredSummary.value
+      expect(rows.length).toBe(1)
+      expect(rows[0].release).toBe('RHELAI-3.2')
+    })
+
+    it('lists available products sorted', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      // rhaii comes from RHAII-3.2.3 — but extractProduct returns 'rhaii'
+      expect(rf.availableProducts.value).toContain('rhoai')
+      expect(rf.availableProducts.value).toContain('rhelai')
+      expect(rf.availableProducts.value).toContain('rhaii')
+    })
+  })
+
+  describe('sorting', function () {
+    it('default sort is release family order', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      var sorted = rf.sortedSummary.value
+      var names = sorted.map(function (r) { return r.release })
+      // Within rhoai: 3.6 family (EA1, EA2, GA) then 3.5 family (EA1, GA)
+      expect(names).toEqual([
+        'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
+        'rhoai-3.5.EA1', 'rhoai-3.5',
+      ])
+    })
+
+    it('toggleSort cycles asc → desc → clear', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+
+      rf.toggleSummarySort('total')
+      expect(rf.sortColumn.value).toBe('total')
+      expect(rf.sortDirection.value).toBe('asc')
+
+      rf.toggleSummarySort('total')
+      expect(rf.sortDirection.value).toBe('desc')
+
+      rf.toggleSummarySort('total')
+      expect(rf.sortColumn.value).toBeNull()
+      expect(rf.sortDirection.value).toBe('asc')
+    })
+
+    it('sorts by total ascending', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('total')
+      var totals = rf.sortedSummary.value.map(function (r) { return r.total })
+      for (var i = 1; i < totals.length; i++) {
+        expect(totals[i]).toBeGreaterThanOrEqual(totals[i - 1])
+      }
+    })
+
+    it('sorts by total descending', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('total')
+      rf.toggleSummarySort('total')
+      var totals = rf.sortedSummary.value.map(function (r) { return r.total })
+      for (var i = 1; i < totals.length; i++) {
+        expect(totals[i]).toBeLessThanOrEqual(totals[i - 1])
+      }
+    })
+
+    it('sorts by alignment_pct', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('alignment_pct')
+      var pcts = rf.sortedSummary.value.map(function (r) { return r.alignment_pct })
+      for (var i = 1; i < pcts.length; i++) {
+        expect(pcts[i]).toBeGreaterThanOrEqual(pcts[i - 1])
+      }
+    })
+
+    it('sortIcon returns correct state', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      expect(rf.summarySortIcon('total')).toBe('none')
+      rf.toggleSummarySort('total')
+      expect(rf.summarySortIcon('total')).toBe('asc')
+      expect(rf.summarySortIcon('aligned')).toBe('none')
+      rf.toggleSummarySort('total')
+      expect(rf.summarySortIcon('total')).toBe('desc')
+    })
+
+    it('switching columns resets direction to asc', function () {
+      var summary = ref(makeSummaryRows())
+      var rf = useReleaseFamily(summary)
+      rf.toggleSummarySort('total')
+      rf.toggleSummarySort('total') // desc
+      rf.toggleSummarySort('aligned') // switch column
+      expect(rf.sortColumn.value).toBe('aligned')
+      expect(rf.sortDirection.value).toBe('asc')
+    })
+  })
+})

--- a/modules/releases/__tests__/server/registry-version-resolution.test.js
+++ b/modules/releases/__tests__/server/registry-version-resolution.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-const { normalizeVersionName, matchVersionsToReleases } = require('../../server/registry');
+const { normalizeVersionName, matchVersionsToReleases, autoResolveFixVersions, REGISTRY_FILE } = require('../../server/registry');
 const { loadRegistryConfig, saveRegistryConfig, STORAGE_KEY } = require('../../server/registry-config');
 
 function createMockStorage(initial = {}) {
@@ -205,5 +205,139 @@ describe('registry-config', () => {
   it('throws on non-object config', () => {
     const storage = createMockStorage();
     expect(() => saveRegistryConfig(storage, null)).toThrow('Config must be an object');
+  });
+});
+
+describe('autoResolveFixVersions', () => {
+  function mockJira(jiraVersions) {
+    return {
+      fetchProjectVersions: async () => jiraVersions,
+      jiraRequest: () => {}
+    };
+  }
+
+  it('populates empty fixVersions from Jira version matches', async () => {
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: 'rhoai-3.5.EA1', id: '2', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' },
+          { id: 'rhoai-3.5.ea1', displayName: 'rhoai-3.5.EA1', fixVersions: [], state: 'active' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
+    expect(result.status).toBe('ok');
+    expect(result.resolved).toBe(2);
+
+    const registry = storage._store[REGISTRY_FILE];
+    const ga = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(ga.fixVersions).toContain('rhoai-3.5');
+
+    const ea1 = registry.releases.find(r => r.id === 'rhoai-3.5.ea1');
+    expect(ea1.fixVersions).toContain('rhoai-3.5.EA1');
+  });
+
+  it('skips releases that already have fixVersions', async () => {
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: 'rhoai-3.6', id: '2', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['already-mapped'], state: 'active' },
+          { id: 'rhoai-3.6', displayName: 'rhoai-3.6', fixVersions: [], state: 'active' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
+    expect(result.status).toBe('ok');
+    expect(result.resolved).toBe(1);
+
+    const registry = storage._store[REGISTRY_FILE];
+    expect(registry.releases.find(r => r.id === 'rhoai-3.5').fixVersions).toEqual(['already-mapped']);
+    expect(registry.releases.find(r => r.id === 'rhoai-3.6').fixVersions).toContain('rhoai-3.6');
+  });
+
+  it('returns skipped when all releases already have fixVersions', async () => {
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['v1'], state: 'active' }
+        ]
+      }
+    });
+
+    const result = await autoResolveFixVersions(storage);
+    expect(result.status).toBe('skipped');
+  });
+
+  it('returns skipped when Jira returns no versions', async () => {
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    const result = await autoResolveFixVersions(storage, mockJira([]));
+    expect(result.status).toBe('skipped');
+    expect(result.message).toMatch(/No Jira versions found/);
+  });
+
+  it('ignores archived releases with empty fixVersions', async () => {
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'archived' }
+        ]
+      }
+    });
+
+    const result = await autoResolveFixVersions(storage);
+    expect(result.status).toBe('skipped');
+  });
+
+  it('writes audit log when versions are resolved', async () => {
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    await autoResolveFixVersions(storage, mockJira(jiraVersions));
+
+    // Verify audit log was written
+    const auditKey = 'releases/audit-log.json';
+    const audit = storage._store[auditKey];
+    expect(audit).toBeDefined();
+    const entry = audit.entries.find(e => e.action === 'registry_auto_resolve_versions');
+    expect(entry).toBeDefined();
+    expect(entry.summary).toMatch(/Auto-resolved/);
   });
 });

--- a/modules/releases/__tests__/server/registry-version-resolution.test.js
+++ b/modules/releases/__tests__/server/registry-version-resolution.test.js
@@ -341,3 +341,131 @@ describe('autoResolveFixVersions', () => {
     expect(entry.summary).toMatch(/Auto-resolved/);
   });
 });
+
+describe('migration + auto-resolve pipeline (integration)', () => {
+  const { migrateNormalizedIds } = require('../../server/registry');
+
+  function mockJira(jiraVersions) {
+    return {
+      fetchProjectVersions: async () => jiraVersions,
+      jiraRequest: () => {}
+    };
+  }
+
+  it('migrates .z entries then auto-resolves fixVersions in one pass', async () => {
+    // Simulate the exact production bug: PP sync created both .z (archived, with
+    // fixVersions) and clean (active, empty fixVersions) entries.
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: 'rhoai-3.5.EA1', id: '2', project: 'RHOAIENG' },
+      { name: 'rhoai-3.5.EA2', id: '3', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          // .z entries (archived, have fixVersions from previous auto-resolve)
+          { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['rhoai-3.5', 'rhoai-3.5.z'], state: 'archived', source: 'product-pages' },
+          { id: 'rhoai-3.5.z.ea1', displayName: 'rhoai-3.5.z.EA1', fixVersions: ['rhoai-3.5.EA1'], state: 'archived', source: 'product-pages' },
+          { id: 'rhoai-3.5.z.ea2', displayName: 'rhoai-3.5.z.EA2', fixVersions: ['rhoai-3.5.EA2'], state: 'archived', source: 'product-pages' },
+          // Clean entries (active, empty fixVersions — the bug)
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active', source: 'product-pages' },
+          { id: 'rhoai-3.5.ea1', displayName: 'rhoai-3.5.EA1', fixVersions: [], state: 'active', source: 'product-pages' },
+          { id: 'rhoai-3.5.ea2', displayName: 'rhoai-3.5.EA2', fixVersions: [], state: 'active', source: 'product-pages' },
+          // Unrelated entry — should be untouched
+          { id: 'rhaii-3.6', displayName: 'RHAII-3.6', fixVersions: ['RHAII-3.6'], state: 'active', source: 'product-pages' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    // Step 1: Migration merges .z entries into clean entries, carrying fixVersions
+    const registry = storage.readFromStorage(REGISTRY_FILE);
+    const migrated = migrateNormalizedIds(registry);
+    storage.writeToStorage(REGISTRY_FILE, registry);
+
+    expect(migrated).toBe(3); // 3 groups merged
+    expect(registry.releases).toHaveLength(4); // 7 → 4
+
+    // After migration, the GA entry should have fixVersions from the .z entry
+    const gaAfterMigrate = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(gaAfterMigrate.state).toBe('active');
+    expect(gaAfterMigrate.fixVersions).toContain('rhoai-3.5');
+    expect(gaAfterMigrate.fixVersions).toContain('rhoai-3.5.z');
+
+    // EA entries should also have fixVersions from their .z counterparts
+    const ea1AfterMigrate = registry.releases.find(r => r.id === 'rhoai-3.5.ea1');
+    expect(ea1AfterMigrate.fixVersions).toContain('rhoai-3.5.EA1');
+
+    // Step 2: Auto-resolve should be a no-op since migration already carried fixVersions
+    const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
+    expect(result.status).toBe('skipped');
+  });
+
+  it('auto-resolves fixVersions for entries that migration could not populate', async () => {
+    // Scenario: .z entries were deleted (not archived) before migration ran,
+    // so clean entries have no fixVersions source to inherit from.
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' },
+      { name: 'rhoai-3.5.EA1', id: '2', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active', source: 'product-pages' },
+          { id: 'rhoai-3.5.ea1', displayName: 'rhoai-3.5.EA1', fixVersions: [], state: 'active', source: 'product-pages' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    // Step 1: Migration is a no-op (IDs already clean)
+    const registry = storage.readFromStorage(REGISTRY_FILE);
+    const migrated = migrateNormalizedIds(registry);
+    storage.writeToStorage(REGISTRY_FILE, registry);
+    expect(migrated).toBe(0);
+
+    // Step 2: Auto-resolve populates fixVersions from Jira
+    const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
+    expect(result.status).toBe('ok');
+    expect(result.resolved).toBe(2);
+
+    const final = storage.readFromStorage(REGISTRY_FILE);
+    expect(final.releases.find(r => r.id === 'rhoai-3.5').fixVersions).toContain('rhoai-3.5');
+    expect(final.releases.find(r => r.id === 'rhoai-3.5.ea1').fixVersions).toContain('rhoai-3.5.EA1');
+  });
+
+  it('preserves manually-curated fixVersions through the full pipeline', async () => {
+    const jiraVersions = [
+      { name: 'rhoai-3.5', id: '1', project: 'RHOAIENG' }
+    ];
+
+    const storage = createMockStorage({
+      [REGISTRY_FILE]: {
+        schemaVersion: 1,
+        releases: [
+          // .z entry has a manually-added fixVersion
+          { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['manual-custom-fv', 'rhoai-3.5'], state: 'archived' },
+          { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' }
+        ]
+      },
+      [STORAGE_KEY]: { jiraProjects: ['RHOAIENG'] }
+    });
+
+    // Migration should carry the manual fixVersion
+    const registry = storage.readFromStorage(REGISTRY_FILE);
+    migrateNormalizedIds(registry);
+    storage.writeToStorage(REGISTRY_FILE, registry);
+
+    const merged = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(merged.fixVersions).toContain('manual-custom-fv');
+    expect(merged.fixVersions).toContain('rhoai-3.5');
+
+    // Auto-resolve should skip since fixVersions are populated
+    const result = await autoResolveFixVersions(storage, mockJira(jiraVersions));
+    expect(result.status).toBe('skipped');
+  });
+});

--- a/modules/releases/__tests__/server/registry.test.js
+++ b/modules/releases/__tests__/server/registry.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-const { readRegistry, writeRegistry, validateRelease, normalizeRelease, REGISTRY_FILE } = require('../../server/registry');
+const { readRegistry, writeRegistry, validateRelease, normalizeRelease, migrateNormalizedIds, REGISTRY_FILE } = require('../../server/registry');
 
 function createMockStorage(initial = {}) {
   const store = { ...initial };
@@ -142,5 +142,160 @@ describe('normalizeRelease', () => {
     });
     expect(result.milestones.ga).toBe('2026-07-01');
     expect(result.milestones.codeFreeze).toBe('2026-06-01');
+  });
+});
+
+describe('migrateNormalizedIds', () => {
+  it('normalises a single .z-suffixed entry ID in place', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['rhoai-3.5'], state: 'active' }
+      ]
+    };
+    const count = migrateNormalizedIds(registry);
+    expect(count).toBe(1);
+    expect(registry.releases).toHaveLength(1);
+    expect(registry.releases[0].id).toBe('rhoai-3.5');
+    expect(registry.releases[0].fixVersions).toEqual(['rhoai-3.5']);
+  });
+
+  it('merges .z and clean entries, preserving fixVersions union', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['rhoai-3.5', 'rhoai-3.5.z'], state: 'archived' },
+        { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active' }
+      ]
+    };
+    const count = migrateNormalizedIds(registry);
+    expect(count).toBe(1);
+    expect(registry.releases).toHaveLength(1);
+    expect(registry.releases[0].id).toBe('rhoai-3.5');
+    expect(registry.releases[0].state).toBe('active');
+    // fixVersions from both entries merged
+    expect(registry.releases[0].fixVersions).toContain('rhoai-3.5');
+    expect(registry.releases[0].fixVersions).toContain('rhoai-3.5.z');
+  });
+
+  it('prefers active entry over archived when merging', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['v1'], state: 'archived' },
+        { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['v2'], state: 'active' }
+      ]
+    };
+    migrateNormalizedIds(registry);
+    expect(registry.releases).toHaveLength(1);
+    expect(registry.releases[0].state).toBe('active');
+    expect(registry.releases[0].fixVersions).toContain('v1');
+    expect(registry.releases[0].fixVersions).toContain('v2');
+  });
+
+  it('handles EA variant merges (rhoai-3.5.z.ea1 → rhoai-3.5.ea1)', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z.ea1', displayName: 'rhoai-3.5.z.EA1', fixVersions: ['rhoai-3.5.EA1'], state: 'archived' },
+        { id: 'rhoai-3.5.ea1', displayName: 'rhoai-3.5.EA1', fixVersions: [], state: 'active' }
+      ]
+    };
+    migrateNormalizedIds(registry);
+    expect(registry.releases).toHaveLength(1);
+    expect(registry.releases[0].id).toBe('rhoai-3.5.ea1');
+    expect(registry.releases[0].fixVersions).toEqual(['rhoai-3.5.EA1']);
+  });
+
+  it('is idempotent — no-op when IDs are already clean', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: ['v1'], state: 'active' },
+        { id: 'rhoai-3.6', displayName: 'rhoai-3.6', fixVersions: ['v2'], state: 'active' }
+      ]
+    };
+    const count = migrateNormalizedIds(registry);
+    expect(count).toBe(0);
+    expect(registry.releases).toHaveLength(2);
+  });
+
+  it('handles multiple duplicate groups in one pass', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z', displayName: 'X', fixVersions: ['fv-a'], state: 'archived' },
+        { id: 'rhoai-3.5', displayName: 'X', fixVersions: [], state: 'active' },
+        { id: 'rhoai-3.6.z', displayName: 'Y', fixVersions: ['fv-b'], state: 'archived' },
+        { id: 'rhoai-3.6', displayName: 'Y', fixVersions: [], state: 'active' },
+        { id: 'rhaii-3.5', displayName: 'Z', fixVersions: ['fv-c'], state: 'active' } // no .z counterpart
+      ]
+    };
+    const count = migrateNormalizedIds(registry);
+    expect(count).toBe(2); // two groups merged
+    expect(registry.releases).toHaveLength(3); // 5 → 3
+    const ids = registry.releases.map(r => r.id).sort();
+    expect(ids).toEqual(['rhaii-3.5', 'rhoai-3.5', 'rhoai-3.6']);
+    expect(registry.releases.find(r => r.id === 'rhoai-3.5').fixVersions).toContain('fv-a');
+    expect(registry.releases.find(r => r.id === 'rhoai-3.6').fixVersions).toContain('fv-b');
+  });
+
+  it('does not lose fixVersions when both entries have them', () => {
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z', displayName: 'X', fixVersions: ['a', 'b'], state: 'active' },
+        { id: 'rhoai-3.5', displayName: 'X', fixVersions: ['b', 'c'], state: 'active' }
+      ]
+    };
+    migrateNormalizedIds(registry);
+    expect(registry.releases).toHaveLength(1);
+    const fvs = registry.releases[0].fixVersions.sort();
+    expect(fvs).toEqual(['a', 'b', 'c']); // union, no duplicates
+  });
+
+  it('preserves non-PP entries that happen to have .z in their ID', () => {
+    const registry = {
+      releases: [
+        { id: 'custom.z-release', displayName: 'Custom', fixVersions: [], state: 'active' }
+      ]
+    };
+    // stripZStream removes ".z" word boundary — "custom.z-release" → "custom-release"
+    migrateNormalizedIds(registry);
+    expect(registry.releases).toHaveLength(1);
+    expect(registry.releases[0].id).toBe('custom-release');
+  });
+
+  it('reproduces the exact production bug scenario', () => {
+    // This is the state observed in production: 6 .z entries (archived, with fixVersions)
+    // and 6 clean entries (active, empty fixVersions)
+    const registry = {
+      releases: [
+        { id: 'rhoai-3.5.z.ea1', displayName: 'rhoai-3.5.z.EA1', fixVersions: ['rhoai-3.5.EA1'], state: 'archived', source: 'product-pages' },
+        { id: 'rhoai-3.5.z.ea2', displayName: 'rhoai-3.5.z.EA2', fixVersions: ['rhoai-3.5.EA2'], state: 'archived', source: 'product-pages' },
+        { id: 'rhoai-3.5.z', displayName: 'rhoai-3.5.z', fixVersions: ['rhoai-3.5', 'rhoai-3.5.z'], state: 'archived', source: 'product-pages' },
+        { id: 'rhoai-3.5.ea1', displayName: 'rhoai-3.5.EA1', fixVersions: [], state: 'active', source: 'product-pages' },
+        { id: 'rhoai-3.5.ea2', displayName: 'rhoai-3.5.EA2', fixVersions: [], state: 'active', source: 'product-pages' },
+        { id: 'rhoai-3.5', displayName: 'rhoai-3.5', fixVersions: [], state: 'active', source: 'product-pages' },
+        // Non-duplicate entry — should be untouched
+        { id: 'rhaii-3.5.ea1', displayName: 'RHAII-3.5.EA1', fixVersions: ['RHAII-3.5 EA1'], state: 'active', source: 'product-pages' }
+      ]
+    };
+
+    migrateNormalizedIds(registry);
+
+    // Should be down to 4 entries (3 merged pairs + 1 untouched)
+    expect(registry.releases).toHaveLength(4);
+
+    const ea1 = registry.releases.find(r => r.id === 'rhoai-3.5.ea1');
+    expect(ea1).toBeDefined();
+    expect(ea1.state).toBe('active');
+    expect(ea1.fixVersions).toEqual(['rhoai-3.5.EA1']);
+
+    const ea2 = registry.releases.find(r => r.id === 'rhoai-3.5.ea2');
+    expect(ea2).toBeDefined();
+    expect(ea2.fixVersions).toEqual(['rhoai-3.5.EA2']);
+
+    const ga = registry.releases.find(r => r.id === 'rhoai-3.5');
+    expect(ga).toBeDefined();
+    expect(ga.fixVersions).toContain('rhoai-3.5');
+    expect(ga.fixVersions).toContain('rhoai-3.5.z');
+
+    const rhaii = registry.releases.find(r => r.id === 'rhaii-3.5.ea1');
+    expect(rhaii).toBeDefined();
+    expect(rhaii.fixVersions).toEqual(['RHAII-3.5 EA1']);
   });
 });

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -1,0 +1,207 @@
+import { ref, computed } from 'vue'
+
+// ═══ RELEASE NAME PARSING ═══
+
+var RELEASE_PATTERN = /^(rhoai|rhelai|rhaii)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
+
+/**
+ * Parse a release name into structured parts.
+ * e.g. "rhoai-3.6.EA1" → { product: "rhoai", major: 3, minor: 6, milestone: "EA1", milestoneOrder: 1 }
+ * e.g. "rhoai-3.5"     → { product: "rhoai", major: 3, minor: 5, milestone: "GA",  milestoneOrder: 99 }
+ */
+function parseReleaseName(name) {
+  var m = RELEASE_PATTERN.exec(name)
+  if (!m) return null
+  var eaNum = m[4] ? parseInt(m[4], 10) : 0
+  return {
+    product: m[1].toLowerCase(),
+    major: parseInt(m[2], 10),
+    minor: parseInt(m[3], 10),
+    milestone: eaNum ? 'EA' + eaNum : 'GA',
+    milestoneOrder: eaNum || 99,
+    raw: name,
+  }
+}
+
+/**
+ * Compare two release names for sorting.
+ * Order: product alpha → major desc → minor desc → milestone asc (EA1 < EA2 < GA).
+ */
+function compareReleases(a, b) {
+  var pa = parseReleaseName(a)
+  var pb = parseReleaseName(b)
+  // Unparseable releases sort last, alphabetically
+  if (!pa && !pb) return a.localeCompare(b)
+  if (!pa) return 1
+  if (!pb) return -1
+
+  // Product alphabetical (rhelai < rhaii < rhoai)
+  if (pa.product !== pb.product) return pa.product.localeCompare(pb.product)
+  // Major descending (3.6 before 3.5)
+  if (pa.major !== pb.major) return pb.major - pa.major
+  // Minor descending
+  if (pa.minor !== pb.minor) return pb.minor - pa.minor
+  // Milestone ascending (EA1 before EA2 before GA)
+  return pa.milestoneOrder - pb.milestoneOrder
+}
+
+/**
+ * Extract the product prefix from a release name.
+ * Returns lowercase: "rhoai", "rhelai", "rhaii", or null.
+ */
+function extractProduct(name) {
+  var m = /^(rhoai|rhelai|rhaii)/i.exec(name)
+  return m ? m[1].toLowerCase() : null
+}
+
+/**
+ * Get display label for a product.
+ */
+var PRODUCT_LABELS = { rhoai: 'RHOAI', rhelai: 'RHELAI', rhaii: 'RHAII' }
+
+function productLabel(product) {
+  return PRODUCT_LABELS[product] || product
+}
+
+// ═══ TARGET ALIGNMENT THRESHOLDS ═══
+
+var ALIGNMENT_TARGETS = [
+  { maxDays: 30, target: 100, label: '100%*' },
+  { maxDays: 60, target: 95, label: '95%*' },
+  { maxDays: 90, target: 90, label: '90%*' },
+]
+
+/**
+ * Get the target alignment percentage for a given number of days to GA.
+ * Returns { target, label } or null if no target applies (>90 days out).
+ */
+function getAlignmentTarget(daysToGa) {
+  if (daysToGa === null || daysToGa === undefined) return null
+  if (daysToGa <= 0) return { target: 100, label: '100%*' }
+  for (var i = 0; i < ALIGNMENT_TARGETS.length; i++) {
+    if (daysToGa <= ALIGNMENT_TARGETS[i].maxDays) return ALIGNMENT_TARGETS[i]
+  }
+  return null
+}
+
+// ═══ COMPOSABLE ═══
+
+/**
+ * Composable for product filtering and release family sorting on the executive summary.
+ */
+export function useReleaseFamily(filteredSummary) {
+  var selectedProduct = ref('rhoai')
+
+  /** Unique products found in the summary rows */
+  var availableProducts = computed(function () {
+    var seen = {}
+    var result = []
+    var rows = filteredSummary.value || []
+    for (var i = 0; i < rows.length; i++) {
+      var p = extractProduct(rows[i].release)
+      if (p && !seen[p]) {
+        seen[p] = true
+        result.push(p)
+      }
+    }
+    return result.sort()
+  })
+
+  /** Summary rows filtered by selected product */
+  var productFilteredSummary = computed(function () {
+    var rows = filteredSummary.value || []
+    if (selectedProduct.value === 'all') return rows
+    return rows.filter(function (row) {
+      return extractProduct(row.release) === selectedProduct.value
+    })
+  })
+
+  // ── Sort state ──
+
+  var sortColumn = ref(null) // null = release family default
+  var sortDirection = ref('asc')
+
+  function toggleSummarySort(column) {
+    if (sortColumn.value === column) {
+      if (sortDirection.value === 'asc') {
+        sortDirection.value = 'desc'
+      } else {
+        // Clear sort → back to release family default
+        sortColumn.value = null
+        sortDirection.value = 'asc'
+      }
+    } else {
+      sortColumn.value = column
+      sortDirection.value = 'asc'
+    }
+  }
+
+  function summarySortIcon(column) {
+    if (sortColumn.value !== column) return 'none'
+    return sortDirection.value
+  }
+
+  /** Sorted + filtered summary rows */
+  var sortedSummary = computed(function () {
+    var rows = productFilteredSummary.value.slice()
+
+    if (!sortColumn.value) {
+      // Default: release family order
+      rows.sort(function (a, b) { return compareReleases(a.release, b.release) })
+      return rows
+    }
+
+    var col = sortColumn.value
+    var dir = sortDirection.value === 'asc' ? 1 : -1
+
+    rows.sort(function (a, b) {
+      var va, vb
+      if (col === 'release') {
+        return compareReleases(a.release, b.release) * dir
+      }
+      if (col === 'alignment_pct' || col === 'total' || col === 'aligned' ||
+          col === 'tv_only' || col === 'fv_only' || col === 'mismatched') {
+        va = a[col] ?? 0
+        vb = b[col] ?? 0
+        return (va - vb) * dir
+      }
+      if (col === 'ga_date' || col === 'planning_freeze') {
+        va = a[col] || ''
+        vb = b[col] || ''
+        return va.localeCompare(vb) * dir
+      }
+      va = a[col] ?? ''
+      vb = b[col] ?? ''
+      return String(va).localeCompare(String(vb)) * dir
+    })
+
+    return rows
+  })
+
+  return {
+    selectedProduct,
+    availableProducts,
+    productFilteredSummary,
+    sortColumn,
+    sortDirection,
+    toggleSummarySort,
+    summarySortIcon,
+    sortedSummary,
+    // Expose utilities for testing
+    parseReleaseName,
+    compareReleases,
+    extractProduct,
+    productLabel,
+    getAlignmentTarget,
+  }
+}
+
+// Named exports for direct use / testing
+export {
+  parseReleaseName,
+  compareReleases,
+  extractProduct,
+  productLabel,
+  getAlignmentTarget,
+  ALIGNMENT_TARGETS,
+}

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -77,7 +77,7 @@ var ALIGNMENT_TARGETS = [
  */
 function getAlignmentTarget(daysToGa) {
   if (daysToGa === null || daysToGa === undefined) return null
-  if (daysToGa <= 0) return { target: 100, label: '100%*' }
+  if (daysToGa <= 0) return { target: 100, label: '100%*', maxDays: 0 }
   for (var i = 0; i < ALIGNMENT_TARGETS.length; i++) {
     if (daysToGa <= ALIGNMENT_TARGETS[i].maxDays) return ALIGNMENT_TARGETS[i]
   }

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -87,32 +87,62 @@ function getAlignmentTarget(daysToGa) {
 // ═══ COMPOSABLE ═══
 
 /**
- * Composable for product filtering and release family sorting on the executive summary.
+ * Extract the release family key from a release name.
+ * e.g. "rhoai-3.6.EA1" → "rhoai-3.6", "RHELAI-3.2" → "rhelai-3.2"
+ * Returns lowercase key for comparison, or the raw name if unparseable.
  */
-export function useReleaseFamily(filteredSummary) {
-  var selectedProduct = ref('rhoai')
+function extractFamily(name) {
+  var parsed = parseReleaseName(name)
+  if (parsed) return parsed.product + '-' + parsed.major + '.' + parsed.minor
+  // Fallback: try to extract product-major.minor pattern directly
+  var m = /^(rhoai|rhelai|rhaii)[- _](\d+\.\d+)/i.exec(name)
+  if (m) return m[1].toLowerCase() + '-' + m[2]
+  return name.toLowerCase()
+}
 
-  /** Unique products found in the summary rows */
-  var availableProducts = computed(function () {
+/**
+ * Get display label for a release family.
+ * e.g. "rhoai-3.6" → "RHOAI 3.6"
+ */
+function familyLabel(familyKey) {
+  var m = /^(rhoai|rhelai|rhaii)-(.+)$/.exec(familyKey)
+  if (m) return PRODUCT_LABELS[m[1]] + ' ' + m[2]
+  return familyKey
+}
+
+/**
+ * Composable for product filtering and release family sorting on the executive summary.
+ *
+ * @param {Ref} filteredSummary — version-picker-filtered summary rows
+ * @param {Ref} data — full API response (used to discover all available families)
+ */
+export function useReleaseFamily(filteredSummary, data) {
+  var selectedFamily = ref('all')
+
+  /** Unique release families found across ALL data */
+  var availableFamilies = computed(function () {
     var seen = {}
-    var result = []
-    var rows = filteredSummary.value || []
+    var families = []
+    var rows = (data && data.value && data.value.executive_summary) || []
+    if (!rows.length) rows = filteredSummary.value || []
     for (var i = 0; i < rows.length; i++) {
-      var p = extractProduct(rows[i].release)
-      if (p && !seen[p]) {
-        seen[p] = true
-        result.push(p)
+      var fam = extractFamily(rows[i].release)
+      if (!seen[fam]) {
+        seen[fam] = true
+        families.push({ key: fam, label: familyLabel(fam) })
       }
     }
-    return result.sort()
+    // Sort by parsed version (newer first), same as compareReleases
+    families.sort(function (a, b) { return compareReleases(a.key, b.key) })
+    return families
   })
 
-  /** Summary rows filtered by selected product */
+  /** Summary rows filtered by selected release family */
   var productFilteredSummary = computed(function () {
     var rows = filteredSummary.value || []
-    if (selectedProduct.value === 'all') return rows
+    if (selectedFamily.value === 'all') return rows
     return rows.filter(function (row) {
-      return extractProduct(row.release) === selectedProduct.value
+      return extractFamily(row.release) === selectedFamily.value
     })
   })
 
@@ -179,8 +209,8 @@ export function useReleaseFamily(filteredSummary) {
   })
 
   return {
-    selectedProduct,
-    availableProducts,
+    selectedFamily,
+    availableFamilies,
     productFilteredSummary,
     sortColumn,
     sortDirection,
@@ -191,6 +221,8 @@ export function useReleaseFamily(filteredSummary) {
     parseReleaseName,
     compareReleases,
     extractProduct,
+    extractFamily,
+    familyLabel,
     productLabel,
     getAlignmentTarget,
   }
@@ -201,6 +233,8 @@ export {
   parseReleaseName,
   compareReleases,
   extractProduct,
+  extractFamily,
+  familyLabel,
   productLabel,
   getAlignmentTarget,
   ALIGNMENT_TARGETS,

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -5,7 +5,7 @@ import FeatureTable from '../components/FeatureTable.vue'
 import { useReleasePicker } from '../composables/useReleasePicker'
 import { useComponentBreakdown } from '../composables/useComponentBreakdown'
 import { useTvFvData } from '../composables/useTvFvData'
-import { useReleaseFamily, getAlignmentTarget, productLabel } from '../composables/useReleaseFamily'
+import { useReleaseFamily, getAlignmentTarget } from '../composables/useReleaseFamily'
 
 const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
 
@@ -69,10 +69,10 @@ const filteredSummary = computed(() => {
 // ---------------------------------------------------------------------------
 
 const {
-  selectedProduct, availableProducts,
+  selectedFamily, availableFamilies,
   toggleSummarySort, summarySortIcon,
   sortedSummary,
-} = useReleaseFamily(filteredSummary)
+} = useReleaseFamily(filteredSummary, data)
 
 /** Compute target alignment for a row based on days to GA */
 function targetForRow(row) {
@@ -178,24 +178,24 @@ onBeforeUnmount(() => {
         <span class="italic">Counts reflect data at fetch time; live Jira may differ</span>
       </div>
 
-      <!-- Product Filter -->
-      <div class="flex items-center gap-1.5 mb-4">
+      <!-- Release Family Filter -->
+      <div class="flex items-center gap-1.5 mb-4 flex-wrap">
         <button
           class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
-          :class="selectedProduct === 'all'
+          :class="selectedFamily === 'all'
             ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
             : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
-          @click="selectedProduct = 'all'"
+          @click="selectedFamily = 'all'"
         >All</button>
         <button
-          v-for="prod in availableProducts"
-          :key="prod"
+          v-for="fam in availableFamilies"
+          :key="fam.key"
           class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
-          :class="selectedProduct === prod
+          :class="selectedFamily === fam.key
             ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
             : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
-          @click="selectedProduct = prod"
-        >{{ productLabel(prod) }}</button>
+          @click="selectedFamily = fam.key"
+        >{{ fam.label }}</button>
       </div>
 
       <!-- Executive Summary -->

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -5,6 +5,7 @@ import FeatureTable from '../components/FeatureTable.vue'
 import { useReleasePicker } from '../composables/useReleasePicker'
 import { useComponentBreakdown } from '../composables/useComponentBreakdown'
 import { useTvFvData } from '../composables/useTvFvData'
+import { useReleaseFamily, getAlignmentTarget, productLabel } from '../composables/useReleaseFamily'
 
 const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
 
@@ -62,6 +63,22 @@ const filteredSummary = computed(() => {
   }
   return rows
 })
+
+// ---------------------------------------------------------------------------
+// Product filter + release family sorting
+// ---------------------------------------------------------------------------
+
+const {
+  selectedProduct, availableProducts,
+  toggleSummarySort, summarySortIcon,
+  sortedSummary,
+} = useReleaseFamily(filteredSummary)
+
+/** Compute target alignment for a row based on days to GA */
+function targetForRow(row) {
+  var d = daysToGa(row.ga_date)
+  return getAlignmentTarget(d)
+}
 
 const { releaseComponentBreakdown } = useComponentBreakdown(data, releaseData)
 
@@ -161,6 +178,26 @@ onBeforeUnmount(() => {
         <span class="italic">Counts reflect data at fetch time; live Jira may differ</span>
       </div>
 
+      <!-- Product Filter -->
+      <div class="flex items-center gap-1.5 mb-4">
+        <button
+          class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+          :class="selectedProduct === 'all'
+            ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
+          @click="selectedProduct = 'all'"
+        >All</button>
+        <button
+          v-for="prod in availableProducts"
+          :key="prod"
+          class="px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+          :class="selectedProduct === prod
+            ? 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 border-gray-800 dark:border-gray-200'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'"
+          @click="selectedProduct = prod"
+        >{{ productLabel(prod) }}</button>
+      </div>
+
       <!-- Executive Summary -->
       <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-6">
         <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
@@ -170,21 +207,40 @@ onBeforeUnmount(() => {
           <table class="min-w-full text-sm">
             <thead>
               <tr class="bg-gray-50 dark:bg-gray-800/50">
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Release</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Total</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Aligned</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">TV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">FV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Mismatched</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Alignment</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">GA Date</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('release')">
+                  <span class="inline-flex items-center gap-1">Release<svg v-if="summarySortIcon('release') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('release') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('total')">
+                  <span class="inline-flex items-center gap-1 justify-end">Total<svg v-if="summarySortIcon('total') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('total') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned')">
+                  <span class="inline-flex items-center gap-1 justify-end">Aligned<svg v-if="summarySortIcon('aligned') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('tv_only')">
+                  <span class="inline-flex items-center gap-1 justify-end">TV-Only<svg v-if="summarySortIcon('tv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('tv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('fv_only')">
+                  <span class="inline-flex items-center gap-1 justify-end">FV-Only<svg v-if="summarySortIcon('fv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('fv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('mismatched')">
+                  <span class="inline-flex items-center gap-1 justify-end">Mismatched<svg v-if="summarySortIcon('mismatched') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('mismatched') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('alignment_pct')">
+                  <span class="inline-flex items-center gap-1 justify-end">Alignment<svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Target</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('ga_date')">
+                  <span class="inline-flex items-center gap-1">GA Date<svg v-if="summarySortIcon('ga_date') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('ga_date') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to GA</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Planning Freeze</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('planning_freeze')">
+                  <span class="inline-flex items-center gap-1">Planning Freeze<svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
               <tr
-                v-for="row in filteredSummary"
+                v-for="row in sortedSummary"
                 :key="row.release"
                 class="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer"
                 :class="{ 'bg-blue-50/50 dark:bg-blue-900/10': row.release === selectedRelease }"
@@ -227,6 +283,19 @@ onBeforeUnmount(() => {
                   >
                     {{ row.alignment_pct }}%
                   </span>
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <td class="px-4 py-2 text-right text-xs whitespace-nowrap">
+                  <template v-if="!row._pending && targetForRow(row)">
+                    <span
+                      class="font-semibold"
+                      :class="{
+                        'text-red-600 dark:text-red-400': row.alignment_pct < targetForRow(row).target,
+                        'text-green-600 dark:text-green-400': row.alignment_pct >= targetForRow(row).target,
+                      }"
+                      :title="'Target: ' + targetForRow(row).label + ' (based on ' + daysToGa(row.ga_date) + ' days to GA)'"
+                    >{{ targetForRow(row).label }}</span>
+                  </template>
                   <span v-else class="text-gray-400">&mdash;</span>
                 </td>
                 <td class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -184,6 +184,155 @@ function matchVersionsToReleases(jiraVersions, registryReleases) {
 }
 
 /**
+ * Migrate registry entries with stale .z-suffixed IDs to their normalized form.
+ * Merges fixVersions when both old (.z) and new (clean) entries exist for the
+ * same logical release. Idempotent — safe to run on every sync.
+ *
+ * Background: Product Pages used to include ".z" in release numbers (e.g.
+ * "rhoai-3.5.z"). stripZStream normalises these to "rhoai-3.5", but the
+ * registry lookup used raw IDs, so sync created duplicate entries — the old
+ * one (with fixVersions) got archived, the new one was born empty.
+ *
+ * @param {object} registry - Registry object (mutated in place)
+ * @returns {number} Number of entries merged or renamed
+ */
+function migrateNormalizedIds(registry) {
+  // Group entries by their normalized (stripped) ID
+  const groups = {};
+  for (const r of registry.releases) {
+    const normId = stripZStream(r.id).toLowerCase();
+    if (!groups[normId]) groups[normId] = [];
+    groups[normId].push(r);
+  }
+
+  let migrated = 0;
+  const toRemove = new Set();
+
+  for (const [normId, entries] of Object.entries(groups)) {
+    if (entries.length === 1) {
+      // Single entry — just normalise its ID if needed
+      if (entries[0].id !== normId) {
+        entries[0].id = normId;
+        entries[0].updatedAt = new Date().toISOString();
+        migrated++;
+      }
+      continue;
+    }
+
+    // Multiple entries share the same normalised ID — merge into one.
+    // Prefer the active entry; if multiple active, prefer the one with the
+    // clean (non-.z) ID; if still tied, prefer the one with more fixVersions.
+    entries.sort(function (a, b) {
+      // active before archived
+      if (a.state !== b.state) return a.state === 'active' ? -1 : 1;
+      // clean ID before .z ID
+      var aClean = stripZStream(a.id).toLowerCase() === a.id ? 1 : 0;
+      var bClean = stripZStream(b.id).toLowerCase() === b.id ? 1 : 0;
+      if (aClean !== bClean) return bClean - aClean;
+      // more fixVersions first
+      return (b.fixVersions || []).length - (a.fixVersions || []).length;
+    });
+
+    const winner = entries[0];
+
+    // Union all fixVersions from every duplicate
+    const allFvs = new Set(winner.fixVersions || []);
+    for (let i = 1; i < entries.length; i++) {
+      for (const fv of (entries[i].fixVersions || [])) allFvs.add(fv);
+      toRemove.add(entries[i]);
+    }
+
+    winner.id = normId;
+    winner.fixVersions = [...allFvs];
+    winner.updatedAt = new Date().toISOString();
+    migrated++;
+  }
+
+  if (toRemove.size > 0) {
+    registry.releases = registry.releases.filter(function (r) { return !toRemove.has(r); });
+  }
+
+  return migrated;
+}
+
+/**
+ * Auto-resolve Jira fixVersions for registry releases that have empty mappings.
+ * Uses the existing matchVersionsToReleases fuzzy matcher against all Jira
+ * project versions. Only touches releases with empty fixVersions — never
+ * overwrites manually-curated mappings.
+ *
+ * @param {object} storage - Storage module
+ * @param {object} [deps] - Optional dependency injection for testing
+ * @param {function} [deps.fetchProjectVersions] - Jira version fetcher
+ * @param {function} [deps.jiraRequest] - Jira request function
+ * @returns {Promise<object>} Resolution results
+ */
+async function autoResolveFixVersions(storage, deps) {
+  const { readFromStorage, writeToStorage } = storage;
+  const registry = readRegistry(readFromStorage);
+
+  // Find active releases with no fixVersions
+  const emptyReleases = registry.releases.filter(function (r) {
+    return r.state === 'active' && (!r.fixVersions || r.fixVersions.length === 0);
+  });
+
+  if (emptyReleases.length === 0) {
+    return { status: 'skipped', message: 'All active releases already have fixVersions' };
+  }
+
+  const config = loadRegistryConfig(storage);
+  const projects = config.jiraProjects || [];
+  if (projects.length === 0) {
+    return { status: 'skipped', message: 'No Jira projects configured for version resolution' };
+  }
+
+  const jira = deps || require('../../../shared/server/jira');
+  const jiraVersions = await jira.fetchProjectVersions(jira.jiraRequest, projects);
+
+  if (!Array.isArray(jiraVersions) || jiraVersions.length === 0) {
+    return { status: 'skipped', message: 'No Jira versions found' };
+  }
+
+  // Run fuzzy matching against ALL active releases (matcher needs full context)
+  const result = matchVersionsToReleases(jiraVersions, registry.releases);
+
+  // Apply only to releases that had empty fixVersions
+  const emptyIds = new Set(emptyReleases.map(function (r) { return r.id; }));
+  const applied = [];
+
+  for (const match of result.matches) {
+    if (!emptyIds.has(match.releaseId)) continue;
+    if (!match.proposedFixVersions || match.proposedFixVersions.length === 0) continue;
+
+    // Find the release in the registry and apply
+    const release = registry.releases.find(function (r) { return r.id === match.releaseId; });
+    if (!release) continue;
+
+    release.fixVersions = match.proposedFixVersions;
+    release.updatedAt = new Date().toISOString();
+    applied.push({ releaseId: release.id, fixVersions: release.fixVersions });
+  }
+
+  if (applied.length > 0) {
+    writeRegistry(writeToStorage, registry);
+    logAudit(readFromStorage, writeToStorage, {
+      domain: 'registry',
+      action: 'registry_auto_resolve_versions',
+      user: 'system',
+      summary: 'Auto-resolved Jira fixVersions for ' + applied.length + ' releases',
+      details: { applied: applied, emptyCount: emptyReleases.length }
+    });
+  }
+
+  return {
+    status: 'ok',
+    resolved: applied.length,
+    emptyBefore: emptyReleases.length,
+    applied: applied
+  };
+}
+
+/**
  * Run Product Pages registry sync (discover + update).
  * Extracted from the POST /registry/discover route handler for reuse
  * by the refresh registry.
@@ -216,7 +365,26 @@ async function runRegistrySync(storage, options) {
   }
 
   const registry = readRegistry(readFromStorage);
-  const existingById = new Map(registry.releases.map(r => [r.id, r]));
+
+  // Merge stale .z-suffixed entries into their clean counterparts before lookup.
+  // This fixes the split caused by stripZStream normalising IDs while the old
+  // lookup used raw IDs, creating orphaned duplicates.
+  const migrated = migrateNormalizedIds(registry);
+  if (migrated > 0) {
+    console.log('[releases/registry] Migrated ' + migrated + ' .z-suffixed registry entries');
+  }
+
+  // Build lookup using NORMALISED IDs so that both "rhoai-3.5.z" (old PP name)
+  // and "rhoai-3.5" (current PP name) resolve to the same registry entry.
+  const existingById = new Map();
+  for (const r of registry.releases) {
+    const normId = stripZStream(r.id).toLowerCase();
+    const prev = existingById.get(normId);
+    // Prefer active over archived when there's a collision
+    if (!prev || (prev.state === 'archived' && r.state !== 'archived')) {
+      existingById.set(normId, r);
+    }
+  }
   let created = 0;
   let updated = 0;
   let archived = 0;
@@ -277,7 +445,9 @@ async function runRegistrySync(storage, options) {
   }
 
   for (const release of registry.releases) {
-    if (release.source === 'product-pages' && release.state === 'active' && !discoveredIds.has(release.id)) {
+    // Use normalised ID for the archive check — discoveredIds contains stripped IDs
+    const normReleaseId = stripZStream(release.id).toLowerCase();
+    if (release.source === 'product-pages' && release.state === 'active' && !discoveredIds.has(normReleaseId)) {
       release.state = 'archived';
       release.updatedAt = new Date().toISOString();
       archived++;
@@ -749,10 +919,20 @@ function registerRegistryRoutes(router, context) {
         return runRegistrySync(storage);
       }
     });
+
+    context.registerRefresh('registry-resolve-versions', {
+      order: 66,
+      timeout: 120000,
+      description: 'Auto-resolves Jira fixVersions for registry releases with empty mappings.',
+      handler: async function() {
+        return autoResolveFixVersions(storage);
+      }
+    });
   }
 }
 
 module.exports = {
   registerRegistryRoutes, readRegistry, writeRegistry, validateRelease, normalizeRelease,
-  normalizeVersionName, matchVersionsToReleases, runRegistrySync, REGISTRY_FILE
+  normalizeVersionName, matchVersionsToReleases, runRegistrySync, migrateNormalizedIds,
+  autoResolveFixVersions, REGISTRY_FILE
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1063.0",
         "@dagrejs/dagre": "^3.0.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
+        "@opencode-ai/sdk": "^1.17.10",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
         "@vue-flow/core": "^1.48.2",
@@ -1216,6 +1218,12 @@
       "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
       "license": "MIT"
     },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -1291,6 +1299,15 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.17.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.10.tgz",
+      "integrity": "sha512-s9OcS7pubNCimS98B9ERJ/59veOj1SSGHD0qGBxGIx+164wSspUlHsAWhQIihvF8eZe16F5VY1XUQIEXGBTm2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1063.0",
         "@dagrejs/dagre": "^3.0.0",
-        "@microsoft/fetch-event-source": "^2.0.1",
         "@opencode-ai/sdk": "^1.17.10",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
@@ -1216,12 +1215,6 @@
       "resolved": "https://registry.npmjs.org/@ldapjs/protocol/-/protocol-1.2.1.tgz",
       "integrity": "sha512-O89xFDLW2gBoZWNXuXpBSM32/KealKCTb3JGtJdtUQc7RjAk8XzrRgyz02cPAwGKwKPxy0ivuC7UP9bmN87egQ==",
       "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "license": "MIT"
-    },
-    "node_modules/@microsoft/fetch-event-source": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
-      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",
     "@dagrejs/dagre": "^3.0.0",
-    "@microsoft/fetch-event-source": "^2.0.1",
     "@opencode-ai/sdk": "^1.17.10",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",
     "@dagrejs/dagre": "^3.0.0",
+    "@microsoft/fetch-event-source": "^2.0.1",
+    "@opencode-ai/sdk": "^1.17.10",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",
     "@vue-flow/core": "^1.48.2",

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -190,6 +190,8 @@
     />
 
     <BackendConnectivityModal />
+
+    <ChatWidget v-if="isAiAssistantEnabled" />
   </div>
 </template>
 
@@ -205,6 +207,7 @@ import AppSidebar from './AppSidebar.vue'
 import LandingPage from './LandingPage.vue'
 import ModuleIframeView from './ModuleIframeView.vue'
 import BackendConnectivityModal from './BackendConnectivityModal.vue'
+import ChatWidget from '@modules/ai-assistant/client/components/ChatWidget.vue'
 import AppMessages from '@shared/client/components/AppMessages.vue'
 import { computed, ref, readonly, provide, onUnmounted, watch } from 'vue'
 import { useAuth } from '@shared/client/composables/useAuth'
@@ -240,7 +243,8 @@ export default {
     LandingPage,
     ModuleIframeView,
     BackendConnectivityModal,
-    AppMessages
+    AppMessages,
+    ChatWidget
   },
   setup() {
     const { user: authUser, isAdmin: authIsAdmin, isTeamAdmin: authIsTeamAdmin, roles: authRoles, refresh: refreshAuth } = useAuth()
@@ -488,6 +492,9 @@ export default {
     }
   },
   computed: {
+    isAiAssistantEnabled() {
+      return this.enabledBuiltInSlugs && this.enabledBuiltInSlugs.includes('ai-assistant')
+    },
     isBuiltInModuleView() {
       const manifest = this.builtInManifests.find(m => m.slug === this.activeModule)
       return !!manifest

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1481,7 +1481,7 @@ test.describe('TV/FV Delta — Registry fixVersions Edge Cases @tv-fv-delta', ()
       releases: [
         { id: 'rhoai-3.5-ea1', displayName: 'RHOAI 3.5 EA1', state: 'active', fixVersions: ['rhoai-3.5.EA1'], milestones: { ga: '2026-07-01' } },
         { id: 'rhoai-3.5-ea2', displayName: 'RHOAI 3.5 EA2', state: 'active', fixVersions: ['rhoai-3.5.EA2'], milestones: { ga: '2026-08-01' } },
-        { id: 'rhoai-3.5', displayName: 'RHOAI 3.5', state: 'active', fixVersions: ['rhoai-3.5', 'rhoai-3.5.z'], milestones: { ga: '2026-09-01' } },
+        { id: 'rhoai-3.5', displayName: 'RHOAI 3.5', state: 'active', fixVersions: ['rhoai-3.5'], milestones: { ga: '2026-09-01' } },
       ],
     };
 

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1430,3 +1430,85 @@ test.describe('TV/FV Delta — Release Picker @tv-fv-delta', () => {
     expect(relevantErrors(page)).toHaveLength(0);
   });
 });
+
+
+test.describe('TV/FV Delta — Registry fixVersions Edge Cases @tv-fv-delta', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should load without errors when registry has empty fixVersions', async ({ page }) => {
+    // Simulate the pre-fix bug: registry returns releases with empty fixVersions.
+    // The view should still load without errors (fallback to cached metadata).
+    const emptyFvRegistry = {
+      releases: [
+        { id: 'rhoai-3.5-ea1', displayName: 'RHOAI 3.5 EA1', state: 'active', fixVersions: [], milestones: {} },
+        { id: 'rhoai-3.5-ea2', displayName: 'RHOAI 3.5 EA2', state: 'active', fixVersions: [], milestones: {} },
+        { id: 'rhoai-3.5', displayName: 'RHOAI 3.5', state: 'active', fixVersions: [], milestones: {} },
+      ],
+    };
+
+    await mockAllApis(page);
+    await page.unroute('**/api/modules/releases/registry');
+    await page.route('**/api/modules/releases/registry', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(emptyFvRegistry)
+      });
+    });
+
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Page should load without errors — data comes from cached TV/FV delta endpoint
+    expect(relevantErrors(page)).toHaveLength(0);
+
+    // The view should still render from the fixture data
+    const heading = page.getByRole('heading', { name: 'TV vs FV Delta' });
+    await expect(heading).toBeVisible();
+  });
+
+  test('should render releases after registry migration populates fixVersions', async ({ page }) => {
+    // Simulate the post-fix state: registry returns clean IDs with populated fixVersions
+    // (after migrateNormalizedIds merged .z entries and carried fixVersions over)
+    const migratedRegistry = {
+      releases: [
+        { id: 'rhoai-3.5-ea1', displayName: 'RHOAI 3.5 EA1', state: 'active', fixVersions: ['rhoai-3.5.EA1'], milestones: { ga: '2026-07-01' } },
+        { id: 'rhoai-3.5-ea2', displayName: 'RHOAI 3.5 EA2', state: 'active', fixVersions: ['rhoai-3.5.EA2'], milestones: { ga: '2026-08-01' } },
+        { id: 'rhoai-3.5', displayName: 'RHOAI 3.5', state: 'active', fixVersions: ['rhoai-3.5', 'rhoai-3.5.z'], milestones: { ga: '2026-09-01' } },
+      ],
+    };
+
+    await mockAllApis(page);
+    await page.unroute('**/api/modules/releases/registry');
+    await page.route('**/api/modules/releases/registry', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(migratedRegistry)
+      });
+    });
+
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    expect(relevantErrors(page)).toHaveLength(0);
+
+    // All three releases should appear as chips (auto-selected because fixVersions are populated)
+    for (const release of ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']) {
+      await expect(page.locator('button', { hasText: release }).first()).toBeVisible();
+    }
+
+    // Executive summary should render with all three releases
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+    const rows = summarySection.locator('tbody tr');
+    await expect(rows).toHaveCount(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ai-assistant` module with Express backend (POST `/api/modules/ai-assistant/chat`) that proxies to an OpenCode server for LLM responses via Vertex AI
- Vue chat widget: floating FAB, slide-out drawer, markdown rendering, session persistence, suggestion chips, page-context injection
- Rate limiting (20 req/min per user), scope-based access control (`ai-assistant:use`), secret management for `OPENCODE_URL`

## Architecture

```
ChatWidget.vue → fetch POST /chat → Express route → @opencode-ai/sdk → OpenCode server → Vertex AI (Claude)
```

- Module is `defaultEnabled: false` — must be explicitly enabled
- Uses blocking `prompt()` API (not streaming) for simplicity
- Session continuity via `sessionId` round-trip

## Test plan

- [x] E2E verified: Express → OpenCode → Vertex AI → JSON response
- [x] Session continuity: follow-up messages reference prior context
- [x] Lint passes, no new warnings
- [ ] Frontend manual test in browser (Vite dev server)
- [ ] Rate limiting edge cases
- [ ] Error handling (OpenCode down, invalid session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)