### PR TITLE
feat(pm-hub): add docs commitment column and filter (D6)

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
@@ -63,12 +63,12 @@ function mountTable(props) {
 
 describe('ComponentReleaseLoadTable sorting (component)', function () {
   describe('header rendering', function () {
-    it('renders 12 sortable th elements when a component is expanded', async function () {
+    it('renders 13 sortable th elements when a component is expanded', async function () {
       var wrapper = mountTable()
       var groupHeader = wrapper.find('tr.cursor-pointer')
       await groupHeader.trigger('click')
       var ths = wrapper.findAll('th')
-      expect(ths.length).toBe(12)
+      expect(ths.length).toBe(13)
     })
 
     it('all headers have cursor-pointer class', async function () {

--- a/modules/releases/__tests__/client/plan/pm-hub-docs-filter.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-docs-filter.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests for PM Hub docs commitment column (D6).
+ *
+ * Covers:
+ * - docsRequired sort ordering
+ * - docsRequired filter logic (Yes / No / Not set)
+ * - docsRequired count helpers
+ */
+import { describe, it, expect } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Inlined from ComponentReleaseLoadTable.vue
+// ---------------------------------------------------------------------------
+
+function getDocsSortValue(feature) {
+  return feature.docsRequired === 'Yes' ? 0 : 1
+}
+
+// ---------------------------------------------------------------------------
+// Inlined from ComponentReleaseLoadReport.vue
+// ---------------------------------------------------------------------------
+
+function filterByDocs(features, filterDocs) {
+  if (filterDocs.length === 0) return features
+  return features.filter(function(f) {
+    var docVal = f.docsRequired || ''
+    for (var di = 0; di < filterDocs.length; di++) {
+      if (filterDocs[di] === 'Yes' && docVal === 'Yes') return true
+      if (filterDocs[di] === 'No' && docVal === 'No') return true
+      if (filterDocs[di] === 'Not set' && !docVal) return true
+    }
+    return false
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Test data factory
+// ---------------------------------------------------------------------------
+
+function makeFeature(overrides) {
+  return Object.assign({
+    key: 'RHAIENG-1',
+    summary: 'Test feature',
+    status: 'In Progress',
+    colorStatus: 'Green',
+    releaseType: 'Feature',
+    priority: 'Major',
+    isBlocked: false,
+    components: ['Dashboard'],
+    fixVersions: ['rhoai-3.5'],
+    targetVersions: ['rhoai-3.5'],
+    riskLevel: 'low',
+    assignee: 'Alice',
+    pmOwner: 'Bob',
+    docsRequired: null
+  }, overrides)
+}
+
+// ---------------------------------------------------------------------------
+// Docs sort ordering
+// ---------------------------------------------------------------------------
+
+describe('docs column sort ordering', function() {
+  it('sorts "Yes" (0) before null/other (1)', function() {
+    expect(getDocsSortValue({ docsRequired: 'Yes' })).toBe(0)
+    expect(getDocsSortValue({ docsRequired: null })).toBe(1)
+    expect(getDocsSortValue({ docsRequired: 'No' })).toBe(1)
+    expect(getDocsSortValue({})).toBe(1)
+  })
+
+  it('returns 0 only for exact "Yes" string', function() {
+    expect(getDocsSortValue({ docsRequired: 'Yes' })).toBe(0)
+    expect(getDocsSortValue({ docsRequired: 'yes' })).toBe(1)
+    expect(getDocsSortValue({ docsRequired: 'YES' })).toBe(1)
+  })
+
+  it('sorts a mixed list correctly', function() {
+    var features = [
+      makeFeature({ key: 'X-1', docsRequired: null }),
+      makeFeature({ key: 'X-2', docsRequired: 'Yes' }),
+      makeFeature({ key: 'X-3', docsRequired: 'No' }),
+      makeFeature({ key: 'X-4', docsRequired: 'Yes' })
+    ]
+    var sorted = features.slice().sort(function(a, b) {
+      return getDocsSortValue(a) - getDocsSortValue(b)
+    })
+    expect(sorted[0].key).toBe('X-2')
+    expect(sorted[1].key).toBe('X-4')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Docs filter logic
+// ---------------------------------------------------------------------------
+
+describe('docs filter logic', function() {
+  var features = [
+    makeFeature({ key: 'X-1', docsRequired: 'Yes' }),
+    makeFeature({ key: 'X-2', docsRequired: 'No' }),
+    makeFeature({ key: 'X-3', docsRequired: null }),
+    makeFeature({ key: 'X-4', docsRequired: 'Yes' }),
+    makeFeature({ key: 'X-5', docsRequired: '' })
+  ]
+
+  it('returns all features when filter is empty', function() {
+    var result = filterByDocs(features, [])
+    expect(result.length).toBe(5)
+  })
+
+  it('filters to Yes only', function() {
+    var result = filterByDocs(features, ['Yes'])
+    expect(result.length).toBe(2)
+    expect(result[0].key).toBe('X-1')
+    expect(result[1].key).toBe('X-4')
+  })
+
+  it('filters to No only', function() {
+    var result = filterByDocs(features, ['No'])
+    expect(result.length).toBe(1)
+    expect(result[0].key).toBe('X-2')
+  })
+
+  it('filters to Not set only (null and empty string)', function() {
+    var result = filterByDocs(features, ['Not set'])
+    expect(result.length).toBe(2)
+    expect(result[0].key).toBe('X-3')
+    expect(result[1].key).toBe('X-5')
+  })
+
+  it('filters to Yes + Not set (multi-select)', function() {
+    var result = filterByDocs(features, ['Yes', 'Not set'])
+    expect(result.length).toBe(4)
+  })
+
+  it('filters to Yes + No (multi-select)', function() {
+    var result = filterByDocs(features, ['Yes', 'No'])
+    expect(result.length).toBe(3)
+  })
+
+  it('filters to all three values returns everything', function() {
+    var result = filterByDocs(features, ['Yes', 'No', 'Not set'])
+    expect(result.length).toBe(5)
+  })
+
+  it('returns empty array when no features match', function() {
+    var noDocsFeatures = [
+      makeFeature({ key: 'X-1', docsRequired: 'Yes' })
+    ]
+    var result = filterByDocs(noDocsFeatures, ['No'])
+    expect(result.length).toBe(0)
+  })
+
+  it('handles empty feature array', function() {
+    var result = filterByDocs([], ['Yes'])
+    expect(result.length).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildFeatureObj docsRequired passthrough
+// ---------------------------------------------------------------------------
+
+describe('buildFeatureObj includes docsRequired', function() {
+  function buildFeatureObj(f, targetVersions) {
+    var tv = targetVersions || []
+    return {
+      key: f.key,
+      summary: f.summary || '',
+      status: f.status || null,
+      statusCategory: f.statusCategory || null,
+      colorStatus: f.colorStatus || null,
+      statusSummary: f.statusSummary || null,
+      releaseType: f.releaseType || null,
+      priority: f.priority || null,
+      isBlocked: f.isBlocked || false,
+      blockedBy: f.blockedBy || [],
+      components: f.components || [],
+      fixVersions: f.fixVersions || [],
+      targetVersions: tv,
+      riskLevel: 'low',
+      assignee: f.assignee || null,
+      pmOwner: f.pmOwner || null,
+      docsRequired: f.docsRequired || null
+    }
+  }
+
+  it('passes through docsRequired "Yes"', function() {
+    var result = buildFeatureObj({ key: 'X-1', docsRequired: 'Yes' }, [])
+    expect(result.docsRequired).toBe('Yes')
+  })
+
+  it('passes through docsRequired "No"', function() {
+    var result = buildFeatureObj({ key: 'X-1', docsRequired: 'No' }, [])
+    expect(result.docsRequired).toBe('No')
+  })
+
+  it('defaults docsRequired to null when missing', function() {
+    var result = buildFeatureObj({ key: 'X-1' }, [])
+    expect(result.docsRequired).toBeNull()
+  })
+
+  it('defaults docsRequired to null for empty string', function() {
+    var result = buildFeatureObj({ key: 'X-1', docsRequired: '' }, [])
+    expect(result.docsRequired).toBeNull()
+  })
+})

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -30,7 +30,7 @@ var expandedComponents = reactive({})
 
 // ═══ SORT STATE ═══
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'riskLevel', 'assignee', 'pmOwner']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'riskLevel', 'assignee', 'pmOwner', 'docs']
 
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
@@ -83,6 +83,7 @@ function getSortValue(feature, column) {
   }
   if (column === 'assignee') return (feature.assignee || '').toLowerCase()
   if (column === 'pmOwner') return (feature.pmOwner || '').toLowerCase()
+  if (column === 'docs') return feature.docsRequired === 'Yes' ? 0 : 1
   return ''
 }
 
@@ -220,6 +221,7 @@ var componentGroups = computed(function() {
             targetVersions: feat.targetVersions || [],
             assignee: feat.assignee,
             pmOwner: feat.pmOwner,
+            docsRequired: feat.docsRequired || null,
             products: [],
             versions: [],
             isRequested: false,
@@ -308,7 +310,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="12" class="px-4 py-3">
+            <td colspan="13" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -406,6 +408,9 @@ defineExpose({ expandAll, collapseAll })
             </th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('pmOwner')">
               <span class="inline-flex items-center gap-1">PM Owner<SortArrow :direction="sortIcon('pmOwner')" /></span>
+            </th>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('docs')">
+              <span class="inline-flex items-center gap-1 justify-center">Docs<SortArrow :direction="sortIcon('docs')" /></span>
             </th>
           </tr>
 
@@ -514,12 +519,22 @@ defineExpose({ expandAll, collapseAll })
               <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
                 {{ feature.pmOwner || '--' }}
               </td>
+              <td class="px-3 py-2.5 text-center">
+                <span
+                  v-if="feature.docsRequired === 'Yes'"
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
+                >Yes</span>
+                <span
+                  v-else
+                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500"
+                >{{ feature.docsRequired || '—' }}</span>
+              </td>
             </tr>
           </template>
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="12" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="13" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -527,7 +542,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="12" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="13" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -206,6 +206,18 @@
           {{ filterBlocked === true ? 'Blocked' : filterBlocked === false ? 'Not Blocked' : 'Blocked' }}
         </button>
 
+        <!-- Docs Required -->
+        <div class="inline-flex items-center rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 overflow-hidden">
+          <button
+            v-for="dv in ['Yes', 'No', 'Not set']"
+            :key="dv"
+            type="button"
+            @click="toggleFilter('filterDocs', dv)"
+            class="px-2.5 py-1 text-[11px] font-medium transition-colors"
+            :class="filterDocs.includes(dv) ? 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'"
+          >{{ dv === 'Not set' ? 'Docs ?' : 'Docs ' + dv }}</button>
+        </div>
+
         <!-- Delivery Owner -->
         <div class="relative" ref="delOwnerDropdownRef">
           <button
@@ -408,6 +420,7 @@ var filterStatus = ref([])
 var filterBlocked = ref(null)
 var filterDelOwner = ref([])
 var filterPmOwner = ref([])
+var filterDocs = ref([])
 
 var productDropdownOpen = ref(false)
 var productDropdownRef = ref(null)
@@ -439,6 +452,7 @@ function saveFilters() {
       blocked: filterBlocked.value,
       delOwner: filterDelOwner.value,
       pmOwner: filterPmOwner.value,
+      docs: filterDocs.value,
       sort: savedSort.value
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
@@ -460,6 +474,7 @@ function restoreFilters() {
     if (state.blocked !== undefined) filterBlocked.value = state.blocked
     if (state.delOwner && Array.isArray(state.delOwner)) filterDelOwner.value = state.delOwner
     if (state.pmOwner && Array.isArray(state.pmOwner)) filterPmOwner.value = state.pmOwner
+    if (state.docs && Array.isArray(state.docs)) filterDocs.value = state.docs
     if (state.sort && typeof state.sort === 'object') savedSort.value = state.sort
     return true
   } catch { return false }
@@ -483,7 +498,8 @@ var filterRefs = {
   filterReleaseType: filterReleaseType,
   filterStatus: filterStatus,
   filterDelOwner: filterDelOwner,
-  filterPmOwner: filterPmOwner
+  filterPmOwner: filterPmOwner,
+  filterDocs: filterDocs
 }
 
 function toggleFilter(filterName, value) {
@@ -503,7 +519,7 @@ function toggleInArray(arrRef, value) {
 var activeFilterCount = computed(function() {
   var count = selectedPillars.value.length + selectedComponents.value.length + selectedVersions.value.length
   count += filterProduct.value.length + filterType.value.length + filterReleaseType.value.length
-  count += filterStatus.value.length + filterDelOwner.value.length + filterPmOwner.value.length
+  count += filterStatus.value.length + filterDelOwner.value.length + filterPmOwner.value.length + filterDocs.value.length
   if (filterBlocked.value !== null) count++
   return count
 })
@@ -522,6 +538,7 @@ function clearAllFilters() {
   filterBlocked.value = null
   filterDelOwner.value = []
   filterPmOwner.value = []
+  filterDocs.value = []
   savedSort.value = { column: null, direction: 'asc' }
   try { localStorage.removeItem(STORAGE_KEY) } catch (e) { void e }
 }
@@ -603,7 +620,7 @@ var filteredPmOwners = computed(function() {
 })
 
 var hasClientFilters = computed(function() {
-  return filterProduct.value.length > 0 || filterType.value.length > 0 || filterReleaseType.value.length > 0 || filterStatus.value.length > 0 || filterBlocked.value !== null || filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0
+  return filterProduct.value.length > 0 || filterType.value.length > 0 || filterReleaseType.value.length > 0 || filterStatus.value.length > 0 || filterBlocked.value !== null || filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0 || filterDocs.value.length > 0
 })
 
 var clientFilteredGroups = computed(function() {
@@ -661,6 +678,16 @@ var clientFilteredGroups = computed(function() {
         if (filterBlocked.value === false && f.isBlocked) return false
         if (filterDelOwner.value.length > 0 && filterDelOwner.value.indexOf(f.assignee || '') === -1) return false
         if (filterPmOwner.value.length > 0 && filterPmOwner.value.indexOf(f.pmOwner || '') === -1) return false
+        if (filterDocs.value.length > 0) {
+          var docVal = f.docsRequired || ''
+          var docsMatch = false
+          for (var di = 0; di < filterDocs.value.length; di++) {
+            if (filterDocs.value[di] === 'Yes' && docVal === 'Yes') docsMatch = true
+            if (filterDocs.value[di] === 'No' && docVal === 'No') docsMatch = true
+            if (filterDocs.value[di] === 'Not set' && !docVal) docsMatch = true
+          }
+          if (!docsMatch) return false
+        }
         return true
       })
 
@@ -1042,7 +1069,7 @@ watch([selectedComponents, selectedVersions, selectedPillars], function() {
 
 // Save filters to localStorage on any filter change
 watch(
-  [selectedPillars, selectedComponents, selectedVersions, filterProduct, filterType, filterReleaseType, filterStatus, filterBlocked, filterDelOwner, filterPmOwner],
+  [selectedPillars, selectedComponents, selectedVersions, filterProduct, filterType, filterReleaseType, filterStatus, filterBlocked, filterDelOwner, filterPmOwner, filterDocs],
   saveFilters,
   { deep: true }
 )

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -374,7 +374,8 @@ const FIELDS_TO_FETCH = [
   CUSTOM_FIELDS.releaseType,
   CUSTOM_FIELDS.statusSummary,
   CUSTOM_FIELDS.colorStatus,
-  CUSTOM_FIELDS.productManager
+  CUSTOM_FIELDS.productManager,
+  CUSTOM_FIELDS.docsRequired
 ].join(',')
 
 function computeRiskLevel(f, targetVersions) {
@@ -406,7 +407,8 @@ function buildFeatureObj(f, targetVersions) {
     targetVersions: tv,
     riskLevel: computeRiskLevel(f, tv),
     assignee: f.assignee || null,
-    pmOwner: f.pmOwner || null
+    pmOwner: f.pmOwner || null,
+    docsRequired: f.docsRequired || null
   }
 }
 


### PR DESCRIPTION
## Summary

Surfaces the `docsRequired` Jira field (customfield_10665) in PM Hub so PMs can see and filter by documentation commitment per feature.

- **Server**: Added `docsRequired` to `FIELDS_TO_FETCH` and `buildFeatureObj()` in `routes.js` — the field was already fetched from Jira by `jira-fetch.js` but not passed through PM Hub's API response
- **Table column**: New "Docs" column (13th) with green "Yes" badge or gray "No"/"—" badge, sortable (Yes sorts first)
- **Filter**: Tri-state button group filter (Docs Yes / Docs No / Docs ?) with localStorage persistence, integrated into active filter count and Clear All

Part of [AIPCC-18735](https://redhat.atlassian.net/browse/AIPCC-18735) — Org Pulse Tool Improvements (D6: docs commitment view).

## Test plan

- [x] ESLint passes on all 5 modified/new files
- [x] All 656 releases module tests pass (27 test files, 0 failures)
- [x] New test file: `pm-hub-docs-filter.test.js` — 16 tests covering sort ordering, filter logic (Yes/No/Not set, multi-select), and buildFeatureObj passthrough
- [x] Updated `component-release-load-table-sort.test.js` — column count 12→13
- [ ] Verify Docs column renders in browser with live Jira data
- [ ] Verify Docs filter toggles work and persist across page reloads
- [ ] Verify sort on Docs column works (Yes first ascending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)