### PR TITLE
AIPCC-19137: Show production artifact keys and registry links

### DIFF
--- a/modules/product-builds/__tests__/client/formatting.test.js
+++ b/modules/product-builds/__tests__/client/formatting.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { getRegistryUrl, getQuayDirectTagUrl, getQuayAllTagsUrl, getDigestUrl } from '../../client/utils/formatting.js'
+
+describe('getRegistryUrl', () => {
+  it('returns quay tags URL for quay.io keys', () => {
+    expect(getRegistryUrl('quay.io/rhoai/spyre-ubi9:3.5.0')).toBe(
+      'https://quay.io/repository/rhoai/spyre-ubi9?tab=tags'
+    )
+  })
+
+  it('returns Red Hat Catalog URL for registry.redhat.io keys', () => {
+    expect(getRegistryUrl('registry.redhat.io/rhoai/spyre-ubi9:3.5.0')).toBe(
+      'https://catalog.redhat.com/en/search?searchType=All&q=rhoai%2Fspyre-ubi9&p=1'
+    )
+  })
+
+  it('returns null for unknown registries', () => {
+    expect(getRegistryUrl('docker.io/library/node:18')).toBeNull()
+  })
+
+  it('returns null for null/undefined', () => {
+    expect(getRegistryUrl(null)).toBeNull()
+    expect(getRegistryUrl(undefined)).toBeNull()
+  })
+})
+
+describe('getQuayDirectTagUrl', () => {
+  it('returns direct tag URL for quay keys with tag', () => {
+    expect(getQuayDirectTagUrl('quay.io/rhoai/spyre-ubi9:3.5.0')).toBe(
+      'https://quay.io/repository/rhoai/spyre-ubi9/tag/3.5.0'
+    )
+  })
+
+  it('returns null for quay keys without tag', () => {
+    expect(getQuayDirectTagUrl('quay.io/rhoai/spyre-ubi9')).toBeNull()
+  })
+
+  it('returns null for non-quay keys', () => {
+    expect(getQuayDirectTagUrl('registry.redhat.io/rhoai/spyre-ubi9:3.5.0')).toBeNull()
+  })
+
+  it('returns null for null', () => {
+    expect(getQuayDirectTagUrl(null)).toBeNull()
+  })
+})
+
+describe('getQuayAllTagsUrl', () => {
+  it('returns all-tags URL with tag filter for quay keys', () => {
+    expect(getQuayAllTagsUrl('quay.io/rhoai/spyre-ubi9:3.5.0')).toBe(
+      'https://quay.io/repository/rhoai/spyre-ubi9?tab=tags&tag=3.5.0'
+    )
+  })
+
+  it('returns all-tags URL without filter when no tag', () => {
+    expect(getQuayAllTagsUrl('quay.io/rhoai/spyre-ubi9')).toBe(
+      'https://quay.io/repository/rhoai/spyre-ubi9?tab=tags'
+    )
+  })
+
+  it('returns null for non-quay keys', () => {
+    expect(getQuayAllTagsUrl('registry.redhat.io/rhoai/spyre-ubi9:3.5.0')).toBeNull()
+  })
+})
+
+describe('getDigestUrl', () => {
+  it('returns quay manifest URL for quay keys', () => {
+    expect(getDigestUrl({ key: 'quay.io/rhoai/spyre-ubi9:3.5.0', sha_digest: 'sha256:abc123' })).toBe(
+      'https://quay.io/repository/rhoai/spyre-ubi9/manifest/sha256:abc123'
+    )
+  })
+
+  it('falls back to registry URL for non-quay keys', () => {
+    expect(getDigestUrl({ key: 'registry.redhat.io/rhoai/spyre-ubi9:3.5.0', sha_digest: 'sha256:abc123' })).toBe(
+      'https://catalog.redhat.com/en/search?searchType=All&q=rhoai%2Fspyre-ubi9&p=1'
+    )
+  })
+
+  it('returns null when no digest', () => {
+    expect(getDigestUrl({ key: 'quay.io/rhoai/spyre-ubi9:3.5.0', sha_digest: null })).toBeNull()
+  })
+
+  it('returns null when no key', () => {
+    expect(getDigestUrl({ key: null, sha_digest: 'sha256:abc123' })).toBeNull()
+  })
+
+  it('returns null for null artifact', () => {
+    expect(getDigestUrl(null)).toBeNull()
+  })
+})

--- a/modules/product-builds/client/utils/formatting.js
+++ b/modules/product-builds/client/utils/formatting.js
@@ -104,3 +104,41 @@ export function getAcceleratorInfo(art) {
     baseImage: labels['com.redhat.aiplatform.image'] || null
   }
 }
