### PR TITLE
feat(product-builds): improve Package Search results UI

### DIFF
--- a/modules/product-builds/client/views/PackageAnalysisView.vue
+++ b/modules/product-builds/client/views/PackageAnalysisView.vue
@@ -55,7 +55,16 @@ const MIN_DAYS = 1
 const MAX_DAYS = 90
 
 // --- Shared state ---
-const activeTab = ref('onboarded')
+function getInitialTab() {
+  const hash = window.location.hash || ''
+  const qIdx = hash.indexOf('?')
+  if (qIdx !== -1) {
+    const params = new URLSearchParams(hash.slice(qIdx + 1))
+    if (params.get('tab') === 'search') return 'search'
+  }
+  return 'onboarded'
+}
+const activeTab = ref(getInitialTab())
 const reports = ref([])
 const loading = ref(true)
 const error = ref(null)

--- a/modules/product-builds/client/views/PackageSearchView.vue
+++ b/modules/product-builds/client/views/PackageSearchView.vue
@@ -48,11 +48,12 @@ const showVersionDropdown = ref(false)
 const versionInputEdited = ref(false)
 
 const filteredProductVersions = computed(() => {
-  if (!options.value || !options.value.product_versions) return []
-  if (!versionInputEdited.value) return options.value.product_versions
+  const versions = options.value?.product_versions
+  if (!versions) return []
+  if (!versionInputEdited.value) return versions
   const q = selectedProductVersion.value.trim().toLowerCase()
-  if (!q) return options.value.product_versions
-  return options.value.product_versions.filter(v => v.toLowerCase().includes(q))
+  if (!q) return versions
+  return versions.filter(v => v.toLowerCase().includes(q))
 })
 
 function onVersionFocus() {
@@ -77,16 +78,71 @@ function hideVersionDropdown() {
 
 const canSubmit = computed(() => !loading.value && packageName.value.trim() && options.value)
 const hasSearched = computed(() => results.value !== null)
+const linkCopied = ref(false)
+
+function copySearchLink() {
+  navigator.clipboard.writeText(window.location.href)
+    .then(() => {
+      linkCopied.value = true
+      setTimeout(() => { linkCopied.value = false }, 2000)
+    })
+    .catch(() => {})
+}
+
+function pushSearchToUrl() {
+  const hash = window.location.hash || ''
+  const basePath = hash.split('?')[0] || '#/product-builds/package-analysis'
+  const params = new URLSearchParams()
+  params.set('tab', 'search')
+  params.set('pkg', packageName.value.trim())
+  if (packageVersion.value.trim()) params.set('ver', packageVersion.value.trim())
+  if (selectedProductVersion.value.trim()) params.set('pv', selectedProductVersion.value.trim())
+  if (selectedVariant.value) params.set('variant', selectedVariant.value)
+  if (selectedRepoTypes.value !== 'default') params.set('repos', selectedRepoTypes.value)
+  const newHash = basePath + '?' + params.toString()
+  if (window.location.hash !== newHash) {
+    history.replaceState(null, '', window.location.pathname + window.location.search + newHash)
+  }
+}
+
+function readSearchFromUrl() {
+  const hash = window.location.hash || ''
+  const qIdx = hash.indexOf('?')
+  if (qIdx === -1) return null
+  const params = new URLSearchParams(hash.slice(qIdx + 1))
+  if (params.get('tab') !== 'search') return null
+  const pkg = params.get('pkg')
+  if (!pkg) return null
+  return {
+    packageName: pkg,
+    packageVersion: params.get('ver') || '',
+    productVersion: params.get('pv') || '',
+    variant: params.get('variant') || '',
+    repoTypes: params.get('repos') || 'default'
+  }
+}
 
 onMounted(async () => {
   await loadOptions()
+  const urlParams = readSearchFromUrl()
+  if (urlParams) {
+    packageName.value = urlParams.packageName
+    packageVersion.value = urlParams.packageVersion
+    selectedProductVersion.value = urlParams.productVersion
+    selectedVariant.value = urlParams.variant
+    selectedRepoTypes.value = urlParams.repoTypes
+    await nextTick()
+    handleSubmit()
+  }
 })
 
 async function handleSubmit() {
   if (!canSubmit.value) return
   expandedVersions.value = new Set()
+  expandedCells.value = new Set()
   versionVariantFilter.value = ''
   versionRepoFilter.value = ''
+  pushSearchToUrl()
   await search({
     packageName: packageName.value,
     packageVersion: packageVersion.value,
@@ -95,55 +151,6 @@ async function handleSubmit() {
     repoTypes: selectedRepoTypes.value
   })
 }
-
-function getVersionResults(pv) {
-  if (!results.value) return []
-  return results.value.results.filter(r => r.product_version === pv)
-}
-
-function getVariantsForVersion(versionResults) {
-  return [...new Set(versionResults.map(r => r.variant))]
-}
-
-function getResult(versionResults, variant, repoType) {
-  return versionResults.find(r => r.variant === variant && r.repo_type === repoType)
-}
-
-function hasFiles(r) {
-  return r && r.found && r.files && r.files.length > 0
-}
-
-const repoAvailability = computed(() => {
-  if (!results.value) return { testOnly: [], prodOnly: [] }
-  const testOnly = []
-  const prodOnly = []
-
-  for (const pv of productVersions.value) {
-    const vr = getVersionResults(pv)
-    for (const v of getVariantsForVersion(vr)) {
-      const test = getResult(vr, v, 'test')
-      const prod = getResult(vr, v, 'production')
-      const inTest = hasFiles(test)
-      const inProd = hasFiles(prod)
-      if (inTest && !inProd) testOnly.push({ productVersion: pv, variant: v })
-      if (inProd && !inTest) prodOnly.push({ productVersion: pv, variant: v })
-    }
-  }
-  return { testOnly, prodOnly }
-})
-
-const hasAvailabilityInsights = computed(() => {
-  return repoAvailability.value.testOnly.length > 0 || repoAvailability.value.prodOnly.length > 0
-})
-
-const resultSummary = computed(() => {
-  if (!results.value) return null
-  const total = results.value.results.length
-  const found = results.value.results.filter(r => r.found && r.files && r.files.length > 0).length
-  const notFound = results.value.results.filter(r => r.index_exists && !r.found).length
-  const noIndex = results.value.results.filter(r => !r.index_exists).length
-  return { total, found, notFound, noIndex }
-})
 
 const expandedVersions = ref(new Set())
 const versionVariantFilter = ref('')
@@ -188,29 +195,21 @@ const versionBreakdown = computed(() => {
     if (!r.found || !r.files) continue
     for (const f of r.files) {
       if (f.version === 'unknown') continue
-      if (!byVersion[f.version]) {
-        byVersion[f.version] = {
-          version: f.version,
-          files: 0,
-          variants: new Set(),
-          repoTypes: new Set(),
-          productVersions: new Set(),
-          byVariant: {}
-        }
+      const entry = byVersion[f.version] ??= {
+        version: f.version,
+        files: 0,
+        variants: new Set(),
+        repoTypes: new Set(),
+        productVersions: new Set(),
+        byVariant: {}
       }
-      const entry = byVersion[f.version]
       entry.files++
       entry.variants.add(r.variant)
       entry.repoTypes.add(r.repo_type)
       entry.productVersions.add(r.product_version)
-      if (!entry.byVariant[r.variant]) {
-        entry.byVariant[r.variant] = { variant: r.variant, repoTypes: {} }
-      }
-      const variantGroup = entry.byVariant[r.variant]
-      if (!variantGroup.repoTypes[r.repo_type]) {
-        variantGroup.repoTypes[r.repo_type] = { repoType: r.repo_type, indexUrl: r.index_url, files: [] }
-      }
-      variantGroup.repoTypes[r.repo_type].files.push(f)
+      const variantGroup = entry.byVariant[r.variant] ??= { variant: r.variant, repoTypes: {} }
+      const repoGroup = variantGroup.repoTypes[r.repo_type] ??= { repoType: r.repo_type, indexUrl: r.index_url, files: [] }
+      repoGroup.files.push(f)
     }
   }
   return Object.values(byVersion)
@@ -276,6 +275,54 @@ const showVersionBreakdown = computed(() => {
 const isMultiProductSearch = computed(() => {
   return results.value && !selectedProductVersion.value.trim() && productVersions.value.length > 1
 })
+
+const expandedCells = ref(new Set())
+
+function cellKey(pv, variant, rt) {
+  return `${pv}\0${variant}\0${rt}`
+}
+
+function toggleCell(key) {
+  const next = new Set(expandedCells.value)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  expandedCells.value = next
+}
+
+const indexAvailability = computed(() => {
+  if (!results.value) return []
+  const byPv = {}
+  for (const r of results.value.results) {
+    const variantMap = (byPv[r.product_version] ??= {})
+    ;(variantMap[r.variant] ??= {})[r.repo_type] = r
+  }
+
+  const repoTypes = [...new Set(results.value.results.map(r => r.repo_type))]
+    .sort((a, b) => REPO_TYPE_ORDER.indexOf(a) - REPO_TYPE_ORDER.indexOf(b))
+
+  return productVersions.value.map(pv => {
+    const variantMap = byPv[pv] || {}
+    const variants = Object.keys(variantMap).sort()
+    return {
+      productVersion: pv,
+      repoTypes,
+      variants: variants.map(v => ({
+        variant: v,
+        repos: variantMap[v]
+      }))
+    }
+  })
+})
+
+function cellStatus(result) {
+  if (!result) return { label: 'N/A', type: 'gray' }
+  if (result.error === 'timeout') return { label: 'Timeout', type: 'amber' }
+  if (result.error) return { label: 'Error', type: 'amber' }
+  if (!result.index_exists) return { label: 'No index', type: 'gray' }
+  if (!result.found) return { label: 'Not found', type: 'amber' }
+  const count = result.files ? result.files.length : 0
+  return { label: `Available (${count} file${count !== 1 ? 's' : ''} found)`, type: 'green' }
+}
 
 const versionMatrix = computed(() => {
   if (!results.value || !isMultiProductSearch.value) return null
@@ -384,7 +431,7 @@ const versionMatrix = computed(() => {
                 class="border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300 w-full"
               >
                 <option value="">All variants</option>
-                <option v-for="v in (options ? options.variants : [])" :key="v" :value="v">{{ v }}</option>
+                <option v-for="v in (options?.variants ?? [])" :key="v" :value="v">{{ v }}</option>
               </select>
             </div>
             <div class="flex-1 min-w-[120px]">
@@ -447,72 +494,161 @@ const versionMatrix = computed(() => {
       {{ error }}
     </div>
 
-    <!-- Not Found Warning -->
-    <div v-if="results && !loading && !error && !anyFound" class="p-3 rounded-xl border border-yellow-300 dark:border-yellow-700 bg-yellow-50 dark:bg-yellow-900/20 text-sm text-yellow-800 dark:text-yellow-300 flex items-center gap-2">
-      <svg class="w-4 h-4 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126Z" />
-      </svg>
-      <span v-if="anyPackageFound">
-        No files found for <strong>{{ results.package_name }}</strong><template v-if="results.requested_version"> version {{ results.requested_version }}</template>
-      </span>
-      <span v-else-if="anyIndexExists">
-        Package <strong>"{{ results.package_name }}"</strong> not found in any index
-      </span>
-      <span v-else>
-        No accessible indexes found for <strong>"{{ results.package_name }}"</strong>
-      </span>
-    </div>
-
     <!-- Results -->
-    <template v-if="results && !loading && !error && anyFound">
+    <template v-if="results && !loading && !error">
 
-      <!-- Summary bar -->
-      <div v-if="resultSummary" class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <div class="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
-          <span class="font-medium text-gray-900 dark:text-gray-100">
-            {{ results.package_name }}<template v-if="results.requested_version"> @ {{ results.requested_version }}</template>
-          </span>
-          <span class="flex items-center gap-1.5">
-            <span class="inline-block w-2 h-2 rounded-full bg-green-500"></span>
-            {{ resultSummary.found }} found
-          </span>
-          <span v-if="resultSummary.notFound > 0" class="flex items-center gap-1.5">
-            <span class="inline-block w-2 h-2 rounded-full bg-amber-400"></span>
-            {{ resultSummary.notFound }} not found
-          </span>
-          <span v-if="resultSummary.noIndex > 0" class="flex items-center gap-1.5">
-            <span class="inline-block w-2 h-2 rounded-full bg-gray-300 dark:bg-gray-600"></span>
-            {{ resultSummary.noIndex }} no index
-          </span>
-          <span class="text-gray-400 dark:text-gray-500">{{ resultSummary.total }} indexes checked</span>
-        </div>
-        <a
-          v-if="packageUiHref"
-          :href="packageUiHref"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="shrink-0 text-sm text-primary-600 dark:text-primary-400 hover:underline"
-        >View on packages.redhat.com &#8599;</a>
+      <!-- Not Found Warning -->
+      <div v-if="!anyFound" class="p-3 rounded-xl border border-yellow-300 dark:border-yellow-700 bg-yellow-50 dark:bg-yellow-900/20 text-sm text-yellow-800 dark:text-yellow-300 flex items-center gap-2">
+        <svg class="w-4 h-4 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126Z" />
+        </svg>
+        <span v-if="anyPackageFound">
+          No files found for <strong>{{ results.package_name }}</strong><template v-if="results.requested_version"> version {{ results.requested_version }}</template>
+        </span>
+        <span v-else-if="anyIndexExists">
+          Package <strong>"{{ results.package_name }}"</strong> not found in any index
+        </span>
+        <span v-else>
+          No accessible indexes found for <strong>"{{ results.package_name }}"</strong>
+        </span>
       </div>
 
-      <!-- Availability Insights -->
-      <div v-if="hasAvailabilityInsights" class="space-y-2">
-        <div v-if="repoAvailability.testOnly.length > 0" class="p-3 rounded-xl border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-sm flex gap-2">
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 shrink-0">Not yet in production</span>
-          <span class="text-gray-600 dark:text-gray-300">
-            Available in test index only for: {{ repoAvailability.testOnly.map(i => i.variant + ' (' + i.productVersion + ')').join(', ') }}
-          </span>
-        </div>
-        <div v-if="repoAvailability.prodOnly.length > 0" class="p-3 rounded-xl border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 text-sm flex gap-2">
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 shrink-0">Production only</span>
-          <span class="text-gray-600 dark:text-gray-300">
-            In production but not in test index for: {{ repoAvailability.prodOnly.map(i => i.variant + ' (' + i.productVersion + ')').join(', ') }}
-          </span>
+      <!-- Results header -->
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm border-t-4 border-t-primary-500">
+        <div class="px-5 py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+              {{ results.package_name }}<template v-if="results.requested_version"> <span class="text-base text-gray-500 dark:text-gray-400 font-normal">@ {{ results.requested_version }}</span></template>
+            </h3>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ results.results.length }} indexes checked</p>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors"
+              :class="linkCopied
+                ? 'border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+              @click="copySearchLink"
+              title="Copy a shareable URL for this search"
+            >
+              <svg v-if="!linkCopied" class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.334a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" />
+              </svg>
+              <svg v-else class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+              </svg>
+              {{ linkCopied ? 'Link copied!' : 'Copy results URL' }}
+            </button>
+            <a
+              v-if="packageUiHref"
+              :href="packageUiHref"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:underline"
+            >View on packages.redhat.com &#8599;</a>
+          </div>
         </div>
       </div>
+
+      <!-- Index Availability Tables -->
+      <details v-for="group in indexAvailability" :key="group.productVersion" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm overflow-hidden group/pv" open>
+        <summary class="px-4 py-3 border-b border-gray-100 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/40 cursor-pointer flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+          <svg class="w-3.5 h-3.5 text-gray-400 transition-transform group-open/pv:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+          <span class="text-sm font-medium text-gray-900 dark:text-gray-100">Product Version: {{ group.productVersion }}</span>
+        </summary>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th class="px-4 py-3 font-medium">Index</th>
+                <th
+                  v-for="rt in group.repoTypes"
+                  :key="rt"
+                  class="px-4 py-3 font-medium text-center"
+                  :class="{
+                    'text-blue-600 dark:text-blue-400': rt === 'test',
+                    'text-green-600 dark:text-green-400': rt === 'production'
+                  }"
+                >{{ REPO_TYPE_LABELS[rt] || rt }}</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+              <template v-for="row in group.variants" :key="row.variant">
+                <tr class="hover:bg-gray-50/80 dark:hover:bg-gray-900/30">
+                  <td class="px-4 py-3 font-mono text-sm text-gray-900 dark:text-gray-100">{{ row.variant }}</td>
+                  <td
+                    v-for="rt in group.repoTypes"
+                    :key="rt"
+                    class="px-4 py-3 text-center"
+                  >
+                    <template v-for="(s, si) in [cellStatus(row.repos[rt])]" :key="si">
+                      <button
+                        v-if="s.type === 'green'"
+                        type="button"
+                        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/50 cursor-pointer transition-colors"
+                        @click="toggleCell(cellKey(group.productVersion, row.variant, rt))"
+                      >
+                        <span class="inline-block w-1.5 h-1.5 rounded-full bg-green-500"></span>
+                        {{ s.label }}
+                        <svg class="w-3 h-3 transition-transform" :class="{ 'rotate-180': expandedCells.has(cellKey(group.productVersion, row.variant, rt)) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                      </button>
+                      <span
+                        v-else-if="s.type === 'amber'"
+                        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                      >
+                        <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-500"></span>
+                        {{ s.label }}
+                      </span>
+                      <span
+                        v-else
+                        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
+                      >
+                        <span class="inline-block w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-gray-500"></span>
+                        {{ s.label }}
+                      </span>
+                    </template>
+                  </td>
+                </tr>
+                <!-- Expanded file details row -->
+                <template v-for="rt in group.repoTypes" :key="'exp-' + rt">
+                  <tr v-if="expandedCells.has(cellKey(group.productVersion, row.variant, rt)) && row.repos[rt]?.files?.length > 0">
+                    <td :colspan="group.repoTypes.length + 1" class="px-4 py-3 bg-gray-50/50 dark:bg-gray-900/20">
+                      <div class="ml-4 border-l-2 border-gray-200 dark:border-gray-600 pl-4">
+                        <div class="flex items-center gap-2 mb-2">
+                          <span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">{{ row.variant }} &middot; {{ REPO_TYPE_LABELS[rt] || rt }}</span>
+                          <a
+                            :href="row.repos[rt].index_url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-xs text-primary-600 dark:text-primary-400 hover:underline"
+                          >Open index &#8599;</a>
+                        </div>
+                        <ul>
+                          <li v-for="f in row.repos[rt].files" :key="f.filename" class="py-0.5">
+                            <a
+                              :href="f.url"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              class="text-sm text-gray-600 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 hover:underline"
+                            >{{ f.filename }}</a>
+                            <span v-if="f.platform && f.platform !== 'any'" class="text-gray-400 dark:text-gray-500 text-xs ml-1">{{ f.platform.replace(/^linux_/, '') }}</span>
+                          </li>
+                        </ul>
+                      </div>
+                    </td>
+                  </tr>
+                </template>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </details>
 
       <!-- Version × Product Version Matrix -->
-      <details v-if="versionMatrix && versionMatrix.pkgVersions.length > 0" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm overflow-hidden group/matrix" open>
+      <details v-if="versionMatrix && versionMatrix.pkgVersions.length > 0" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm overflow-hidden group/matrix">
         <summary class="px-4 py-3 bg-gray-100 dark:bg-gray-700 cursor-pointer flex items-center gap-2 hover:bg-gray-200/80 dark:hover:bg-gray-600 transition-colors">
           <svg class="w-3.5 h-3.5 text-gray-400 transition-transform group-open/matrix:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
@@ -551,13 +687,14 @@ const versionMatrix = computed(() => {
                   :key="pv"
                   class="px-4 py-3 text-center"
                 >
-                  <template v-if="versionMatrix.getCell(pkgVer, pv)">
+                  <template v-for="(cell, ci) in [versionMatrix.getCell(pkgVer, pv)]" :key="ci">
                     <span
+                      v-if="cell"
                       class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
-                      :title="[...versionMatrix.getCell(pkgVer, pv).variants].join(', ')"
-                    >{{ versionMatrix.getCell(pkgVer, pv).count }} file{{ versionMatrix.getCell(pkgVer, pv).count !== 1 ? 's' : '' }}</span>
+                      :title="[...cell.variants].join(', ')"
+                    >{{ cell.count }} file{{ cell.count !== 1 ? 's' : '' }}</span>
+                    <span v-else class="text-gray-300 dark:text-gray-600">&mdash;</span>
                   </template>
-                  <span v-else class="text-gray-300 dark:text-gray-600">&mdash;</span>
                 </td>
               </tr>
             </tbody>
@@ -565,16 +702,20 @@ const versionMatrix = computed(() => {
         </div>
       </details>
 
-      <!-- Version Breakdown (expandable with filters) -->
-      <div v-if="showVersionBreakdown" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden shadow-sm">
-        <!-- Header with filter pills -->
-        <div class="px-4 py-3 border-b border-gray-100 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/40">
-          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
-              {{ filteredVersionBreakdown.length }} version{{ filteredVersionBreakdown.length !== 1 ? 's' : '' }} built
-            </p>
+      <!-- Version Breakdown (collapsed by default) -->
+      <details v-if="showVersionBreakdown" class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden shadow-sm group/vb">
+        <summary class="px-4 py-3 bg-gray-100 dark:bg-gray-700 cursor-pointer flex items-center gap-2 hover:bg-gray-200/80 dark:hover:bg-gray-600 transition-colors">
+          <svg class="w-3.5 h-3.5 text-gray-400 transition-transform group-open/vb:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+          <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+            Version details &mdash; {{ filteredVersionBreakdown.length }} version{{ filteredVersionBreakdown.length !== 1 ? 's' : '' }} built
+          </span>
+        </summary>
+        <div class="border-t border-gray-100 dark:border-gray-700">
+          <!-- Filter pills -->
+          <div class="px-4 py-3 border-b border-gray-100 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/40">
             <div class="flex flex-wrap items-center gap-2">
-              <!-- Variant filter pills -->
               <button
                 v-for="variant in allVersionVariants"
                 :key="'fv-' + variant"
@@ -585,7 +726,6 @@ const versionMatrix = computed(() => {
                   : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'"
                 @click="toggleVariantFilter(variant)"
               >{{ variant }}</button>
-              <!-- Repo type filter pills -->
               <button
                 v-for="rt in allVersionRepoTypes"
                 :key="'fr-' + rt"
@@ -596,7 +736,6 @@ const versionMatrix = computed(() => {
                   : (rt === 'production' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/50' : rt === 'test' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600')"
                 @click="toggleRepoFilter(rt)"
               >{{ REPO_TYPE_LABELS[rt] || rt }}</button>
-              <!-- Clear filters -->
               <button
                 v-if="versionVariantFilter || versionRepoFilter"
                 type="button"
@@ -605,87 +744,86 @@ const versionMatrix = computed(() => {
               >&times; Clear</button>
             </div>
           </div>
-        </div>
-        <!-- Version rows -->
-        <div class="divide-y divide-gray-100 dark:divide-gray-700">
-          <div v-for="v in filteredVersionBreakdown" :key="v.version" :id="'pkg-ver-' + v.version">
-            <div
-              class="px-4 py-3 flex items-center gap-4 cursor-pointer hover:bg-gray-50/80 dark:hover:bg-gray-900/30 transition-colors"
-              @click="toggleVersion(v.version)"
-            >
-              <svg
-                class="w-3.5 h-3.5 text-gray-400 transition-transform shrink-0"
-                :class="{ 'rotate-90': expandedVersions.has(v.version) }"
-                xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+          <!-- Version rows -->
+          <div class="divide-y divide-gray-100 dark:divide-gray-700">
+            <div v-for="v in filteredVersionBreakdown" :key="v.version" :id="'pkg-ver-' + v.version">
+              <div
+                class="px-4 py-3 flex items-center gap-4 cursor-pointer hover:bg-gray-50/80 dark:hover:bg-gray-900/30 transition-colors"
+                @click="toggleVersion(v.version)"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-              </svg>
-              <span class="font-medium text-gray-900 dark:text-gray-100 min-w-[80px]">{{ v.version }}</span>
-              <span
-                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
-              >{{ v.files }} file{{ v.files !== 1 ? 's' : '' }}</span>
-              <div class="flex flex-wrap gap-1">
+                <svg
+                  class="w-3.5 h-3.5 text-gray-400 transition-transform shrink-0"
+                  :class="{ 'rotate-90': expandedVersions.has(v.version) }"
+                  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                </svg>
+                <span class="font-medium text-gray-900 dark:text-gray-100 min-w-[80px]">{{ v.version }}</span>
                 <span
-                  v-for="variant in v.variants"
-                  :key="variant"
                   class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
-                >{{ variant }}</span>
+                >{{ v.files }} file{{ v.files !== 1 ? 's' : '' }}</span>
+                <div class="flex flex-wrap gap-1">
+                  <span
+                    v-for="variant in v.variants"
+                    :key="variant"
+                    class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                  >{{ variant }}</span>
+                </div>
+                <div class="flex flex-wrap gap-1 ml-auto">
+                  <span
+                    v-for="rt in v.repoTypes"
+                    :key="rt"
+                    class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                    :class="{
+                      'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300': rt === 'production',
+                      'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300': rt === 'test',
+                      'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400': rt !== 'production' && rt !== 'test'
+                    }"
+                  >{{ REPO_TYPE_LABELS[rt] || rt }}</span>
+                </div>
               </div>
-              <div class="flex flex-wrap gap-1 ml-auto">
-                <span
-                  v-for="rt in v.repoTypes"
-                  :key="rt"
-                  class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
-                  :class="{
-                    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300': rt === 'production',
-                    'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300': rt === 'test',
-                    'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400': rt !== 'production' && rt !== 'test'
-                  }"
-                >{{ REPO_TYPE_LABELS[rt] || rt }}</span>
-              </div>
-            </div>
-            <!-- Expanded: files grouped by variant -->
-            <div v-if="expandedVersions.has(v.version)" class="px-4 pb-4 pt-2 ml-8 border-l-2 border-gray-100 dark:border-gray-700">
-              <div v-for="group in v.groups" :key="group.variant" class="mb-4 last:mb-0">
-                <div class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">{{ group.variant }}</div>
-                <div class="grid gap-4" :style="{ gridTemplateColumns: 'repeat(' + group.columns.length + ', 1fr)' }">
-                  <div v-for="col in group.columns" :key="col.repoType">
-                    <div class="flex items-center gap-2 mb-1.5">
-                      <span
-                        class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium"
-                        :class="{
-                          'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300': col.repoType === 'production',
-                          'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300': col.repoType === 'test',
-                          'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400': col.repoType !== 'production' && col.repoType !== 'test'
-                        }"
-                      >{{ REPO_TYPE_LABELS[col.repoType] || col.repoType }}</span>
-                      <a
-                        :href="col.indexUrl"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-xs text-primary-600 dark:text-primary-400 hover:underline truncate"
-                        @click.stop
-                      >&#8599;</a>
-                    </div>
-                    <ul class="pl-1">
-                      <li v-for="f in col.files" :key="f.filename" class="text-sm py-0.5">
+              <div v-if="expandedVersions.has(v.version)" class="px-4 pb-4 pt-2 ml-8 border-l-2 border-gray-100 dark:border-gray-700">
+                <div v-for="group in v.groups" :key="group.variant" class="mb-4 last:mb-0">
+                  <div class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">{{ group.variant }}</div>
+                  <div class="grid gap-4" :style="{ gridTemplateColumns: 'repeat(' + group.columns.length + ', 1fr)' }">
+                    <div v-for="col in group.columns" :key="col.repoType">
+                      <div class="flex items-center gap-2 mb-1.5">
+                        <span
+                          class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium"
+                          :class="{
+                            'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300': col.repoType === 'production',
+                            'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300': col.repoType === 'test',
+                            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400': col.repoType !== 'production' && col.repoType !== 'test'
+                          }"
+                        >{{ REPO_TYPE_LABELS[col.repoType] || col.repoType }}</span>
                         <a
-                          :href="f.url"
+                          :href="col.indexUrl"
                           target="_blank"
                           rel="noopener noreferrer"
-                          class="text-gray-600 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 hover:underline"
+                          class="text-xs text-primary-600 dark:text-primary-400 hover:underline truncate"
                           @click.stop
-                        >{{ f.filename }}</a>
-                        <span v-if="f.platform && f.platform !== 'any'" class="text-gray-400 dark:text-gray-500 text-xs ml-1">{{ f.platform.replace(/^linux_/, '') }}</span>
-                      </li>
-                    </ul>
+                        >&#8599;</a>
+                      </div>
+                      <ul class="pl-1">
+                        <li v-for="f in col.files" :key="f.filename" class="text-sm py-0.5">
+                          <a
+                            :href="f.url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-gray-600 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 hover:underline"
+                            @click.stop
+                          >{{ f.filename }}</a>
+                          <span v-if="f.platform && f.platform !== 'any'" class="text-gray-400 dark:text-gray-500 text-xs ml-1">{{ f.platform.replace(/^linux_/, '') }}</span>
+                        </li>
+                      </ul>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </details>
 
     </template>
   </div>


### PR DESCRIPTION
## Summary

- **Index Availability Table** — primary results view with one collapsible table per product version; rows are variants, columns are repo types (Test/Production). Cells are color-coded pills: green ("Available (N files found)", clickable to expand file list), amber (not found/timeout/error), gray (no index/N/A)
- **Results header** — prominent header with package name, indexes checked count, "Copy results URL" button (clipboard icon, green confirmation state), and external link to packages.redhat.com
- **Shareable URLs** — search params encoded in hash query string (`?tab=search&pkg=...&pv=...`); on page load, parent view auto-switches to Search tab and child auto-populates form + runs search
- **Version breakdown** — collapsible section with variant/repo-type filter pills, expandable per-version file details
- **Version × Product Version Matrix** — cross-reference table for multi-product searches (collapsed by default)

## Test plan

- [ ] Search for a package (e.g. `vllm`, `torch`) and verify results display in the availability table
- [ ] Click green pills to expand/collapse file lists
- [ ] Click "Copy results URL" — verify clipboard contains shareable URL
- [ ] Open the copied URL in a new tab — verify search auto-runs with correct params
- [ ] Search across all product versions (leave Product Version blank) — verify matrix appears
- [ ] Test with a package that doesn't exist — verify warning banner
- [ ] Verify dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)