### PR TITLE
feat(okr-hub): Add OKR Hub module with reports dashboard

### DIFF
--- a/modules/okr-hub/client/components/CveSlaReport.vue
+++ b/modules/okr-hub/client/components/CveSlaReport.vue
@@ -123,7 +123,7 @@
                       class="w-16 px-1.5 py-0.5 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-center text-xs tabular-nums text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-400 focus:border-primary-400 outline-none"
                     />
                   </td>
-                  <td class="px-3 py-1.5 text-center font-semibold text-gray-900 dark:text-gray-100 tabular-nums border-l border-gray-200 dark:border-gray-700">{{ monthTotal(monthKey, 'met') }}</td>
+                  <td class="px-3 py-1.5 text-center font-semibold text-gray-900 dark:text-gray-100 tabular-nums border-l border-gray-200 dark:border-gray-700">{{ monthTotal(monthKey, 'met') || '' }}</td>
                 </tr>
                 <!-- Missed row -->
                 <tr class="bg-white dark:bg-gray-900">
@@ -137,7 +137,7 @@
                       class="w-16 px-1.5 py-0.5 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-center text-xs tabular-nums text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-400 focus:border-primary-400 outline-none"
                     />
                   </td>
-                  <td class="px-3 py-1.5 text-center font-semibold text-gray-900 dark:text-gray-100 tabular-nums border-l border-gray-200 dark:border-gray-700">{{ monthTotal(monthKey, 'missed') }}</td>
+                  <td class="px-3 py-1.5 text-center font-semibold text-gray-900 dark:text-gray-100 tabular-nums border-l border-gray-200 dark:border-gray-700">{{ monthTotal(monthKey, 'missed') || '' }}</td>
                 </tr>
                 <!-- Percentage row -->
                 <tr class="bg-gray-50/50 dark:bg-gray-800/30 border-b border-gray-200 dark:border-gray-700">
@@ -193,32 +193,39 @@ function monthLabel(key) { return MONTH_LABELS[key] || key }
 
 function ensureMonthProduct(monthKey, prod) {
   if (!data.value.months[monthKey]) data.value.months[monthKey] = {}
-  if (!data.value.months[monthKey][prod]) data.value.months[monthKey][prod] = { met: 0, missed: 0 }
+  if (!data.value.months[monthKey][prod]) data.value.months[monthKey][prod] = { met: null, missed: null }
 }
 
 function getVal(monthKey, prod, field) {
   ensureMonthProduct(monthKey, prod)
-  return data.value.months[monthKey][prod][field] || 0
+  var v = data.value.months[monthKey][prod][field]
+  return v === null || v === undefined ? '' : v
+}
+
+function getNumVal(monthKey, prod, field) {
+  ensureMonthProduct(monthKey, prod)
+  var v = data.value.months[monthKey][prod][field]
+  return (v === null || v === undefined) ? 0 : v
 }
 
 function setVal(monthKey, prod, field, event) {
   ensureMonthProduct(monthKey, prod)
-  var v = parseInt(event.target.value, 10)
-  data.value.months[monthKey][prod][field] = isNaN(v) ? 0 : Math.max(0, v)
+  var raw = event.target.value.trim()
+  data.value.months[monthKey][prod][field] = raw === '' ? null : Math.max(0, parseInt(raw, 10) || 0)
   dirty.value = true
 }
 
 function monthTotal(monthKey, field) {
   var sum = 0
   for (var i = 0; i < data.value.products.length; i++) {
-    sum += getVal(monthKey, data.value.products[i], field)
+    sum += getNumVal(monthKey, data.value.products[i], field)
   }
   return sum
 }
 
 function monthPct(monthKey, prod) {
-  var m = getVal(monthKey, prod, 'met')
-  var mi = getVal(monthKey, prod, 'missed')
+  var m = getNumVal(monthKey, prod, 'met')
+  var mi = getNumVal(monthKey, prod, 'missed')
   var total = m + mi
   if (total === 0) return ''
   return Math.round((m / total) * 100) + '%'

--- a/modules/okr-hub/client/components/CveSlaReport.vue
+++ b/modules/okr-hub/client/components/CveSlaReport.vue
@@ -1,0 +1,341 @@
+<template>
+  <div class="space-y-5">
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading CVE SLA data...</div>
+    <div v-else-if="error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ error }}</div>
+
+    <template v-else-if="data">
+      <!-- Summary Header -->
+      <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+        <div class="text-center">
+          <div class="text-4xl font-black tabular-nums" :class="overallPctClass">{{ overallPct }}%</div>
+          <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">YTD SLA</div>
+        </div>
+        <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+        <div class="flex items-center gap-5 text-sm">
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ totalMet }}</div>
+            <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">CVEs Met</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ totalMissed }}</div>
+            <div class="text-[10px] font-medium text-red-600 dark:text-red-400 uppercase">CVEs Missed</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.products.length }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Products</div>
+          </div>
+        </div>
+        <div class="ml-auto flex items-center gap-2">
+          <span v-if="dirty" class="text-xs text-amber-600 dark:text-amber-400 font-medium">Unsaved changes</span>
+          <button
+            v-if="dirty"
+            @click="save"
+            :disabled="saving"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-primary-600 text-white hover:bg-primary-700 transition-colors disabled:opacity-50"
+          >
+            <svg v-if="saving" class="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" class="opacity-25" /><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="4" stroke-linecap="round" class="opacity-75" /></svg>
+            {{ saving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Manage Products -->
+      <div class="flex items-center gap-2 flex-wrap">
+        <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Products:</span>
+        <span
+          v-for="(prod, pi) in data.products"
+          :key="prod"
+          class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs text-gray-700 dark:text-gray-300"
+        >
+          {{ prod }}
+          <button @click="removeProduct(pi)" class="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors" title="Remove product">
+            <svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" /></svg>
+          </button>
+        </span>
+        <button @click="showAddProduct = true" v-if="!showAddProduct" class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border border-dashed border-gray-300 dark:border-gray-600 text-xs text-gray-500 dark:text-gray-400 hover:border-primary-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors">
+          <svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" /></svg>
+          Add
+        </button>
+        <div v-if="showAddProduct" class="flex items-center gap-1">
+          <input
+            ref="addProductInput"
+            v-model="newProductName"
+            @keyup.enter="addProduct"
+            @keyup.escape="showAddProduct = false; newProductName = ''"
+            class="px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-xs text-gray-900 dark:text-gray-100 w-40"
+            placeholder="Product name"
+          />
+          <button @click="addProduct" class="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400">
+            <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" /></svg>
+          </button>
+          <button @click="showAddProduct = false; newProductName = ''" class="text-gray-400 hover:text-red-500">
+            <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" /></svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Quarter Sections -->
+      <div v-for="q in quarters" :key="q.label" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+        <!-- Quarter Header (clickable) -->
+        <button
+          @click="toggleQuarter(q.label)"
+          class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          <div class="flex items-center gap-3">
+            <svg
+              class="w-4 h-4 text-gray-400 transition-transform duration-200"
+              :class="{ 'rotate-90': openQuarters[q.label] }"
+              viewBox="0 0 20 20" fill="currentColor"
+            ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+            <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ q.label }} {{ data.year }}</span>
+          </div>
+          <span
+            class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full"
+            :class="quarterPctClass(quarterPct(q))"
+          >{{ quarterPct(q) }}%</span>
+        </button>
+
+        <!-- Quarter Table (collapsible) -->
+        <div v-show="openQuarters[q.label]" class="overflow-x-auto">
+          <table class="w-full text-xs border-collapse">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/60">
+                <th class="px-3 py-2 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36 sticky left-0 bg-gray-50 dark:bg-gray-800/60 z-10">Month</th>
+                <th
+                  v-for="prod in data.products"
+                  :key="prod"
+                  class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-[80px]"
+                >{{ prod }}</th>
+                <th class="px-3 py-2 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-20 border-l border-gray-200 dark:border-gray-700">Totals</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template v-for="monthKey in q.months" :key="monthKey">
+                <!-- Met row -->
+                <tr class="border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+                  <td class="px-3 py-1.5 font-medium text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-900 z-10">{{ monthLabel(monthKey) }} CVE Met</td>
+                  <td v-for="prod in data.products" :key="prod + '-met'" class="px-1 py-1 text-center">
+                    <input
+                      type="number"
+                      :value="getVal(monthKey, prod, 'met')"
+                      @input="setVal(monthKey, prod, 'met', $event)"
+                      min="0"
+                      class="w-16 px-1.5 py-0.5 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-center text-xs tabular-nums text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-400 focus:border-primary-400 outline-none"
+                    />
+                  </td>
+                  <td class="px-3 py-1.5 text-center font-semibold text-gray-900 dark:text-gray-100 tabular-nums border-l border-gray-200 dark:border-gray-700">{{ monthTotal(monthKey, 'met') }}</td>
+                </tr>
+                <!-- Missed row -->
+                <tr class="bg-white dark:bg-gray-900">
+                  <td class="px-3 py-1.5 font-medium text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-900 z-10">{{ monthLabel(monthKey) }} CVE Missed</td>
+                  <td v-for="prod in data.products" :key="prod + '-missed'" class="px-1 py-1 text-center">
+                    <input
+                      type="number"
+                      :value="getVal(monthKey, prod, 'missed')"
+                      @input="setVal(monthKey, prod, 'missed', $event)"
+                      min="0"
+                      class="w-16 px-1.5 py-0.5 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-center text-xs tabular-nums text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-400 focus:border-primary-400 outline-none"
+                    />
+                  </td>
+                  <td class="px-3 py-1.5 text-center font-semibold text-gray-900 dark:text-gray-100 tabular-nums border-l border-gray-200 dark:border-gray-700">{{ monthTotal(monthKey, 'missed') }}</td>
+                </tr>
+                <!-- Percentage row -->
+                <tr class="bg-gray-50/50 dark:bg-gray-800/30 border-b border-gray-200 dark:border-gray-700">
+                  <td class="px-3 py-1 sticky left-0 bg-gray-50/50 dark:bg-gray-800/30 z-10"></td>
+                  <td v-for="prod in data.products" :key="prod + '-pct'" class="px-1 py-1 text-center">
+                    <span class="text-[10px] font-bold tabular-nums" :class="cellPctClass(monthPct(monthKey, prod))">{{ monthPct(monthKey, prod) }}</span>
+                  </td>
+                  <td class="px-3 py-1 text-center border-l border-gray-200 dark:border-gray-700">
+                    <span class="text-[10px] font-bold tabular-nums" :class="cellPctClass(monthTotalPct(monthKey))">{{ monthTotalPct(monthKey) }}</span>
+                  </td>
+                </tr>
+              </template>
+              <!-- Quarter Total Row -->
+              <tr class="bg-amber-50 dark:bg-amber-900/20 border-t-2 border-amber-300 dark:border-amber-700">
+                <td class="px-3 py-2 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-amber-50 dark:bg-amber-900/20 z-10">{{ q.label }} {{ data.year }} Total</td>
+                <td :colspan="data.products.length" class="px-3 py-2"></td>
+                <td class="px-3 py-2 text-center border-l border-amber-300 dark:border-amber-700">
+                  <span class="text-sm font-black tabular-nums" :class="quarterPctClass(quarterPct(q))">{{ quarterPct(q) }}%</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+var MONTH_KEYS = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']
+var MONTH_LABELS = { jan: 'Jan', feb: 'Feb', mar: 'Mar', apr: 'Apr', may: 'May', jun: 'Jun', jul: 'Jul', aug: 'Aug', sep: 'Sep', oct: 'Oct', nov: 'Nov', dec: 'Dec' }
+
+var quarters = [
+  { label: 'Q1', months: ['jan', 'feb', 'mar'] },
+  { label: 'Q2', months: ['apr', 'may', 'jun'] },
+  { label: 'Q3', months: ['jul', 'aug', 'sep'] },
+  { label: 'Q4', months: ['oct', 'nov', 'dec'] }
+]
+
+var loading = ref(true)
+var error = ref(null)
+var data = ref(null)
+var dirty = ref(false)
+var saving = ref(false)
+var openQuarters = ref({ Q1: true, Q2: true, Q3: false, Q4: false })
+var showAddProduct = ref(false)
+var newProductName = ref('')
+var addProductInput = ref(null)
+
+function monthLabel(key) { return MONTH_LABELS[key] || key }
+
+function ensureMonthProduct(monthKey, prod) {
+  if (!data.value.months[monthKey]) data.value.months[monthKey] = {}
+  if (!data.value.months[monthKey][prod]) data.value.months[monthKey][prod] = { met: 0, missed: 0 }
+}
+
+function getVal(monthKey, prod, field) {
+  ensureMonthProduct(monthKey, prod)
+  return data.value.months[monthKey][prod][field] || 0
+}
+
+function setVal(monthKey, prod, field, event) {
+  ensureMonthProduct(monthKey, prod)
+  var v = parseInt(event.target.value, 10)
+  data.value.months[monthKey][prod][field] = isNaN(v) ? 0 : Math.max(0, v)
+  dirty.value = true
+}
+
+function monthTotal(monthKey, field) {
+  var sum = 0
+  for (var i = 0; i < data.value.products.length; i++) {
+    sum += getVal(monthKey, data.value.products[i], field)
+  }
+  return sum
+}
+
+function monthPct(monthKey, prod) {
+  var m = getVal(monthKey, prod, 'met')
+  var mi = getVal(monthKey, prod, 'missed')
+  var total = m + mi
+  if (total === 0) return ''
+  return Math.round((m / total) * 100) + '%'
+}
+
+function monthTotalPct(monthKey) {
+  var met = monthTotal(monthKey, 'met')
+  var missed = monthTotal(monthKey, 'missed')
+  var total = met + missed
+  if (total === 0) return ''
+  return Math.round((met / total) * 100) + '%'
+}
+
+function quarterPct(q) {
+  var met = 0
+  var missed = 0
+  for (var mi = 0; mi < q.months.length; mi++) {
+    met += monthTotal(q.months[mi], 'met')
+    missed += monthTotal(q.months[mi], 'missed')
+  }
+  var total = met + missed
+  if (total === 0) return 0
+  return Math.round((met / total) * 100)
+}
+
+var totalMet = computed(function() {
+  var sum = 0
+  for (var i = 0; i < MONTH_KEYS.length; i++) sum += monthTotal(MONTH_KEYS[i], 'met')
+  return sum
+})
+
+var totalMissed = computed(function() {
+  var sum = 0
+  for (var i = 0; i < MONTH_KEYS.length; i++) sum += monthTotal(MONTH_KEYS[i], 'missed')
+  return sum
+})
+
+var overallPct = computed(function() {
+  var total = totalMet.value + totalMissed.value
+  if (total === 0) return 0
+  return Math.round((totalMet.value / total) * 100)
+})
+
+var overallPctClass = computed(function() {
+  var p = overallPct.value
+  if (p === 100) return 'text-emerald-600 dark:text-emerald-400'
+  if (p >= 66) return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-red-600 dark:text-red-400'
+})
+
+function quarterPctClass(pct) {
+  if (pct === 100) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
+  if (pct >= 66) return 'text-yellow-700 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/40'
+  return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40'
+}
+
+function cellPctClass(val) {
+  if (!val) return 'text-gray-300 dark:text-gray-600'
+  var n = parseInt(val)
+  if (n === 100) return 'text-emerald-600 dark:text-emerald-400'
+  if (n >= 66) return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-red-600 dark:text-red-400'
+}
+
+function toggleQuarter(label) {
+  openQuarters.value[label] = !openQuarters.value[label]
+}
+
+function addProduct() {
+  var name = newProductName.value.trim()
+  if (!name || data.value.products.indexOf(name) !== -1) return
+  data.value.products.push(name)
+  dirty.value = true
+  newProductName.value = ''
+  showAddProduct.value = false
+}
+
+function removeProduct(index) {
+  var prod = data.value.products[index]
+  data.value.products.splice(index, 1)
+  for (var mk = 0; mk < MONTH_KEYS.length; mk++) {
+    var m = data.value.months[MONTH_KEYS[mk]]
+    if (m && m[prod]) delete m[prod]
+  }
+  dirty.value = true
+}
+
+async function save() {
+  saving.value = true
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/cve-sla', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data.value)
+    })
+    if (!res.ok) throw new Error('Save failed: ' + res.status)
+    dirty.value = false
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async function() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/cve-sla')
+    if (!res.ok) throw new Error('Failed to load CVE SLA data: ' + res.status)
+    data.value = await res.json()
+    if (!data.value.months) data.value.months = {}
+    for (var i = 0; i < MONTH_KEYS.length; i++) {
+      if (!data.value.months[MONTH_KEYS[i]]) data.value.months[MONTH_KEYS[i]] = {}
+    }
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/modules/okr-hub/client/components/OnTimeReleasesReport.vue
+++ b/modules/okr-hub/client/components/OnTimeReleasesReport.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="space-y-4">
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading release data...</div>
+    <div v-else-if="error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ error }}</div>
+
+    <template v-else-if="data">
+      <!-- Summary -->
+      <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+        <div class="text-center">
+          <div
+            class="text-4xl font-black tabular-nums"
+            :class="pctClass"
+          >{{ data.summary.pct }}%</div>
+          <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">On Time</div>
+        </div>
+        <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+        <div class="flex items-center gap-5 text-sm">
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.summary.onTime }}</div>
+            <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">On Time</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.summary.late }}</div>
+            <div class="text-[10px] font-medium text-red-600 dark:text-red-400 uppercase">Late</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.summary.upcoming }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Upcoming</div>
+          </div>
+        </div>
+        <div class="ml-auto text-xs text-gray-400 dark:text-gray-500">
+          Releases with planned GA after {{ data.since }}
+        </div>
+      </div>
+
+      <!-- Table -->
+      <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700">
+              <th class="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
+              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Planned GA</th>
+              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Actual GA</th>
+              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Status</th>
+              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Days Late</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="rel in data.releases"
+              :key="rel.id"
+              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+            >
+              <td class="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100">{{ rel.displayName }}</td>
+              <td class="px-4 py-3 text-center text-gray-600 dark:text-gray-400 tabular-nums">{{ formatDate(rel.plannedGa) }}</td>
+              <td class="px-4 py-3 text-center tabular-nums" :class="rel.actualGa ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'">
+                {{ rel.actualGa ? formatDate(rel.actualGa) : '—' }}
+              </td>
+              <td class="px-4 py-3 text-center">
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold"
+                  :class="statusBadgeClass(rel)"
+                >{{ statusLabel(rel) }}</span>
+              </td>
+              <td class="px-4 py-3 text-center tabular-nums" :class="daysLateClass(rel)">
+                {{ rel.daysLate != null ? (rel.daysLate <= 0 ? '0' : '+' + rel.daysLate) : '—' }}
+              </td>
+            </tr>
+            <tr v-if="!data.releases.length">
+              <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500 text-sm italic">
+                No releases found after {{ data.since }}.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+var loading = ref(true)
+var error = ref(null)
+var data = ref(null)
+
+var pctClass = computed(function() {
+  if (!data.value) return 'text-gray-400'
+  var pct = data.value.summary.pct
+  if (pct === 100) return 'text-emerald-600 dark:text-emerald-400'
+  if (pct >= 66) return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-red-600 dark:text-red-400'
+})
+
+function statusBadgeClass(rel) {
+  if (!rel.released) return 'bg-gray-100 dark:bg-gray-700/60 text-gray-500 dark:text-gray-400'
+  if (rel.onTime) return 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+  return 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+}
+
+function statusLabel(rel) {
+  if (!rel.released) return 'Upcoming'
+  if (rel.onTime) return 'On Time'
+  return 'Late'
+}
+
+function daysLateClass(rel) {
+  if (rel.daysLate == null) return 'text-gray-300 dark:text-gray-600'
+  if (rel.daysLate <= 0) return 'text-emerald-600 dark:text-emerald-400 font-semibold'
+  return 'text-red-600 dark:text-red-400 font-semibold'
+}
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  var d = new Date(iso + 'T00:00:00')
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+onMounted(async function() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/on-time-releases')
+    if (!res.ok) throw new Error('Failed to load report: ' + res.status)
+    data.value = await res.json()
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/modules/okr-hub/client/components/OnTimeReleasesReport.vue
+++ b/modules/okr-hub/client/components/OnTimeReleasesReport.vue
@@ -7,10 +7,7 @@
       <!-- Summary -->
       <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
         <div class="text-center">
-          <div
-            class="text-4xl font-black tabular-nums"
-            :class="pctClass"
-          >{{ data.summary.pct }}%</div>
+          <div class="text-4xl font-black tabular-nums" :class="pctClass">{{ data.summary.pct }}%</div>
           <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">On Time</div>
         </div>
         <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
@@ -28,51 +25,127 @@
             <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Upcoming</div>
           </div>
         </div>
-        <div class="ml-auto text-xs text-gray-400 dark:text-gray-500">
-          Releases with planned GA after {{ data.since }}
+        <div class="ml-auto flex items-center gap-3">
+          <span class="text-xs text-gray-400 dark:text-gray-500">Releases with planned GA after {{ data.since }}</span>
+          <button
+            @click="showSettings = !showSettings"
+            class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            title="Manage releases"
+          >
+            <svg class="w-5 h-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.331 1.652a6.993 6.993 0 011.929 1.115l1.598-.54a1 1 0 011.186.447l1.18 2.044a1 1 0 01-.205 1.251l-1.267 1.113a7.047 7.047 0 010 2.228l1.267 1.113a1 1 0 01.206 1.25l-1.18 2.045a1 1 0 01-1.187.447l-1.598-.54a6.993 6.993 0 01-1.929 1.115l-.33 1.652a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.331-1.652a6.993 6.993 0 01-1.929-1.115l-1.598.54a1 1 0 01-1.186-.447l-1.18-2.044a1 1 0 01.205-1.251l1.267-1.114a7.05 7.05 0 010-2.227L1.821 7.773a1 1 0 01-.206-1.25l1.18-2.045a1 1 0 011.187-.447l1.598.54A6.993 6.993 0 017.51 3.456l.33-1.652zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+            </svg>
+          </button>
         </div>
       </div>
 
-      <!-- Table -->
-      <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-        <table class="w-full text-sm border-collapse">
-          <thead>
-            <tr class="bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700">
-              <th class="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
-              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Planned GA</th>
-              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Actual GA</th>
-              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Status</th>
-              <th class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Days Late</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="rel in data.releases"
-              :key="rel.id"
-              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+      <!-- Settings Panel -->
+      <div v-if="showSettings" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg overflow-hidden">
+        <div class="px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <span class="text-sm font-bold text-gray-900 dark:text-gray-100">Manage Releases</span>
+          <button @click="addCustomRelease" class="text-xs font-semibold text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">+ Add Release</button>
+        </div>
+        <div class="divide-y divide-gray-100 dark:divide-gray-800 max-h-96 overflow-y-auto">
+          <div v-for="(entry, idx) in settingsEntries" :key="entry.id" class="px-5 py-3 flex items-center gap-3" :class="entry.removed ? 'opacity-40' : ''">
+            <div class="flex-1 grid grid-cols-3 gap-3">
+              <div>
+                <label class="text-[10px] font-semibold text-gray-400 uppercase">Name</label>
+                <input
+                  v-model="entry.displayName"
+                  class="mt-0.5 w-full text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                  placeholder="Release name"
+                />
+              </div>
+              <div>
+                <label class="text-[10px] font-semibold text-gray-400 uppercase">Planned GA</label>
+                <input
+                  v-model="entry.plannedGa"
+                  type="date"
+                  class="mt-0.5 w-full text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                />
+              </div>
+              <div>
+                <label class="text-[10px] font-semibold text-gray-400 uppercase">Actual GA</label>
+                <input
+                  v-model="entry.actualGa"
+                  type="date"
+                  class="mt-0.5 w-full text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                />
+              </div>
+            </div>
+            <button
+              @click="toggleRemove(idx)"
+              class="mt-4 p-1 rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+              :title="entry.removed ? 'Restore' : 'Remove'"
             >
-              <td class="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100">{{ rel.displayName }}</td>
-              <td class="px-4 py-3 text-center text-gray-600 dark:text-gray-400 tabular-nums">{{ formatDate(rel.plannedGa) }}</td>
-              <td class="px-4 py-3 text-center tabular-nums" :class="rel.actualGa ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'">
-                {{ rel.actualGa ? formatDate(rel.actualGa) : '—' }}
-              </td>
-              <td class="px-4 py-3 text-center">
-                <span
-                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold"
-                  :class="statusBadgeClass(rel)"
-                >{{ statusLabel(rel) }}</span>
-              </td>
-              <td class="px-4 py-3 text-center tabular-nums" :class="daysLateClass(rel)">
-                {{ rel.daysLate != null ? (rel.daysLate <= 0 ? '0' : '+' + rel.daysLate) : '—' }}
-              </td>
-            </tr>
-            <tr v-if="!data.releases.length">
-              <td colspan="5" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500 text-sm italic">
-                No releases found after {{ data.since }}.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              <svg v-if="!entry.removed" class="w-4 h-4 text-red-400 hover:text-red-600" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.519.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 01.78.72l.5 6.5a.75.75 0 01-1.49.12l-.5-6.5a.75.75 0 01.71-.84zm3.62.72a.75.75 0 10-1.49-.12l-.5 6.5a.75.75 0 101.49.12l.5-6.5z" clip-rule="evenodd" /></svg>
+              <svg v-else class="w-4 h-4 text-emerald-500 hover:text-emerald-600" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H4.598a.75.75 0 00-.75.75v3.634a.75.75 0 001.5 0v-2.033l.312.312a7 7 0 0011.712-3.138.75.75 0 00-1.06-.18zm-1.024-7.848a7 7 0 00-11.712 3.138.75.75 0 001.06.18 5.5 5.5 0 019.201-2.466l.312.311h-2.433a.75.75 0 000 1.5h3.634a.75.75 0 00.75-.75V1.855a.75.75 0 00-1.5 0v2.033l-.312-.312z" clip-rule="evenodd" /></svg>
+            </button>
+          </div>
+          <div v-if="settingsEntries.length === 0" class="px-5 py-6 text-center text-sm text-gray-400 italic">No releases configured.</div>
+        </div>
+        <div class="px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-2">
+          <button @click="cancelSettings" class="px-3 py-1.5 text-xs font-semibold text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors">Cancel</button>
+          <button @click="saveSettings" :disabled="saving" class="px-4 py-1.5 text-xs font-bold text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors disabled:opacity-50">{{ saving ? 'Saving...' : 'Save' }}</button>
+        </div>
+      </div>
+
+      <!-- Quarterly Collapsibles -->
+      <div v-for="q in quarters" :key="q.label" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+        <button
+          @click="toggleQuarter(q.label)"
+          class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          <div class="flex items-center gap-3">
+            <svg
+              class="w-4 h-4 text-gray-400 transition-transform duration-200"
+              :class="{ 'rotate-90': openQuarters[q.label] }"
+              viewBox="0 0 20 20" fill="currentColor"
+            ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+            <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ q.label }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ q.releases.length }} release{{ q.releases.length !== 1 ? 's' : '' }}</span>
+          </div>
+          <span class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="quarterBadgeClass(q)">{{ q.pct !== null ? q.pct + '%' : '—' }}</span>
+        </button>
+
+        <div v-show="openQuarters[q.label]" class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/60">
+                <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Planned GA</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-36">Actual GA</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Status</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Days Late</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="rel in q.releases"
+                :key="rel.id"
+                class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+              >
+                <td class="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100">
+                  {{ rel.displayName }}
+                  <span v-if="rel.custom" class="ml-1 text-[9px] font-bold text-primary-500 uppercase">custom</span>
+                </td>
+                <td class="px-4 py-3 text-center text-gray-600 dark:text-gray-400 tabular-nums">{{ formatDate(rel.plannedGa) }}</td>
+                <td class="px-4 py-3 text-center tabular-nums" :class="rel.actualGa ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'">
+                  {{ rel.actualGa ? formatDate(rel.actualGa) : '—' }}
+                </td>
+                <td class="px-4 py-3 text-center">
+                  <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold" :class="statusBadgeClass(rel)">{{ statusLabel(rel) }}</span>
+                </td>
+                <td class="px-4 py-3 text-center tabular-nums" :class="daysLateClass(rel)">
+                  {{ rel.daysLate != null ? (rel.daysLate <= 0 ? '0' : '+' + rel.daysLate) : '—' }}
+                </td>
+              </tr>
+              <tr v-if="q.releases.length === 0">
+                <td colspan="5" class="px-4 py-6 text-center text-gray-400 dark:text-gray-500 text-sm italic">No releases in this quarter.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </template>
   </div>
