### PR TITLE
feat(big-rocks): group features by outcome with collapsible sections

### DIFF
--- a/modules/releases/__tests__/client/plan/big-rock-outcome-grouping.test.js
+++ b/modules/releases/__tests__/client/plan/big-rock-outcome-grouping.test.js
@@ -1,0 +1,197 @@
+/**
+ * Tests for Big Rock outcome grouping logic.
+ *
+ * Covers:
+ * - featuresByOutcome grouping (features split by parentKey)
+ * - Unlinked features collected under "Other"
+ * - Empty outcomes shown with zero count
+ * - parentKey passthrough in mapToCandidate
+ */
+import { describe, it, expect } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Inlined from BigRockExpandedRow.vue
+// ---------------------------------------------------------------------------
+
+function groupFeaturesByOutcome(features, outcomeKeys, outcomeDescriptions) {
+  if (!outcomeKeys || outcomeKeys.length === 0) return []
+  var groups = []
+  var used = {}
+  for (var oi = 0; oi < outcomeKeys.length; oi++) {
+    var oKey = outcomeKeys[oi]
+    var feats = []
+    for (var fi = 0; fi < features.length; fi++) {
+      var f = features[fi]
+      if (f.parentKey === oKey) {
+        feats.push(f)
+        used[f.key] = true
+      }
+    }
+    groups.push({
+      key: oKey,
+      description: (outcomeDescriptions && outcomeDescriptions[oKey]) || '',
+      features: feats
+    })
+  }
+  var other = []
+  for (var ui = 0; ui < features.length; ui++) {
+    if (!used[features[ui].key]) {
+      other.push(features[ui])
+    }
+  }
+  if (other.length > 0) {
+    groups.push({
+      key: '_other',
+      description: 'Other features',
+      features: other
+    })
+  }
+  return groups
+}
+
+// ---------------------------------------------------------------------------
+// Inlined from cache-reader.js mapToCandidate
+// ---------------------------------------------------------------------------
+
+function extractParentKey(item) {
+  return item.parentKey || (item._indexEntry && item._indexEntry.parentKey) || ''
+}
+
+// ---------------------------------------------------------------------------
+// Test data factory
+// ---------------------------------------------------------------------------
+
+function makeFeature(overrides) {
+  return Object.assign({
+    key: 'RHAIENG-1',
+    parentKey: '',
+    level: 'green',
+    summary: 'Test feature',
+    status: 'In Progress',
+    deliveryOwner: 'Alice',
+    bigRock: 'Rock 1'
+  }, overrides)
+}
+
+// ---------------------------------------------------------------------------
+// Outcome grouping
+// ---------------------------------------------------------------------------
+
+describe('groupFeaturesByOutcome', function() {
+  it('groups features under their parent outcome', function() {
+    var features = [
+      makeFeature({ key: 'F-1', parentKey: 'RHAISTRAT-100' }),
+      makeFeature({ key: 'F-2', parentKey: 'RHAISTRAT-200' }),
+      makeFeature({ key: 'F-3', parentKey: 'RHAISTRAT-100' })
+    ]
+    var outcomeKeys = ['RHAISTRAT-100', 'RHAISTRAT-200']
+    var descriptions = { 'RHAISTRAT-100': 'Improve throughput', 'RHAISTRAT-200': 'Reduce latency' }
+    var groups = groupFeaturesByOutcome(features, outcomeKeys, descriptions)
+
+    expect(groups.length).toBe(2)
+    expect(groups[0].key).toBe('RHAISTRAT-100')
+    expect(groups[0].features.length).toBe(2)
+    expect(groups[0].description).toBe('Improve throughput')
+    expect(groups[1].key).toBe('RHAISTRAT-200')
+    expect(groups[1].features.length).toBe(1)
+    expect(groups[1].description).toBe('Reduce latency')
+  })
+
+  it('puts unlinked features in _other group', function() {
+    var features = [
+      makeFeature({ key: 'F-1', parentKey: 'RHAISTRAT-100' }),
+      makeFeature({ key: 'F-2', parentKey: '' }),
+      makeFeature({ key: 'F-3', parentKey: 'UNKNOWN-999' })
+    ]
+    var outcomeKeys = ['RHAISTRAT-100']
+    var groups = groupFeaturesByOutcome(features, outcomeKeys, {})
+
+    expect(groups.length).toBe(2)
+    expect(groups[0].key).toBe('RHAISTRAT-100')
+    expect(groups[0].features.length).toBe(1)
+    expect(groups[1].key).toBe('_other')
+    expect(groups[1].features.length).toBe(2)
+  })
+
+  it('shows outcomes with zero features', function() {
+    var features = [
+      makeFeature({ key: 'F-1', parentKey: 'RHAISTRAT-100' })
+    ]
+    var outcomeKeys = ['RHAISTRAT-100', 'RHAISTRAT-200']
+    var groups = groupFeaturesByOutcome(features, outcomeKeys, {})
+
+    expect(groups.length).toBe(2)
+    expect(groups[0].features.length).toBe(1)
+    expect(groups[1].key).toBe('RHAISTRAT-200')
+    expect(groups[1].features.length).toBe(0)
+  })
+
+  it('no _other group when all features are linked', function() {
+    var features = [
+      makeFeature({ key: 'F-1', parentKey: 'RHAISTRAT-100' })
+    ]
+    var outcomeKeys = ['RHAISTRAT-100']
+    var groups = groupFeaturesByOutcome(features, outcomeKeys, {})
+
+    expect(groups.length).toBe(1)
+    expect(groups[0].key).toBe('RHAISTRAT-100')
+  })
+
+  it('returns empty array when no outcome keys', function() {
+    var features = [makeFeature({ key: 'F-1' })]
+    expect(groupFeaturesByOutcome(features, [], {})).toEqual([])
+    expect(groupFeaturesByOutcome(features, null, {})).toEqual([])
+  })
+
+  it('handles empty features array', function() {
+    var outcomeKeys = ['RHAISTRAT-100']
+    var groups = groupFeaturesByOutcome([], outcomeKeys, {})
+
+    expect(groups.length).toBe(1)
+    expect(groups[0].features.length).toBe(0)
+  })
+
+  it('preserves outcome key order', function() {
+    var features = [
+      makeFeature({ key: 'F-1', parentKey: 'RHAISTRAT-300' }),
+      makeFeature({ key: 'F-2', parentKey: 'RHAISTRAT-100' })
+    ]
+    var outcomeKeys = ['RHAISTRAT-300', 'RHAISTRAT-100', 'RHAISTRAT-200']
+    var groups = groupFeaturesByOutcome(features, outcomeKeys, {})
+
+    expect(groups[0].key).toBe('RHAISTRAT-300')
+    expect(groups[1].key).toBe('RHAISTRAT-100')
+    expect(groups[2].key).toBe('RHAISTRAT-200')
+  })
+
+  it('handles missing descriptions gracefully', function() {
+    var features = [makeFeature({ key: 'F-1', parentKey: 'RHAISTRAT-100' })]
+    var outcomeKeys = ['RHAISTRAT-100']
+    var groups = groupFeaturesByOutcome(features, outcomeKeys, undefined)
+
+    expect(groups[0].description).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parentKey extraction (mapToCandidate logic)
+// ---------------------------------------------------------------------------
+
+describe('extractParentKey', function() {
+  it('returns parentKey directly from item', function() {
+    expect(extractParentKey({ parentKey: 'RHAISTRAT-100' })).toBe('RHAISTRAT-100')
+  })
+
+  it('falls back to _indexEntry.parentKey', function() {
+    expect(extractParentKey({ _indexEntry: { parentKey: 'RHAISTRAT-200' } })).toBe('RHAISTRAT-200')
+  })
+
+  it('returns empty string when no parentKey', function() {
+    expect(extractParentKey({})).toBe('')
+    expect(extractParentKey({ _indexEntry: {} })).toBe('')
+  })
+
+  it('prefers item.parentKey over _indexEntry', function() {
+    expect(extractParentKey({ parentKey: 'A', _indexEntry: { parentKey: 'B' } })).toBe('A')
+  })
+})

--- a/modules/releases/client/plan/components/BigRockExpandedRow.vue
+++ b/modules/releases/client/plan/components/BigRockExpandedRow.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, reactive } from 'vue'
 import StatusInfoPopover from './StatusInfoPopover.vue'
 
 var props = defineProps({
@@ -7,7 +7,10 @@ var props = defineProps({
   colspan: { type: Number, default: 7 },
   loading: { type: Boolean, default: false },
   rockName: { type: String, default: '' },
-  releasePhaseMode: { type: String, default: 'unknown' }
+  releasePhaseMode: { type: String, default: 'unknown' },
+  outcomeKeys: { type: Array, default: () => [] },
+  outcomeDescriptions: { type: Object, default: () => ({}) },
+  jiraBaseUrl: { type: String, default: '' }
 })
 
 var isPlanningMode = computed(function() {
@@ -53,6 +56,60 @@ function completionBarColor(pct) {
   return 'bg-red-500'
 }
 
+var expandedOutcomes = reactive({})
+
+function toggleOutcome(key) {
+  if (expandedOutcomes[key]) {
+    delete expandedOutcomes[key]
+  } else {
+    expandedOutcomes[key] = true
+  }
+}
+
+function isOutcomeExpanded(key) {
+  return !!expandedOutcomes[key]
+}
+
+var hasOutcomes = computed(function() {
+  return props.outcomeKeys && props.outcomeKeys.length > 0
+})
+
+var outcomeGroups = computed(function() {
+  if (!hasOutcomes.value) return []
+  var groups = []
+  var used = {}
+  for (var oi = 0; oi < props.outcomeKeys.length; oi++) {
+    var oKey = props.outcomeKeys[oi]
+    var feats = []
+    for (var fi = 0; fi < props.features.length; fi++) {
+      var f = props.features[fi]
+      if (f.parentKey === oKey) {
+        feats.push(f)
+        used[f.key] = true
+      }
+    }
+    groups.push({
+      key: oKey,
+      description: props.outcomeDescriptions[oKey] || '',
+      features: feats
+    })
+  }
+  var other = []
+  for (var ui = 0; ui < props.features.length; ui++) {
+    if (!used[props.features[ui].key]) {
+      other.push(props.features[ui])
+    }
+  }
+  if (other.length > 0) {
+    groups.push({
+      key: '_other',
+      description: 'Other features',
+      features: other
+    })
+  }
+  return groups
+})
+
 </script>
 
 <template>
@@ -71,7 +128,148 @@ function completionBarColor(pct) {
       No feature health data available
     </div>
 
-    <!-- Feature detail table -->
+    <!-- Outcome-grouped view -->
+    <div v-else-if="hasOutcomes" class="p-3 max-h-96 overflow-y-auto" role="region" :aria-label="'Feature health details for ' + rockName">
+      <div v-for="group in outcomeGroups" :key="group.key" class="mb-2 last:mb-0">
+        <!-- Outcome sub-header -->
+        <div
+          class="flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer select-none transition-colors"
+          :class="group.features.length > 0 ? 'hover:bg-gray-100 dark:hover:bg-gray-800/60' : 'opacity-60'"
+          @click="group.features.length > 0 ? toggleOutcome(group.key) : null"
+        >
+          <svg
+            class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
+            :class="{ 'rotate-90': isOutcomeExpanded(group.key) }"
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+          <span class="w-1 h-4 rounded-full bg-primary-400 dark:bg-primary-600 flex-shrink-0" />
+          <a
+            v-if="group.key !== '_other'"
+            :href="`${jiraBaseUrl}/${group.key}`"
+            target="_blank"
+            rel="noopener"
+            class="text-primary-600 dark:text-blue-400 font-mono text-xs font-medium hover:underline"
+            @click.stop
+          >{{ group.key }}</a>
+          <span v-else class="text-xs font-medium text-gray-500 dark:text-gray-400">Other features</span>
+          <span v-if="group.description && group.key !== '_other'" class="text-xs text-gray-500 dark:text-gray-400 truncate">
+            — {{ group.description }}
+          </span>
+          <span
+            class="ml-auto inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold flex-shrink-0"
+            :class="group.features.length > 0 ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300' : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
+          >{{ group.features.length }}</span>
+        </div>
+
+        <!-- Feature table for this outcome (shown when expanded) -->
+        <div v-if="isOutcomeExpanded(group.key) && group.features.length > 0" class="ml-6 mt-1 mb-2">
+          <table class="w-full text-xs">
+            <thead>
+              <tr>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Feature</th>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Summary</th>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">
+                  Status
+                  <StatusInfoPopover />
+                </th>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Owner</th>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Release Type</th>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Target</th>
+                <th class="px-2 py-1 text-left text-gray-600 dark:text-gray-400 font-semibold">Fix Version</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="f in group.features"
+                :key="f.key"
+                class="odd:bg-white dark:odd:bg-gray-800/30 even:bg-gray-50 dark:even:bg-gray-900/20"
+              >
+                <td class="px-2 py-1.5">
+                  <span class="inline-flex items-center gap-1.5">
+                    <span
+                      class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                      :class="DOT_CLASS[f.level] || DOT_CLASS.green"
+                      role="img"
+                      :aria-label="'Risk level: ' + f.level"
+                    ></span>
+                    <a
+                      v-if="f.jiraUrl"
+                      :href="f.jiraUrl"
+                      target="_blank"
+                      rel="noopener"
+                      class="text-primary-600 dark:text-blue-400 font-mono hover:underline"
+                      @click.stop
+                    >{{ f.key }}</a>
+                    <span v-else class="font-mono text-gray-700 dark:text-gray-300">{{ f.key }}</span>
+                  </span>
+                  <span v-if="f.override" class="ml-1 text-[9px] text-amber-600 dark:text-amber-400" title="Risk level manually overridden">M</span>
+                  <span v-if="f.bigRock && f.bigRock.includes(', ')" class="ml-1 text-[9px] text-indigo-600 dark:text-indigo-400" :title="'Shared across: ' + f.bigRock">S</span>
+                </td>
+                <td class="px-2 py-1.5 text-gray-700 dark:text-gray-300 max-w-[250px]">
+                  <span :title="f.summary">{{ truncate(f.summary, 60) }}</span>
+                </td>
+                <td class="px-2 py-1.5">
+                  <template v-if="isPlanningMode">
+                    <span
+                      v-if="f.planningStatus"
+                      class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                      :class="PLANNING_STATUS_CLASSES[f.planningStatus] || ''"
+                    >{{ PLANNING_STATUS_LABELS[f.planningStatus] || f.planningStatus }}</span>
+                    <span v-if="f.planningChecks" class="ml-1 text-[10px] text-gray-500 dark:text-gray-400">
+                      {{ f.planningChecks.passedCount }}/{{ f.planningChecks.totalCount }}
+                    </span>
+                  </template>
+                  <template v-else>
+                    <div class="inline-flex items-center gap-1.5">
+                      <div class="w-12 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                        <div class="h-full rounded-full" :style="{ width: f.completionPct + '%' }" :class="completionBarColor(f.completionPct)" />
+                      </div>
+                      <span class="text-[10px] font-semibold">{{ f.completionPct }}%</span>
+                    </div>
+                  </template>
+                </td>
+                <td class="px-2 py-1.5 text-gray-600 dark:text-gray-400">
+                  {{ f.deliveryOwner || '-' }}
+                </td>
+                <td class="px-2 py-1.5">
+                  <span
+                    v-if="f.releaseType && ['DP', 'TP', 'GA'].includes(f.releaseType)"
+                    class="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                    :class="releaseTypeBadgeClass(f.releaseType)"
+                  >{{ f.releaseType }}</span>
+                  <span v-else class="text-gray-400 text-[10px]">--</span>
+                </td>
+                <td class="px-2 py-1.5">
+                  <span v-if="f.targetRelease" class="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300">
+                    {{ f.targetRelease }}
+                  </span>
+                  <span v-else class="text-gray-400 text-[10px]">--</span>
+                </td>
+                <td class="px-2 py-1.5">
+                  <div v-if="f.fixVersions" class="flex flex-wrap gap-0.5">
+                    <span
+                      v-for="fv in f.fixVersions.split(', ').filter(Boolean)"
+                      :key="fv"
+                      class="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300"
+                    >{{ fv }}</span>
+                  </div>
+                  <span v-else class="inline-flex items-center gap-0.5 text-amber-500 dark:text-amber-400 text-[10px]">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    --
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- Flat view fallback (no outcomes configured) -->
     <div v-else class="p-3 max-h-80 overflow-y-auto" role="region" :aria-label="'Feature health details for ' + rockName">
       <table class="w-full text-xs">
         <thead>
@@ -119,7 +317,6 @@ function completionBarColor(pct) {
               <span :title="f.summary">{{ truncate(f.summary, 60) }}</span>
             </td>
             <td class="px-2 py-1.5">
-              <!-- Planning mode: existing badge -->
               <template v-if="isPlanningMode">
                 <span
                   v-if="f.planningStatus"
@@ -130,7 +327,6 @@ function completionBarColor(pct) {
                   {{ f.planningChecks.passedCount }}/{{ f.planningChecks.totalCount }}
                 </span>
               </template>
-              <!-- Execution mode: completion bar -->
               <template v-else>
                 <div class="inline-flex items-center gap-1.5">
                   <div class="w-12 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">

--- a/modules/releases/client/plan/components/BigRocksTable.vue
+++ b/modules/releases/client/plan/components/BigRocksTable.vue
@@ -282,6 +282,9 @@ function handleDeleteClick(event, rock) {
                   :loading="healthLoading"
                   :rockName="rock.name"
                   :releasePhaseMode="releasePhaseMode"
+                  :outcomeKeys="rock.outcomeKeys || []"
+                  :outcomeDescriptions="rock.outcomeDescriptions || {}"
+                  :jiraBaseUrl="jiraBaseUrl"
                 />
               </tr>
             </template>

--- a/modules/releases/client/plan/composables/useHealthAggregation.js
+++ b/modules/releases/client/plan/composables/useHealthAggregation.js
@@ -197,7 +197,8 @@ export function useHealthAggregation(healthData, features, _rfes, _bigRocks) {
           targetRelease: h ? (h.targetRelease || '') : '',
           versionStatus: h ? (h.versionStatus || 'none') : 'none',
           completionPct: h ? (h.completionPct || 0) : 0,
-          planningChecks: h && h.planningChecks ? h.planningChecks : null
+          planningChecks: h && h.planningChecks ? h.planningChecks : null,
+          parentKey: f.parentKey || ''
         })
       }
     }

--- a/modules/releases/server/planning/cache-reader.js
+++ b/modules/releases/server/planning/cache-reader.js
@@ -122,7 +122,8 @@ function mapToCandidate(item, bigRockName, sourcePass) {
     rfeStatus: '',
     source: item.key.startsWith('RHAIRFE-') ? 'rfe' : 'jira',
     sourcePass: sourcePass,
-    jiraUrl: JIRA_BROWSE_URL + '/' + item.key
+    jiraUrl: JIRA_BROWSE_URL + '/' + item.key,
+    parentKey: item.parentKey || (item._indexEntry && item._indexEntry.parentKey) || ''
   }
 }
 


### PR DESCRIPTION
## Summary

- **Server**: Added `parentKey` to `mapToCandidate()` output in `cache-reader.js` — this passes the outcome key (parent Jira issue) through to the client for each feature
- **Composable**: Passed `parentKey` through in `rockFeatures` entries in `useHealthAggregation.js`
- **UI**: Rewrote `BigRockExpandedRow.vue` to group features under collapsible outcome sub-headers. Each outcome shows its Jira key (clickable link), description, and feature count badge. Click to expand/collapse features underneath. Outcomes start collapsed by default.
- **Fallback**: Big Rocks without outcomes still render the existing flat feature table (no regression)

## Test plan

- [x] ESLint passes on all 5 modified/new files
- [x] All 664 client plan tests pass (28 test files, 0 failures)
- [x] All 696 server planning tests pass (24 test files, 0 failures)
- [x] New test file: `big-rock-outcome-grouping.test.js` — 12 tests covering outcome grouping logic (split by parentKey, unlinked features, empty outcomes, order preservation, missing descriptions)
- [ ] Verify outcome grouping renders correctly in browser with live data
- [ ] Verify collapsible expand/collapse works on outcome sub-headers
- [ ] Verify Big Rocks without outcomes still show flat feature list

🤖 Generated with [Claude Code](https://claude.com/claude-code)