### PR TITLE
fix(system-health): refresh odh-dashboard quality reports

### DIFF
--- a/modules/system-health/client/generated-reports/index.html
+++ b/modules/system-health/client/generated-reports/index.html
@@ -45,7 +45,7 @@
 <body>
   <div class="card">
     <h1>Quality Analysis (334 Repos)</h1>
-    <p><strong>Generated:</strong> 2026-06-10 18:26:42</p>
+    <p><strong>Generated:</strong> 2026-07-01 20:55:05</p>
     <p><strong>Average score:</strong> 5.0/10</p>
     <p>Quality analysis of 334 repositories.</p>
   </div>
@@ -65,6 +65,14 @@
       </thead>
       <tbody>
             <tr>
+              <td><a href="quality-report-red-hat-data-services-odh-dashboard.html">red-hat-data-services/odh-dashboard</a></td>
+              <td><a href="https://github.com/red-hat-data-services/odh-dashboard" target="_blank">GitHub</a></td>
+              <td>downstream</td>
+              <td>AI Core Dashboard</td>
+              <td>9.2/10</td>
+              <td>Coverage enforcement is informational only, No container runtime validation in CI</td>
+            </tr>
+            <tr>
               <td><a href="quality-report-openclaw-openclaw.html">openclaw/openclaw</a></td>
               <td><a href="https://github.com/openclaw/openclaw" target="_blank">GitHub</a></td>
               <td>upstream</td>
@@ -78,7 +86,7 @@
               <td>midstream</td>
               <td>AI Core Dashboard</td>
               <td>9.1/10</td>
-              <td>No container image vulnerability scanning in CI, No PR-time Konflux build simulation</td>
+              <td>No container vulnerability scanning (Trivy/Snyk) in PR or periodic CI, No CodeQL/SAST scanning workflow</td>
             </tr>
             <tr>
               <td><a href="quality-report-kubernetes-sigs-kueue.html">kubernetes-sigs/kueue</a></td>
@@ -111,14 +119,6 @@
               <td>Notebooks Server</td>
               <td>8.7/10</td>
               <td>Coverage thresholds are informational only, No SBOM generation or image signing in GHA pipeline</td>
-            </tr>
-            <tr>
-              <td><a href="quality-report-red-hat-data-services-odh-dashboard.html">red-hat-data-services/odh-dashboard</a></td>
-              <td><a href="https://github.com/red-hat-data-services/odh-dashboard" target="_blank">GitHub</a></td>
-              <td>downstream</td>
-              <td>AI Core Dashboard</td>
-              <td>8.7/10</td>
-              <td>No PR-time Konflux build simulation, No container image runtime validation</td>
             </tr>
             <tr>
               <td><a href="quality-report-BerriAI-litellm.html">BerriAI/litellm</a></td>

--- a/modules/system-health/client/generated-reports/quality-analysis-opendatahub-io-odh-dashboard.md
+++ b/modules/system-health/client/generated-reports/quality-analysis-opendatahub-io-odh-dashboard.md
@@ -4,60 +4,58 @@ overall_score: 9.1
 scorecard:
   - dimension: "Unit Tests"
     score: 9.0
-    status: "981 test files across Jest and Go testing; 28% test-to-code ratio with coverage enforcement"
+    status: "891 test files across Jest + RTL with comprehensive coverage generation and aggregation"
   - dimension: "Integration/E2E"
     score: 9.5
-    status: "235+ Cypress E2E tests with live cluster execution, smart tag selection, cluster failover, BFF integration, and contract testing"
+    status: "181 Cypress tests (90 E2E + 91 mocked), live-cluster E2E with failover, contract tests, smart test selection"
   - dimension: "Build Integration"
-    score: 8.0
-    status: "Docker build with RHOAI/ODH modes, Tekton pipelines for Konflux, kustomize validation, but no PR-time Konflux simulation"
+    score: 9.5
+    status: "PR-time Konflux simulator with 4-phase validation, hermetic build testing, dual-mode (ODH/RHOAI), runtime + Module Federation artifact validation"
   - dimension: "Image Testing"
-    score: 7.0
-    status: "Multi-stage Dockerfile with runtime health checks, but no Trivy/Snyk scanning in PR workflow"
+    score: 8.5
+    status: "Multi-stage Docker builds validated at PR time, branding verification, runtime startup validation, but no Trivy/Snyk scanning in CI"
   - dimension: "Coverage Tracking"
     score: 8.5
-    status: "Codecov integration with merged unit+Cypress coverage, 70% patch target, nyc report generation"
+    status: "Codecov integration with merged unit+Cypress coverage, 70% patch target (informational), combined coverage report generation"
   - dimension: "CI/CD Automation"
     score: 9.5
-    status: "26 workflows, concurrency control, turbo caching, parallel matrix tests, modular architecture quality gates"
+    status: "27 workflows, path-filtered per-package triggers, concurrency control, turbo caching, dynamic test group discovery, modular quality gates"
   - dimension: "Agent Rules"
     score: 10.0
-    status: "18 comprehensive rules covering all test types, 20+ skills, 3,550 lines of test guidance, contract test framework"
+    status: "20 specialized rules, 23 custom skills, comprehensive AGENTS.md, full test type coverage with actionable guidance"
 critical_gaps:
-  - title: "No container image vulnerability scanning in CI"
-    impact: "Security vulnerabilities in base images or dependencies not caught until Konflux/production scanning"
-    severity: "HIGH"
-    effort: "2-4 hours"
-  - title: "No PR-time Konflux build simulation"
-    impact: "Build failures in Konflux pipelines discovered only post-merge"
-    severity: "MEDIUM"
-    effort: "8-12 hours"
-  - title: "No SBOM generation"
-    impact: "Supply chain transparency and compliance requirements not met in CI"
+  - title: "No container vulnerability scanning (Trivy/Snyk) in PR or periodic CI"
+    impact: "Vulnerabilities in base images or dependencies not detected until downstream Konflux pipeline"
     severity: "MEDIUM"
     effort: "2-4 hours"
-quick_wins:
-  - title: "Add Trivy scanning to PR workflow"
+  - title: "No CodeQL/SAST scanning workflow"
+    impact: "Static security analysis gaps — relying solely on gitleaks for secret detection"
+    severity: "MEDIUM"
     effort: "2-3 hours"
-    impact: "Catch container image CVEs before merge, align with notebooks gold standard"
-  - title: "Add SBOM generation to Dockerfile or CI"
+  - title: "Coverage enforcement is informational only"
+    impact: "Coverage regressions not blocked — threshold set to informational mode"
+    severity: "LOW"
+    effort: "1 hour"
+quick_wins:
+  - title: "Add Trivy container scanning to PR workflow"
+    effort: "2-3 hours"
+    impact: "Catch CVEs in base images and dependencies before merge"
+  - title: "Enable CodeQL analysis workflow"
     effort: "1-2 hours"
-    impact: "Supply chain compliance and artifact attestation"
-  - title: "Enable performance regression testing for BFF endpoints"
-    effort: "4-6 hours"
-    impact: "Catch API latency regressions in Go BFF services before merge"
+    impact: "Automated SAST for TypeScript and Go code paths"
+  - title: "Switch Codecov status from informational to enforced"
+    effort: "30 minutes"
+    impact: "Prevent coverage regressions from merging"
 recommendations:
   priority_0:
-    - "Add Trivy or Grype container scanning to the PR workflow or Tekton pipeline"
-    - "Generate SBOM (syft or cdxgen) as part of the image build process"
+    - "Add Trivy or Snyk container vulnerability scanning to the PR build validation workflow"
+    - "Enable CodeQL or Semgrep SAST scanning for TypeScript and Go code"
   priority_1:
-    - "Add PR-time Konflux build simulation for the main dashboard image"
-    - "Enable the disabled quality gate checks (contract testing, API functional, bundle size monitoring)"
-    - "Add API performance regression testing for BFF Go services"
+    - "Switch Codecov patch and project status from informational to enforced with appropriate thresholds"
+    - "Add SBOM generation to container image builds"
   priority_2:
-    - "Expand accessibility testing coverage beyond axe-core basics"
-    - "Add chaos engineering / resilience testing for operator controller"
-    - "Consider CodeQL SAST integration for TypeScript/Go code paths"
+    - "Add multi-architecture (amd64/arm64) build validation to the Konflux simulator"
+    - "Add performance regression testing for frontend bundle size tracking"
 ---
 
 # Quality Analysis: odh-dashboard
@@ -65,368 +63,353 @@ recommendations:
 ## Executive Summary
 
 - **Overall Score: 9.1/10**
-- **Repository Type**: Monorepo — React/TypeScript frontend + Go BFF services + Go operator
-- **Primary Languages**: TypeScript (frontend), Go (BFF, operator)
-- **Framework**: React 18, PatternFly v6, Webpack Module Federation, controller-runtime
+- **Repository Type**: TypeScript/React monorepo + Go operator + Go BFFs
+- **Key Strengths**: Industry-leading CI/CD automation, multi-layer testing pyramid, PR-time Konflux build simulation, exceptional agent rules ecosystem
+- **Critical Gaps**: No container vulnerability scanning, no SAST/CodeQL integration
+- **Agent Rules Status**: **Exemplary** — 20 specialized rules, 23 custom skills, comprehensive coverage of all test types
 
-**Key Strengths**: odh-dashboard is an industry-leading example of comprehensive quality engineering. With 981 test files, multi-layer testing (unit, mock, E2E, contract), a sophisticated CI/CD pipeline with 26 workflows, and the most comprehensive agent rules seen in any repository (18 rules, 20+ skills, 3,550 lines of test guidance), this repository sets the gold standard for monorepo quality practices. The E2E infrastructure with cluster failover, smart test tag selection, BFF auto-detection, and dynamic port allocation is exceptionally well-engineered.
-
-**Critical Gaps**: The primary gaps are in container security scanning (no Trivy/Snyk in CI) and SBOM generation. There is no PR-time Konflux build simulation, though Tekton pipelines exist for pull-request and push events. Several quality gate checks in the modular architecture workflow are still disabled (contract testing enforcement, API functional testing, bundle size monitoring).
-
-**Agent Rules Status**: Exemplary — most comprehensive seen in any repository
+odh-dashboard is a **gold standard** repository for quality practices in the OpenShift AI ecosystem. It demonstrates exceptional test infrastructure across unit, mock, E2E, and contract testing layers. The PR Build Validation workflow simulates Konflux hermetic builds at PR time — a capability that most projects lack entirely. The agent rules ecosystem is the most comprehensive found in any analyzed repository.
 
 ## Quality Scorecard
 
 | Dimension | Score | Status |
 |-----------|-------|--------|
-| Unit Tests | 9.0/10 | 981 test files (Jest + Go), 28% test-to-code ratio, coverage enforcement |
-| Integration/E2E | 9.5/10 | 235+ Cypress E2E, live cluster testing, contract tests, BFF integration |
-| **Build Integration** | **8.0/10** | **Tekton pipelines, kustomize validation, no PR-time Konflux simulation** |
-| Image Testing | 7.0/10 | Multi-stage Dockerfile, health checks, no vulnerability scanning |
-| Coverage Tracking | 8.5/10 | Codecov with merged unit+Cypress, 70% patch target |
-| CI/CD Automation | 9.5/10 | 26 workflows, turbo caching, matrix parallelization |
-| Agent Rules | 10.0/10 | 18 rules, 20+ skills, contract test framework, comprehensive guidance |
+| Unit Tests | 9.0/10 | 891 test files across Jest + RTL with comprehensive coverage |
+| Integration/E2E | 9.5/10 | 181 Cypress tests, live-cluster E2E with failover, contract tests |
+| **Build Integration** | **9.5/10** | **PR-time Konflux simulator, hermetic build testing, dual-mode validation** |
+| Image Testing | 8.5/10 | Multi-stage builds validated at PR time, but no vulnerability scanning |
+| Coverage Tracking | 8.5/10 | Codecov with merged unit+Cypress coverage, informational mode |
+| CI/CD Automation | 9.5/10 | 27 workflows, path-filtered triggers, turbo caching, dynamic matrix |
+| Agent Rules | 10.0/10 | 20 rules, 23 skills, AGENTS.md, full test type coverage |
 
 ## Critical Gaps
 
-1. **No container image vulnerability scanning in CI**
-   - Impact: Security vulnerabilities in base images (ubi9/nodejs-22) or npm dependencies not caught until downstream Konflux/production scanning
-   - Severity: HIGH
-   - Effort: 2-4 hours
-   - The `semgrep.yaml` covers source code but not container image CVEs
-
-2. **No PR-time Konflux build simulation**
-   - Impact: Build differences between GitHub CI and Tekton/Konflux pipelines discovered only post-merge
-   - Severity: MEDIUM
-   - Effort: 8-12 hours
-   - Tekton pipelines exist in `.tekton/` (20 pipeline definitions for PR and push) but aren't triggered from GitHub Actions
-
-3. **No SBOM generation**
-   - Impact: Supply chain transparency requirements not met; no artifact attestation
+1. **No container vulnerability scanning in CI**
+   - Impact: CVEs in base images (UBI9) and npm/Go dependencies not caught until downstream Konflux pipelines
    - Severity: MEDIUM
    - Effort: 2-4 hours
+   - Note: Gitleaks covers secret detection but not CVE scanning
 
-4. **Disabled quality gate checks**
-   - Impact: Modular architecture quality gates only enforce unit tests and E2E tests; contract testing, API functional testing, API performance testing, and bundle size monitoring are all disabled
+2. **No CodeQL/SAST scanning workflow**
+   - Impact: No automated static security analysis for TypeScript or Go code
    - Severity: MEDIUM
-   - Effort: 4-8 hours per check
+   - Effort: 2-3 hours
+   - Note: ESLint covers code quality but not security-specific patterns
+
+3. **Coverage enforcement is informational only**
+   - Impact: PRs can merge with coverage regressions; 70% patch target exists but doesn't block
+   - Severity: LOW
+   - Effort: 1 hour (change `informational: true` to `false` in `.codecov.yml`)
 
 ## Quick Wins
 
-1. **Add Trivy scanning to PR workflow** (2-3 hours)
-   - Impact: Catch container image CVEs before merge
-   - Implementation: Add Trivy action after Docker build step or as a standalone job
-   ```yaml
-   - name: Run Trivy vulnerability scanner
-     uses: aquasecurity/trivy-action@master
-     with:
-       image-ref: 'odh-dashboard:pr-${{ github.event.number }}'
-       format: 'sarif'
-       severity: 'CRITICAL,HIGH'
-   ```
+1. **Add Trivy container scanning to PR build validation**
+   - Effort: 2-3 hours
+   - Impact: Detect CVEs before merge, leveraging images already built by `pr-build-validation.yml`
+   - Implementation: Add `aquasecurity/trivy-action` step after Docker builds
 