@@ -84,6 +157,10 @@ import { ref, computed, onMounted } from 'vue'
 var loading = ref(true)
 var error = ref(null)
 var data = ref(null)
+var openQuarters = ref({})
+var showSettings = ref(false)
+var saving = ref(false)
+var settingsEntries = ref([])
 
 var pctClass = computed(function() {
   if (!data.value) return 'text-gray-400'
@@ -92,6 +169,49 @@ var pctClass = computed(function() {
   if (pct >= 66) return 'text-yellow-600 dark:text-yellow-400'
   return 'text-red-600 dark:text-red-400'
 })
+
+var quarters = computed(function() {
+  if (!data.value || !data.value.releases) return []
+  var map = {}
+  for (var i = 0; i < data.value.releases.length; i++) {
+    var rel = data.value.releases[i]
+    var d = new Date(rel.plannedGa + 'T00:00:00')
+    var year = d.getFullYear()
+    var qNum = Math.floor(d.getMonth() / 3) + 1
+    var label = 'Q' + qNum + ' ' + year
+    if (!map[label]) {
+      map[label] = { label: label, releases: [], sortKey: year * 10 + qNum }
+    }
+    map[label].releases.push(rel)
+  }
+  var result = Object.keys(map).map(function(k) { return map[k] })
+  result.sort(function(a, b) { return a.sortKey - b.sortKey })
+  for (var qi = 0; qi < result.length; qi++) {
+    var q = result[qi]
+    var released = 0
+    var onTime = 0
+    for (var ri = 0; ri < q.releases.length; ri++) {
+      if (q.releases[ri].released) {
+        released++
+        if (q.releases[ri].onTime) onTime++
+      }
+    }
+    q.pct = released > 0 ? Math.round((onTime / released) * 100) : null
+    delete q.sortKey
+  }
+  return result
+})
+
+function quarterBadgeClass(q) {
+  if (q.pct === null) return 'text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700/60'
+  if (q.pct === 100) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
+  if (q.pct >= 66) return 'text-yellow-700 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/40'
+  return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40'
+}
+
+function toggleQuarter(label) {
+  openQuarters.value[label] = !openQuarters.value[label]
+}
 
 function statusBadgeClass(rel) {
   if (!rel.released) return 'bg-gray-100 dark:bg-gray-700/60 text-gray-500 dark:text-gray-400'
@@ -118,15 +238,104 @@ function formatDate(iso) {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
-onMounted(async function() {
+function addCustomRelease() {
+  settingsEntries.value.push({
+    id: 'custom-' + Date.now(),
+    displayName: '',
+    plannedGa: '',
+    actualGa: '',
+    custom: true,
+    removed: false
+  })
+}
+
+function toggleRemove(idx) {
+  settingsEntries.value[idx].removed = !settingsEntries.value[idx].removed
+}
+
+function cancelSettings() {
+  showSettings.value = false
+  loadSettingsEntries()
+}
+
+async function saveSettings() {
+  saving.value = true
+  try {
+    var payload = {
+      releases: settingsEntries.value.map(function(e) {
+        var entry = { id: e.id, displayName: e.displayName, plannedGa: e.plannedGa, actualGa: e.actualGa || null }
+        if (e.custom) entry.custom = true
+        if (e.removed) entry.removed = true
+        return entry
+      })
+    }
+    var res = await fetch('/api/modules/okr-hub/reports/on-time-releases/overrides', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!res.ok) throw new Error('Save failed: ' + res.status)
+    showSettings.value = false
+    await loadData()
+  } catch (err) {
+    alert('Failed to save: ' + err.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function loadSettingsEntries() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/on-time-releases/overrides')
+    if (res.ok) {
+      var result = await res.json()
+      settingsEntries.value = (result.releases || []).map(function(r) {
+        return { id: r.id, displayName: r.displayName || '', plannedGa: r.plannedGa || '', actualGa: r.actualGa || '', custom: r.custom || false, removed: r.removed || false }
+      })
+    }
+  } catch (loadErr) {
+    console.warn('[okr-hub] Failed to load overrides:', loadErr.message)
+    /* ignore */
+  }
+
+  if (data.value && data.value.releases) {
+    var existingIds = {}
+    for (var i = 0; i < settingsEntries.value.length; i++) {
+      existingIds[settingsEntries.value[i].id] = true
+    }
+    for (var j = 0; j < data.value.releases.length; j++) {
+      var rel = data.value.releases[j]
+      if (!existingIds[rel.id] && !rel.custom) {
+        settingsEntries.value.push({
+          id: rel.id,
+          displayName: rel.displayName,
+          plannedGa: rel.plannedGa,
+          actualGa: rel.actualGa || '',
+          custom: false,
+          removed: false
+        })
+      }
+    }
+  }
+}
+
+async function loadData() {
   try {
     var res = await fetch('/api/modules/okr-hub/reports/on-time-releases')
     if (!res.ok) throw new Error('Failed to load report: ' + res.status)
     data.value = await res.json()
+
+    var now = new Date()
+    var currentQ = 'Q' + (Math.floor(now.getMonth() / 3) + 1) + ' ' + now.getFullYear()
+    openQuarters.value[currentQ] = true
   } catch (err) {
     error.value = err.message
-  } finally {
-    loading.value = false
   }
+}
+
+onMounted(async function() {
+  await loadData()
+  await loadSettingsEntries()
+  loading.value = false
 })
 </script>

--- a/modules/okr-hub/client/components/SupportCaseReport.vue
+++ b/modules/okr-hub/client/components/SupportCaseReport.vue
@@ -1,0 +1,370 @@
+<template>
+  <div class="space-y-4">
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading support case data...</div>
+    <div v-else-if="error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ error }}</div>
+
+    <template v-else-if="data">
+      <!-- Summary Header -->
+      <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+        <div class="text-center">
+          <div class="text-4xl font-black tabular-nums" :class="overallDefectRateClass">{{ overallDefectRate }}%</div>
+          <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">Defect Rate</div>
+        </div>
+        <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+        <div class="flex items-center gap-5 text-sm">
+          <div class="text-center">
+            <div class="text-lg font-bold tabular-nums" :class="overallAvgResClass">{{ overallAvgRes }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Avg Resolution (days)</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold tabular-nums" :class="overallMedianResClass">{{ overallMedianRes }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Median Resolution (days)</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ overallTotalCases }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Total Cases</div>
+          </div>
+        </div>
+        <div class="ml-auto flex items-center gap-3">
+          <div class="text-right text-xs text-gray-400 dark:text-gray-500">
+            <div>Defect Rate Target: &lt;= 10%</div>
+            <div>Resolution Target: 10-14 days</div>
+          </div>
+          <button @click="openSettings" class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="Edit data">
+            <svg class="w-5 h-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.331 1.652a6.993 6.993 0 011.929 1.115l1.598-.54a1 1 0 011.186.447l1.18 2.044a1 1 0 01-.205 1.251l-1.267 1.113a7.047 7.047 0 010 2.228l1.267 1.113a1 1 0 01.206 1.25l-1.18 2.045a1 1 0 01-1.187.447l-1.598-.54a6.993 6.993 0 01-1.929 1.115l-.33 1.652a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.331-1.652a6.993 6.993 0 01-1.929-1.115l-1.598.54a1 1 0 01-1.186-.447l-1.18-2.044a1 1 0 01.205-1.251l1.267-1.114a7.05 7.05 0 010-2.227L1.821 7.773a1 1 0 01-.206-1.25l1.18-2.045a1 1 0 011.187-.447l1.598.54A6.993 6.993 0 017.51 3.456l.33-1.652zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Settings Panel -->
+      <div v-if="showSettings" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg overflow-hidden">
+        <div class="px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <span class="text-sm font-bold text-gray-900 dark:text-gray-100">Edit Support Case Data</span>
+          <div class="flex gap-1">
+            <button v-for="qKey in quarterKeys" :key="qKey" @click="editQuarter = qKey"
+              class="px-3 py-1 text-xs font-semibold rounded-md transition-colors"
+              :class="editQuarter === qKey ? 'bg-primary-600 text-white' : 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700'">{{ qKey }} {{ data.year }}</button>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-xs border-collapse">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/60">
+                <th class="px-3 py-2 text-left text-[10px] font-semibold text-gray-500 uppercase">Product</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-20">Total Cases</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-16">Defects</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-20">Cases Closed</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-20">Bugs (ENG)</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-14">RFE</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-20">Support Ex</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-14">Other</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-20">Avg Res (days)</th>
+                <th class="px-2 py-2 text-center text-[10px] font-semibold text-gray-500 uppercase w-20">Median Res (days)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="product in data.products" :key="product" class="border-b border-gray-100 dark:border-gray-800">
+                <td class="px-3 py-2 font-medium text-gray-900 dark:text-gray-100">{{ product }}</td>
+                <td class="px-1 py-1" v-for="field in editFields" :key="field">
+                  <input
+                    :value="getEditVal(product, field)"
+                    @input="setEditVal(product, field, $event.target.value)"
+                    type="number" step="any"
+                    class="w-full text-center text-xs rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-1 py-1 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-2">
+          <button @click="cancelSettings" class="px-3 py-1.5 text-xs font-semibold text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors">Cancel</button>
+          <button @click="saveSettings" :disabled="saving" class="px-4 py-1.5 text-xs font-bold text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors disabled:opacity-50">{{ saving ? 'Saving...' : 'Save' }}</button>
+        </div>
+      </div>
+
+      <!-- Q1-Q4 Collapsibles -->
+      <div v-for="qKey in quarterKeys" :key="qKey" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+        <button
+          @click="toggleQuarter(qKey)"
+          class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          <div class="flex items-center gap-3">
+            <svg class="w-4 h-4 text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': openQuarters[qKey] }" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+            <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ qKey }} {{ data.year }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ quarterSummaryText(qKey) }}</span>
+          </div>
+          <span class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="defectRateBadgeClass(quarterDefectRate(qKey))">{{ quarterDefectRate(qKey) }}%</span>
+        </button>
+
+        <div v-show="openQuarters[qKey]" class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/60">
+                <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Product</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Total Cases</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Defects</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Defect Rate</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Cases Closed</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Bugs (ENG)</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">RFE</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Support Ex</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Other</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Avg Res (days)</th>
+                <th class="px-3 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Median Res (days)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="product in data.products" :key="product" class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                <td class="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100">{{ product }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'totalCases') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'defects') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums font-semibold" :class="defectRateColorClass(productDefectRate(qKey, product))">{{ productDefectRate(qKey, product) }}%</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'casesClosed') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'bugsEng') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'rfe') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'supportEx') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ displayVal(qKey, product, 'other') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums font-semibold" :class="resolutionColorClass(getNum(qKey, product, 'avgResolutionDays'))">{{ displayVal(qKey, product, 'avgResolutionDays') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums font-semibold" :class="resolutionColorClass(getNum(qKey, product, 'medianResolutionDays'))">{{ displayVal(qKey, product, 'medianResolutionDays') }}</td>
+              </tr>
+              <!-- TOTAL row -->
+              <tr class="bg-gray-50 dark:bg-gray-800/60 font-bold border-t-2 border-gray-300 dark:border-gray-600">
+                <td class="px-4 py-2.5 text-gray-900 dark:text-gray-100">TOTAL</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'totalCases') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'defects') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums" :class="defectRateColorClass(quarterDefectRate(qKey))">{{ quarterDefectRate(qKey) }}%</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'casesClosed') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'bugsEng') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'rfe') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'supportEx') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ quarterTotal(qKey, 'other') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums" :class="resolutionColorClass(quarterAvg(qKey, 'avgResolutionDays'))">{{ quarterAvgDisplay(qKey, 'avgResolutionDays') }}</td>
+                <td class="px-3 py-2.5 text-center tabular-nums" :class="resolutionColorClass(quarterAvg(qKey, 'medianResolutionDays'))">{{ quarterAvgDisplay(qKey, 'medianResolutionDays') }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+var loading = ref(true)
+var error = ref(null)
+var data = ref(null)
+var openQuarters = ref({})
+var showSettings = ref(false)
+var saving = ref(false)
+var editQuarter = ref('Q1')
+var editData = ref(null)
+var quarterKeys = ['Q1', 'Q2', 'Q3', 'Q4']
+var editFields = ['totalCases', 'defects', 'casesClosed', 'bugsEng', 'rfe', 'supportEx', 'other', 'avgResolutionDays', 'medianResolutionDays']
+
+function getNum(qKey, product, field) {
+  if (!data.value || !data.value.quarters[qKey] || !data.value.quarters[qKey][product]) return null
+  var v = data.value.quarters[qKey][product][field]
+  return v != null ? v : null
+}
+
+function displayVal(qKey, product, field) {
+  var v = getNum(qKey, product, field)
+  if (v == null) return ''
+  if (field === 'avgResolutionDays' || field === 'medianResolutionDays') return Number(v).toFixed(1)
+  return v
+}
+
+function productDefectRate(qKey, product) {
+  var total = getNum(qKey, product, 'totalCases')
+  var defects = getNum(qKey, product, 'defects')
+  if (!total || total === 0) return '—'
+  return ((defects || 0) / total * 100).toFixed(1)
+}
+
+function quarterTotal(qKey, field) {
+  if (!data.value || !data.value.quarters[qKey]) return 0
+  var sum = 0
+  var hasAny = false
+  for (var i = 0; i < data.value.products.length; i++) {
+    var p = data.value.products[i]
+    var v = getNum(qKey, p, field)
+    if (v != null) { sum += v; hasAny = true }
+  }
+  return hasAny ? sum : ''
+}
+
+function quarterDefectRate(qKey) {
+  var total = quarterTotal(qKey, 'totalCases')
+  var defects = quarterTotal(qKey, 'defects')
+  if (!total || total === 0) return '—'
+  return ((defects || 0) / total * 100).toFixed(1)
+}
+
+function quarterAvg(qKey, field) {
+  if (!data.value || !data.value.quarters[qKey]) return null
+  var sum = 0
+  var count = 0
+  for (var i = 0; i < data.value.products.length; i++) {
+    var v = getNum(qKey, data.value.products[i], field)
+    if (v != null && v > 0) { sum += v; count++ }
+  }
+  return count > 0 ? sum / count : null
+}
+
+function quarterAvgDisplay(qKey, field) {
+  var avg = quarterAvg(qKey, field)
+  return avg != null ? avg.toFixed(1) : ''
+}
+
+function quarterSummaryText(qKey) {
+  var total = quarterTotal(qKey, 'totalCases')
+  if (!total) return 'No data'
+  return total + ' cases, ' + quarterTotal(qKey, 'defects') + ' defects'
+}
+
+var overallDefectRate = computed(function() {
+  if (!data.value) return '—'
+  var totalCases = 0
+  var totalDefects = 0
+  for (var qi = 0; qi < quarterKeys.length; qi++) {
+    var t = quarterTotal(quarterKeys[qi], 'totalCases')
+    var d = quarterTotal(quarterKeys[qi], 'defects')
+    if (typeof t === 'number') totalCases += t
+    if (typeof d === 'number') totalDefects += d
+  }
+  if (totalCases === 0) return '—'
+  return ((totalDefects / totalCases) * 100).toFixed(1)
+})
+
+var overallDefectRateClass = computed(function() {
+  var v = parseFloat(overallDefectRate.value)
+  if (isNaN(v)) return 'text-gray-400'
+  return v <= 10 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+})
+
+var overallTotalCases = computed(function() {
+  if (!data.value) return 0
+  var total = 0
+  for (var qi = 0; qi < quarterKeys.length; qi++) {
+    var t = quarterTotal(quarterKeys[qi], 'totalCases')
+    if (typeof t === 'number') total += t
+  }
+  return total
+})
+
+var overallAvgRes = computed(function() {
+  return computeOverallAvg('avgResolutionDays')
+})
+
+var overallMedianRes = computed(function() {
+  return computeOverallAvg('medianResolutionDays')
+})
+
+var overallAvgResClass = computed(function() {
+  var v = parseFloat(overallAvgRes.value)
+  if (isNaN(v)) return 'text-gray-400'
+  return v <= 14 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+})
+
+var overallMedianResClass = computed(function() {
+  var v = parseFloat(overallMedianRes.value)
+  if (isNaN(v)) return 'text-gray-400'
+  return v <= 14 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+})
+
+function computeOverallAvg(field) {
+  if (!data.value) return '—'
+  var sum = 0
+  var count = 0
+  for (var qi = 0; qi < quarterKeys.length; qi++) {
+    var avg = quarterAvg(quarterKeys[qi], field)
+    if (avg != null) { sum += avg; count++ }
+  }
+  return count > 0 ? (sum / count).toFixed(1) : '—'
+}
+
+function defectRateColorClass(rate) {
+  var v = parseFloat(rate)
+  if (isNaN(v)) return 'text-gray-400'
+  return v <= 10 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+}
+
+function defectRateBadgeClass(rate) {
+  var v = parseFloat(rate)
+  if (isNaN(v)) return 'text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700/60'
+  if (v <= 10) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
+  return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40'
+}
+
+function resolutionColorClass(val) {
+  if (val == null) return 'text-gray-400'
+  return val <= 14 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+}
+
+function toggleQuarter(qKey) {
+  openQuarters.value[qKey] = !openQuarters.value[qKey]
+}
+
+function getEditVal(product, field) {
+  if (!editData.value || !editData.value[editQuarter.value] || !editData.value[editQuarter.value][product]) return ''
+  var v = editData.value[editQuarter.value][product][field]
+  return v != null ? v : ''
+}
+
+function setEditVal(product, field, rawVal) {
+  if (!editData.value[editQuarter.value]) editData.value[editQuarter.value] = {}
+  if (!editData.value[editQuarter.value][product]) editData.value[editQuarter.value][product] = {}
+  var val = rawVal === '' ? null : parseFloat(rawVal)
+  editData.value[editQuarter.value][product][field] = isNaN(val) ? null : val
+}
+
+function openSettings() {
+  editData.value = JSON.parse(JSON.stringify(data.value.quarters))
+  editQuarter.value = 'Q1'
+  showSettings.value = true
+}
+
+function cancelSettings() {
+  showSettings.value = false
+}
+
+async function saveSettings() {
+  saving.value = true
+  try {
+    var payload = { year: data.value.year, products: data.value.products, quarters: editData.value }
+    var res = await fetch('/api/modules/okr-hub/reports/support-cases', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!res.ok) throw new Error('Save failed: ' + res.status)
+    data.value = payload
+    showSettings.value = false
+  } catch (err) {
+    alert('Failed to save: ' + err.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async function() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/support-cases')
+    if (!res.ok) throw new Error('Failed to load report: ' + res.status)
+    data.value = await res.json()
+
+    var now = new Date()
+    var currentQ = 'Q' + (Math.floor(now.getMonth() / 3) + 1)
+    openQuarters.value[currentQ] = true
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/modules/okr-hub/client/components/TechVisibilityReport.vue
+++ b/modules/okr-hub/client/components/TechVisibilityReport.vue
@@ -1,116 +1,254 @@
 <template>
   <div class="space-y-5">
-    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading visibility data from Google Sheets...</div>
-    <div v-else-if="error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ error }}</div>
+    <!-- KR1: Weekly Posts -->
+    <div class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+      <button
+        @click="kr1Open = !kr1Open"
+        class="w-full flex items-center justify-between px-5 py-4 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <div class="flex items-center gap-3">
+          <svg
+            class="w-4 h-4 text-gray-400 transition-transform duration-200"
+            :class="{ 'rotate-90': kr1Open }"
+            viewBox="0 0 20 20" fill="currentColor"
+          ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+          <div>
+            <div class="text-sm font-bold text-gray-900 dark:text-gray-100">KR1: Weekly Posts</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">>= 5 posts/week across internal and external sources</div>
+          </div>
+        </div>
+        <span v-if="kr1Data" class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="pctBadgeClass(kr1Data.overall.pct)">{{ kr1Data.overall.pct }}%</span>
+        <span v-else-if="kr1Loading" class="text-xs text-gray-400">Loading...</span>
+      </button>
 
-    <template v-else-if="data">
-      <!-- Summary Header -->
-      <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
-        <div class="text-center">
-          <div class="text-4xl font-black tabular-nums" :class="overallPctClass">{{ data.overall.pct }}%</div>
-          <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">Weeks Met</div>
-        </div>
-        <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
-        <div class="flex items-center gap-5 text-sm">
-          <div class="text-center">
-            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.overall.weeksMet }}</div>
-            <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">Met Target</div>
+      <div v-show="kr1Open" class="p-5 space-y-4 bg-white dark:bg-gray-900">
+        <div v-if="kr1Loading" class="text-sm text-gray-500 dark:text-gray-400">Loading weekly posts data...</div>
+        <div v-else-if="kr1Error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ kr1Error }}</div>
+        <template v-else-if="kr1Data">
+          <!-- Summary -->
+          <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+            <div class="text-center">
+              <div class="text-4xl font-black tabular-nums" :class="pctColorClass(kr1Data.overall.pct)">{{ kr1Data.overall.pct }}%</div>
+              <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">Weeks Met</div>
+            </div>
+            <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+            <div class="flex items-center gap-5 text-sm">
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ kr1Data.overall.weeksMet }}</div>
+                <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">Met Target</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ kr1Data.overall.totalWeeks - kr1Data.overall.weeksMet }}</div>
+                <div class="text-[10px] font-medium text-red-600 dark:text-red-400 uppercase">Missed</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ kr1Data.overall.totalWeeks }}</div>
+                <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Total Weeks</div>
+              </div>
+            </div>
+            <div class="ml-auto text-xs text-gray-400 dark:text-gray-500">Target: >= {{ kr1Data.target }} posts/week</div>
           </div>