+
+export function getRegistryUrl(key) {
+  if (!key) return null
+  if (key.startsWith('quay.io/')) {
+    const path = key.replace('quay.io/', '').split(':')[0]
+    return `https://quay.io/repository/${path}?tab=tags`
+  }
+  if (key.startsWith('registry.redhat.io/')) {
+    const path = key.replace('registry.redhat.io/', '').split(':')[0]
+    return `https://catalog.redhat.com/en/search?searchType=All&q=${encodeURIComponent(path)}&p=1`
+  }
+  return null
+}
+
+export function getQuayDirectTagUrl(key) {
+  if (!key || !key.startsWith('quay.io/')) return null
+  const withoutRegistry = key.replace('quay.io/', '')
+  const [path, tag] = withoutRegistry.split(':')
+  if (!tag) return null
+  return `https://quay.io/repository/${path}/tag/${tag}`
+}
+
+export function getQuayAllTagsUrl(key) {
+  if (!key || !key.startsWith('quay.io/')) return null
+  const withoutRegistry = key.replace('quay.io/', '')
+  const [path, tag] = withoutRegistry.split(':')
+  const url = `https://quay.io/repository/${path}?tab=tags`
+  return tag ? `${url}&tag=${tag}` : url
+}
+
+export function getDigestUrl(art) {
+  if (!art?.sha_digest || !art?.key) return null
+  if (art.key.startsWith('quay.io/')) {
+    const path = art.key.replace('quay.io/', '').split(':')[0]
+    return `https://quay.io/repository/${path}/manifest/${art.sha_digest}`
+  }
+  return getRegistryUrl(art.key)
+}

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, inject, defineAsyncComponent } from 'vue'
 import { useArtifactDetail } from '../composables/useArtifacts'
-import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo, getCommitUrl } from '../utils/formatting'
+import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo, getCommitUrl, getRegistryUrl, getDigestUrl } from '../utils/formatting'
 import ChiBadge from '../components/ChiBadge.vue'
 
 const DependencyGraph = defineAsyncComponent(() => import('../components/DependencyGraph.vue'))
@@ -168,14 +168,19 @@ function copyToClipboard(value) {
   setTimeout(() => { copiedValue.value = null }, 1500)
 }
 
