### PR TITLE
feat(releases): add refresh button and auto-refresh to PM Hub

### DIFF
--- a/modules/releases/__tests__/client/plan/pm-hub-refresh-cadence.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-refresh-cadence.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests for PM Hub refresh cadence logic.
+ *
+ * Covers:
+ * - Auto-refresh timer setup and cleanup
+ * - Visibility-based skip logic
+ * - startAutoRefresh / stopAutoRefresh lifecycle
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Inlined from ComponentReleaseLoadReport.vue
+// ---------------------------------------------------------------------------
+
+var AUTO_REFRESH_MS = 5 * 60 * 1000
+
+function createRefreshManager() {
+  var timer = null
+  var hasFetched = false
+  var loadingData = false
+  var loadDataCalls = 0
+  var visibilityState = 'visible'
+
+  function loadData() {
+    loadDataCalls++
+  }
+
+  function stopAutoRefresh() {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  function startAutoRefresh() {
+    stopAutoRefresh()
+    timer = setInterval(function () {
+      if (!hasFetched || loadingData) return
+      if (visibilityState !== 'visible') return
+      loadData()
+    }, AUTO_REFRESH_MS)
+  }
+
+  return {
+    get timer() { return timer },
+    set timer(v) { timer = v },
+    get hasFetched() { return hasFetched },
+    set hasFetched(v) { hasFetched = v },
+    get loadingData() { return loadingData },
+    set loadingData(v) { loadingData = v },
+    get loadDataCalls() { return loadDataCalls },
+    get visibilityState() { return visibilityState },
+    set visibilityState(v) { visibilityState = v },
+    startAutoRefresh: startAutoRefresh,
+    stopAutoRefresh: stopAutoRefresh,
+    loadData: loadData
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AUTO_REFRESH_MS constant', function () {
+  it('equals 5 minutes in milliseconds', function () {
+    expect(AUTO_REFRESH_MS).toBe(300000)
+  })
+})
+
+describe('auto-refresh timer lifecycle', function () {
+  beforeEach(function () {
+    vi.useFakeTimers()
+  })
+
+  afterEach(function () {
+    vi.useRealTimers()
+  })
+
+  it('startAutoRefresh creates an interval timer', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.startAutoRefresh()
+    expect(mgr.timer).not.toBeNull()
+    mgr.stopAutoRefresh()
+  })
+
+  it('stopAutoRefresh clears the timer', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.startAutoRefresh()
+    expect(mgr.timer).not.toBeNull()
+    mgr.stopAutoRefresh()
+    expect(mgr.timer).toBeNull()
+  })
+
+  it('stopAutoRefresh is safe to call when no timer exists', function () {
+    var mgr = createRefreshManager()
+    expect(function () { mgr.stopAutoRefresh() }).not.toThrow()
+    expect(mgr.timer).toBeNull()
+  })
+
+  it('startAutoRefresh replaces existing timer', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.startAutoRefresh()
+    var firstTimer = mgr.timer
+    mgr.startAutoRefresh()
+    expect(mgr.timer).not.toBeNull()
+    expect(mgr.timer).not.toBe(firstTimer)
+    mgr.stopAutoRefresh()
+  })
+
+  it('calls loadData after AUTO_REFRESH_MS when conditions are met', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.visibilityState = 'visible'
+    mgr.startAutoRefresh()
+
+    expect(mgr.loadDataCalls).toBe(0)
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(1)
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(2)
+
+    mgr.stopAutoRefresh()
+  })
+
+  it('does not call loadData before AUTO_REFRESH_MS elapses', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.visibilityState = 'visible'
+    mgr.startAutoRefresh()
+
+    vi.advanceTimersByTime(AUTO_REFRESH_MS - 1)
+    expect(mgr.loadDataCalls).toBe(0)
+
+    mgr.stopAutoRefresh()
+  })
+
+  it('skips refresh when hasFetched is false', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = false
+    mgr.visibilityState = 'visible'
+    mgr.startAutoRefresh()
+
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(0)
+
+    mgr.stopAutoRefresh()
+  })
+
+  it('skips refresh when loadingData is true', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.loadingData = true
+    mgr.visibilityState = 'visible'
+    mgr.startAutoRefresh()
+
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(0)
+
+    mgr.stopAutoRefresh()
+  })
+
+  it('skips refresh when tab is not visible', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.visibilityState = 'hidden'
+    mgr.startAutoRefresh()
+
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(0)
+
+    mgr.stopAutoRefresh()
+  })
+
+  it('resumes refresh when tab becomes visible again', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.visibilityState = 'hidden'
+    mgr.startAutoRefresh()
+
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(0)
+
+    mgr.visibilityState = 'visible'
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(1)
+
+    mgr.stopAutoRefresh()
+  })
+
+  it('does not call loadData after stopAutoRefresh', function () {
+    var mgr = createRefreshManager()
+    mgr.hasFetched = true
+    mgr.visibilityState = 'visible'
+    mgr.startAutoRefresh()
+
+    vi.advanceTimersByTime(AUTO_REFRESH_MS)
+    expect(mgr.loadDataCalls).toBe(1)
+
+    mgr.stopAutoRefresh()
+    vi.advanceTimersByTime(AUTO_REFRESH_MS * 5)
+    expect(mgr.loadDataCalls).toBe(1)
+  })
+})

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -6,8 +6,10 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Track component workload distribution across releases.
         </p>