-          <div class="text-center">
-            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.overall.totalWeeks - data.overall.weeksMet }}</div>
-            <div class="text-[10px] font-medium text-red-600 dark:text-red-400 uppercase">Missed</div>
+
+          <!-- Quarter sections -->
+          <div v-for="q in kr1Data.quarters" :key="q.label" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <button
+              @click="toggleSection('kr1-' + q.label)"
+              class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <div class="flex items-center gap-3">
+                <svg class="w-4 h-4 text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': openSections['kr1-' + q.label] }" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+                <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ q.label }}</span>
+                <span class="text-xs text-gray-500 dark:text-gray-400">{{ q.weeksMet }} of {{ q.totalWeeks }} weeks met</span>
+              </div>
+              <span class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="pctBadgeClass(q.pct)">{{ q.pct }}%</span>
+            </button>
+            <div v-show="openSections['kr1-' + q.label]" class="overflow-x-auto">
+              <table class="w-full text-sm border-collapse">
+                <thead>
+                  <tr class="bg-gray-50 dark:bg-gray-800/60">
+                    <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Week Of</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Articles</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="week in q.weeks" :key="week.weekOf" class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                    <td class="px-4 py-2.5 text-gray-700 dark:text-gray-300">{{ formatDate(week.weekOf) }}</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums font-semibold" :class="week.met ? 'text-gray-900 dark:text-gray-100' : 'text-red-600 dark:text-red-400'">{{ week.count }}</td>
+                    <td class="px-4 py-2.5 text-center">
+                      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold" :class="week.met ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300' : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'">{{ week.met ? 'Met' : 'Missed' }}</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
-          <div class="text-center">
-            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.overall.totalWeeks }}</div>
-            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Total Weeks</div>
+
+          <div v-if="kr1Data.source" class="text-xs text-gray-400 dark:text-gray-500 text-center">
+            Source: Google Sheets tab "{{ kr1Data.source }}" | Last fetched: {{ formatDateTime(kr1Data.fetchedAt) }}
           </div>
-        </div>
-        <div class="ml-auto text-xs text-gray-400 dark:text-gray-500">
-          Target: >= {{ data.target }} posts/week
-        </div>
+        </template>
       </div>
+    </div>
 
-      <!-- Quarter Sections -->
-      <div v-for="q in data.quarters" :key="q.label" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
-        <button
-          @click="toggleQuarter(q.label)"
-          class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-        >
-          <div class="flex items-center gap-3">
-            <svg
-              class="w-4 h-4 text-gray-400 transition-transform duration-200"
-              :class="{ 'rotate-90': openQuarters[q.label] }"
-              viewBox="0 0 20 20" fill="currentColor"
-            ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
-            <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ q.label }}</span>
-            <span class="text-xs text-gray-500 dark:text-gray-400">{{ q.weeksMet }} of {{ q.totalWeeks }} weeks met</span>
+    <!-- KR2: Associate Content Contributions -->
+    <div class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+      <button
+        @click="kr2Open = !kr2Open"
+        class="w-full flex items-center justify-between px-5 py-4 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <div class="flex items-center gap-3">
+          <svg
+            class="w-4 h-4 text-gray-400 transition-transform duration-200"
+            :class="{ 'rotate-90': kr2Open }"
+            viewBox="0 0 20 20" fill="currentColor"
+          ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+          <div>
+            <div class="text-sm font-bold text-gray-900 dark:text-gray-100">KR2: Associate Content Contributions</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">1 piece of content per AI Eng associate for the year (blog, demo, tutorial)</div>
           </div>
-          <span
-            class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full"
-            :class="pctBadgeClass(q.pct)"
-          >{{ q.pct }}%</span>
-        </button>
-
-        <div v-show="openQuarters[q.label]" class="overflow-x-auto">
-          <table class="w-full text-sm border-collapse">
-            <thead>
-              <tr class="bg-gray-50 dark:bg-gray-800/60">
-                <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Week Of</th>
-                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Articles</th>
-                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="week in q.weeks"
-                :key="week.weekOf"
-                class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-              >
-                <td class="px-4 py-2.5 text-gray-700 dark:text-gray-300">{{ formatDate(week.weekOf) }}</td>
-                <td class="px-4 py-2.5 text-center tabular-nums font-semibold" :class="week.met ? 'text-gray-900 dark:text-gray-100' : 'text-red-600 dark:text-red-400'">{{ week.count }}</td>
-                <td class="px-4 py-2.5 text-center">
-                  <span
-                    class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold"
-                    :class="week.met ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300' : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'"
-                  >{{ week.met ? 'Met' : 'Missed' }}</span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
         </div>
-      </div>
+        <span v-if="kr2Data" class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="pctBadgeClass(kr2Data.overall.pct)">{{ kr2Data.overall.pct }}%</span>
+        <span v-else-if="kr2Loading" class="text-xs text-gray-400">Loading...</span>
+      </button>
 
