### PR TITLE
docs: update documentation for core-split architecture

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@ hard constraints, and code style: see AGENTS.md (imported above).
 
 ```bash
 npm install
+npm run setup          # Symlinks core platform files into workspace
 cp .env.example .env   # Edit with your credentials
 npm run dev:full       # Starts Vite (5173) + Express (3001)
 ```
@@ -95,48 +96,50 @@ npm run dev:full       # Starts Vite (5173) + Express (3001)
 
 ## Project Structure
 
+This repo is the AI Engineering consumer of `@org-pulse/core`. Core files are symlinked by `npm run setup`.
+
 ```
-src/
-  components/       # App shell (App.vue, AppSidebar, LandingPage, SettingsView)
-  composables/      # Shell-only composables (useModules, useModuleAdmin)
-  module-loader.js  # Frontend module auto-discovery via import.meta.glob
-  __tests__/        # Frontend tests
+server/
+  index.js            # Thin wrapper calling core's startServer() with AI Eng config
 
-shared/
-  client/
-    composables/    # Shared composables (useRoster, useAuth, useGithubStats, etc.)
-    services/       # API client with caching (api.js)
-    components/     # Shared UI (Toast, LoadingOverlay, RefreshModal)
-    index.js        # Barrel export
-  server/
-    storage.js      # Filesystem storage abstraction
-    demo-storage.js # Fixture-backed storage for demo mode
-    auth.js         # Auth middleware (requireAuth, requireAdmin)
-    roster-sync/    # Roster sync engine (LDAP + Google Sheets), config, constants
-    index.js        # Barrel export
+modules/              # AI Eng-specific modules (auto-discovered)
+platform/             # AI Eng-specific core UI customizations
+fixtures/             # Demo mode fixture data for AI Eng modules
+scripts/
+  setup.js            # Symlinks core files (src/, shared/, modules/team-tracker)
+  validate-dockerfile-deps.js  # CI check: Dockerfile deps match package.json
+
+deploy/
+  ai-eng.backend.Dockerfile    # Extends core backend image
+  ai-eng.frontend.Dockerfile   # Extends core builder + runtime images
+  openshift/overlays/ai-eng*/  # Kustomize overlays (remote base from core repo)
+
+# Symlinked from @org-pulse/core (do not edit directly):
+src/                  # App shell (App.vue, AppSidebar, LandingPage, SettingsView)
+shared/               # Shared client/server code (composables, storage, auth)
+modules/team-tracker/ # Core team-tracker module
 ```
-
-## Local Kind Cluster
-
-For testing the containerized deployment locally, see `deploy/KIND.md`. The `deploy/openshift/overlays/local/` overlay strips OpenShift-specific resources (OAuth proxy, Route, ServiceAccount) and uses locally-built images with `imagePullPolicy: Never`. Cluster name is `team-tracker` (not the default `kind`). If using Podman: `export KIND_EXPERIMENTAL_PROVIDER=podman`.
 
 ## Deployment
 
-Deployed to OpenShift via ArgoCD. Full guide: `deploy/OPENSHIFT.md`.
+Deployed to OpenShift via ArgoCD. Full guide: `docs/DEPLOYMENT.md`.
 
