### PR TITLE
feat(releases): add risk column and fetchedAt timestamp to PM Hub

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
@@ -68,7 +68,7 @@ describe('ComponentReleaseLoadTable sorting (component)', function () {
       var groupHeader = wrapper.find('tr.cursor-pointer')
       await groupHeader.trigger('click')
       var ths = wrapper.findAll('th')
-      expect(ths.length).toBe(11)
+      expect(ths.length).toBe(12)
     })
 
     it('all headers have cursor-pointer class', async function () {

--- a/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
@@ -63,7 +63,7 @@ function mountTable(props) {
 
 describe('ComponentReleaseLoadTable sorting (component)', function () {
   describe('header rendering', function () {
-    it('renders 11 sortable th elements when a component is expanded', async function () {
+    it('renders 12 sortable th elements when a component is expanded', async function () {
       var wrapper = mountTable()
       var groupHeader = wrapper.find('tr.cursor-pointer')
       await groupHeader.trigger('click')

--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -145,10 +145,12 @@ function buildComponentGroups(groups) {
     var reqCount = 0
     var comCount = 0
     var blkCount = 0
+    var riskCount = 0
     for (var fli = 0; fli < featureList.length; fli++) {
       if (featureList[fli].isRequested) reqCount++
       if (featureList[fli].isCommitted) comCount++
       if (featureList[fli].isBlocked) blkCount++
+      if (featureList[fli].riskLevel === 'high' || featureList[fli].riskLevel === 'medium') riskCount++
     }
 
     result.push({
@@ -156,7 +158,8 @@ function buildComponentGroups(groups) {
       features: featureList,
       requestedCount: reqCount,
       committedCount: comCount,
-      blockedCount: blkCount
+      blockedCount: blkCount,
+      atRiskCount: riskCount
     })
   }
 

--- a/modules/releases/__tests__/client/plan/pm-hub-risk-column.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-risk-column.test.js
@@ -1,0 +1,334 @@
+/**
+ * Tests for PM Hub risk column, at-risk counts, and fetchedAt timestamp.
+ *
+ * Covers:
+ * - computeRiskLevel() server-side logic (inlined from routes.js)
+ * - At-risk count in component group headers
+ * - totalAtRisk summary card computation
+ * - formattedFetchedAt computed property
+ * - riskLevel sort ordering
+ */
+import { describe, it, expect } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Inlined from modules/releases/server/pm-hub/routes.js
+// ---------------------------------------------------------------------------
+
+function computeRiskLevel(f, targetVersions) {
+  var hasFixVersion = f.fixVersions && f.fixVersions.length > 0
+  var hasTargetVersion = targetVersions && targetVersions.length > 0
+  if (!hasFixVersion && hasTargetVersion) return 'high'
+  if (hasFixVersion) {
+    var cs = (f.colorStatus || '').toLowerCase()
+    if (f.isBlocked || cs === 'red' || cs === 'yellow') return 'medium'
+  }
+  return 'low'
+}
+
+// ---------------------------------------------------------------------------
+// Inlined from ComponentReleaseLoadTable.vue
+// ---------------------------------------------------------------------------
+
+var RISK_ORDER = { 'high': 0, 'medium': 1, 'low': 2 }
+
+function getRiskSortValue(feature) {
+  var ro = RISK_ORDER[(feature.riskLevel || '').toLowerCase()]
+  return ro !== undefined ? ro : 99
+}
+
+function computeAtRiskCount(features) {
+  var count = 0
+  for (var i = 0; i < features.length; i++) {
+    if (features[i].riskLevel === 'high' || features[i].riskLevel === 'medium') count++
+  }
+  return count
+}
+
+// ---------------------------------------------------------------------------
+// Inlined from ComponentReleaseLoadReport.vue
+// ---------------------------------------------------------------------------
+
+function computeTotalAtRisk(groups) {
+  var count = 0
+  for (var i = 0; i < groups.length; i++) {
+    var comps = groups[i].components || []
+    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].atRiskCount || 0
+  }
+  return count
+}
+
+function formatFetchedAt(isoString) {
+  if (!isoString) return null
+  try {
+    var d = new Date(isoString)
+    if (isNaN(d.getTime())) return null
+    return d.toLocaleString()
+  } catch { return null }
+}
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeFeature(overrides) {
+  return Object.assign({
+    key: 'RHAIENG-1',
+    summary: 'Test feature',
+    status: 'In Progress',
+    colorStatus: 'Green',
+    releaseType: 'Feature',
+    priority: 'Major',
+    isBlocked: false,
+    components: ['Dashboard'],
+    fixVersions: ['rhoai-3.5'],
+    targetVersions: ['rhoai-3.5'],
+    riskLevel: 'low',
+    assignee: 'Alice',
+    pmOwner: 'Bob'
+  }, overrides)
+}
+
+function makeComponentGroup(features) {
+  return {
+    component: 'TestComp',
+    requestedFeatures: features,
+    committedFeatures: features,
+    requestedCount: features.length,
+    committedCount: features.length,
+    blockedCount: features.filter(function (f) { return f.isBlocked }).length,
+    atRiskCount: computeAtRiskCount(features)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// computeRiskLevel
+// ---------------------------------------------------------------------------
+
+describe('computeRiskLevel', function () {
+  it('returns high when no fix version but has target version', function () {
+    var f = { fixVersions: [], colorStatus: 'Green', isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('high')
+  })
+
+  it('returns high when fixVersions is null and target exists', function () {
+    var f = { fixVersions: null, colorStatus: 'Green', isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('high')
+  })
+
+  it('returns medium when committed but blocked', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Green', isBlocked: true }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
+  })
+
+  it('returns medium when committed but red status', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Red', isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
+  })
+
+  it('returns medium when committed but yellow status', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Yellow', isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
+  })
+
+  it('returns medium when committed, blocked, and red', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Red', isBlocked: true }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
+  })
+
+  it('returns low when committed and green', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Green', isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('low')
+  })
+
+  it('returns low when no fix version and no target version', function () {
+    var f = { fixVersions: [], colorStatus: 'Green', isBlocked: false }
+    expect(computeRiskLevel(f, [])).toBe('low')
+  })
+
+  it('returns low when no fix version and target is null', function () {
+    var f = { fixVersions: [], colorStatus: 'Green', isBlocked: false }
+    expect(computeRiskLevel(f, null)).toBe('low')
+  })
+
+  it('is case-insensitive for colorStatus', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'RED', isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
+  })
+
+  it('handles missing colorStatus gracefully', function () {
+    var f = { fixVersions: ['rhoai-3.5'], colorStatus: null, isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('low')
+  })
+
+  it('handles undefined colorStatus', function () {
+    var f = { fixVersions: ['rhoai-3.5'], isBlocked: false }
+    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('low')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Risk sort ordering
+// ---------------------------------------------------------------------------
+
+describe('riskLevel sort ordering', function () {
+  it('sorts high before medium before low', function () {
+    expect(getRiskSortValue({ riskLevel: 'high' })).toBe(0)
+    expect(getRiskSortValue({ riskLevel: 'medium' })).toBe(1)
+    expect(getRiskSortValue({ riskLevel: 'low' })).toBe(2)
+  })
+
+  it('returns 99 for missing riskLevel', function () {
+    expect(getRiskSortValue({})).toBe(99)
+    expect(getRiskSortValue({ riskLevel: null })).toBe(99)
+    expect(getRiskSortValue({ riskLevel: '' })).toBe(99)
+  })
+
+  it('is case-insensitive', function () {
+    expect(getRiskSortValue({ riskLevel: 'HIGH' })).toBe(0)
+    expect(getRiskSortValue({ riskLevel: 'Medium' })).toBe(1)
+    expect(getRiskSortValue({ riskLevel: 'LOW' })).toBe(2)
+  })
+
+  it('returns 99 for unknown values', function () {
+    expect(getRiskSortValue({ riskLevel: 'critical' })).toBe(99)
+    expect(getRiskSortValue({ riskLevel: 'none' })).toBe(99)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// At-risk count in component groups
+// ---------------------------------------------------------------------------
+
+describe('at-risk count in component groups', function () {
+  it('counts high and medium risk features', function () {
+    var features = [
+      makeFeature({ key: 'X-1', riskLevel: 'high' }),
+      makeFeature({ key: 'X-2', riskLevel: 'medium' }),
+      makeFeature({ key: 'X-3', riskLevel: 'low' })
+    ]
+    var group = makeComponentGroup(features)
+    expect(group.atRiskCount).toBe(2)
+  })
+
+  it('returns 0 when all features are low risk', function () {
+    var features = [
+      makeFeature({ key: 'X-1', riskLevel: 'low' }),
+      makeFeature({ key: 'X-2', riskLevel: 'low' })
+    ]
+    var group = makeComponentGroup(features)
+    expect(group.atRiskCount).toBe(0)
+  })
+
+  it('returns 0 for empty feature list', function () {
+    var group = makeComponentGroup([])
+    expect(group.atRiskCount).toBe(0)
+  })
+
+  it('counts all features when all are at risk', function () {
+    var features = [
+      makeFeature({ key: 'X-1', riskLevel: 'high' }),
+      makeFeature({ key: 'X-2', riskLevel: 'medium' }),
+      makeFeature({ key: 'X-3', riskLevel: 'high' })
+    ]
+    var group = makeComponentGroup(features)
+    expect(group.atRiskCount).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// totalAtRisk summary computation
+// ---------------------------------------------------------------------------
+
+describe('totalAtRisk summary card', function () {
+  it('sums atRiskCount across all components in all groups', function () {
+    var groups = [
+      {
+        version: 'rhoai-3.5',
+        components: [
+          { component: 'CompA', atRiskCount: 2 },
+          { component: 'CompB', atRiskCount: 1 }
+        ]
+      },
+      {
+        version: 'rhoai-3.6',
+        components: [
+          { component: 'CompC', atRiskCount: 3 }
+        ]
+      }
+    ]
+    expect(computeTotalAtRisk(groups)).toBe(6)
+  })
+
+  it('returns 0 when no components have at-risk features', function () {
+    var groups = [
+      {
+        version: 'rhoai-3.5',
+        components: [
+          { component: 'CompA', atRiskCount: 0 },
+          { component: 'CompB', atRiskCount: 0 }
+        ]
+      }
+    ]
+    expect(computeTotalAtRisk(groups)).toBe(0)
+  })
+
+  it('returns 0 for empty groups', function () {
+    expect(computeTotalAtRisk([])).toBe(0)
+  })
+
+  it('handles missing atRiskCount gracefully', function () {
+    var groups = [
+      {
+        version: 'rhoai-3.5',
+        components: [
+          { component: 'CompA' }
+        ]
+      }
+    ]
+    expect(computeTotalAtRisk(groups)).toBe(0)
+  })
+
+  it('handles groups with empty components array', function () {
+    var groups = [{ version: 'rhoai-3.5', components: [] }]
+    expect(computeTotalAtRisk(groups)).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formattedFetchedAt
+// ---------------------------------------------------------------------------
+
+describe('formattedFetchedAt', function () {
+  it('formats a valid ISO string', function () {
+    var result = formatFetchedAt('2025-06-28T14:30:00.000Z')
+    expect(result).toBeTruthy()
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('returns null for null input', function () {
+    expect(formatFetchedAt(null)).toBeNull()
+  })
+
+  it('returns null for undefined input', function () {
+    expect(formatFetchedAt(undefined)).toBeNull()
+  })
+
+  it('returns null for empty string', function () {
+    expect(formatFetchedAt('')).toBeNull()
+  })
+
+  it('returns null for invalid date string', function () {
+    expect(formatFetchedAt('not-a-date')).toBeNull()
+  })
+
+  it('returns null for nonsense string', function () {
+    expect(formatFetchedAt('abc123xyz')).toBeNull()
+  })
+
+  it('formats a date-only string', function () {
+    var result = formatFetchedAt('2025-06-28')
+    expect(result).toBeTruthy()
+    expect(typeof result).toBe('string')
+  })
+})

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -30,10 +30,11 @@ var expandedComponents = reactive({})
 
 // ═══ SORT STATE ═══
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'assignee', 'pmOwner']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'riskLevel', 'assignee', 'pmOwner']
 
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
+var RISK_ORDER = { 'high': 0, 'medium': 1, 'low': 2 }
 
 var sortState = reactive({
   column: SORT_COLUMNS.indexOf(props.initialSort.column) !== -1 ? props.initialSort.column : null,
@@ -76,6 +77,10 @@ function getSortValue(feature, column) {
     return feature.targetVersions && feature.targetVersions.length > 0 ? feature.targetVersions[0] : ''
   }
   if (column === 'blocked') return feature.isBlocked ? 1 : 0
+  if (column === 'riskLevel') {
+    var ro = RISK_ORDER[(feature.riskLevel || '').toLowerCase()]
+    return ro !== undefined ? ro : 99
+  }
   if (column === 'assignee') return (feature.assignee || '').toLowerCase()
   if (column === 'pmOwner') return (feature.pmOwner || '').toLowerCase()
   return ''
@@ -209,6 +214,7 @@ var componentGroups = computed(function() {
             priority: feat.priority,
             isBlocked: feat.isBlocked,
             blockedBy: feat.blockedBy || [],
+            riskLevel: feat.riskLevel || 'low',
             components: feat.components,
             fixVersions: feat.fixVersions || [],
             targetVersions: feat.targetVersions || [],
@@ -245,10 +251,12 @@ var componentGroups = computed(function() {
     var reqCount = 0
     var comCount = 0
     var blkCount = 0
+    var riskCount = 0
     for (var fli = 0; fli < featureList.length; fli++) {
       if (featureList[fli].isRequested) reqCount++
       if (featureList[fli].isCommitted) comCount++
       if (featureList[fli].isBlocked) blkCount++
+      if (featureList[fli].riskLevel === 'high' || featureList[fli].riskLevel === 'medium') riskCount++
     }
 
     result.push({
@@ -256,7 +264,8 @@ var componentGroups = computed(function() {
       features: featureList,
       requestedCount: reqCount,
       committedCount: comCount,
-      blockedCount: blkCount
+      blockedCount: blkCount,
+      atRiskCount: riskCount
     })
   }
 
@@ -299,7 +308,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="11" class="px-4 py-3">
+            <td colspan="12" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -322,6 +331,12 @@ defineExpose({ expandAll, collapseAll })
                     ? 'bg-red-100 dark:bg-red-800/40 text-red-700 dark:text-red-300'
                     : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
                 >{{ comp.blockedCount }} blocked</span>
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold"
+                  :class="comp.atRiskCount > 0
+                    ? 'bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300'
+                    : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
+                >{{ comp.atRiskCount }} at risk</span>
                 <span
                   v-if="getComponentVelocity(comp.component)"
                   class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300"
@@ -382,6 +397,9 @@ defineExpose({ expandAll, collapseAll })
             </th>
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('blocked')">
               <span class="inline-flex items-center gap-1 justify-center">Blocked<SortArrow :direction="sortIcon('blocked')" /></span>
+            </th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-20 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('riskLevel')">
+              <span class="inline-flex items-center gap-1 justify-center">At Risk<SortArrow :direction="sortIcon('riskLevel')" /></span>
             </th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('assignee')">
               <span class="inline-flex items-center gap-1">Delivery Owner<SortArrow :direction="sortIcon('assignee')" /></span>
@@ -479,6 +497,17 @@ defineExpose({ expandAll, collapseAll })
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                  :class="{
+                    'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300': feature.riskLevel === 'high',
+                    'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300': feature.riskLevel === 'medium',
+                    'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300': feature.riskLevel === 'low'
+                  }"
+                  :title="feature.riskLevel === 'high' ? 'Not committed — has target version but no fix version' : feature.riskLevel === 'medium' ? 'Committed but blocked or status is red/yellow' : 'On track'"
+                >{{ feature.riskLevel === 'high' ? 'High' : feature.riskLevel === 'medium' ? 'Medium' : 'Low' }}</span>
+              </td>
               <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
                 {{ feature.assignee || '--' }}
               </td>
@@ -490,7 +519,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="11" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -498,7 +527,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="11" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -862,10 +862,22 @@ var blockedPercent = computed(function() {
 
 var totalAtRisk = computed(function() {
   var source = clientFilteredGroups.value
+  var seen = {}
   var count = 0
-  for (var i = 0; i < source.length; i++) {
-    var comps = source[i].components || []
-    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].atRiskCount || 0
+  for (var gi = 0; gi < source.length; gi++) {
+    var comps = source[gi].components || []
+    for (var ci = 0; ci < comps.length; ci++) {
+      var lists = [comps[ci].requestedFeatures || [], comps[ci].committedFeatures || []]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!seen[f.key] && (f.riskLevel === 'high' || f.riskLevel === 'medium')) {
+            seen[f.key] = true
+            count++
+          }
+        }
+      }
+    }
   }
   return count
 })

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -6,6 +6,9 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Track component workload distribution across releases.
         </p>
+        <p v-if="formattedFetchedAt" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5" :title="'Data fetched from Jira at ' + fetchedAt">
+          Data from {{ formattedFetchedAt }}
+        </p>
       </div>
       <div class="flex items-center gap-2">
         <button
@@ -248,7 +251,7 @@
     </div>
 
     <!-- Summary cards -->
-    <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+    <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-6 gap-3">
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5 cursor-pointer transition-all" :class="filterType.includes('requested') ? 'ring-2 ring-blue-300 dark:ring-blue-700' : 'hover:shadow-md'" @click="toggleFilter('filterType', 'requested')" title="Filter by Requested">
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
@@ -283,11 +286,21 @@
         <div class="absolute top-0 left-0 w-1 h-full bg-amber-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
-            <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
+            <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+          </span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">At Risk</span>
+        </div>
+        <div class="text-2xl font-bold ml-7" :class="totalAtRisk > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ totalAtRisk }}</div>
+      </div>
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+        <div class="absolute top-0 left-0 w-1 h-full bg-violet-500 rounded-l-xl" />
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-violet-100 dark:bg-violet-900/40">
+            <svg class="w-3 h-3 text-violet-600 dark:text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Avg Features Delivered</span>
         </div>
-        <div class="text-2xl font-bold text-amber-600 dark:text-amber-400 ml-7">{{ velocity ? velocity.avgPerRelease : '—' }}<span v-if="velocity && velocity.hasPartialYear" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-0.5" title="Includes components with less than a year of data">*</span></div>
+        <div class="text-2xl font-bold text-violet-600 dark:text-violet-400 ml-7">{{ velocity ? velocity.avgPerRelease : '—' }}<span v-if="velocity && velocity.hasPartialYear" class="text-sm font-normal text-gray-400 dark:text-gray-500 ml-0.5" title="Includes components with less than a year of data">*</span></div>
       </div>
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-gray-400 rounded-l-xl" />
@@ -386,6 +399,7 @@ var loadingData = ref(false)
 var dataError = ref(null)
 var hasFetched = ref(false)
 var tableRef = ref(null)
+var fetchedAt = ref(null)
 
 var filterProduct = ref([])
 var filterType = ref([])
@@ -663,7 +677,8 @@ var clientFilteredGroups = computed(function() {
         committedFeatures: newCom,
         requestedCount: newReq.length,
         committedCount: newCom.length,
-        blockedCount: filtered.filter(function(ff) { return ff.isBlocked }).length
+        blockedCount: filtered.filter(function(ff) { return ff.isBlocked }).length,
+        atRiskCount: filtered.filter(function(ff) { return ff.riskLevel === 'high' || ff.riskLevel === 'medium' }).length
       })
     }).filter(function(comp) {
       return (comp.requestedFeatures.length + comp.committedFeatures.length) > 0
@@ -845,7 +860,26 @@ var blockedPercent = computed(function() {
   return Math.round((totalBlocked.value / total) * 100)
 })
 
+var totalAtRisk = computed(function() {
+  var source = clientFilteredGroups.value
+  var count = 0
+  for (var i = 0; i < source.length; i++) {
+    var comps = source[i].components || []
+    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].atRiskCount || 0
+  }
+  return count
+})
+
 var velocity = ref(null)
+
+var formattedFetchedAt = computed(function() {
+  if (!fetchedAt.value) return null
+  try {
+    var d = new Date(fetchedAt.value)
+    if (isNaN(d.getTime())) return null
+    return d.toLocaleString()
+  } catch { return null }
+})
 
 function togglePillar(name) {
   var idx = selectedPillars.value.indexOf(name)
@@ -966,10 +1000,12 @@ async function loadData() {
     var data = await response.json()
     groups.value = data.groups || []
     velocity.value = data.velocity || null
+    fetchedAt.value = data.fetchedAt || null
   } catch (err) {
     dataError.value = err.message
     groups.value = []
     velocity.value = null
+    fetchedAt.value = null
   } finally {
     loadingData.value = false
   }

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -377,7 +377,19 @@ const FIELDS_TO_FETCH = [
   CUSTOM_FIELDS.productManager
 ].join(',')
 
+function computeRiskLevel(f, targetVersions) {
+  var hasFixVersion = f.fixVersions && f.fixVersions.length > 0
+  var hasTargetVersion = targetVersions && targetVersions.length > 0
+  if (!hasFixVersion && hasTargetVersion) return 'high'
+  if (hasFixVersion) {
+    var cs = (f.colorStatus || '').toLowerCase()
+    if (f.isBlocked || cs === 'red' || cs === 'yellow') return 'medium'
+  }
+  return 'low'
+}
+
 function buildFeatureObj(f, targetVersions) {
+  var tv = targetVersions || []
   return {
     key: f.key,
     summary: f.summary || '',
@@ -391,7 +403,8 @@ function buildFeatureObj(f, targetVersions) {
     blockedBy: f.blockedBy || [],
     components: f.components || [],
     fixVersions: f.fixVersions || [],
-    targetVersions: targetVersions || [],
+    targetVersions: tv,
+    riskLevel: computeRiskLevel(f, tv),
     assignee: f.assignee || null,
     pmOwner: f.pmOwner || null
   }


### PR DESCRIPTION
## Summary

Adds three capabilities to the PM Hub Component Release Load Tracking view:

- **Risk level column**: Server-side `computeRiskLevel()` classifies features as high (target version but no fix version), medium (committed but blocked or red/yellow status), or low (on track). Rendered as color-coded badges with descriptive tooltips, sortable by severity.
- **At-risk counts**: Component group headers show an "at risk" badge count (high + medium). A new At Risk summary card displays the total count across all filtered groups.
- **Data freshness timestamp**: Surfaces the existing `fetchedAt` from the API response as a "Data from" label with locale-formatted display and ISO tooltip.

## Changes

| File | Change |
|------|--------|
| `modules/releases/server/pm-hub/routes.js` | Add `computeRiskLevel()` function, add `riskLevel` field to `buildFeatureObj()` |
| `modules/releases/client/plan/components/ComponentReleaseLoadTable.vue` | Add At Risk column (header, cell, sort), `atRiskCount` in component groups, update colspan 11→12 |
| `modules/releases/client/plan/views/ComponentReleaseLoadReport.vue` | Add At Risk summary card, `totalAtRisk` computed, `fetchedAt` ref + display, update grid to 6 columns |
| `modules/releases/__tests__/client/plan/pm-hub-risk-column.test.js` | 32 tests for risk computation, sort ordering, at-risk counts, totalAtRisk, fetchedAt formatting |
| `modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js` | Update column count 11→12 |
| `modules/releases/__tests__/client/plan/component-release-load-table.test.js` | Add `atRiskCount` to inlined componentGroups logic |

## Risk Level Criteria

| Level | Condition | Badge Color |
|-------|-----------|-------------|
| High | Has target version but no fix version (not committed) | Red |
| Medium | Has fix version but is blocked, red, or yellow status | Amber |
| Low | On track (committed + green, or no target version) | Emerald |

## Test Results

- [x] ESLint clean across all 6 files
- [x] 32 new tests pass (pm-hub-risk-column.test.js)
- [x] 2590 releases module tests pass, zero regressions
- [x] Existing sort tests updated for 12-column layout

## Items Addressed

- B5 from AIPCC-18735: Add risk level classification to PM Hub features
- D2 from AIPCC-18735: Show data freshness timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)