### PR TITLE
fix(releases): remove Type column, normalize versions, rename avg label

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
@@ -63,12 +63,12 @@ function mountTable(props) {
 
 describe('ComponentReleaseLoadTable sorting (component)', function () {
   describe('header rendering', function () {
-    it('renders 12 sortable th elements when a component is expanded', async function () {
+    it('renders 11 sortable th elements when a component is expanded', async function () {
       var wrapper = mountTable()
       var groupHeader = wrapper.find('tr.cursor-pointer')
       await groupHeader.trigger('click')
       var ths = wrapper.findAll('th')
-      expect(ths.length).toBe(12)
+      expect(ths.length).toBe(11)
     })
 
     it('all headers have cursor-pointer class', async function () {

--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -572,9 +572,6 @@ function getSortValue(feature, column) {
     var po = PRIORITY_ORDER[feature.priority]
     return po !== undefined ? po : 99
   }
-  if (column === 'type') {
-    return (feature.isCommitted ? 2 : 0) + (feature.isRequested ? 1 : 0)
-  }
   if (column === 'releaseType') return (feature.releaseType || '').toLowerCase()
   if (column === 'status') return (feature.status || '').toLowerCase()
   if (column === 'colorStatus') {
@@ -647,25 +644,6 @@ describe('getSortValue', function () {
   it('returns 99 for unknown or null priority', function () {
     expect(getSortValue(makeFeature({ priority: 'Minor' }), 'priority')).toBe(99)
     expect(getSortValue(makeFeature({ priority: null }), 'priority')).toBe(99)
-  })
-
-  it('returns type score based on isRequested/isCommitted', function () {
-    var feat = makeFeature({})
-    feat.isRequested = true
-    feat.isCommitted = false
-    expect(getSortValue(feat, 'type')).toBe(1)
-
-    feat.isRequested = false
-    feat.isCommitted = true
-    expect(getSortValue(feat, 'type')).toBe(2)
-
-    feat.isRequested = true
-    feat.isCommitted = true
-    expect(getSortValue(feat, 'type')).toBe(3)
-
-    feat.isRequested = false
-    feat.isCommitted = false
-    expect(getSortValue(feat, 'type')).toBe(0)
   })
 
   it('returns lowercased releaseType', function () {
@@ -774,11 +752,6 @@ describe('sortFeatures', function () {
   it('sorts by assignee descending', function () {
     var result = sortFeatures(features, 'assignee', 'desc')
     expect(result.map(function (f) { return f.assignee })).toEqual(['Charlie', 'Bob', 'Alice'])
-  })
-
-  it('sorts by type (committed > requested > none)', function () {
-    var result = sortFeatures(features, 'type', 'desc')
-    expect(result.map(function (f) { return f.key })).toEqual(['X-1', 'X-2', 'X-3'])
   })
 
   it('sorts by colorStatus ascending (Red first)', function () {

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -30,13 +30,13 @@ var expandedComponents = reactive({})
 
 // ═══ SORT STATE ═══
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'type', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'assignee', 'pmOwner']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'assignee', 'pmOwner']
 
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
 
 var sortState = reactive({
-  column: props.initialSort.column,
+  column: SORT_COLUMNS.indexOf(props.initialSort.column) !== -1 ? props.initialSort.column : null,
   direction: props.initialSort.direction || 'asc'
 })
 
@@ -62,9 +62,6 @@ function getSortValue(feature, column) {
   if (column === 'priority') {
     var po = PRIORITY_ORDER[feature.priority]
     return po !== undefined ? po : 99
-  }
-  if (column === 'type') {
-    return (feature.isCommitted ? 2 : 0) + (feature.isRequested ? 1 : 0)
   }
   if (column === 'releaseType') return (feature.releaseType || '').toLowerCase()
   if (column === 'status') return (feature.status || '').toLowerCase()
@@ -148,6 +145,11 @@ function extractProduct(versionName) {
   if (lower.startsWith('rhelai')) return 'RHELAI'
   if (lower.startsWith('rhaii')) return 'RHAII'
   return versionName.split('-')[0] || versionName
+}
+
+function normalizeVersion(v) {
+  if (!v || typeof v !== 'string') return v
+  return v.replace(/^rhoai-/i, '')
 }
 
 var componentGroups = computed(function() {
@@ -296,7 +298,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="12" class="px-4 py-3">
+            <td colspan="11" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -362,9 +364,6 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('priority')">
               <span class="inline-flex items-center gap-1 justify-center">Priority<SortArrow :direction="sortIcon('priority')" /></span>
             </th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('type')">
-              <span class="inline-flex items-center gap-1 justify-center">Type<SortArrow :direction="sortIcon('type')" /></span>
-            </th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('releaseType')">
               <span class="inline-flex items-center gap-1 justify-center">Release Type<SortArrow :direction="sortIcon('releaseType')" /></span>
             </th>
@@ -423,18 +422,6 @@ defineExpose({ expandAll, collapseAll })
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
               <td class="px-3 py-2.5 text-center">
-                <div class="flex items-center justify-center gap-1">
-                  <span
-                    v-if="feature.isRequested"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-800/40 text-blue-700 dark:text-blue-300"
-                  >REQ</span>
-                  <span
-                    v-if="feature.isCommitted"
-                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-800/40 text-emerald-700 dark:text-emerald-300"
-                  >COM</span>
-                </div>
-              </td>
-              <td class="px-3 py-2.5 text-center">
                 <span
                   v-if="feature.releaseType"
                   class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300"
@@ -463,7 +450,7 @@ defineExpose({ expandAll, collapseAll })
                     v-for="fv in feature.fixVersions"
                     :key="fv"
                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
-                  >{{ fv }}</span>
+                  >{{ normalizeVersion(fv) }}</span>
                 </div>
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
@@ -473,7 +460,7 @@ defineExpose({ expandAll, collapseAll })
                     v-for="tv in feature.targetVersions"
                     :key="tv"
                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300"
-                  >{{ tv }}</span>
+                  >{{ normalizeVersion(tv) }}</span>
                 </div>
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
@@ -502,7 +489,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="11" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -510,7 +497,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="11" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -285,7 +285,7 @@
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
             <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Avg / Monthly Release</span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Avg Features Delivered</span>
         </div>
         <div class="text-2xl font-bold text-amber-600 dark:text-amber-400 ml-7">{{ velocity ? velocity.avgPerRelease : '—' }}<span v-if="velocity && velocity.hasPartialYear" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-0.5" title="Includes components with less than a year of data">*</span></div>
       </div>

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -315,8 +315,8 @@ test.describe('Releases PM Hub @releases', () => {
       await firstOption.click();
       await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-      // Verify the Avg / Monthly Release summary card is visible
-      var avgCard = page.locator('text=Avg / Monthly Release');
+      // Verify the Avg Features Delivered summary card is visible
+      var avgCard = page.locator('text=Avg Features Delivered');
       await expect(avgCard.first()).toBeVisible();
 
       // Check for component rows with velocity badges (avg/rel text)


### PR DESCRIPTION
## Summary
- Remove the REQ/COM type badges column from PM Hub table — it conflated commitment status with release type, causing confusion
- Add `normalizeVersion()` helper to strip "rhoai-" prefix from version display (e.g., "rhoai-3.5.EA2" → "3.5.EA2")
- Rename "Avg / Monthly Release" summary card to "Avg Features Delivered"
- Fix colspan mismatch (12→11) and validate initialSort against valid columns

## Changes
| File | Change |
|------|--------|
| `modules/releases/client/plan/components/ComponentReleaseLoadTable.vue` | Remove Type column header/cell/sort, add normalizeVersion, fix colspan, validate initialSort |
| `modules/releases/client/plan/views/ComponentReleaseLoadReport.vue` | Rename summary card label |
| `modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js` | Update column count assertion (12→11) |

## Context
Implements items A2, A3, B7, D8 from [AIPCC-18735](https://redhat.atlassian.net/browse/AIPCC-18735):
- A2: Remove inconsistent Type REQ/COM rendering
- A3: Normalize version display
- B7: Rename "Average/monthly release" label
- D8: Clean up Type column

Note: `isRequested`/`isCommitted` data and `requestedCount`/`committedCount` are intentionally kept — they're used by summary cards and component group headers.

## Test plan
- [x] Sort column count test updated (12→11), all 14 sort tests pass
- [x] Full test suite: 5047 tests pass, zero regressions
- [x] ESLint passes
- [ ] Verify in PM Hub: Type column gone, versions show without "rhoai-" prefix, label updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)