-2. **Add SBOM generation** (1-2 hours)
-   - Impact: Supply chain compliance
-   - Add `syft` or `cdxgen` to CI or Dockerfile
+2. **Enable CodeQL analysis**
+   - Effort: 1-2 hours
+   - Impact: Automated SAST for TypeScript and Go code
+   - Implementation: Add `.github/workflows/codeql.yml` with JavaScript/TypeScript and Go language matrix
 
-3. **Enable contract testing quality gate** (2-3 hours)
-   - Impact: Enforce contract test presence for all BFF modules
-   - The contract test infrastructure already exists across 8 packages; just uncomment the quality gate check
+3. **Switch Codecov to enforced mode**
+   - Effort: 30 minutes
+   - Impact: Block PRs that reduce coverage below threshold
+   - Implementation: Change `informational: true` to `informational: false` in `.codecov.yml`
 
 ## Detailed Findings
 
 ### CI/CD Pipeline
 
-**Workflow Inventory** (26 workflows):
+**Score: 9.5/10** — Exceptional automation with 27 workflows.
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `test.yml` | push, PR | Main test pipeline: Setup → Type-Check → Lint → Unit Tests → Contract Tests → Cypress Mock Tests → Coverage combine + Codecov upload |
-| `cypress-e2e-test.yml` | After `test.yml` completes on PR | Live cluster E2E with cluster failover, smart tag detection, BFF auto-start |
-| `dashboard-operator-tests.yml` | push/PR (operator paths) | Go lint + build + test for operator controller |
-| `modular-arch-quality-gates.yml` | PR (packages paths) | Testing maturity assessment per module |
-| `validate-kustomize.yml` | push/PR (manifests paths) | Kustomize build validation for RHOAI and ODH overlays |
-| `dependency-validation.yml` | PR (package-lock.json) | npm audit diff — blocks new HIGH+ vulnerabilities |
-| BFF test workflows (×7) | push, PR | Separate test workflows for model-registry, gen-ai, mlflow, maas, automl, autorag, eval-hub BFFs |
-| `core-bff-build.yml` | push, PR | Core BFF build and tests |
-| Build workflows (×2) | push, PR | Gen AI frontend build, Gen AI BFF build |
-| `agentready-weekly.yml` | weekly cron | Weekly agent readiness assessment |
-| `claude-preflight.yml` | schedule | Agent preflight checks |
-| Release/admin workflows | manual dispatch | Release creation, auto-merge, stale management |
+**Workflow Inventory (27 total)**:
+
+| Category | Workflows | Trigger |
+|----------|-----------|---------|
+| Core Testing | `test.yml` | push + PR |
+| Per-Package BFF Tests | `automl-bff-tests.yml`, `autorag-bff-tests.yml`, `core-bff-build.yml`, `eval-hub-bff-tests.yml`, `gen-ai-bff-build.yml`, `maas-bff-tests.yml`, `mlflow-bff-tests.yml`, `model-registry-bff-tests.yml` | Path-filtered PR |
+| Per-Package Frontend Tests | `eval-hub-frontend-tests.yml`, `gen-ai-frontend-build.yml`, `model-registry-frontend-tests.yml` | Path-filtered PR |
+| E2E Tests | `cypress-e2e-test.yml` | After `Test` completes on PR |
+| Build Validation | `pr-build-validation.yml` (Konflux Simulator) | PR to main |
+| Manifest Validation | `validate-kustomize.yml` | Push/PR on `manifests/**` |
+| Operator | `dashboard-operator-tests.yml` | Path-filtered PR |
+| Quality Gates | `modular-arch-quality-gates.yml` | PR on `packages/**` |
+| Dependency | `dependency-validation.yml`, `dependabot-auto-merge.yml` | PR |
+| Agent/Claude | `claude-preflight.yml` | PR open/reopen |
+| Release | `release-odh-dashboard.yml`, `release-auto-merge.yml` | Dispatch |
+| Maintenance | `stale.yml`, `pr-image-expiry.yml`, `audit-bypass-notice.yml`, `agentready-weekly.yml` | Schedule/PR |
 
 **Strengths**:
-- Excellent concurrency control across all workflows (`cancel-in-progress: true`)
-- Turbo caching for incremental builds — significantly reduces CI time
-- Module caching via composite action (`.github/actions/module-caches`)
-- Dynamic test group discovery from package.json metadata
-- Sophisticated E2E infrastructure with:
-  - Cluster health checks (DSC condition monitoring) with automatic failover
-  - Smart test tag selection (PR labels, turbo change detection, frontend area mapping)
-  - Dynamic port allocation for parallel execution
-  - BFF auto-detection and startup (with command injection protection)
-  - Self-hosted runner disk space management
-  - Emergency cleanup protocols with parallel-job safety
-
-**Tekton/Konflux Pipelines**: 20 pipeline definitions in `.tekton/` covering:
-- Main dashboard: pull-request + push
-- Dashboard operator: pull-request + push
-- 8 modular architecture modules: pull-request + push each
+- **Concurrency control**: All major workflows use `cancel-in-progress: true`
+- **Caching**: Turbo cache + Node module cache + Cypress build cache
+- **Path filtering**: Package-specific workflows only run when relevant files change
+- **Dynamic test groups**: Cypress mock tests discover test groups dynamically at runtime
+- **Smart E2E selection**: E2E workflow uses turbo change detection + PR labels + `e2eCiTags` in package.json
+- **Cluster failover**: E2E tests have primary/secondary cluster health checking
 
 ### Test Coverage
 
-**Unit Tests (Jest)**:
-- 981 test files across frontend, backend, and packages
-- Test-to-code ratio: 990 test files / 3,475 source files = **28.5%**
-- Framework: Jest with TypeScript support
-- Coverage generation: `test-unit-coverage` script produces `jest-coverage/`
-- Organized under `__tests__/` directories with `*.spec.ts(x)` naming
+**Score: 9.0/10 (Unit) + 9.5/10 (Integration/E2E)** — Comprehensive multi-layer testing.
 
-**Cypress Mock Tests**:
-- Extensive mocked Cypress test suite run on every PR
-- Dynamic test group discovery from `packages/cypress/cypress/tests/mocked/`
-- Package-level Cypress tests via `cypress.mocked` in `package.json`
-- Coverage collection via Istanbul/nyc
-- Parallelized via matrix strategy based on test group discovery
+**Test File Counts**:
+- Unit/Component tests: **891 files** (486 `.spec.ts`, 366 `.spec.tsx`, 20 `.test.ts`, 19 `.test.tsx`)
+- Cypress mock tests: **91 test files** (component/integration with mocked backends)
+- Cypress E2E tests: **90 test files** (live cluster, 23 feature directories)
+- Contract tests: **41 files** across model-registry, mlflow, gen-ai, core-bff
+- Go operator tests: **8 test files** / 10 source files (80% test ratio)
+- Source files (TS/TSX/JS): ~4,918
 
-**Cypress E2E Tests** (235+ `.cy.ts` files):
-- Runs against live OpenShift clusters
-- Cluster failover: primary (`dash-e2e-int`) → secondary (`dash-e2e`)
-- Smart test selection:
-  - Default: `@ci-dashboard-regression-tags` (always runs)
-  - PR labels: `test:*` pattern → Cypress grep tags
-  - Auto-detected: Turbo change detection + frontend area mapping via `.github/frontend-ci-tags.json`
-  - Package `e2eCiTags` in `package.json` for self-service opt-in
-- BFF auto-detection and startup with port/command allowlisting
-- Non-admin test mode support (`@NonAdmin` tag uses TEST_USER_3 credentials)
-- Accessibility testing: `axe-core` integration via `cypress/support/commands/axe.ts`
+**Test-to-Code Ratio**: ~891/4918 = **18.1%** (strong for a frontend monorepo)
 
-**Contract Tests**:
-- Full contract test framework in `packages/contract-tests/`
-- 8 packages with contract tests: model-registry, mlflow, gen-ai, eval-hub, autorag, automl, agent-ops, core-bff
-- Schema validation against OpenAPI specs
-- HTML report generation for results
-- Runs as part of main `test.yml` workflow with Go 1.25 + uv for Python dependencies
+**Testing Frameworks**:
+- Jest + React Testing Library (unit/component)
+- Cypress 13+ (mock + E2E)
+- Go `testing` + controller-runtime envtest (operator)
+- Custom `@odh-dashboard/contract-tests` framework (API contract validation)
 
-**Go Operator Tests** (5 test files):
-- CRD type tests (`dashboard_types_test.go`)
-- Controller reconciler tests (`dashboard_reconciler_test.go`)
-- Controller action tests (`actions_test.go`)
-- Support utility tests (`support_test.go`)
-- Webhook validation tests (`dashboard_webhook_test.go`)
+**Test Types Coverage**:
 
-**Go BFF Tests** (184 test files):
-- Extensive test coverage across all BFF packages
-- Repository-level tests, handler tests, integration tests
-- Kubernetes client integration tests (token, namespace registry, factory)
-- Run via dedicated per-package CI workflows
+| Test Type | Present | Framework | Location |
+|-----------|---------|-----------|----------|
+| Unit Tests | Yes | Jest + RTL | `**/__tests__/*.spec.ts(x)` |
+| Cypress Mock Tests | Yes | Cypress | `packages/cypress/cypress/tests/mocked/` + per-package |
+| Cypress E2E Tests | Yes | Cypress | `packages/cypress/cypress/tests/e2e/` |
+| Contract Tests | Yes | Custom framework | `packages/*/contract-tests/` |
+| Operator Tests | Yes | Go testing + envtest | `dashboard-operator/**/*_test.go` |
+| Helm Chart Validation | Yes | Helm lint | `dashboard-operator` workflow |
+
+### Build Integration (Konflux Simulator)
+
+**Score: 9.5/10** — Best-in-class PR-time build validation.
+
+The `pr-build-validation.yml` workflow is a **4-phase Konflux simulator** that catches build failures before merge:
+
+**Phase 0: Hermetic Build Preflight** (static checks):
+- Validates `package-lock.json` for unsupported protocols (git+, github:, file:)
+- Tests hermetic `npm ci --offline` in a Docker container (simulates Cachi2)
+- Validates workspace dependencies match Dockerfile COPY instructions
+- FIPS compliance check (esbuild binary removal)
+
+**Phase 1: Docker Build Validation**:
+- Builds images in both ODH and RHOAI modes
+- Full multi-stage Dockerfile build (not just npm build)
+- Images saved as artifacts for later phases
+
+**Phase 2-3: Runtime & Module Federation Validation**:
+- Loads built images and extracts artifacts
+- Validates branding (ODH vs RHOAI) in built HTML
+- Validates Module Federation artifacts (remoteEntry.js, webpack chunks)
+- Checks favicon, logo, product name in both build modes
+
+**Phase 4: Kustomize Manifest Validation** (separate workflow):
+- Validates all Kustomize overlays build successfully
+- Runs on manifest changes
+
+### Container Image Testing
+
+**Score: 8.5/10** — Strong build validation but no vulnerability scanning.
+
+**Strengths**:
+- Multi-stage Dockerfile (builder + runtime)
+- UBI9 base image
+- Dual-mode builds (ODH/RHOAI) validated at PR time
+- Runtime startup validation (curl health probes configured)
+- FIPS compliance checking (esbuild binary removal)
+- Separate operator Dockerfile with Go multi-stage build
+
+**Gaps**:
+- No Trivy/Snyk/Grype vulnerability scanning in CI
+- No SBOM generation
+- No image signing/attestation at PR level (handled by Konflux downstream)
+- No multi-architecture build validation (amd64/arm64)
 
 ### Code Quality
 
-**Linting**:
-- ESLint: Shared config (`@odh-dashboard/eslint-config`) with recommended React/TypeScript rules
-- ESLint goal config (`frontend/.eslintrc.goal.js`) — progressive tightening
-- golangci-lint v2 with standard linters enabled for operator (govet with most checks enabled)
-- Prettier: `.prettierrc` for consistent formatting
-- TypeScript: Strict type checking via `turbo` across all packages
+**Score: 9.0/10** — Strong linting ecosystem.
 
-**Pre-commit Hooks**:
-- Husky pre-commit hook with `lint-staged`
-- Module Federation port validation on staged `package.json` changes
-- Helpful error messages with auto-fix instructions
-- Skip/force override mechanisms (`SKIP_LINT_HOOK`, `FORCE_LINT_HOOK`)
+**Tools Configured**:
+- **ESLint**: Custom shared config (`@odh-dashboard/eslint-config`) with React/TypeScript rules
+- **Prettier**: Configured (`.prettierrc`) with single quotes, trailing commas
+- **TypeScript**: Strict type checking via `npm run type-check` (turbo-managed)
+- **Husky**: Pre-commit hook with lint-staged
+- **Gitleaks**: Secret detection with comprehensive allowlist (`.gitleaks.toml`)
+- **Go linting**: `make lint` in operator workflow
 
-**Static Analysis**:
-- Semgrep: Comprehensive unified rules (`semgrep.yaml`) covering:
-  - Go (Kubernetes controllers/operators)
-  - TypeScript/JavaScript (React frontends)
-  - YAML (Kubernetes manifests, GitHub Actions)
-  - Generic secrets detection across all file types
-- Gitleaks: `.gitleaks.toml` with test file exclusions
-- npm audit: Dependency validation workflow with diff-based analysis (only blocks NEW advisories)
+**Pre-commit Hook Features**:
+- lint-staged on all staged files
+- Module federation port uniqueness validation
+- Skip/force override mechanisms
+- Helpful error messages with fix instructions
 
-### Container Images
-
-**Dockerfile Analysis**:
-- Multi-stage build (builder → runtime)
-- Base image: `registry.access.redhat.com/ubi9/nodejs-22:latest`
-- Build modes: ODH (default) and RHOAI (via `BUILD_MODE` arg)
-- Production dependency optimization: Custom `prepare-production-manifest.js` script
-- FIPS compliance: esbuild binary removal post-build
-- Runtime: Minimal with `curl-minimal` for health probes
-- Non-root user execution (USER 1001:0)
-- Proper labels for OpenShift integration
-
-**Multi-architecture Support**:
-- Makefile target `docker-buildx` for `linux/s390x,linux/amd64,linux/ppc64le`
-
-**Gaps**:
-- No Trivy/Snyk/Grype scanning in CI workflows
-- No SBOM generation (syft, cdxgen)
-- No image signing/attestation in GitHub Actions (may be handled by Konflux)
+**Missing**:
+- No CodeQL/SAST workflow
+- No Semgrep or gosec integration
+- No dependency vulnerability scanning (Dependabot auto-merge exists but no periodic scan)
 
 ### Security
 
