### PR TITLE
feat(product-builds): display Container Health Index (CHI) for Product-Builds

### DIFF
--- a/modules/product-builds/client/components/ChiBadge.vue
+++ b/modules/product-builds/client/components/ChiBadge.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { chiGradeBadgeClass, formatDate } from '../utils/formatting'
+
+defineProps({
+  healthIndex: { type: Object, default: null },
+  showDetails: { type: Boolean, default: false },
+})
+</script>
+
+<template>
+  <div v-if="healthIndex" class="flex items-center gap-2">
+    <span
+      class="inline-flex items-center px-2.5 py-1 rounded text-sm font-bold"
+      :class="chiGradeBadgeClass(healthIndex.grade)"
+      :title="healthIndex.grade !== 'Unknown' && healthIndex.vulnerability_count != null
+        ? `${healthIndex.vulnerability_count} vulnerabilities`
+        : ''"
+    >{{ healthIndex.grade }}</span>
+    <template v-if="showDetails && healthIndex.grade !== 'Unknown'">
+      <span
+        v-if="healthIndex.vulnerability_count != null"
+        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+      >{{ healthIndex.vulnerability_count }} vulnerabilities</span>
+      <span v-if="healthIndex.grade_date" class="text-xs text-gray-400 dark:text-gray-500">
+        · {{ formatDate(healthIndex.grade_date) }}
+      </span>
+    </template>
+  </div>
+</template>

--- a/modules/product-builds/client/utils/formatting.js
+++ b/modules/product-builds/client/utils/formatting.js
@@ -76,6 +76,20 @@ export function getCommitUrl(artifact) {
   return `${baseUrl}/-/commit/${commit}`
 }
 
+export const CHI_GRADE_CLASSES = {
+  A: 'bg-green-600 text-white',
+  B: 'bg-lime-500 text-white',
+  C: 'bg-yellow-400 text-gray-900',
+  D: 'bg-orange-500 text-white',
+  E: 'bg-amber-600 text-white',
+  F: 'bg-red-700 text-white',
+  Unknown: 'bg-gray-400 text-white',
+}
+
+export function chiGradeBadgeClass(grade) {
+  return CHI_GRADE_CLASSES[grade] || CHI_GRADE_CLASSES.Unknown
+}
+
 export function getAcceleratorInfo(art) {
   const labels = art?.labels || {}
   let accel = art?.variant ? art.variant.split('-')[0] : null

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -2,6 +2,7 @@
 import { ref, reactive, computed, watch, onMounted, inject, defineAsyncComponent } from 'vue'
 import { useArtifactDetail } from '../composables/useArtifacts'
 import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo, getCommitUrl } from '../utils/formatting'
+import ChiBadge from '../components/ChiBadge.vue'
 
 const DependencyGraph = defineAsyncComponent(() => import('../components/DependencyGraph.vue'))
 