-      <div v-if="data.source" class="text-xs text-gray-400 dark:text-gray-500 text-center">
-        Source: Google Sheets tab "{{ data.source }}" | Last fetched: {{ formatDateTime(data.fetchedAt) }}
+      <div v-show="kr2Open" class="p-5 space-y-4 bg-white dark:bg-gray-900">
+        <div v-if="kr2Loading" class="text-sm text-gray-500 dark:text-gray-400">Loading content contributions data...</div>
+        <div v-else-if="kr2Error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ kr2Error }}</div>
+        <template v-else-if="kr2Data">
+          <!-- Summary -->
+          <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+            <div class="text-center">
+              <div class="text-4xl font-black tabular-nums" :class="pctColorClass(kr2Data.overall.pct)">{{ kr2Data.overall.pct }}%</div>
+              <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">Completed</div>
+            </div>
+            <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+            <div class="flex items-center gap-5 text-sm">
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ kr2Data.overall.completed }}</div>
+                <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">Completed</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ kr2Data.overall.associates - kr2Data.overall.completed }}</div>
+                <div class="text-[10px] font-medium text-red-600 dark:text-red-400 uppercase">Remaining</div>
+              </div>
+              <div class="text-center">
+                <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ kr2Data.overall.associates }}</div>
+                <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Total Associates</div>
+              </div>
+            </div>
+            <div class="ml-auto text-xs text-gray-400 dark:text-gray-500">Target: 1 content/associate/year</div>
+          </div>
+
+          <!-- Quarter sections -->
+          <div v-for="q in kr2Data.quarters" :key="q.label" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <button
+              @click="toggleSection('kr2-' + q.label)"
+              class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <div class="flex items-center gap-3">
+                <svg class="w-4 h-4 text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': openSections['kr2-' + q.label] }" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+                <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ q.label }}</span>
+                <span class="text-xs text-gray-500 dark:text-gray-400">{{ q.total.completed }} of {{ q.total.associates }} associates completed</span>
+              </div>
+              <span class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="pctBadgeClass(q.total.pct)">{{ q.total.pct }}%</span>
+            </button>
+            <div v-show="openSections['kr2-' + q.label]" class="overflow-x-auto">
+              <table class="w-full text-sm border-collapse">
+                <thead>
+                  <tr class="bg-gray-50 dark:bg-gray-800/60">
+                    <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Team Name</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Associates</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Completed</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">% Done</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">Status</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Target Date</th>
+                    <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-44">Performance vs. Quarter</th>
+                    <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-40">Progress</th>
+                    <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">End of Q Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="team in q.teams" :key="team.name" class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                    <td class="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100">{{ team.name }}</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ team.associates }}</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums text-gray-700 dark:text-gray-300">{{ team.completed }}</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums font-semibold" :class="pctColorClass(team.pct)">{{ team.pct }}%</td>
+                    <td class="px-4 py-2.5 text-center">
+                      <span v-if="team.status" class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300">{{ team.status }}</span>
+                    </td>
+                    <td class="px-4 py-2.5 text-center text-xs text-gray-600 dark:text-gray-400">{{ q.targetDate || '' }}</td>
+                    <td class="px-4 py-2.5 text-xs text-gray-600 dark:text-gray-400">{{ team.performance || '' }}</td>
+                    <td class="px-4 py-2.5">
+                      <div class="w-full h-3 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                        <div class="h-full rounded-full transition-all duration-300" :class="progressBarClass(team.pct)" :style="{ width: Math.min(team.pct, 100) + '%' }" />
+                      </div>
+                    </td>
+                    <td class="px-4 py-2.5 text-center tabular-nums text-xs font-semibold" :class="team.endQPct != null ? pctColorClass(team.endQPct) : 'text-gray-400'">{{ team.endQPct != null ? team.endQPct + '%' : '' }}</td>
+                  </tr>
+                  <!-- TOTAL row -->
+                  <tr class="bg-gray-50 dark:bg-gray-800/60 font-bold border-t-2 border-gray-300 dark:border-gray-600">
+                    <td class="px-4 py-2.5 text-gray-900 dark:text-gray-100">TOTAL</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ q.total.associates }}</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums text-gray-900 dark:text-gray-100">{{ q.total.completed }}</td>
+                    <td class="px-4 py-2.5 text-center tabular-nums" :class="pctColorClass(q.total.pct)">{{ q.total.pct }}%</td>
+                    <td class="px-4 py-2.5" />
+                    <td class="px-4 py-2.5" />
+                    <td class="px-4 py-2.5" />
+                    <td class="px-4 py-2.5">
+                      <div class="w-full h-3 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                        <div class="h-full rounded-full transition-all duration-300" :class="progressBarClass(q.total.pct)" :style="{ width: Math.min(q.total.pct, 100) + '%' }" />
+                      </div>
+                    </td>
+                    <td class="px-4 py-2.5 text-center tabular-nums text-xs font-semibold" :class="q.total.endQPct != null ? pctColorClass(q.total.endQPct) : 'text-gray-400'">{{ q.total.endQPct != null ? q.total.endQPct + '%' : '' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="text-xs text-gray-400 dark:text-gray-500 text-center">
+            Last fetched: {{ formatDateTime(kr2Data.fetchedAt) }}
+          </div>
+        </template>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 
-var loading = ref(true)
-var error = ref(null)
-var data = ref(null)
-var openQuarters = ref({})
+var kr1Open = ref(false)
+var kr2Open = ref(false)
+var kr1Loading = ref(true)
+var kr2Loading = ref(true)
+var kr1Error = ref(null)
+var kr2Error = ref(null)
+var kr1Data = ref(null)
+var kr2Data = ref(null)
+var openSections = ref({})
 
-var overallPctClass = computed(function() {
-  if (!data.value) return 'text-gray-400'
-  var pct = data.value.overall.pct
-  if (pct === 100) return 'text-emerald-600 dark:text-emerald-400'
-  if (pct >= 66) return 'text-yellow-600 dark:text-yellow-400'
+function pctColorClass(pct) {
+  if (pct >= 100) return 'text-emerald-600 dark:text-emerald-400'
+  if (pct >= 50) return 'text-yellow-600 dark:text-yellow-400'
   return 'text-red-600 dark:text-red-400'
-})
+}
 
 function pctBadgeClass(pct) {
-  if (pct === 100) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
-  if (pct >= 66) return 'text-yellow-700 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/40'
+  if (pct >= 100) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
+  if (pct >= 50) return 'text-yellow-700 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/40'
   return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40'
 }
 
-function toggleQuarter(label) {
-  openQuarters.value[label] = !openQuarters.value[label]
+function progressBarClass(pct) {
+  if (pct >= 100) return 'bg-emerald-500'
+  if (pct >= 50) return 'bg-yellow-500'
+  return 'bg-amber-500'
+}
+
+function toggleSection(key) {
+  openSections.value[key] = !openSections.value[key]
 }
 
 function formatDate(iso) {
@@ -127,23 +265,48 @@ function formatDateTime(iso) {
   return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
 }
 
-onMounted(async function() {
+onMounted(function() {
+  fetchKr1()
+  fetchKr2()
+})
+
+async function fetchKr1() {
   try {
     var res = await fetch('/api/modules/okr-hub/reports/tech-visibility')
     if (!res.ok) throw new Error('Failed to load report: ' + res.status)
     var result = await res.json()
     if (result.error) {
-      error.value = result.error
+      kr1Error.value = result.error
     } else {
-      data.value = result
+      kr1Data.value = result
       if (result.quarters && result.quarters.length > 0) {
-        openQuarters.value[result.quarters[result.quarters.length - 1].label] = true
+        openSections.value['kr1-' + result.quarters[result.quarters.length - 1].label] = true
       }
     }
   } catch (err) {
-    error.value = err.message
+    kr1Error.value = err.message
   } finally {
-    loading.value = false
+    kr1Loading.value = false
   }
-})
+}
+
+async function fetchKr2() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/content-contributions')
+    if (!res.ok) throw new Error('Failed to load report: ' + res.status)
+    var result = await res.json()
+    if (result.error) {
+      kr2Error.value = result.error
+    } else {
+      kr2Data.value = result
+      if (result.quarters && result.quarters.length > 0) {
+        openSections.value['kr2-' + result.quarters[result.quarters.length - 1].label] = true
+      }
+    }
+  } catch (err) {
+    kr2Error.value = err.message
+  } finally {
+    kr2Loading.value = false
+  }
+}
 </script>

--- a/modules/okr-hub/client/components/TechVisibilityReport.vue
+++ b/modules/okr-hub/client/components/TechVisibilityReport.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="space-y-5">
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading visibility data from Google Sheets...</div>
+    <div v-else-if="error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ error }}</div>
+
+    <template v-else-if="data">
+      <!-- Summary Header -->
+      <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+        <div class="text-center">
+          <div class="text-4xl font-black tabular-nums" :class="overallPctClass">{{ data.overall.pct }}%</div>
+          <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">Weeks Met</div>
+        </div>
+        <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+        <div class="flex items-center gap-5 text-sm">
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.overall.weeksMet }}</div>
+            <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">Met Target</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.overall.totalWeeks - data.overall.weeksMet }}</div>
+            <div class="text-[10px] font-medium text-red-600 dark:text-red-400 uppercase">Missed</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.overall.totalWeeks }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Total Weeks</div>
+          </div>
+        </div>
+        <div class="ml-auto text-xs text-gray-400 dark:text-gray-500">
+          Target: >= {{ data.target }} posts/week
+        </div>
+      </div>
+
+      <!-- Quarter Sections -->
+      <div v-for="q in data.quarters" :key="q.label" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+        <button
+          @click="toggleQuarter(q.label)"
+          class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          <div class="flex items-center gap-3">
+            <svg
+              class="w-4 h-4 text-gray-400 transition-transform duration-200"
+              :class="{ 'rotate-90': openQuarters[q.label] }"
+              viewBox="0 0 20 20" fill="currentColor"
+            ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+            <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ q.label }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ q.weeksMet }} of {{ q.totalWeeks }} weeks met</span>
+          </div>
+          <span
+            class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full"
+            :class="pctBadgeClass(q.pct)"
+          >{{ q.pct }}%</span>
+        </button>
+
+        <div v-show="openQuarters[q.label]" class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/60">
+                <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Week Of</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Articles</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="week in q.weeks"
+                :key="week.weekOf"
+                class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+              >
+                <td class="px-4 py-2.5 text-gray-700 dark:text-gray-300">{{ formatDate(week.weekOf) }}</td>
+                <td class="px-4 py-2.5 text-center tabular-nums font-semibold" :class="week.met ? 'text-gray-900 dark:text-gray-100' : 'text-red-600 dark:text-red-400'">{{ week.count }}</td>
+                <td class="px-4 py-2.5 text-center">
+                  <span
+                    class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold"
+                    :class="week.met ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300' : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'"
+                  >{{ week.met ? 'Met' : 'Missed' }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div v-if="data.source" class="text-xs text-gray-400 dark:text-gray-500 text-center">
+        Source: Google Sheets tab "{{ data.source }}" | Last fetched: {{ formatDateTime(data.fetchedAt) }}
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+var loading = ref(true)
+var error = ref(null)
+var data = ref(null)
+var openQuarters = ref({})
+
+var overallPctClass = computed(function() {
+  if (!data.value) return 'text-gray-400'
+  var pct = data.value.overall.pct
+  if (pct === 100) return 'text-emerald-600 dark:text-emerald-400'
+  if (pct >= 66) return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-red-600 dark:text-red-400'
+})
+
+function pctBadgeClass(pct) {
+  if (pct === 100) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
+  if (pct >= 66) return 'text-yellow-700 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/40'
+  return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40'
+}
+
+function toggleQuarter(label) {
+  openQuarters.value[label] = !openQuarters.value[label]
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  var d = new Date(iso + 'T00:00:00')
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function formatDateTime(iso) {
+  if (!iso) return ''
+  var d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+}
+
+onMounted(async function() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/tech-visibility')
+    if (!res.ok) throw new Error('Failed to load report: ' + res.status)
+    var result = await res.json()
+    if (result.error) {
+      error.value = result.error
+    } else {
+      data.value = result
+      if (result.quarters && result.quarters.length > 0) {
+        openQuarters.value[result.quarters[result.quarters.length - 1].label] = true
+      }
+    }
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/modules/okr-hub/client/components/commitment-tracking/CommitmentTrackingReport.vue
+++ b/modules/okr-hub/client/components/commitment-tracking/CommitmentTrackingReport.vue
@@ -1,0 +1,294 @@
+<template>
+  <div>
+    <!-- Filter bar with snapshot creation -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 mb-6">
+      <div class="flex flex-wrap items-center gap-4 mb-3">
+        <div class="flex items-center gap-2">
+          <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Release:</label>
+          <select
+            v-model="selectedVersion"
+            @change="handleFilterChange"
+            class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+          >
+            <option value="">Select a release...</option>
+            <option v-for="r in releases" :key="r.version" :value="r.version">
+              {{ r.version }}
+            </option>
+          </select>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Phase:</label>
+          <select
+            v-model="selectedPhase"
+            @change="handleFilterChange"
+            class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+          >
+            <option value="">Select a phase...</option>
+            <option value="EA1">EA1</option>
+            <option value="EA2">EA2</option>
+            <option value="GA">GA</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Snapshot creation (always show when version+phase selected) -->
+      <div v-if="selectedVersion && selectedPhase"
+           class="border-t border-gray-200 dark:border-gray-700 pt-3">
+        <div class="flex items-center justify-between">
+          <div>
+            <p v-if="!data && error?.includes('No snapshot')" class="text-sm text-gray-600 dark:text-gray-400">
+              No baseline snapshot exists for <span class="font-medium">{{ selectedVersion }} {{ selectedPhase }}</span>
+            </p>
+            <p v-else class="text-sm text-gray-600 dark:text-gray-400">
+              Create a new baseline snapshot for <span class="font-medium">{{ selectedVersion }} {{ selectedPhase }}</span>
+            </p>
+            <p v-if="snapshotError" class="text-xs text-red-600 dark:text-red-400 mt-1">
+              {{ snapshotError }}
+            </p>
+          </div>
+          <button
+            @click="createSnapshot"
+            :disabled="creatingSnapshot"
+            class="px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {{ creatingSnapshot ? 'Creating...' : 'Create Snapshot' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="error" class="rounded-lg border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 p-4 text-red-700 dark:text-red-400 text-sm">
+      {{ error }}
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!selectedVersion || !selectedPhase" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-12 text-center text-gray-400 dark:text-gray-500">
+      <p class="text-lg mb-2">Select a release and phase to view commitment tracking</p>
+      <p class="text-sm">Choose a release version and phase (EA1, EA2, or GA) from the filters above.</p>
+    </div>
+
+    <!-- Data view -->
+    <div v-else-if="data">
+      <!-- OKR Status Banner -->
+      <div
+        class="rounded-lg border px-4 py-3 mb-6 flex items-center gap-3"
+        :class="okrStatusClass"
+      >
+        <component :is="okrIcon" :size="20" />
+        <div>
+          <div class="font-semibold">{{ okrStatusText }}</div>
+          <div class="text-xs opacity-90">
+            {{ data.metrics.delivered }} of {{ data.metrics.committed }} committed features delivered
+            ({{ data.metrics.percentDelivered }}%)
+          </div>
+        </div>
+      </div>
+
+      <!-- Metrics Cards -->
+      <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-1">Committed</div>
+          <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ data.metrics.committed }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">At planning freeze</div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-1">Delivered</div>
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ data.metrics.delivered }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ data.metrics.percentDelivered }}% of committed</div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-1">Added</div>
+          <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">{{ data.metrics.added }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">After freeze</div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-1">Removed</div>
+          <div class="text-2xl font-bold text-amber-600 dark:text-amber-400">{{ data.metrics.removed }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">After freeze</div>
+        </div>
+      </div>
+
+      <!-- Feature Changes Tables -->
+      <div class="space-y-4">
+        <div v-if="data.features.delivered.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <button @click="toggleSection('delivered')" class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <div class="flex items-center gap-2">
+              <component :is="expandedSections.delivered ? ChevronDown : ChevronRight" :size="16" class="text-gray-400" />
+              <span class="font-semibold text-gray-900 dark:text-gray-100">Delivered Features ({{ data.features.delivered.length }})</span>
+            </div>
+            <span class="text-xs text-green-600 dark:text-green-400 font-medium">Completed</span>
+          </button>
+          <div v-if="expandedSections.delivered" class="border-t border-gray-200 dark:border-gray-700 p-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <FeatureCard v-for="feature in data.features.delivered" :key="feature.key" :feature="feature" variant="delivered" />
+            </div>
+          </div>
+        </div>
+
+        <div v-if="data.features.added.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <button @click="toggleSection('added')" class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <div class="flex items-center gap-2">
+              <component :is="expandedSections.added ? ChevronDown : ChevronRight" :size="16" class="text-gray-400" />
+              <span class="font-semibold text-gray-900 dark:text-gray-100">Added Features ({{ data.features.added.length }})</span>
+            </div>
+            <span class="text-xs text-blue-600 dark:text-blue-400 font-medium">After Freeze</span>
+          </button>
+          <div v-if="expandedSections.added" class="border-t border-gray-200 dark:border-gray-700 p-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <FeatureCard v-for="feature in data.features.added" :key="feature.key" :feature="feature" variant="added" />
+            </div>
+          </div>
+        </div>
+
+        <div v-if="data.features.removed.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <button @click="toggleSection('removed')" class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <div class="flex items-center gap-2">
+              <component :is="expandedSections.removed ? ChevronDown : ChevronRight" :size="16" class="text-gray-400" />
+              <span class="font-semibold text-gray-900 dark:text-gray-100">Removed Features ({{ data.features.removed.length }})</span>
+            </div>
+            <span class="text-xs text-amber-600 dark:text-amber-400 font-medium">After Freeze</span>
+          </button>
+          <div v-if="expandedSections.removed" class="border-t border-gray-200 dark:border-gray-700 p-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <FeatureCard v-for="feature in data.features.removed" :key="feature.key" :feature="feature" variant="removed" />
+            </div>
+          </div>
+        </div>
+
+        <div v-if="data.features.inProgress.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <button @click="toggleSection('inProgress')" class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <div class="flex items-center gap-2">
+              <component :is="expandedSections.inProgress ? ChevronDown : ChevronRight" :size="16" class="text-gray-400" />
+              <span class="font-semibold text-gray-900 dark:text-gray-100">In Progress ({{ data.features.inProgress.length }})</span>
+            </div>
+            <span class="text-xs text-yellow-600 dark:text-yellow-400 font-medium">Not Delivered</span>
+          </button>
+          <div v-if="expandedSections.inProgress" class="border-t border-gray-200 dark:border-gray-700 p-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <FeatureCard v-for="feature in data.features.inProgress" :key="feature.key" :feature="feature" variant="in-progress" />
+            </div>
+          </div>
+        </div>
+
+        <div v-if="data.features.notStarted.length > 0" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          <button @click="toggleSection('notStarted')" class="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <div class="flex items-center gap-2">
+              <component :is="expandedSections.notStarted ? ChevronDown : ChevronRight" :size="16" class="text-gray-400" />
+              <span class="font-semibold text-gray-900 dark:text-gray-100">Not Started ({{ data.features.notStarted.length }})</span>
+            </div>
+            <span class="text-xs text-red-600 dark:text-red-400 font-medium">Not Delivered</span>
+          </button>
+          <div v-if="expandedSections.notStarted" class="border-t border-gray-200 dark:border-gray-700 p-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <FeatureCard v-for="feature in data.features.notStarted" :key="feature.key" :feature="feature" variant="not-started" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Snapshot metadata -->
+      <div class="mt-6 text-xs text-gray-500 dark:text-gray-400 text-center">
+        Snapshot created: {{ formatDate(data.snapshot.snapshotAt) }}
+        ({{ data.snapshot.trigger }})
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { ChevronRight, ChevronDown, CheckCircle, AlertTriangle, XCircle } from 'lucide-vue-next'
+import { useCommitmentTracking } from './useCommitmentTracking'
+import FeatureCard from './FeatureCard.vue'
+
+const { data, loading, error, loadCommitment, releases, loadReleases } = useCommitmentTracking()
+
+const selectedVersion = ref('')
+const selectedPhase = ref('')
+const creatingSnapshot = ref(false)
+const snapshotError = ref(null)
+const expandedSections = ref({
+  delivered: false,
+  added: false,
+  removed: false,
+  inProgress: false,
+  notStarted: false
+})
+
+const okrStatusClass = computed(() => {
+  if (!data.value) return ''
+  const pct = data.value.metrics.percentDelivered
+  if (pct >= 90) {
+    return 'border-green-200 dark:border-green-700/50 bg-green-50/60 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+  } else if (pct >= 70) {
+    return 'border-yellow-200 dark:border-yellow-500/30 bg-yellow-50 dark:bg-yellow-500/10 text-yellow-700 dark:text-yellow-400'
+  } else {
+    return 'border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400'
+  }
+})
+
+const okrIcon = computed(() => {
+  if (!data.value) return CheckCircle
+  const pct = data.value.metrics.percentDelivered
+  if (pct >= 90) return CheckCircle
+  if (pct >= 70) return AlertTriangle
+  return XCircle
+})
+
+const okrStatusText = computed(() => {
+  if (!data.value) return ''
+  const pct = data.value.metrics.percentDelivered
+  if (pct >= 90) return 'Meeting OKR (>=90%)'
+  if (pct >= 70) return 'Below OKR Target'
+  return 'Significantly Below OKR'
+})
+
+function formatDate(isoDate) {
+  if (!isoDate) return 'Unknown'
+  const date = new Date(isoDate)
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function toggleSection(section) {
+  expandedSections.value[section] = !expandedSections.value[section]
+}
+
+function handleFilterChange() {
+  if (selectedVersion.value && selectedPhase.value) {
+    loadCommitment(selectedVersion.value, selectedPhase.value)
+  }
+}
+
+async function createSnapshot() {
+  if (!selectedVersion.value || !selectedPhase.value) return
+  creatingSnapshot.value = true
+  snapshotError.value = null
+  try {
+    /* eslint-disable-next-line org-pulse/no-cross-module-imports -- approved cross-module API; okr-hub requires releases in module.json */
+    const response = await fetch(`/api/modules/releases/delivery/commitment/snapshot/${selectedVersion.value}/${selectedPhase.value}`, {
+      method: 'POST'
+    })
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || `Server error: ${response.status}`)
+    }
+    await loadCommitment(selectedVersion.value, selectedPhase.value)
+  } catch (err) {
+    console.error('[CommitmentTracking] Snapshot creation failed:', err)
+    snapshotError.value = err.message
+  } finally {
+    creatingSnapshot.value = false
+  }
+}
+
+onMounted(() => {
+  loadReleases()
+})
+</script>

--- a/modules/okr-hub/client/components/commitment-tracking/FeatureCard.vue
+++ b/modules/okr-hub/client/components/commitment-tracking/FeatureCard.vue
@@ -1,0 +1,107 @@
+<template>
+  <div
+    class="border rounded-lg p-4 transition-shadow hover:shadow-md"
+    :class="cardBorderClass"
+  >
+    <!-- Header: Jira Key + Status -->
+    <div class="flex items-start justify-between gap-3 mb-3">
+      <a
+        :href="`https://redhat.atlassian.net/browse/${feature.key}`"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-semibold text-sm inline-flex items-center gap-1 hover:underline"
+        @click.stop
+      >
+        {{ feature.key }}
+        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+        </svg>
+      </a>
+
+      <span
+        v-if="feature.status"
+        class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap"
+        :class="statusBadgeClass"
+      >
+        {{ feature.status }}
+      </span>
+    </div>
+
+    <!-- Summary -->
+    <h3 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3 leading-snug">
+      {{ feature.summary }}
+    </h3>
+
+    <!-- Metadata Grid -->
+    <div class="grid grid-cols-2 gap-3 text-xs">
+      <!-- Components -->
+      <div v-if="feature.components?.length">
+        <div class="text-gray-500 dark:text-gray-400 mb-1">Components</div>
+        <div class="text-gray-900 dark:text-gray-100 font-medium">
+          {{ Array.isArray(feature.components) ? feature.components.join(', ') : feature.components }}
+        </div>
+      </div>
+
+      <!-- Delivery Owner -->
+      <div v-if="feature.deliveryOwner">
+        <div class="text-gray-500 dark:text-gray-400 mb-1">Owner</div>
+        <div class="text-gray-900 dark:text-gray-100 font-medium">
+          {{ feature.deliveryOwner }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  feature: {
+    type: Object,
+    required: true
+  },
+  variant: {
+    type: String,
+    default: 'default',
+    validator: (val) => ['default', 'delivered', 'in-progress', 'not-started', 'added', 'removed'].includes(val)
+  }
+})
+
+const cardBorderClass = computed(() => {
+  const baseClass = 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+
+  switch (props.variant) {
+    case 'delivered':
+      return `${baseClass} border-l-4 border-l-green-500`
+    case 'in-progress':
+      return `${baseClass} border-l-4 border-l-yellow-500`
+    case 'not-started':
+      return `${baseClass} border-l-4 border-l-gray-400`
+    case 'added':
+      return `${baseClass} border-l-4 border-l-blue-500 bg-blue-50/30 dark:bg-blue-500/5`
+    case 'removed':
+      return `${baseClass} border-l-4 border-l-red-500 bg-red-50/30 dark:bg-red-500/5`
+    default:
+      return baseClass
+  }
+})
+
+const statusBadgeClass = computed(() => {
+  const status = props.feature.status?.toLowerCase() || ''
+
+  if (status.includes('done') || status.includes('closed') || status.includes('resolved')) {
+    return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  }
+
+  if (status.includes('progress') || status.includes('review')) {
+    return 'bg-yellow-100 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400'
+  }
+
+  if (status.includes('blocked')) {
+    return 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'
+  }
+
+  return 'bg-gray-100 dark:bg-gray-500/20 text-gray-700 dark:text-gray-400'
+})
+</script>

--- a/modules/okr-hub/client/components/commitment-tracking/useCommitmentTracking.js
+++ b/modules/okr-hub/client/components/commitment-tracking/useCommitmentTracking.js
@@ -1,0 +1,70 @@
+import { ref } from 'vue'
+
+/* eslint-disable-next-line org-pulse/no-cross-module-imports -- approved cross-module API; okr-hub requires releases in module.json */
+const API_BASE = '/api/modules/releases/delivery'
+
+export function useCommitmentTracking() {
+  const data = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+  const releases = ref([])
+  const releasesLoading = ref(false)
+
+  async function loadCommitment(version, phase) {
+    if (!version || !phase) {
+      error.value = 'Version and phase are required'
+      return
+    }
+
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await fetch(`${API_BASE}/commitment/${encodeURIComponent(version)}/${encodeURIComponent(phase)}`)
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error(`No snapshot found for ${version} ${phase}. Create a snapshot in the Health Dashboard first.`)
+        }
+        if (response.status === 400) {
+          throw new Error('Invalid phase. Must be EA1, EA2, or GA.')
+        }
+        throw new Error(`Failed to load commitment data: ${response.statusText}`)
+      }
+
+      data.value = await response.json()
+    } catch (err) {
+      error.value = err.message || 'Failed to load commitment tracking data'
+      data.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadReleases() {
+    releasesLoading.value = true
+    try {
+      const response = await fetch(`${API_BASE}/commitment/versions`)
+      if (!response.ok) {
+        throw new Error('Failed to load versions for commitment tracking')
+      }
+      const data = await response.json()
+      releases.value = data.versions || []
+    } catch (err) {
+      console.error('Failed to load commitment tracking versions:', err)
+      releases.value = []
+    } finally {
+      releasesLoading.value = false
+    }
+  }
+
+  return {
+    data,
+    loading,
+    error,
+    loadCommitment,
+    releases,
+    releasesLoading,
+    loadReleases
+  }
+}

--- a/modules/okr-hub/client/components/post-release-defects/ComponentFilter.vue
+++ b/modules/okr-hub/client/components/post-release-defects/ComponentFilter.vue
@@ -1,0 +1,21 @@
+<template>
+  <select
+    :value="modelValue"
+    @change="emit('update:modelValue', $event.target.value || null)"
+    class="w-full px-3 py-2 text-sm border-2 rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:focus:ring-blue-900"
+  >
+    <option value="">All Components</option>
+    <option v-for="comp in components" :key="comp.name" :value="comp.name">
+      {{ comp.name }} ({{ comp.count }})
+    </option>
+  </select>
+</template>
+
+<script setup>
+defineProps({
+  modelValue: { type: String, default: null },
+  components: { type: Array, required: true }
+});
+
+const emit = defineEmits(['update:modelValue']);
+</script>

--- a/modules/okr-hub/client/components/post-release-defects/CumulativeBugChart.vue
+++ b/modules/okr-hub/client/components/post-release-defects/CumulativeBugChart.vue
@@ -1,0 +1,63 @@
+<template>
+  <Line :data="chartData" :options="chartOptions" />
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { Line } from 'vue-chartjs';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const props = defineProps({
+  labels: { type: Array, required: true },
+  datasets: { type: Array, required: true }
+});
+
+const COLORS = [
+  '#2563eb', '#16a34a', '#dc2626', '#f59e0b',
+  '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16'
+];
+
+const chartData = computed(() => ({
+  labels: props.labels.map(d => `Day ${d}`),
+  datasets: props.datasets.map((ds, i) => ({
+    label: ds.label,
+    data: ds.data,
+    borderColor: COLORS[i % COLORS.length],
+    backgroundColor: (COLORS[i % COLORS.length]) + '20',
+    borderWidth: 2,
+    pointRadius: 2,
+    tension: 0.3,
+    spanGaps: false
+  }))
+}));
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: 'index', intersect: false },
+  plugins: {
+    legend: { display: true, position: 'top' },
+    tooltip: {
+      callbacks: {
+        label(context) {
+          return `${context.dataset.label}: ${context.parsed.y} bugs`;
+        }
+      }
+    }
+  },
+  scales: {
+    x: { title: { display: true, text: 'Days Since Release' } },
+    y: { title: { display: true, text: 'Cumulative Bug Count' }, beginAtZero: true }
+  }
+};
+</script>