-**Implemented**:
-- Semgrep security rules (hardcoded secrets, CWE-798 detection)
-- Gitleaks for secret scanning
-- npm audit with differential analysis (new vulnerabilities only)
-- BFF command injection protection (allowlisted commands and directories)
-- Agent rule for security review (`.claude/rules/security.md`)
-- Non-root container execution
-- Audit bypass tracking with labeled PRs and artifact upload
+**Score: 7.5/10** — Good secret detection but gaps in SAST and container scanning.
 
-**Gaps**:
-- No CodeQL/SAST integration for TypeScript or Go code
-- No container image scanning (Trivy/Snyk)
-- No dependency-level CVE tracking beyond npm audit
+**Present**:
+- Gitleaks with comprehensive allowlist covering test files, fixtures, known test credentials
+- FIPS compliance validation in Konflux simulator
+- Security-specific agent rule (`.claude/rules/security.md`)
+- `audit-bypass-notice.yml` — PR comments when `ok-to-skip-audit` label used
+
+**Missing**:
+- No CodeQL or Semgrep SAST scanning
+- No Trivy/Snyk container vulnerability scanning
+- No dependency vulnerability scanning workflow (only Dependabot auto-merge)
 
 ### Agent Rules (Agentic Flow Quality)
 
-**Status**: Exemplary — the most comprehensive agent rules implementation observed
+**Score: 10.0/10** — The most comprehensive agent rules ecosystem analyzed.
 
-**Rules** (18 files, 3,550+ lines of test guidance):
-| Rule | Lines | Coverage |
-|------|-------|----------|
-| `testing-standards.md` | 69 | Cross-cutting test type selection guide |
-| `unit-tests.md` | 610 | Jest patterns, hooks, components, mocking |
-| `cypress-mock.md` | 1,206 | Mock test patterns, intercepts, page objects |
-| `cypress-e2e.md` | 668 | Live cluster testing, tagging, prerequisites |
-| `contract-tests.md` | 997 | BFF API validation, schema matching |
-| `bff-go.md` | — | Go BFF patterns and conventions |
-| `architecture.md` | — | Monorepo structure and boundaries |
-| `conventions.md` | — | TypeScript/React coding standards |
-| `css-patternfly.md` | — | PatternFly v6 styling conventions |
-| `modular-architecture.md` | — | Module Federation, plugin system |
-| `module-federation.md` | — | Module exposure/consumption patterns |
-| `module-onboarding.md` | — | New module creation guide |
-| `operator-controller.md` | — | Go controller-runtime patterns |
-| `pull-requests.md` | — | PR template and guidelines |
-| `react.md` | — | React component/hook conventions |
-| `security.md` | — | Auth, secrets, input validation |
-| `jira-creation.md` | — | Jira issue formatting |
-| `third-party-theming.md` | — | External library theming |
+**AGENTS.md**: Detailed 11K document covering repository structure, development requirements, key technologies, package-specific guidelines, and comprehensive rule/skill index tables.
 
-**Skills** (20+ custom skills):
-- Development workflow (`dev-workflow`)
-- Code review (`coderabbit-autofix`, `coderabbit-code-review`, `coderabbit-review`)
-- RBAC review (`rbac-review`)
-- Style review (`style-review`)
-- Preflight checks (`preflight`)
-- Jira integration (6 skills: triage, validate-area, validate-description, validate-issue-type, validate-priority, evaluate-blockers)
-- Documentation (3 skills: create, create-package, update)
-- Upstream sync (2 skills: sync, sync-status)
-- Evaluation review (`jira-eval-review`)
+**20 Specialized Rules** (`.claude/rules/`):
 
-**Quality Assessment**:
-- All test types are covered with dedicated rules
-- Rules are actionable with specific patterns, examples, and checklists
-- Framework-specific (Jest, Cypress, Go testing)
-- Cross-cutting testing standards guide for test type selection
-- Contract test guidelines specific to BFF API validation
-- Weekly agent readiness assessment via CI (`agentready-weekly.yml`)
+| Category | Rules |
+|----------|-------|
+| Testing | `unit-tests.md`, `cypress-e2e.md`, `cypress-mock.md`, `contract-tests.md`, `testing-standards.md` |
+| Architecture | `architecture.md`, `modular-architecture.md`, `module-federation.md`, `module-onboarding.md`, `distributions.md` |
+| Code Quality | `conventions.md`, `css-patternfly.md`, `react.md`, `bff-go.md`, `operator-controller.md` |
+| Process | `pull-requests.md`, `jira-creation.md`, `security.md`, `third-party-theming.md` |
 
-**Recommendation**: This repository's agent rules serve as the gold standard. Other repositories should model their rules after this implementation.
+**23 Custom Skills** (`.claude/skills/`):
+
+| Category | Skills |
+|----------|--------|
+| Development | `dev-workflow`, `module-onboarding`, `upstream-sync`, `upstream-sync-status`, `konflux-onboarding` |
+| Review | `style-review`, `rbac-review`, `coderabbit-code-review`, `coderabbit-review`, `coderabbit-autofix` |
+| Documentation | `docs-create`, `docs-create-package`, `docs-update` |
+| Jira | `jira-triage`, `jira-validate-priority-severity`, `jira-validate-description`, `jira-evaluate-blockers`, `jira-validate-issue-type`, `jira-validate-area-label`, `jira-assign-scrum-team`, `jira-eval-review` |
+| CI/Ops | `ci-flake-classifier`, `preflight` |
+
+**Why 10/10**:
+- Every test type has its own dedicated rule with framework-specific guidance
+- Rules use glob patterns for automatic activation when editing relevant files
+- Cross-cutting `testing-standards.md` rule helps agents choose the right test type
+- Skills automate complex multi-step workflows (triage, sync, review)
+- `AGENTS.md` provides a structured index that agents can navigate
+- Agent-powered CI (`claude-preflight.yml`) runs on PR open/reopen
+
+### Tekton/Konflux Pipelines
+
+**22 Tekton pipeline files** in `.tekton/`:
+- Pull request + push pipelines for: dashboard, operator, and 8 modular architecture modules
+- Each module has its own dedicated pipeline (agent-ops, automl, autorag, eval-hub, gen-ai, maas, mlflow, modular-architecture)
 
 ## Recommendations
 
 ### Priority 0 (Critical)
 
-1. **Add container image vulnerability scanning** (2-4 hours)
-   - Add Trivy or Grype scanning to the main PR workflow or as a Tekton task
-   - Configure severity thresholds (block on CRITICAL, warn on HIGH)
-   - This is the most significant security gap
+1. **Add container vulnerability scanning**
+   - Add Trivy scanning step to `pr-build-validation.yml` after Docker builds
+   - Scan both ODH and RHOAI images
+   - Block on HIGH/CRITICAL CVEs
+   ```yaml
+   - name: Scan ODH image for vulnerabilities
+     uses: aquasecurity/trivy-action@0.30.0
+     with:
+       image-ref: odh-dashboard:odh-test
+       format: 'table'
+       exit-code: '1'
+       severity: 'HIGH,CRITICAL'
+   ```
 
-2. **Generate SBOM for built images** (1-2 hours)
-   - Add syft or cdxgen to the Docker build or CI pipeline
-   - Attach SBOM as a build artifact for supply chain compliance
+2. **Enable CodeQL SAST scanning**
+   - Add CodeQL workflow for JavaScript/TypeScript and Go
+   - Run on PR and weekly schedule
+   ```yaml
+   name: CodeQL Analysis
+   on:
+     pull_request:
+     schedule:
+       - cron: '0 6 * * 1'
+   ```
 
 ### Priority 1 (High Value)
 
-3. **Add PR-time Konflux build simulation** (8-12 hours)
-   - Create a CI job that simulates the Tekton pipeline locally
-   - Catch build differences between GitHub Actions and Konflux before merge
-   - Alternatively, integrate Tekton-as-Code to trigger Konflux pipelines from PRs
+3. **Switch Codecov to enforced mode**
+   - Change `.codecov.yml` to block PRs below threshold:
+   ```yaml
+   status:
+     project:
+       default:
+         informational: false  # was: true
+         target: auto
+         threshold: 1%
+     patch:
+       default:
+         informational: false  # was: true
+         target: 70%
+   ```
 
-4. **Enable disabled quality gate checks** (4-8 hours each)
-   - Contract testing gate: Infrastructure exists, just needs enforcement
-   - API functional testing: Requires common testing framework for modular architecture
-   - Bundle size monitoring: Important for Module Federation performance
-
-5. **Add API performance regression testing for BFF services** (4-6 hours)
-   - The Go BFF services (7+ packages) lack performance benchmarks
-   - Add Go benchmarks or k6/vegeta load testing to catch latency regressions
+4. **Add SBOM generation to image builds**
+   - Use Syft or Trivy to generate SBOM alongside image builds
+   - Upload as build artifact for compliance
 
 ### Priority 2 (Nice-to-Have)
 
-6. **Expand accessibility testing** (4-6 hours)
-   - axe-core is integrated but coverage could be expanded
-   - Add automated a11y checks to Cypress mock tests
-
-7. **Add CodeQL SAST scanning** (2-4 hours)
-   - Complement Semgrep with CodeQL for deeper TypeScript/Go analysis
-   - GitHub-native integration, free for open source
-
-8. **Add chaos engineering for operator** (8-16 hours)
-   - Test controller reconciliation under failure conditions
-   - Validate webhook behavior with invalid/corrupt input
+5. **Multi-architecture build validation** — Validate arm64 builds in the Konflux simulator
+6. **Bundle size monitoring** — Track and enforce JavaScript bundle size budgets per package
+7. **Performance regression testing** — Add Lighthouse CI or similar for frontend performance baselines
 
 ## Comparison to Gold Standards
 
-| Dimension | odh-dashboard | notebooks (gold std) | kserve (gold std) | Kubernetes best practices |
-|-----------|:------------:|:-------------------:|:-----------------:|:------------------------:|
-| Unit Tests | 9.0 | 7.0 | 8.0 | 8.0 |
-| Integration/E2E | 9.5 | 8.0 | 9.0 | 8.0 |
-| Build Integration | 8.0 | 7.0 | 7.0 | 8.0 |
-| Image Testing | 7.0 | 9.0 | 7.0 | 8.0 |
-| Coverage Tracking | 8.5 | 6.0 | 9.0 | 8.0 |
-| CI/CD Automation | 9.5 | 8.0 | 8.0 | 8.0 |
-| Agent Rules | **10.0** | 4.0 | 3.0 | N/A |
-| Container Scanning | ❌ | ✅ Trivy 5-layer | ❌ | ✅ Expected |
-| SBOM | ❌ | ✅ | ❌ | ✅ Expected |
-| Contract Tests | ✅ 8 packages | ❌ | ❌ | ❌ |
-| Accessibility | ✅ axe-core | N/A | N/A | N/A |
-| Pre-commit | ✅ Husky | ❌ | ❌ | ✅ Expected |
+| Dimension | odh-dashboard | notebooks | kserve | k8s Best Practice |
+|-----------|:------------:|:---------:|:------:|:-----------------:|
+| Unit Tests | 9.0 | 5.0 | 8.0 | 8.0 |
+| Integration/E2E | 9.5 | 7.0 | 8.5 | 8.0 |
+| Build Integration | 9.5 | 6.0 | 5.0 | 7.0 |
+| Image Testing | 8.5 | 9.0 | 6.0 | 7.0 |
+| Coverage Tracking | 8.5 | 3.0 | 9.0 | 8.0 |
+| CI/CD Automation | 9.5 | 7.0 | 8.5 | 8.0 |
+| Agent Rules | 10.0 | 1.0 | 2.0 | 3.0 |
+| Container Scanning | 0.0 | 8.0 | 5.0 | 9.0 |
+| **Overall** | **9.1** | **5.8** | **7.0** | **7.3** |
 
-**odh-dashboard IS the gold standard** for:
-- Agent rules and agentic workflow quality
-- Multi-layer testing (unit → mock → E2E → contract)
-- CI/CD sophistication and automation
-- Monorepo quality practices with modular architecture quality gates
-
-**Areas where others lead**:
-- **notebooks**: Container image testing (5-layer validation, Trivy scanning, SBOM)
-- **kserve**: Coverage enforcement thresholds
+**Notable**: odh-dashboard is the **reference gold standard** for agent rules, build integration, and CI/CD automation. Its only significant weakness is the absence of container vulnerability scanning and SAST — areas where the `notebooks` repo excels.
 
 ## File Paths Reference
 
 ### CI/CD
-- `.github/workflows/test.yml` — Main test pipeline (unit, lint, type-check, contract, Cypress mock)
-- `.github/workflows/cypress-e2e-test.yml` — Live cluster E2E with failover
-- `.github/workflows/dashboard-operator-tests.yml` — Go operator CI
-- `.github/workflows/modular-arch-quality-gates.yml` — Module quality assessment
-- `.github/workflows/validate-kustomize.yml` — Manifest validation
-- `.github/workflows/dependency-validation.yml` — npm audit diff
-- `.github/workflows/*-bff-tests.yml` — Per-package BFF test workflows (×7)
-- `.tekton/` — 20 Tekton pipeline definitions
+- `.github/workflows/test.yml` — Main test workflow (type-check, lint, unit, contract, cypress mock)
+- `.github/workflows/cypress-e2e-test.yml` — E2E tests with cluster failover
+- `.github/workflows/pr-build-validation.yml` — Konflux build simulator (4-phase)
+- `.github/workflows/validate-kustomize.yml` — Kustomize manifest validation
+- `.github/workflows/modular-arch-quality-gates.yml` — Per-module quality gates
+- `.github/workflows/dashboard-operator-tests.yml` — Go operator tests
+- `.github/workflows/*-bff-tests.yml` — Per-package BFF test workflows (8 total)
+- `.github/workflows/claude-preflight.yml` — AI agent PR preflight
 
 ### Testing
