### PR TITLE
fix: update assess-rfe repo URL to opendatahub-io org

### DIFF
--- a/modules/ai-impact/client/components/AssessmentGuideModal.vue
+++ b/modules/ai-impact/client/components/AssessmentGuideModal.vue
@@ -156,7 +156,7 @@ function handleClose() {
               <div class="rounded-lg bg-gray-50 dark:bg-gray-700/30 border border-gray-200 dark:border-gray-700 px-4 py-3">
                 <h4 class="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-2">CLI Tools</h4>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
-                  The scoring rubric is maintained in the <span class="font-mono text-xs bg-gray-200 dark:bg-gray-600 px-1 py-0.5 rounded">assess-rfe</span> plugin (source: <a href="https://github.com/n1hility/assess-rfe" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline">n1hility/assess-rfe</a>).
+                  The scoring rubric is maintained in the <span class="font-mono text-xs bg-gray-200 dark:bg-gray-600 px-1 py-0.5 rounded">assess-rfe</span> plugin (source: <a href="https://github.com/opendatahub-io/assess-rfe" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline">opendatahub-io/assess-rfe</a>).
                 </p>
                 <div class="space-y-1.5 text-xs font-mono">
                   <div class="flex items-start gap-2">
@@ -516,7 +516,7 @@ function handleClose() {
                   </div>
                 </div>
                 <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                  Source: <a href="https://github.com/n1hility/assess-rfe" target="_blank" rel="noopener noreferrer" class="font-mono text-blue-600 dark:text-blue-400 hover:underline">n1hility/assess-rfe</a> and <a href="https://github.com/jwforres/rfe-creator" target="_blank" rel="noopener noreferrer" class="font-mono text-blue-600 dark:text-blue-400 hover:underline">jwforres/rfe-creator</a>
+                  Source: <a href="https://github.com/opendatahub-io/assess-rfe" target="_blank" rel="noopener noreferrer" class="font-mono text-blue-600 dark:text-blue-400 hover:underline">opendatahub-io/assess-rfe</a> and <a href="https://github.com/jwforres/rfe-creator" target="_blank" rel="noopener noreferrer" class="font-mono text-blue-600 dark:text-blue-400 hover:underline">jwforres/rfe-creator</a>
                 </p>
               </div>
             </div>

--- a/modules/ai-impact/client/views/AIFactoryGuideView.vue
+++ b/modules/ai-impact/client/views/AIFactoryGuideView.vue
@@ -136,7 +136,7 @@ const rfeLearnLinks = [
 ]
 
 const rfeToolLinks = [
-  { label: 'assess-rfe plugin', icon: Code, url: 'https://github.com/n1hility/assess-rfe' },
+  { label: 'assess-rfe plugin', icon: Code, url: 'https://github.com/opendatahub-io/assess-rfe' },
   { label: 'rfe-creator plugin', icon: Code, url: 'https://github.com/jwforres/rfe-creator' },
   { label: 'Skills Registry', icon: BookOpen, url: 'https://github.com/opendatahub-io/skills-registry' },
   { label: '#wg-rhai-rfe-builder', icon: MessageSquare, url: 'https://app.slack.com/client/E030G10V24F/C0AMPLH0Y9G' },


### PR DESCRIPTION
## Summary
- The `assess-rfe` plugin has moved from `n1hility/assess-rfe` to `opendatahub-io/assess-rfe`
- Updates all 3 references across `AssessmentGuideModal.vue` and `AIFactoryGuideView.vue` to point to the canonical URL
- GitHub silently redirects the old URL, but linking to the canonical org URL is correct

## Test plan
- [x] Verify links in AI Impact Assessment Guide modal (scoring rubric source + RFE Creator source)
- [x] Verify link in AI Factory Guide view (assess-rfe plugin resource)

Co-Authored-By: Claude <noreply@anthropic.com>

## Test proofs

<img width="775" height="160" alt="image" src="https://github.com/user-attachments/assets/c2e3bd56-71d4-46df-939c-09162f74acb3" />
<img width="1246" height="323" alt="image" src="https://github.com/user-attachments/assets/5c74e7fb-1c52-457b-93b2-9f27fb1a5248" />