-function getDigestUrl(art) {
-  if (!art?.sha_digest || !art?.key) return null
-  if (art.key.startsWith('quay.io/')) {
-    const path = art.key.replace('quay.io/', '').split(':')[0]
-    return `https://quay.io/repository/${path}/manifest/${art.sha_digest}`
+const prodKey = computed(() => {
+  const names = artifact.value?.alternative_names
+  if (!Array.isArray(names)) return null
+  return names.find(n => n.startsWith('registry.redhat.io/')) || null
+})
+
+const allNames = computed(() => {
+  const names = artifact.value?.alternative_names || []
+  if (prodKey.value) {
+    return [artifact.value.key, ...names]
   }
-  return null
-}
+  return names
+})
 
 function sbomState(art) {
   const links = art?.sbom_links
@@ -304,7 +309,14 @@ const otherLabels = computed(() => {
     <template v-if="artifact">
       <!-- Header -->
       <div>
-        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100 break-all">{{ artifact.key }}</h1>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100 break-all">{{ prodKey || artifact.key }}</h1>
+        <div v-if="prodKey" class="flex items-center gap-2 mt-1">
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">Production</span>
+          <a v-if="getRegistryUrl(prodKey)" :href="getRegistryUrl(prodKey)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline text-sm inline-flex items-center gap-1">
+            View in Red Hat Catalog
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+          </a>
+        </div>
         <div v-if="artifact.series" class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400">
           <span>Series: <span class="text-gray-900 dark:text-gray-100">{{ artifact.series }}</span></span>
         </div>
@@ -436,6 +448,19 @@ const otherLabels = computed(() => {
           <div v-else-if="isContainerType(artifact) && sbomState(artifact) === 'empty'">
             <dt class="text-gray-500 dark:text-gray-400">Atlas SBOMs</dt>
             <dd class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">No SBOM links available</dd>
+          </div>
+          <div v-if="allNames.length" class="md:col-span-2">
+            <dt class="text-gray-500 dark:text-gray-400">Alternative Names</dt>
+            <dd class="mt-0.5 space-y-1">
+              <div v-for="name in allNames" :key="name" class="flex items-center gap-1.5">
+                <a v-if="getRegistryUrl(name)" :href="getRegistryUrl(name)" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline break-all">{{ name }}</a>
+                <span v-else class="font-mono text-xs text-gray-900 dark:text-gray-100 break-all">{{ name }}</span>
+                <button @click="copyToClipboard(name)" class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                  <svg v-if="copiedValue === name" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                  <svg v-else class="w-3 h-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                </button>
+              </div>
+            </dd>
           </div>
         </dl>
       </div>

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -177,7 +177,7 @@ const prodKey = computed(() => {
 const allNames = computed(() => {
   const names = artifact.value?.alternative_names || []
   if (prodKey.value) {
-    return [artifact.value.key, ...names]
+    return [artifact.value.key, ...names.filter(n => n !== prodKey.value)]
   }
   return names
 })

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -3,7 +3,7 @@ import { onMounted, inject, ref, computed, reactive, watch } from 'vue'
 import { useDropDetail } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { apiRequest } from '@shared/client/services/api'
-import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getCommitUrl } from '../utils/formatting'
+import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getCommitUrl, getRegistryUrl, getQuayDirectTagUrl, getQuayAllTagsUrl, getDigestUrl } from '../utils/formatting'
 import ChiBadge from '../components/ChiBadge.vue'
 import DropTimeline from '../components/DropTimeline.vue'
 
@@ -120,33 +120,10 @@ function formatRelativeDate(dateString) {
   return diffYears === 1 ? '1 year ago' : `${diffYears} years ago`
 }
 
-function getQuayDirectTagUrl(key) {
-  if (!key || !key.startsWith('quay.io/')) return null
-  const withoutRegistry = key.replace('quay.io/', '')
-  const [path, tag] = withoutRegistry.split(':')
-  if (!tag) return null
-  return `https://quay.io/repository/${path}/tag/${tag}`
-}
-
-function getQuayAllTagsUrl(key) {
-  if (!key || !key.startsWith('quay.io/')) return null
-  const withoutRegistry = key.replace('quay.io/', '')
-  const [path, tag] = withoutRegistry.split(':')
-  const url = `https://quay.io/repository/${path}?tab=tags`
-  return tag ? `${url}&tag=${tag}` : url
-}
-
-function getRegistryUrl(key) {
-  if (!key) return null
-  if (key.startsWith('quay.io/')) {
-    const path = key.replace('quay.io/', '').split(':')[0]
-    return `https://quay.io/repository/${path}?tab=tags`
-  }
-  if (key.startsWith('registry.redhat.io/')) {
-    const path = key.replace('registry.redhat.io/', '').split(':')[0]
-    return `https://catalog.redhat.com/en/search?searchType=All&q=${encodeURIComponent(path)}&p=1`
-  }
-  return null
+function getProdKey(art) {
+  const names = art?.alternative_names
+  if (!Array.isArray(names)) return null
+  return names.find(n => n.startsWith('registry.redhat.io/')) || null
 }
 
 function downloadPackagesAsJson(artifactKey) {
@@ -228,13 +205,6 @@ function getAcceleratorInfo(artifact) {
     python: labels['com.redhat.aiplatform.python'] || 'unknown',
     baseImage: labels['com.redhat.aiplatform.image'] || null
   }
-}
-
-function getDigestUrl(artifact) {
-  if (!artifact?.sha_digest || !artifact?.key) return null
-  if (!artifact.key.startsWith('quay.io/')) return null
-  const path = artifact.key.replace('quay.io/', '').split(':')[0]
-  return `https://quay.io/repository/${path}/manifest/${artifact.sha_digest}`
 }
 
 const totalColumns = 7
@@ -320,48 +290,68 @@ const totalColumns = 7
                       <span
                         class="text-sm font-medium text-primary-600 dark:text-blue-400 truncate hover:underline"
                         @click.stop="navigateToArtifact(art.key)"
-                      >{{ art.key }}</span>
+                      >{{ getProdKey(art) || art.key }}</span>
                       <button
-                        @click="copyKey(art.key, $event)"
+                        @click="copyKey(getProdKey(art) || art.key, $event)"
                         class="shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
                         title="Copy artifact key"
                       >
-                        <svg v-if="copiedKey === art.key" class="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                        <svg v-if="copiedKey === (getProdKey(art) || art.key)" class="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
                         <svg v-else class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
                       </button>
                     </div>
                   </td>
                   <td class="px-4 py-3" @click.stop>
                     <div class="flex items-center gap-1.5">
-                      <a
-                        v-if="getQuayDirectTagUrl(art.key)"
-                        :href="getQuayDirectTagUrl(art.key)"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
-                        title="Direct link to this tag"
-                      >
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
-                      </a>
-                      <a
-                        v-if="getQuayAllTagsUrl(art.key)"
-                        :href="getQuayAllTagsUrl(art.key)"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50"
-                        title="View all tags (old Quay.io UI)"
-                      >all tags</a>
-                      <a
-                        v-if="!getQuayDirectTagUrl(art.key) && getRegistryUrl(art.key)"
-                        :href="getRegistryUrl(art.key)"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
-                        title="View in registry"
-                      >
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
-                      </a>
-                      <span v-if="!getQuayDirectTagUrl(art.key) && !getQuayAllTagsUrl(art.key) && !getRegistryUrl(art.key)" class="text-gray-400 dark:text-gray-500">—</span>
+                      <template v-if="getProdKey(art)">
+                        <a
+                          :href="getRegistryUrl(getProdKey(art))"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
+                          title="View production image in Red Hat Catalog"
+                        >
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                        </a>
+                        <a
+                          :href="getRegistryUrl(getProdKey(art))"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50"
+                          title="View production image in Red Hat Catalog"
+                        >prod</a>
+                      </template>
+                      <template v-else>
+                        <a
+                          v-if="getQuayDirectTagUrl(art.key)"
+                          :href="getQuayDirectTagUrl(art.key)"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
+                          title="Direct link to this tag"
+                        >
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                        </a>
+                        <a
+                          v-if="getQuayAllTagsUrl(art.key)"
+                          :href="getQuayAllTagsUrl(art.key)"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50"
+                          title="View all tags (old Quay.io UI)"
+                        >all tags</a>
+                        <a
+                          v-if="!getQuayDirectTagUrl(art.key) && getRegistryUrl(art.key)"
+                          :href="getRegistryUrl(art.key)"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-primary-600 dark:text-blue-400 hover:text-primary-700 dark:hover:text-blue-300"
+                          title="View in registry"
+                        >
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                        </a>
+                        <span v-if="!getQuayDirectTagUrl(art.key) && !getQuayAllTagsUrl(art.key) && !getRegistryUrl(art.key)" class="text-gray-400 dark:text-gray-500">—</span>
+                      </template>
                     </div>
                   </td>
                   <td class="px-4 py-3">
@@ -451,10 +441,19 @@ const totalColumns = 7
                               <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
                             </button>
                           </div>
-                          <div v-if="art.alternative_names?.length" class="mt-3">
+                          <div v-if="art.alternative_names?.length || getProdKey(art)" class="mt-3">
                             <span class="font-medium text-gray-900 dark:text-gray-100">Alternative Names:</span>
-                            <div v-for="name in art.alternative_names" :key="name" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
-                              - <span class="font-mono text-xs">{{ name }}</span>
+                            <div v-if="getProdKey(art)" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
+                              - <a v-if="getRegistryUrl(art.key)" :href="getRegistryUrl(art.key)" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline" @click.stop>{{ art.key }}</a>
+                              <span v-else class="font-mono text-xs">{{ art.key }}</span>
+                              <button @click="copyKey(art.key, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">
+                                <svg v-if="copiedKey === art.key" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                                <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                              </button>
+                            </div>
+                            <div v-for="name in (art.alternative_names || [])" :key="name" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
+                              - <a v-if="getRegistryUrl(name)" :href="getRegistryUrl(name)" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline" @click.stop>{{ name }}</a>
+                              <span v-else class="font-mono text-xs">{{ name }}</span>
                               <button @click="copyKey(name, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">
                                 <svg v-if="copiedKey === name" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
                                 <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -451,7 +451,7 @@ const totalColumns = 7
                                 <svg v-else class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
                               </button>
                             </div>
-                            <div v-for="name in (art.alternative_names || [])" :key="name" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
+                            <div v-for="name in (art.alternative_names || []).filter(n => n !== getProdKey(art))" :key="name" class="ml-3 text-gray-600 dark:text-gray-400 mt-0.5">
                               - <a v-if="getRegistryUrl(name)" :href="getRegistryUrl(name)" target="_blank" rel="noopener noreferrer" class="font-mono text-xs text-primary-600 dark:text-blue-400 hover:underline" @click.stop>{{ name }}</a>
                               <span v-else class="font-mono text-xs">{{ name }}</span>
                               <button @click="copyKey(name, $event)" class="ml-1 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex align-middle">


### PR DESCRIPTION
## Summary

- Artifact detail page now shows the production image key (registry.redhat.io/...) as the primary title with a "Production" badge and clickable Red Hat Catalog link when the artifact is in prod
- Drop detail table shows the prod key and prod registry link instead of quay links for production artifacts
- Alternative names are now displayed with clickable registry links and copy buttons on both pages
- Shared registry URL utility functions extracted to formatting.js to eliminate duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)