--- a/modules/okr-hub/client/components/post-release-defects/PostReleaseDefectsReport.vue
+++ b/modules/okr-hub/client/components/post-release-defects/PostReleaseDefectsReport.vue
@@ -1,0 +1,251 @@
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <div></div>
+      <button
+        v-if="isAdmin"
+        @click="handleRefresh"
+        :disabled="refreshing"
+        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+      >
+        {{ refreshing ? 'Refreshing...' : 'Refresh Data' }}
+      </button>
+    </div>
+
+    <div v-if="error" class="rounded-lg border border-red-300 bg-red-50 dark:bg-red-900/20 dark:border-red-700/60 text-red-700 dark:text-red-300 px-4 py-3 text-sm mb-6">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400 mb-6">
+      Loading quality metrics...
+    </div>
+
+    <template v-else>
+      <!-- Stepped Filter Interface - Horizontal -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <!-- Step 1: Product Selection -->
+          <div class="relative">
+            <div class="flex items-center gap-2 mb-3">
+              <div class="flex items-center justify-center w-7 h-7 rounded-full bg-blue-600 text-white text-sm font-semibold flex-shrink-0">
+                1
+              </div>
+              <h3 class="text-base font-semibold">Product</h3>
+            </div>
+            <div class="pl-9">
+              <select
+                v-model="selectedProduct"
+                class="w-full px-3 py-2 text-sm border-2 rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:focus:ring-blue-900"
+              >
+                <option value="">All Products</option>
+                <option v-for="product in products" :key="product" :value="product">
+                  {{ product.toUpperCase() }}
+                </option>
+              </select>
+            </div>
+            <!-- Horizontal connector -->
+            <div class="hidden lg:block absolute top-3 -right-3 w-6 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
+          </div>
+
+          <!-- Step 2: Version Selection (only if product selected or versions exist) -->
+          <div v-if="selectedProduct || filteredVersions.length > 0" class="relative">
+            <div class="flex items-center gap-2 mb-3">
+              <div class="flex items-center justify-center w-7 h-7 rounded-full bg-blue-600 text-white text-sm font-semibold flex-shrink-0">
+                2
+              </div>
+              <h3 class="text-base font-semibold">Versions <span class="text-xs font-normal text-gray-500">(max 6)</span></h3>
+            </div>
+            <div class="pl-9">
+              <VersionSelector
+                v-model="selectedVersions"
+                :versions="filteredVersions"
+                :max-selections="6"
+              />
+            </div>
+            <!-- Horizontal connector -->
+            <div class="hidden lg:block absolute top-3 -right-3 w-6 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
+          </div>
+
+          <!-- Step 3: Component Filter (optional) -->
+          <div v-if="selectedVersions.length > 0 || selectedComponent" class="relative">
+            <div class="flex items-center gap-2 mb-3">
+              <div class="flex items-center justify-center w-7 h-7 rounded-full bg-gray-400 dark:bg-gray-600 text-white text-sm font-semibold flex-shrink-0">
+                3
+              </div>
+              <h3 class="text-base font-semibold">Component <span class="text-xs font-normal text-gray-500">(optional)</span></h3>
+            </div>
+            <div class="pl-9">
+              <ComponentFilter
+                v-model="selectedComponent"
+                :components="allComponents"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="selectedVersions.length > 0" class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
+        <h2 class="text-lg font-semibold mb-4">Cumulative Bug Count vs Days Since Release</h2>
+        <div class="h-96">
+          <CumulativeBugChart
+            :labels="chartData.labels"
+            :datasets="chartData.datasets"
+          />
+        </div>
+      </div>
+
+      <div v-else class="text-center py-12 text-gray-500 dark:text-gray-400">
+        <p>Select versions to view cumulative bug trends</p>
+      </div>
+
+      <div v-if="selectedVersions.length > 0" class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h2 class="text-lg font-semibold mb-4">Summary Statistics</h2>
+        <table class="w-full">
+          <thead>
+            <tr class="border-b dark:border-gray-700">
+              <th class="text-left py-2">Version</th>
+              <th class="text-right py-2">Total Bugs</th>
+              <th class="text-right py-2">Days Tracked</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(dataset, i) in chartData.datasets" :key="i" class="border-b dark:border-gray-700">
+              <td class="py-2">{{ dataset.label }}</td>
+              <td class="text-right">{{ lastValue(dataset.data) }}</td>
+              <td class="text-right">{{ lastIndex(dataset.data) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue';
+import { useAuth } from '@shared/client/composables/useAuth';
+import VersionSelector from './VersionSelector.vue';
+import ComponentFilter from './ComponentFilter.vue';
+import CumulativeBugChart from './CumulativeBugChart.vue';
+import { getVersions, getBugData, getComponents, refreshData } from './api';
+import { extractProduct } from './release-utils';
+
+const { isAdmin } = useAuth();
+
+const versions = ref([]);
+const allComponents = ref([]);
+const selectedProduct = ref('');
+const selectedVersions = ref([]);
+const selectedComponent = ref(null);
+const chartData = ref({ labels: [], datasets: [] });
+const loading = ref(true);
+const refreshing = ref(false);
+const error = ref(null);
+
+const products = computed(() => {
+  const productSet = new Set();
+  for (const v of versions.value) {
+    const p = extractProduct(v.name);
+    if (p) productSet.add(p);
+  }
+  return Array.from(productSet).sort();
+});
+
+const filteredVersions = computed(() => {
+  if (!selectedProduct.value) return versions.value;
+  return versions.value.filter(v =>
+    v.name.toLowerCase().startsWith(selectedProduct.value + '-')
+  );
+});
+
+watch(selectedProduct, () => {
+  selectedVersions.value = [];
+  selectedComponent.value = null;
+});
+
+onMounted(async () => {
+  try {
+    error.value = null;
+    loading.value = true;
+
+    allComponents.value = await getComponents();
+    versions.value = await getVersions();
+
+    const versionsWithBugs = versions.value.filter(v => v.bugCount > 0);
+    if (versionsWithBugs.length > 0) {
+      selectedVersions.value = versionsWithBugs.slice(0, 3).map(v => v.name);
+    }
+  } catch (err) {
+    console.error('[quality] Failed to load initial data:', err);
+    error.value = err.message || 'Failed to load quality metrics data';
+  } finally {
+    loading.value = false;
+  }
+});
+
+watch(selectedComponent, async () => {
+  try {
+    error.value = null;
+
+    if (selectedVersions.value.length > 0) {
+      const response = await getBugData(selectedVersions.value, selectedComponent.value);
+      chartData.value = { labels: response.labels, datasets: response.datasets };
+    }
+  } catch (err) {
+    console.error('[quality] Failed to filter by component:', err);
+    error.value = err.message || 'Failed to filter chart data by component';
+  }
+});
+
+watch(selectedVersions, async () => {
+  try {
+    error.value = null;
+
+    if (selectedVersions.value.length > 0) {
+      const response = await getBugData(selectedVersions.value, selectedComponent.value);
+      chartData.value = { labels: response.labels, datasets: response.datasets };
+    } else {
+      chartData.value = { labels: [], datasets: [] };
+    }
+  } catch (err) {
+    console.error('[quality] Failed to load bug data:', err);
+    error.value = err.message || 'Failed to load bug data for selected versions';
+  }
+}, { deep: true });
+
+function lastValue(data) {
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (data[i] !== null) return data[i];
+  }
+  return 0;
+}
+
+function lastIndex(data) {
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (data[i] !== null) return i;
+  }
+  return 0;
+}
+
+async function handleRefresh() {
+  try {
+    error.value = null;
+    refreshing.value = true;
+
+    await refreshData();
+
+    allComponents.value = await getComponents();
+    versions.value = await getVersions();
+
+    if (selectedVersions.value.length > 0) {
+      const response = await getBugData(selectedVersions.value, selectedComponent.value);
+      chartData.value = { labels: response.labels, datasets: response.datasets };
+    }
+  } catch (err) {
+    console.error('[quality] Failed to refresh data:', err);
+    error.value = err.message || 'Failed to refresh quality metrics data';
+  } finally {
+    refreshing.value = false;
+  }
+}
+</script>

--- a/modules/okr-hub/client/components/post-release-defects/VersionSelector.vue
+++ b/modules/okr-hub/client/components/post-release-defects/VersionSelector.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="w-full">
+    <!-- Selected versions as removable chips -->
+    <div v-if="modelValue.length > 0" class="flex flex-wrap gap-1.5 mb-2">
+      <span
+        v-for="versionName in modelValue"
+        :key="versionName"
+        class="inline-flex items-center px-2 py-1 bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 rounded-full text-xs font-medium"
+      >
+        {{ versionName }}
+        <button
+          @click="removeVersion(versionName)"
+          class="ml-1.5 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200 font-bold text-base leading-none"
+          aria-label="Remove"
+        >
+          ×
+        </button>
+      </span>
+    </div>
+
+    <!-- Dropdown with search -->
+    <div class="relative">
+      <input
+        v-model="searchQuery"
+        @focus="isOpen = true"
+        @blur="handleBlur"
+        type="text"
+        placeholder="Search versions..."
+        class="w-full px-3 py-2 text-sm border-2 rounded-lg dark:bg-gray-700 dark:border-gray-600 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:focus:ring-blue-900"
+        :disabled="modelValue.length >= maxSelections"
+      />
+
+      <div
+        v-if="isOpen && filteredVersions.length > 0"
+        class="absolute z-10 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto"
+      >
+        <button
+          v-for="version in filteredVersions"
+          :key="version.name"
+          @mousedown.prevent="addVersion(version.name)"
+          class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 flex items-center justify-between gap-4"
+          :disabled="modelValue.includes(version.name)"
+          :class="{ 'opacity-50 cursor-not-allowed': modelValue.includes(version.name) }"
+        >
+          <span class="flex-1">{{ version.name }}</span>
+          <div class="flex items-center gap-3 text-xs text-gray-500">
+            <span class="font-semibold" :class="getBugCountClass(version.bugCount)">
+              {{ version.bugCount }} {{ version.bugCount === 1 ? 'bug' : 'bugs' }}
+            </span>
+            <span>{{ version.releaseDate }}</span>
+          </div>
+        </button>
+      </div>
+
+      <div v-if="isOpen && filteredVersions.length === 0" class="absolute z-10 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-4 text-center text-gray-500 dark:text-gray-400">
+        No versions found
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  modelValue: { type: Array, required: true },
+  versions: { type: Array, required: true },
+  maxSelections: { type: Number, default: 6 }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const searchQuery = ref('');
+const isOpen = ref(false);
+
+const filteredVersions = computed(() => {
+  if (!searchQuery.value) {
+    return props.versions.filter(v => !props.modelValue.includes(v.name));
+  }
+  const query = searchQuery.value.toLowerCase();
+  return props.versions.filter(v =>
+    !props.modelValue.includes(v.name) &&
+    v.name.toLowerCase().includes(query)
+  );
+});
+
+function addVersion(versionName) {
+  if (props.modelValue.length >= props.maxSelections) return;
+  if (props.modelValue.includes(versionName)) return;
+
+  emit('update:modelValue', [...props.modelValue, versionName]);
+  searchQuery.value = '';
+  isOpen.value = false;
+}
+
+function removeVersion(versionName) {
+  emit('update:modelValue', props.modelValue.filter(v => v !== versionName));
+}
+
+function handleBlur() {
+  setTimeout(() => {
+    isOpen.value = false;
+  }, 200);
+}
+
+function getBugCountClass(count) {
+  if (count === 0) return 'text-gray-400 dark:text-gray-500';
+  if (count >= 10) return 'text-red-600 dark:text-red-400';
+  return 'text-orange-500 dark:text-orange-400';
+}
+</script>

--- a/modules/okr-hub/client/components/post-release-defects/api.js
+++ b/modules/okr-hub/client/components/post-release-defects/api.js
@@ -1,0 +1,22 @@
+import { apiRequest } from '@shared/client';
+
+/* eslint-disable-next-line org-pulse/no-cross-module-imports -- approved cross-module API; okr-hub requires releases in module.json */
+const BASE = '/modules/releases/delivery/quality';
+
+export async function getVersions() {
+  return apiRequest(`${BASE}/versions`);
+}
+
+export async function getBugData(versions, component = null) {
+  const params = new URLSearchParams({ versions: versions.join(',') });
+  if (component) params.set('component', component);
+  return apiRequest(`${BASE}/bugs?${params}`);
+}
+
+export async function getComponents() {
+  return apiRequest(`${BASE}/components`);
+}
+
+export async function refreshData() {
+  return apiRequest(`${BASE}/refresh`, { method: 'POST' });
+}

--- a/modules/okr-hub/client/components/post-release-defects/release-utils.js
+++ b/modules/okr-hub/client/components/post-release-defects/release-utils.js
@@ -1,0 +1,10 @@
+export const KNOWN_PRODUCTS = ['base-images', 'rhel-ai', 'rhoai', 'rhaii']
+
+export function extractProduct(releaseNumber) {
+  const s = (releaseNumber || '').toLowerCase()
+  for (const p of KNOWN_PRODUCTS) {
+    if (s.startsWith(p + '-') && /\d/.test(s[p.length + 1])) return p
+  }
+  const m = s.match(/^(.+?)-(\d.*)$/)
+  return m ? m[1] : ''
+}