-| Component | Core Image | AI Eng Image |
+AI Eng images extend core images from `@org-pulse/core`. Core images are built and published by the [core repo](https://github.com/red-hat-data-services/org-pulse-core).
+
+| Component | Core Image (from core repo) | AI Eng Image (from this repo) |
 |-----------|-----------|--------------|
 | Backend | `quay.io/org-pulse/org-pulse-core-backend` | `quay.io/org-pulse/team-tracker-backend` (extends core) |
-| Frontend | `quay.io/org-pulse/org-pulse-core-frontend` | `quay.io/org-pulse/team-tracker-frontend` (extends core) |
 | Frontend Builder | `quay.io/org-pulse/org-pulse-core-frontend-builder` | — (used as build stage) |
 | Frontend Runtime | `quay.io/org-pulse/org-pulse-core-frontend-runtime` | — (used as runtime stage) |
+| Frontend | — | `quay.io/org-pulse/team-tracker-frontend` (built from builder + runtime) |
 | OAuth Proxy | `quay.io/openshift/origin-oauth-proxy:4.16` (sidecar) | same |
 
-Kustomize layers: `base/` (core platform + team-tracker) → `overlays/ai-eng/` (AI Eng modules + secrets) → `overlays/ai-eng-{dev,preprod,prod}/` (environment-specific). The `overlays/local/` overlay uses core images for Kind testing.
+Kustomize layers: remote `base/` from core repo → `overlays/ai-eng/` (AI Eng modules + secrets) → `overlays/ai-eng-{dev,preprod,prod}/` (environment-specific).
 
 ### CI/CD
-- **`ci.yml`** — PRs + main: lint, test, build, kustomize validate. Required check: "Test & Build".
-- **`build-images.yml`** — main pushes: builds core images first (backend, frontend, frontend-builder, frontend-runtime), then AI Eng images FROM core, runs smoke tests, pushes to Quay (`:<sha>` + `:latest`), commits prod image tag update directly to main (`[skip ci]`).
+- **`ci.yml`** — PRs + main: lint, test, build, kustomize validate, Dockerfile dep sync check. Required check: "Test & Build".
+- **`build-images.yml`** — main pushes: pulls core images (by version from `@org-pulse/core/package.json`), builds AI Eng images FROM core, runs smoke tests, pushes to Quay (`:<sha>` + `:latest`), commits prod image tag update directly to main (`[skip ci]`).
+- **`core-upgrade.yml`** — triggered by `repository_dispatch` from core repo on new releases. Creates a PR to bump `@org-pulse/core` version and kustomize remote ref.
 - ConfigMap changes auto-trigger rollouts via kustomize `configMapGenerator` — ConfigMap names include a content hash suffix (e.g., `team-tracker-config-5h2f9k`), so any data change produces a new name and triggers a pod rollout automatically.
 
 **Branch protection** uses a GitHub repository ruleset on `main`:
@@ -159,12 +162,8 @@ Kustomize layers: `base/` (core platform + team-tracker) → `overlays/ai-eng/` 
 **Smoke tests** use Playwright to verify the production container images. Located in `tests/smoke/app-loads.spec.js`. These run automatically in CI after images are built and can also be run locally:
 
 ```bash
-make build-core-frontend-image  # Build core frontend image (team-tracker only)
-make build-core-backend-image   # Build core backend image (team-tracker only)
-make smoke-test-core            # Run smoke tests against core images
-
-make build-frontend-image       # Build AI Eng frontend image (all modules)
-make build-backend-image        # Build AI Eng backend image (all modules)
+make build-frontend-image       # Build AI Eng frontend image (extends core)
+make build-backend-image        # Build AI Eng backend image (extends core)
 make smoke-test                 # Run smoke tests against AI Eng images
 ```
 
@@ -180,10 +179,11 @@ Playwright runs in a container (`quay.io/browser/playwright-chromium`), so no lo
 **IMPORTANT:** The Playwright version must match between `package.json` (`@playwright/test`) and `Makefile` (`PLAYWRIGHT_IMAGE`). When updating Playwright, change both files to the same version to prevent browser binary mismatches. The Quay image uses `playwright-<version>` tags (e.g., `playwright-1.60.0`).
 
 CI workflow (`build-images.yml`):
-1. Builds core images (backend, frontend, frontend-builder, frontend-runtime) with smoke test
-2. Builds AI Eng images FROM core (backend extends core-backend, frontend uses core-builder + core-runtime)
-3. Runs Playwright smoke tests against AI Eng images
-4. Pushes all images to Quay, commits prod image tag update directly to main
+1. Resolves core image tag from `@org-pulse/core/package.json` version
+2. Pulls pre-built core images from Quay
+3. Builds AI Eng images FROM core (backend extends core-backend, frontend uses core-builder + core-runtime)
+4. Runs Playwright smoke tests against AI Eng images
+5. Pushes AI Eng images to Quay, commits prod image tag update directly to main
 
 **Integration tests** use Playwright to verify module-specific functionality against production containers in demo mode. Located in `tests/integration/<module>.spec.js`:
 
@@ -213,7 +213,7 @@ To add integration tests for a new module:
 3. That's it! The matrix automatically picks up the new module when it changes
 
 ### Building images on ARM Macs
-Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. See `deploy/OPENSHIFT.md` step 3 for details. This works because the backend has no native Node addons (all pure JS).
+Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. This works because the backend has no native Node addons (all pure JS).
 
 ### Dev vs prod
 - **Base** sets `ADMIN_EMAILS=` (empty) and `CRON_ADMIN_EMAIL=`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,6 @@ hard constraints, and code style: see AGENTS.md (imported above).
 
 ```bash
 npm install
-npm run setup          # Symlinks core platform files into workspace
 cp .env.example .env   # Edit with your credentials
 npm run dev:full       # Starts Vite (5173) + Express (3001)
 ```
@@ -96,50 +95,48 @@ npm run dev:full       # Starts Vite (5173) + Express (3001)
 
 ## Project Structure
 
-This repo is the AI Engineering consumer of `@org-pulse/core`. Core files are symlinked by `npm run setup`.
-
 ```
-server/
-  index.js            # Thin wrapper calling core's startServer() with AI Eng config
+src/
+  components/       # App shell (App.vue, AppSidebar, LandingPage, SettingsView)
+  composables/      # Shell-only composables (useModules, useModuleAdmin)
+  module-loader.js  # Frontend module auto-discovery via import.meta.glob
+  __tests__/        # Frontend tests
 
-modules/              # AI Eng-specific modules (auto-discovered)
-platform/             # AI Eng-specific core UI customizations
-fixtures/             # Demo mode fixture data for AI Eng modules
-scripts/
-  setup.js            # Symlinks core files (src/, shared/, modules/team-tracker)
-  validate-dockerfile-deps.js  # CI check: Dockerfile deps match package.json
-
-deploy/
-  ai-eng.backend.Dockerfile    # Extends core backend image
-  ai-eng.frontend.Dockerfile   # Extends core builder + runtime images
-  openshift/overlays/ai-eng*/  # Kustomize overlays (remote base from core repo)
-
-# Symlinked from @org-pulse/core (do not edit directly):
-src/                  # App shell (App.vue, AppSidebar, LandingPage, SettingsView)
-shared/               # Shared client/server code (composables, storage, auth)
-modules/team-tracker/ # Core team-tracker module
+shared/
+  client/
+    composables/    # Shared composables (useRoster, useAuth, useGithubStats, etc.)
+    services/       # API client with caching (api.js)
+    components/     # Shared UI (Toast, LoadingOverlay, RefreshModal)
+    index.js        # Barrel export
+  server/
+    storage.js      # Filesystem storage abstraction
+    demo-storage.js # Fixture-backed storage for demo mode
+    auth.js         # Auth middleware (requireAuth, requireAdmin)
+    roster-sync/    # Roster sync engine (LDAP + Google Sheets), config, constants
+    index.js        # Barrel export
 ```
+
+## Local Kind Cluster
+
+For testing the containerized deployment locally, see `deploy/KIND.md`. The `deploy/openshift/overlays/local/` overlay strips OpenShift-specific resources (OAuth proxy, Route, ServiceAccount) and uses locally-built images with `imagePullPolicy: Never`. Cluster name is `team-tracker` (not the default `kind`). If using Podman: `export KIND_EXPERIMENTAL_PROVIDER=podman`.
 
 ## Deployment
 
-Deployed to OpenShift via ArgoCD. Full guide: `docs/DEPLOYMENT.md`.
+Deployed to OpenShift via ArgoCD. Full guide: `deploy/OPENSHIFT.md`.
 
-AI Eng images extend core images from `@org-pulse/core`. Core images are built and published by the [core repo](https://github.com/red-hat-data-services/org-pulse-core).
-
-| Component | Core Image (from core repo) | AI Eng Image (from this repo) |
+| Component | Core Image | AI Eng Image |
 |-----------|-----------|--------------|
 | Backend | `quay.io/org-pulse/org-pulse-core-backend` | `quay.io/org-pulse/team-tracker-backend` (extends core) |
+| Frontend | `quay.io/org-pulse/org-pulse-core-frontend` | `quay.io/org-pulse/team-tracker-frontend` (extends core) |
 | Frontend Builder | `quay.io/org-pulse/org-pulse-core-frontend-builder` | — (used as build stage) |
 | Frontend Runtime | `quay.io/org-pulse/org-pulse-core-frontend-runtime` | — (used as runtime stage) |
-| Frontend | — | `quay.io/org-pulse/team-tracker-frontend` (built from builder + runtime) |
 | OAuth Proxy | `quay.io/openshift/origin-oauth-proxy:4.16` (sidecar) | same |
 
-Kustomize layers: remote `base/` from core repo → `overlays/ai-eng/` (AI Eng modules + secrets) → `overlays/ai-eng-{dev,preprod,prod}/` (environment-specific).
+Kustomize layers: `base/` (core platform + team-tracker) → `overlays/ai-eng/` (AI Eng modules + secrets) → `overlays/ai-eng-{dev,preprod,prod}/` (environment-specific). The `overlays/local/` overlay uses core images for Kind testing.
 
 ### CI/CD
-- **`ci.yml`** — PRs + main: lint, test, build, kustomize validate, Dockerfile dep sync check. Required check: "Test & Build".
-- **`build-images.yml`** — main pushes: pulls core images (by version from `@org-pulse/core/package.json`), builds AI Eng images FROM core, runs smoke tests, pushes to Quay (`:<sha>` + `:latest`), commits prod image tag update directly to main (`[skip ci]`).
-- **`core-upgrade.yml`** — triggered by `repository_dispatch` from core repo on new releases. Creates a PR to bump `@org-pulse/core` version and kustomize remote ref.
+- **`ci.yml`** — PRs + main: lint, test, build, kustomize validate. Required check: "Test & Build".
+- **`build-images.yml`** — main pushes: builds core images first (backend, frontend, frontend-builder, frontend-runtime), then AI Eng images FROM core, runs smoke tests, pushes to Quay (`:<sha>` + `:latest`), commits prod image tag update directly to main (`[skip ci]`).
 - ConfigMap changes auto-trigger rollouts via kustomize `configMapGenerator` — ConfigMap names include a content hash suffix (e.g., `team-tracker-config-5h2f9k`), so any data change produces a new name and triggers a pod rollout automatically.
 
 **Branch protection** uses a GitHub repository ruleset on `main`:
@@ -162,8 +159,12 @@ Kustomize layers: remote `base/` from core repo → `overlays/ai-eng/` (AI Eng m
 **Smoke tests** use Playwright to verify the production container images. Located in `tests/smoke/app-loads.spec.js`. These run automatically in CI after images are built and can also be run locally:
 
 ```bash
-make build-frontend-image       # Build AI Eng frontend image (extends core)
-make build-backend-image        # Build AI Eng backend image (extends core)
+make build-core-frontend-image  # Build core frontend image (team-tracker only)
+make build-core-backend-image   # Build core backend image (team-tracker only)
+make smoke-test-core            # Run smoke tests against core images
+
+make build-frontend-image       # Build AI Eng frontend image (all modules)
+make build-backend-image        # Build AI Eng backend image (all modules)
 make smoke-test                 # Run smoke tests against AI Eng images
 ```
 
@@ -179,11 +180,10 @@ Playwright runs in a container (`quay.io/browser/playwright-chromium`), so no lo
 **IMPORTANT:** The Playwright version must match between `package.json` (`@playwright/test`) and `Makefile` (`PLAYWRIGHT_IMAGE`). When updating Playwright, change both files to the same version to prevent browser binary mismatches. The Quay image uses `playwright-<version>` tags (e.g., `playwright-1.60.0`).
 
 CI workflow (`build-images.yml`):
-1. Resolves core image tag from `@org-pulse/core/package.json` version
-2. Pulls pre-built core images from Quay
-3. Builds AI Eng images FROM core (backend extends core-backend, frontend uses core-builder + core-runtime)
-4. Runs Playwright smoke tests against AI Eng images
-5. Pushes AI Eng images to Quay, commits prod image tag update directly to main
+1. Builds core images (backend, frontend, frontend-builder, frontend-runtime) with smoke test
+2. Builds AI Eng images FROM core (backend extends core-backend, frontend uses core-builder + core-runtime)
+3. Runs Playwright smoke tests against AI Eng images
+4. Pushes all images to Quay, commits prod image tag update directly to main
 
 **Integration tests** use Playwright to verify module-specific functionality against production containers in demo mode. Located in `tests/integration/<module>.spec.js`:
 
@@ -213,7 +213,7 @@ To add integration tests for a new module:
 3. That's it! The matrix automatically picks up the new module when it changes
 
 ### Building images on ARM Macs
-Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. This works because the backend has no native Node addons (all pure JS).
+Standard `--platform linux/amd64` builds fail: npm times out under QEMU, esbuild crashes. Workaround: build/install natively, then copy into amd64 base images. See `deploy/OPENSHIFT.md` step 3 for details. This works because the backend has no native Node addons (all pure JS).
 
 ### Dev vs prod
 - **Base** sets `ADMIN_EMAILS=` (empty) and `CRON_ADMIN_EMAIL=`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,16 @@ deployed on OpenShift via ArgoCD.
 
 ## Architecture
 
+This repo is the **AI Engineering consumer** of [`@org-pulse/core`](https://github.com/red-hat-data-services/org-pulse-core). Core platform code (app shell, shared utilities, team-tracker module) is installed as an npm dependency and symlinked into the workspace by `npm run setup`.
+
+- **Core platform**: `@org-pulse/core` npm package — app shell, shared client/server code, team-tracker module
 - **Frontend**: Vue 3 SPA (`<script setup>`), Vite 8, Tailwind CSS 3, Chart.js 4
-- **Backend**: Express (port 3001), single `server/dev-server.js` for dev + prod
-- **Modules**: Built-in modules in `modules/<slug>/` with `module.json` manifests, auto-discovered
+- **Backend**: Express (port 3001), thin `server/index.js` wrapper calling core's `startServer()`
+- **Modules**: AI Eng modules in `modules/<slug>/` with `module.json` manifests, auto-discovered
 - **Auth**: OpenShift OAuth proxy in prod; no auth locally (uses `ADMIN_EMAILS`)
 - **Storage**: Local filesystem (`./data/`), mounted as PVC in OpenShift
-- **Shared code**: `shared/client/` and `shared/server/`, importable via `@shared` alias
-- **Platform extensions**: `platform/` holds deployment-specific core UI customizations (e.g., About page tabs), importable via `@platform` alias. Separate from modules — see `docs/PLATFORM.md`
+- **Shared code**: `shared/client/` and `shared/server/` (from core), importable via `@shared` alias
+- **Platform extensions**: `platform/` holds AI Eng-specific core UI customizations (e.g., About page tabs), importable via `@platform` alias. Separate from modules — see `docs/PLATFORM.md`
 
 See `docs/MODULES.md` for the module development guide.
 
@@ -126,6 +129,7 @@ checklist, which explicitly enforces the hard constraints above.
 ## Commands
 
 ```bash
+npm run setup                   # Symlink core platform into workspace (run after npm install)
 npm run dev:full              # Start Vite (5173) + Express (3001)
 npm run dev                   # Vite only
 npm run dev:server            # Express only (needs .env)
@@ -136,9 +140,9 @@ npm run build                 # Production build
 npm run validate:modules      # Validate module manifests
 npm run validate:platform     # Validate platform extension manifests
 npm run validate:openapi      # Validate OpenAPI annotations
+npm run validate:dockerfile-deps  # Verify Dockerfile deps match package.json
 
 # Container-based tests (requires Docker/Podman)
-make smoke-test-core            # Run smoke tests against core images
 make smoke-test                 # Run smoke tests against AI Eng images
 make test-module MODULE=<name>  # Run integration tests for a module
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
 git clone https://github.com/red-hat-data-services/rhai-org-pulse.git
 cd rhai-org-pulse
 npm install
+npm run setup    # Symlinks core platform files (src/, shared/, modules/team-tracker) into workspace
 ```
 
 ### 2. Configure environment
@@ -62,76 +63,50 @@ npm run lint        # linting
 
 ## Project Structure
 
+This repo is the AI Engineering consumer of [`@org-pulse/core`](https://github.com/red-hat-data-services/org-pulse-core). Core platform files (`src/`, `shared/`, `modules/team-tracker`) are symlinked into the workspace by `npm run setup`.
+
 ```
-src/
-  components/         # App shell components (App.vue, AppSidebar, SettingsView, etc.)
-  composables/        # Shell-only hooks (useModules, useTheme, useApiTokens, etc.)
-  module-loader.js    # Frontend module auto-discovery via import.meta.glob
-  __tests__/          # App shell tests (Vitest + jsdom)
+server/
+  index.js            # Thin wrapper — calls core's startServer() with AI Eng config
 
-shared/
-  client/
-    composables/      # Shared composables (useRoster, useAuth, useGithubStats, etc.)
-    services/api.js   # API client with caching
-    components/       # Shared UI (Toast, LoadingOverlay, RefreshModal, etc.)
-  server/
-    storage.js        # Local file storage abstraction
-    demo-storage.js   # Demo mode fixture storage
-    auth.js           # Auth middleware (requireAuth, requireAdmin)
-    roster-sync/      # Automated roster building
-      index.js        # Orchestrator (sync + daily scheduler)
-      ipa-client.js   # LDAP client (Red Hat IPA directory)
-      sheets.js       # Google Sheets API (enrichment data)
-      merge.js        # Combines LDAP + Sheets into roster format
-      config.js       # Sync config CRUD (stored on PVC/filesystem)
-      constants.js    # Shared constants
-
-modules/              # Feature modules (auto-discovered via module.json)
+modules/              # AI Eng-specific feature modules (auto-discovered via module.json)
   ai-impact/          # AI Impact assessments
   releases/           # Release tracking & execution pipeline
   system-health/      # System health monitoring
-  team-tracker/       # Team metrics (Jira, GitHub, GitLab)
-    server/
-      jira/           # Jira Cloud API integration
-        jira-client.js    # HTTP client (basic auth, Jira Cloud endpoints)
-        person-metrics.js # Per-person JQL metrics
-        sprint-report.js  # Sprint report API
-      github/
-        contributions.js  # GitHub GraphQL API (contribution stats)
-    client/
-      utils/metrics.js    # Metric calculations
-      composables/        # Module-specific hooks
-      views/              # Module views
   upstream-pulse/     # Upstream community tracking
+  catalyst-showcase/  # Catalyst showcase
+  customer-insights/  # Customer insights (Google Sheets)
+  okr-hub/            # OKR tracking & commitment reports
+  product-builds/     # Product build tracking
+  sotu-dashboard/     # State of the Union dashboard
 
-server/
-  dev-server.js       # Express server (local dev + production)
-  module-loader.js    # Backend module auto-discovery
-
-platform/             # Deployment-specific core UI customizations
+platform/             # AI Eng-specific core UI customizations (About page tabs, etc.)
 
 deploy/
-  core.backend.Dockerfile       # Core backend image (platform + team-tracker)
-  core.frontend.Dockerfile      # Core frontend image (complete, core-only)
-  core.frontend-builder.Dockerfile  # Core frontend build stage (for orgs adding modules)
-  core.frontend-runtime.Dockerfile  # Core frontend nginx runtime
-  ai-eng.backend.Dockerfile     # AI Eng backend (extends core + all modules)
-  ai-eng.frontend.Dockerfile    # AI Eng frontend (extends core + all modules)
-  nginx-default.conf    # nginx config for container/smoke-test SPA + API proxy
+  ai-eng.backend.Dockerfile     # AI Eng backend (extends core backend image)
+  ai-eng.frontend.Dockerfile    # AI Eng frontend (extends core builder + runtime)
   openshift/
-    base/               # Kustomize base manifests
-    overlays/ai-eng/    # AI Engineering shared overlay
+    overlays/ai-eng/        # AI Engineering shared overlay (kustomize remote base from core)
     overlays/ai-eng-dev/    # AI Eng dev cluster overlay
     overlays/ai-eng-preprod/ # AI Eng preprod overlay
     overlays/ai-eng-prod/   # AI Eng prod overlay
-    overlays/local/     # Local Kind cluster overlay
+
+scripts/
+  setup.js                  # Symlinks core files into workspace
+  validate-dockerfile-deps.js  # Verifies Dockerfile deps match package.json
+  openapi-route-count.json  # Route count snapshot for OpenAPI validation
 
 tests/
   smoke/              # Playwright smoke tests (container images)
   integration/        # Playwright module integration tests
-fixtures/             # Demo mode fixture data
+fixtures/             # Demo mode fixture data (AI Eng modules)
 data/                 # Local dev data (gitignored)
 secrets/              # Service account keys (gitignored)
+
+# Symlinked from @org-pulse/core (created by npm run setup):
+src/                  # → node_modules/@org-pulse/core/src/
+shared/               # → node_modules/@org-pulse/core/shared/
+modules/team-tracker/ # → node_modules/@org-pulse/core/modules/team-tracker/
 ```
 
 ## Making Changes
@@ -189,12 +164,8 @@ Smoke tests use **Playwright** to verify the production container images work co
 **Note:** First-time image pulls can take a while (~5-10 minutes)
 
 ```bash
-make build-core-backend-image   # Build core backend image (team-tracker only)
-make build-core-frontend-image  # Build core frontend image (team-tracker only)
-make smoke-test-core            # Run smoke tests against core images
-
-make build-backend-image   # Build AI Eng backend image (all modules)
-make build-frontend-image  # Build AI Eng frontend image (all modules)
+make build-backend-image   # Build AI Eng backend image (extends core)
+make build-frontend-image  # Build AI Eng frontend image (extends core)
 make smoke-test            # Run smoke tests against AI Eng images
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,10 @@ modules/              # AI Eng-specific feature modules (auto-discovered via mod
   releases/           # Release tracking & execution pipeline
   system-health/      # System health monitoring
   upstream-pulse/     # Upstream community tracking
-  catalyst-showcase/  # Catalyst showcase
+  ai-catalyst/        # AI Catalyst
   customer-insights/  # Customer insights (Google Sheets)
   okr-hub/            # OKR tracking & commitment reports
   product-builds/     # Product build tracking
-  sotu-dashboard/     # State of the Union dashboard
 
 platform/             # AI Eng-specific core UI customizations (About page tabs, etc.)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AI Engineering People & Teams
 
-Internal dashboard for tracking AI Platform engineering team productivity across Jira and GitHub.
+AI Engineering modules and deployment for [Org Pulse](https://github.com/red-hat-data-services/org-pulse-core), an internal engineering dashboard connecting Jira, GitHub, and GitLab data with team rosters to surface delivery insights.
+
+This repo contains AI Eng-specific modules, platform customizations, and deployment overlays. The core platform (`@org-pulse/core`) is installed as an npm dependency.
 
 ## Quick Start (Demo Mode)
 
@@ -8,6 +10,7 @@ Run the app with sample data — no credentials needed:
 
 ```bash
 npm install
+npm run setup          # Symlinks core platform files into the workspace
 
 echo "DEMO_MODE=true" > .env
 echo "VITE_DEMO_MODE=true" >> .env
@@ -31,6 +34,7 @@ For real Jira and GitHub data:
 
 ```bash
 npm install
+npm run setup          # Symlinks core platform files into the workspace
 ```
 
 ### 2. Configure environment
@@ -103,11 +107,12 @@ npm test                      # Run all tests
 npm run test:watch            # Tests in watch mode
 npm run lint                  # ESLint
 npm run build                 # Production build
+npm run setup                   # Symlink core platform into workspace
 npm run validate:modules      # Validate module manifests
 npm run validate:openapi      # Validate OpenAPI annotations
+npm run validate:dockerfile-deps  # Verify Dockerfile deps match package.json
 
 # Container-based tests (requires Docker/Podman)
-make smoke-test-core            # Run smoke tests against core images
 make smoke-test                 # Run smoke tests against AI Eng images
 make test-module MODULE=<name>  # Run integration tests for a module
 ```
@@ -123,9 +128,7 @@ make test-module MODULE=<name>  # Run integration tests for a module
 
 ## Deployment
 
-The app is deployed to OpenShift via ArgoCD. See [deploy/OPENSHIFT.md](deploy/OPENSHIFT.md) for the full deployment guide, including building images on ARM Macs, creating secrets, and troubleshooting.
-
-For local testing with Kind (Kubernetes in Docker), see [deploy/KIND.md](deploy/KIND.md).
+Deployed to OpenShift via ArgoCD. AI Eng images extend core images from `@org-pulse/core`. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full deployment guide.
 
 ## Contributing
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -36,7 +36,7 @@ kind: Kustomization
 namespace: your-namespace
 
 resources:
-  - https://github.com/red-hat-data-services/rhai-org-pulse//deploy/openshift/base?ref=v1.0.0
+  - https://github.com/red-hat-data-services/org-pulse-core//deploy/openshift/base?ref=v2.0.8
 
 patches:
   - path: route-patch.yaml


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the new consumer model where this repo installs `@org-pulse/core` as an npm dependency rather than containing core code directly.

- **README.md** — Add `npm run setup` to quick start, link to core repo, update commands (add `validate:dockerfile-deps`, remove `smoke-test-core`)
- **CONTRIBUTING.md** — Rewrite project structure to show symlinked layout, remove core-only Makefile targets, add setup step to getting started
- **AGENTS.md** — Update architecture section (`server/index.js` wrapper, not `server/dev-server.js`), add new commands
- **`.claude/CLAUDE.md`** — Update project structure, deployment table (core images from core repo), CI/CD description (pulls pre-built core images, new `core-upgrade.yml` workflow), remove stale `deploy/OPENSHIFT.md` reference
- **`docs/DEPLOYMENT.md`** — Update kustomize remote base URL to `org-pulse-core` repo

## Test plan

- [ ] Verify `npm run setup` instructions work on fresh clone
- [ ] Verify all file paths referenced in docs exist
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)