-- `packages/cypress/cypress/tests/mocked/` — Cypress mock tests
-- `packages/cypress/cypress/tests/e2e/` — Cypress E2E tests
-- `packages/*/contract-tests/` — Contract test suites (8 packages)
-- `dashboard-operator/internal/controller/*_test.go` — Operator tests
-- `packages/*/bff/**/*_test.go` — BFF Go tests (184 files)
+- `packages/cypress/` — Cypress test framework and shared tests
+- `packages/cypress/cypress/tests/e2e/` — 90 E2E test files (23 feature directories)
+- `packages/cypress/cypress/tests/mocked/` — 91 mock test files
+- `packages/contract-tests/` — Contract test framework
+- `packages/*/contract-tests/` — Per-module contract tests
+- `dashboard-operator/*_test.go` — 8 Go operator test files
+- `frontend/jest.config.ts` — Frontend Jest configuration
+- `backend/jest.config.ts` — Backend Jest configuration
 
 ### Code Quality
-- `.eslintrc.js` — Root ESLint config (shared)
-- `dashboard-operator/.golangci.yml` — Go linter (v2, standard)
-- `.prettierrc` — Formatting
-- `.husky/pre-commit` — Pre-commit hook with lint-staged
-- `semgrep.yaml` — Unified security rules
-- `.gitleaks.toml` — Secret scanning config
-- `.codecov.yml` — Coverage config (70% patch target)
+- `.eslintrc.js` — ESLint config (shared via `@odh-dashboard/eslint-config`)
+- `.prettierrc` — Prettier configuration
+- `.husky/pre-commit` — Pre-commit hook with lint-staged + port validation
+- `.gitleaks.toml` — Secret detection configuration
+- `.codecov.yml` — Coverage tracking configuration
+
+### Container Images
+- `Dockerfile` — Main dashboard multi-stage build (Node.js)
+- `dashboard-operator/Dockerfile` — Go operator multi-stage build
+- `.tekton/` — 22 Tekton/Konflux pipeline files
 
 ### Agent Rules
-- `.claude/rules/` — 18 rule files (3,550+ lines)
-- `.claude/skills/` — 20+ custom skills
-- `CLAUDE.md` / `AGENTS.md` — Agent guidance documents
-- `.agentready-config.yaml` — Agent readiness config
+- `AGENTS.md` / `CLAUDE.md` — Comprehensive agent documentation
+- `.claude/rules/` — 20 specialized rules
+- `.claude/skills/` — 23 custom skills
+- `.claude/commands/` — Custom commands

--- a/modules/system-health/client/generated-reports/quality-analysis-red-hat-data-services-odh-dashboard.md
+++ b/modules/system-health/client/generated-reports/quality-analysis-red-hat-data-services-odh-dashboard.md
@@ -1,143 +1,141 @@
 ---
 repository: "red-hat-data-services/odh-dashboard"
-overall_score: 8.7
+overall_score: 9.2
 scorecard:
   - dimension: "Unit Tests"
-    score: 8.5
-    status: "753 unit/spec test files across frontend, backend, and packages using Jest; strong test-to-code ratio"
-  - dimension: "Integration/E2E"
     score: 9.0
-    status: "235 Cypress tests spanning 25+ mocked areas and 21 E2E areas; contract tests across 9 modules; cluster failover E2E"
+    status: "891 test files across frontend/backend/packages with Jest + coverage upload to Codecov"
+  - dimension: "Integration/E2E"
+    score: 9.5
+    status: "181 Cypress mock tests, 23 E2E test groups with cluster failover, contract tests for BFF APIs"
   - dimension: "Build Integration"
-    score: 7.5
-    status: "Kustomize validation, modular architecture quality gates, BFF build verification; no PR-time Konflux simulation"
+    score: 9.5
+    status: "PR-time Konflux simulator with hermetic build testing, kustomize validation, workspace COPY verification"
   - dimension: "Image Testing"
-    score: 6.5
-    status: "11 Dockerfiles including Konflux variants; multi-stage builds; no runtime validation or startup testing in CI"
+    score: 8.5
+    status: "13 Dockerfiles including Konflux and Sealights variants, multi-arch support, but no runtime validation"
   - dimension: "Coverage Tracking"
-    score: 8.0
-    status: "Codecov integration with merged unit+Cypress coverage; informational mode with 70% patch target; no hard enforcement"
+    score: 8.5
+    status: "Codecov integration with merged unit+Cypress coverage, 70% patch target (informational mode)"
   - dimension: "CI/CD Automation"
     score: 9.5
-    status: "26 workflows with concurrency control, caching, matrix strategies, Tekton pipelines, Turbo-based parallelism"
+    status: "26 workflows with concurrency control, turbo caching, matrix strategies, and path-filtered triggers"
   - dimension: "Agent Rules"
-    score: 9.5
-    status: "19 comprehensive agent rules covering all test types, architecture, security, conventions; 20 custom skills; AgentReady weekly"
+    score: 10.0
+    status: "20 agent rules covering all test types, 23 custom skills, AGENTS.md with full architecture guidance"
 critical_gaps:
-  - title: "No PR-time Konflux build simulation"
-    impact: "Build issues in Konflux Dockerfiles discovered only after merge; divergence between Dockerfile and Dockerfile.konflux"
-    severity: "HIGH"
-    effort: "8-12 hours"
-  - title: "No container image runtime validation"
-    impact: "Image startup failures, missing environment variables, or broken Node.js entrypoints not caught until deployment"
-    severity: "HIGH"
-    effort: "6-8 hours"
-  - title: "No security scanning in GitHub workflows"
-    impact: "Vulnerabilities in dependencies or code not detected at PR time; relies entirely on Konflux/external scanning"
+  - title: "Coverage enforcement is informational only"
+    impact: "Coverage regressions can merge without blocking; the 70% patch target is advisory"
+    severity: "MEDIUM"
+    effort: "1-2 hours"
+  - title: "No container runtime validation in CI"
+    impact: "Image startup failures or misconfiguration not caught until deployment"
     severity: "MEDIUM"
     effort: "4-6 hours"
-  - title: "Coverage enforcement is informational only"
-    impact: "Coverage can regress without blocking PRs; 70% patch target is advisory"
+  - title: "No SAST/CodeQL workflow in GitHub Actions"
+    impact: "Static application security testing relies solely on semgrep rules (1875 lines) but no automated SAST pipeline"
     severity: "MEDIUM"
-    effort: "1-2 hours"
-quick_wins:
-  - title: "Add Trivy container scanning to PR workflow"
     effort: "2-3 hours"
-    impact: "Early detection of CVEs in base images and dependencies before merge"
-  - title: "Enable Semgrep scanning in CI"
-    effort: "1-2 hours"
-    impact: "Semgrep rules exist (semgrep.yaml) but no CI workflow runs them; immediate SAST coverage"
-  - title: "Switch Codecov from informational to blocking"
+  - title: "No Trivy/Snyk container scanning in CI"
+    impact: "Container image vulnerabilities not caught until Konflux/production scanning"
+    severity: "MEDIUM"
+    effort: "2-3 hours"
+quick_wins:
+  - title: "Switch Codecov patch coverage from informational to blocking"
     effort: "30 minutes"
-    impact: "Prevent coverage regressions by enforcing the 70% patch target"
-  - title: "Add Gitleaks scanning to PR workflow"
+    impact: "Prevents coverage regressions from merging; enforces 70% threshold"
+  - title: "Add CodeQL or Semgrep CI workflow"
     effort: "1-2 hours"
-    impact: "Gitleaks config exists (.gitleaks.toml) but no CI workflow runs it; detect secrets in PRs"
+    impact: "Automated SAST scanning on every PR, complementing the existing semgrep rules"
+  - title: "Add Trivy container scanning to PR workflow"
+    effort: "1-2 hours"
+    impact: "Early detection of container image CVEs before Konflux"
+  - title: "Add image smoke test to PR build validation"
+    effort: "2-3 hours"
+    impact: "Validates container starts and serves healthcheck endpoint"
 recommendations:
   priority_0:
-    - "Add PR-time Konflux Dockerfile build validation — build Dockerfile.konflux in CI to catch build divergence early"
-    - "Add container image runtime validation — build and start the image in CI, verify health endpoint responds"
+    - "Enforce Codecov coverage thresholds (change informational to required) to prevent silent coverage decay"
+    - "Add container image vulnerability scanning (Trivy) to PR workflow for early CVE detection"
   priority_1:
-    - "Enable existing Semgrep and Gitleaks configs in CI workflows — the rules are already authored, just not wired into automation"
-    - "Add Trivy or Snyk scanning to the PR workflow for container image vulnerability detection"
-    - "Switch Codecov enforcement from informational to required status check"
+    - "Add CodeQL/Semgrep automated SAST workflow alongside the existing semgrep.yaml rules"
+    - "Add container runtime smoke test (health check, port binding) to PR Build Validation workflow"
+    - "Enable the disabled quality gate checks (Mock Tests, Contract Testing, Bundle Size) in modular-arch-quality-gates.yml"
   priority_2:
-    - "Add performance regression testing for dashboard page load times"
-    - "Enable the disabled modular architecture quality gate checks (mock tests, contract testing, API functional/perf, bundle size)"
-    - "Add multi-architecture image build testing (currently single-arch only in CI)"
+    - "Add performance regression testing for API endpoints and frontend bundle size tracking"
+    - "Add accessibility testing (axe-core) to Cypress test suite"
+    - "Implement visual regression testing for UI components"
 ---
 
-# Quality Analysis: odh-dashboard
+# Quality Analysis: odh-dashboard (red-hat-data-services/odh-dashboard)
 
 ## Executive Summary
 
-- **Overall Score: 8.7/10**
-- **Repository Type**: TypeScript/React monorepo with Go BFF services and Go operator
-- **Primary Languages**: TypeScript (frontend/backend), Go (BFF services, operator)
-- **Framework**: React 18 + PatternFly v6 + Module Federation + Turbo monorepo
+- **Overall Score: 9.2/10**
+- **Repository Type**: TypeScript/React monorepo with Go BFFs and a Kubernetes operator
+- **Primary Technologies**: React 18, TypeScript, PatternFly v6, Go, Cypress, Jest, Turbo
+- **Monorepo Structure**: 29 packages + frontend + backend + dashboard-operator + distributions
+- **Agent Rules Status**: Exemplary - 20 rules, 23 skills, comprehensive AGENTS.md
 
-### Key Strengths
-- **Multi-layer testing**: Unit (Jest), Cypress mock, Cypress E2E (live cluster), contract tests — one of the most comprehensive test pyramids in the OpenShift AI ecosystem
-- **Contract testing**: 9 modules with contract test suites validating frontend-BFF API boundaries
-- **Agent rules excellence**: 19 detailed agent rules + 20 custom skills + weekly AgentReady assessment — industry-leading AI-assisted development infrastructure
-- **CI/CD sophistication**: 26 GitHub workflows + Tekton pipelines with concurrency control, aggressive caching, matrix parallelization, and smart test selection
-
-### Critical Gaps
-- No PR-time Konflux build simulation — Dockerfile.konflux divergence caught post-merge
-- No container image runtime validation in CI
-- Security scanning tools (Semgrep, Gitleaks) are configured but not wired into CI workflows
-- Coverage enforcement is informational (advisory, not blocking)
-
-### Agent Rules Status: **Exemplary**
-19 rules covering architecture, BFF, contract tests, Cypress E2E/mock, unit tests, security, operator patterns, conventions, CSS/PatternFly, modular architecture, module federation, onboarding, pull requests, React, Jira, testing standards, and third-party theming. Plus 20 custom skills for development workflows.
+The odh-dashboard repository represents a **gold-standard** for quality practices in the OpenShift AI ecosystem. It features multi-layer testing (unit, mock Cypress, E2E with live clusters, contract tests), a Konflux build simulator for PR-time validation, comprehensive agent rules for AI-assisted development, and sophisticated CI/CD automation with 26 workflows. The few gaps are largely in the container security scanning and coverage enforcement areas.
 
 ## Quality Scorecard
 
 | Dimension | Score | Status |
 |-----------|-------|--------|
-| Unit Tests | 8.5/10 | 753 test files, Jest framework, strong coverage across all workspace packages |
-| Integration/E2E | 9.0/10 | 235 Cypress files, 25 mocked areas, 21 E2E areas, contract tests in 9 modules |
-| **Build Integration** | **7.5/10** | **Kustomize validation, modular quality gates; no Konflux simulation** |
-| Image Testing | 6.5/10 | 11 Dockerfiles with multi-stage builds; no runtime validation or startup checks |
-| Coverage Tracking | 8.0/10 | Codecov with merged unit+Cypress coverage; informational mode only |
-| CI/CD Automation | 9.5/10 | 26 workflows, Tekton, concurrency control, caching, matrix strategies |
-| Agent Rules | 9.5/10 | 19 rules, 20 skills, AgentReady weekly assessment, comprehensive guidance |
+| Unit Tests | 9.0/10 | 891 test files, Jest + coverage, turbo parallelization |
+| Integration/E2E | 9.5/10 | 181 mock Cypress + 23 E2E groups + contract tests + cluster failover |
+| **Build Integration** | **9.5/10** | **PR-time Konflux simulator, hermetic build testing, kustomize validation** |
+| Image Testing | 8.5/10 | 13 Dockerfiles, multi-arch, but no runtime validation |
+| Coverage Tracking | 8.5/10 | Codecov with merged coverage, but informational-only enforcement |
+| CI/CD Automation | 9.5/10 | 26 workflows, concurrency control, turbo caching, matrix strategies |
+| Agent Rules | 10.0/10 | 20 rules, 23 skills, comprehensive architecture guidance |
 
 ## Critical Gaps
 
-### 1. No PR-Time Konflux Build Simulation
-- **Impact**: `Dockerfile` and `Dockerfile.konflux` can diverge (different base image pinning, different env vars, different build steps). Build failures in Konflux discovered only post-merge.
-- **Severity**: HIGH
-- **Effort**: 8-12 hours
-- **Evidence**: `Dockerfile` uses `ARG BASE_IMAGE` with build mode switching; `Dockerfile.konflux` hardcodes RHOAI env vars and pins a specific `ubi9/nodejs-22` digest. These can drift apart.
-
-### 2. No Container Image Runtime Validation
-- **Impact**: Node.js server startup failures, missing assets, broken module federation configs not caught until deployment to a cluster
-- **Severity**: HIGH
-- **Effort**: 6-8 hours
-- **Evidence**: No workflow step builds and starts the container image to verify health. 11 Dockerfiles × 0 runtime tests = significant risk surface.
-
-### 3. Security Scanning Not Wired Into CI
-- **Impact**: `semgrep.yaml` has comprehensive rules (generic secrets, TypeScript, Go, YAML, Kubernetes patterns) and `.gitleaks.toml` has allowlists configured — but neither is run in any GitHub workflow. Vulnerabilities detected only post-merge by external tools.
+### 1. Coverage Enforcement is Informational Only
+- **Impact**: Coverage regressions can merge without blocking the PR
 - **Severity**: MEDIUM
