### PR TITLE
feat(okr-hub): enhance Timeline with live data, edit permissions, and report navigation

### DIFF
--- a/modules/okr-hub/client/components/OnTimeReleasesReport.vue
+++ b/modules/okr-hub/client/components/OnTimeReleasesReport.vue
@@ -28,6 +28,7 @@
         <div class="ml-auto flex items-center gap-3">
           <span class="text-xs text-gray-400 dark:text-gray-500">Releases with planned GA after {{ data.since }}</span>
           <button
+            v-if="canEdit"
             @click="showSettings = !showSettings"
             class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             title="Manage releases"
@@ -153,7 +154,9 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useOkrPermissions } from '../composables/useOkrPermissions.js'
 
+var { canEdit } = useOkrPermissions()
 var loading = ref(true)
 var error = ref(null)
 var data = ref(null)

--- a/modules/okr-hub/client/components/SupportCaseReport.vue
+++ b/modules/okr-hub/client/components/SupportCaseReport.vue
@@ -30,7 +30,7 @@
             <div>Defect Rate Target: &lt;= 10%</div>
             <div>Resolution Target: 10-14 days</div>
           </div>
-          <button @click="openSettings" class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="Edit data">
+          <button v-if="canEdit" @click="openSettings" class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="Edit data">
             <svg class="w-5 h-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" viewBox="0 0 20 20" fill="currentColor">
               <path fill-rule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.331 1.652a6.993 6.993 0 011.929 1.115l1.598-.54a1 1 0 011.186.447l1.18 2.044a1 1 0 01-.205 1.251l-1.267 1.113a7.047 7.047 0 010 2.228l1.267 1.113a1 1 0 01.206 1.25l-1.18 2.045a1 1 0 01-1.187.447l-1.598-.54a6.993 6.993 0 01-1.929 1.115l-.33 1.652a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.331-1.652a6.993 6.993 0 01-1.929-1.115l-1.598.54a1 1 0 01-1.186-.447l-1.18-2.044a1 1 0 01.205-1.251l1.267-1.114a7.05 7.05 0 010-2.227L1.821 7.773a1 1 0 01-.206-1.25l1.18-2.045a1 1 0 011.187-.447l1.598.54A6.993 6.993 0 017.51 3.456l.33-1.652zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
             </svg>
@@ -154,7 +154,9 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useOkrPermissions } from '../composables/useOkrPermissions.js'
 
+var { canEdit } = useOkrPermissions()
 var loading = ref(true)
 var error = ref(null)
 var data = ref(null)

--- a/modules/okr-hub/client/composables/useOkrPermissions.js
+++ b/modules/okr-hub/client/composables/useOkrPermissions.js
@@ -1,0 +1,24 @@
+import { computed } from 'vue'
+import { useAuth } from '@shared/client/composables/useAuth'
+
+var OKR_EDITORS = [
+  'saprabhu@redhat.com',
+  'trozell@redhat.com',
+  'dodaniel@redhat.com',
+  'shuels@redhat.com'
+]
+
+export function useOkrPermissions() {
+  var { user, isAdmin } = useAuth()
+
+  var canEdit = computed(function () {
+    if (isAdmin.value) return true
+    var u = user.value
+    if (!u) return false
+    if (u.authMethod === 'local-dev') return true
+    var email = (u.email || '').toLowerCase()
+    return OKR_EDITORS.indexOf(email) !== -1
+  })
+
+  return { canEdit }
+}

--- a/modules/okr-hub/client/constants/mock-okrs.js
+++ b/modules/okr-hub/client/constants/mock-okrs.js
@@ -58,17 +58,19 @@ export var OKR_DATA = {
         {
           id: 'support-cases',
           name: 'Support Case Time to Resolution',
-          measure: 'Defect Rate for Product: 10% | Time to Resolution Target: 10-14 days',
+          measure: 'Defect Rate for Product: 10%\nTime to Resolution Target: 10-14 days',
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
-            { id: 'kr-sc-1', label: 'KR1', description: 'Defect rate for product: 10%', status: 'not-started' },
-            { id: 'kr-sc-2', label: 'KR2', description: 'Time to resolution target: 10-14 days', status: 'not-started' }
+            { id: 'kr-sc-rhoai', label: 'RHOAI', description: 'RHOAI', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } },
+            { id: 'kr-sc-rhelai', label: 'RHEL-AI', description: 'RHEL AI', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } },
+            { id: 'kr-sc-rhaii', label: 'RHAII', description: 'RHAIIS', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } }
           ]
         },
         {
           id: 'open-source-leadership',
           name: 'Open Source Leadership',
           measure: 'RH wants to be the open source leader in AI - Investment areas identified.',
+          editable: true,
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
             { id: 'kr-osl-1', label: 'KR1', description: 'Upstream contributions and community engagement targets', status: 'not-started' }
@@ -98,6 +100,7 @@ export var OKR_DATA = {
           id: 'adoption-of-ai',
           name: 'Adoption of AI',
           measure: '100% of AI Eng teams using RFE Builder/Ambient Platform as part of the daily release process',
+          editable: true,
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
             { id: 'kr-aai-1', label: 'KR1', description: '100% of AI Eng teams using RFE Builder/Ambient Platform as part of the daily release process', status: 'not-started' }

--- a/modules/okr-hub/client/constants/mock-okrs.js
+++ b/modules/okr-hub/client/constants/mock-okrs.js
@@ -35,12 +35,12 @@ export var OKR_DATA = {
   year: 2026,
   categories: [
     {
-      name: 'Quality & Reliability',
+      name: 'AI Engineering OKRs',
       objectives: [
         {
           id: 'on-time-releases',
           name: 'On Time Releases',
-          measure: '100% of releases hit planned GA date',
+          measure: 'Number of Releases On Time - 100%',
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
             { id: 'kr-otr-1', label: 'KR1', description: 'Number of releases on time — 100%', status: 'not-started' }
@@ -49,63 +49,67 @@ export var OKR_DATA = {
         {
           id: 'cve-sla',
           name: 'CVE SLA Compliance',
-          measure: '100% on-time escalation response',
+          measure: 'Number of Escalations and On Time Response - 100%',
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
             { id: 'kr-cve-1', label: 'KR1', description: 'Number of escalations and on time response — 100%', status: 'not-started' }
           ]
         },
         {
-          id: 'post-release-defects',
-          name: 'Post-Release Defects',
-          measure: '90% reduction in bugs discovered post-release',
-          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
-          keyResults: [
-            { id: 'kr-prd-1', label: 'KR1', description: '90% reduction in functional, UX, and regression bugs found post-release by the field', status: 'not-started' }
-          ]
-        }
-      ]
-    },
-    {
-      name: 'Delivery Predictability',
-      objectives: [
-        {
-          id: 'commitment-tracking',
-          name: 'Commitment Tracking',
-          measure: '>90% of planned features delivered in target release',
-          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
-          keyResults: [
-            { id: 'kr-ct-1', label: 'KR1', description: '>90% of planned features for a release are delivered in the target release', status: 'not-started' }
-          ]
-        }
-      ]
-    },
-    {
-      name: 'Technical Visibility',
-      objectives: [
-        {
-          id: 'tech-visibility',
-          name: 'Technical Visibility',
-          measure: '>5 posts/week and 1 content per associate',
-          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
-          keyResults: [
-            { id: 'kr-tv-1', label: 'KR1', description: '>= 5 posts per week across internal and external sources', status: 'not-started' },
-            { id: 'kr-tv-2', label: 'KR2', description: '1 piece of content from each AI Eng associate', status: 'not-started' }
-          ]
-        }
-      ]
-    },
-    {
-      name: 'Support & Customer Success',
-      objectives: [
-        {
           id: 'support-cases',
-          name: 'Support Case Time To Resolution',
-          measure: 'Defect rate <= 10%, resolution target 10-14 days',
+          name: 'Support Case Time to Resolution',
+          measure: 'Defect Rate for Product: 10% | Time to Resolution Target: 10-14 days',
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
             { id: 'kr-sc-1', label: 'KR1', description: 'Defect rate for product: 10%', status: 'not-started' },
             { id: 'kr-sc-2', label: 'KR2', description: 'Time to resolution target: 10-14 days', status: 'not-started' }
+          ]
+        },
+        {
+          id: 'open-source-leadership',
+          name: 'Open Source Leadership',
+          measure: 'RH wants to be the open source leader in AI - Investment areas identified.',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-osl-1', label: 'KR1', description: 'Upstream contributions and community engagement targets', status: 'not-started' }
+          ]
+        },
+        {
+          id: 'associate-well-being',
+          name: 'Associate Well Being',
+          measure: 'Implement programs that supports employee balance & engagement.',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-awb-1', label: 'KR1', description: 'Associate satisfaction and well-being targets', status: 'not-started' }
+          ]
+        },
+        {
+          id: 'improve-quality-usability',
+          name: 'Improve Quality and Usability',
+          measure: '',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-iqu-1', label: 'KR1', description: '90% reduction in bugs (Functional, UX, Regressions) discovered post-release by the field', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } },
+            { id: 'kr-iqu-2', label: 'KR2', description: '>90% of planned features for a release are delivered in the target release', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } }
+          ]
+        },
+        {
+          id: 'adoption-of-ai',
+          name: 'Adoption of AI',
+          measure: '100% of AI Eng teams using RFE Builder/Ambient Platform as part of the daily release process',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-aai-1', label: 'KR1', description: '100% of AI Eng teams using RFE Builder/Ambient Platform as part of the daily release process', status: 'not-started' }
+          ]
+        },
+        {
+          id: 'tech-visibility',
+          name: 'Increase Red Hat AI technical visibility across internal and external sources',
+          measure: '',
+          quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
+          keyResults: [
+            { id: 'kr-tv-1', label: 'KR1', description: '>5 posts per week to rh-ai-sme@redhat.com', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } },
+            { id: 'kr-tv-2', label: 'KR2', description: '1 piece of content from each AI Eng associate for internal or external consumption (ie, blog, feature demo, tutorial) for the year', quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() } }
           ]
         }
       ]