@@ -326,6 +327,12 @@ const otherLabels = computed(() => {
                 class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
                 :class="envBadgeClass(env)"
               >{{ env }}</span>
+            </dd>
+          </div>
+          <div v-if="artifact.health_index">
+            <dt class="text-gray-500 dark:text-gray-400">Health Index</dt>
+            <dd class="mt-0.5">
+              <ChiBadge :health-index="artifact.health_index" show-details />
             </dd>
           </div>
           <div v-if="artifact.drop_keys?.length">

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -4,6 +4,7 @@ import { useDropDetail } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { apiRequest } from '@shared/client/services/api'
 import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getCommitUrl } from '../utils/formatting'
+import ChiBadge from '../components/ChiBadge.vue'
 import DropTimeline from '../components/DropTimeline.vue'
 
 const BASE = '/modules/product-builds'
@@ -458,6 +459,12 @@ const totalColumns = 7
                                 <svg v-if="copiedKey === name" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
                                 <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
                               </button>
+                            </div>
+                          </div>
+                          <div v-if="art.health_index" class="mt-3">
+                            <span class="font-medium text-gray-900 dark:text-gray-100">Health Index:</span>
+                            <div class="mt-1">
+                              <ChiBadge :health-index="art.health_index" show-details />
                             </div>
                           </div>
                           <div v-if="art.drop_keys?.length" class="mt-3">

--- a/modules/product-builds/client/views/ProductView.vue
+++ b/modules/product-builds/client/views/ProductView.vue
@@ -4,6 +4,7 @@ import { useScroll } from '@vueuse/core'
 import { useProduct, useDrops, useSeries } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { formatDate, envBadgeClass } from '../utils/formatting'
+import ChiBadge from '../components/ChiBadge.vue'
 
 const PRODUCT_CONFIGS = {
   'rhaiis':            { key: 'rhaiis',        artifactType: 'containers' },
@@ -289,6 +290,7 @@ const groupedDrops = computed(() => {
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Variant</th>
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Architectures</th>
                   <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Environments</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">CHI</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -311,11 +313,15 @@ const groupedDrops = computed(() => {
                       >{{ env }}</span>
                     </div>
                   </td>
+                  <td class="px-4 py-3">
+                    <ChiBadge v-if="art.health_index" :health-index="art.health_index" />
+                    <span v-else class="text-sm text-gray-400 dark:text-gray-500">—</span>
+                  </td>
                 </tr>
               </tbody>
               <tfoot v-if="artifactsLoading">
                 <tr>
-                  <td colspan="4" class="px-4 py-3 text-center text-sm text-gray-500 dark:text-gray-400">
+                  <td colspan="5" class="px-4 py-3 text-center text-sm text-gray-500 dark:text-gray-400">
                     <span class="inline-flex items-center gap-2">
                       <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/tests/integration/product-builds.spec.js
+++ b/tests/integration/product-builds.spec.js
@@ -1,0 +1,104 @@
+const { test, expect } = require('@playwright/test');
+const { DEFAULT_PAGE_WAIT_TIME } = require('./constants');
+const { setupErrorTracking, logCapturedErrors, mainContentIsVisible } = require('./helpers');
+
+/**
+ * Integration tests for Product Builds module
+ *
+ * These tests verify:
+ * - Module loads and renders correctly
+ * - CHI column appears in artifacts table
+ * - CHI badge renders in artifact detail view
+ * - Artifacts without health_index don't show CHI
+ *
+ * Tag: @product-builds
+ * Usage: npx playwright test --grep @product-builds
+ */
+
+test.describe('Product Builds Module @product-builds', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('should be visible in sidebar navigation', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const moduleNav = page.locator('aside nav').filter({ hasText: 'Product Bu' });
+    const count = await moduleNav.count();
+    expect(count).toBeGreaterThan(0);
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
+    expect(appErrors).toHaveLength(0);
+  });
+
+  test('should navigate to RHAIIS view', async ({ page }) => {
+    await page.goto('/#/product-builds/rhaiis');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    expect(page.url()).toMatch(/product-builds\/rhaiis/);
+
+    const mainContentVisible = await mainContentIsVisible(page);
+    expect(mainContentVisible).toBe(true);
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
+    expect(appErrors).toHaveLength(0);
+  });
+
+  test('should show CHI column header in artifacts tab', async ({ page }) => {
+    await page.goto('/#/product-builds/rhaiis');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const artifactsTab = page.locator('button').filter({ hasText: 'Artifacts' });
+    if (await artifactsTab.isVisible()) {
+      await artifactsTab.click();
+      await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+      const chiHeader = page.locator('th').filter({ hasText: 'CHI' });
+      await expect(chiHeader).toBeVisible();
+    }
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
+    expect(appErrors).toHaveLength(0);
+  });
+
+  test('should show Health Index in artifact detail when data exists', async ({ page }) => {
+    await page.goto('/#/product-builds/rhaiis');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const artifactsTab = page.locator('button').filter({ hasText: 'Artifacts' });
+    if (await artifactsTab.isVisible()) {
+      await artifactsTab.click();
+      await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+      const firstArtifact = page.locator('tbody tr').first();
+      if (await firstArtifact.isVisible()) {
+        await firstArtifact.click();
+        await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+        const healthLabel = page.locator('dt').filter({ hasText: 'Health Index' });
+        const hasHealth = await healthLabel.count();
+        if (hasHealth > 0) {
+          await expect(healthLabel).toBeVisible();
+          const gradeBadge = page.locator('.font-bold').first();
+          const gradeText = await gradeBadge.textContent();
+          if (gradeText && gradeText.trim() !== 'Unknown') {
+            const vulnerabilities = page.locator('text=vulnerabilities');
+            await expect(vulnerabilities).toBeVisible();
+          }
+        }
+      }
+    }
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
+    expect(appErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Display Container Health Index (CHI) grades from the AIPCC Dashboard API on container artifacts in the Product Builds module
- Add colored grade badge (A–F) using the official Red Hat catalog color scheme, with vulnerability count and grade date
- CHI appears in three views: artifact detail metadata grid, drop detail expandable row, and product view artifacts tab column
- Gracefully hidden for artifacts without CHI data (stage-only images not in Red Hat catalog)
- Vulnerability count hidden for "Unknown" grades (no scan data available)

Screenshot of sample output in individual artifact view: 
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/6bba62a8-0e13-4073-b182-a9b8dc3b0e84" />

Screenshot of sample output in artifact tab view with extra column named "CHI":
<img width="2808" height="632" alt="image" src="https://github.com/user-attachments/assets/4cf39cc3-4cd0-4432-b398-1f5c2275c84e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)