-- **Effort**: 4-6 hours (combined)
-- **Evidence**: `grep -rl "trivy\|snyk\|codeql\|semgrep\|gitleaks\|gosec" .github/workflows/` returns empty. The `semgrep.yaml` is a detailed 3.0.0 template covering 5 languages.
+- **Effort**: 30 minutes
+- **Details**: The `.codecov.yml` sets both `project` and `patch` status to `informational: true` with a 70% patch target. This means Codecov reports coverage but does not block merges when coverage drops.
+- **Fix**: Change `informational: true` to `informational: false` for the `patch` status
 
-### 4. Coverage Enforcement is Informational
-- **Impact**: The `.codecov.yml` sets `informational: true` for both project and patch status — coverage regressions don't block PRs
+### 2. No Container Runtime Validation
+- **Impact**: Image startup failures or misconfiguration not caught until deployment
 - **Severity**: MEDIUM
-- **Effort**: 30 minutes to toggle
-- **Evidence**: `.codecov.yml` lines: `informational: true` under both `project.default` and `patch.default`
+- **Effort**: 4-6 hours
+- **Details**: While the PR Build Validation workflow tests hermetic builds, it does not start the built container and validate it responds to health checks. The Dockerfile builds are verified but runtime behavior is not.
+
+### 3. No Automated SAST Pipeline
+- **Impact**: 1875-line semgrep.yaml exists but no CI workflow runs it automatically
+- **Severity**: MEDIUM
+- **Effort**: 2-3 hours
+- **Details**: The repository has an extensive `semgrep.yaml` configuration covering Go, TypeScript, Python, YAML, and generic secrets detection, but there is no GitHub Actions workflow that runs Semgrep on PRs. The rules need a workflow to be executed.
+
+### 4. No Container Image Vulnerability Scanning
+- **Impact**: Image CVEs discovered only at Konflux stage, not during PR review
+- **Severity**: MEDIUM
+- **Effort**: 2-3 hours
+- **Details**: Despite having gitleaks for secret detection, there is no Trivy, Snyk, or Grype scanning workflow for container images.
 
 ## Quick Wins
 
-### 1. Enable Semgrep in CI (1-2 hours)
-The `semgrep.yaml` file already exists with comprehensive rules. Add a workflow:
+### 1. Enforce Codecov Patch Coverage (30 minutes)
+Change `.codecov.yml`:
 ```yaml
-name: Semgrep
+patch:
+  default:
+    informational: false  # was: true
+    target: 70%
+```
+
+### 2. Add Semgrep CI Workflow (1-2 hours)
+Create `.github/workflows/semgrep.yml` to run the existing 1875-line semgrep rules on PRs:
+```yaml
+name: Semgrep SAST
 on: [pull_request]
 jobs:
-  scan:
+  semgrep:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -146,304 +144,313 @@ jobs:
           config: semgrep.yaml
 ```
 
-### 2. Enable Gitleaks in CI (1-2 hours)
-`.gitleaks.toml` is already configured with test file allowlists:
+### 3. Add Trivy Container Scanning (1-2 hours)
+Add a Trivy scan step to the PR Build Validation workflow after the Docker build:
 ```yaml
-name: Gitleaks
-on: [pull_request]
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-```
-
-### 3. Switch Codecov to Blocking (30 minutes)
-Change `.codecov.yml`:
-```yaml
-status:
-  patch:
-    default:
-      informational: false  # was: true
-      target: 70%
-```
-
-### 4. Add Trivy Scanning (2-3 hours)
-```yaml
-- name: Build image
-  run: docker build -t dashboard:test .
-- name: Run Trivy
+- name: Run Trivy vulnerability scanner
   uses: aquasecurity/trivy-action@master
   with:
-    image-ref: dashboard:test
-    severity: HIGH,CRITICAL
+    image-ref: 'odh-dashboard:pr-test'
+    severity: 'CRITICAL,HIGH'
+    exit-code: '1'
+```
+
+### 4. Add Container Smoke Test (2-3 hours)
+Add a step to PR Build Validation that starts the built container and validates health:
+```yaml
+- name: Container smoke test
+  run: |
+    docker run -d --name smoke-test -p 8080:8080 odh-dashboard:pr-test
+    sleep 5
+    curl -f http://localhost:8080/api/health || exit 1
+    docker stop smoke-test
 ```
 
 ## Detailed Findings
 
 ### CI/CD Pipeline
 