-        <p v-if="formattedFetchedAt" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5" :title="'Data fetched from Jira at ' + fetchedAt">
+        <p v-if="formattedFetchedAt" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5" :title="'Live data — fetched from Jira each time you load or refresh. Last fetched: ' + fetchedAt">
           Data from {{ formattedFetchedAt }}
+          <span class="text-gray-300 dark:text-gray-600 mx-0.5">&middot;</span>
+          <span class="text-[10px]">auto-refreshes every 5 min</span>
         </p>
       </div>
       <div class="flex items-center gap-2">
@@ -31,6 +33,22 @@
           @click="handleCollapseAll"
           class="px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
         >Collapse All</button>
+        <button
+          v-if="hasFetched"
+          @click="loadData()"
+          :disabled="loadingData"
+          class="px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors"
+          :class="loadingData
+            ? 'text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 cursor-not-allowed'
+            : 'text-white bg-primary-600 hover:bg-primary-700 border border-primary-600 hover:border-primary-700'"
+          title="Re-fetch data from Jira"
+        >
+          <span v-if="loadingData" class="inline-flex items-center gap-1">
+            <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" /><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+            Refreshing…
+          </span>
+          <span v-else>Refresh</span>
+        </button>
       </div>
     </div>
 
@@ -367,6 +385,7 @@ import PillarConfigPanel from '../components/PillarConfigPanel.vue'
 
 const API_BASE = '/modules/releases/pm-hub'
 var STORAGE_KEY = 'pm-hub-filters'
+var AUTO_REFRESH_MS = 5 * 60 * 1000
 
 var selectedPillars = ref([])
 var selectedComponents = ref([])
@@ -400,6 +419,7 @@ var dataError = ref(null)
 var hasFetched = ref(false)
 var tableRef = ref(null)
 var fetchedAt = ref(null)
+var autoRefreshTimer = ref(null)
 
 var filterProduct = ref([])
 var filterType = ref([])
@@ -990,6 +1010,22 @@ function getEffectiveComponents() {
   return []
 }
 
+function stopAutoRefresh() {
+  if (autoRefreshTimer.value) {
+    clearInterval(autoRefreshTimer.value)
+    autoRefreshTimer.value = null
+  }
+}
+
+function startAutoRefresh() {
+  stopAutoRefresh()
+  autoRefreshTimer.value = setInterval(function() {
+    if (!hasFetched.value || loadingData.value) return
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+    loadData()
+  }, AUTO_REFRESH_MS)
+}
+
 async function loadData() {
   var effectiveComponents = getEffectiveComponents()
   if (effectiveComponents.length === 0 && selectedVersions.value.length === 0) return
@@ -1020,6 +1056,7 @@ async function loadData() {
     fetchedAt.value = null
   } finally {
     loadingData.value = false
+    if (hasFetched.value && !autoRefreshTimer.value) startAutoRefresh()
   }
 }
 
@@ -1056,5 +1093,6 @@ onMounted(function() {
 
 onBeforeUnmount(function() {
   document.removeEventListener('mousedown', handleClickOutside)
+  stopAutoRefresh()
 })
 </script>


### PR DESCRIPTION
## Summary

Surfaces the PM Hub data refresh cadence so PMs know how fresh their data is and can control it:

- **Refresh button**: Primary-colored button in the header bar (appears after first data load) re-fetches live Jira data on demand. Shows spinner while loading.
- **Auto-refresh**: 5-minute interval timer that fires only when the tab is visible and no fetch is in progress. Starts automatically after the first successful data load. Cleaned up on component unmount.
- **Enhanced tooltip**: "Data from" label now explains that data is fetched live from Jira on each load or refresh, and notes the 5-minute auto-refresh cadence.

## Changes

| File | Change |
|------|--------|
| `modules/releases/client/plan/views/ComponentReleaseLoadReport.vue` | Add Refresh button, auto-refresh timer (start/stop/visibility check), enhanced "Data from" tooltip |
| `modules/releases/__tests__/client/plan/pm-hub-refresh-cadence.test.js` | 12 tests for timer lifecycle, visibility skip, loading guard, cleanup |

## How it works

PM Hub fetches **live from Jira** on every API call — there is no server-side cache. The auto-refresh simply re-calls `loadData()` every 5 minutes with two guards:
- **Visibility**: skips if the browser tab is not visible (`document.visibilityState !== 'visible'`)
- **Loading**: skips if a fetch is already in progress (`loadingData` is true)

## Test Results

- [x] ESLint clean
- [x] 12 new tests pass (pm-hub-refresh-cadence.test.js)
- [x] 2644 releases module tests pass, zero regressions

## Items Addressed

- C1 from AIPCC-18735: Surface refresh cadence — document and communicate when data auto-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)