### PR TITLE
feat(okr-hub): OKR Hub report enhancements

### DIFF
--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -1631,6 +1631,62 @@ Synced from a Google Sheet via the ai-catalyst module (showcase feature). Contai
 
 ---
 
+## OKR Hub — Feature Delivery Accuracy
+
+### Config: `okr-hub/feature-delivery-config.json`
+
+```json
+{
+  "releases": [
+    {
+      "name": "Release 3.4",
+      "products": [
+        { "version": "rhoai-3.4", "freezeDate": "2026-03-01", "releaseDate": "2026-05-14" },
+        { "version": "rhelai-3.4", "freezeDate": "2026-02-15", "releaseDate": "2026-03-19" },
+        { "version": "rhaii-3.4", "freezeDate": "2026-02-15", "releaseDate": "2026-03-19" }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `releases[].name` | string | Display name for the release group |
+| `releases[].products[].version` | string | Jira version name used in Target Version and Fix Version queries |
+| `releases[].products[].freezeDate` | ISO date string | Planning freeze cutoff date for committed feature count |
+| `releases[].products[].releaseDate` | ISO date string | GA date for the product version |
+
+### Response: `GET /api/modules/okr-hub/reports/feature-delivery`
+
+```json
+{
+  "releases": [
+    {
+      "name": "Release 3.4",
+      "products": [
+        { "version": "rhoai-3.4", "freezeDate": "2026-03-01", "releaseDate": "2026-05-14", "committed": 42, "delivered": 38, "accuracy": 90 }
+      ],
+      "committed": 42,
+      "delivered": 38,
+      "accuracy": 90
+    }
+  ],
+  "summary": { "committed": 42, "delivered": 38, "accuracy": 90 }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `releases[].products[].committed` | number | Feature count with Target Version set before freeze date |
+| `releases[].products[].delivered` | number | Feature count with Fix Version set to this version |
+| `releases[].products[].accuracy` | number | `round(delivered / committed * 100)`, 0 if committed is 0 |
+| `summary.committed` | number | Total committed across all releases |
+| `summary.delivered` | number | Total delivered across all releases |
+| `summary.accuracy` | number | Overall accuracy percentage |
+
+---
+
 ## Fixture Rules
 
 The `fixtures/` directory provides read-only demo data used when `DEMO_MODE=true`. These rules prevent data format drift:

--- a/docs/DATA-FORMATS.md
+++ b/docs/DATA-FORMATS.md
@@ -919,6 +919,62 @@ The API response format:
 
 ---
 
+## Releases — Quality 90-Day Summary (API Response)
+
+**Note:** Computed dynamically by the `GET /api/modules/releases/delivery/quality/90day-summary` endpoint from stored versions and bug files. No stored file — data is derived at request time.
+
+The API response format:
+
+```json
+{
+  "releases": [
+    {
+      "version": "3.4",
+      "products": [
+        {
+          "name": "rhoai-3.4",
+          "bugCount": 12,
+          "daysElapsed": 54,
+          "isComplete": false,
+          "releaseDate": "2026-05-08"
+        },
+        {
+          "name": "rhelai-3.4",
+          "bugCount": 5,
+          "daysElapsed": 54,
+          "isComplete": false,
+          "releaseDate": "2026-05-08"
+        },
+        {
+          "name": "rhaii-3.4",
+          "bugCount": 3,
+          "daysElapsed": 54,
+          "isComplete": false,
+          "releaseDate": "2026-05-08"
+        }
+      ],
+      "total": 20
+    }
+  ]
+}
+```
+
+**Fields (release):**
+- `version` (string): Release family number (e.g., "3.4")
+- `products` (array): Product-level breakdown
+- `total` (number): Total bugs across all products in this release family
+
+**Fields (product):**
+- `name` (string): Full version name (e.g., "rhoai-3.4")
+- `bugCount` (number): Bugs created within 90 days of GA
+- `daysElapsed` (number): Days since GA, capped at 90
+- `isComplete` (boolean): Whether the 90-day tracking window has closed
+- `releaseDate` (string): ISO date (YYYY-MM-DD) of the GA release
+
+Releases are sorted descending by version number (newest first). Only major versions (X.X) are included; z-stream versions (e.g., 3.3.1) are excluded.
+
+---
+
 ## API Tokens — `data/api-tokens.json`
 
 Stores hashed API tokens for bearer-token authentication. Created on first token creation.

--- a/modules/okr-hub/client/components/CveSlaReport.vue
+++ b/modules/okr-hub/client/components/CveSlaReport.vue
@@ -172,19 +172,20 @@ import { ref, computed, onMounted } from 'vue'
 var MONTH_KEYS = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']
 var MONTH_LABELS = { jan: 'Jan', feb: 'Feb', mar: 'Mar', apr: 'Apr', may: 'May', jun: 'Jun', jul: 'Jul', aug: 'Aug', sep: 'Sep', oct: 'Oct', nov: 'Nov', dec: 'Dec' }
 
-var quarters = [
+var ALL_QUARTERS = [
   { label: 'Q1', months: ['jan', 'feb', 'mar'] },
   { label: 'Q2', months: ['apr', 'may', 'jun'] },
   { label: 'Q3', months: ['jul', 'aug', 'sep'] },
   { label: 'Q4', months: ['oct', 'nov', 'dec'] }
 ]
+var quarters = ref(ALL_QUARTERS)
 
 var loading = ref(true)
 var error = ref(null)
 var data = ref(null)
 var dirty = ref(false)
 var saving = ref(false)
-var openQuarters = ref({ Q1: true, Q2: true, Q3: false, Q4: false })
+var openQuarters = ref({})
 var showAddProduct = ref(false)
 var newProductName = ref('')
 var addProductInput = ref(null)
@@ -330,6 +331,30 @@ async function save() {
   }
 }
 
+function quarterHasData(q) {
+  if (!data.value || !data.value.months) return false
+  for (var mi = 0; mi < q.months.length; mi++) {
+    var m = data.value.months[q.months[mi]]
+    if (!m) continue
+    for (var pi = 0; pi < (data.value.products || []).length; pi++) {
+      var prod = data.value.products[pi]
+      if (m[prod] && (m[prod].met != null || m[prod].missed != null)) return true
+    }
+  }
+  return false
+}
+
+function reorderQuarters() {
+  var withData = []
+  var withoutData = []
+  for (var i = 0; i < ALL_QUARTERS.length; i++) {
+    if (quarterHasData(ALL_QUARTERS[i])) withData.push(ALL_QUARTERS[i])
+    else withoutData.push(ALL_QUARTERS[i])
+  }
+  withData.reverse()
+  quarters.value = withData.concat(withoutData)
+}
+
 onMounted(async function() {
   try {
     var res = await fetch('/api/modules/okr-hub/reports/cve-sla')
@@ -338,6 +363,11 @@ onMounted(async function() {
     if (!data.value.months) data.value.months = {}
     for (var i = 0; i < MONTH_KEYS.length; i++) {
       if (!data.value.months[MONTH_KEYS[i]]) data.value.months[MONTH_KEYS[i]] = {}
+    }
+
+    reorderQuarters()
+    if (quarters.value.length > 0) {
+      openQuarters.value[quarters.value[0].label] = true
     }
   } catch (err) {
     error.value = err.message

--- a/modules/okr-hub/client/components/FeatureDeliveryReport.vue
+++ b/modules/okr-hub/client/components/FeatureDeliveryReport.vue
@@ -1,0 +1,298 @@
+<template>
+  <div class="space-y-4">
+    <div v-if="loading" class="text-sm text-gray-500 dark:text-gray-400">Loading feature delivery data...</div>
+    <div v-else-if="error" class="rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">{{ error }}</div>
+
+    <template v-else>
+      <!-- Summary Header -->
+      <div class="flex items-center gap-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-5">
+        <div class="text-center">
+          <div class="text-4xl font-black tabular-nums" :class="accuracyColorClass(data.summary.accuracy)">{{ data.summary.accuracy }}%</div>
+          <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mt-1">Accuracy</div>
+        </div>
+        <div class="h-12 w-px bg-gray-200 dark:bg-gray-700" />
+        <div class="flex items-center gap-5 text-sm">
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.summary.committed }}</div>
+            <div class="text-[10px] font-medium text-blue-600 dark:text-blue-400 uppercase">Committed</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.summary.delivered }}</div>
+            <div class="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase">Delivered</div>
+          </div>
+          <div class="text-center">
+            <div class="text-lg font-bold text-gray-900 dark:text-gray-100 tabular-nums">{{ data.releases.length }}</div>
+            <div class="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Releases</div>
+          </div>
+        </div>
+        <div class="ml-auto flex items-center gap-3">
+          <span class="text-xs text-gray-400 dark:text-gray-500">Committed (TV) vs Delivered (FV)</span>
+          <button
+            v-if="canEdit"
+            @click="showSettings = !showSettings"
+            class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            title="Configure releases"
+          >
+            <svg class="w-5 h-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.331 1.652a6.993 6.993 0 011.929 1.115l1.598-.54a1 1 0 011.186.447l1.18 2.044a1 1 0 01-.205 1.251l-1.267 1.113a7.047 7.047 0 010 2.228l1.267 1.113a1 1 0 01.206 1.25l-1.18 2.045a1 1 0 01-1.187.447l-1.598-.54a6.993 6.993 0 01-1.929 1.115l-.33 1.652a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.331-1.652a6.993 6.993 0 01-1.929-1.115l-1.598.54a1 1 0 01-1.186-.447l-1.18-2.044a1 1 0 01.205-1.251l1.267-1.114a7.05 7.05 0 010-2.227L1.821 7.773a1 1 0 01-.206-1.25l1.18-2.045a1 1 0 011.187-.447l1.598.54A6.993 6.993 0 017.51 3.456l.33-1.652zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Settings Panel -->
+      <div v-if="showSettings" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg overflow-hidden">
+        <div class="px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <span class="text-sm font-bold text-gray-900 dark:text-gray-100">Configure Releases</span>
+          <button @click="addRelease" class="text-xs font-semibold text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">+ Add Release</button>
+        </div>
+        <div class="max-h-[28rem] overflow-y-auto divide-y divide-gray-100 dark:divide-gray-800">
+          <div v-for="(rel, ri) in settingsEntries" :key="ri" class="px-5 py-4">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <label class="text-[10px] font-semibold text-gray-400 uppercase">Release Name</label>
+                <input
+                  v-model="rel.name"
+                  class="w-48 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                  placeholder="e.g. Release 3.4"
+                />
+              </div>
+              <div class="flex items-center gap-1">
+                <button @click="addProduct(ri)" class="px-2 py-1 text-xs text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded transition-colors">+ Version</button>
+                <button @click="removeRelease(ri)" class="px-2 py-1 text-xs text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors">Remove</button>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <div class="grid grid-cols-[1fr_auto_auto_auto] gap-2 text-[10px] font-semibold text-gray-400 uppercase pl-1">
+                <span>Version Name</span>
+                <span class="w-36 text-center">Planning Freeze</span>
+                <span class="w-36 text-center">Release Date</span>
+                <span class="w-6"></span>
+              </div>
+              <div v-for="(p, pi) in rel.products" :key="pi" class="grid grid-cols-[1fr_auto_auto_auto] gap-2 items-center">
+                <input
+                  v-model="p.version"
+                  class="text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                  placeholder="e.g. rhoai-3.4"
+                />
+                <input
+                  v-model="p.freezeDate"
+                  type="date"
+                  class="w-36 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                />
+                <input
+                  v-model="p.releaseDate"
+                  type="date"
+                  class="w-36 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                />
+                <button @click="removeProduct(ri, pi)" class="p-1 text-red-400 hover:text-red-600 dark:hover:text-red-300 rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors" title="Remove version">
+                  <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div v-if="settingsEntries.length === 0" class="px-5 py-8 text-center text-sm text-gray-400 italic">No releases configured. Click "+ Add Release" to get started.</div>
+        </div>
+        <div class="px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-2">
+          <button @click="cancelSettings" class="px-3 py-1.5 text-xs font-semibold text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors">Cancel</button>
+          <button @click="saveSettings" :disabled="saving" class="px-4 py-1.5 text-xs font-bold text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors disabled:opacity-50">{{ saving ? 'Saving...' : 'Save & Compute' }}</button>
+        </div>
+      </div>
+
+      <!-- No config state -->
+      <div v-if="data.releases.length === 0 && !showSettings" class="text-center py-12 text-gray-500 dark:text-gray-400">
+        <p class="text-sm">No releases configured.</p>
+        <p v-if="canEdit" class="text-xs mt-1">Click the gear icon to add releases and product versions.</p>
+      </div>
+
+      <!-- Release Sections -->
+      <div v-for="rel in data.releases" :key="rel.name" class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm">
+        <button
+          @click="toggleRelease(rel.name)"
+          class="w-full flex items-center justify-between px-5 py-3 bg-gray-50 dark:bg-gray-800/80 border-b border-gray-200 dark:border-gray-700 text-left hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          <div class="flex items-center gap-3">
+            <svg
+              class="w-4 h-4 text-gray-400 transition-transform duration-200"
+              :class="{ 'rotate-90': openReleases[rel.name] }"
+              viewBox="0 0 20 20" fill="currentColor"
+            ><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+            <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ rel.name }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ rel.committed }} committed, {{ rel.delivered }} delivered</span>
+          </div>
+          <span class="text-sm font-bold tabular-nums px-2.5 py-0.5 rounded-full" :class="accuracyBadgeClass(rel.accuracy)">{{ rel.accuracy }}%</span>
+        </button>
+
+        <div v-show="openReleases[rel.name]" class="overflow-x-auto">
+          <table class="w-full text-sm border-collapse">
+            <thead>
+              <tr class="bg-gray-50 dark:bg-gray-800/60">
+                <th class="px-4 py-2.5 text-left text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Product Version</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Committed</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Delivered</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28">Accuracy</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Freeze Date</th>
+                <th class="px-4 py-2.5 text-center text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Release Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="p in rel.products" :key="p.version" class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                <td class="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100">{{ p.version }}</td>
+                <td class="px-4 py-2.5 text-center tabular-nums text-blue-600 dark:text-blue-400 font-semibold">{{ p.committed }}</td>
+                <td class="px-4 py-2.5 text-center tabular-nums text-emerald-600 dark:text-emerald-400 font-semibold">{{ p.delivered }}</td>
+                <td class="px-4 py-2.5 text-center">
+                  <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold" :class="accuracyBadgeClass(p.accuracy)">{{ p.accuracy }}%</span>
+                </td>
+                <td class="px-4 py-2.5 text-center text-gray-600 dark:text-gray-400 tabular-nums">{{ formatDate(p.freezeDate) }}</td>
+                <td class="px-4 py-2.5 text-center text-gray-600 dark:text-gray-400 tabular-nums">{{ formatDate(p.releaseDate) }}</td>
+              </tr>
+              <!-- Total row -->
+              <tr class="bg-gray-50 dark:bg-gray-800/60 font-bold border-t-2 border-gray-300 dark:border-gray-600">
+                <td class="px-4 py-2.5 text-gray-900 dark:text-gray-100">Total</td>
+                <td class="px-4 py-2.5 text-center tabular-nums text-blue-600 dark:text-blue-400">{{ rel.committed }}</td>
+                <td class="px-4 py-2.5 text-center tabular-nums text-emerald-600 dark:text-emerald-400">{{ rel.delivered }}</td>
+                <td class="px-4 py-2.5 text-center">
+                  <span class="text-sm font-black tabular-nums" :class="accuracyColorClass(rel.accuracy)">{{ rel.accuracy }}%</span>
+                </td>
+                <td class="px-4 py-2.5"></td>
+                <td class="px-4 py-2.5"></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useOkrPermissions } from '../composables/useOkrPermissions.js'
+
+var { canEdit } = useOkrPermissions()
+var loading = ref(true)
+var error = ref(null)
+var data = ref({ releases: [], summary: { committed: 0, delivered: 0, accuracy: 0 } })
+var openReleases = ref({})
+var showSettings = ref(false)
+var saving = ref(false)
+var settingsEntries = ref([])
+
+function accuracyColorClass(pct) {
+  if (pct >= 90) return 'text-emerald-600 dark:text-emerald-400'
+  if (pct >= 70) return 'text-yellow-600 dark:text-yellow-400'
+  return 'text-red-600 dark:text-red-400'
+}
+
+function accuracyBadgeClass(pct) {
+  if (pct >= 90) return 'text-emerald-600 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/40'
+  if (pct >= 70) return 'text-yellow-700 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/40'
+  return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40'
+}
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  var d = new Date(iso + 'T00:00:00')
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function toggleRelease(name) {
+  openReleases.value[name] = !openReleases.value[name]
+}
+
+function addRelease() {
+  settingsEntries.value.push({
+    name: '',
+    products: [
+      { version: '', freezeDate: '', releaseDate: '' },
+      { version: '', freezeDate: '', releaseDate: '' },
+      { version: '', freezeDate: '', releaseDate: '' }
+    ]
+  })
+}
+
+function removeRelease(ri) {
+  settingsEntries.value.splice(ri, 1)
+}
+
+function addProduct(ri) {
+  settingsEntries.value[ri].products.push({ version: '', freezeDate: '', releaseDate: '' })
+}
+
+function removeProduct(ri, pi) {
+  settingsEntries.value[ri].products.splice(pi, 1)
+}
+
+function cancelSettings() {
+  showSettings.value = false
+  loadSettingsEntries()
+}
+
+async function loadSettingsEntries() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/feature-delivery-config')
+    if (res.ok) {
+      var result = await res.json()
+      settingsEntries.value = (result.releases || []).map(function(r) {
+        return {
+          name: r.name || '',
+          products: (r.products || []).map(function(p) {
+            return { version: p.version || '', freezeDate: p.freezeDate || '', releaseDate: p.releaseDate || '' }
+          })
+        }
+      })
+    }
+  } catch (loadErr) {
+    console.warn('[okr-hub] Failed to load feature delivery config:', loadErr.message)
+  }
+}
+
+async function saveSettings() {
+  saving.value = true
+  try {
+    var cleaned = settingsEntries.value
+      .filter(function(r) { return r.name })
+      .map(function(r) {
+        return {
+          name: r.name,
+          products: r.products.filter(function(p) { return p.version })
+        }
+      })
+      .filter(function(r) { return r.products.length > 0 })
+
+    var res = await fetch('/api/modules/okr-hub/reports/feature-delivery-config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ releases: cleaned })
+    })
+    if (!res.ok) throw new Error('Save failed: ' + res.status)
+    showSettings.value = false
+    await loadData()
+  } catch (err) {
+    alert('Failed to save: ' + err.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function loadData() {
+  try {
+    var res = await fetch('/api/modules/okr-hub/reports/feature-delivery')
+    if (!res.ok) throw new Error('Failed to load report: ' + res.status)
+    data.value = await res.json()
+
+    if (data.value.releases.length > 0) {
+      openReleases.value[data.value.releases[0].name] = true
+    }
+  } catch (err) {
+    error.value = err.message
+  }
+}
+
+onMounted(async function() {
+  await loadData()
+  await loadSettingsEntries()
+  loading.value = false
+})
+</script>

--- a/modules/okr-hub/client/components/OnTimeReleasesReport.vue
+++ b/modules/okr-hub/client/components/OnTimeReleasesReport.vue
@@ -188,7 +188,7 @@ var quarters = computed(function() {
     map[label].releases.push(rel)
   }
   var result = Object.keys(map).map(function(k) { return map[k] })
-  result.sort(function(a, b) { return a.sortKey - b.sortKey })
+  result.sort(function(a, b) { return b.sortKey - a.sortKey })
   for (var qi = 0; qi < result.length; qi++) {
     var q = result[qi]
     var released = 0

--- a/modules/okr-hub/client/components/SupportCaseReport.vue
+++ b/modules/okr-hub/client/components/SupportCaseReport.vue
@@ -165,7 +165,8 @@ var showSettings = ref(false)
 var saving = ref(false)
 var editQuarter = ref('Q1')
 var editData = ref(null)
-var quarterKeys = ['Q1', 'Q2', 'Q3', 'Q4']
+var ALL_QUARTER_KEYS = ['Q1', 'Q2', 'Q3', 'Q4']
+var quarterKeys = ref(ALL_QUARTER_KEYS)
 var editFields = ['totalCases', 'defects', 'casesClosed', 'bugsEng', 'rfe', 'supportEx', 'other', 'avgResolutionDays', 'medianResolutionDays']
 
 function getNum(qKey, product, field) {
@@ -233,9 +234,9 @@ var overallDefectRate = computed(function() {
   if (!data.value) return '—'
   var totalCases = 0
   var totalDefects = 0
-  for (var qi = 0; qi < quarterKeys.length; qi++) {
-    var t = quarterTotal(quarterKeys[qi], 'totalCases')
-    var d = quarterTotal(quarterKeys[qi], 'defects')
+  for (var qi = 0; qi < ALL_QUARTER_KEYS.length; qi++) {
+    var t = quarterTotal(ALL_QUARTER_KEYS[qi], 'totalCases')
+    var d = quarterTotal(ALL_QUARTER_KEYS[qi], 'defects')
     if (typeof t === 'number') totalCases += t
     if (typeof d === 'number') totalDefects += d
   }
@@ -252,8 +253,8 @@ var overallDefectRateClass = computed(function() {
 var overallTotalCases = computed(function() {
   if (!data.value) return 0
   var total = 0
-  for (var qi = 0; qi < quarterKeys.length; qi++) {
-    var t = quarterTotal(quarterKeys[qi], 'totalCases')
+  for (var qi = 0; qi < ALL_QUARTER_KEYS.length; qi++) {
+    var t = quarterTotal(ALL_QUARTER_KEYS[qi], 'totalCases')
     if (typeof t === 'number') total += t
   }
   return total
@@ -283,8 +284,8 @@ function computeOverallAvg(field) {
   if (!data.value) return '—'
   var sum = 0
   var count = 0
-  for (var qi = 0; qi < quarterKeys.length; qi++) {
-    var avg = quarterAvg(quarterKeys[qi], field)
+  for (var qi = 0; qi < ALL_QUARTER_KEYS.length; qi++) {
+    var avg = quarterAvg(ALL_QUARTER_KEYS[qi], field)
     if (avg != null) { sum += avg; count++ }
   }
   return count > 0 ? (sum / count).toFixed(1) : '—'
@@ -354,15 +355,36 @@ async function saveSettings() {
   }
 }
 
+function quarterHasData(qKey) {
+  if (!data.value || !data.value.quarters || !data.value.quarters[qKey]) return false
+  for (var i = 0; i < data.value.products.length; i++) {
+    var p = data.value.products[i]
+    if (data.value.quarters[qKey][p] && data.value.quarters[qKey][p].totalCases != null) return true
+  }
+  return false
+}
+
+function reorderQuarters() {
+  var withData = []
+  var withoutData = []
+  for (var i = 0; i < ALL_QUARTER_KEYS.length; i++) {
+    if (quarterHasData(ALL_QUARTER_KEYS[i])) withData.push(ALL_QUARTER_KEYS[i])
+    else withoutData.push(ALL_QUARTER_KEYS[i])
+  }
+  withData.reverse()
+  quarterKeys.value = withData.concat(withoutData)
+}
+
 onMounted(async function() {
   try {
     var res = await fetch('/api/modules/okr-hub/reports/support-cases')
     if (!res.ok) throw new Error('Failed to load report: ' + res.status)
     data.value = await res.json()
 
-    var now = new Date()
-    var currentQ = 'Q' + (Math.floor(now.getMonth() / 3) + 1)
-    openQuarters.value[currentQ] = true
+    reorderQuarters()
+    if (quarterKeys.value.length > 0) {
+      openQuarters.value[quarterKeys.value[0]] = true
+    }
   } catch (err) {
     error.value = err.message
   } finally {

--- a/modules/okr-hub/client/components/TechVisibilityReport.vue
+++ b/modules/okr-hub/client/components/TechVisibilityReport.vue
@@ -278,9 +278,12 @@ async function fetchKr1() {
     if (result.error) {
       kr1Error.value = result.error
     } else {
+      if (result.quarters && result.quarters.length > 0) {
+        result.quarters.reverse()
+      }
       kr1Data.value = result
       if (result.quarters && result.quarters.length > 0) {
-        openSections.value['kr1-' + result.quarters[result.quarters.length - 1].label] = true
+        openSections.value['kr1-' + result.quarters[0].label] = true
       }
     }
   } catch (err) {
@@ -298,9 +301,12 @@ async function fetchKr2() {
     if (result.error) {
       kr2Error.value = result.error
     } else {
+      if (result.quarters && result.quarters.length > 0) {
+        result.quarters.reverse()
+      }
       kr2Data.value = result
       if (result.quarters && result.quarters.length > 0) {
-        openSections.value['kr2-' + result.quarters[result.quarters.length - 1].label] = true
+        openSections.value['kr2-' + result.quarters[0].label] = true
       }
     }
   } catch (err) {

--- a/modules/okr-hub/client/components/post-release-defects/PostReleaseDefectsReport.vue
+++ b/modules/okr-hub/client/components/post-release-defects/PostReleaseDefectsReport.vue
@@ -98,7 +98,7 @@
         <p>Select versions to view cumulative bug trends</p>
       </div>
 
-      <div v-if="selectedVersions.length > 0" class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <div v-if="selectedVersions.length > 0" class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
         <h2 class="text-lg font-semibold mb-4">Summary Statistics</h2>
         <table class="w-full">
           <thead>
@@ -117,6 +117,165 @@
           </tbody>
         </table>
       </div>
+
+      <!-- 90-Day Post-Release Bug Tracking -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <div class="flex items-center justify-between mb-1">
+          <h2 class="text-lg font-semibold">90-Day Post-Release Bug Tracking</h2>
+          <button
+            v-if="canEdit"
+            @click="showTrackingSettings = !showTrackingSettings"
+            class="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            title="Configure versions"
+          >
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </button>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-5">Bugs created within 90 days of each version's GA date. Versions under 90 days show elapsed days.</p>
+
+        <!-- Settings Panel -->
+        <div v-if="showTrackingSettings" class="mb-6 border border-blue-200 dark:border-blue-800 rounded-lg bg-blue-50/50 dark:bg-blue-900/10 p-4">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-200">Version Configuration</h3>
+            <div class="flex items-center gap-2">
+              <button
+                @click="addRelease"
+                class="px-3 py-1.5 text-xs bg-emerald-600 text-white rounded hover:bg-emerald-700 transition-colors"
+              >+ Add Release</button>
+              <button
+                @click="saveTrackingConfig"
+                :disabled="savingConfig"
+                class="px-3 py-1.5 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >{{ savingConfig ? 'Saving...' : 'Save & Reload' }}</button>
+            </div>
+          </div>
+
+          <div v-if="configError" class="text-xs text-red-600 dark:text-red-400 mb-3">{{ configError }}</div>
+
+          <div class="space-y-4">
+            <div v-for="(rel, ri) in editableConfig" :key="ri" class="border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 p-3">
+              <div class="flex items-center justify-between mb-2">
+                <div class="flex items-center gap-2">
+                  <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Release</label>
+                  <input
+                    v-model="rel.version"
+                    class="w-20 px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 focus:border-blue-500 focus:ring-1 focus:ring-blue-200"
+                    placeholder="3.4"
+                  />
+                </div>
+                <div class="flex items-center gap-1">
+                  <button
+                    @click="addProduct(ri)"
+                    class="px-2 py-1 text-xs text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded transition-colors"
+                  >+ Version</button>
+                  <button
+                    @click="removeRelease(ri)"
+                    class="px-2 py-1 text-xs text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                  >Remove</button>
+                </div>
+              </div>
+              <div class="space-y-1.5">
+                <div v-for="(p, pi) in rel.products" :key="pi" class="flex items-center gap-2">
+                  <input
+                    v-model="p.name"
+                    class="flex-1 px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 focus:border-blue-500 focus:ring-1 focus:ring-blue-200"
+                    placeholder="e.g. rhoai-3.4"
+                  />
+                  <input
+                    v-model="p.gaDate"
+                    type="date"
+                    class="px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 focus:border-blue-500 focus:ring-1 focus:ring-blue-200"
+                  />
+                  <button
+                    @click="removeProduct(ri, pi)"
+                    class="p-1 text-red-400 hover:text-red-600 dark:hover:text-red-300 rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                    title="Remove version"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="editableConfig.length === 0" class="text-center py-4 text-sm text-gray-500 dark:text-gray-400">
+            No release configuration. Click "+ Add Release" to get started, or close settings to use auto-detected versions.
+          </div>
+
+          <div class="mt-3 flex items-center justify-between">
+            <button
+              v-if="editableConfig.length > 0"
+              @click="clearConfig"
+              class="px-3 py-1.5 text-xs text-gray-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+            >Clear All (use auto-detected)</button>
+            <span v-else></span>
+            <span class="text-xs text-gray-400">Version names map to Jira affectedVersion field</span>
+          </div>
+        </div>
+
+        <div v-if="trackingLoading" class="text-sm text-gray-500 dark:text-gray-400">Loading 90-day tracking data...</div>
+        <div v-else-if="trackingError" class="text-sm text-red-600 dark:text-red-400">{{ trackingError }}</div>
+        <div v-else-if="trackingData.length === 0" class="text-sm text-gray-500 dark:text-gray-400">No release data available.</div>
+
+        <div v-else class="space-y-3">
+          <div v-for="rel in trackingData" :key="rel.version" class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+            <button
+              class="w-full flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-800/60 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors text-left"
+              @click="toggleTracking(rel.version)"
+            >
+              <div class="flex items-center gap-2">
+                <svg
+                  class="w-4 h-4 text-gray-400 transition-transform duration-200"
+                  :class="{ 'rotate-90': isTrackingOpen(rel.version) }"
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+                <span class="font-semibold text-sm text-gray-900 dark:text-gray-100">Release {{ rel.version }}</span>
+                <span v-if="!rel.isAllComplete" class="text-xs text-amber-600 dark:text-amber-400 font-medium">({{ rel.maxDaysElapsed }} days)</span>
+              </div>
+              <span class="text-sm font-bold" :class="rel.total > 0 ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'">{{ rel.total }} bugs</span>
+            </button>
+
+            <div v-show="isTrackingOpen(rel.version)">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="border-t border-b border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/30">
+                    <th class="text-left px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Version</th>
+                    <th class="text-right px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Bug Count</th>
+                    <th class="text-right px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Days Elapsed</th>
+                    <th class="text-right px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="p in rel.products" :key="p.name" class="border-b border-gray-100 dark:border-gray-800">
+                    <td class="px-4 py-2 text-gray-900 dark:text-gray-100">{{ p.name }}</td>
+                    <td class="text-right px-4 py-2 font-medium" :class="p.bugCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'">{{ p.bugCount }}</td>
+                    <td class="text-right px-4 py-2 text-gray-600 dark:text-gray-400">{{ p.daysElapsed }} / 90</td>
+                    <td class="text-right px-4 py-2">
+                      <span
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                        :class="p.isComplete ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'"
+                      >{{ p.isComplete ? 'Complete' : 'In Progress' }}</span>
+                    </td>
+                  </tr>
+                  <tr class="bg-gray-50 dark:bg-gray-800/40 font-semibold">
+                    <td class="px-4 py-2 text-gray-900 dark:text-gray-100">Total</td>
+                    <td class="text-right px-4 py-2" :class="rel.total > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-500'">{{ rel.total }}</td>
+                    <td class="text-right px-4 py-2 text-gray-600 dark:text-gray-400"></td>
+                    <td class="text-right px-4 py-2"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
     </template>
   </div>
 </template>
@@ -124,13 +283,15 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue';
 import { useAuth } from '@shared/client/composables/useAuth';
+import { useOkrPermissions } from '../../composables/useOkrPermissions';
 import VersionSelector from './VersionSelector.vue';
 import ComponentFilter from './ComponentFilter.vue';
 import CumulativeBugChart from './CumulativeBugChart.vue';
-import { getVersions, getBugData, getComponents, refreshData } from './api';
+import { getVersions, getBugData, getComponents, refreshData, get90DaySummary, get90DayTrackingConfig, save90DayTrackingConfig } from './api';
 import { extractProduct } from './release-utils';
 
 const { isAdmin } = useAuth();
+const { canEdit } = useOkrPermissions();
 
 const versions = ref([]);
 const allComponents = ref([]);
@@ -141,6 +302,17 @@ const chartData = ref({ labels: [], datasets: [] });
 const loading = ref(true);
 const refreshing = ref(false);
 const error = ref(null);
+
+const trackingData = ref([]);
+const trackingLoading = ref(true);
+const trackingError = ref(null);
+const openTrackingSections = ref({});
+
+const showTrackingSettings = ref(false);
+const trackingConfig = ref(null);
+const editableConfig = ref([]);
+const savingConfig = ref(false);
+const configError = ref(null);
 
 const products = computed(() => {
   const productSet = new Set();
@@ -181,7 +353,122 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
+
+  load90DayTracking();
 });
+
+async function load90DayTracking() {
+  try {
+    trackingLoading.value = true;
+    trackingError.value = null;
+
+    // Load saved config
+    try {
+      const cfg = await get90DayTrackingConfig();
+      trackingConfig.value = cfg;
+      if (cfg && cfg.releases && cfg.releases.length > 0) {
+        editableConfig.value = JSON.parse(JSON.stringify(cfg.releases));
+      }
+    } catch (cfgErr) { // eslint-disable-line no-unused-vars
+      trackingConfig.value = null;
+    }
+
+    const configToSend = trackingConfig.value && trackingConfig.value.releases && trackingConfig.value.releases.length > 0
+      ? trackingConfig.value
+      : null;
+    const result = await get90DaySummary(configToSend);
+    const releases = result.releases || [];
+    for (const rel of releases) {
+      rel.isAllComplete = rel.products.every(function(p) { return p.isComplete; });
+      rel.maxDaysElapsed = 0;
+      for (const p of rel.products) {
+        if (p.daysElapsed > rel.maxDaysElapsed) rel.maxDaysElapsed = p.daysElapsed;
+      }
+    }
+    trackingData.value = releases;
+    if (releases.length > 0) {
+      openTrackingSections.value[releases[0].version] = true;
+    }
+  } catch (err) {
+    console.error('[quality] Failed to load 90-day tracking:', err);
+    trackingError.value = err.message || 'Failed to load 90-day tracking data';
+  } finally {
+    trackingLoading.value = false;
+  }
+}
+
+function toggleTracking(version) {
+  openTrackingSections.value[version] = !openTrackingSections.value[version];
+}
+
+function isTrackingOpen(version) {
+  return !!openTrackingSections.value[version];
+}
+
+function addRelease() {
+  editableConfig.value.push({ version: '', products: [
+    { name: '', gaDate: '' },
+    { name: '', gaDate: '' },
+    { name: '', gaDate: '' }
+  ]});
+}
+
+function removeRelease(ri) {
+  editableConfig.value.splice(ri, 1);
+}
+
+function addProduct(ri) {
+  editableConfig.value[ri].products.push({ name: '', gaDate: '' });
+}
+
+function removeProduct(ri, pi) {
+  editableConfig.value[ri].products.splice(pi, 1);
+}
+
+async function saveTrackingConfig() {
+  try {
+    savingConfig.value = true;
+    configError.value = null;
+    // Filter out empty entries
+    const cleaned = editableConfig.value
+      .filter(function(r) { return r.version; })
+      .map(function(r) {
+        return {
+          version: r.version,
+          products: r.products.filter(function(p) { return p.name && p.gaDate; })
+        };
+      })
+      .filter(function(r) { return r.products.length > 0; });
+
+    const payload = { releases: cleaned };
+    await save90DayTrackingConfig(payload);
+    trackingConfig.value = payload;
+    showTrackingSettings.value = false;
+    await load90DayTracking();
+  } catch (err) {
+    console.error('[quality] Failed to save tracking config:', err);
+    configError.value = err.message || 'Failed to save configuration';
+  } finally {
+    savingConfig.value = false;
+  }
+}
+
+async function clearConfig() {
+  try {
+    savingConfig.value = true;
+    configError.value = null;
+    await save90DayTrackingConfig({ releases: [] });
+    trackingConfig.value = null;
+    editableConfig.value = [];
+    showTrackingSettings.value = false;
+    await load90DayTracking();
+  } catch (err) {
+    console.error('[quality] Failed to clear tracking config:', err);
+    configError.value = err.message || 'Failed to clear configuration';
+  } finally {
+    savingConfig.value = false;
+  }
+}
 
 watch(selectedComponent, async () => {
   try {
@@ -241,6 +528,8 @@ async function handleRefresh() {
       const response = await getBugData(selectedVersions.value, selectedComponent.value);
       chartData.value = { labels: response.labels, datasets: response.datasets };
     }
+
+    load90DayTracking();
   } catch (err) {
     console.error('[quality] Failed to refresh data:', err);
     error.value = err.message || 'Failed to refresh quality metrics data';

--- a/modules/okr-hub/client/components/post-release-defects/api.js
+++ b/modules/okr-hub/client/components/post-release-defects/api.js
@@ -2,6 +2,7 @@ import { apiRequest } from '@shared/client';
 
 /* eslint-disable-next-line org-pulse/no-cross-module-imports -- approved cross-module API; okr-hub requires releases in module.json */
 const BASE = '/modules/releases/delivery/quality';
+const OKR_BASE = '/modules/okr-hub/reports';
 
 export async function getVersions() {
   return apiRequest(`${BASE}/versions`);
@@ -19,4 +20,27 @@ export async function getComponents() {
 
 export async function refreshData() {
   return apiRequest(`${BASE}/refresh`, { method: 'POST' });
+}
+
+export async function get90DaySummary(config = null) {
+  if (config && config.releases && config.releases.length > 0) {
+    return apiRequest(`${BASE}/90day-summary`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config)
+    });
+  }
+  return apiRequest(`${BASE}/90day-summary`);
+}
+
+export async function get90DayTrackingConfig() {
+  return apiRequest(`${OKR_BASE}/90day-tracking-config`);
+}
+
+export async function save90DayTrackingConfig(config) {
+  return apiRequest(`${OKR_BASE}/90day-tracking-config`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config)
+  });
 }

--- a/modules/okr-hub/client/views/ReportsView.vue
+++ b/modules/okr-hub/client/views/ReportsView.vue
@@ -53,6 +53,7 @@
     <CommitmentTrackingReport v-if="activeReport === 'commitment-tracking'" />
     <TechVisibilityReport v-if="activeReport === 'tech-visibility'" />
     <SupportCaseReport v-if="activeReport === 'support-cases'" />
+    <FeatureDeliveryReport v-if="activeReport === 'feature-delivery'" />
   </div>
 </template>
 
@@ -64,6 +65,7 @@ import PostReleaseDefectsReport from '../components/post-release-defects/PostRel
 import CommitmentTrackingReport from '../components/commitment-tracking/CommitmentTrackingReport.vue'
 import TechVisibilityReport from '../components/TechVisibilityReport.vue'
 import SupportCaseReport from '../components/SupportCaseReport.vue'
+import FeatureDeliveryReport from '../components/FeatureDeliveryReport.vue'
 
 var activeReport = ref(null)
 
@@ -134,6 +136,15 @@ var reports = [
     icon: '🔧',
     iconBg: 'bg-orange-50 dark:bg-orange-900/30',
     measure: 'Defect Rate for Product: 10% | Time to Resolution Target: 10-14 days',
+    measureColor: 'text-gray-600 dark:text-gray-300'
+  },
+  {
+    id: 'feature-delivery',
+    title: 'Feature Delivery Accuracy',
+    description: 'Committed vs delivered features per release. Compares Target Version (before freeze) to Fix Version at release.',
+    icon: '📊',
+    iconBg: 'bg-indigo-50 dark:bg-indigo-900/30',
+    measure: '>90% of committed features delivered per release',
     measureColor: 'text-gray-600 dark:text-gray-300'
   }
 ]

--- a/modules/okr-hub/module.json
+++ b/modules/okr-hub/module.json
@@ -24,7 +24,8 @@
     "files": [
       { "path": "okr-hub/cve-sla-data.json", "notes": "CVE SLA compliance data (products x months)" },
       { "path": "okr-hub/on-time-overrides.json", "notes": "Custom release overrides for on-time report" },
-      { "path": "okr-hub/support-case-data.json", "notes": "Support case resolution data by quarter and product" }
+      { "path": "okr-hub/support-case-data.json", "notes": "Support case resolution data by quarter and product" },
+      { "path": "okr-hub/90day-tracking-config.json", "notes": "90-day post-release tracking version configuration" }
     ]
   }
 }

--- a/modules/okr-hub/module.json
+++ b/modules/okr-hub/module.json
@@ -25,7 +25,8 @@
       { "path": "okr-hub/cve-sla-data.json", "notes": "CVE SLA compliance data (products x months)" },
       { "path": "okr-hub/on-time-overrides.json", "notes": "Custom release overrides for on-time report" },
       { "path": "okr-hub/support-case-data.json", "notes": "Support case resolution data by quarter and product" },
-      { "path": "okr-hub/90day-tracking-config.json", "notes": "90-day post-release tracking version configuration" }
+      { "path": "okr-hub/90day-tracking-config.json", "notes": "90-day post-release tracking version configuration" },
+      { "path": "okr-hub/feature-delivery-config.json", "notes": "Feature delivery accuracy release/version configuration" }
     ]
   }
 }

--- a/modules/okr-hub/server/export.js
+++ b/modules/okr-hub/server/export.js
@@ -39,4 +39,18 @@ module.exports = async function okrHubExport(addFile, storage) {
       })
     })
   }
+
+  var featureConfig = storage.readFromStorage('okr-hub/feature-delivery-config.json')
+  if (featureConfig) {
+    addFile('okr-hub/feature-delivery-config.json', {
+      releases: (featureConfig.releases || []).map(function(r) {
+        return {
+          name: 'Release',
+          products: (r.products || []).map(function() {
+            return { version: 'version-name', freezeDate: '2026-01-01', releaseDate: '2026-06-01' }
+          })
+        }
+      })
+    })
+  }
 }

--- a/modules/okr-hub/server/export.js
+++ b/modules/okr-hub/server/export.js
@@ -25,4 +25,18 @@ module.exports = async function okrHubExport(addFile, storage) {
       })
     })
   }
+
+  var trackingConfig = storage.readFromStorage('okr-hub/90day-tracking-config.json')
+  if (trackingConfig) {
+    addFile('okr-hub/90day-tracking-config.json', {
+      releases: (trackingConfig.releases || []).map(function(r) {
+        return {
+          version: r.version,
+          products: (r.products || []).map(function(p) {
+            return { name: 'version-name', gaDate: p.gaDate }
+          })
+        }
+      })
+    })
+  }
 }

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -16,6 +16,9 @@ var contentCacheAt = 0
 var CONTENT_CACHE_TTL = 15 * 60 * 1000
 var CONTENT_SHEET_ID = '1LePie38Eg1gUEIO6qu5zifgnCe9ASj8QHE8n_sgsrVk'
 
+var featureDeliveryCache = {}
+var FEATURE_DELIVERY_CACHE_TTL = 10 * 60 * 1000
+
 /**
  * @param {import('express').Router} router
  * @param {import('@shared/server/module-context').ModuleContext} context
@@ -686,6 +689,161 @@ module.exports = function registerRoutes(router, context) {
       res.json({ ok: true })
     } catch (err) {
       console.error('[okr-hub] 90day-tracking-config save error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/feature-delivery-config:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Get feature delivery accuracy configuration
+   *     responses:
+   *       200:
+   *         description: Release configuration with product versions and dates
+   */
+  router.get('/reports/feature-delivery-config', requireScope('okr-hub:read'), function(req, res) {
+    var saved = storage.readFromStorage('okr-hub/feature-delivery-config.json')
+    if (saved && Array.isArray(saved.releases)) {
+      return res.json(saved)
+    }
+    res.json({ releases: [] })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/feature-delivery-config:
+   *   put:
+   *     tags: [OKR Hub]
+   *     summary: Save feature delivery accuracy configuration
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema: { type: object }
+   *     responses:
+   *       200:
+   *         description: Saved
+   */
+  router.put('/reports/feature-delivery-config', requireScope('okr-hub:write'), function(req, res) {
+    try {
+      var body = req.body
+      if (!body || !Array.isArray(body.releases)) {
+        return res.status(400).json({ error: 'Invalid payload: requires releases array' })
+      }
+      storage.writeToStorage('okr-hub/feature-delivery-config.json', body)
+      featureDeliveryCache = {}
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[okr-hub] feature-delivery-config save error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/feature-delivery:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Compute feature delivery accuracy from Jira
+   *     responses:
+   *       200:
+   *         description: Per-release committed vs delivered feature counts
+   */
+  router.get('/reports/feature-delivery', requireScope('okr-hub:read'), async function(req, res) {
+    try {
+      var config = storage.readFromStorage('okr-hub/feature-delivery-config.json')
+      if (!config || !Array.isArray(config.releases) || config.releases.length === 0) {
+        return res.json({ releases: [], summary: { committed: 0, delivered: 0, accuracy: 0 } })
+      }
+
+      var now = Date.now()
+      var totalCommitted = 0
+      var totalDelivered = 0
+      var releases = []
+
+      for (var ri = 0; ri < config.releases.length; ri++) {
+        var rel = config.releases[ri]
+        var products = []
+        var relCommitted = 0
+        var relDelivered = 0
+
+        for (var pi = 0; pi < (rel.products || []).length; pi++) {
+          var p = rel.products[pi]
+          if (!p.version) continue
+
+          var cacheKey = p.version + '|' + (p.freezeDate || '') + '|' + (p.releaseDate || '')
+          var cached = featureDeliveryCache[cacheKey]
+
+          if (cached && (now - cached.at) < FEATURE_DELIVERY_CACHE_TTL) {
+            products.push(cached.data)
+            relCommitted += cached.data.committed
+            relDelivered += cached.data.delivered
+            continue
+          }
+
+          var committed = 0
+          var delivered = 0
+
+          try {
+            if (p.freezeDate) {
+              var committedJql = 'issuetype = Feature AND cf[10855] = "' + p.version + '" AND created <= "' + p.freezeDate + '"'
+              var committedResults = await jira.fetchAllJqlResults(committedJql, 'summary')
+              committed = committedResults.length
+            } else {
+              var tvJql = 'issuetype = Feature AND cf[10855] = "' + p.version + '"'
+              var tvResults = await jira.fetchAllJqlResults(tvJql, 'summary')
+              committed = tvResults.length
+            }
+          } catch (jiraErr) {
+            console.warn('[okr-hub] feature-delivery committed query failed for ' + p.version + ':', jiraErr.message)
+          }
+
+          try {
+            var deliveredJql = 'issuetype = Feature AND fixVersion = "' + p.version + '"'
+            var deliveredResults = await jira.fetchAllJqlResults(deliveredJql, 'summary')
+            delivered = deliveredResults.length
+          } catch (jiraErr) {
+            console.warn('[okr-hub] feature-delivery delivered query failed for ' + p.version + ':', jiraErr.message)
+          }
+
+          var accuracy = committed > 0 ? Math.round((delivered / committed) * 100) : 0
+          var productData = {
+            version: p.version,
+            freezeDate: p.freezeDate || null,
+            releaseDate: p.releaseDate || null,
+            committed: committed,
+            delivered: delivered,
+            accuracy: accuracy
+          }
+
+          featureDeliveryCache[cacheKey] = { data: productData, at: now }
+          products.push(productData)
+          relCommitted += committed
+          relDelivered += delivered
+        }
+
+        var relAccuracy = relCommitted > 0 ? Math.round((relDelivered / relCommitted) * 100) : 0
+        releases.push({
+          name: rel.name,
+          products: products,
+          committed: relCommitted,
+          delivered: relDelivered,
+          accuracy: relAccuracy
+        })
+      }
+
+      totalCommitted = releases.reduce(function(s, r) { return s + r.committed }, 0)
+      totalDelivered = releases.reduce(function(s, r) { return s + r.delivered }, 0)
+      var overallAccuracy = totalCommitted > 0 ? Math.round((totalDelivered / totalCommitted) * 100) : 0
+
+      res.json({
+        releases: releases,
+        summary: { committed: totalCommitted, delivered: totalDelivered, accuracy: overallAccuracy }
+      })
+    } catch (err) {
+      console.error('[okr-hub] feature-delivery compute error:', err)
       res.status(500).json({ error: err.message })
     }
   })

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -643,6 +643,53 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/90day-tracking-config:
+   *   get:
+   *     tags: [OKR Hub]
+   *     summary: Get 90-day post-release tracking version configuration
+   *     responses:
+   *       200:
+   *         description: Version configuration per release family
+   */
+  router.get('/reports/90day-tracking-config', requireScope('okr-hub:read'), function(req, res) {
+    var saved = storage.readFromStorage('okr-hub/90day-tracking-config.json')
+    if (saved && Array.isArray(saved.releases)) {
+      return res.json(saved)
+    }
+    res.json({ releases: [] })
+  })
+
+  /**
+   * @openapi
+   * /api/modules/okr-hub/reports/90day-tracking-config:
+   *   put:
+   *     tags: [OKR Hub]
+   *     summary: Save 90-day post-release tracking version configuration
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema: { type: object }
+   *     responses:
+   *       200:
+   *         description: Saved
+   */
+  router.put('/reports/90day-tracking-config', requireScope('okr-hub:write'), function(req, res) {
+    try {
+      var body = req.body
+      if (!body || !Array.isArray(body.releases)) {
+        return res.status(400).json({ error: 'Invalid payload: requires releases array' })
+      }
+      storage.writeToStorage('okr-hub/90day-tracking-config.json', body)
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[okr-hub] 90day-tracking-config save error:', err)
+      res.status(500).json({ error: err.message })
+    }
+  })
+
   context.registerDiagnostics(async function() {
     return { status: 'ok' }
   })

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -2006,6 +2006,186 @@ module.exports = function registerRoutes(router, context) {
     }
   })
 
+  // Normalize product prefix: rhaiis/RHAIIS -> rhaii, preserve rhoai/rhelai/rhaii
+  function normalizeProduct(versionName) {
+    const lower = versionName.toLowerCase()
+    if (lower.startsWith('rhaiis-')) return 'rhaii'
+    const dashIdx = lower.indexOf('-')
+    return dashIdx > 0 ? lower.substring(0, dashIdx) : lower
+  }
+
+  function compute90DaySummary(configReleases, allBugs, storedVersions) {
+    const now = Date.now()
+    const MS_PER_DAY = 86400000
+    const TRACKING_DAYS = 90
+
+    // Build affected-version index for fast lookups
+    const bugsByVersion = {}
+    for (const bug of allBugs) {
+      if (!bug.affectedVersions) continue
+      for (const av of bug.affectedVersions) {
+        if (!bugsByVersion[av]) bugsByVersion[av] = []
+        bugsByVersion[av].push(bug)
+      }
+    }
+
+    if (configReleases && configReleases.length > 0) {
+      // Config-driven mode: use exact version names and GA dates from config
+      const releases = []
+      for (const rel of configReleases) {
+        const products = []
+        var familyTotal = 0
+        for (const p of (rel.products || [])) {
+          if (!p.name || !p.gaDate) continue
+          const relDate = new Date(p.gaDate + 'T00:00:00Z')
+          const daysSince = Math.floor((now - relDate.getTime()) / MS_PER_DAY)
+          const daysElapsed = Math.min(TRACKING_DAYS, Math.max(0, daysSince))
+          const isComplete = daysSince >= TRACKING_DAYS
+          const cutoff = new Date(relDate.getTime() + TRACKING_DAYS * MS_PER_DAY)
+
+          const vBugs = bugsByVersion[p.name] || []
+          var bugCount = 0
+          for (const bug of vBugs) {
+            const created = new Date(bug.created)
+            if (created >= relDate && created <= cutoff) bugCount++
+          }
+
+          familyTotal += bugCount
+          products.push({
+            name: p.name,
+            bugCount: bugCount,
+            daysElapsed: daysElapsed,
+            isComplete: isComplete,
+            releaseDate: p.gaDate
+          })
+        }
+        releases.push({ version: rel.version, products: products, total: familyTotal })
+      }
+      return releases
+    }
+
+    // Auto-detect mode: group from stored versions.json
+    const familyMap = {}
+    for (const v of storedVersions) {
+      if (!v.releaseDate) continue
+      const match = v.name.match(/-(\d+\.\d+)$/)
+      if (!match) continue
+      const familyNum = match[1]
+      if (parseFloat(familyNum) < 3.0) continue
+      const product = normalizeProduct(v.name)
+      const key = product + '-' + familyNum
+      if (!familyMap[familyNum]) familyMap[familyNum] = {}
+      if (!familyMap[familyNum][key]) {
+        familyMap[familyNum][key] = { product: product, familyNum: familyNum, rawVersions: [] }
+      }
+      familyMap[familyNum][key].rawVersions.push(v)
+    }
+
+    const releases = []
+    const familyKeys = Object.keys(familyMap).sort(function(a, b) {
+      return parseFloat(b) - parseFloat(a)
+    })
+
+    for (const familyNum of familyKeys) {
+      const productEntries = familyMap[familyNum]
+      const products = []
+      let familyTotal = 0
+
+      for (const key of Object.keys(productEntries)) {
+        const entry = productEntries[key]
+        let earliestDate = null
+        for (const v of entry.rawVersions) {
+          const d = new Date(v.releaseDate + 'T00:00:00Z')
+          if (!earliestDate || d < earliestDate) earliestDate = d
+        }
+
+        const daysSince = Math.floor((now - earliestDate.getTime()) / MS_PER_DAY)
+        const daysElapsed = Math.min(TRACKING_DAYS, Math.max(0, daysSince))
+        const isComplete = daysSince >= TRACKING_DAYS
+        const cutoff = new Date(earliestDate.getTime() + TRACKING_DAYS * MS_PER_DAY)
+
+        const seen = new Set()
+        let bugCount = 0
+        for (const v of entry.rawVersions) {
+          const vBugs = bugsByVersion[v.name] || []
+          for (const bug of vBugs) {
+            if (seen.has(bug.key)) continue
+            seen.add(bug.key)
+            const created = new Date(bug.created)
+            if (created >= earliestDate && created <= cutoff) bugCount++
+          }
+        }
+
+        familyTotal += bugCount
+        const displayName = entry.product + '-' + familyNum
+        products.push({
+          name: displayName,
+          bugCount: bugCount,
+          daysElapsed: daysElapsed,
+          isComplete: isComplete,
+          releaseDate: earliestDate.toISOString().split('T')[0]
+        })
+      }
+
+      products.sort(function(a, b) { return a.name.localeCompare(b.name) })
+      releases.push({ version: familyNum, products: products, total: familyTotal })
+    }
+
+    return releases
+  }
+
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/quality/90day-summary:
+   *   get:
+   *     tags: ['Releases: Quality']
+   *     summary: 90-day post-release bug summary grouped by release family (auto-detected)
+   *     responses:
+   *       200:
+   *         description: Bug counts per product within 90 days of GA for each major release
+   */
+  router.get('/quality/90day-summary', requireAuth, requireScope('releases:read'), function(req, res) {
+    try {
+      const config = getConfig(readFromStorage)
+      const versions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const allBugs = loadAllBugs(config.projectKeys)
+      const releases = compute90DaySummary(null, allBugs, versions)
+      res.json({ releases: releases })
+    } catch (error) {
+      console.error('[releases/quality] 90day-summary error:', error)
+      res.status(500).json({ error: error.message })
+    }
+  })
+
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/quality/90day-summary:
+   *   post:
+   *     tags: ['Releases: Quality']
+   *     summary: 90-day post-release bug summary with custom version overrides
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema: { type: object }
+   *     responses:
+   *       200:
+   *         description: Bug counts per product within 90 days of GA using provided config
+   */
+  router.post('/quality/90day-summary', requireAuth, requireScope('releases:read'), function(req, res) {
+    try {
+      const config = getConfig(readFromStorage)
+      const versions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const allBugs = loadAllBugs(config.projectKeys)
+      const configReleases = req.body && req.body.releases ? req.body.releases : null
+      const releases = compute90DaySummary(configReleases, allBugs, versions)
+      res.json({ releases: releases })
+    } catch (error) {
+      console.error('[releases/quality] 90day-summary error:', error)
+      res.status(500).json({ error: error.message })
+    }
+  })
+
   /**
    * @openapi
    * /api/modules/releases/delivery/discover-releases:


### PR DESCRIPTION
## Summary

- **90-Day Post-Release Bug Tracking**: Configurable section in Post-Release Defects report to track bug counts within 90 days of GA for major releases, with gear icon settings for product versions and GA dates
- **Quarter ordering in reports**: On Time Releases, CVE SLA Compliance, Technical Visibility, and Support Case Time to Resolution reports now show the current/most recent quarter with data first
- **Feature Delivery Accuracy report**: New report tracking committed (Target Version before planning freeze) vs delivered (Fix Version) features per release with live Jira queries, 10-min caching, configurable releases/versions via gear icon, and per-release accuracy breakdowns

## Test plan

- [ ] Verify 90-day tracking section loads in Post-Release Defects report and gear icon config saves/loads
- [ ] Confirm quarter ordering shows current quarter first across all four updated reports
- [ ] Open Feature Delivery Accuracy report — should show empty state with gear icon for admins
- [ ] Configure a release with product versions, freeze dates, and release dates via settings panel
- [ ] Verify committed/delivered counts populate from Jira after save
- [ ] Check accuracy percentages and color-coded badges render correctly
- [ ] Validate module manifests pass (`npm run validate:modules`)
- [ ] Confirm lint passes (`npm run lint`)


Made with [Cursor](https://cursor.com)