### PR TITLE
fix(team-tracker): improve data quality exceptions UX

### DIFF
--- a/modules/team-tracker/client/components/AddExceptionModal.vue
+++ b/modules/team-tracker/client/components/AddExceptionModal.vue
@@ -132,6 +132,7 @@ import { apiRequest } from '@shared/client/services/api'
 const props = defineProps({
   people: { type: Array, default: () => [] },
   teams: { type: Array, default: () => [] },
+  orgKeys: { type: Array, default: () => [] },
   fieldDefinitions: { type: Object, default: () => ({ person: [], team: [] }) },
   prefillEntityType: { type: String, default: null },
   prefillEntityId: { type: String, default: null },
@@ -176,7 +177,10 @@ const filteredEntities = computed(() => {
     return props.teams
       .filter(t => t.name?.toLowerCase().includes(q))
       .slice(0, 20)
-      .map(t => ({ id: t.id, label: t.name, sub: t.orgKey }))
+      .map(t => {
+        const org = props.orgKeys.find(o => o.key === t.orgKey)
+        return { id: t.id, label: t.name, sub: org?.displayName || t.orgKey }
+      })
   }
 })
 

--- a/modules/team-tracker/client/components/DataQualityTab.vue
+++ b/modules/team-tracker/client/components/DataQualityTab.vue
@@ -448,6 +448,11 @@
                         @view-all="navigateToExceptionsTab"
                       />
                       <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                      <button
+                        v-if="(!team.boards || team.boards.length === 0) && !hasExceptionFor('team', team.id, '__boards__')"
+                        class="hidden group-hover:inline-flex items-center gap-0.5 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                        @click.stop="openExceptionModal('team', team.id, team.name, '__boards__')"
+                      >Add Exception</button>
                       <svg class="h-3 w-3 text-gray-400 dark:text-gray-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                       </svg>
@@ -474,6 +479,7 @@
       v-if="showExceptionModal"
       :people="allPeople.map(p => ({ uid: p.uid, name: p.name }))"
       :teams="teams.map(t => ({ id: t.id, name: t.name, orgKey: t.orgKey }))"
+      :org-keys="orgKeys"
       :field-definitions="fieldDefinitions"
       :prefill-entity-type="exceptionPrefill.entityType"
       :prefill-entity-id="exceptionPrefill.entityId"

--- a/modules/team-tracker/client/components/FieldExceptionsTab.vue
+++ b/modules/team-tracker/client/components/FieldExceptionsTab.vue
@@ -82,6 +82,10 @@
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
                 {{ resolveEntityName(ex) }}
+                <span
+                  v-if="ex.entityType === 'team' && resolveOrgName(ex)"
+                  class="ml-1.5 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                >{{ resolveOrgName(ex) }}</span>
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
                 {{ resolveFieldLabel(ex) }}
@@ -115,6 +119,7 @@
       v-if="showAddModal"
       :people="allPeople"
       :teams="allTeams"
+      :org-keys="orgKeys"
       :field-definitions="fieldDefinitions"
       @close="showAddModal = false"
       @created="handleCreated"
@@ -128,7 +133,7 @@ import { apiRequest } from '@shared/client/services/api'
 import { useFieldCompleteness } from '../composables/useFieldCompleteness'
 import AddExceptionModal from './AddExceptionModal.vue'
 
-const { people, teams, fieldDefinitions, load: loadCompleteness } = useFieldCompleteness()
+const { people, teams, fieldDefinitions, orgKeys, load: loadCompleteness } = useFieldCompleteness()
 
 const exceptions = ref([])
 const loading = ref(false)
@@ -156,6 +161,15 @@ function resolveEntityName(ex) {
     const team = teams.value.find(t => t.id === ex.entityId)
     return team?.name || ex.entityId
   }
+}
+
+// Resolve org display name for a team exception
+function resolveOrgName(ex) {
+  if (ex.entityType !== 'team') return null
+  const team = teams.value.find(t => t.id === ex.entityId)
+  if (!team?.orgKey) return null
+  const org = orgKeys.value.find(o => o.key === team.orgKey)
+  return org?.displayName || team.orgKey
 }
 
 // Resolve field label from field definitions


### PR DESCRIPTION
## Summary

- Add hover-revealed "Add Exception" button on empty boards cells in the Data Quality tab, so exceptions can be registered for teams without boards directly from the data quality view
- Show org display names instead of raw org keys (leader usernames like `shgriffi`) in the AddExceptionModal team selector
- Display org name as a pill badge next to team names in the Exceptions tab for easier identification

## Test plan

- [ ] Navigate to Manage → Data Quality → Teams tab
- [ ] Hover over an empty boards cell — verify "Add Exception" link appears on hover
- [ ] Click "Add Exception" — verify the modal opens prefilled with the team and `__boards__` field
- [ ] Create the exception — verify the cell now shows the Exception popover instead of red highlight
- [ ] Open the AddExceptionModal (from either Data Quality or Exceptions tab), select Team type, search — verify org display names show instead of org keys
- [ ] Navigate to Manage → Exceptions tab — verify team rows show an org name pill badge next to the team name

🤖 Generated with [Claude Code](https://claude.com/claude-code)