### PR TITLE
fix(releases): rename Sustaining tab and expand feedback sources

### DIFF
--- a/modules/releases/client/plan/components/BuFeedbackTable.vue
+++ b/modules/releases/client/plan/components/BuFeedbackTable.vue
@@ -34,6 +34,7 @@
             <a :href="issue.url" target="_blank" rel="noopener" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">{{ issue.key }}</a>
           </td>
           <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.issueType }}</td>
+          <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ (issue.components || []).join(', ') || '—' }}</td>
           <td class="px-3 py-2 text-gray-700 dark:text-gray-300 max-w-md truncate" :title="issue.summary">{{ issue.summary }}</td>
           <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.assignee }}</td>
           <td class="px-3 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.reporter }}</td>
@@ -53,6 +54,14 @@
           <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ formatDate(issue.created) }}</td>
           <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ formatDate(issue.updated) }}</td>
           <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ issue.dueDate ? formatDate(issue.dueDate) : 'None' }}</td>
+          <td class="px-3 py-2 whitespace-nowrap">
+            <span
+              v-for="lbl in (issue.feedbackLabels || [])"
+              :key="lbl"
+              class="inline-block px-2 py-0.5 text-xs font-medium rounded-full mr-1"
+              :class="lbl === 'AIBU_Feedback' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'"
+            >{{ lbl }}</span>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -69,6 +78,7 @@ var props = defineProps({
 var columns = [
   { key: 'key', label: 'Key', filterable: false },
   { key: 'issueType', label: 'Type', filterable: true },
+  { key: 'component', label: 'Component', filterable: true },
   { key: 'summary', label: 'Summary', filterable: false },
   { key: 'assignee', label: 'Assignee', filterable: true },
   { key: 'reporter', label: 'Reporter', filterable: true },
@@ -77,16 +87,19 @@ var columns = [
   { key: 'resolution', label: 'Resolution', filterable: true },
   { key: 'created', label: 'Created', filterable: false },
   { key: 'updated', label: 'Updated', filterable: false },
-  { key: 'dueDate', label: 'Due date', filterable: false }
+  { key: 'dueDate', label: 'Due date', filterable: false },
+  { key: 'source', label: 'Source', filterable: true }
 ]
 
 var columnFilters = ref({
   issueType: '',
+  component: '',
   assignee: '',
   reporter: '',
   priority: '',
   status: '',
-  resolution: ''
+  resolution: '',
+  source: ''
 })
 
 var sortKey = ref('created')
@@ -94,16 +107,34 @@ var sortDir = ref('desc')
 
 var filterOptions = computed(function() {
   var opts = {}
-  var filterableKeys = ['issueType', 'assignee', 'reporter', 'priority', 'status', 'resolution']
+  var filterableKeys = ['issueType', 'component', 'assignee', 'reporter', 'priority', 'status', 'resolution', 'source']
   for (var ki = 0; ki < filterableKeys.length; ki++) {
     var key = filterableKeys[ki]
     var seen = {}
     var values = []
     for (var i = 0; i < props.issues.length; i++) {
-      var val = props.issues[i][key] || ''
-      if (val && !seen[val]) {
-        seen[val] = true
-        values.push(val)
+      if (key === 'component') {
+        var comps = props.issues[i].components || []
+        for (var ci = 0; ci < comps.length; ci++) {
+          if (comps[ci] && !seen[comps[ci]]) {
+            seen[comps[ci]] = true
+            values.push(comps[ci])
+          }
+        }
+      } else if (key === 'source') {
+        var fbLabels = props.issues[i].feedbackLabels || []
+        for (var si = 0; si < fbLabels.length; si++) {
+          if (fbLabels[si] && !seen[fbLabels[si]]) {
+            seen[fbLabels[si]] = true
+            values.push(fbLabels[si])
+          }
+        }
+      } else {
+        var val = props.issues[i][key] || ''
+        if (val && !seen[val]) {
+          seen[val] = true
+          values.push(val)
+        }
       }
     }
     values.sort()
@@ -118,7 +149,14 @@ var filteredIssues = computed(function() {
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i]
       var filterVal = columnFilters.value[key]
-      if (filterVal && issue[key] !== filterVal) return false
+      if (!filterVal) continue
+      if (key === 'component') {
+        if (!(issue.components || []).includes(filterVal)) return false
+      } else if (key === 'source') {
+        if (!(issue.feedbackLabels || []).includes(filterVal)) return false
+      } else {
+        if (issue[key] !== filterVal) return false
+      }
     }
     return true
   })
@@ -130,8 +168,8 @@ var sortedIssues = computed(function() {
   var dir = sortDir.value === 'asc' ? 1 : -1
 
   arr.sort(function(a, b) {
-    var aVal = a[key] || ''
-    var bVal = b[key] || ''
+    var aVal = key === 'component' ? (a.components || []).join(', ') : key === 'source' ? (a.feedbackLabels || []).join(', ') : (a[key] || '')
+    var bVal = key === 'component' ? (b.components || []).join(', ') : key === 'source' ? (b.feedbackLabels || []).join(', ') : (b[key] || '')
     if (aVal < bVal) return -1 * dir
     if (aVal > bVal) return 1 * dir
     return 0

--- a/modules/releases/client/plan/views/BuFeedbackView.vue
+++ b/modules/releases/client/plan/views/BuFeedbackView.vue
@@ -2,9 +2,9 @@
   <div class="space-y-4">
     <div class="flex items-center justify-between">
       <div>
-        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Sustaining</h2>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Field and BU Feedback</h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-          Issues labeled <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AIBU_Feedback</code> from Jira, ordered by creation date.
+          Issues labeled <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AIBU_Feedback</code> or <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">AISSA_Feedback</code> from Jira, ordered by creation date.
         </p>
       </div>
       <div class="flex items-center gap-3">

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -35,7 +35,7 @@ const tabs = [
   { id: 'outcomes', label: 'Big Rocks' },
   { id: 'pm-hub', label: 'PM Hub' },
   { id: 'feature-readiness', label: 'Features List (1-n)' },
-  { id: 'bu-feedback', label: 'Sustaining' },
+  { id: 'bu-feedback', label: 'Field and BU Feedback' },
 ]
 
 var moduleNav = inject('moduleNav', null)

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -490,10 +490,10 @@ module.exports = function registerPlanningRoutes(router, context) {
    * @openapi
    * /api/modules/releases/planning/bu-feedback:
    *   get:
-   *     summary: List BU non-feature-ask issues from Jira
+   *     summary: List field and BU feedback issues from Jira
    *     tags: [releases-planning]
    *     security: [{ bearerAuth: [] }]
-   *     description: Queries Jira for issues labeled AIBU_Feedback, ordered by creation date descending.
+   *     description: Queries Jira for issues labeled AIBU_Feedback or AISSA_Feedback, deduplicated, ordered by creation date descending.
    *     responses:
    *       200:
    *         description: Array of BU feedback issues
@@ -505,15 +505,22 @@ module.exports = function registerPlanningRoutes(router, context) {
       return res.json({ issues: [], fetchedAt: new Date().toISOString(), warning: 'Jira not configured' })
     }
 
-    try {
-      var jql = 'labels = "AIBU_Feedback" ORDER BY createdDate DESC'
-      var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels'
-      var rawIssues = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 100 })
+    var FEEDBACK_LABELS = ['AIBU_Feedback', 'AISSA_Feedback']
 
+    try {
+      var jql = 'labels IN ("AIBU_Feedback", "AISSA_Feedback") ORDER BY createdDate DESC'
+      var fields = 'summary,status,issuetype,assignee,reporter,priority,resolution,created,updated,duedate,components,fixVersions,labels'
+      var rawIssues = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200 })
+
+      var seen = {}
       var issues = []
       for (var i = 0; i < rawIssues.length; i++) {
         var raw = rawIssues[i]
+        if (seen[raw.key]) continue
+        seen[raw.key] = true
         var f = raw.fields || {}
+        var allLabels = f.labels || []
+        var feedbackLabels = allLabels.filter(function(l) { return FEEDBACK_LABELS.indexOf(l) !== -1 })
         issues.push({
           key: raw.key,
           summary: f.summary || '',
@@ -529,7 +536,8 @@ module.exports = function registerPlanningRoutes(router, context) {
           dueDate: f.duedate || null,
           components: (f.components || []).map(function(c) { return c.name }),
           fixVersions: (f.fixVersions || []).map(function(v) { return v.name }),
-          labels: f.labels || [],
+          labels: allLabels,
+          feedbackLabels: feedbackLabels,
           url: 'https://issues.redhat.com/browse/' + raw.key
         })
       }


### PR DESCRIPTION
## Summary
- Rename "Sustaining" tab to "Field and BU Feedback" across the Plan view, page heading, and description
- Expand Jira query to include both `AIBU_Feedback` and `AISSA_Feedback` labels with deduplication
- Add filterable Component column (between Type and Summary) showing Jira components
- Add filterable Source column (after Due date) showing which feedback label(s) each issue has, with color-coded badges

## Test plan
- [ ] Navigate to Releases → Plan → Field and BU Feedback tab
- [ ] Verify tab label reads "Field and BU Feedback"
- [ ] Verify description mentions both `AIBU_Feedback` and `AISSA_Feedback`
- [ ] Verify Component column appears between Type and Summary with filter dropdown
- [ ] Verify Source column appears after Due date with filter dropdown
- [ ] Filter by Source to confirm AIBU_Feedback and AISSA_Feedback filter correctly
- [ ] Verify issues with both labels appear only once with both badges shown


Made with [Cursor](https://cursor.com)