### PR TITLE
fix(releases): fix blocked false positives and add blockedBy detail

### DIFF
--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -206,6 +206,7 @@ var componentGroups = computed(function() {
             releaseType: feat.releaseType,
             priority: feat.priority,
             isBlocked: feat.isBlocked,
+            blockedBy: feat.blockedBy || [],
             components: feat.components,
             fixVersions: feat.fixVersions || [],
             targetVersions: feat.targetVersions || [],
@@ -481,7 +482,7 @@ defineExpose({ expandAll, collapseAll })
                 <span
                   v-if="feature.isBlocked"
                   class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 dark:bg-red-900/30 ring-1 ring-red-200 dark:ring-red-800"
-                  title="Blocked"
+                  :title="feature.blockedBy && feature.blockedBy.length ? 'Blocked by: ' + feature.blockedBy.map(function(b) { return b.key + ' (' + b.status + ')' }).join(', ') : 'Blocked'"
                 >
                   <svg class="w-3.5 h-3.5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />

--- a/modules/releases/server/hygiene/__tests__/blocked-detection.test.js
+++ b/modules/releases/server/hygiene/__tests__/blocked-detection.test.js
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+
+const { transformIssue } = require('../jira-fetch')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal raw Jira issue with the given issuelinks.
+ * Only fields relevant to blocked detection are populated.
+ */
+function makeRawIssue(issueLinks, overrides) {
+  return Object.assign({
+    key: 'RHAISTRAT-100',
+    fields: Object.assign({
+      summary: 'Test feature',
+      status: { name: 'In Progress', statusCategory: { name: 'In Progress' } },
+      issuetype: { name: 'Feature' },
+      issuelinks: issueLinks
+    }, overrides)
+  })
+}
+
+/**
+ * Build an inward "Blocks" link with the given blocking issue details.
+ * @param {string} key - Blocking issue key
+ * @param {string} statusName - Status name of the blocking issue
+ * @param {string} statusCategoryName - Status category name of the blocking issue
+ * @param {string} [summary] - Optional summary
+ */
+function makeBlocksLink(key, statusName, statusCategoryName, summary) {
+  return {
+    type: { name: 'Blocks', inward: 'is blocked by', outward: 'blocks' },
+    inwardIssue: {
+      key: key,
+      fields: {
+        summary: summary || 'Blocking issue ' + key,
+        status: {
+          name: statusName,
+          statusCategory: { name: statusCategoryName }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Build an outward "Blocks" link (this issue blocks another).
+ */
+function makeOutwardBlocksLink(key, statusName, statusCategoryName) {
+  return {
+    type: { name: 'Blocks', inward: 'is blocked by', outward: 'blocks' },
+    outwardIssue: {
+      key: key,
+      fields: {
+        summary: 'Downstream issue ' + key,
+        status: {
+          name: statusName,
+          statusCategory: { name: statusCategoryName }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Build a non-blocking link (e.g., "Relates").
+ */
+function makeRelatesLink(key) {
+  return {
+    type: { name: 'Relates', inward: 'relates to', outward: 'relates to' },
+    inwardIssue: {
+      key: key,
+      fields: {
+        summary: 'Related issue ' + key,
+        status: {
+          name: 'In Progress',
+          statusCategory: { name: 'In Progress' }
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('blocked detection in transformIssue', function () {
+  var rfeMap = {}
+
+  it('Done category resolves block — blocking issue with statusCategory "Done" does NOT block', function () {
+    var links = [makeBlocksLink('RHOAIENG-50', 'Closed', 'Done')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Non-done category causes block — statusCategory "In Progress" with status "In Progress" blocks', function () {
+    var links = [makeBlocksLink('RHOAIENG-51', 'In Progress', 'In Progress')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(true)
+    expect(result.blockedBy).toHaveLength(1)
+    expect(result.blockedBy[0]).toEqual({
+      key: 'RHOAIENG-51',
+      summary: 'Blocking issue RHOAIENG-51',
+      status: 'In Progress'
+    })
+  })
+
+  it('Status-name fallback — "Resolved" with non-Done category is treated as resolved', function () {
+    var links = [makeBlocksLink('RHOAIENG-52', 'Resolved', 'In Progress')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Status-name fallback — "Closed" with non-Done category is treated as resolved', function () {
+    var links = [makeBlocksLink('RHOAIENG-53', 'Closed', 'Complete')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Status-name fallback — "Release Pending" with non-Done category is treated as resolved', function () {
+    var links = [makeBlocksLink('RHOAIENG-54', 'Release Pending', 'In Progress')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Multiple blockers — 1 resolved (Done) + 2 unresolved yields blockedBy with 2 entries', function () {
+    var links = [
+      makeBlocksLink('RHOAIENG-60', 'Closed', 'Done'),
+      makeBlocksLink('RHOAIENG-61', 'In Progress', 'In Progress', 'First unresolved'),
+      makeBlocksLink('RHOAIENG-62', 'Open', 'To Do', 'Second unresolved')
+    ]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(true)
+    expect(result.blockedBy).toHaveLength(2)
+
+    var keys = result.blockedBy.map(function (b) { return b.key })
+    expect(keys).toContain('RHOAIENG-61')
+    expect(keys).toContain('RHOAIENG-62')
+
+    // Verify structure of each entry
+    for (var i = 0; i < result.blockedBy.length; i++) {
+      expect(result.blockedBy[i]).toHaveProperty('key')
+      expect(result.blockedBy[i]).toHaveProperty('summary')
+      expect(result.blockedBy[i]).toHaveProperty('status')
+    }
+  })
+
+  it('No issuelinks field — not blocked, blockedBy empty', function () {
+    var raw = {
+      key: 'RHAISTRAT-200',
+      fields: {
+        summary: 'Feature without links',
+        status: { name: 'In Progress', statusCategory: { name: 'In Progress' } },
+        issuetype: { name: 'Feature' }
+        // issuelinks is undefined
+      }
+    }
+    var result = transformIssue(raw, rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Empty issuelinks array — not blocked, blockedBy empty', function () {
+    var links = []
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Non-blocking link type ("Relates") is ignored — not blocked', function () {
+    var links = [makeRelatesLink('RHOAIENG-70')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+
+  it('Outward "Blocks" link only (no inwardIssue) is ignored — not blocked', function () {
+    var links = [makeOutwardBlocksLink('RHOAIENG-80', 'In Progress', 'In Progress')]
+    var result = transformIssue(makeRawIssue(links), rfeMap)
+
+    expect(result.isBlocked).toBe(false)
+    expect(result.blockedBy).toEqual([])
+  })
+})

--- a/modules/releases/server/hygiene/jira-fetch.js
+++ b/modules/releases/server/hygiene/jira-fetch.js
@@ -241,24 +241,29 @@ function transformIssue(rawIssue, rfeMap) {
   }
 
   // Blocked: check for unresolved inward "Blocks" links
-  let isBlocked = false
+  const blockedBy = []
   const issueLinks = fields.issuelinks
   if (Array.isArray(issueLinks)) {
+    const resolvedStatusNames = ['Closed', 'Resolved', 'Release Pending']
     for (let bli = 0; bli < issueLinks.length; bli++) {
       const link = issueLinks[bli]
       if (!link.inwardIssue) continue
       const type = link.type || {}
       if (type.name !== 'Blocks' && type.inward !== 'is blocked by') continue
-      const linkedStatusCat = link.inwardIssue.fields &&
-        link.inwardIssue.fields.status &&
-        link.inwardIssue.fields.status.statusCategory &&
-        link.inwardIssue.fields.status.statusCategory.name
-      if (linkedStatusCat !== 'Done') {
-        isBlocked = true
-        break
-      }
+      const linkedFields = link.inwardIssue.fields || {}
+      const linkedStatus = linkedFields.status || {}
+      const linkedStatusCat = linkedStatus.statusCategory &&
+        linkedStatus.statusCategory.name
+      const linkedStatusName = linkedStatus.name || ''
+      if (linkedStatusCat === 'Done' || resolvedStatusNames.includes(linkedStatusName)) continue
+      blockedBy.push({
+        key: link.inwardIssue.key,
+        summary: (linkedFields.summary || ''),
+        status: linkedStatusName
+      })
     }
   }
+  const isBlocked = blockedBy.length > 0
 
   // Priority
   const priority = fields.priority ? fields.priority.name : null
@@ -291,6 +296,7 @@ function transformIssue(rawIssue, rfeMap) {
     riceScore: fields[CUSTOM_FIELDS.riceScore] || null,
     priority,
     isBlocked,
+    blockedBy,
     pmOwner,
     linkedRfeKey,
     linkedRfeApproved,

--- a/modules/releases/server/hygiene/jira-fetch.js
+++ b/modules/releases/server/hygiene/jira-fetch.js
@@ -244,7 +244,6 @@ function transformIssue(rawIssue, rfeMap) {
   const blockedBy = []
   const issueLinks = fields.issuelinks
   if (Array.isArray(issueLinks)) {
-    const resolvedStatusNames = ['Closed', 'Resolved', 'Release Pending']
     for (let bli = 0; bli < issueLinks.length; bli++) {
       const link = issueLinks[bli]
       if (!link.inwardIssue) continue
@@ -255,7 +254,7 @@ function transformIssue(rawIssue, rfeMap) {
       const linkedStatusCat = linkedStatus.statusCategory &&
         linkedStatus.statusCategory.name
       const linkedStatusName = linkedStatus.name || ''
-      if (linkedStatusCat === 'Done' || resolvedStatusNames.includes(linkedStatusName)) continue
+      if (linkedStatusCat === 'Done' || TERMINAL_STATUSES.includes(linkedStatusName)) continue
       blockedBy.push({
         key: link.inwardIssue.key,
         summary: (linkedFields.summary || ''),

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -388,6 +388,7 @@ function buildFeatureObj(f, targetVersions) {
     releaseType: f.releaseType || null,
     priority: f.priority || null,
     isBlocked: f.isBlocked || false,
+    blockedBy: f.blockedBy || [],
     components: f.components || [],
     fixVersions: f.fixVersions || [],
     targetVersions: targetVersions || [],


### PR DESCRIPTION
## Summary
- Fix blocked detection false positives in PM Hub — statuses like "Resolved", "Closed", and "Release Pending" are now correctly treated as resolved even when their Jira `statusCategory` isn't "Done"
- Add `blockedBy` array to feature objects containing `{ key, summary, status }` for each unresolved blocking issue
- PM Hub blocked icon tooltip now shows which specific issues are causing the block

## Changes
| File | Change |
|------|--------|
| `modules/releases/server/hygiene/jira-fetch.js` | Status-name fallback + `blockedBy` array in `transformIssue()` |
| `modules/releases/server/pm-hub/routes.js` | Pass `blockedBy` through `buildFeatureObj()` |
| `modules/releases/client/plan/components/ComponentReleaseLoadTable.vue` | Dynamic tooltip + `blockedBy` on component feature objects |
| `modules/releases/server/hygiene/__tests__/blocked-detection.test.js` | 10 new tests (was 0 coverage for blocked detection) |

## Context
Implements item A1 from [AIPCC-18735](https://redhat.atlassian.net/browse/AIPCC-18735) — "Blocked field incorrectly showing issues as blocked."

Root cause: `transformIssue()` only checked `statusCategory === 'Done'` to determine if a blocking issue was resolved. Some Jira workflows have terminal statuses (Resolved, Closed, Release Pending) whose `statusCategory` is "In Progress" or "Complete" rather than "Done", producing false positives.

## Test plan
- [x] 10 new unit tests covering: done category, non-done category, status-name fallback (Resolved/Closed/Release Pending), multiple blockers, no links, empty links, non-blocking link types, outward-only links
- [x] Full test suite: 5057 tests pass (284 files), zero regressions
- [x] ESLint passes on all modified files
- [ ] Verify in production PM Hub that previously false-positive blocked issues now show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)