--- a/modules/okr-hub/client/constants/mock-okrs.js
+++ b/modules/okr-hub/client/constants/mock-okrs.js
@@ -1,0 +1,126 @@
+export var QUARTERS = ['Q1', 'Q2', 'Q3', 'Q4']
+
+export var STATUS_CONFIG = {
+  green: {
+    label: 'On Track',
+    bg: 'bg-emerald-50 dark:bg-emerald-900/20',
+    text: 'text-emerald-700 dark:text-emerald-300',
+    dot: 'bg-emerald-500'
+  },
+  yellow: {
+    label: 'Partial',
+    bg: 'bg-yellow-50 dark:bg-yellow-900/20',
+    text: 'text-yellow-700 dark:text-yellow-300',
+    dot: 'bg-yellow-500'
+  },
+  red: {
+    label: 'At Risk',
+    bg: 'bg-red-50 dark:bg-red-900/20',
+    text: 'text-red-700 dark:text-red-300',
+    dot: 'bg-red-500'
+  },
+  'not-started': {
+    label: 'Not Started',
+    bg: 'bg-gray-50 dark:bg-gray-800/30',
+    text: 'text-gray-500 dark:text-gray-400',
+    dot: 'bg-gray-400'
+  }
+}
+
+function emptyQuarter() {
+  return { status: 'not-started', summary: '' }
+}
+
+export var OKR_DATA = {
+  year: 2026,
+  categories: [
+    {
+      name: 'Quality & Reliability',
+      objectives: [
+        {
+          id: 'on-time-releases',
+          name: 'On Time Releases',
+          measure: '100% of releases hit planned GA date',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-otr-1', label: 'KR1', description: 'Number of releases on time — 100%', status: 'not-started' }
+          ]
+        },
+        {
+          id: 'cve-sla',
+          name: 'CVE SLA Compliance',
+          measure: '100% on-time escalation response',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-cve-1', label: 'KR1', description: 'Number of escalations and on time response — 100%', status: 'not-started' }
+          ]
+        },
+        {
+          id: 'post-release-defects',
+          name: 'Post-Release Defects',
+          measure: '90% reduction in bugs discovered post-release',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-prd-1', label: 'KR1', description: '90% reduction in functional, UX, and regression bugs found post-release by the field', status: 'not-started' }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'Delivery Predictability',
+      objectives: [
+        {
+          id: 'commitment-tracking',
+          name: 'Commitment Tracking',
+          measure: '>90% of planned features delivered in target release',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-ct-1', label: 'KR1', description: '>90% of planned features for a release are delivered in the target release', status: 'not-started' }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'Technical Visibility',
+      objectives: [
+        {
+          id: 'tech-visibility',
+          name: 'Technical Visibility',
+          measure: '>5 posts/week and 1 content per associate',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-tv-1', label: 'KR1', description: '>= 5 posts per week across internal and external sources', status: 'not-started' },
+            { id: 'kr-tv-2', label: 'KR2', description: '1 piece of content from each AI Eng associate', status: 'not-started' }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'Support & Customer Success',
+      objectives: [
+        {
+          id: 'support-cases',
+          name: 'Support Case Time To Resolution',
+          measure: 'Defect rate <= 10%, resolution target 10-14 days',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-sc-1', label: 'KR1', description: 'Defect rate for product: 10%', status: 'not-started' },
+            { id: 'kr-sc-2', label: 'KR2', description: 'Time to resolution target: 10-14 days', status: 'not-started' }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+export function findObjectiveById(id) {
+  for (var ci = 0; ci < OKR_DATA.categories.length; ci++) {
+    var cat = OKR_DATA.categories[ci]
+    for (var oi = 0; oi < cat.objectives.length; oi++) {
+      if (cat.objectives[oi].id === id) {
+        return { category: cat.name, objective: cat.objectives[oi] }
+      }
+    }
+  }
+  return null
+}

--- a/modules/okr-hub/client/index.js
+++ b/modules/okr-hub/client/index.js
@@ -1,0 +1,7 @@
+import { defineAsyncComponent } from 'vue'
+
+export const routes = {
+  'timeline': defineAsyncComponent(() => import('./views/TimelineView.vue')),
+  'deep-dive': defineAsyncComponent(() => import('./views/DeepDiveView.vue')),
+  'reports': defineAsyncComponent(() => import('./views/ReportsView.vue')),
+}

--- a/modules/okr-hub/client/index.js
+++ b/modules/okr-hub/client/index.js
@@ -2,6 +2,5 @@ import { defineAsyncComponent } from 'vue'
 
 export const routes = {
   'timeline': defineAsyncComponent(() => import('./views/TimelineView.vue')),
-  'deep-dive': defineAsyncComponent(() => import('./views/DeepDiveView.vue')),
   'reports': defineAsyncComponent(() => import('./views/ReportsView.vue')),
 }

--- a/modules/okr-hub/client/index.js
+++ b/modules/okr-hub/client/index.js
@@ -3,4 +3,5 @@ import { defineAsyncComponent } from 'vue'
 export const routes = {
   'timeline': defineAsyncComponent(() => import('./views/TimelineView.vue')),
   'reports': defineAsyncComponent(() => import('./views/ReportsView.vue')),
+  'deep-dive': defineAsyncComponent(() => import('./views/DeepDiveView.vue')),
 }

--- a/modules/okr-hub/client/views/DeepDiveView.vue
+++ b/modules/okr-hub/client/views/DeepDiveView.vue
@@ -106,7 +106,7 @@
 
 <script setup>
 import { computed, inject } from 'vue'
-import { findObjectiveById, STATUS_CONFIG, QUARTERS, OKR_DATA } from '../data/mock-okrs.js'
+import { findObjectiveById, STATUS_CONFIG, QUARTERS, OKR_DATA } from '../constants/mock-okrs.js'
 
 var nav = inject('moduleNav', null)
 var params = inject('routeParams', null)

--- a/modules/okr-hub/client/views/DeepDiveView.vue
+++ b/modules/okr-hub/client/views/DeepDiveView.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="space-y-6">
+    <!-- Breadcrumb -->
+    <button
+      class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+      @click="goBack"
+    >
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      Back to Timeline
+    </button>
+
+    <!-- Not found -->
+    <div v-if="!match" class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-8 text-center">
+      <p class="text-gray-500 dark:text-gray-400">Select an OKR from the Timeline view to see its detail.</p>
+    </div>
+
+    <template v-else>
+      <!-- Header -->
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="flex items-center gap-2 mb-1">
+            <span
+              class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold"
+              :class="[overallStatus.bg, overallStatus.text]"
+            >
+              <span class="inline-block w-2 h-2 rounded-full" :class="overallStatus.dot" />
+              {{ overallStatus.label }}
+            </span>
+            <span class="text-xs text-gray-400 dark:text-gray-500 font-medium">{{ match.category }}</span>
+          </div>
+          <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">{{ obj.name }}</h2>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 whitespace-pre-line">{{ obj.measure }}</p>
+        </div>
+      </div>
+
+      <!-- Quarterly Progress Cards -->
+      <div>
+        <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">Quarterly Progress</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div
+            v-for="q in quarters"
+            :key="q"
+            class="rounded-xl border p-4"
+            :class="quarterCardClass(obj.quarters[q])"
+          >
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-sm font-bold text-gray-800 dark:text-gray-200">{{ q }} {{ shortYear }}</span>
+              <span
+                class="inline-block w-3 h-3 rounded-full"
+                :class="statusConfig[obj.quarters[q].status].dot"
+              />
+            </div>
+            <p
+              v-if="obj.quarters[q].summary"
+              class="text-xs leading-relaxed whitespace-pre-line"
+              :class="statusConfig[obj.quarters[q].status].text"
+            >{{ obj.quarters[q].summary }}</p>
+            <p v-else class="text-xs text-gray-300 dark:text-gray-600 italic">No data yet</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Key Results -->
+      <div>
+        <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">Key Results</h3>
+        <div v-if="obj.keyResults.length > 0" class="space-y-3">
+          <div
+            v-for="kr in obj.keyResults"
+            :key="kr.id"
+            class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 flex items-start gap-3"
+          >
+            <span
+              class="inline-flex items-center justify-center w-6 h-6 rounded-full shrink-0 mt-0.5"
+              :class="statusConfig[kr.status].bg"
+            >
+              <span class="inline-block w-2.5 h-2.5 rounded-full" :class="statusConfig[kr.status].dot" />
+            </span>
+            <div class="min-w-0">
+              <span class="text-xs font-bold text-gray-700 dark:text-gray-300 uppercase tracking-wide">{{ kr.label }}</span>
+              <p class="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{{ kr.description }}</p>
+            </div>
+          </div>
+        </div>
+        <div v-else class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30 px-4 py-6 text-center">
+          <p class="text-sm text-gray-400 dark:text-gray-500">No key results defined yet. These will be added when data is available.</p>
+        </div>
+      </div>
+
+      <!-- Detailed Metrics Placeholder -->
+      <div>
+        <h3 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">Detailed Metrics</h3>
+        <div class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30 px-4 py-10 text-center">
+          <svg class="w-10 h-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+          </svg>
+          <p class="text-sm text-gray-400 dark:text-gray-500">
+            Detailed metrics and charts for <strong>{{ obj.name }}</strong> will appear here once data sources are connected.
+          </p>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, inject } from 'vue'
+import { findObjectiveById, STATUS_CONFIG, QUARTERS, OKR_DATA } from '../data/mock-okrs.js'
+
+var nav = inject('moduleNav', null)
+var params = inject('routeParams', null)
+
+var statusConfig = STATUS_CONFIG
+var quarters = QUARTERS
+var shortYear = String(OKR_DATA.year).slice(-2)
+
+var okrId = computed(function() {
+  if (params && params.value && params.value.okr) return params.value.okr
+  return null
+})
+
+var match = computed(function() {
+  if (!okrId.value) return null
+  return findObjectiveById(okrId.value)
+})
+
+var obj = computed(function() {
+  return match.value ? match.value.objective : null
+})
+
+var overallStatus = computed(function() {
+  if (!obj.value) return statusConfig['not-started']
+  var latestQ = null
+  for (var i = 0; i < quarters.length; i++) {
+    var q = obj.value.quarters[quarters[i]]
+    if (q && q.status !== 'not-started') latestQ = q
+  }
+  if (!latestQ) return statusConfig['not-started']
+  return statusConfig[latestQ.status]
+})
+
+function quarterCardClass(q) {
+  if (!q || q.status === 'not-started') return 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900'
+  var cfg = statusConfig[q.status]
+  return cfg.bg + ' border-transparent'
+}
+
+function goBack() {
+  if (nav) nav.navigateTo('timeline')
+}
+</script>

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -49,6 +49,7 @@
     <!-- Active Report Detail -->
     <OnTimeReleasesReport v-if="activeReport === 'on-time-releases'" />
     <CveSlaReport v-if="activeReport === 'cve-sla'" />
+    <PostReleaseDefectsReport v-if="activeReport === 'post-release-defects'" />
   </div>
 </template>
 
@@ -56,6 +57,7 @@
 import { ref, computed } from 'vue'
 import OnTimeReleasesReport from '../components/OnTimeReleasesReport.vue'
 import CveSlaReport from '../components/CveSlaReport.vue'
+import PostReleaseDefectsReport from '../components/post-release-defects/PostReleaseDefectsReport.vue'
 
 var activeReport = ref(null)
 
@@ -77,6 +79,15 @@ var reports = [
     iconBg: 'bg-purple-50 dark:bg-purple-900/30',
     measure: '100%',
     measureColor: 'text-emerald-600 dark:text-emerald-400'
+  },
+  {
+    id: 'post-release-defects',
+    title: 'Post-Release Defects',
+    description: 'Cumulative bug trends across releases. Compare defect rates by version, product, and component.',
+    icon: '🐛',
+    iconBg: 'bg-red-50 dark:bg-red-900/30',
+    measure: null,
+    measureColor: ''
   }
 ]
 

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="space-y-6">
+    <!-- Header with back button when drilled in -->
+    <div class="flex items-center gap-3">
+      <button
+        v-if="activeReport"
+        @click="activeReport = null"
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
+      >
+        <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clip-rule="evenodd" /></svg>
+        All Reports
+      </button>
+      <div>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+          {{ activeReport ? activeReportDef.title : 'Reports' }}
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+          {{ activeReport ? activeReportDef.description : 'OKR analytics and reporting dashboards.' }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Flash Cards Grid -->
+    <div v-if="!activeReport" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <button
+        v-for="report in reports"
+        :key="report.id"
+        @click="activeReport = report.id"
+        class="group text-left rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 shadow-sm hover:shadow-md hover:border-primary-300 dark:hover:border-primary-600 transition-all duration-200"
+      >
+        <div class="flex items-start gap-3">
+          <div
+            class="flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center text-lg"
+            :class="report.iconBg"
+          >{{ report.icon }}</div>
+          <div class="min-w-0 flex-1">
+            <div class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">{{ report.title }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">{{ report.description }}</div>
+          </div>
+          <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 group-hover:text-primary-400 dark:group-hover:text-primary-400 transition-colors mt-1 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3 10a.75.75 0 01.75-.75h10.638L10.23 5.29a.75.75 0 111.04-1.08l5.5 5.25a.75.75 0 010 1.08l-5.5 5.25a.75.75 0 11-1.04-1.08l4.158-3.96H3.75A.75.75 0 013 10z" clip-rule="evenodd" /></svg>
+        </div>
+        <div v-if="report.measure" class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800">
+          <span class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Measure of Success</span>
+          <span class="ml-2 text-xs font-bold" :class="report.measureColor">{{ report.measure }}</span>
+        </div>
+      </button>
+    </div>
+
+    <!-- Active Report Detail -->
+    <OnTimeReleasesReport v-if="activeReport === 'on-time-releases'" />
+    <CveSlaReport v-if="activeReport === 'cve-sla'" />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import OnTimeReleasesReport from '../components/OnTimeReleasesReport.vue'
+import CveSlaReport from '../components/CveSlaReport.vue'
+
+var activeReport = ref(null)
+
+var reports = [
+  {
+    id: 'on-time-releases',
+    title: 'On Time Releases',
+    description: 'Did we hit the planned GA date? Tracks all point and major RHAI releases GA\'d after April 1, 2026.',
+    icon: '🚀',
+    iconBg: 'bg-blue-50 dark:bg-blue-900/30',
+    measure: '100%',
+    measureColor: 'text-emerald-600 dark:text-emerald-400'
+  },
+  {
+    id: 'cve-sla',
+    title: 'CVE SLA Compliance',
+    description: 'Number of escalations & on-time responses. Tracks CVE met vs missed across all products per quarter.',
+    icon: '🛡️',
+    iconBg: 'bg-purple-50 dark:bg-purple-900/30',
+    measure: '100%',
+    measureColor: 'text-emerald-600 dark:text-emerald-400'
+  }
+]
+
+var activeReportDef = computed(function() {
+  if (!activeReport.value) return {}
+  for (var i = 0; i < reports.length; i++) {
+    if (reports[i].id === activeReport.value) return reports[i]
+  }
+  return {}
+})
+</script>

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -51,6 +51,7 @@
     <CveSlaReport v-if="activeReport === 'cve-sla'" />
     <PostReleaseDefectsReport v-if="activeReport === 'post-release-defects'" />
     <CommitmentTrackingReport v-if="activeReport === 'commitment-tracking'" />
+    <TechVisibilityReport v-if="activeReport === 'tech-visibility'" />
   </div>
 </template>
 
@@ -60,6 +61,7 @@ import OnTimeReleasesReport from '../components/OnTimeReleasesReport.vue'
 import CveSlaReport from '../components/CveSlaReport.vue'
 import PostReleaseDefectsReport from '../components/post-release-defects/PostReleaseDefectsReport.vue'
 import CommitmentTrackingReport from '../components/commitment-tracking/CommitmentTrackingReport.vue'
+import TechVisibilityReport from '../components/TechVisibilityReport.vue'
 
 var activeReport = ref(null)
 
@@ -98,6 +100,15 @@ var reports = [
     icon: '🎯',
     iconBg: 'bg-emerald-50 dark:bg-emerald-900/30',
     measure: '>90%',
+    measureColor: 'text-emerald-600 dark:text-emerald-400'
+  },
+  {
+    id: 'tech-visibility',
+    title: 'Technical Visibility',
+    description: 'Red Hat AI technical visibility across internal and external sources. Tracks weekly article output.',
+    icon: '📝',
+    iconBg: 'bg-amber-50 dark:bg-amber-900/30',
+    measure: '>5 posts/week',
     measureColor: 'text-emerald-600 dark:text-emerald-400'
   }
 ]

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -50,6 +50,7 @@
     <OnTimeReleasesReport v-if="activeReport === 'on-time-releases'" />
     <CveSlaReport v-if="activeReport === 'cve-sla'" />
     <PostReleaseDefectsReport v-if="activeReport === 'post-release-defects'" />
+    <CommitmentTrackingReport v-if="activeReport === 'commitment-tracking'" />
   </div>
 </template>
 
@@ -58,6 +59,7 @@ import { ref, computed } from 'vue'
 import OnTimeReleasesReport from '../components/OnTimeReleasesReport.vue'
 import CveSlaReport from '../components/CveSlaReport.vue'
 import PostReleaseDefectsReport from '../components/post-release-defects/PostReleaseDefectsReport.vue'
+import CommitmentTrackingReport from '../components/commitment-tracking/CommitmentTrackingReport.vue'
 
 var activeReport = ref(null)
 
@@ -88,6 +90,15 @@ var reports = [
     iconBg: 'bg-red-50 dark:bg-red-900/30',
     measure: null,
     measureColor: ''
+  },
+  {
+    id: 'commitment-tracking',
+    title: 'Commitment Tracking',
+    description: 'Track committed vs. delivered features per release phase. Monitor >90% delivery OKR.',
+    icon: '🎯',
+    iconBg: 'bg-emerald-50 dark:bg-emerald-900/30',
+    measure: '>90%',
+    measureColor: 'text-emerald-600 dark:text-emerald-400'
   }
 ]
 

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -52,6 +52,7 @@
     <PostReleaseDefectsReport v-if="activeReport === 'post-release-defects'" />
     <CommitmentTrackingReport v-if="activeReport === 'commitment-tracking'" />
     <TechVisibilityReport v-if="activeReport === 'tech-visibility'" />
+    <SupportCaseReport v-if="activeReport === 'support-cases'" />
   </div>
 </template>
 
@@ -62,6 +63,7 @@ import CveSlaReport from '../components/CveSlaReport.vue'
 import PostReleaseDefectsReport from '../components/post-release-defects/PostReleaseDefectsReport.vue'
 import CommitmentTrackingReport from '../components/commitment-tracking/CommitmentTrackingReport.vue'
 import TechVisibilityReport from '../components/TechVisibilityReport.vue'
+import SupportCaseReport from '../components/SupportCaseReport.vue'
 
 var activeReport = ref(null)
 
@@ -72,8 +74,8 @@ var reports = [
     description: 'Did we hit the planned GA date? Tracks all point and major RHAI releases GA\'d after April 1, 2026.',
     icon: '🚀',
     iconBg: 'bg-blue-50 dark:bg-blue-900/30',
-    measure: '100%',
-    measureColor: 'text-emerald-600 dark:text-emerald-400'
+    measure: 'Number of Releases On Time - 100%',
+    measureColor: 'text-gray-600 dark:text-gray-300'
   },
   {
     id: 'cve-sla',
@@ -81,8 +83,8 @@ var reports = [
     description: 'Number of escalations & on-time responses. Tracks CVE met vs missed across all products per quarter.',
     icon: '🛡️',
     iconBg: 'bg-purple-50 dark:bg-purple-900/30',
-    measure: '100%',
-    measureColor: 'text-emerald-600 dark:text-emerald-400'
+    measure: 'Number of Escalations and On Time Response - 100%',
+    measureColor: 'text-gray-600 dark:text-gray-300'
   },
   {
     id: 'post-release-defects',
@@ -90,8 +92,8 @@ var reports = [
     description: 'Cumulative bug trends across releases. Compare defect rates by version, product, and component.',
     icon: '🐛',
     iconBg: 'bg-red-50 dark:bg-red-900/30',
-    measure: null,
-    measureColor: ''
+    measure: '90% reduction in bugs (Functional, UX, Regressions) discovered post-release by the field',
+    measureColor: 'text-gray-600 dark:text-gray-300'
   },
   {
     id: 'commitment-tracking',
@@ -99,8 +101,8 @@ var reports = [
     description: 'Track committed vs. delivered features per release phase. Monitor >90% delivery OKR.',
     icon: '🎯',
     iconBg: 'bg-emerald-50 dark:bg-emerald-900/30',
-    measure: '>90%',
-    measureColor: 'text-emerald-600 dark:text-emerald-400'
+    measure: '>90% of planned features for a release are delivered in the target release',
+    measureColor: 'text-gray-600 dark:text-gray-300'
   },
   {
     id: 'tech-visibility',
@@ -108,8 +110,17 @@ var reports = [
     description: 'Red Hat AI technical visibility across internal and external sources. Tracks weekly article output.',
     icon: '📝',
     iconBg: 'bg-amber-50 dark:bg-amber-900/30',
-    measure: '>5 posts/week',
-    measureColor: 'text-emerald-600 dark:text-emerald-400'
+    measure: 'KR1: >5 posts/week | KR2: 1 piece of content from each AI Eng associate',
+    measureColor: 'text-gray-600 dark:text-gray-300'
+  },
+  {
+    id: 'support-cases',
+    title: 'Support Case Time To Resolution',
+    description: 'Track defect rates and resolution times across products. Monitor support case closure efficiency per quarter.',
+    icon: '🔧',
+    iconBg: 'bg-orange-50 dark:bg-orange-900/30',
+    measure: 'Defect Rate for Product: 10% | Time to Resolution Target: 10-14 days',
+    measureColor: 'text-gray-600 dark:text-gray-300'
   }
 ]
 

--- a/modules/okr-hub/client/views/TimelineView.vue
+++ b/modules/okr-hub/client/views/TimelineView.vue
@@ -98,7 +98,7 @@
 
 <script setup>
 import { reactive, inject } from 'vue'
-import { OKR_DATA, STATUS_CONFIG, QUARTERS } from '../data/mock-okrs.js'
+import { OKR_DATA, STATUS_CONFIG, QUARTERS } from '../constants/mock-okrs.js'
 
 var nav = inject('moduleNav', null)
 

--- a/modules/okr-hub/client/views/TimelineView.vue
+++ b/modules/okr-hub/client/views/TimelineView.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="space-y-6">
+    <div class="flex items-center justify-between">
+      <div>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+          AI Engineering OKR Scorecard — {{ data.year }}
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Quarter-over-quarter tracking of all engineering OKRs.
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <span
+          v-for="s in statusList"
+          :key="s.key"
+          class="inline-flex items-center gap-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-300"
+        >
+          <span class="inline-block w-2.5 h-2.5 rounded-full" :class="s.dot" />
+          {{ s.label }}
+        </span>
+      </div>
+    </div>
+
+    <div v-for="category in data.categories" :key="category.name" class="space-y-2">
+      <button
+        class="w-full flex items-center gap-2 text-left group"
+        @click="toggleCategory(category.name)"
+      >
+        <svg
+          class="w-4 h-4 text-gray-400 transition-transform duration-200"
+          :class="{ 'rotate-90': isCategoryOpen(category.name) }"
+          fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+        <h3 class="text-sm font-bold text-gray-800 dark:text-gray-200 uppercase tracking-wide group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+          {{ category.name }}
+        </h3>
+        <span class="text-xs text-gray-400 dark:text-gray-500 font-medium">
+          {{ category.objectives.length }} objective{{ category.objectives.length === 1 ? '' : 's' }}
+        </span>
+      </button>
+
+      <div
+        v-show="isCategoryOpen(category.name)"
+        class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm"
+      >
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700">
+              <th class="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-48">Objective</th>
+              <th class="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-56">Measure of Success</th>
+              <th
+                v-for="q in quarters"
+                :key="q"
+                class="px-4 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-40"
+              >{{ q }} {{ shortYear }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="obj in category.objectives"
+              :key="obj.id"
+              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
+              @click="navigateToDeepDive(obj.id)"
+            >
+              <td class="px-4 py-3">
+                <span class="font-semibold text-gray-900 dark:text-gray-100 text-sm">{{ obj.name }}</span>
+              </td>
+              <td class="px-4 py-3 text-xs text-gray-600 dark:text-gray-400 whitespace-pre-line leading-relaxed">
+                {{ obj.measure }}
+              </td>
+              <td
+                v-for="q in quarters"
+                :key="q"
+                class="px-3 py-3 text-center"
+              >
+                <div
+                  v-if="obj.quarters[q]"
+                  class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
+                  :class="statusConfig[obj.quarters[q].status].bg"
+                >
+                  <span
+                    v-if="obj.quarters[q].summary"
+                    class="text-[11px] font-medium leading-tight whitespace-pre-line"
+                    :class="statusConfig[obj.quarters[q].status].text"
+                  >{{ obj.quarters[q].summary }}</span>
+                  <span v-else class="text-xs text-gray-300 dark:text-gray-600">—</span>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, inject } from 'vue'
+import { OKR_DATA, STATUS_CONFIG, QUARTERS } from '../data/mock-okrs.js'
+
+var nav = inject('moduleNav', null)
+
+var data = OKR_DATA
+var statusConfig = STATUS_CONFIG
+var quarters = QUARTERS
+var shortYear = String(data.year).slice(-2)
+
+var statusList = [
+  { key: 'green', label: 'On Track', dot: statusConfig.green.dot },
+  { key: 'yellow', label: 'Partial', dot: statusConfig.yellow.dot },
+  { key: 'red', label: 'At Risk', dot: statusConfig.red.dot },
+  { key: 'not-started', label: 'Not Started', dot: statusConfig['not-started'].dot }
+]
+
+var openCategories = reactive({})
+for (var i = 0; i < data.categories.length; i++) {
+  openCategories[data.categories[i].name] = true
+}
+
+function isCategoryOpen(name) {
+  return !!openCategories[name]
+}
+
+function toggleCategory(name) {
+  openCategories[name] = !openCategories[name]
+}
+
+function navigateToDeepDive(objectiveId) {
+  if (nav) nav.navigateTo('deep-dive', { okr: objectiveId })
+}
+</script>

--- a/modules/okr-hub/module.json
+++ b/modules/okr-hub/module.json
@@ -7,7 +7,7 @@
   "defaultEnabled": true,
   "requires": ["releases"],
   "secrets": {
-    "platform": ["jira"]
+    "platform": ["jira", "google"]
   },
   "client": {
     "entry": "./client/index.js",

--- a/modules/okr-hub/module.json
+++ b/modules/okr-hub/module.json
@@ -23,7 +23,8 @@
   "export": {
     "hook": "./server/export.js",
     "files": [
-      { "path": "okr-hub/cve-sla-data.json", "notes": "CVE SLA compliance data (products x months)" }
+      { "path": "okr-hub/cve-sla-data.json", "notes": "CVE SLA compliance data (products x months)" },
+      { "path": "okr-hub/on-time-overrides.json", "notes": "Custom release overrides for on-time report" }
     ]
   }
 }

--- a/modules/okr-hub/module.json
+++ b/modules/okr-hub/module.json
@@ -1,0 +1,29 @@
+{
+  "name": "OKR Hub",
+  "slug": "okr-hub",
+  "description": "Track and manage OKRs (Objectives and Key Results) across teams",
+  "icon": "Target",
+  "order": 7,
+  "defaultEnabled": true,
+  "requires": ["releases"],
+  "secrets": {
+    "platform": ["jira"]
+  },
+  "client": {
+    "entry": "./client/index.js",
+    "navItems": [
+      { "id": "timeline", "label": "Timeline", "icon": "BarChart3", "default": true },
+      { "id": "deep-dive", "label": "Deep Dive", "icon": "Search" },
+      { "id": "reports", "label": "Reports", "icon": "BarChart3" }
+    ]
+  },
+  "server": {
+    "entry": "./server/index.js"
+  },
+  "export": {
+    "hook": "./server/export.js",
+    "files": [
+      { "path": "okr-hub/cve-sla-data.json", "notes": "CVE SLA compliance data (products x months)" }
+    ]
+  }
+}

--- a/modules/okr-hub/module.json
+++ b/modules/okr-hub/module.json
@@ -13,7 +13,6 @@
     "entry": "./client/index.js",
     "navItems": [
       { "id": "timeline", "label": "Timeline", "icon": "BarChart3", "default": true },
-      { "id": "deep-dive", "label": "Deep Dive", "icon": "Search" },
       { "id": "reports", "label": "Reports", "icon": "BarChart3" }
     ]
   },
@@ -24,7 +23,8 @@
     "hook": "./server/export.js",
     "files": [
       { "path": "okr-hub/cve-sla-data.json", "notes": "CVE SLA compliance data (products x months)" },
-      { "path": "okr-hub/on-time-overrides.json", "notes": "Custom release overrides for on-time report" }
+      { "path": "okr-hub/on-time-overrides.json", "notes": "Custom release overrides for on-time report" },
+      { "path": "okr-hub/support-case-data.json", "notes": "Support case resolution data by quarter and product" }
     ]
   }
 }

--- a/modules/okr-hub/server/export.js
+++ b/modules/okr-hub/server/export.js
@@ -7,4 +7,13 @@ module.exports = async function okrHubExport(addFile, storage) {
       months: {}
     })
   }
+
+  var overrides = storage.readFromStorage('okr-hub/on-time-overrides.json')
+  if (overrides) {
+    addFile('okr-hub/on-time-overrides.json', {
+      releases: (overrides.releases || []).map(function(r) {
+        return { id: r.id, displayName: 'Release', plannedGa: r.plannedGa, actualGa: r.actualGa, custom: r.custom || false, removed: r.removed || false }
+      })
+    })
+  }
 }

--- a/modules/okr-hub/server/export.js
+++ b/modules/okr-hub/server/export.js
@@ -8,6 +8,15 @@ module.exports = async function okrHubExport(addFile, storage) {
     })
   }
 
+  var supportCases = storage.readFromStorage('okr-hub/support-case-data.json')
+  if (supportCases) {
+    addFile('okr-hub/support-case-data.json', {
+      year: supportCases.year || 2026,
+      products: (supportCases.products || []).map(function() { return 'Product' }),
+      quarters: {}
+    })
+  }
+
   var overrides = storage.readFromStorage('okr-hub/on-time-overrides.json')
   if (overrides) {
     addFile('okr-hub/on-time-overrides.json', {

--- a/modules/okr-hub/server/export.js
+++ b/modules/okr-hub/server/export.js
@@ -1,0 +1,10 @@
+module.exports = async function okrHubExport(addFile, storage) {
+  var cveSla = storage.readFromStorage('okr-hub/cve-sla-data.json')
+  if (cveSla) {
+    addFile('okr-hub/cve-sla-data.json', {
+      year: cveSla.year || 2026,
+      products: (cveSla.products || []).map(function() { return 'Product' }),
+      months: {}
+    })
+  }
+}

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -11,6 +11,11 @@ var TECH_VIS_CACHE_TTL = 15 * 60 * 1000
 var TECH_VIS_SHEET_ID = '1gUAxe2LtmTjzcN8Wt3LfaXswSfK9emM40OtwmSsxMaU'
 var TECH_VIS_TARGET = 5
 
+var contentCache = null
+var contentCacheAt = 0
+var CONTENT_CACHE_TTL = 15 * 60 * 1000
+var CONTENT_SHEET_ID = '1LePie38Eg1gUEIO6qu5zifgnCe9ASj8QHE8n_sgsrVk'
+
 /**
  * @param {import('express').Router} router
  * @param {import('@shared/server/module-context').ModuleContext} context
@@ -353,6 +358,157 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/content-contributions:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Associate content contributions - per-team completion tracking from Google Sheets
+   *     responses:
+   *       200:
+   *         description: Per-quarter breakdown of team content contributions
+   */
+  router.get('/reports/content-contributions', requireScope('okr-hub:read'), async function(req, res) {
+    try {
+      var now = Date.now()
+      if (contentCache && (now - contentCacheAt) < CONTENT_CACHE_TTL) {
+        return res.json(contentCache)
+      }
+
+      var sheetsClient = createGoogleSheetsClient()
+      var tabNames
+      try {
+        tabNames = await sheetsClient.discoverSheetNames(CONTENT_SHEET_ID)
+      } catch (authErr) {
+        console.warn('[okr-hub] Google Sheets unavailable for content contributions, using sample data:', authErr.message)
+        var sample = getSampleContentData()
+        contentCache = sample
+        contentCacheAt = now
+        return res.json(sample)
+      }
+
+      if (!tabNames || tabNames.length === 0) {
+        return res.json({ error: 'No tabs found in spreadsheet', quarters: [], overall: { associates: 0, completed: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
+      }
+
+      var quarters = []
+      for (var ti = 0; ti < tabNames.length; ti++) {
+        var tabName = tabNames[ti]
+        var qMatch = tabName.match(/Q(\d)\s*(\d{4})?/i)
+        if (!qMatch) continue
+
+        var raw = await sheetsClient.fetchRawSheet(CONTENT_SHEET_ID, tabName)
+        if (!raw || !raw.headers || raw.headers.length === 0) continue
+
+        var teamCol = findColumnIndex(raw.headers, ['team name', 'team'])
+        var assocCol = findColumnIndex(raw.headers, ['number of associates', 'associates', '# associates'])
+        var completedCol = findColumnIndex(raw.headers, ['associates completed', 'completed content', 'completed'])
+        var pctCol = findColumnIndex(raw.headers, ['percentage completed', '% completed', 'percentage', '%'])
+        var statusCol = findColumnIndex(raw.headers, ['status'])
+        var perfCol = findColumnIndex(raw.headers, ['performance vs', 'performance'])
+        var endQCol = findColumnIndex(raw.headers, ['end of q', 'end of quarter', 'q1 status', 'q2 status', 'q3 status', 'q4 status'])
+
+        if (teamCol === -1 || assocCol === -1) continue
+
+        var teams = []
+        var totalRow = null
+        for (var ri = 0; ri < raw.rows.length; ri++) {
+          var row = raw.rows[ri]
+          var name = String(row[teamCol] || '').trim()
+          if (!name) continue
+
+          var associates = parseNum(row[assocCol])
+          var completed = completedCol !== -1 ? parseNum(row[completedCol]) : 0
+          var pct = pctCol !== -1 ? parsePct(row[pctCol]) : (associates > 0 ? Math.round((completed / associates) * 100) : 0)
+          var status = statusCol !== -1 ? String(row[statusCol] || '').trim() : ''
+          var perf = perfCol !== -1 ? String(row[perfCol] || '').trim() : ''
+          var endQ = endQCol !== -1 ? parsePct(row[endQCol]) : null
+
+          var entry = { name: name, associates: associates, completed: completed, pct: pct, status: status, performance: perf, endQPct: endQ }
+
+          if (name.toLowerCase() === 'total') {
+            totalRow = entry
+          } else {
+            teams.push(entry)
+          }
+        }
+
+        if (teams.length === 0) continue
+
+        if (!totalRow) {
+          var tAssoc = 0
+          var tComp = 0
+          for (var tmi = 0; tmi < teams.length; tmi++) { tAssoc += teams[tmi].associates; tComp += teams[tmi].completed }
+          totalRow = { name: 'TOTAL', associates: tAssoc, completed: tComp, pct: tAssoc > 0 ? Math.round((tComp / tAssoc) * 100) : 0, status: '', performance: '', endQPct: null }
+        }
+
+        var qLabel = tabName.trim()
+        quarters.push({
+          label: qLabel,
+          teams: teams,
+          total: { associates: totalRow.associates, completed: totalRow.completed, pct: totalRow.pct, endQPct: totalRow.endQPct },
+          targetDate: '12/31/2026'
+        })
+      }
+
+      if (quarters.length === 0) {
+        var raw0 = await sheetsClient.fetchRawSheet(CONTENT_SHEET_ID, tabNames[0])
+        if (raw0 && raw0.headers) {
+          var parsed = parseContentTab(raw0, tabNames[0])
+          if (parsed) quarters.push(parsed)
+        }
+      }
+
+      var latestQ = quarters.length > 0 ? quarters[quarters.length - 1] : null
+      var result = {
+        quarters: quarters,
+        overall: latestQ ? { associates: latestQ.total.associates, completed: latestQ.total.completed, pct: latestQ.total.pct } : { associates: 0, completed: 0, pct: 0 },
+        target: '1 piece of content per associate',
+        fetchedAt: new Date().toISOString()
+      }
+
+      contentCache = result
+      contentCacheAt = now
+      res.json(result)
+    } catch (err) {
+      console.error('[okr-hub] content-contributions error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  function parseContentTab(raw, tabName) {
+    if (!raw || !raw.headers || raw.headers.length === 0) return null
+
+    var teamCol = findColumnIndex(raw.headers, ['team name', 'team'])
+    var assocCol = findColumnIndex(raw.headers, ['number of associates', 'associates', '# associates'])
+    var completedCol = findColumnIndex(raw.headers, ['associates completed', 'completed content', 'completed'])
+    var pctCol = findColumnIndex(raw.headers, ['percentage completed', '% completed', 'percentage', '%'])
+    var statusCol = findColumnIndex(raw.headers, ['status'])
+
+    if (teamCol === -1 || assocCol === -1) return null
+
+    var teams = []
+    var totalRow = null
+    for (var ri = 0; ri < raw.rows.length; ri++) {
+      var row = raw.rows[ri]
+      var name = String(row[teamCol] || '').trim()
+      if (!name) continue
+      var associates = parseNum(row[assocCol])
+      var completed = completedCol !== -1 ? parseNum(row[completedCol]) : 0
+      var pct = pctCol !== -1 ? parsePct(row[pctCol]) : (associates > 0 ? Math.round((completed / associates) * 100) : 0)
+      var status = statusCol !== -1 ? String(row[statusCol] || '').trim() : ''
+      var entry = { name: name, associates: associates, completed: completed, pct: pct, status: status, performance: '', endQPct: null }
+      if (name.toLowerCase() === 'total') { totalRow = entry } else { teams.push(entry) }
+    }
+    if (teams.length === 0) return null
+    if (!totalRow) {
+      var tA = 0; var tC = 0
+      for (var i = 0; i < teams.length; i++) { tA += teams[i].associates; tC += teams[i].completed }
+      totalRow = { name: 'TOTAL', associates: tA, completed: tC, pct: tA > 0 ? Math.round((tC / tA) * 100) : 0 }
+    }
+      return { label: tabName.trim(), teams: teams, total: { associates: totalRow.associates, completed: totalRow.completed, pct: totalRow.pct, endQPct: totalRow.endQPct }, targetDate: '12/31/2026' }
+  }
+
   context.registerDiagnostics(async function() {
     return { status: 'ok' }
   })
@@ -443,6 +599,47 @@ function getDefaultCveSlaData() {
       nov: {},
       dec: {}
     }
+  }
+}
+
+function parseNum(val) {
+  if (val == null || val === '') return 0
+  if (typeof val === 'number') return val
+  var n = parseInt(String(val).replace(/,/g, ''), 10)
+  return isNaN(n) ? 0 : n
+}
+
+function parsePct(val) {
+  if (val == null || val === '') return null
+  if (typeof val === 'number') return Math.round(val * (val < 1 ? 100 : 1))
+  var s = String(val).replace('%', '').trim()
+  var n = parseFloat(s)
+  if (isNaN(n)) return null
+  return Math.round(n < 1 && n > 0 ? n * 100 : n)
+}
+
+function getSampleContentData() {
+  var teams = [
+    { name: "Steven's Directs", associates: 14, completed: 1, pct: 7, status: 'Started', performance: 'Behind (43% to go)', endQPct: 7 },
+    { name: 'Cat Agentics & AI Eng Tooling', associates: 58, completed: 18, pct: 31, status: 'Started', performance: 'Behind (19% to go)', endQPct: 6 },
+    { name: 'Sherard AI Platform', associates: 192, completed: 34, pct: 18, status: 'Started', performance: 'Behind (32% to go)', endQPct: 6 },
+    { name: 'Taneem Inf Engineering', associates: 59, completed: 21, pct: 36, status: 'Started', performance: 'Behind (14% to go)', endQPct: 7 },
+    { name: 'Kai AI Innovation', associates: 13, completed: 2, pct: 15, status: 'Started', performance: 'Behind (35% to go)', endQPct: 0 },
+    { name: 'Tom AIPCC', associates: 147, completed: 19, pct: 13, status: 'Started', performance: 'Behind (37% to go)', endQPct: 6 },
+    { name: 'Monica watsonx', associates: 48, completed: 18, pct: 38, status: 'Started', performance: 'Behind (13% to go)', endQPct: 10 }
+  ]
+  return {
+    quarters: [
+      {
+        label: 'Q1 2026',
+        teams: teams,
+        total: { associates: 531, completed: 113, pct: 21, endQPct: 7 },
+        targetDate: '12/31/2026'
+      }
+    ],
+    overall: { associates: 531, completed: 113, pct: 21 },
+    target: '1 piece of content per associate',
+    fetchedAt: new Date().toISOString()
   }
 }
 

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -1,0 +1,296 @@
+const { createJiraClient } = require('../../../shared/server/jira')
+
+var versionsCache = null
+var versionsCacheAt = 0
+var VERSIONS_CACHE_TTL = 10 * 60 * 1000
+
+/**
+ * @param {import('express').Router} router
+ * @param {import('@shared/server/module-context').ModuleContext} context
+ */
+module.exports = function registerRoutes(router, context) {
+  const { storage, requireScope, secrets } = context
+
+  var jira = createJiraClient({
+    email: (secrets && secrets.JIRA_EMAIL) || '',
+    token: (secrets && secrets.JIRA_TOKEN) || '',
+    host: process.env.JIRA_HOST
+  })
+
+  var JIRA_PROJECTS = ['RHAISTRAT', 'RHOAIENG']
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/status:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: OKR Hub status
+   *     responses:
+   *       200:
+   *         description: Success
+   */
+  router.get('/status', requireScope('okr-hub:read'), function(req, res) {
+    res.json({ status: 'ok', message: 'OKR Hub is running' })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/on-time-releases:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: On Time Releases report comparing planned vs actual GA dates
+   *     parameters:
+   *       - name: since
+   *         in: query
+   *         schema: { type: string }
+   *         description: ISO date cutoff for planned GA (default 2026-04-01)
+   *     responses:
+   *       200:
+   *         description: Array of releases with on-time analysis
+   */
+  router.get('/reports/on-time-releases', requireScope('okr-hub:read'), async function(req, res) {
+    try {
+      var since = req.query.since || '2026-04-01'
+
+      var registry = storage.readFromStorage('releases/registry.json')
+      if (!registry || !Array.isArray(registry.releases)) {
+        return res.json({ releases: [], summary: { total: 0, onTime: 0, late: 0, upcoming: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
+      }
+
+      var candidates = []
+      for (var i = 0; i < registry.releases.length; i++) {
+        var rel = registry.releases[i]
+        var ga = rel.milestones && rel.milestones.ga
+        if (!ga || ga < since) continue
+        if (isEaRelease(rel.id)) continue
+        candidates.push(rel)
+      }
+
+      var jiraVersions = await fetchJiraVersions(jira)
+
+      var jiraVersionMap = {}
+      for (var vi = 0; vi < jiraVersions.length; vi++) {
+        var v = jiraVersions[vi]
+        jiraVersionMap[v.name.toLowerCase()] = v
+      }
+
+      var results = []
+      for (var ri = 0; ri < candidates.length; ri++) {
+        var release = candidates[ri]
+        var plannedGa = release.milestones.ga
+        var actualGa = null
+        var released = false
+
+        var fvList = release.fixVersions || []
+        for (var fvi = 0; fvi < fvList.length; fvi++) {
+          var match = jiraVersionMap[fvList[fvi].toLowerCase()]
+          if (match && match.released && match.releaseDate) {
+            actualGa = match.releaseDate
+            released = true
+            break
+          }
+        }
+
+        var onTime = null
+        var daysLate = null
+        if (released && actualGa) {
+          var planned = new Date(plannedGa + 'T00:00:00Z')
+          var actual = new Date(actualGa + 'T00:00:00Z')
+          var diffMs = actual.getTime() - planned.getTime()
+          daysLate = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+          onTime = daysLate <= 0
+        }
+
+        results.push({
+          id: release.id,
+          displayName: release.displayName,
+          plannedGa: plannedGa,
+          actualGa: actualGa,
+          released: released,
+          onTime: onTime,
+          daysLate: daysLate
+        })
+      }
+
+      results.sort(function(a, b) {
+        return b.plannedGa.localeCompare(a.plannedGa)
+      })
+
+      var totalReleased = 0
+      var onTimeCount = 0
+      var lateCount = 0
+      var upcomingCount = 0
+      for (var si = 0; si < results.length; si++) {
+        if (!results[si].released) { upcomingCount++; continue }
+        totalReleased++
+        if (results[si].onTime) onTimeCount++
+        else lateCount++
+      }
+
+      var pct = totalReleased > 0 ? Math.round((onTimeCount / totalReleased) * 100) : 0
+
+      res.json({
+        releases: results,
+        summary: {
+          total: results.length,
+          totalReleased: totalReleased,
+          onTime: onTimeCount,
+          late: lateCount,
+          upcoming: upcomingCount,
+          pct: pct
+        },
+        since: since,
+        fetchedAt: new Date().toISOString()
+      })
+    } catch (err) {
+      console.error('[okr-hub] on-time-releases error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  async function fetchJiraVersions(jiraClient) {
+    var now = Date.now()
+    if (versionsCache && (now - versionsCacheAt) < VERSIONS_CACHE_TTL) {
+      return versionsCache
+    }
+
+    var allVersions = []
+    for (var pi = 0; pi < JIRA_PROJECTS.length; pi++) {
+      var project = JIRA_PROJECTS[pi]
+      try {
+        var data = await jiraClient.jiraRequest('/rest/api/3/project/' + project + '/versions')
+        for (var dvi = 0; dvi < data.length; dvi++) {
+          allVersions.push({
+            name: data[dvi].name,
+            releaseDate: data[dvi].releaseDate || null,
+            released: data[dvi].released || false,
+            project: project
+          })
+        }
+      } catch (err) {
+        console.warn('[okr-hub] Failed to fetch versions for ' + project + ':', err.message)
+      }
+    }
+
+    versionsCache = allVersions
+    versionsCacheAt = now
+    return allVersions
+  }
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/cve-sla:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: CVE SLA Compliance data (products x months with met/missed counts)
+   *     responses:
+   *       200:
+   *         description: CVE SLA dataset
+   */
+  router.get('/reports/cve-sla', requireScope('okr-hub:read'), function(req, res) {
+    var saved = storage.readFromStorage('okr-hub/cve-sla-data.json')
+    if (saved && saved.products && saved.months) {
+      return res.json(saved)
+    }
+    res.json(getDefaultCveSlaData())
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/cve-sla:
+   *   put:
+   *     tags: [OKR Hub]
+   *     summary: Save CVE SLA Compliance data
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema: { type: object }
+   *     responses:
+   *       200:
+   *         description: Saved successfully
+   */
+  router.put('/reports/cve-sla', requireScope('okr-hub:write'), function(req, res) {
+    try {
+      var body = req.body
+      if (!body || !Array.isArray(body.products) || !body.months) {
+        return res.status(400).json({ error: 'Invalid payload: requires products array and months object' })
+      }
+      storage.writeToStorage('okr-hub/cve-sla-data.json', body)
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[okr-hub] cve-sla save error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  context.registerDiagnostics(async function() {
+    return { status: 'ok' }
+  })
+}
+
+function isEaRelease(id) {
+  var lower = (id || '').toLowerCase()
+  return lower.includes('.ea') || lower.includes('-ea')
+}
+
+function getDefaultCveSlaData() {
+  return {
+    year: 2026,
+    products: [
+      'RHOAI',
+      'RHOAI 2.16',
+      'RHOAI 2.25',
+      'RHOAI 3.2',
+      'RHEL AI',
+      'RH AI Inference Server',
+      'RH Inference Server 3.2'
+    ],
+    months: {
+      jan: {
+        'RHOAI': { met: 27, missed: 1 },
+        'RHOAI 2.16': { met: 0, missed: 0 },
+        'RHOAI 2.25': { met: 23, missed: 0 },
+        'RHOAI 3.2': { met: 0, missed: 0 },
+        'RHEL AI': { met: 0, missed: 0 },
+        'RH AI Inference Server': { met: 1, missed: 0 },
+        'RH Inference Server 3.2': { met: 14, missed: 0 }
+      },
+      feb: {
+        'RHOAI': { met: 108, missed: 117 },
+        'RHOAI 2.16': { met: 0, missed: 0 },
+        'RHOAI 2.25': { met: 74, missed: 113 },
+        'RHOAI 3.2': { met: 3, missed: 0 },
+        'RHEL AI': { met: 0, missed: 0 },
+        'RH AI Inference Server': { met: 0, missed: 87 },
+        'RH Inference Server 3.2': { met: 4, missed: 10 }
+      },
+      mar: {
+        'RHOAI': { met: 221, missed: 2 },
+        'RHOAI 2.16': { met: 0, missed: 0 },
+        'RHOAI 2.25': { met: 94, missed: 0 },
+        'RHOAI 3.2': { met: 0, missed: 0 },
+        'RHEL AI': { met: 0, missed: 0 },
+        'RH AI Inference Server': { met: 5, missed: 0 },
+        'RH Inference Server 3.2': { met: 29, missed: 0 }
+      },
+      apr: {
+        'RHOAI': { met: 66, missed: 89 },
+        'RHOAI 2.16': { met: 3, missed: 0 },
+        'RHOAI 2.25': { met: 38, missed: 10 },
+        'RHOAI 3.2': { met: 0, missed: 0 },
+        'RHEL AI': { met: 0, missed: 0 },
+        'RH AI Inference Server': { met: 12, missed: 0 },
+        'RH Inference Server 3.2': { met: 15, missed: 6 }
+      },
+      may: {},
+      jun: {},
+      jul: {},
+      aug: {},
+      sep: {},
+      oct: {},
+      nov: {},
+      dec: {}
+    }
+  }
+}

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -749,11 +749,15 @@ function parseNum(val) {
 
 function parsePct(val) {
   if (val == null || val === '') return null
-  if (typeof val === 'number') return Math.round(val * (val < 1 ? 100 : 1))
+  if (typeof val === 'number') {
+    // Google Sheets UNFORMATTED_VALUE returns percentages as decimals (0-1)
+    return Math.round(val <= 1 ? val * 100 : val)
+  }
   var s = String(val).replace('%', '').trim()
   var n = parseFloat(s)
   if (isNaN(n)) return null
-  return Math.round(n < 1 && n > 0 ? n * 100 : n)
+  // String values with '%' stripped: if already 0-100 range, use as-is; if 0-1, convert
+  return Math.round(n <= 1 ? n * 100 : n)
 }
 
 function getSampleContentData() {

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -600,6 +600,53 @@ module.exports = function registerRoutes(router, context) {
       return { label: tabName.trim(), teams: teams, total: { associates: totalRow.associates, completed: totalRow.completed, pct: totalRow.pct, endQPct: totalRow.endQPct }, targetDate: '12/31/2026' }
   }
 
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/support-cases:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Support case time to resolution data
+   *     responses:
+   *       200:
+   *         description: Support case data by quarter and product
+   */
+  router.get('/reports/support-cases', requireScope('okr-hub:read'), function(req, res) {
+    var saved = storage.readFromStorage('okr-hub/support-case-data.json')
+    if (saved && saved.products && saved.quarters) {
+      return res.json(saved)
+    }
+    res.json(getDefaultSupportCaseData())
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/support-cases:
+   *   put:
+   *     tags: [OKR Hub]
+   *     summary: Save support case data
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema: { type: object }
+   *     responses:
+   *       200:
+   *         description: Saved
+   */
+  router.put('/reports/support-cases', requireScope('okr-hub:write'), function(req, res) {
+    try {
+      var body = req.body
+      if (!body || !Array.isArray(body.products) || !body.quarters) {
+        return res.status(400).json({ error: 'Invalid payload: requires products array and quarters object' })
+      }
+      storage.writeToStorage('okr-hub/support-case-data.json', body)
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[okr-hub] support-cases save error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
   context.registerDiagnostics(async function() {
     return { status: 'ok' }
   })
@@ -765,4 +812,20 @@ function getSampleTechVisData() {
     source: '(sample data)',
     fetchedAt: new Date().toISOString()
   }
+}
+
+function getDefaultSupportCaseData() {
+  var emptyProduct = { totalCases: null, defects: null, casesClosed: null, bugsEng: null, rfe: null, supportEx: null, other: null, avgResolutionDays: null, medianResolutionDays: null }
+  var products = ['RHOAI', 'RHEL-AI', 'RHAII']
+  var quarters = {}
+  var qNames = ['Q1', 'Q2', 'Q3', 'Q4']
+  for (var qi = 0; qi < qNames.length; qi++) {
+    quarters[qNames[qi]] = {}
+    for (var pi = 0; pi < products.length; pi++) {
+      quarters[qNames[qi]][products[pi]] = Object.assign({}, emptyProduct)
+    }
+  }
+  quarters.Q1.RHOAI = { totalCases: 107, defects: 36, casesClosed: 25, bugsEng: 0, rfe: 0, supportEx: 0, other: 0, avgResolutionDays: 45.2, medianResolutionDays: 32.9 }
+  quarters.Q2.RHOAI = { totalCases: 120, defects: 37, casesClosed: 14, bugsEng: 0, rfe: 0, supportEx: 0, other: 0, avgResolutionDays: 17.6, medianResolutionDays: 15.3 }
+  return { year: 2026, products: products, quarters: quarters }
 }

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -1,8 +1,15 @@
 const { createJiraClient } = require('../../../shared/server/jira')
+const { createGoogleSheetsClient } = require('../../../shared/server/google-sheets')
 
 var versionsCache = null
 var versionsCacheAt = 0
 var VERSIONS_CACHE_TTL = 10 * 60 * 1000
+
+var techVisCache = null
+var techVisCacheAt = 0
+var TECH_VIS_CACHE_TTL = 15 * 60 * 1000
+var TECH_VIS_SHEET_ID = '1gUAxe2LtmTjzcN8Wt3LfaXswSfK9emM40OtwmSsxMaU'
+var TECH_VIS_TARGET = 5
 
 /**
  * @param {import('express').Router} router
@@ -224,6 +231,128 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/tech-visibility:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Technical visibility report - weekly article counts from Google Sheets
+   *     responses:
+   *       200:
+   *         description: Quarterly breakdown of weekly article counts
+   */
+  router.get('/reports/tech-visibility', requireScope('okr-hub:read'), async function(req, res) {
+    try {
+      var now = Date.now()
+      if (techVisCache && (now - techVisCacheAt) < TECH_VIS_CACHE_TTL) {
+        return res.json(techVisCache)
+      }
+
+      var sheetsClient = createGoogleSheetsClient()
+      var tabNames
+      try {
+        tabNames = await sheetsClient.discoverSheetNames(TECH_VIS_SHEET_ID)
+      } catch (authErr) {
+        console.warn('[okr-hub] Google Sheets unavailable, using sample data:', authErr.message)
+        var sample = getSampleTechVisData()
+        techVisCache = sample
+        techVisCacheAt = now
+        return res.json(sample)
+      }
+      if (!tabNames || tabNames.length === 0) {
+        return res.json({ error: 'No tabs found in spreadsheet', quarters: [], overall: { weeksMet: 0, totalWeeks: 0, pct: 0 }, target: TECH_VIS_TARGET, fetchedAt: new Date().toISOString() })
+      }
+
+      var sheetData = null
+      for (var ti = 0; ti < tabNames.length; ti++) {
+        var raw = await sheetsClient.fetchRawSheet(TECH_VIS_SHEET_ID, tabNames[ti])
+        if (raw && raw.headers && raw.headers.length > 0) {
+          var hasWeekCol = findColumnIndex(raw.headers, ['week', 'date', 'week of', 'week starting'])
+          var hasCountCol = findColumnIndex(raw.headers, ['count', 'articles', 'posts', 'total', '# of articles', 'number'])
+          if (hasWeekCol !== -1 && hasCountCol !== -1) {
+            sheetData = { headers: raw.headers, rows: raw.rows, weekCol: hasWeekCol, countCol: hasCountCol, tabName: tabNames[ti] }
+            break
+          }
+        }
+      }
+
+      if (!sheetData) {
+        return res.json({ error: 'Could not find columns for week dates and article counts. Available tabs: ' + tabNames.join(', '), quarters: [], overall: { weeksMet: 0, totalWeeks: 0, pct: 0 }, target: TECH_VIS_TARGET, fetchedAt: new Date().toISOString() })
+      }
+
+      var weeks = []
+      for (var ri = 0; ri < sheetData.rows.length; ri++) {
+        var row = sheetData.rows[ri]
+        var weekVal = row[sheetData.weekCol]
+        var countVal = row[sheetData.countCol]
+        if (weekVal == null || weekVal === '') continue
+
+        var weekDate = parseSheetDate(weekVal)
+        if (!weekDate) continue
+
+        var count = typeof countVal === 'number' ? countVal : parseInt(String(countVal || '0'), 10)
+        if (isNaN(count)) count = 0
+
+        weeks.push({
+          weekOf: weekDate,
+          count: count,
+          met: count >= TECH_VIS_TARGET
+        })
+      }
+
+      weeks.sort(function(a, b) { return a.weekOf.localeCompare(b.weekOf) })
+
+      var quarterMap = {}
+      for (var wi = 0; wi < weeks.length; wi++) {
+        var w = weeks[wi]
+        var d = new Date(w.weekOf + 'T00:00:00Z')
+        var year = d.getUTCFullYear()
+        var month = d.getUTCMonth()
+        var qNum = Math.floor(month / 3) + 1
+        var qLabel = 'Q' + qNum + ' ' + year
+        if (!quarterMap[qLabel]) {
+          quarterMap[qLabel] = { label: qLabel, weeks: [], weeksMet: 0, totalWeeks: 0, pct: 0, sortKey: year * 10 + qNum }
+        }
+        quarterMap[qLabel].weeks.push(w)
+        quarterMap[qLabel].totalWeeks++
+        if (w.met) quarterMap[qLabel].weeksMet++
+      }
+
+      var quarters = Object.keys(quarterMap).map(function(k) { return quarterMap[k] })
+      quarters.sort(function(a, b) { return a.sortKey - b.sortKey })
+      for (var qi = 0; qi < quarters.length; qi++) {
+        quarters[qi].pct = quarters[qi].totalWeeks > 0 ? Math.round((quarters[qi].weeksMet / quarters[qi].totalWeeks) * 100) : 0
+        delete quarters[qi].sortKey
+      }
+
+      var overallMet = 0
+      var overallTotal = 0
+      for (var oi = 0; oi < quarters.length; oi++) {
+        overallMet += quarters[oi].weeksMet
+        overallTotal += quarters[oi].totalWeeks
+      }
+
+      var result = {
+        quarters: quarters,
+        overall: {
+          weeksMet: overallMet,
+          totalWeeks: overallTotal,
+          pct: overallTotal > 0 ? Math.round((overallMet / overallTotal) * 100) : 0
+        },
+        target: TECH_VIS_TARGET,
+        source: sheetData.tabName,
+        fetchedAt: new Date().toISOString()
+      }
+
+      techVisCache = result
+      techVisCacheAt = now
+      res.json(result)
+    } catch (err) {
+      console.error('[okr-hub] tech-visibility error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
   context.registerDiagnostics(async function() {
     return { status: 'ok' }
   })
@@ -232,6 +361,28 @@ module.exports = function registerRoutes(router, context) {
 function isEaRelease(id) {
   var lower = (id || '').toLowerCase()
   return lower.includes('.ea') || lower.includes('-ea')
+}
+
+function findColumnIndex(headers, candidates) {
+  for (var hi = 0; hi < headers.length; hi++) {
+    var h = (headers[hi] || '').toLowerCase().trim()
+    for (var ci = 0; ci < candidates.length; ci++) {
+      if (h === candidates[ci] || h.includes(candidates[ci])) return hi
+    }
+  }
+  return -1
+}
+
+function parseSheetDate(val) {
+  if (typeof val === 'number') {
+    var epoch = new Date(Date.UTC(1899, 11, 30))
+    var d = new Date(epoch.getTime() + val * 86400000)
+    return d.toISOString().slice(0, 10)
+  }
+  var s = String(val).trim()
+  var parsed = new Date(s)
+  if (!isNaN(parsed.getTime())) return parsed.toISOString().slice(0, 10)
+  return null
 }
 
 function getDefaultCveSlaData() {
@@ -292,5 +443,38 @@ function getDefaultCveSlaData() {
       nov: {},
       dec: {}
     }
+  }
+}
+
+function getSampleTechVisData() {
+  var q2Weeks = [
+    { weekOf: '2026-04-06', count: 7, met: true },
+    { weekOf: '2026-04-13', count: 5, met: true },
+    { weekOf: '2026-04-20', count: 3, met: false },
+    { weekOf: '2026-04-27', count: 6, met: true },
+    { weekOf: '2026-05-04', count: 8, met: true },
+    { weekOf: '2026-05-11', count: 4, met: false },
+    { weekOf: '2026-05-18', count: 5, met: true },
+    { weekOf: '2026-05-25', count: 9, met: true },
+    { weekOf: '2026-06-01', count: 6, met: true },
+    { weekOf: '2026-06-08', count: 2, met: false },
+    { weekOf: '2026-06-15', count: 7, met: true },
+    { weekOf: '2026-06-22', count: 5, met: true },
+    { weekOf: '2026-06-29', count: 4, met: false }
+  ]
+  var met = 0
+  for (var i = 0; i < q2Weeks.length; i++) { if (q2Weeks[i].met) met++ }
+  return {
+    quarters: [{
+      label: 'Q2 2026',
+      weeks: q2Weeks,
+      weeksMet: met,
+      totalWeeks: q2Weeks.length,
+      pct: Math.round((met / q2Weeks.length) * 100)
+    }],
+    overall: { weeksMet: met, totalWeeks: q2Weeks.length, pct: Math.round((met / q2Weeks.length) * 100) },
+    target: TECH_VIS_TARGET,
+    source: '(sample data)',
+    fetchedAt: new Date().toISOString()
   }
 }

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -23,6 +23,8 @@ var CONTENT_SHEET_ID = '1LePie38Eg1gUEIO6qu5zifgnCe9ASj8QHE8n_sgsrVk'
 module.exports = function registerRoutes(router, context) {
   const { storage, requireScope, secrets } = context
 
+  var googleKeyFile = context.resolveSecret('GOOGLE_SERVICE_ACCOUNT_KEY_FILE') || '/etc/secrets/google-sa-key.json'
+
   var jira = createJiraClient({
     email: (secrets && secrets.JIRA_EMAIL) || '',
     token: (secrets && secrets.JIRA_TOKEN) || '',
@@ -344,7 +346,7 @@ module.exports = function registerRoutes(router, context) {
         return res.json(techVisCache)
       }
 
-      var sheetsClient = createGoogleSheetsClient()
+      var sheetsClient = createGoogleSheetsClient({ keyFile: googleKeyFile })
       var tabNames
       try {
         tabNames = await sheetsClient.discoverSheetNames(TECH_VIS_SHEET_ID)
@@ -466,7 +468,7 @@ module.exports = function registerRoutes(router, context) {
         return res.json(contentCache)
       }
 
-      var sheetsClient = createGoogleSheetsClient()
+      var sheetsClient = createGoogleSheetsClient({ keyFile: googleKeyFile })
       var tabNames
       try {
         tabNames = await sheetsClient.discoverSheetNames(CONTENT_SHEET_ID)

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -64,17 +64,35 @@ module.exports = function registerRoutes(router, context) {
     try {
       var since = req.query.since || '2026-04-01'
 
-      var registry = storage.readFromStorage('releases/registry.json')
-      if (!registry || !Array.isArray(registry.releases)) {
-        return res.json({ releases: [], summary: { total: 0, onTime: 0, late: 0, upcoming: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
+      var overrides = storage.readFromStorage('okr-hub/on-time-overrides.json')
+      var overrideMap = {}
+      var removedIds = {}
+      var customReleases = []
+      if (overrides && Array.isArray(overrides.releases)) {
+        for (var oi = 0; oi < overrides.releases.length; oi++) {
+          var ov = overrides.releases[oi]
+          if (ov.removed) { removedIds[ov.id] = true; continue }
+          if (ov.custom) { customReleases.push(ov); continue }
+          overrideMap[ov.id] = ov
+        }
       }
 
+      var registry = storage.readFromStorage('releases/registry.json')
+      var registryReleases = (registry && Array.isArray(registry.releases)) ? registry.releases : []
+
       var candidates = []
-      for (var i = 0; i < registry.releases.length; i++) {
-        var rel = registry.releases[i]
+      for (var i = 0; i < registryReleases.length; i++) {
+        var rel = registryReleases[i]
+        if (removedIds[rel.id]) continue
         var ga = rel.milestones && rel.milestones.ga
         if (!ga || ga < since) continue
         if (isEaRelease(rel.id)) continue
+        if (overrideMap[rel.id]) {
+          var ovr = overrideMap[rel.id]
+          rel = Object.assign({}, rel, { milestones: Object.assign({}, rel.milestones, { ga: ovr.plannedGa || rel.milestones.ga }) })
+          rel._overrideActualGa = ovr.actualGa || null
+          rel._overrideDisplayName = ovr.displayName || null
+        }
         candidates.push(rel)
       }
 
@@ -90,16 +108,18 @@ module.exports = function registerRoutes(router, context) {
       for (var ri = 0; ri < candidates.length; ri++) {
         var release = candidates[ri]
         var plannedGa = release.milestones.ga
-        var actualGa = null
-        var released = false
+        var actualGa = release._overrideActualGa || null
+        var released = !!actualGa
 
-        var fvList = release.fixVersions || []
-        for (var fvi = 0; fvi < fvList.length; fvi++) {
-          var match = jiraVersionMap[fvList[fvi].toLowerCase()]
-          if (match && match.released && match.releaseDate) {
-            actualGa = match.releaseDate
-            released = true
-            break
+        if (!actualGa) {
+          var fvList = release.fixVersions || []
+          for (var fvi = 0; fvi < fvList.length; fvi++) {
+            var match = jiraVersionMap[fvList[fvi].toLowerCase()]
+            if (match && match.released && match.releaseDate) {
+              actualGa = match.releaseDate
+              released = true
+              break
+            }
           }
         }
 
@@ -115,12 +135,39 @@ module.exports = function registerRoutes(router, context) {
 
         results.push({
           id: release.id,
-          displayName: release.displayName,
+          displayName: release._overrideDisplayName || release.displayName,
           plannedGa: plannedGa,
           actualGa: actualGa,
           released: released,
           onTime: onTime,
-          daysLate: daysLate
+          daysLate: daysLate,
+          custom: false
+        })
+      }
+
+      for (var ci = 0; ci < customReleases.length; ci++) {
+        var cr = customReleases[ci]
+        if (removedIds[cr.id]) continue
+        if (!cr.plannedGa || cr.plannedGa < since) continue
+        var crReleased = !!cr.actualGa
+        var crOnTime = null
+        var crDaysLate = null
+        if (crReleased && cr.actualGa) {
+          var crPlanned = new Date(cr.plannedGa + 'T00:00:00Z')
+          var crActual = new Date(cr.actualGa + 'T00:00:00Z')
+          var crDiffMs = crActual.getTime() - crPlanned.getTime()
+          crDaysLate = Math.ceil(crDiffMs / (1000 * 60 * 60 * 24))
+          crOnTime = crDaysLate <= 0
+        }
+        results.push({
+          id: cr.id,
+          displayName: cr.displayName,
+          plannedGa: cr.plannedGa,
+          actualGa: cr.actualGa || null,
+          released: crReleased,
+          onTime: crOnTime,
+          daysLate: crDaysLate,
+          custom: true
         })
       }
 
@@ -156,6 +203,50 @@ module.exports = function registerRoutes(router, context) {
       })
     } catch (err) {
       console.error('[okr-hub] on-time-releases error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/on-time-releases/overrides:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Get custom release overrides
+   *     responses:
+   *       200:
+   *         description: Override entries
+   */
+  router.get('/reports/on-time-releases/overrides', requireScope('okr-hub:read'), function(req, res) {
+    var saved = storage.readFromStorage('okr-hub/on-time-overrides.json')
+    res.json(saved || { releases: [] })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/on-time-releases/overrides:
+   *   put:
+   *     tags: [OKR Hub]
+   *     summary: Save custom release overrides
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema: { type: object }
+   *     responses:
+   *       200:
+   *         description: Saved
+   */
+  router.put('/reports/on-time-releases/overrides', requireScope('okr-hub:write'), function(req, res) {
+    try {
+      var body = req.body
+      if (!body || !Array.isArray(body.releases)) {
+        return res.status(400).json({ error: 'Invalid payload: requires releases array' })
+      }
+      storage.writeToStorage('okr-hub/on-time-overrides.json', body)
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[okr-hub] on-time-overrides save error:', err)
       res.status(500).json({ error: err.message })
     }
   })

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -6,14 +6,6 @@ import { defineAsyncComponent } from 'vue'
 
 export const reports = [
   {
-    id: 'commitment-tracking',
-    label: 'Commitment Tracking',
-    description: 'Track committed vs. delivered features per release phase. Monitor >90% delivery OKR.',
-    icon: 'Target',
-    tags: ['Planning', 'OKR'],
-    component: defineAsyncComponent(() => import('./CommitmentTrackingReport.vue'))
-  },
-  {
     id: 'program-hygiene',
     label: 'Program Hygiene Report',
     description: 'Cross-version hygiene summary with violation breakdowns by rule, team, and version. Designed for program-level reporting.',

--- a/modules/releases/client/views/DeliverView.vue
+++ b/modules/releases/client/views/DeliverView.vue
@@ -40,7 +40,6 @@ import ReleaseChipBar from '../deliver/components/ReleaseChipBar.vue'
 
 const RiskDashboard = defineAsyncComponent(() => import('../deliver/views/MainView.vue'))
 const ConformaInsights = defineAsyncComponent(() => import('../deliver/views/ConformaExceptionsView.vue'))
-const PostReleaseDefects = defineAsyncComponent(() => import('../deliver/views/PostReleaseDefectsView.vue'))
 
 const { loading, refreshing, error, analysis, refreshAnalysis } = useReleaseAnalysis()
 const conformaState = useConformaExceptions()
@@ -63,7 +62,6 @@ provide('conformaState', conformaState)
 const tabs = [
   { id: 'risk-dashboard', label: 'Risk Dashboard' },
   { id: 'conforma-insights', label: 'Conforma Insights' },
-  { id: 'post-release-defects', label: 'Post-Release Defects' },
 ]
 
 var moduleNav = inject('moduleNav', null)
@@ -94,7 +92,6 @@ if (moduleNav && moduleNav.params) {
 const componentMap = {
   'risk-dashboard': RiskDashboard,
   'conforma-insights': ConformaInsights,
-  'post-release-defects': PostReleaseDefects,
 }
 
 const activeComponent = computed(() => componentMap[activeTab.value])


### PR DESCRIPTION
## Summary

- **OKR Hub module**: New module with Timeline and Reports tabs, positioned after AI Impact in the sidebar
- **On Time Releases report**: Tracks planned vs actual GA dates for RHAI releases after April 2026, with gear icon for managing custom releases and Q1-Q4 collapsible sections
- **CVE SLA Compliance report**: Editable per-product per-month CVE met/missed tracking with quarterly drill-down
- **Post-Release Defects report**: Moved from Releases "Deliver" tab to OKR Hub Reports (server APIs remain in releases module, accessed cross-module)
- **Commitment Tracking report**: Moved from Releases "Reports" section to OKR Hub Reports
- **Technical Visibility report**: Two collapsible KRs — KR1 tracks weekly article counts (>5/week target) from Google Sheets, KR2 tracks per-team associate content contributions from a second Google Sheet
- **Support Case Time To Resolution report**: Per-quarter editable data for 3 products (RHOAI, RHEL-AI, RHAII) with defect rate and resolution time targets
- All reports displayed as flash cards with descriptive measure of success labels
- Data persistence via storage abstractions with proper export hooks for all stored files

## Test plan

- [ ] Verify OKR Hub appears in sidebar after AI Impact
- [ ] Click each report flash card and confirm it drills into the report view
- [ ] On Time Releases: verify Q1-Q4 collapsibles, gear icon add/edit/remove releases, save persists
- [ ] CVE SLA: verify editable cells, quarterly sections, save/load round-trip
- [ ] Post-Release Defects: verify it loads and renders (uses releases module APIs)
- [ ] Commitment Tracking: verify it loads and renders (uses releases module APIs)
- [ ] Technical Visibility: verify KR1 and KR2 collapsibles render with sample data locally
- [ ] Support Cases: verify Q1-Q4 tables, gear icon data entry for all 3 products, save persists
- [ ] Run `npm run validate:modules` — all modules pass
- [ ] Run `npm run lint` — no errors


Made with [Cursor](https://cursor.com)