--- a/modules/okr-hub/client/constants/mock-okrs.js
+++ b/modules/okr-hub/client/constants/mock-okrs.js
@@ -78,6 +78,7 @@ export var OKR_DATA = {
           id: 'associate-well-being',
           name: 'Associate Well Being',
           measure: 'Implement programs that supports employee balance & engagement.',
+          editable: true,
           quarters: { Q1: emptyQuarter(), Q2: emptyQuarter(), Q3: emptyQuarter(), Q4: emptyQuarter() },
           keyResults: [
             { id: 'kr-awb-1', label: 'KR1', description: 'Associate satisfaction and well-being targets', status: 'not-started' }

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import OnTimeReleasesReport from '../components/OnTimeReleasesReport.vue'
 import CveSlaReport from '../components/CveSlaReport.vue'
 import PostReleaseDefectsReport from '../components/post-release-defects/PostReleaseDefectsReport.vue'
@@ -66,6 +66,20 @@ import TechVisibilityReport from '../components/TechVisibilityReport.vue'
 import SupportCaseReport from '../components/SupportCaseReport.vue'
 
 var activeReport = ref(null)
+
+onMounted(function() {
+  var hash = window.location.hash || ''
+  var qIdx = hash.indexOf('?')
+  if (qIdx === -1) return
+  var qs = hash.substring(qIdx + 1)
+  var params = new URLSearchParams(qs)
+  var reportId = params.get('report')
+  if (reportId) {
+    for (var i = 0; i < reports.length; i++) {
+      if (reports[i].id === reportId) { activeReport.value = reportId; break }
+    }
+  }
+})
 
 var reports = [
   {

--- a/modules/okr-hub/client/views/TimelineView.vue
+++ b/modules/okr-hub/client/views/TimelineView.vue
@@ -48,6 +48,7 @@
         <table class="w-full text-sm border-collapse">
           <thead>
             <tr class="bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700">
+              <th class="px-3 py-3 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-10">#</th>
               <th class="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-48">Objective</th>
               <th class="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-56">Measure of Success</th>
               <th
@@ -58,37 +59,60 @@
             </tr>
           </thead>
           <tbody>
-            <tr
-              v-for="obj in category.objectives"
-              :key="obj.id"
-              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
-              @click="navigateToDeepDive(obj.id)"
-            >
-              <td class="px-4 py-3">
-                <span class="font-semibold text-gray-900 dark:text-gray-100 text-sm">{{ obj.name }}</span>
-              </td>
-              <td class="px-4 py-3 text-xs text-gray-600 dark:text-gray-400 whitespace-pre-line leading-relaxed">
-                {{ obj.measure }}
-              </td>
-              <td
-                v-for="q in quarters"
-                :key="q"
-                class="px-3 py-3 text-center"
+            <template v-for="(obj, objIdx) in category.objectives" :key="obj.id">
+              <!-- Single-row objectives (1 KR or no per-KR quarters) -->
+              <tr
+                v-if="!hasMultiKrRows(obj)"
+                class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
+                @click="navigateToDeepDive(obj.id)"
               >
-                <div
-                  v-if="obj.quarters[q]"
-                  class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
-                  :class="statusConfig[obj.quarters[q].status].bg"
+                <td class="px-3 py-3 text-center text-xs font-bold text-gray-400 dark:text-gray-500">{{ objIdx + 1 }}</td>
+                <td class="px-4 py-3">
+                  <span class="font-semibold text-gray-900 dark:text-gray-100 text-sm">{{ obj.name }}</span>
+                </td>
+                <td class="px-4 py-3 text-xs text-gray-600 dark:text-gray-400 whitespace-pre-line leading-relaxed">
+                  {{ obj.measure }}
+                </td>
+                <td v-for="q in quarters" :key="q" class="px-3 py-3 text-center">
+                  <div
+                    v-if="obj.quarters[q]"
+                    class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
+                    :class="statusConfig[obj.quarters[q].status].bg"
+                  >
+                    <span v-if="obj.quarters[q].summary" class="text-[11px] font-medium leading-tight whitespace-pre-line" :class="statusConfig[obj.quarters[q].status].text">{{ obj.quarters[q].summary }}</span>
+                    <span v-else class="text-xs text-gray-300 dark:text-gray-600">—</span>
+                  </div>
+                </td>
+              </tr>
+
+              <!-- Multi-row objectives (separate row per KR) -->
+              <template v-if="hasMultiKrRows(obj)">
+                <tr
+                  v-for="(kr, krIdx) in obj.keyResults"
+                  :key="kr.id"
+                  class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
+                  @click="navigateToDeepDive(obj.id)"
                 >
-                  <span
-                    v-if="obj.quarters[q].summary"
-                    class="text-[11px] font-medium leading-tight whitespace-pre-line"
-                    :class="statusConfig[obj.quarters[q].status].text"
-                  >{{ obj.quarters[q].summary }}</span>
-                  <span v-else class="text-xs text-gray-300 dark:text-gray-600">—</span>
-                </div>
-              </td>
-            </tr>
+                  <td v-if="krIdx === 0" class="px-3 py-3 text-center align-top text-xs font-bold text-gray-400 dark:text-gray-500" :rowspan="obj.keyResults.length">{{ objIdx + 1 }}</td>
+                  <td v-if="krIdx === 0" class="px-4 py-3 align-top" :rowspan="obj.keyResults.length">
+                    <span class="font-semibold text-gray-900 dark:text-gray-100 text-sm">{{ obj.name }}</span>
+                  </td>
+                  <td class="px-4 py-3 text-xs text-gray-600 dark:text-gray-400 leading-relaxed">
+                    {{ kr.description }}
+                  </td>
+                  <td v-for="q in quarters" :key="q" class="px-3 py-3 text-center">
+                    <div
+                      v-if="kr.quarters && kr.quarters[q]"
+                      class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
+                      :class="statusConfig[kr.quarters[q].status].bg"
+                    >
+                      <span v-if="kr.quarters[q].summary" class="text-[11px] font-medium leading-tight whitespace-pre-line" :class="statusConfig[kr.quarters[q].status].text">{{ kr.quarters[q].summary }}</span>
+                      <span v-else class="text-xs text-gray-300 dark:text-gray-600">—</span>
+                    </div>
+                  </td>
+                </tr>
+              </template>
+            </template>
           </tbody>
         </table>
       </div>
@@ -125,6 +149,14 @@ function isCategoryOpen(name) {
 
 function toggleCategory(name) {
   openCategories[name] = !openCategories[name]
+}
+
+function hasMultiKrRows(obj) {
+  if (!obj.keyResults || obj.keyResults.length < 2) return false
+  for (var i = 0; i < obj.keyResults.length; i++) {
+    if (obj.keyResults[i].quarters) return true
+  }
+  return false
 }
 
 function navigateToDeepDive(objectiveId) {

--- a/modules/okr-hub/client/views/TimelineView.vue
+++ b/modules/okr-hub/client/views/TimelineView.vue
@@ -74,8 +74,21 @@
                   {{ obj.measure }}
                 </td>
                 <td v-for="q in quarters" :key="q" class="px-3 py-3 text-center">
+                  <!-- Editable text input for objectives like Associate Well Being -->
+                  <div v-if="obj.editable">
+                    <textarea
+                      :value="obj.quarters[q] ? obj.quarters[q].summary : ''"
+                      @input="updateEditableQuarter(obj.id, q, $event.target.value)"
+                      @blur="saveEditableData()"
+                      class="w-full text-[11px] leading-relaxed text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-2 min-h-[5.5rem] resize-y focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                      style="word-wrap: break-word; overflow-wrap: break-word; white-space: pre-wrap;"
+                      placeholder="Enter status..."
+                      @click.stop
+                    />
+                  </div>
+                  <!-- Read-only status box -->
                   <div
-                    v-if="obj.quarters[q]"
+                    v-else-if="obj.quarters[q]"
                     class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
                     :class="statusConfig[obj.quarters[q].status].bg"
                   >
@@ -121,12 +134,12 @@
 </template>
 
 <script setup>
-import { reactive, inject } from 'vue'
+import { reactive, inject, onMounted } from 'vue'
 import { OKR_DATA, STATUS_CONFIG, QUARTERS } from '../constants/mock-okrs.js'
 
 var nav = inject('moduleNav', null)
 
-var data = OKR_DATA
+var data = reactive(JSON.parse(JSON.stringify(OKR_DATA)))
 var statusConfig = STATUS_CONFIG
 var quarters = QUARTERS
 var shortYear = String(data.year).slice(-2)
@@ -162,4 +175,224 @@ function hasMultiKrRows(obj) {
 function navigateToDeepDive(objectiveId) {
   if (nav) nav.navigateTo('deep-dive', { okr: objectiveId })
 }
+
+function findObjective(id) {
+  for (var ci = 0; ci < data.categories.length; ci++) {
+    var cat = data.categories[ci]
+    for (var oi = 0; oi < cat.objectives.length; oi++) {
+      if (cat.objectives[oi].id === id) return cat.objectives[oi]
+    }
+  }
+  return null
+}
+
+function pctToStatus(pct) {
+  if (pct === 100) return 'green'
+  if (pct >= 50) return 'yellow'
+  return 'red'
+}
+
+async function fetchOnTimeReleases() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/on-time-releases')
+    if (!res.ok) return
+    var result = await res.json()
+    if (!result.releases) return
+
+    var obj = findObjective('on-time-releases')
+    if (!obj) return
+
+    var qMap = {}
+    for (var i = 0; i < result.releases.length; i++) {
+      var rel = result.releases[i]
+      var d = new Date(rel.plannedGa + 'T00:00:00')
+      var qNum = Math.floor(d.getMonth() / 3) + 1
+      var qKey = 'Q' + qNum
+      if (!qMap[qKey]) qMap[qKey] = { released: 0, onTime: 0, total: 0 }
+      qMap[qKey].total++
+      if (rel.released) {
+        qMap[qKey].released++
+        if (rel.onTime) qMap[qKey].onTime++
+      }
+    }
+
+    for (var qi = 0; qi < quarters.length; qi++) {
+      var q = quarters[qi]
+      var stats = qMap[q]
+      if (stats && stats.released > 0) {
+        var pct = Math.round((stats.onTime / stats.released) * 100)
+        obj.quarters[q] = { status: pctToStatus(pct), summary: pct + '%\n' + stats.onTime + ' of ' + stats.released + ' on time' }
+      } else if (stats && stats.total > 0) {
+        obj.quarters[q] = { status: 'not-started', summary: stats.total + ' upcoming' }
+      }
+    }
+  } catch (err) {
+    console.warn('[okr-hub] Failed to fetch on-time-releases for timeline:', err.message)
+  }
+}
+
+var quarterMonths = {
+  Q1: ['jan', 'feb', 'mar'],
+  Q2: ['apr', 'may', 'jun'],
+  Q3: ['jul', 'aug', 'sep'],
+  Q4: ['oct', 'nov', 'dec']
+}
+
+async function fetchCveSla() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/cve-sla')
+    if (!res.ok) return
+    var result = await res.json()
+    if (!result.months || !result.products) return
+
+    var obj = findObjective('cve-sla')
+    if (!obj) return
+
+    for (var qi = 0; qi < quarters.length; qi++) {
+      var q = quarters[qi]
+      var months = quarterMonths[q]
+      var totalMet = 0
+      var totalMissed = 0
+      var hasData = false
+
+      for (var mi = 0; mi < months.length; mi++) {
+        var monthData = result.months[months[mi]]
+        if (!monthData) continue
+        for (var pi = 0; pi < result.products.length; pi++) {
+          var pd = monthData[result.products[pi]]
+          if (!pd) continue
+          var met = pd.met != null ? pd.met : 0
+          var missed = pd.missed != null ? pd.missed : 0
+          if (met > 0 || missed > 0) hasData = true
+          totalMet += met
+          totalMissed += missed
+        }
+      }
+
+      if (hasData) {
+        var total = totalMet + totalMissed
+        var pct = total > 0 ? Math.round((totalMet / total) * 100) : 0
+        obj.quarters[q] = { status: pctToStatus(pct), summary: pct + '%\n' + totalMet + ' met, ' + totalMissed + ' missed' }
+      }
+    }
+  } catch (err) {
+    console.warn('[okr-hub] Failed to fetch cve-sla for timeline:', err.message)
+  }
+}
+
+async function fetchSupportCases() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/support-cases')
+    if (!res.ok) return
+    var result = await res.json()
+    if (!result.quarters || !result.products) return
+
+    var obj = findObjective('support-cases')
+    if (!obj) return
+
+    for (var qi = 0; qi < quarters.length; qi++) {
+      var q = quarters[qi]
+      var qData = result.quarters[q]
+      if (!qData) continue
+
+      var totalCases = 0
+      var totalDefects = 0
+      var hasData = false
+      var avgResSum = 0
+      var avgResCount = 0
+
+      for (var pi = 0; pi < result.products.length; pi++) {
+        var pd = qData[result.products[pi]]
+        if (!pd) continue
+        if (pd.totalCases != null && pd.totalCases > 0) {
+          hasData = true
+          totalCases += pd.totalCases
+          totalDefects += pd.defects || 0
+        }
+        if (pd.avgResolutionDays != null && pd.avgResolutionDays > 0) {
+          avgResSum += pd.avgResolutionDays
+          avgResCount++
+        }
+      }
+
+      if (hasData) {
+        var defectRate = totalCases > 0 ? ((totalDefects / totalCases) * 100).toFixed(1) : 0
+        var avgRes = avgResCount > 0 ? (avgResSum / avgResCount).toFixed(1) : null
+        var defectOk = parseFloat(defectRate) <= 10
+        var resOk = avgRes != null && parseFloat(avgRes) <= 14
+        var status = (defectOk && resOk) ? 'green' : (defectOk || resOk) ? 'yellow' : 'red'
+        var summary = defectRate + '% defect rate'
+        if (avgRes != null) summary += '\n——————\n' + avgRes + ' avg days'
+        obj.quarters[q] = { status: status, summary: summary }
+      }
+    }
+  } catch (err) {
+    console.warn('[okr-hub] Failed to fetch support-cases for timeline:', err.message)
+  }
+}
+
+async function fetchTechnicalVisibility() {
+  try {
+    var obj = findObjective('tech-visibility')
+    if (!obj || !obj.keyResults) return
+
+    var kr1 = null
+    var kr2 = null
+    for (var ki = 0; ki < obj.keyResults.length; ki++) {
+      if (obj.keyResults[ki].id === 'kr-tv-1') kr1 = obj.keyResults[ki]
+      if (obj.keyResults[ki].id === 'kr-tv-2') kr2 = obj.keyResults[ki]
+    }
+
+    var [tvRes, ccRes] = await Promise.all([
+      fetch('/api/modules/okr-hub/reports/tech-visibility'),
+      fetch('/api/modules/okr-hub/reports/content-contributions')
+    ])
+
+    if (kr1 && tvRes.ok) {
+      var tvData = await tvRes.json()
+      if (tvData.quarters) {
+        for (var tvi = 0; tvi < tvData.quarters.length; tvi++) {
+          var tvQ = tvData.quarters[tvi]
+          var qMatch = tvQ.label.match(/Q(\d)/i)
+          if (!qMatch) continue
+          var qKey = 'Q' + qMatch[1]
+          if (!kr1.quarters) kr1.quarters = {}
+          kr1.quarters[qKey] = {
+            status: pctToStatus(tvQ.pct),
+            summary: tvQ.pct + '%\n' + tvQ.weeksMet + ' of ' + tvQ.totalWeeks + ' weeks met'
+          }
+        }
+      }
+    }
+
+    if (kr2 && ccRes.ok) {
+      var ccData = await ccRes.json()
+      if (ccData.quarters) {
+        for (var cci = 0; cci < ccData.quarters.length; cci++) {
+          var ccQ = ccData.quarters[cci]
+          var ccMatch = ccQ.label.match(/Q(\d)/i)
+          if (!ccMatch) continue
+          var ccKey = 'Q' + ccMatch[1]
+          if (!kr2.quarters) kr2.quarters = {}
+          var completed = ccQ.total ? ccQ.total.completed : 0
+          var associates = ccQ.total ? ccQ.total.associates : 0
+          var pct = ccQ.total ? ccQ.total.pct : 0
+          kr2.quarters[ccKey] = {
+            status: pctToStatus(pct),
+            summary: pct + '%\n' + completed + ' of ' + associates + ' completed'
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[okr-hub] Failed to fetch tech-visibility for timeline:', err.message)
+  }
+}
+
+onMounted(function() {
+  fetchOnTimeReleases()
+  fetchCveSla()
+  fetchSupportCases()
+  fetchTechnicalVisibility()
+})
 </script>

--- a/modules/okr-hub/client/views/TimelineView.vue
+++ b/modules/okr-hub/client/views/TimelineView.vue
@@ -74,23 +74,44 @@
                   {{ obj.measure }}
                 </td>
                 <td v-for="q in quarters" :key="q" class="px-3 py-3 text-center">
-                  <!-- Editable text input for objectives like Associate Well Being -->
-                  <div v-if="obj.editable">
+                  <!-- Editable text input with color picker on focus -->
+                  <div
+                    v-if="obj.editable && canEdit"
+                    class="rounded-lg px-2 py-2"
+                    :class="obj.quarters[q] && obj.quarters[q].status !== 'not-started' ? statusConfig[obj.quarters[q].status].bg : 'bg-gray-50 dark:bg-gray-800/30'"
+                    @click.stop
+                  >
+                    <div v-if="editableFocus[obj.id + '-' + q]" class="flex items-center gap-1 mb-1.5 justify-center">
+                      <button
+                        v-for="s in editableStatuses"
+                        :key="s.key"
+                        class="w-4 h-4 rounded-full border-2 transition-all"
+                        :class="[
+                          s.dot,
+                          (obj.quarters[q] && obj.quarters[q].status === s.key) || (!obj.quarters[q] && s.key === 'not-started')
+                            ? 'border-gray-800 dark:border-white scale-110 ring-1 ring-gray-400'
+                            : 'border-transparent opacity-60 hover:opacity-100'
+                        ]"
+                        :title="s.label"
+                        @mousedown.prevent="updateEditableStatus(obj.id, q, s.key)"
+                      />
+                    </div>
                     <textarea
                       :value="obj.quarters[q] ? obj.quarters[q].summary : ''"
                       @input="updateEditableQuarter(obj.id, q, $event.target.value)"
-                      @blur="saveEditableData()"
-                      class="w-full text-[11px] leading-relaxed text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-2 min-h-[5.5rem] resize-y focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                      @focus="editableFocus[obj.id + '-' + q] = true"
+                      @blur="editableFocus[obj.id + '-' + q] = false; saveEditableData()"
+                      class="w-full text-[11px] leading-relaxed text-gray-700 dark:text-gray-300 bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-2 min-h-[5rem] resize-y focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
                       style="word-wrap: break-word; overflow-wrap: break-word; white-space: pre-wrap;"
                       placeholder="Enter status..."
-                      @click.stop
                     />
                   </div>
-                  <!-- Read-only status box -->
+                  <!-- Read-only status box (clickable if linked to a report) -->
                   <div
                     v-else-if="obj.quarters[q]"
                     class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
-                    :class="statusConfig[obj.quarters[q].status].bg"
+                    :class="[statusConfig[obj.quarters[q].status].bg, reportMap[obj.id] ? 'cursor-pointer hover:ring-2 hover:ring-primary-400 transition-all' : '']"
+                    @click.stop="reportMap[obj.id] ? navigateToReport(reportMap[obj.id]) : null"
                   >
                     <span v-if="obj.quarters[q].summary" class="text-[11px] font-medium leading-tight whitespace-pre-line" :class="statusConfig[obj.quarters[q].status].text">{{ obj.quarters[q].summary }}</span>
                     <span v-else class="text-xs text-gray-300 dark:text-gray-600">—</span>
@@ -117,7 +138,8 @@
                     <div
                       v-if="kr.quarters && kr.quarters[q]"
                       class="rounded-lg px-2 py-2 min-h-[3rem] flex items-center justify-center"
-                      :class="statusConfig[kr.quarters[q].status].bg"
+                      :class="[statusConfig[kr.quarters[q].status].bg, reportMap[obj.id] ? 'cursor-pointer hover:ring-2 hover:ring-primary-400 transition-all' : '']"
+                      @click.stop="reportMap[obj.id] ? navigateToReport(reportMap[obj.id]) : null"
                     >
                       <span v-if="kr.quarters[q].summary" class="text-[11px] font-medium leading-tight whitespace-pre-line" :class="statusConfig[kr.quarters[q].status].text">{{ kr.quarters[q].summary }}</span>
                       <span v-else class="text-xs text-gray-300 dark:text-gray-600">—</span>
@@ -136,8 +158,10 @@
 <script setup>
 import { reactive, inject, onMounted } from 'vue'
 import { OKR_DATA, STATUS_CONFIG, QUARTERS } from '../constants/mock-okrs.js'
+import { useOkrPermissions } from '../composables/useOkrPermissions.js'
 
 var nav = inject('moduleNav', null)
+var { canEdit } = useOkrPermissions()
 
 var data = reactive(JSON.parse(JSON.stringify(OKR_DATA)))
 var statusConfig = STATUS_CONFIG
@@ -151,6 +175,7 @@ var statusList = [
   { key: 'not-started', label: 'Not Started', dot: statusConfig['not-started'].dot }
 ]
 
+var editableFocus = reactive({})
 var openCategories = reactive({})
 for (var i = 0; i < data.categories.length; i++) {
   openCategories[data.categories[i].name] = true
@@ -172,8 +197,45 @@ function hasMultiKrRows(obj) {
   return false
 }
 
+var reportMap = {
+  'on-time-releases': 'on-time-releases',
+  'cve-sla': 'cve-sla',
+  'support-cases': 'support-cases',
+  'tech-visibility': 'tech-visibility'
+}
+
+function navigateToReport(reportId) {
+  if (nav) nav.navigateTo('reports', { report: reportId })
+}
+
 function navigateToDeepDive(objectiveId) {
   if (nav) nav.navigateTo('deep-dive', { okr: objectiveId })
+}
+
+var editableStatuses = [
+  { key: 'green', label: 'On Track', dot: statusConfig.green.dot },
+  { key: 'yellow', label: 'Partial', dot: statusConfig.yellow.dot },
+  { key: 'red', label: 'At Risk', dot: statusConfig.red.dot },
+  { key: 'not-started', label: 'Not Started', dot: statusConfig['not-started'].dot }
+]
+
+function updateEditableQuarter(objId, q, text) {
+  var obj = findObjective(objId)
+  if (!obj) return
+  if (!obj.quarters[q]) obj.quarters[q] = { status: 'not-started', summary: '' }
+  obj.quarters[q].summary = text
+}
+
+function updateEditableStatus(objId, q, statusKey) {
+  var obj = findObjective(objId)
+  if (!obj) return
+  if (!obj.quarters[q]) obj.quarters[q] = { status: 'not-started', summary: '' }
+  obj.quarters[q].status = statusKey
+  saveEditableData()
+}
+
+function saveEditableData() {
+  // placeholder for future persistence
 }
 
 function findObjective(id) {
@@ -280,6 +342,18 @@ async function fetchCveSla() {
   }
 }
 
+var productKrMap = {
+  'RHOAI': 'kr-sc-rhoai',
+  'RHEL-AI': 'kr-sc-rhelai',
+  'RHAII': 'kr-sc-rhaii'
+}
+
+function scStatus(defectRate, avgRes) {
+  var defectOk = parseFloat(defectRate) <= 10
+  var resOk = avgRes != null && parseFloat(avgRes) <= 14
+  return (defectOk && resOk) ? 'green' : (defectOk || resOk) ? 'yellow' : 'red'
+}
+
 async function fetchSupportCases() {
   try {
     var res = await fetch('/api/modules/okr-hub/reports/support-cases')
@@ -288,42 +362,32 @@ async function fetchSupportCases() {
     if (!result.quarters || !result.products) return
 
     var obj = findObjective('support-cases')
-    if (!obj) return
+    if (!obj || !obj.keyResults) return
 
     for (var qi = 0; qi < quarters.length; qi++) {
       var q = quarters[qi]
       var qData = result.quarters[q]
       if (!qData) continue
 
-      var totalCases = 0
-      var totalDefects = 0
-      var hasData = false
-      var avgResSum = 0
-      var avgResCount = 0
-
       for (var pi = 0; pi < result.products.length; pi++) {
-        var pd = qData[result.products[pi]]
-        if (!pd) continue
-        if (pd.totalCases != null && pd.totalCases > 0) {
-          hasData = true
-          totalCases += pd.totalCases
-          totalDefects += pd.defects || 0
-        }
-        if (pd.avgResolutionDays != null && pd.avgResolutionDays > 0) {
-          avgResSum += pd.avgResolutionDays
-          avgResCount++
-        }
-      }
+        var productName = result.products[pi]
+        var krId = productKrMap[productName]
+        if (!krId) continue
 
-      if (hasData) {
-        var defectRate = totalCases > 0 ? ((totalDefects / totalCases) * 100).toFixed(1) : 0
-        var avgRes = avgResCount > 0 ? (avgResSum / avgResCount).toFixed(1) : null
-        var defectOk = parseFloat(defectRate) <= 10
-        var resOk = avgRes != null && parseFloat(avgRes) <= 14
-        var status = (defectOk && resOk) ? 'green' : (defectOk || resOk) ? 'yellow' : 'red'
-        var summary = defectRate + '% defect rate'
-        if (avgRes != null) summary += '\n——————\n' + avgRes + ' avg days'
-        obj.quarters[q] = { status: status, summary: summary }
+        var kr = null
+        for (var ki = 0; ki < obj.keyResults.length; ki++) {
+          if (obj.keyResults[ki].id === krId) { kr = obj.keyResults[ki]; break }
+        }
+        if (!kr) continue
+
+        var pd = qData[productName]
+        if (!pd || pd.totalCases == null || pd.totalCases === 0) continue
+
+        var defectRate = ((pd.defects || 0) / pd.totalCases * 100).toFixed(1)
+        var avgRes = pd.avgResolutionDays != null ? pd.avgResolutionDays.toFixed(1) : null
+        var summary = defectRate + '% defect rate\n——————\n' + (avgRes != null ? avgRes + ' avg days' : '0 avg days')
+        if (!kr.quarters) kr.quarters = {}
+        kr.quarters[q] = { status: scStatus(defectRate, avgRes), summary: summary }
       }
     }
   } catch (err) {

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -484,78 +484,105 @@ module.exports = function registerRoutes(router, context) {
         return res.json({ error: 'No tabs found in spreadsheet', quarters: [], overall: { associates: 0, completed: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
       }
 
-      var quarters = []
-      for (var ti = 0; ti < tabNames.length; ti++) {
-        var tabName = tabNames[ti]
-        var qMatch = tabName.match(/Q(\d)\s*(\d{4})?/i)
-        if (!qMatch) continue
+      var raw = await sheetsClient.fetchRawSheet(CONTENT_SHEET_ID, tabNames[0])
+      if (!raw || !raw.headers || raw.headers.length === 0) {
+        return res.json({ error: 'No data in spreadsheet', quarters: [], overall: { associates: 0, completed: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
+      }
 
-        var raw = await sheetsClient.fetchRawSheet(CONTENT_SHEET_ID, tabName)
-        if (!raw || !raw.headers || raw.headers.length === 0) continue
+      var teamCol = findColumnIndex(raw.headers, ['team name', 'team'])
+      var assocCol = findColumnIndex(raw.headers, ['number of associates', 'associates', '# associates'])
+      var completedCol = findColumnIndex(raw.headers, ['associates completed', 'completed content', 'completed'])
+      var pctCol = findColumnIndex(raw.headers, ['percentage completed', '% completed', 'percentage', '%'])
+      var statusCol = findColumnIndex(raw.headers, ['status'])
+      var perfCol = findColumnIndex(raw.headers, ['performance vs', 'performance'])
 
-        var teamCol = findColumnIndex(raw.headers, ['team name', 'team'])
-        var assocCol = findColumnIndex(raw.headers, ['number of associates', 'associates', '# associates'])
-        var completedCol = findColumnIndex(raw.headers, ['associates completed', 'completed content', 'completed'])
-        var pctCol = findColumnIndex(raw.headers, ['percentage completed', '% completed', 'percentage', '%'])
-        var statusCol = findColumnIndex(raw.headers, ['status'])
-        var perfCol = findColumnIndex(raw.headers, ['performance vs', 'performance'])
-        var endQCol = findColumnIndex(raw.headers, ['end of q', 'end of quarter', 'q1 status', 'q2 status', 'q3 status', 'q4 status'])
+      var endQCols = {}
+      for (var hi = 0; hi < raw.headers.length; hi++) {
+        var hdr = String(raw.headers[hi] || '').toLowerCase().trim()
+        var eqMatch = hdr.match(/end of q(\d)/)
+        if (eqMatch) endQCols['Q' + eqMatch[1]] = hi
+      }
 
-        if (teamCol === -1 || assocCol === -1) continue
+      if (teamCol === -1 || assocCol === -1) {
+        return res.json({ error: 'Required columns not found', quarters: [], overall: { associates: 0, completed: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
+      }
 
-        var teams = []
-        var totalRow = null
-        for (var ri = 0; ri < raw.rows.length; ri++) {
-          var row = raw.rows[ri]
-          var name = String(row[teamCol] || '').trim()
-          if (!name) continue
+      var teams = []
+      var totalRow = null
+      for (var ri = 0; ri < raw.rows.length; ri++) {
+        var row = raw.rows[ri]
+        var name = String(row[teamCol] || '').trim()
+        if (!name) continue
 
-          var associates = parseNum(row[assocCol])
-          var completed = completedCol !== -1 ? parseNum(row[completedCol]) : 0
-          var pct = pctCol !== -1 ? parsePct(row[pctCol]) : (associates > 0 ? Math.round((completed / associates) * 100) : 0)
-          var status = statusCol !== -1 ? String(row[statusCol] || '').trim() : ''
-          var perf = perfCol !== -1 ? String(row[perfCol] || '').trim() : ''
-          var endQ = endQCol !== -1 ? parsePct(row[endQCol]) : null
+        var associates = parseNum(row[assocCol])
+        var completed = completedCol !== -1 ? parseNum(row[completedCol]) : 0
+        var pct = pctCol !== -1 ? parsePct(row[pctCol]) : (associates > 0 ? Math.round((completed / associates) * 100) : 0)
+        var status = statusCol !== -1 ? String(row[statusCol] || '').trim() : ''
+        var perf = perfCol !== -1 ? String(row[perfCol] || '').trim() : ''
 
-          var entry = { name: name, associates: associates, completed: completed, pct: pct, status: status, performance: perf, endQPct: endQ }
+        var qPcts = {}
+        var qKeys = Object.keys(endQCols)
+        for (var qki = 0; qki < qKeys.length; qki++) {
+          var qk = qKeys[qki]
+          var val = row[endQCols[qk]]
+          qPcts[qk] = val != null ? parsePct(val) : null
+        }
 
-          if (name.toLowerCase() === 'total') {
-            totalRow = entry
-          } else {
-            teams.push(entry)
+        var entry = { name: name, associates: associates, completed: completed, pct: pct, status: status, performance: perf, qPcts: qPcts }
+
+        if (name.toLowerCase() === 'total') {
+          totalRow = entry
+        } else {
+          teams.push(entry)
+        }
+      }
+
+      if (teams.length === 0) {
+        return res.json({ error: 'No team data found', quarters: [], overall: { associates: 0, completed: 0, pct: 0 }, fetchedAt: new Date().toISOString() })
+      }
+
+      if (!totalRow) {
+        var tAssoc = 0; var tComp = 0
+        for (var tmi = 0; tmi < teams.length; tmi++) { tAssoc += teams[tmi].associates; tComp += teams[tmi].completed }
+        var tQPcts = {}
+        var allQKeys = Object.keys(endQCols)
+        for (var aqi = 0; aqi < allQKeys.length; aqi++) {
+          var aqk = allQKeys[aqi]
+          var sum = 0; var cnt = 0
+          for (var si = 0; si < teams.length; si++) {
+            if (teams[si].qPcts[aqk] != null) { sum += teams[si].qPcts[aqk] * teams[si].associates; cnt += teams[si].associates }
           }
+          tQPcts[aqk] = cnt > 0 ? Math.round(sum / cnt) : null
         }
+        totalRow = { name: 'TOTAL', associates: tAssoc, completed: tComp, pct: tAssoc > 0 ? Math.round((tComp / tAssoc) * 100) : 0, status: '', performance: '', qPcts: tQPcts }
+      }
 
-        if (teams.length === 0) continue
-
-        if (!totalRow) {
-          var tAssoc = 0
-          var tComp = 0
-          for (var tmi = 0; tmi < teams.length; tmi++) { tAssoc += teams[tmi].associates; tComp += teams[tmi].completed }
-          totalRow = { name: 'TOTAL', associates: tAssoc, completed: tComp, pct: tAssoc > 0 ? Math.round((tComp / tAssoc) * 100) : 0, status: '', performance: '', endQPct: null }
+      var quarters = []
+      var sortedQKeys = Object.keys(endQCols).sort()
+      for (var sqi = 0; sqi < sortedQKeys.length; sqi++) {
+        var sqk = sortedQKeys[sqi]
+        var qTeams = []
+        for (var ti = 0; ti < teams.length; ti++) {
+          var t = teams[ti]
+          var teamQPct = t.qPcts[sqk] != null ? t.qPcts[sqk] : 0
+          var teamQCompleted = t.associates > 0 ? Math.round(t.associates * teamQPct / 100) : 0
+          qTeams.push({ name: t.name, associates: t.associates, completed: teamQCompleted, pct: teamQPct, status: t.status, performance: t.performance, endQPct: teamQPct })
         }
-
-        var qLabel = tabName.trim()
+        var totalQPct = totalRow.qPcts[sqk] != null ? totalRow.qPcts[sqk] : 0
+        var totalQCompleted = totalRow.associates > 0 ? Math.round(totalRow.associates * totalQPct / 100) : 0
+        var qNum = sqk.replace('Q', '')
+        var endMonths = { '1': '03/31', '2': '06/30', '3': '09/30', '4': '12/31' }
         quarters.push({
-          label: qLabel,
-          teams: teams,
-          total: { associates: totalRow.associates, completed: totalRow.completed, pct: totalRow.pct, endQPct: totalRow.endQPct },
-          targetDate: '12/31/2026'
+          label: sqk + ' 2026',
+          teams: qTeams,
+          total: { associates: totalRow.associates, completed: totalQCompleted, pct: totalQPct, endQPct: totalQPct },
+          targetDate: (endMonths[qNum] || '12/31') + '/2026'
         })
       }
 
-      if (quarters.length === 0) {
-        var raw0 = await sheetsClient.fetchRawSheet(CONTENT_SHEET_ID, tabNames[0])
-        if (raw0 && raw0.headers) {
-          var parsed = parseContentTab(raw0, tabNames[0])
-          if (parsed) quarters.push(parsed)
-        }
-      }
-
-      var latestQ = quarters.length > 0 ? quarters[quarters.length - 1] : null
       var result = {
         quarters: quarters,
-        overall: latestQ ? { associates: latestQ.total.associates, completed: latestQ.total.completed, pct: latestQ.total.pct } : { associates: 0, completed: 0, pct: 0 },
+        overall: { associates: totalRow.associates, completed: totalRow.completed, pct: totalRow.pct },
         target: '1 piece of content per associate',
         fetchedAt: new Date().toISOString()
       }
@@ -568,39 +595,6 @@ module.exports = function registerRoutes(router, context) {
       res.status(500).json({ error: err.message })
     }
   })
-
-  function parseContentTab(raw, tabName) {
-    if (!raw || !raw.headers || raw.headers.length === 0) return null
-
-    var teamCol = findColumnIndex(raw.headers, ['team name', 'team'])
-    var assocCol = findColumnIndex(raw.headers, ['number of associates', 'associates', '# associates'])
-    var completedCol = findColumnIndex(raw.headers, ['associates completed', 'completed content', 'completed'])
-    var pctCol = findColumnIndex(raw.headers, ['percentage completed', '% completed', 'percentage', '%'])
-    var statusCol = findColumnIndex(raw.headers, ['status'])
-
-    if (teamCol === -1 || assocCol === -1) return null
-
-    var teams = []
-    var totalRow = null
-    for (var ri = 0; ri < raw.rows.length; ri++) {
-      var row = raw.rows[ri]
-      var name = String(row[teamCol] || '').trim()
-      if (!name) continue
-      var associates = parseNum(row[assocCol])
-      var completed = completedCol !== -1 ? parseNum(row[completedCol]) : 0
-      var pct = pctCol !== -1 ? parsePct(row[pctCol]) : (associates > 0 ? Math.round((completed / associates) * 100) : 0)
-      var status = statusCol !== -1 ? String(row[statusCol] || '').trim() : ''
-      var entry = { name: name, associates: associates, completed: completed, pct: pct, status: status, performance: '', endQPct: null }
-      if (name.toLowerCase() === 'total') { totalRow = entry } else { teams.push(entry) }
-    }
-    if (teams.length === 0) return null
-    if (!totalRow) {
-      var tA = 0; var tC = 0
-      for (var i = 0; i < teams.length; i++) { tA += teams[i].associates; tC += teams[i].completed }
-      totalRow = { name: 'TOTAL', associates: tA, completed: tC, pct: tA > 0 ? Math.round((tC / tA) * 100) : 0 }
-    }
-      return { label: tabName.trim(), teams: teams, total: { associates: totalRow.associates, completed: totalRow.completed, pct: totalRow.pct, endQPct: totalRow.endQPct }, targetDate: '12/31/2026' }
-  }
 
   /**
    * @openapi
@@ -763,57 +757,76 @@ function parsePct(val) {
 }
 
 function getSampleContentData() {
-  var teams = [
-    { name: "Steven's Directs", associates: 14, completed: 1, pct: 7, status: 'Started', performance: 'Behind (43% to go)', endQPct: 7 },
-    { name: 'Cat Agentics & AI Eng Tooling', associates: 58, completed: 18, pct: 31, status: 'Started', performance: 'Behind (19% to go)', endQPct: 6 },
-    { name: 'Sherard AI Platform', associates: 192, completed: 34, pct: 18, status: 'Started', performance: 'Behind (32% to go)', endQPct: 6 },
-    { name: 'Taneem Inf Engineering', associates: 59, completed: 21, pct: 36, status: 'Started', performance: 'Behind (14% to go)', endQPct: 7 },
-    { name: 'Kai AI Innovation', associates: 13, completed: 2, pct: 15, status: 'Started', performance: 'Behind (35% to go)', endQPct: 0 },
-    { name: 'Tom AIPCC', associates: 147, completed: 19, pct: 13, status: 'Started', performance: 'Behind (37% to go)', endQPct: 6 },
-    { name: 'Monica watsonx', associates: 48, completed: 18, pct: 38, status: 'Started', performance: 'Behind (13% to go)', endQPct: 10 }
+  var teamData = [
+    { name: "Steven's Directs", associates: 14, completed: 1, pct: 7, status: 'Started', performance: 'Behind (43% to go)', q1: 7, q2: 7 },
+    { name: 'Cat Agentics & AI Eng Tooling', associates: 58, completed: 19, pct: 33, status: 'Started', performance: 'Behind (17% to go)', q1: 6, q2: 31 },
+    { name: 'Sherard AI Platform', associates: 192, completed: 34, pct: 18, status: 'Started', performance: 'Behind (32% to go)', q1: 6, q2: 18 },
+    { name: 'Taneem Inf Engineering', associates: 59, completed: 21, pct: 36, status: 'Started', performance: 'Behind (14% to go)', q1: 7, q2: 36 },
+    { name: 'Kai AI Innovation', associates: 13, completed: 2, pct: 15, status: 'Started', performance: 'Behind (35% to go)', q1: 0, q2: 15 },
+    { name: 'Tom AIPCC', associates: 147, completed: 19, pct: 13, status: 'Started', performance: 'Behind (37% to go)', q1: 6, q2: 13 },
+    { name: 'Monica watsonx', associates: 48, completed: 18, pct: 38, status: 'Started', performance: 'Behind (13% to go)', q1: 10, q2: 38 }
   ]
+
+  function buildQuarter(qKey, qNum) {
+    var teams = []
+    for (var i = 0; i < teamData.length; i++) {
+      var t = teamData[i]
+      var qPct = t[qKey] != null ? t[qKey] : 0
+      var qCompleted = Math.round(t.associates * qPct / 100)
+      teams.push({ name: t.name, associates: t.associates, completed: qCompleted, pct: qPct, status: t.status, performance: t.performance, endQPct: qPct })
+    }
+    var tA = 0; var tC = 0
+    for (var j = 0; j < teams.length; j++) { tA += teams[j].associates; tC += teams[j].completed }
+    var tPct = tA > 0 ? Math.round((tC / tA) * 100) : 0
+    var endMonths = { 1: '03/31', 2: '06/30', 3: '09/30', 4: '12/31' }
+    return { label: 'Q' + qNum + ' 2026', teams: teams, total: { associates: tA, completed: tC, pct: tPct, endQPct: tPct }, targetDate: endMonths[qNum] + '/2026' }
+  }
+
+  var quarters = [buildQuarter('q1', 1), buildQuarter('q2', 2)]
+
+  var tA = 0; var tC = 0
+  for (var i = 0; i < teamData.length; i++) { tA += teamData[i].associates; tC += teamData[i].completed }
+
   return {
-    quarters: [
-      {
-        label: 'Q1 2026',
-        teams: teams,
-        total: { associates: 531, completed: 113, pct: 21, endQPct: 7 },
-        targetDate: '12/31/2026'
-      }
-    ],
-    overall: { associates: 531, completed: 113, pct: 21 },
+    quarters: quarters,
+    overall: { associates: tA, completed: tC, pct: tA > 0 ? Math.round((tC / tA) * 100) : 0 },
     target: '1 piece of content per associate',
     fetchedAt: new Date().toISOString()
   }
 }
 
 function getSampleTechVisData() {
-  var q2Weeks = [
-    { weekOf: '2026-04-06', count: 7, met: true },
-    { weekOf: '2026-04-13', count: 5, met: true },
-    { weekOf: '2026-04-20', count: 3, met: false },
-    { weekOf: '2026-04-27', count: 6, met: true },
-    { weekOf: '2026-05-04', count: 8, met: true },
-    { weekOf: '2026-05-11', count: 4, met: false },
-    { weekOf: '2026-05-18', count: 5, met: true },
-    { weekOf: '2026-05-25', count: 9, met: true },
-    { weekOf: '2026-06-01', count: 6, met: true },
-    { weekOf: '2026-06-08', count: 2, met: false },
-    { weekOf: '2026-06-15', count: 7, met: true },
-    { weekOf: '2026-06-22', count: 5, met: true },
-    { weekOf: '2026-06-29', count: 4, met: false }
+  var q1Weeks = [
+    { weekOf: '2026-01-09', count: 4, met: false }, { weekOf: '2026-01-16', count: 2, met: false },
+    { weekOf: '2026-01-23', count: 2, met: false }, { weekOf: '2026-01-30', count: 4, met: false },
+    { weekOf: '2026-02-06', count: 5, met: true },  { weekOf: '2026-02-13', count: 4, met: false },
+    { weekOf: '2026-02-20', count: 3, met: false }, { weekOf: '2026-02-27', count: 3, met: false },
+    { weekOf: '2026-03-06', count: 2, met: false }, { weekOf: '2026-03-13', count: 6, met: true },
+    { weekOf: '2026-03-20', count: 7, met: true },  { weekOf: '2026-03-27', count: 3, met: false }
   ]
-  var met = 0
-  for (var i = 0; i < q2Weeks.length; i++) { if (q2Weeks[i].met) met++ }
+  var q2Weeks = [
+    { weekOf: '2026-04-03', count: 4, met: false }, { weekOf: '2026-04-10', count: 1, met: false },
+    { weekOf: '2026-04-17', count: 4, met: false }, { weekOf: '2026-04-23', count: 11, met: true },
+    { weekOf: '2026-04-30', count: 7, met: true },  { weekOf: '2026-05-07', count: 2, met: false },
+    { weekOf: '2026-05-14', count: 2, met: false }, { weekOf: '2026-05-21', count: 1, met: false },
+    { weekOf: '2026-05-28', count: 3, met: false }, { weekOf: '2026-06-04', count: 5, met: true },
+    { weekOf: '2026-06-11', count: 2, met: false }, { weekOf: '2026-06-18', count: 5, met: true },
+    { weekOf: '2026-06-25', count: 3, met: false }
+  ]
+
+  function buildQ(weeks, label) {
+    var m = 0
+    for (var i = 0; i < weeks.length; i++) { if (weeks[i].met) m++ }
+    return { label: label, weeks: weeks, weeksMet: m, totalWeeks: weeks.length, pct: Math.round((m / weeks.length) * 100) }
+  }
+
+  var allQ = [buildQ(q1Weeks, 'Q1 2026'), buildQ(q2Weeks, 'Q2 2026')]
+  var totalMet = 0; var totalWeeks = 0
+  for (var i = 0; i < allQ.length; i++) { totalMet += allQ[i].weeksMet; totalWeeks += allQ[i].totalWeeks }
+
   return {
-    quarters: [{
-      label: 'Q2 2026',
-      weeks: q2Weeks,
-      weeksMet: met,
-      totalWeeks: q2Weeks.length,
-      pct: Math.round((met / q2Weeks.length) * 100)
-    }],
-    overall: { weeksMet: met, totalWeeks: q2Weeks.length, pct: Math.round((met / q2Weeks.length) * 100) },
+    quarters: allQ,
+    overall: { weeksMet: totalMet, totalWeeks: totalWeeks, pct: totalWeeks > 0 ? Math.round((totalMet / totalWeeks) * 100) : 0 },
     target: TECH_VIS_TARGET,
     source: '(sample data)',
     fetchedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary

- **Timeline live data wiring**: On Time Releases, CVE SLA Compliance, Support Cases, and Technical Visibility (KR1 + KR2) now fetch live data from their respective API endpoints and populate the Timeline scorecard dynamically
- **Per-product Support Cases**: Support Case Time to Resolution now shows 3 separate rows (RHOAI, RHEL-AI, RHAII) with individual defect rates and avg resolution days per quarter
- **Edit permissions**: New `useOkrPermissions` composable restricts editing (timeline text fields, report gear icons) to authorized users (saprabhu, trozell, dodaniel, shuels) with admin and local-dev fallback
- **Editable objectives**: Open Source Leadership, Associate Well Being, and Adoption of AI have text input fields with color picker (green/yellow/red/gray) that appear on focus
- **Report navigation**: Clicking live-data quarter cells in the Timeline navigates to the corresponding report; Reports view auto-opens from URL query param
- **Content contributions fix**: Server now reads "End of Q1/Q2/Q3/Q4 Status" columns from a single Google Sheet tab instead of looking for separate quarterly tabs
- **Sample data accuracy**: Tech visibility and content contribution sample data updated to match real Google Sheet values

## Test plan

- [ ] Verify Timeline shows live data for On Time Releases, CVE SLA, Support Cases (per product), and Technical Visibility (KR1 + KR2)
- [ ] Verify editable objectives show text input with color picker only for authorized users
- [ ] Verify non-authorized users see read-only views (no gear icons, no text fields)
- [ ] Verify clicking a live-data quarter cell navigates to the correct report
- [ ] Verify local dev mode grants edit access without authentication


Made with [Cursor](https://cursor.com)