-**Workflows (26 total)**:
+**Score: 9.5/10** - Exceptional
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| test.yml | push, PR | Main test suite: setup, type-check, lint, unit tests, contract tests, Cypress mock tests, coverage merge + Codecov upload |
-| cypress-e2e-test.yml | After test.yml on PRs | Live cluster E2E with failover (primary: dash-e2e-int, secondary: dash-e2e), smart test selection via PR labels and Turbo change detection |
-| dashboard-operator-tests.yml | push/PR (operator paths) | Go operator lint, build, test with coverage |
-| core-bff-build.yml | push/PR (core-bff paths) | Core BFF Go lint, build, test |
-| automl-bff-tests.yml | push/PR | AutoML BFF tests |
-| autorag-bff-tests.yml | push/PR | AutoRAG BFF tests |
-| eval-hub-bff-tests.yml | push/PR | EvalHub BFF tests |
-| gen-ai-bff-build.yml | push/PR | Gen AI BFF build + test |
-| gen-ai-frontend-build.yml | push/PR | Gen AI frontend test + build |
-| maas-bff-tests.yml | push/PR | MaaS BFF tests |
-| mlflow-bff-tests.yml | push/PR | MLflow BFF tests |
-| model-registry-bff-tests.yml | push/PR | Model Registry BFF tests |
-| model-registry-frontend-tests.yml | push/PR | Model Registry frontend tests |
-| eval-hub-frontend-tests.yml | push/PR | EvalHub frontend tests |
-| modular-arch-quality-gates.yml | PR (packages/**) | Per-module testing maturity assessment |
-| validate-kustomize.yml | push/PR (manifests/**) | RHOAI and ODH Kustomize build validation |
-| dependency-validation.yml | PR (package-lock.json) | npm audit diff: blocks PRs that introduce new HIGH advisories |
-| agentready-weekly.yml | Weekly schedule | AgentReady assessment, creates issue if score < 75% |
-| dependabot-auto-merge.yml | Dependabot PRs | Auto-merge minor/patch updates |
-| stale.yml | Daily schedule | Mark stale issues/PRs |
-| audit-bypass-notice.yml | PR label | Notification when audit bypass label is applied |
-| release-*.yml | workflow_dispatch | Release automation |
-| pr-image-expiry.yml | workflow_dispatch | PR image cleanup |
+The repository has 26 GitHub Actions workflows with sophisticated automation:
 
-**Strengths**:
-- Concurrency control on all major workflows (`cancel-in-progress: true`)
-- Aggressive caching: npm modules, Turbo cache, Cypress build cache
-- Matrix strategy for Cypress tests (auto-discovered test groups)
-- Smart test selection in E2E: PR labels, Turbo change detection, frontend area mapping
-- Cluster failover for E2E tests (primary/secondary cluster health checks)
-- Path-based triggering to avoid unnecessary runs
+**PR-Triggered Workflows (13)**:
+- `test.yml` - Main test pipeline (lint, type-check, unit tests, contract tests, Cypress mock tests, coverage upload)
+- `pr-build-validation.yml` - Konflux build simulator with hermetic build testing
+- `validate-kustomize.yml` - Kustomize manifest validation (RHOAI + ODH)
+- `dependency-validation.yml` - npm audit with base comparison (blocks new vulnerabilities)
+- `modular-arch-quality-gates.yml` - Per-module testing maturity assessment
+- 8 BFF/module-specific test workflows (automl, autorag, core, eval-hub, gen-ai, maas, mlflow, model-registry)
 
-**Tekton Pipelines**: 21 pipeline definitions in `.tekton/` for Konflux integration covering:
-- Main dashboard (pull-request, push)
-- Dashboard operator (pull-request, push)
-- Modular architecture packages: MaaS, agent-ops, AutoML, AutoRAG, EvalHub, GenAI, MLflow, Model Registry
-- Combined modular architecture pipeline
+**Periodic/Dispatch Workflows (6)**:
+- `agentready-weekly.yml` - Weekly agent readiness assessment
+- `cypress-e2e-test.yml` - E2E tests with cluster failover (dash-e2e-int primary, dash-e2e secondary)
+- `release-auto-merge.yml` - Sync main to ODH/RHOAI release branches
+- `release-odh-dashboard.yml` - Release automation
+- `stale.yml` - Stale issue/PR management
+- `pr-image-expiry.yml` - PR image cleanup
+
+**Key Strengths**:
+- Concurrency control on all PR workflows (`cancel-in-progress: true`)
+- Turbo caching for build and test parallelization
+- Dynamic test group discovery for Cypress (matrix strategy)
+- Path-filtered triggers (only run relevant tests for changed code)
+- npm audit comparison between base and head (blocks new vulnerabilities)
+- Module federation port validation on every commit
+- Tekton pipelines (22 files) for Konflux CI/CD
 
 ### Test Coverage
 
-**Test-to-Code Ratio Analysis**:
+**Score: 9.0/10** - Excellent
 
-| Component | Source Files | Test Files | Ratio | Framework |
-|-----------|-------------|------------|-------|-----------|
-| Frontend | 1,803 TS/TSX | 310 spec/test | 1:5.8 | Jest |
-| Backend | 99 TS | 6 spec/test | 1:16.5 | Jest |
-| Packages | — | 437 spec/test | — | Jest |
-| Cypress (mocked) | — | ~200 cy.ts | — | Cypress |
-| Cypress (E2E) | — | ~35 cy.ts | — | Cypress |
-| Go (operator) | ~200 .go | 223 _test.go | 1:0.9 | Go testing |
-| Contract Tests | — | 24 files | — | Custom + schema validation |
+**Unit Tests (331 frontend + 10 backend + 543 packages = 884 total)**:
+- Framework: Jest with TypeScript
+- Test-to-code ratio: 0.19 (891 test files / 4569 source files)
+- Coverage: Generated via `test-unit-coverage` with nyc aggregation
+- Organization: `__tests__` directories co-located with source
 
-**Notable**:
-- Backend test coverage is low (6 test files for 99 source files)
-- Go operator has excellent test coverage (nearly 1:1 test-to-code ratio)
-- Contract tests cover 9 separate modules: model-registry, mlflow, gen-ai, eval-hub, autorag, automl, agent-ops, core-bff, plus shared utilities
-- Coverage merge combines Jest unit + Cypress instrumented coverage into single Codecov report
+**Cypress Mock Tests (181 .cy.ts files, 25 test groups)**:
+- Framework: Cypress with TypeScript
+- Coverage: Istanbul instrumentation with `cypress:server:build:coverage`
+- Parallel execution: Dynamic matrix strategy based on test directory discovery
+- Groups: applications, clusterSettings, connectionTypes, customServingRuntimes, distributedWorkloads, featureStore, hardwareProfiles, home, modelRegistry, modelServing, modelTraining, pipelines, projects, and more
+
+**Cypress E2E Tests (23 test groups)**:
+- Run against live clusters with failover (primary: dash-e2e-int, secondary: dash-e2e)
+- Smart test selection via PR labels (`test:*`), auto-detection from turbo, and manual override
+- BFF support: auto-starts backend-for-frontend services for packages with `bffConfig.enabled`
+- Tags: `@ci-dashboard-regression-tags` always runs, plus package-specific tags
+
+**Contract Tests (23 files)**:
+- Framework: Custom schema validation + OpenAPI validation
+- Scope: BFF API contracts (model-registry, gen-ai, mlflow, core-bff)
+- Features: Schema conversion, HTML report generation, Go BFF consumer testing
+- Runs sequentially via turbo (`--concurrency=1`)
+
+**Dashboard Operator Tests (8 Go test files / 10 source files)**:
+- Framework: Go testing with envtest (controller-runtime)
+- Coverage: Reconciler tests, webhook tests, action tests, config tests, module tests
+- Excellent ratio: 8 test files for 10 source files (0.8 ratio)
 
 ### Code Quality
 
+**Score: 9.0/10** - Excellent
+
 **Linting**:
-- **ESLint**: Shared config via `@odh-dashboard/eslint-config` package with React TypeScript preset
-- **Prettier**: Configured (single quotes, trailing commas, 100 char width)
-- **golangci-lint v2.1.0**: Standard linters enabled for operator and BFF services
-- **Turbo**: Monorepo task runner for parallel lint/type-check/test across all packages
+- ESLint: Custom configuration with shared packages (`@odh-dashboard/eslint-config`, `@odh-dashboard/eslint-plugin`)
+- Prettier: Configured via `.prettierrc`
+- TypeScript: Strict type checking via `npm run type-check` (turbo)
+- Go: `golangci-lint` for dashboard-operator and BFF packages
 
 **Pre-commit Hooks**:
-- **Husky**: Pre-commit hook runs `lint-staged` on all staged files
-- Module federation port validation on `package.json` changes
-- Skip/force override with environment variables
-- Helpful error messages with fix instructions
+- Husky pre-commit hook with lint-staged
+- Module federation port validation on package.json changes
+- Detailed error messages with fix instructions
+- Skip/force override mechanisms (`SKIP_LINT_HOOK`, `FORCE_LINT_HOOK`)
 
 **Static Analysis**:
-- `semgrep.yaml`: Comprehensive rule set covering Go, Python, TypeScript, YAML, generic secrets — **NOT wired into CI**
-- `.gitleaks.toml`: Secret detection config with test file allowlists — **NOT wired into CI**
-- No CodeQL, Trivy, or Snyk integration in GitHub workflows
+- Semgrep: 1875-line unified configuration covering Go, TypeScript, Python, YAML, and generic secrets
+- Gitleaks: Configured with comprehensive allowlists for test files and known test credentials
+- CodeRabbit: "Assertive" profile with detailed path-specific review instructions
+- Dependency validation: npm audit with base comparison on PRs
+
+### Build Integration
+
+**Score: 9.5/10** - Exceptional
+
+**PR Build Validation (Konflux Simulator)** - This is a standout feature:
+1. **Phase 0: Hermetic Build Preflight**
+   - Validates lockfile for Hermeto/Cachi2 compatibility
+   - Tests hermetic npm install (offline mode in Docker)
+   - Validates workspace dependencies vs Dockerfile COPY statements
+   
+2. **Phase 1: Multi-Variant Docker Build**
+   - Builds multiple Dockerfile variants (Konflux, Sealights, dashboard-operator)
+   - Tests both RHOAI and ODH build modes
+   - Validates all distribution builds
+
+3. **Kustomize Validation**
+   - Validates manifests for both RHOAI and ODH overlays
+   - Pinned kustomize version with caching
+
+4. **Modular Architecture Quality Gates**
+   - Per-module testing maturity assessment
+   - Checks for unit tests, E2E tests, mock tests, contract tests
+   - RHOAI quality threshold (75%)
 
 ### Container Images
 
-**Dockerfiles (11 total)**:
-- `Dockerfile`: Multi-stage build with ODH/RHOAI build mode switching
-- `Dockerfile.konflux`: RHOAI-specific with pinned base image digest
-- `Dockerfile.konflux.*`: 9 variant Dockerfiles for modular architecture packages (agent-ops, automl, autorag, eval-hub, genai, maas, mlflow, modelregistry, sealights)
+**Score: 8.5/10** - Strong
 
-**Build Practices**:
+**Dockerfiles (13 total)**:
+- `Dockerfile` - Main development build
+- `Dockerfile.konflux` - RHOAI Konflux build (hermetic)
+- `Dockerfile.konflux.{agent-ops,automl,autorag,core-bff,eval-hub,genai,maas,mlflow,modelregistry}` - Module-specific builds
+- `Dockerfile.konflux.dashboard-operator` - Go operator build
+- `Dockerfile.konflux.sealights` - Sealights instrumented build
+
+**Build Features**:
 - Multi-stage builds (builder → runtime)
-- UBI9 Node.js 22 base image
-- Production dependency pruning via custom `prepare-production-manifest.js`
-- FIPS compliance: explicit removal of esbuild Go binaries
-- Sealights instrumentation variant for code coverage in deployed environments
+- UBI9 base images (Red Hat certified)
+- FIPS compliance (esbuild binary removal)
+- Production dependency pruning
+- Multi-architecture support via `docker buildx` (linux/s390x, linux/amd64, linux/ppc64le)
 
 **Gaps**:
-- No image startup validation in CI
-- No multi-architecture build testing
-- No container scanning workflow
-- Potential Dockerfile/Dockerfile.konflux drift (different base image strategies)
+- No container image vulnerability scanning (Trivy/Snyk)
+- No runtime validation (health check testing)
+- No SBOM generation in CI
 
 ### Security
 
-**Configured but not automated**:
-- `semgrep.yaml`: 30+ rules across 5 languages (comprehensive template v3.0.0)
-- `.gitleaks.toml`: Secret detection with smart allowlists for test fixtures
-- `.gitleaksignore`: Known false positive suppression
+**Score: 8.0/10** - Strong
 
-**Automated**:
-- `dependency-validation.yml`: npm audit diff on PR — blocks PRs introducing new HIGH/CRITICAL advisories
-- `audit-bypass-notice.yml`: Tracks when teams bypass audit with `ok-to-skip-audit` label
-- Sealights integration for runtime code coverage analysis
+**Implemented**:
+- Gitleaks configuration with comprehensive test file exclusions
+- Semgrep rules (1875 lines) covering secrets, injection, XSS, SSRF, path traversal
+- npm audit with base comparison (blocks new vulnerabilities)
+- CodeRabbit security-focused review instructions
+- Pin all GitHub Actions to commit SHAs (supply chain protection)
+- Dependency validation workflow
+- FIPS compliance in Docker builds
 
-**Missing**:
-- No Trivy/Snyk container scanning in CI
-- No CodeQL/SAST workflow
-- Semgrep and Gitleaks rules not executed in any workflow
+**Gaps**:
+- No GitHub Actions workflow runs semgrep/CodeQL automatically
+- No container image scanning (Trivy, Snyk, Grype)
+- No SBOM generation
+- No image signing/attestation
 
 ### Agent Rules (Agentic Flow Quality)
 
-**Status**: Exemplary — best-in-class across the ecosystem
+**Score: 10.0/10** - Gold Standard
 
-**Coverage** (19 rules):
-| Rule | Description |
-|------|-------------|
-| `architecture.md` | Monorepo package boundaries and BFF structure |
-| `bff-go.md` | BFF API patterns and Go conventions |
-| `contract-tests.md` | Contract test guidelines with BFF API validation |
-| `conventions.md` | TypeScript, React, PatternFly coding conventions |
-| `css-patternfly.md` | CSS and PatternFly v6 styling rules |
-| `cypress-e2e.md` | E2E test creation for live cluster testing |
-| `cypress-mock.md` | Mock test creation for isolated component testing |
-| `jira-creation.md` | Jira issue creation with RHOAIENG project formatting |
-| `modular-architecture.md` | Module Federation and plugin/extension system |
-| `module-federation.md` | Module exposure and consumption patterns |
-| `module-onboarding.md` | New module/package creation guide |
-| `operator-controller.md` | Go operator/controller-runtime patterns |
-| `pull-requests.md` | PR creation guidelines with template usage |
-| `react.md` | React component/hook/page conventions |
-| `security.md` | Auth, secrets, input validation, K8s API reviews |
-| `testing-standards.md` | Cross-cutting test type selection guidance |
-| `third-party-theming.md` | External library theming with PF tokens |
-| `unit-tests.md` | Jest unit test guidelines for utilities/hooks/components |
+This is the most comprehensive agent rules setup in the ecosystem.
 
-**Skills (20)**:
-- Development workflows: `dev-workflow`, `preflight`, `upstream-sync`, `upstream-sync-status`
-- Code review: `coderabbit-autofix`, `coderabbit-code-review`, `coderabbit-review`, `style-review`, `rbac-review`
-- Documentation: `docs-create`, `docs-create-package`, `docs-update`
-- Jira: `jira-assign-scrum-team`, `jira-eval-review`, `jira-evaluate-blockers`, `jira-triage`, `jira-validate-area-label`, `jira-validate-description`, `jira-validate-issue-type`, `jira-validate-priority-severity`
+**AGENTS.md / CLAUDE.md** (11,204 bytes):
+- Full repository structure documentation
+- Development requirements and key technologies
+- Common commands reference
+- Architecture guidance for the monorepo
 
-**Quality Assurance**:
-- Weekly AgentReady assessment with automatic issue creation on score regression
-- `AGENTS.md` with comprehensive monorepo overview, technology table, and command reference
-- `CLAUDE.md` for additional agent context
-- `BOOKMARKS.md` indexing key documentation areas
+**Agent Rules (20 files in `.claude/rules/`)**:
+| Rule | Purpose |
+|------|---------|
+| `unit-tests.md` (16,767 bytes) | Comprehensive unit test patterns with Jest |
+| `cypress-mock.md` (39,396 bytes) | Exhaustive Cypress mock test guide |
+| `cypress-e2e.md` (23,697 bytes) | E2E test patterns and infrastructure |
+| `contract-tests.md` (27,578 bytes) | BFF API contract testing guide |
+| `react.md` (14,448 bytes) | React component patterns |
+| `jira-creation.md` (20,911 bytes) | Jira issue creation standards |
+| `architecture.md` (6,390 bytes) | Monorepo architecture guide |
+| `bff-go.md` (6,113 bytes) | Go BFF development patterns |
+| `operator-controller.md` (9,556 bytes) | Dashboard operator testing |
+| `module-federation.md` (5,316 bytes) | Module federation patterns |
+| `modular-architecture.md` (5,540 bytes) | Modular architecture guide |
+| `module-onboarding.md` (8,046 bytes) | New module onboarding |
+| `distributions.md` (5,034 bytes) | Distribution build guide |
+| `css-patternfly.md` (7,794 bytes) | CSS and PatternFly patterns |
+| `conventions.md` (3,988 bytes) | Code conventions |
+| `security.md` (2,574 bytes) | Security guidelines |
+| `testing-standards.md` (3,172 bytes) | Testing standards overview |
+| `pull-requests.md` (1,222 bytes) | PR guidelines |
+| `third-party-theming.md` (3,290 bytes) | Theming guide |
+
+**Custom Skills (23 in `.claude/skills/`)**:
+- `preflight` - Pre-flight checks before commits
+- `upstream-sync` / `upstream-sync-status` - Upstream synchronization
+- `style-review` - Style review automation
+- `rbac-review` - RBAC configuration review
+- `module-onboarding` - Module onboarding automation
+- `jira-triage` / `jira-assign-scrum-team` / `jira-evaluate-blockers` - Jira workflow automation
+- `konflux-onboarding` - Konflux CI onboarding
+- `ci-flake-classifier` - CI flake detection
+- `coderabbit-autofix` / `coderabbit-code-review` / `coderabbit-review` - CodeRabbit integration
+- `dev-workflow` - Development workflow automation
+- `docs-create` / `docs-create-package` / `docs-update` - Documentation automation
+- And more...
+
+**Additional AI Tooling**:
+- `.coderabbit.yaml` - CodeRabbit configuration with assertive review profile
+- `.cursor/` directory - Cursor IDE configuration
+- `constitution.md` - AI agent behavior constitution
+- `claude-preflight.yml` - Claude agent preflight workflow
 
 ## Recommendations
 
 ### Priority 0 (Critical)
-
-1. **Add PR-time Konflux Dockerfile build validation**
-   - Build `Dockerfile.konflux` in a CI workflow step to catch build divergence
-   - Compare build outputs between `Dockerfile` and `Dockerfile.konflux`
-   - Effort: 8-12 hours
-
-2. **Add container image runtime validation**
-   - Build image → start container → verify health endpoint → check for startup errors
-   - Cover at least the main `Dockerfile.konflux` and 2-3 modular variants
-   - Effort: 6-8 hours
+1. **Enforce Codecov coverage thresholds** - Change `informational: true` to `false` for patch coverage to prevent silent coverage decay (30 minutes)
+2. **Add container vulnerability scanning** - Add Trivy scanning to PR Build Validation workflow (2-3 hours)
 
 ### Priority 1 (High Value)
-
-3. **Wire Semgrep into CI**
-   - `semgrep.yaml` already has comprehensive rules — just add the workflow
-   - Effort: 1-2 hours
-
-4. **Wire Gitleaks into CI**
-   - `.gitleaks.toml` already configured — just add the workflow
-   - Effort: 1-2 hours
-
-5. **Add Trivy container scanning**
-   - Scan built images for CVEs before merge
-   - Effort: 2-3 hours
-
-6. **Switch Codecov to blocking mode**
-   - Change `informational: true` to `false` for patch coverage
-   - Effort: 30 minutes
-
-7. **Increase backend test coverage**
-   - 6 test files for 99 source files is significantly below the frontend ratio
-   - Effort: 20-30 hours (incremental)
+3. **Add SAST CI workflow** - Create a workflow to run the existing 1875-line semgrep rules on PRs (1-2 hours)
+4. **Add container runtime smoke test** - Validate built images start and serve health endpoint (2-3 hours)
+5. **Enable disabled quality gates** - Activate Mock Tests, Contract Testing, Bundle Size checks in `modular-arch-quality-gates.yml` (4-8 hours)
+6. **Add SBOM generation** - Add Syft/Trivy SBOM generation to Konflux builds (2-3 hours)
 
 ### Priority 2 (Nice-to-Have)
-
-8. **Enable disabled modular architecture quality gate checks**
-   - Mock tests, contract testing, API functional/performance, bundle size monitoring are all defined but disabled
-   - Effort: Variable per check
-
-9. **Add performance regression testing**
-   - Dashboard page load time benchmarks (Lighthouse CI or similar)
-   - Effort: 8-12 hours
-
-10. **Add multi-architecture image build testing**
-    - Verify ARM64 builds alongside AMD64
-    - Effort: 4-6 hours
+7. **Add accessibility testing** - Integrate axe-core into Cypress test suite (4-8 hours)
+8. **Add visual regression testing** - Implement screenshot comparison for UI components (8-16 hours)
+9. **Add API performance regression testing** - Track BFF response times over time (8-16 hours)
+10. **Add bundle size tracking** - Track frontend bundle size regressions per PR (2-4 hours)
 
 ## Comparison to Gold Standards
 
-| Dimension | odh-dashboard | Gold Standard (odh-dashboard itself IS the gold standard for many) | Notes |
-|-----------|--------------|-------------------------------------------------------------------|-------|
-| Unit Tests | 8.5 | 9.0 (kserve: coverage enforcement) | Backend test coverage gap |
-| Integration/E2E | 9.0 | 9.0 (odh-dashboard) | Contract tests + E2E with cluster failover is best-in-class |
-| Build Integration | 7.5 | 9.0 (notebooks: 5-layer validation) | Missing Konflux simulation |
-| Image Testing | 6.5 | 9.0 (notebooks: runtime validation) | No startup/runtime checks |
-| Coverage Tracking | 8.0 | 9.0 (kserve: enforced thresholds) | Informational only |
-| CI/CD Automation | 9.5 | 9.5 (odh-dashboard) | Exemplary workflow organization |
-| Agent Rules | 9.5 | 9.5 (odh-dashboard) | Sets the standard for the ecosystem |
+| Dimension | odh-dashboard | notebooks | kserve | Industry Best |
+|-----------|:---:|:---:|:---:|:---:|
+| Unit Tests | 9.0 | 6.0 | 8.0 | 9.0 |
+| Integration/E2E | 9.5 | 7.0 | 8.0 | 9.0 |
+| Build Integration | 9.5 | 6.0 | 5.0 | 8.0 |
+| Image Testing | 8.5 | 9.0 | 6.0 | 9.0 |
+| Coverage Tracking | 8.5 | 5.0 | 8.0 | 9.0 |
+| CI/CD Automation | 9.5 | 7.0 | 8.0 | 9.0 |
+| Agent Rules | 10.0 | 2.0 | 3.0 | 7.0 |
+| **Overall** | **9.2** | **6.0** | **6.7** | **8.7** |
 
-**odh-dashboard IS the gold standard** for agent rules, CI/CD organization, and multi-layer testing strategy. The gaps are concentrated in container image lifecycle (build simulation, runtime validation, security scanning) — areas where the `notebooks` repository excels.
+odh-dashboard **exceeds** the industry best practice in several dimensions, particularly in Build Integration (Konflux simulator) and Agent Rules. It **sets the gold standard** for AI-assisted development practices and PR-time build validation in the OpenShift AI ecosystem.
 
 ## File Paths Reference
 
 ### CI/CD
-- `.github/workflows/test.yml` — Main test suite (lint, type-check, unit, Cypress mock, contract, coverage)
-- `.github/workflows/cypress-e2e-test.yml` — Live cluster E2E with failover
-- `.github/workflows/modular-arch-quality-gates.yml` — Per-module testing maturity
-- `.github/workflows/validate-kustomize.yml` — Kustomize manifest validation
-- `.github/workflows/dependency-validation.yml` — npm audit diff
-- `.github/workflows/dashboard-operator-tests.yml` — Go operator tests
-- `.github/workflows/*-bff-*.yml` — BFF service test workflows (7 total)
-- `.tekton/` — 21 Tekton pipeline definitions
+- `.github/workflows/test.yml` - Main test pipeline
+- `.github/workflows/pr-build-validation.yml` - Konflux build simulator
+- `.github/workflows/cypress-e2e-test.yml` - E2E tests with cluster failover
+- `.github/workflows/modular-arch-quality-gates.yml` - Module quality gates
+- `.github/workflows/validate-kustomize.yml` - Manifest validation
+- `.github/workflows/dependency-validation.yml` - npm audit comparison
+- `.github/workflows/dashboard-operator-tests.yml` - Operator tests
+- `.github/workflows/{automl,autorag,core,eval-hub,gen-ai,maas,mlflow,model-registry}-bff-tests.yml` - BFF tests
+- `.tekton/` - 22 Tekton pipeline configurations
 
 ### Testing
-- `frontend/src/` — 310 Jest test files
-- `backend/src/` — 6 Jest test files
-- `packages/*/` — 437 Jest test files across feature packages
-- `packages/cypress/cypress/tests/mocked/` — 25 mocked test areas
-- `packages/cypress/cypress/tests/e2e/` — 21 E2E test areas
-- `packages/*/contract-tests/` — Contract tests in 9 modules
-- `dashboard-operator/` — 223 Go test files
+- `frontend/src/` - 331 unit test files (Jest)
+- `backend/src/__tests__/` - 10 backend test files
+- `packages/*/` - 543 package test files
+- `packages/cypress/cypress/tests/mocked/` - 25 mock test groups (181 .cy.ts files)
+- `packages/cypress/cypress/tests/e2e/` - 23 E2E test groups
+- `packages/contract-tests/` - Contract test framework (23 files)
+- `dashboard-operator/` - 8 Go test files (envtest)
 
 ### Code Quality
-- `.eslintrc.js` — Root ESLint config (shared config package)
-- `.prettierrc` — Prettier config
-- `semgrep.yaml` — Comprehensive Semgrep rules (NOT in CI)
-- `.gitleaks.toml` — Gitleaks config (NOT in CI)
-- `.husky/pre-commit` — lint-staged + port validation
-- `dashboard-operator/.golangci.yml` — Go linter config
+- `.eslintrc.js` - ESLint configuration
+- `.prettierrc` - Prettier configuration
+- `.husky/pre-commit` - Pre-commit hooks with lint-staged
+- `semgrep.yaml` - 1875-line Semgrep rules
+- `.gitleaks.toml` - Gitleaks configuration
+- `.coderabbit.yaml` - CodeRabbit review configuration
+- `turbo.jsonc` - Turbo monorepo configuration
 
 ### Container Images
-- `Dockerfile` — Main build with ODH/RHOAI mode switching
-- `Dockerfile.konflux` — RHOAI Konflux build with pinned digest
-- `Dockerfile.konflux.*` — 9 modular architecture variants
-- `.codecov.yml` — Coverage config (informational mode)
+- `Dockerfile` - Main development build
+- `Dockerfile.konflux` - RHOAI Konflux build
+- `Dockerfile.konflux.*` - 11 module-specific Konflux builds
+- `.dockerignore` - Docker build exclusions
+
+### Coverage
+- `.codecov.yml` - Codecov configuration (informational mode)
 
 ### Agent Rules
-- `CLAUDE.md` — Root agent context
-- `AGENTS.md` — Comprehensive monorepo guide
-- `.claude/rules/` — 19 detailed rules
-- `.claude/skills/` — 20 custom skills
-- `.github/workflows/agentready-weekly.yml` — Weekly AgentReady assessment
+- `AGENTS.md` / `CLAUDE.md` - Repository documentation for AI agents
+- `.claude/rules/` - 20 agent rule files
+- `.claude/skills/` - 23 custom Claude skills
+- `.claude/commands/` - 3 custom Claude commands
+- `constitution.md` - AI agent behavior constitution

--- a/modules/system-health/client/generated-reports/quality-report-opendatahub-io-odh-dashboard.html
+++ b/modules/system-health/client/generated-reports/quality-report-opendatahub-io-odh-dashboard.html
@@ -332,7 +332,7 @@
     <div class="container">
         <header>
             <h1>Quality Analysis Report</h1>
-            <p class="timestamp">Generated on June 03, 2026 at 10:45 AM</p>
+            <p class="timestamp">Generated on July 01, 2026 at 08:28 PM</p>
             <h2 style="margin-top: 1rem; font-weight: 400;">opendatahub-io/odh-dashboard</h2>
         </header>
 
@@ -365,37 +365,37 @@
                         <div class="scorecard-item">
                             <h3>Unit Tests</h3>
                             <div class="scorecard-score" style="color: #28a745;">9.0/10</div>
-                            <div class="scorecard-status">981 test files across Jest and Go testing; 28% test-to-code ratio with coverage enforcement</div>
+                            <div class="scorecard-status">891 test files across Jest + RTL with comprehensive coverage generation and aggregation</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Integration/E2E</h3>
                             <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
-                            <div class="scorecard-status">235+ Cypress E2E tests with live cluster execution, smart tag selection, cluster failover, BFF integration, and contract testing</div>
+                            <div class="scorecard-status">181 Cypress tests (90 E2E + 91 mocked), live-cluster E2E with failover, contract tests, smart test selection</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Build Integration</h3>
-                            <div class="scorecard-score" style="color: #28a745;">8.0/10</div>
-                            <div class="scorecard-status">Docker build with RHOAI/ODH modes, Tekton pipelines for Konflux, kustomize validation, but no PR-time Konflux simulation</div>
+                            <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
+                            <div class="scorecard-status">PR-time Konflux simulator with 4-phase validation, hermetic build testing, dual-mode (ODH/RHOAI), runtime + Module Federation artifact validation</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Image Testing</h3>
-                            <div class="scorecard-score" style="color: #ffc107;">7.0/10</div>
-                            <div class="scorecard-status">Multi-stage Dockerfile with runtime health checks, but no Trivy/Snyk scanning in PR workflow</div>
+                            <div class="scorecard-score" style="color: #28a745;">8.5/10</div>
+                            <div class="scorecard-status">Multi-stage Docker builds validated at PR time, branding verification, runtime startup validation, but no Trivy/Snyk scanning in CI</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Coverage Tracking</h3>
                             <div class="scorecard-score" style="color: #28a745;">8.5/10</div>
-                            <div class="scorecard-status">Codecov integration with merged unit+Cypress coverage, 70% patch target, nyc report generation</div>
+                            <div class="scorecard-status">Codecov integration with merged unit+Cypress coverage, 70% patch target (informational), combined coverage report generation</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>CI/CD Automation</h3>
                             <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
-                            <div class="scorecard-status">26 workflows, concurrency control, turbo caching, parallel matrix tests, modular architecture quality gates</div>
+                            <div class="scorecard-status">27 workflows, path-filtered per-package triggers, concurrency control, turbo caching, dynamic test group discovery, modular quality gates</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Agent Rules</h3>
                             <div class="scorecard-score" style="color: #28a745;">10.0/10</div>
-                            <div class="scorecard-status">18 comprehensive rules covering all test types, 20+ skills, 3,550 lines of test guidance, contract test framework</div>
+                            <div class="scorecard-status">20 specialized rules, 23 custom skills, comprehensive AGENTS.md, full test type coverage with actionable guidance</div>
                         </div>
                     </div>
                 </div>
@@ -410,28 +410,28 @@
                 <div class="section-content">
                     <ul class="items-list">
                         
-                        <li class="item-card high">
-                            <div class="item-description">No container image vulnerability scanning in CI</div>
-                            <p>Security vulnerabilities in base images or dependencies not caught until Konflux/production scanning</p>
+                        <li class="item-card medium">
+                            <div class="item-description">No container vulnerability scanning (Trivy/Snyk) in PR or periodic CI</div>
+                            <p>Vulnerabilities in base images or dependencies not detected until downstream Konflux pipeline</p>
                             <div class="item-meta">
-                                <span class="meta-tag severity-high">HIGH</span>
+                                <span class="meta-tag severity-medium">MEDIUM</span>
                                 <span class="meta-tag effort-tag">2-4 hours</span>
                             </div>
                         </li>
                         <li class="item-card medium">
-                            <div class="item-description">No PR-time Konflux build simulation</div>
-                            <p>Build failures in Konflux pipelines discovered only post-merge</p>
+                            <div class="item-description">No CodeQL/SAST scanning workflow</div>
+                            <p>Static security analysis gaps — relying solely on gitleaks for secret detection</p>
                             <div class="item-meta">
                                 <span class="meta-tag severity-medium">MEDIUM</span>
-                                <span class="meta-tag effort-tag">8-12 hours</span>
+                                <span class="meta-tag effort-tag">2-3 hours</span>
                             </div>
                         </li>
-                        <li class="item-card medium">
-                            <div class="item-description">No SBOM generation</div>
-                            <p>Supply chain transparency and compliance requirements not met in CI</p>
+                        <li class="item-card low">
+                            <div class="item-description">Coverage enforcement is informational only</div>
+                            <p>Coverage regressions not blocked — threshold set to informational mode</p>
                             <div class="item-meta">
-                                <span class="meta-tag severity-medium">MEDIUM</span>
-                                <span class="meta-tag effort-tag">2-4 hours</span>
+                                <span class="meta-tag severity-low">LOW</span>
+                                <span class="meta-tag effort-tag">1 hour</span>
                             </div>
                         </li>
                     </ul>
@@ -448,27 +448,27 @@
                     <ul class="items-list">
                         
                         <li class="item-card ">
-                            <div class="item-description">Add Trivy scanning to PR workflow</div>
-                            <p>Catch container image CVEs before merge, align with notebooks gold standard</p>
+                            <div class="item-description">Add Trivy container scanning to PR workflow</div>
+                            <p>Catch CVEs in base images and dependencies before merge</p>
                             <div class="item-meta">
                                 
                                 <span class="meta-tag effort-tag">2-3 hours</span>
                             </div>
                         </li>
                         <li class="item-card ">
-                            <div class="item-description">Add SBOM generation to Dockerfile or CI</div>
-                            <p>Supply chain compliance and artifact attestation</p>
+                            <div class="item-description">Enable CodeQL analysis workflow</div>
+                            <p>Automated SAST for TypeScript and Go code paths</p>
                             <div class="item-meta">
                                 
                                 <span class="meta-tag effort-tag">1-2 hours</span>
                             </div>
                         </li>
                         <li class="item-card ">
-                            <div class="item-description">Enable performance regression testing for BFF endpoints</div>
-                            <p>Catch API latency regressions in Go BFF services before merge</p>
+                            <div class="item-description">Switch Codecov status from informational to enforced</div>
+                            <p>Prevent coverage regressions from merging</p>
                             <div class="item-meta">
                                 
-                                <span class="meta-tag effort-tag">4-6 hours</span>
+                                <span class="meta-tag effort-tag">30 minutes</span>
                             </div>
                         </li>
                     </ul>
@@ -485,15 +485,15 @@
                         
                         <div class="rec-priority p0">
                             <h3>Priority 0: Critical</h3>
-                            <ul><li>Add Trivy or Grype container scanning to the PR workflow or Tekton pipeline</li><li>Generate SBOM (syft or cdxgen) as part of the image build process</li></ul>
+                            <ul><li>Add Trivy or Snyk container vulnerability scanning to the PR build validation workflow</li><li>Enable CodeQL or Semgrep SAST scanning for TypeScript and Go code</li></ul>
                         </div>
                         <div class="rec-priority p1">
                             <h3>Priority 1: High Value</h3>
-                            <ul><li>Add PR-time Konflux build simulation for the main dashboard image</li><li>Enable the disabled quality gate checks (contract testing, API functional, bundle size monitoring)</li><li>Add API performance regression testing for BFF Go services</li></ul>
+                            <ul><li>Switch Codecov patch and project status from informational to enforced with appropriate thresholds</li><li>Add SBOM generation to container image builds</li></ul>
                         </div>
                         <div class="rec-priority p2">
                             <h3>Priority 2: Nice-to-Have</h3>
-                            <ul><li>Expand accessibility testing coverage beyond axe-core basics</li><li>Add chaos engineering / resilience testing for operator controller</li><li>Consider CodeQL SAST integration for TypeScript/Go code paths</li></ul>
+                            <ul><li>Add multi-architecture (amd64/arm64) build validation to the Konflux simulator</li><li>Add performance regression testing for frontend bundle size tracking</li></ul>
                         </div>
                     </div>
                 </div>

--- a/modules/system-health/client/generated-reports/quality-report-red-hat-data-services-odh-dashboard.html
+++ b/modules/system-health/client/generated-reports/quality-report-red-hat-data-services-odh-dashboard.html
@@ -332,7 +332,7 @@
     <div class="container">
         <header>
             <h1>Quality Analysis Report</h1>
-            <p class="timestamp">Generated on June 03, 2026 at 11:55 AM</p>
+            <p class="timestamp">Generated on July 01, 2026 at 08:38 PM</p>
             <h2 style="margin-top: 1rem; font-weight: 400;">red-hat-data-services/odh-dashboard</h2>
         </header>
 
@@ -344,11 +344,11 @@
                         <circle class="score-arc" cx="100" cy="100" r="90"
                                 stroke="#28a745"
                                 stroke-dasharray="565.4861999999999"
-                                stroke-dashoffset="73.51320600000005"
+                                stroke-dashoffset="45.23889600000003"
                                 id="scoreArc"></circle>
                     </svg>
                     <div class="score-text">
-                        <div class="score-value">8.7</div>
+                        <div class="score-value">9.2</div>
                         <div class="score-label">Overall Score</div>
                     </div>
                 </div>
@@ -364,38 +364,38 @@
                         
                         <div class="scorecard-item">
                             <h3>Unit Tests</h3>
-                            <div class="scorecard-score" style="color: #28a745;">8.5/10</div>
-                            <div class="scorecard-status">753 unit/spec test files across frontend, backend, and packages using Jest; strong test-to-code ratio</div>
+                            <div class="scorecard-score" style="color: #28a745;">9.0/10</div>
+                            <div class="scorecard-status">891 test files across frontend/backend/packages with Jest + coverage upload to Codecov</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Integration/E2E</h3>
-                            <div class="scorecard-score" style="color: #28a745;">9.0/10</div>
-                            <div class="scorecard-status">235 Cypress tests spanning 25+ mocked areas and 21 E2E areas; contract tests across 9 modules; cluster failover E2E</div>
+                            <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
+                            <div class="scorecard-status">181 Cypress mock tests, 23 E2E test groups with cluster failover, contract tests for BFF APIs</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Build Integration</h3>
-                            <div class="scorecard-score" style="color: #ffc107;">7.5/10</div>
-                            <div class="scorecard-status">Kustomize validation, modular architecture quality gates, BFF build verification; no PR-time Konflux simulation</div>
+                            <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
+                            <div class="scorecard-status">PR-time Konflux simulator with hermetic build testing, kustomize validation, workspace COPY verification</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Image Testing</h3>
-                            <div class="scorecard-score" style="color: #ffc107;">6.5/10</div>
-                            <div class="scorecard-status">11 Dockerfiles including Konflux variants; multi-stage builds; no runtime validation or startup testing in CI</div>
+                            <div class="scorecard-score" style="color: #28a745;">8.5/10</div>
+                            <div class="scorecard-status">13 Dockerfiles including Konflux and Sealights variants, multi-arch support, but no runtime validation</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Coverage Tracking</h3>
-                            <div class="scorecard-score" style="color: #28a745;">8.0/10</div>
-                            <div class="scorecard-status">Codecov integration with merged unit+Cypress coverage; informational mode with 70% patch target; no hard enforcement</div>
+                            <div class="scorecard-score" style="color: #28a745;">8.5/10</div>
+                            <div class="scorecard-status">Codecov integration with merged unit+Cypress coverage, 70% patch target (informational mode)</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>CI/CD Automation</h3>
                             <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
-                            <div class="scorecard-status">26 workflows with concurrency control, caching, matrix strategies, Tekton pipelines, Turbo-based parallelism</div>
+                            <div class="scorecard-status">26 workflows with concurrency control, turbo caching, matrix strategies, and path-filtered triggers</div>
                         </div>
                         <div class="scorecard-item">
                             <h3>Agent Rules</h3>
-                            <div class="scorecard-score" style="color: #28a745;">9.5/10</div>
-                            <div class="scorecard-status">19 comprehensive agent rules covering all test types, architecture, security, conventions; 20 custom skills; AgentReady weekly</div>
+                            <div class="scorecard-score" style="color: #28a745;">10.0/10</div>
+                            <div class="scorecard-status">20 agent rules covering all test types, 23 custom skills, AGENTS.md with full architecture guidance</div>
                         </div>
                     </div>
                 </div>
@@ -410,36 +410,36 @@
                 <div class="section-content">
                     <ul class="items-list">
                         
-                        <li class="item-card high">
-                            <div class="item-description">No PR-time Konflux build simulation</div>
-                            <p>Build issues in Konflux Dockerfiles discovered only after merge; divergence between Dockerfile and Dockerfile.konflux</p>
+                        <li class="item-card medium">
+                            <div class="item-description">Coverage enforcement is informational only</div>
+                            <p>Coverage regressions can merge without blocking; the 70% patch target is advisory</p>
                             <div class="item-meta">
-                                <span class="meta-tag severity-high">HIGH</span>
-                                <span class="meta-tag effort-tag">8-12 hours</span>
-                            </div>
-                        </li>
-                        <li class="item-card high">
-                            <div class="item-description">No container image runtime validation</div>
-                            <p>Image startup failures, missing environment variables, or broken Node.js entrypoints not caught until deployment</p>
-                            <div class="item-meta">
-                                <span class="meta-tag severity-high">HIGH</span>
-                                <span class="meta-tag effort-tag">6-8 hours</span>
+                                <span class="meta-tag severity-medium">MEDIUM</span>
+                                <span class="meta-tag effort-tag">1-2 hours</span>
                             </div>
                         </li>
                         <li class="item-card medium">
-                            <div class="item-description">No security scanning in GitHub workflows</div>
-                            <p>Vulnerabilities in dependencies or code not detected at PR time; relies entirely on Konflux/external scanning</p>
+                            <div class="item-description">No container runtime validation in CI</div>
+                            <p>Image startup failures or misconfiguration not caught until deployment</p>
                             <div class="item-meta">
                                 <span class="meta-tag severity-medium">MEDIUM</span>
                                 <span class="meta-tag effort-tag">4-6 hours</span>
                             </div>
                         </li>
                         <li class="item-card medium">
-                            <div class="item-description">Coverage enforcement is informational only</div>
-                            <p>Coverage can regress without blocking PRs; 70% patch target is advisory</p>
+                            <div class="item-description">No SAST/CodeQL workflow in GitHub Actions</div>
+                            <p>Static application security testing relies solely on semgrep rules (1875 lines) but no automated SAST pipeline</p>
                             <div class="item-meta">
                                 <span class="meta-tag severity-medium">MEDIUM</span>
-                                <span class="meta-tag effort-tag">1-2 hours</span>
+                                <span class="meta-tag effort-tag">2-3 hours</span>
+                            </div>
+                        </li>
+                        <li class="item-card medium">
+                            <div class="item-description">No Trivy/Snyk container scanning in CI</div>
+                            <p>Container image vulnerabilities not caught until Konflux/production scanning</p>
+                            <div class="item-meta">
+                                <span class="meta-tag severity-medium">MEDIUM</span>
+                                <span class="meta-tag effort-tag">2-3 hours</span>
                             </div>
                         </li>
                     </ul>
@@ -456,35 +456,35 @@
                     <ul class="items-list">
                         
                         <li class="item-card ">
-                            <div class="item-description">Add Trivy container scanning to PR workflow</div>
-                            <p>Early detection of CVEs in base images and dependencies before merge</p>
-                            <div class="item-meta">
-                                
-                                <span class="meta-tag effort-tag">2-3 hours</span>
-                            </div>
-                        </li>
-                        <li class="item-card ">
-                            <div class="item-description">Enable Semgrep scanning in CI</div>
-                            <p>Semgrep rules exist (semgrep.yaml) but no CI workflow runs them; immediate SAST coverage</p>
-                            <div class="item-meta">
-                                
-                                <span class="meta-tag effort-tag">1-2 hours</span>
-                            </div>
-                        </li>
-                        <li class="item-card ">
-                            <div class="item-description">Switch Codecov from informational to blocking</div>
-                            <p>Prevent coverage regressions by enforcing the 70% patch target</p>
+                            <div class="item-description">Switch Codecov patch coverage from informational to blocking</div>
+                            <p>Prevents coverage regressions from merging; enforces 70% threshold</p>
                             <div class="item-meta">
                                 
                                 <span class="meta-tag effort-tag">30 minutes</span>
                             </div>
                         </li>
                         <li class="item-card ">
-                            <div class="item-description">Add Gitleaks scanning to PR workflow</div>
-                            <p>Gitleaks config exists (.gitleaks.toml) but no CI workflow runs it; detect secrets in PRs</p>
+                            <div class="item-description">Add CodeQL or Semgrep CI workflow</div>
+                            <p>Automated SAST scanning on every PR, complementing the existing semgrep rules</p>
                             <div class="item-meta">
                                 
                                 <span class="meta-tag effort-tag">1-2 hours</span>
+                            </div>
+                        </li>
+                        <li class="item-card ">
+                            <div class="item-description">Add Trivy container scanning to PR workflow</div>
+                            <p>Early detection of container image CVEs before Konflux</p>
+                            <div class="item-meta">
+                                
+                                <span class="meta-tag effort-tag">1-2 hours</span>
+                            </div>
+                        </li>
+                        <li class="item-card ">
+                            <div class="item-description">Add image smoke test to PR build validation</div>
+                            <p>Validates container starts and serves healthcheck endpoint</p>
+                            <div class="item-meta">
+                                
+                                <span class="meta-tag effort-tag">2-3 hours</span>
                             </div>
                         </li>
                     </ul>
@@ -501,15 +501,15 @@
                         
                         <div class="rec-priority p0">
                             <h3>Priority 0: Critical</h3>
-                            <ul><li>Add PR-time Konflux Dockerfile build validation — build Dockerfile.konflux in CI to catch build divergence early</li><li>Add container image runtime validation — build and start the image in CI, verify health endpoint responds</li></ul>
+                            <ul><li>Enforce Codecov coverage thresholds (change informational to required) to prevent silent coverage decay</li><li>Add container image vulnerability scanning (Trivy) to PR workflow for early CVE detection</li></ul>
                         </div>
                         <div class="rec-priority p1">
                             <h3>Priority 1: High Value</h3>
-                            <ul><li>Enable existing Semgrep and Gitleaks configs in CI workflows — the rules are already authored, just not wired into automation</li><li>Add Trivy or Snyk scanning to the PR workflow for container image vulnerability detection</li><li>Switch Codecov enforcement from informational to required status check</li></ul>
+                            <ul><li>Add CodeQL/Semgrep automated SAST workflow alongside the existing semgrep.yaml rules</li><li>Add container runtime smoke test (health check, port binding) to PR Build Validation workflow</li><li>Enable the disabled quality gate checks (Mock Tests, Contract Testing, Bundle Size) in modular-arch-quality-gates.yml</li></ul>
                         </div>
                         <div class="rec-priority p2">
                             <h3>Priority 2: Nice-to-Have</h3>
-                            <ul><li>Add performance regression testing for dashboard page load times</li><li>Enable the disabled modular architecture quality gate checks (mock tests, contract testing, API functional/perf, bundle size)</li><li>Add multi-architecture image build testing (currently single-arch only in CI)</li></ul>
+                            <ul><li>Add performance regression testing for API endpoints and frontend bundle size tracking</li><li>Add accessibility testing (axe-core) to Cypress test suite</li><li>Implement visual regression testing for UI components</li></ul>
                         </div>
                     </div>
                 </div>

--- a/modules/system-health/client/qualityReports.data.js
+++ b/modules/system-health/client/qualityReports.data.js
@@ -3,13 +3,13 @@
  * Each reportUrl is resolved by Vite (?url) so the browser loads a full HTML document
  * inside an iframe — no v-html.
  */
+import reportRedHatDataServicesOdhDashboard from './generated-reports/quality-report-red-hat-data-services-odh-dashboard.html?url'
 import reportOpenclawOpenclaw from './generated-reports/quality-report-openclaw-openclaw.html?url'
 import reportOpendatahubIoOdhDashboard from './generated-reports/quality-report-opendatahub-io-odh-dashboard.html?url'
 import reportKubernetesSigsKueue from './generated-reports/quality-report-kubernetes-sigs-kueue.html?url'
 import reportOpendatahubIoOpenclaw from './generated-reports/quality-report-opendatahub-io-openclaw.html?url'
 import reportLlmDLlmDInferenceScheduler from './generated-reports/quality-report-llm-d-llm-d-inference-scheduler.html?url'
 import reportRedHatDataServicesNotebooks from './generated-reports/quality-report-red-hat-data-services-notebooks.html?url'
-import reportRedHatDataServicesOdhDashboard from './generated-reports/quality-report-red-hat-data-services-odh-dashboard.html?url'
 import reportBerriaiLitellm from './generated-reports/quality-report-BerriAI-litellm.html?url'
 import reportKubeflowPipelines from './generated-reports/quality-report-kubeflow-pipelines.html?url'
 import reportLangfuseLangfuse from './generated-reports/quality-report-langfuse-langfuse.html?url'
@@ -339,7 +339,7 @@ import reportOpendatahubIoGuidesVllmLlmD from './generated-reports/quality-repor
 import reportRedHatDataServicesKronophage from './generated-reports/quality-report-red-hat-data-services-kronophage.html?url'
 
 export const QUALITY_SAMPLE_META = {
-  generatedAt: '2026-06-10 18:26:42',
+  generatedAt: '2026-07-01 20:55:05',
   averageScore: '5.0/10',
   blurb:
     'Quality analysis of 334 repositories.'
@@ -347,6 +347,18 @@ export const QUALITY_SAMPLE_META = {
 
 /** @type {Array<{ id: string, label: string, githubUrl: string, score: string, gaps: string, tier: string, component: string, team: string, reportUrl: string }>} */
 export const QUALITY_REPORTS = [
+  {
+    id: 'red-hat-data-services-odh-dashboard',
+    label: 'red-hat-data-services/odh-dashboard',
+    githubUrl: 'https://github.com/red-hat-data-services/odh-dashboard',
+    score: '9.2/10',
+    gaps:
+      'Coverage enforcement is informational only, No container runtime validation in CI',
+    tier: 'downstream',
+    component: 'AI Core Dashboard',
+    team: 'Crimson',
+    reportUrl: reportRedHatDataServicesOdhDashboard
+  },
   {
     id: 'openclaw-openclaw',
     label: 'openclaw/openclaw',
@@ -365,7 +377,7 @@ export const QUALITY_REPORTS = [
     githubUrl: 'https://github.com/opendatahub-io/odh-dashboard',
     score: '9.1/10',
     gaps:
-      'No container image vulnerability scanning in CI, No PR-time Konflux build simulation',
+      'No container vulnerability scanning (Trivy/Snyk) in PR or periodic CI, No CodeQL/SAST scanning workflow',
     tier: 'midstream',
     component: 'AI Core Dashboard',
     team: 'Crimson',
@@ -417,18 +429,6 @@ export const QUALITY_REPORTS = [
     component: 'Notebooks Server',
     team: '',
     reportUrl: reportRedHatDataServicesNotebooks
-  },
-  {
-    id: 'red-hat-data-services-odh-dashboard',
-    label: 'red-hat-data-services/odh-dashboard',
-    githubUrl: 'https://github.com/red-hat-data-services/odh-dashboard',
-    score: '8.7/10',
-    gaps:
-      'No PR-time Konflux build simulation, No container image runtime validation',
-    tier: 'downstream',
-    component: 'AI Core Dashboard',
-    team: 'Crimson',
-    reportUrl: reportRedHatDataServicesOdhDashboard
   },
   {
     id: 'BerriAI-litellm',


### PR DESCRIPTION
#### Summary
 
- Regenerated quality analysis reports for both odh-dashboard repos with latest repo state
- opendatahub-io/odh-dashboard: 9.1/10
- red-hat-data-services/odh-dashboard: 9.2/10
- Updated registry and landing page

<img width="1180" height="302" alt="image (1)" src="https://github.com/user-attachments/assets/079aad46-01f2-42f4-83e5-a48bad73d5e5" />


#### Test plan

- [x] npm run lint passes
- [x] npm run build succeeds (no broken imports)
- [x] Test failures are pre-existing on main (27 files, 129 tests — identical count)
