### PR TITLE
feat(product-builds): add nightly pipeline analysis tab

### DIFF
--- a/modules/product-builds/client/composables/useNightlyPipelines.js
+++ b/modules/product-builds/client/composables/useNightlyPipelines.js
@@ -1,0 +1,104 @@
+import { ref, computed } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const BASE = '/modules/product-builds/nightly-pipelines'
+
+export function useNightlyPipelines() {
+  const pipelines = ref([])
+  const schedule = ref(null)
+  const jobs = ref(null)
+  const selectedPipelineId = ref(null)
+  const loading = ref(false)
+  const jobsLoading = ref(false)
+  const error = ref(null)
+  const packages = ref({})
+  const packagesLoading = ref(new Set())
+
+  async function loadPipelines(limit = 14) {
+    loading.value = true
+    error.value = null
+    try {
+      const data = await apiRequest(`${BASE}?limit=${limit}`)
+      pipelines.value = data.pipelines || []
+      schedule.value = data.schedule || null
+    } catch (e) {
+      error.value = e.message
+      pipelines.value = []
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadPipelineJobs(pipelineId) {
+    jobsLoading.value = true
+    selectedPipelineId.value = pipelineId
+    jobs.value = null
+    packages.value = {}
+    packagesLoading.value = new Set()
+    try {
+      jobs.value = await apiRequest(`${BASE}/${pipelineId}/jobs`)
+    } catch (e) {
+      error.value = e.message
+      jobs.value = null
+    } finally {
+      jobsLoading.value = false
+    }
+  }
+
+  async function loadCollectionPackages(pipelineId, collection) {
+    if (packages.value[collection] || packagesLoading.value.has(collection)) return
+    packagesLoading.value = new Set([...packagesLoading.value, collection])
+    try {
+      const data = await apiRequest(`${BASE}/${pipelineId}/packages?collection=${encodeURIComponent(collection)}`)
+      packages.value = { ...packages.value, [collection]: data }
+    } catch (e) {
+      packages.value = { ...packages.value, [collection]: { error: e.message } }
+    } finally {
+      const next = new Set(packagesLoading.value)
+      next.delete(collection)
+      packagesLoading.value = next
+    }
+  }
+
+  const latestPipeline = computed(() => pipelines.value[0] || null)
+
+  const successRate = computed(() => {
+    if (!pipelines.value.length) return 0
+    const passed = pipelines.value.filter(p => p.status === 'success').length
+    return Math.round((passed / pipelines.value.length) * 100)
+  })
+
+  const currentStreak = computed(() => {
+    if (!pipelines.value.length) return { status: null, count: 0 }
+    const first = pipelines.value[0].status
+    let count = 0
+    for (const p of pipelines.value) {
+      if (p.status !== first) break
+      count++
+    }
+    return { status: first, count }
+  })
+
+  const lastSuccess = computed(() => {
+    return pipelines.value.find(p => p.status === 'success') || null
+  })
+
+  return {
+    pipelines,
+    schedule,
+    jobs,
+    selectedPipelineId,
+    loading,
+    jobsLoading,
+    error,
+    packages,
+    packagesLoading,
+    loadPipelines,
+    loadPipelineJobs,
+    loadCollectionPackages,
+    latestPipeline,
+    successRate,
+    currentStreak,
+    lastSuccess,
+  }
+}

--- a/modules/product-builds/client/composables/useNightlyPipelines.js
+++ b/modules/product-builds/client/composables/useNightlyPipelines.js
@@ -31,6 +31,7 @@ export function useNightlyPipelines() {
 
   async function loadPipelineJobs(pipelineId) {
     jobsLoading.value = true
+    error.value = null
     selectedPipelineId.value = pipelineId
     jobs.value = null
     packages.value = {}

--- a/modules/product-builds/client/views/NightlyAnalysisView.vue
+++ b/modules/product-builds/client/views/NightlyAnalysisView.vue
@@ -10,18 +10,127 @@ const STAGE_LABELS = {
   'release-tarball': 'Tarball',
 }
 
-const SCHEDULE_INFO = {
-  description: 'Nightly Builds for Automated Updates [managed by gitlabform]',
+const SCHEDULE_FALLBACK = {
+  description: 'Nightly Builds for Automated Updates',
   time: 'Daily at 8:00 PM ET',
   target: 'main',
 }
 
+const THEMES = {
+  success: {
+    banner: 'bg-green-50 dark:bg-green-900/10 border-green-200 dark:border-green-800/40',
+    iconBg: 'bg-green-100 dark:bg-green-900/30',
+    icon: 'text-green-600 dark:text-green-400',
+    title: 'text-green-800 dark:text-green-300',
+    subtitle: 'text-green-700 dark:text-green-400',
+    info: 'text-green-600 dark:text-green-400/80',
+    link: 'text-green-700 dark:text-green-400 border-green-300 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/30',
+    tile: 'bg-green-50 dark:bg-green-950/40 hover:bg-green-100 dark:hover:bg-green-900/50',
+    tileSelected: 'border-green-500 dark:border-green-400 shadow-sm shadow-green-200 dark:shadow-green-900/40',
+    tileLabel: 'text-green-500 dark:text-green-500',
+    tileDay: 'text-green-700 dark:text-green-300',
+    label: 'PASSING',
+  },
+  failed: {
+    banner: 'bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-800/40',
+    iconBg: 'bg-red-100 dark:bg-red-900/30',
+    icon: 'text-red-600 dark:text-red-400',
+    title: 'text-red-800 dark:text-red-300',
+    subtitle: 'text-red-700 dark:text-red-400',
+    info: 'text-red-600 dark:text-red-400/80',
+    link: 'text-red-700 dark:text-red-400 border-red-300 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/30',
+    tile: 'bg-red-50 dark:bg-red-950/40 hover:bg-red-100 dark:hover:bg-red-900/50',
+    tileSelected: 'border-red-500 dark:border-red-400 shadow-sm shadow-red-200 dark:shadow-red-900/40',
+    tileLabel: 'text-red-400 dark:text-red-500',
+    tileDay: 'text-red-700 dark:text-red-300',
+    label: 'FAILING',
+  },
+  _default: {
+    banner: 'bg-blue-50 dark:bg-blue-900/10 border-blue-200 dark:border-blue-800/40',
+    iconBg: 'bg-blue-100 dark:bg-blue-900/30',
+    icon: 'text-blue-600 dark:text-blue-400',
+    title: 'text-blue-800 dark:text-blue-300',
+    subtitle: 'text-blue-700 dark:text-blue-400',
+    info: 'text-blue-600 dark:text-blue-400/80',
+    link: 'text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/30',
+    tile: 'bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50',
+    tileSelected: 'border-blue-500 dark:border-blue-400 shadow-sm shadow-blue-200 dark:shadow-blue-900/40',
+    tileLabel: 'text-blue-400 dark:text-blue-500',
+    tileDay: 'text-blue-700 dark:text-blue-300',
+    label: null,
+  },
+}
+
+const STATUS_BADGE = {
+  success: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  running: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  canceled: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  _default: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+}
+
+const JOB_CELL = {
+  success: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:ring-green-400',
+  failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:ring-red-400',
+  _default: 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400 hover:ring-gray-400',
+}
+
+function theme(status) { return THEMES[status] || THEMES._default }
+function badgeClass(status) { return STATUS_BADGE[status] || STATUS_BADGE._default }
+function jobCellClass(status) { return JOB_CELL[status] || JOB_CELL._default }
+function jobLabel(status) { return status === 'success' ? 'Pass' : status === 'failed' ? 'Fail' : status }
+
 const {
-  pipelines, jobs, selectedPipelineId, loading, jobsLoading, error,
+  pipelines, schedule, jobs, selectedPipelineId, loading, jobsLoading, error,
   packages, packagesLoading,
   loadPipelines, loadPipelineJobs, loadCollectionPackages,
   latestPipeline, successRate, currentStreak, lastSuccess,
 } = useNightlyPipelines()
+
+const heroTheme = computed(() => theme(latestPipeline.value?.status))
+
+const scheduleInfo = computed(() => {
+  const s = schedule.value
+  if (!s?.description) return SCHEDULE_FALLBACK
+  return {
+    description: s.description.replace(/\s*\[.*\]$/, ''),
+    time: s.cron ? `${s.cron} ${s.cron_timezone || 'UTC'}` : SCHEDULE_FALLBACK.time,
+    target: s.ref || SCHEDULE_FALLBACK.target,
+  }
+})
+
+const selectedPipeline = computed(() =>
+  pipelines.value.find(p => p.id === jobs.value?.pipeline_id) || null
+)
+
+const timelinePipelines = computed(() => [...pipelines.value].reverse())
+
+const sortedCollections = computed(() => {
+  if (!jobs.value?.collections) return []
+  return Object.entries(jobs.value.collections)
+    .sort(([, a], [, b]) => {
+      if (a.status === 'failed' && b.status !== 'failed') return -1
+      if (a.status !== 'failed' && b.status === 'failed') return 1
+      return 0
+    })
+    .map(([name, data]) => {
+      let jobCount = 0, failCount = 0
+      const variantEntries = Object.entries(data.variants)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([variant, archs]) => ({
+          variant,
+          archs: Object.entries(archs)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([arch, stages]) => {
+              const stageJobs = Object.values(stages)
+              jobCount += stageJobs.length
+              failCount += stageJobs.filter(j => j.status === 'failed').length
+              return { arch, stages }
+            }),
+        }))
+      return { name, ...data, variantEntries, jobCount, failCount }
+    })
+})
 
 function selectPipeline(p) {
   if (selectedPipelineId.value === p.id) return
@@ -38,35 +147,24 @@ function formatTeamName(source) {
   return source.replace(/^team-/, '').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
-function formatPipelineDate(iso) {
+function formatDate(iso) {
   if (!iso) return ''
-  const d = new Date(iso)
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
-function formatPipelineDateFull(iso) {
+function formatDateFull(iso) {
   if (!iso) return ''
-  const d = new Date(iso)
-  return d.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+  return new Date(iso).toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
 }
 
-function formatDurationSec(sec) {
+function formatDuration(sec) {
   if (!sec) return ''
   const h = Math.floor(sec / 3600)
   const m = Math.floor((sec % 3600) / 60)
-  if (h > 0) return `${h}h ${m}m`
-  return `${m}m`
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
 }
 
-function statusBadgeClass(status) {
-  if (status === 'success') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  if (status === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-  if (status === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-  if (status === 'canceled') return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-}
-
-function pipelineDateParts(iso) {
+function dateParts(iso) {
   if (!iso) return {}
   const d = new Date(iso)
   return {
@@ -76,55 +174,13 @@ function pipelineDateParts(iso) {
   }
 }
 
-const timelinePipelines = computed(() => [...pipelines.value].reverse())
-
-const sortedCollections = computed(() => {
-  if (!jobs.value?.collections) return []
-  return Object.entries(jobs.value.collections)
-    .sort(([, a], [, b]) => {
-      if (a.status === 'failed' && b.status !== 'failed') return -1
-      if (a.status !== 'failed' && b.status === 'failed') return 1
-      return 0
-    })
-    .map(([name, data]) => ({ name, ...data }))
-})
-
-function getVariantEntries(variants) {
-  return Object.entries(variants)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([variant, archs]) => ({
-      variant,
-      archs: Object.entries(archs)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([arch, stages]) => ({ arch, stages })),
-    }))
+function jobTitle(job) {
+  const parts = [job.status]
+  if (job.duration) parts.push(formatDuration(job.duration))
+  return parts.join(' · ')
 }
 
-function collectionJobCount(data) {
-  let count = 0
-  for (const archs of Object.values(data.variants)) {
-    for (const stages of Object.values(archs)) {
-      count += Object.keys(stages).length
-    }
-  }
-  return count
-}
-
-function collectionFailCount(data) {
-  let count = 0
-  for (const archs of Object.values(data.variants)) {
-    for (const stages of Object.values(archs)) {
-      for (const job of Object.values(stages)) {
-        if (job.status === 'failed') count++
-      }
-    }
-  }
-  return count
-}
-
-onMounted(() => {
-  loadPipelines()
-})
+onMounted(() => loadPipelines())
 </script>
 
 <template>
@@ -145,63 +201,27 @@ onMounted(() => {
 
     <template v-else-if="pipelines.length > 0">
       <!-- ===== TIER 1: Hero Status Banner ===== -->
-      <div v-if="latestPipeline" class="mb-6 p-5 rounded-lg border flex items-center gap-4"
-        :class="latestPipeline.status === 'success'
-          ? 'bg-green-50 dark:bg-green-900/10 border-green-200 dark:border-green-800/40'
-          : latestPipeline.status === 'failed'
-            ? 'bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-800/40'
-            : 'bg-blue-50 dark:bg-blue-900/10 border-blue-200 dark:border-blue-800/40'"
-      >
-        <!-- Status icon -->
-        <div class="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center"
-          :class="latestPipeline.status === 'success'
-            ? 'bg-green-100 dark:bg-green-900/30'
-            : latestPipeline.status === 'failed'
-              ? 'bg-red-100 dark:bg-red-900/30'
-              : 'bg-blue-100 dark:bg-blue-900/30'"
-        >
-          <!-- Checkmark -->
-          <svg v-if="latestPipeline.status === 'success'" class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div v-if="latestPipeline" :class="heroTheme.banner" class="mb-6 p-5 rounded-lg border flex items-center gap-4">
+        <div :class="heroTheme.iconBg" class="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center">
+          <svg v-if="latestPipeline.status === 'success'" :class="heroTheme.icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
           </svg>
-          <!-- X mark -->
-          <svg v-else-if="latestPipeline.status === 'failed'" class="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-else-if="latestPipeline.status === 'failed'" :class="heroTheme.icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
           </svg>
-          <!-- Running spinner -->
-          <svg v-else class="w-6 h-6 text-blue-600 dark:text-blue-400 animate-spin" fill="none" viewBox="0 0 24 24">
+          <svg v-else :class="heroTheme.icon" class="w-6 h-6 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>
         </div>
 
         <div class="flex-1 min-w-0">
-          <div class="text-lg font-bold"
-            :class="latestPipeline.status === 'success'
-              ? 'text-green-800 dark:text-green-300'
-              : latestPipeline.status === 'failed'
-                ? 'text-red-800 dark:text-red-300'
-                : 'text-blue-800 dark:text-blue-300'"
-          >
-            Nightly Builds for Automated Updates
+          <div :class="heroTheme.title" class="text-lg font-bold">{{ scheduleInfo.description }}</div>
+          <div :class="heroTheme.subtitle" class="text-sm font-semibold mt-1">
+            {{ theme(latestPipeline.status).label || latestPipeline.status.toUpperCase() }}
           </div>
-          <div class="text-sm font-semibold mt-1"
-            :class="latestPipeline.status === 'success'
-              ? 'text-green-700 dark:text-green-400'
-              : latestPipeline.status === 'failed'
-                ? 'text-red-700 dark:text-red-400'
-                : 'text-blue-700 dark:text-blue-400'"
-          >
-            {{ latestPipeline.status === 'success' ? 'PASSING' : latestPipeline.status === 'failed' ? 'FAILING' : latestPipeline.status.toUpperCase() }}
-          </div>
-          <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs"
-            :class="latestPipeline.status === 'success'
-              ? 'text-green-600 dark:text-green-400/80'
-              : latestPipeline.status === 'failed'
-                ? 'text-red-600 dark:text-red-400/80'
-                : 'text-blue-600 dark:text-blue-400/80'"
-          >
-            <span>{{ formatPipelineDateFull(latestPipeline.created_at) }}</span>
+          <div :class="heroTheme.info" class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs">
+            <span>{{ formatDateFull(latestPipeline.created_at) }}</span>
             <span v-if="currentStreak.count > 1">
               {{ currentStreak.count }} {{ currentStreak.status === 'success' ? 'passing' : 'failing' }} in a row
             </span>
@@ -209,23 +229,19 @@ onMounted(() => {
           <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs text-gray-500 dark:text-gray-400">
             <span class="flex items-center gap-1">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-              {{ SCHEDULE_INFO.time }}
+              {{ scheduleInfo.time }}
             </span>
             <span class="flex items-center gap-1">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" /></svg>
-              Target: {{ SCHEDULE_INFO.target }}
+              Target: {{ scheduleInfo.target }}
             </span>
           </div>
         </div>
 
         <a :href="latestPipeline.web_url" target="_blank" rel="noopener noreferrer"
+          :class="heroTheme.link"
           class="flex-shrink-0 text-sm font-medium px-3 py-1.5 rounded-lg border transition-colors"
-          :class="latestPipeline.status === 'success'
-            ? 'text-green-700 dark:text-green-400 border-green-300 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/30'
-            : latestPipeline.status === 'failed'
-              ? 'text-red-700 dark:text-red-400 border-red-300 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/30'
-              : 'text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/30'"
-        >View on GitLab →</a>
+        >View on GitLab &rarr;</a>
       </div>
 
       <!-- ===== TIER 2: Pipeline Timeline ===== -->
@@ -235,7 +251,7 @@ onMounted(() => {
           <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
             <span>{{ successRate }}% pass rate</span>
             <span v-if="lastSuccess && latestPipeline?.status !== 'success'">
-              Last success: {{ formatPipelineDate(lastSuccess.created_at) }}
+              Last success: {{ formatDate(lastSuccess.created_at) }}
             </span>
           </div>
         </div>
@@ -243,52 +259,21 @@ onMounted(() => {
         <div class="flex gap-1.5 overflow-x-auto pb-1">
           <button
             v-for="p in timelinePipelines" :key="p.id"
+            :class="[theme(p.status).tile, selectedPipelineId === p.id ? theme(p.status).tileSelected : 'border-transparent']"
             class="flex-shrink-0 w-16 rounded-lg pt-1.5 pb-2 text-center cursor-pointer transition-all border-2"
-            :class="[
-              p.status === 'success'
-                ? 'bg-green-50 dark:bg-green-950/40 hover:bg-green-100 dark:hover:bg-green-900/50'
-                : p.status === 'failed'
-                  ? 'bg-red-50 dark:bg-red-950/40 hover:bg-red-100 dark:hover:bg-red-900/50'
-                  : 'bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50',
-              selectedPipelineId === p.id
-                ? p.status === 'success'
-                  ? 'border-green-500 dark:border-green-400 shadow-sm shadow-green-200 dark:shadow-green-900/40'
-                  : p.status === 'failed'
-                    ? 'border-red-500 dark:border-red-400 shadow-sm shadow-red-200 dark:shadow-red-900/40'
-                    : 'border-blue-500 dark:border-blue-400 shadow-sm shadow-blue-200 dark:shadow-blue-900/40'
-                : 'border-transparent',
-            ]"
             @click="selectPipeline(p)"
           >
-            <div class="text-[10px] leading-tight font-medium"
-              :class="p.status === 'success'
-                ? 'text-green-500 dark:text-green-500'
-                : p.status === 'failed'
-                  ? 'text-red-400 dark:text-red-500'
-                  : 'text-blue-400 dark:text-blue-500'"
-            >{{ pipelineDateParts(p.created_at).dow }}</div>
-            <div class="text-xl font-bold leading-tight mt-0.5"
-              :class="p.status === 'success'
-                ? 'text-green-700 dark:text-green-300'
-                : p.status === 'failed'
-                  ? 'text-red-700 dark:text-red-300'
-                  : 'text-blue-700 dark:text-blue-300'"
-            >{{ pipelineDateParts(p.created_at).day }}</div>
-            <div class="text-[10px] leading-tight"
-              :class="p.status === 'success'
-                ? 'text-green-500 dark:text-green-500'
-                : p.status === 'failed'
-                  ? 'text-red-400 dark:text-red-500'
-                  : 'text-blue-400 dark:text-blue-500'"
-            >{{ pipelineDateParts(p.created_at).month }}</div>
+            <div :class="theme(p.status).tileLabel" class="text-[10px] leading-tight font-medium">{{ dateParts(p.created_at).dow }}</div>
+            <div :class="theme(p.status).tileDay" class="text-xl font-bold leading-tight mt-0.5">{{ dateParts(p.created_at).day }}</div>
+            <div :class="theme(p.status).tileLabel" class="text-[10px] leading-tight">{{ dateParts(p.created_at).month }}</div>
             <div class="mt-1">
-              <svg v-if="p.status === 'success'" class="w-4 h-4 mx-auto text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg v-if="p.status === 'success'" :class="theme(p.status).icon" class="w-4 h-4 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
               </svg>
-              <svg v-else-if="p.status === 'failed'" class="w-4 h-4 mx-auto text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg v-else-if="p.status === 'failed'" :class="theme(p.status).icon" class="w-4 h-4 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
               </svg>
-              <svg v-else class="w-4 h-4 mx-auto text-blue-500 dark:text-blue-400 animate-spin" fill="none" viewBox="0 0 24 24">
+              <svg v-else class="w-4 h-4 mx-auto animate-spin" :class="theme(p.status).icon" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -298,15 +283,16 @@ onMounted(() => {
       </div>
 
       <!-- ===== TIER 3: Pipeline Detail ===== -->
-      <!-- Prompt to select a pipeline -->
+      <!-- Prompt to select -->
       <div v-if="!selectedPipelineId && !jobsLoading && !jobs" class="text-center py-10 bg-gray-50 dark:bg-gray-800/50 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
         <svg class="w-8 h-8 text-gray-400 dark:text-gray-500 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
         </svg>
         <div class="text-sm font-medium text-gray-600 dark:text-gray-400">Click a pipeline above to view job details</div>
-        <div class="text-xs text-gray-400 dark:text-gray-500 mt-1">Each row represents one nightly pipeline run</div>
+        <div class="text-xs text-gray-400 dark:text-gray-500 mt-1">Each tile represents one nightly pipeline run</div>
       </div>
 
+      <!-- Jobs loading -->
       <div v-if="jobsLoading" class="text-center py-12">
         <svg class="animate-spin h-8 w-8 text-gray-400 mx-auto" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
@@ -315,23 +301,23 @@ onMounted(() => {
         <div class="mt-2 text-gray-500 dark:text-gray-400 text-sm">Loading job details...</div>
       </div>
 
-      <template v-else-if="jobs">
-        <!-- Pipeline header with date context -->
+      <template v-else-if="jobs && selectedPipeline">
+        <!-- Pipeline header -->
         <div class="mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg">
           <div class="flex items-center gap-3 flex-wrap">
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="statusBadgeClass(pipelines.find(p => p.id === jobs.pipeline_id)?.status)">
-              {{ pipelines.find(p => p.id === jobs.pipeline_id)?.status }}
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="badgeClass(selectedPipeline.status)">
+              {{ selectedPipeline.status }}
             </span>
             <span class="text-sm font-semibold text-gray-900 dark:text-white">
-              {{ formatPipelineDateFull(pipelines.find(p => p.id === jobs.pipeline_id)?.created_at) }}
+              {{ formatDateFull(selectedPipeline.created_at) }}
             </span>
             <span class="text-xs text-gray-400 dark:text-gray-500">Pipeline #{{ jobs.pipeline_id }}</span>
             <span class="text-sm text-gray-500 dark:text-gray-400 ml-auto">
-              {{ jobs.summary.total }} jobs · {{ jobs.summary.success }} passed · {{ jobs.summary.failed }} failed · {{ jobs.summary.skipped }} skipped
+              {{ jobs.summary.total }} jobs &middot; {{ jobs.summary.success }} passed &middot; {{ jobs.summary.failed }} failed &middot; {{ jobs.summary.skipped }} skipped
             </span>
-            <a :href="pipelines.find(p => p.id === jobs.pipeline_id)?.web_url" target="_blank" rel="noopener noreferrer"
+            <a :href="selectedPipeline.web_url" target="_blank" rel="noopener noreferrer"
               class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
-              View on GitLab →
+              View on GitLab &rarr;
             </a>
           </div>
         </div>
@@ -354,7 +340,7 @@ onMounted(() => {
                   {{ fj.name }}
                 </a>
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  {{ fj.collection }} · {{ fj.variant }} · {{ fj.arch }} · {{ STAGE_LABELS[fj.stage] || fj.stage }}
+                  {{ fj.collection }} &middot; {{ fj.variant }} &middot; {{ fj.arch }} &middot; {{ STAGE_LABELS[fj.stage] || fj.stage }}
                 </div>
               </div>
               <span v-if="fj.failure_reason" class="text-xs text-gray-400 dark:text-gray-500">{{ fj.failure_reason }}</span>
@@ -381,16 +367,9 @@ onMounted(() => {
               ></span>
 
               <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ col.name }}</span>
-
-              <span class="text-xs text-gray-500 dark:text-gray-400">
-                {{ collectionJobCount(col) }} jobs
-              </span>
-
-              <span v-if="col.status === 'failed'" class="text-xs text-red-600 dark:text-red-400 font-medium">
-                {{ collectionFailCount(col) }} failed
-              </span>
-
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ml-auto" :class="statusBadgeClass(col.status)">
+              <span class="text-xs text-gray-500 dark:text-gray-400">{{ col.jobCount }} jobs</span>
+              <span v-if="col.failCount > 0" class="text-xs text-red-600 dark:text-red-400 font-medium">{{ col.failCount }} failed</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ml-auto" :class="badgeClass(col.status)">
                 {{ col.status }}
               </span>
             </summary>
@@ -415,7 +394,6 @@ onMounted(() => {
                 </summary>
 
                 <div class="px-4 py-3 border-t border-gray-100 dark:border-gray-700/50">
-                  <!-- Loading -->
                   <div v-if="packagesLoading.has(col.name)" class="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500 py-2">
                     <svg class="animate-spin h-3.5 w-3.5" fill="none" viewBox="0 0 24 24">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
@@ -424,12 +402,10 @@ onMounted(() => {
                     Loading packages...
                   </div>
 
-                  <!-- Error -->
                   <div v-else-if="packages[col.name]?.error" class="text-xs text-red-500 dark:text-red-400 py-1">
                     Failed to load packages: {{ packages[col.name].error }}
                   </div>
 
-                  <!-- Package groups -->
                   <div v-else-if="packages[col.name]?.groups" class="space-y-3">
                     <div v-for="group in packages[col.name].groups" :key="group.source">
                       <div class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1.5">{{ formatTeamName(group.source) }}</div>
@@ -441,7 +417,6 @@ onMounted(() => {
                     </div>
                   </div>
 
-                  <!-- Not loaded yet -->
                   <div v-else class="text-xs text-gray-400 dark:text-gray-500 py-1">
                     Package data not available
                   </div>
@@ -472,7 +447,7 @@ onMounted(() => {
                       </tr>
                     </thead>
                     <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
-                      <template v-for="ve in getVariantEntries(col.variants)" :key="ve.variant">
+                      <template v-for="ve in col.variantEntries" :key="ve.variant">
                         <tr v-for="(ae, ai) in ve.archs" :key="`${ve.variant}-${ae.arch}`"
                           class="hover:bg-gray-50 dark:hover:bg-gray-750/50 transition-colors"
                         >
@@ -484,14 +459,8 @@ onMounted(() => {
                             <template v-if="ae.stages[stage]">
                               <a :href="ae.stages[stage].web_url" target="_blank" rel="noopener noreferrer"
                                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors hover:ring-1 hover:ring-offset-1 dark:hover:ring-offset-gray-800"
-                                :class="ae.stages[stage].status === 'success'
-                                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:ring-green-400'
-                                  : ae.stages[stage].status === 'failed'
-                                    ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:ring-red-400'
-                                    : ae.stages[stage].status === 'skipped'
-                                      ? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400 hover:ring-gray-400'
-                                      : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:ring-gray-400'"
-                                :title="`${ae.stages[stage].status}${ae.stages[stage].duration ? ' · ' + formatDurationSec(ae.stages[stage].duration) : ''} — click to view job`"
+                                :class="jobCellClass(ae.stages[stage].status)"
+                                :title="jobTitle(ae.stages[stage])"
                               >
                                 <svg v-if="ae.stages[stage].status === 'success'" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
@@ -501,7 +470,7 @@ onMounted(() => {
                                 </svg>
                                 <span v-else-if="ae.stages[stage].status === 'skipped'" class="w-3 text-center">-</span>
                                 <span v-else class="w-3 text-center">?</span>
-                                {{ ae.stages[stage].status === 'success' ? 'Pass' : ae.stages[stage].status === 'failed' ? 'Fail' : ae.stages[stage].status }}
+                                {{ jobLabel(ae.stages[stage].status) }}
                               </a>
                             </template>
                             <span v-else class="text-gray-300 dark:text-gray-600">&mdash;</span>

--- a/modules/product-builds/client/views/NightlyAnalysisView.vue
+++ b/modules/product-builds/client/views/NightlyAnalysisView.vue
@@ -1,0 +1,536 @@
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useNightlyPipelines } from '../composables/useNightlyPipelines.js'
+
+const STAGE_ORDER = ['bootstrap-and-onboard', 'build-wheels', 'publish-wheels', 'release-tarball']
+const STAGE_LABELS = {
+  'bootstrap-and-onboard': 'Bootstrap',
+  'build-wheels': 'Build',
+  'publish-wheels': 'Publish',
+  'release-tarball': 'Tarball',
+}
+
+const SCHEDULE_INFO = {
+  description: 'Nightly Builds for Automated Updates [managed by gitlabform]',
+  time: 'Daily at 8:00 PM ET',
+  target: 'main',
+}
+
+const {
+  pipelines, jobs, selectedPipelineId, loading, jobsLoading, error,
+  packages, packagesLoading,
+  loadPipelines, loadPipelineJobs, loadCollectionPackages,
+  latestPipeline, successRate, currentStreak, lastSuccess,
+} = useNightlyPipelines()
+
+function selectPipeline(p) {
+  if (selectedPipelineId.value === p.id) return
+  loadPipelineJobs(p.id)
+}
+
+function onCollectionToggle(event, collectionName) {
+  if (event.target.open && !packages.value[collectionName]) {
+    loadCollectionPackages(selectedPipelineId.value, collectionName)
+  }
+}
+
+function formatTeamName(source) {
+  return source.replace(/^team-/, '').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function formatPipelineDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function formatPipelineDateFull(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function formatDurationSec(sec) {
+  if (!sec) return ''
+  const h = Math.floor(sec / 3600)
+  const m = Math.floor((sec % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  return `${m}m`
+}
+
+function statusBadgeClass(status) {
+  if (status === 'success') return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+  if (status === 'failed') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  if (status === 'running') return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+  if (status === 'canceled') return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+}
+
+function pipelineDateParts(iso) {
+  if (!iso) return {}
+  const d = new Date(iso)
+  return {
+    dow: d.toLocaleDateString('en-US', { weekday: 'short' }),
+    month: d.toLocaleDateString('en-US', { month: 'short' }),
+    day: d.getDate(),
+  }
+}
+
+const timelinePipelines = computed(() => [...pipelines.value].reverse())
+
+const sortedCollections = computed(() => {
+  if (!jobs.value?.collections) return []
+  return Object.entries(jobs.value.collections)
+    .sort(([, a], [, b]) => {
+      if (a.status === 'failed' && b.status !== 'failed') return -1
+      if (a.status !== 'failed' && b.status === 'failed') return 1
+      return 0
+    })
+    .map(([name, data]) => ({ name, ...data }))
+})
+
+function getVariantEntries(variants) {
+  return Object.entries(variants)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([variant, archs]) => ({
+      variant,
+      archs: Object.entries(archs)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([arch, stages]) => ({ arch, stages })),
+    }))
+}
+
+function collectionJobCount(data) {
+  let count = 0
+  for (const archs of Object.values(data.variants)) {
+    for (const stages of Object.values(archs)) {
+      count += Object.keys(stages).length
+    }
+  }
+  return count
+}
+
+function collectionFailCount(data) {
+  let count = 0
+  for (const archs of Object.values(data.variants)) {
+    for (const stages of Object.values(archs)) {
+      for (const job of Object.values(stages)) {
+        if (job.status === 'failed') count++
+      }
+    }
+  }
+  return count
+}
+
+onMounted(() => {
+  loadPipelines()
+})
+</script>
+
+<template>
+  <div>
+    <!-- Error -->
+    <div v-if="error" class="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+      {{ error }}
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-center py-24">
+      <svg class="animate-spin h-10 w-10 text-gray-400 mx-auto" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      <div class="mt-4 text-gray-500 dark:text-gray-400">Loading nightly pipeline data...</div>
+    </div>
+
+    <template v-else-if="pipelines.length > 0">
+      <!-- ===== TIER 1: Hero Status Banner ===== -->
+      <div v-if="latestPipeline" class="mb-6 p-5 rounded-lg border flex items-center gap-4"
+        :class="latestPipeline.status === 'success'
+          ? 'bg-green-50 dark:bg-green-900/10 border-green-200 dark:border-green-800/40'
+          : latestPipeline.status === 'failed'
+            ? 'bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-800/40'
+            : 'bg-blue-50 dark:bg-blue-900/10 border-blue-200 dark:border-blue-800/40'"
+      >
+        <!-- Status icon -->
+        <div class="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center"
+          :class="latestPipeline.status === 'success'
+            ? 'bg-green-100 dark:bg-green-900/30'
+            : latestPipeline.status === 'failed'
+              ? 'bg-red-100 dark:bg-red-900/30'
+              : 'bg-blue-100 dark:bg-blue-900/30'"
+        >
+          <!-- Checkmark -->
+          <svg v-if="latestPipeline.status === 'success'" class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+          </svg>
+          <!-- X mark -->
+          <svg v-else-if="latestPipeline.status === 'failed'" class="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <!-- Running spinner -->
+          <svg v-else class="w-6 h-6 text-blue-600 dark:text-blue-400 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <div class="text-lg font-bold"
+            :class="latestPipeline.status === 'success'
+              ? 'text-green-800 dark:text-green-300'
+              : latestPipeline.status === 'failed'
+                ? 'text-red-800 dark:text-red-300'
+                : 'text-blue-800 dark:text-blue-300'"
+          >
+            Nightly Builds for Automated Updates
+          </div>
+          <div class="text-sm font-semibold mt-1"
+            :class="latestPipeline.status === 'success'
+              ? 'text-green-700 dark:text-green-400'
+              : latestPipeline.status === 'failed'
+                ? 'text-red-700 dark:text-red-400'
+                : 'text-blue-700 dark:text-blue-400'"
+          >
+            {{ latestPipeline.status === 'success' ? 'PASSING' : latestPipeline.status === 'failed' ? 'FAILING' : latestPipeline.status.toUpperCase() }}
+          </div>
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs"
+            :class="latestPipeline.status === 'success'
+              ? 'text-green-600 dark:text-green-400/80'
+              : latestPipeline.status === 'failed'
+                ? 'text-red-600 dark:text-red-400/80'
+                : 'text-blue-600 dark:text-blue-400/80'"
+          >
+            <span>{{ formatPipelineDateFull(latestPipeline.created_at) }}</span>
+            <span v-if="currentStreak.count > 1">
+              {{ currentStreak.count }} {{ currentStreak.status === 'success' ? 'passing' : 'failing' }} in a row
+            </span>
+          </div>
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+            <span class="flex items-center gap-1">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              {{ SCHEDULE_INFO.time }}
+            </span>
+            <span class="flex items-center gap-1">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" /></svg>
+              Target: {{ SCHEDULE_INFO.target }}
+            </span>
+          </div>
+        </div>
+
+        <a :href="latestPipeline.web_url" target="_blank" rel="noopener noreferrer"
+          class="flex-shrink-0 text-sm font-medium px-3 py-1.5 rounded-lg border transition-colors"
+          :class="latestPipeline.status === 'success'
+            ? 'text-green-700 dark:text-green-400 border-green-300 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/30'
+            : latestPipeline.status === 'failed'
+              ? 'text-red-700 dark:text-red-400 border-red-300 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/30'
+              : 'text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/30'"
+        >View on GitLab →</a>
+      </div>
+
+      <!-- ===== TIER 2: Pipeline Timeline ===== -->
+      <div class="mb-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <div class="flex items-center justify-between mb-4">
+          <div class="text-sm font-semibold text-gray-700 dark:text-gray-300">Pipeline History</div>
+          <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+            <span>{{ successRate }}% pass rate</span>
+            <span v-if="lastSuccess && latestPipeline?.status !== 'success'">
+              Last success: {{ formatPipelineDate(lastSuccess.created_at) }}
+            </span>
+          </div>
+        </div>
+
+        <div class="flex gap-1.5 overflow-x-auto pb-1">
+          <button
+            v-for="p in timelinePipelines" :key="p.id"
+            class="flex-shrink-0 w-16 rounded-lg pt-1.5 pb-2 text-center cursor-pointer transition-all border-2"
+            :class="[
+              p.status === 'success'
+                ? 'bg-green-50 dark:bg-green-950/40 hover:bg-green-100 dark:hover:bg-green-900/50'
+                : p.status === 'failed'
+                  ? 'bg-red-50 dark:bg-red-950/40 hover:bg-red-100 dark:hover:bg-red-900/50'
+                  : 'bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50',
+              selectedPipelineId === p.id
+                ? p.status === 'success'
+                  ? 'border-green-500 dark:border-green-400 shadow-sm shadow-green-200 dark:shadow-green-900/40'
+                  : p.status === 'failed'
+                    ? 'border-red-500 dark:border-red-400 shadow-sm shadow-red-200 dark:shadow-red-900/40'
+                    : 'border-blue-500 dark:border-blue-400 shadow-sm shadow-blue-200 dark:shadow-blue-900/40'
+                : 'border-transparent',
+            ]"
+            @click="selectPipeline(p)"
+          >
+            <div class="text-[10px] leading-tight font-medium"
+              :class="p.status === 'success'
+                ? 'text-green-500 dark:text-green-500'
+                : p.status === 'failed'
+                  ? 'text-red-400 dark:text-red-500'
+                  : 'text-blue-400 dark:text-blue-500'"
+            >{{ pipelineDateParts(p.created_at).dow }}</div>
+            <div class="text-xl font-bold leading-tight mt-0.5"
+              :class="p.status === 'success'
+                ? 'text-green-700 dark:text-green-300'
+                : p.status === 'failed'
+                  ? 'text-red-700 dark:text-red-300'
+                  : 'text-blue-700 dark:text-blue-300'"
+            >{{ pipelineDateParts(p.created_at).day }}</div>
+            <div class="text-[10px] leading-tight"
+              :class="p.status === 'success'
+                ? 'text-green-500 dark:text-green-500'
+                : p.status === 'failed'
+                  ? 'text-red-400 dark:text-red-500'
+                  : 'text-blue-400 dark:text-blue-500'"
+            >{{ pipelineDateParts(p.created_at).month }}</div>
+            <div class="mt-1">
+              <svg v-if="p.status === 'success'" class="w-4 h-4 mx-auto text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+              </svg>
+              <svg v-else-if="p.status === 'failed'" class="w-4 h-4 mx-auto text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+              <svg v-else class="w-4 h-4 mx-auto text-blue-500 dark:text-blue-400 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <!-- ===== TIER 3: Pipeline Detail ===== -->
+      <!-- Prompt to select a pipeline -->
+      <div v-if="!selectedPipelineId && !jobsLoading && !jobs" class="text-center py-10 bg-gray-50 dark:bg-gray-800/50 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
+        <svg class="w-8 h-8 text-gray-400 dark:text-gray-500 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
+        </svg>
+        <div class="text-sm font-medium text-gray-600 dark:text-gray-400">Click a pipeline above to view job details</div>
+        <div class="text-xs text-gray-400 dark:text-gray-500 mt-1">Each row represents one nightly pipeline run</div>
+      </div>
+
+      <div v-if="jobsLoading" class="text-center py-12">
+        <svg class="animate-spin h-8 w-8 text-gray-400 mx-auto" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+        <div class="mt-2 text-gray-500 dark:text-gray-400 text-sm">Loading job details...</div>
+      </div>
+
+      <template v-else-if="jobs">
+        <!-- Pipeline header with date context -->
+        <div class="mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <div class="flex items-center gap-3 flex-wrap">
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="statusBadgeClass(pipelines.find(p => p.id === jobs.pipeline_id)?.status)">
+              {{ pipelines.find(p => p.id === jobs.pipeline_id)?.status }}
+            </span>
+            <span class="text-sm font-semibold text-gray-900 dark:text-white">
+              {{ formatPipelineDateFull(pipelines.find(p => p.id === jobs.pipeline_id)?.created_at) }}
+            </span>
+            <span class="text-xs text-gray-400 dark:text-gray-500">Pipeline #{{ jobs.pipeline_id }}</span>
+            <span class="text-sm text-gray-500 dark:text-gray-400 ml-auto">
+              {{ jobs.summary.total }} jobs · {{ jobs.summary.success }} passed · {{ jobs.summary.failed }} failed · {{ jobs.summary.skipped }} skipped
+            </span>
+            <a :href="pipelines.find(p => p.id === jobs.pipeline_id)?.web_url" target="_blank" rel="noopener noreferrer"
+              class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+              View on GitLab →
+            </a>
+          </div>
+        </div>
+
+        <!-- Failed Jobs Alert -->
+        <div v-if="jobs.failed_jobs.length > 0" class="mb-4 border border-red-200 dark:border-red-800/50 rounded-lg overflow-hidden">
+          <div class="px-4 py-3 bg-red-50 dark:bg-red-900/10 border-b border-red-200 dark:border-red-800/50">
+            <span class="text-sm font-semibold text-red-800 dark:text-red-300">
+              {{ jobs.failed_jobs.length }} Failed Job{{ jobs.failed_jobs.length !== 1 ? 's' : '' }}
+            </span>
+          </div>
+          <div class="divide-y divide-red-100 dark:divide-red-900/20">
+            <div v-for="fj in jobs.failed_jobs" :key="fj.id" class="px-4 py-2.5 flex items-center gap-3 bg-white dark:bg-gray-800">
+              <svg class="w-4 h-4 text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+              </svg>
+              <div class="flex-1 min-w-0">
+                <a :href="fj.web_url" target="_blank" rel="noopener noreferrer"
+                  class="text-sm font-medium text-red-700 dark:text-red-400 hover:underline">
+                  {{ fj.name }}
+                </a>
+                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  {{ fj.collection }} · {{ fj.variant }} · {{ fj.arch }} · {{ STAGE_LABELS[fj.stage] || fj.stage }}
+                </div>
+              </div>
+              <span v-if="fj.failure_reason" class="text-xs text-gray-400 dark:text-gray-500">{{ fj.failure_reason }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Collection Grid -->
+        <div class="space-y-3">
+          <details v-for="col in sortedCollections" :key="col.name"
+            class="rounded-xl border shadow-sm overflow-hidden group/col"
+            :class="col.status === 'failed' ? 'border-red-200 dark:border-red-800/50' : 'border-gray-200 dark:border-gray-700'"
+            @toggle="onCollectionToggle($event, col.name)"
+          >
+            <summary
+              class="px-4 py-3 flex items-center gap-3 cursor-pointer bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors list-none [&::-webkit-details-marker]:hidden"
+            >
+              <svg class="w-3.5 h-3.5 text-gray-400 transition-transform group-open/col:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+              </svg>
+
+              <span class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                :class="col.status === 'success' ? 'bg-green-500' : col.status === 'failed' ? 'bg-red-500' : 'bg-gray-400'"
+              ></span>
+
+              <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ col.name }}</span>
+
+              <span class="text-xs text-gray-500 dark:text-gray-400">
+                {{ collectionJobCount(col) }} jobs
+              </span>
+
+              <span v-if="col.status === 'failed'" class="text-xs text-red-600 dark:text-red-400 font-medium">
+                {{ collectionFailCount(col) }} failed
+              </span>
+
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ml-auto" :class="statusBadgeClass(col.status)">
+                {{ col.status }}
+              </span>
+            </summary>
+
+            <div class="bg-white dark:bg-gray-800">
+              <!-- Packages Section -->
+              <details open class="group/pkgs">
+                <summary class="px-4 py-2.5 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 cursor-pointer flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors list-none [&::-webkit-details-marker]:hidden">
+                  <svg class="w-3 h-3 text-gray-400 transition-transform group-open/pkgs:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                  </svg>
+                  <svg class="w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                  </svg>
+                  <span class="text-xs font-medium text-gray-600 dark:text-gray-400">Packages</span>
+                  <span v-if="packages[col.name]?.totalCount" class="text-xs text-gray-400 dark:text-gray-500">
+                    {{ packages[col.name].totalCount }} packages
+                  </span>
+                  <span v-if="packages[col.name]?.variant" class="text-xs text-gray-400 dark:text-gray-500 ml-auto">
+                    {{ packages[col.name].variant }}
+                  </span>
+                </summary>
+
+                <div class="px-4 py-3 border-t border-gray-100 dark:border-gray-700/50">
+                  <!-- Loading -->
+                  <div v-if="packagesLoading.has(col.name)" class="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500 py-2">
+                    <svg class="animate-spin h-3.5 w-3.5" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Loading packages...
+                  </div>
+
+                  <!-- Error -->
+                  <div v-else-if="packages[col.name]?.error" class="text-xs text-red-500 dark:text-red-400 py-1">
+                    Failed to load packages: {{ packages[col.name].error }}
+                  </div>
+
+                  <!-- Package groups -->
+                  <div v-else-if="packages[col.name]?.groups" class="space-y-3">
+                    <div v-for="group in packages[col.name].groups" :key="group.source">
+                      <div class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1.5">{{ formatTeamName(group.source) }}</div>
+                      <div class="flex flex-wrap gap-1.5">
+                        <span v-for="pkg in group.packages" :key="pkg"
+                          class="inline-block px-2 py-0.5 rounded-md text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                        >{{ pkg }}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Not loaded yet -->
+                  <div v-else class="text-xs text-gray-400 dark:text-gray-500 py-1">
+                    Package data not available
+                  </div>
+                </div>
+              </details>
+
+              <!-- Jobs Matrix Section -->
+              <details open class="group/jobs">
+                <summary class="px-4 py-2.5 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 cursor-pointer flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors list-none [&::-webkit-details-marker]:hidden">
+                  <svg class="w-3 h-3 text-gray-400 transition-transform group-open/jobs:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                  </svg>
+                  <svg class="w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                  </svg>
+                  <span class="text-xs font-medium text-gray-600 dark:text-gray-400">Jobs Matrix</span>
+                </summary>
+
+                <div class="border-t border-gray-100 dark:border-gray-700/50">
+                  <table class="w-full text-sm">
+                    <thead>
+                      <tr class="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
+                        <th class="text-left py-2 px-4 font-medium text-gray-600 dark:text-gray-400 w-28">Variant</th>
+                        <th class="text-left py-2 px-4 font-medium text-gray-600 dark:text-gray-400 w-24">Arch</th>
+                        <th v-for="stage in STAGE_ORDER" :key="stage" class="text-center py-2 px-2 font-medium text-gray-600 dark:text-gray-400">
+                          {{ STAGE_LABELS[stage] }}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
+                      <template v-for="ve in getVariantEntries(col.variants)" :key="ve.variant">
+                        <tr v-for="(ae, ai) in ve.archs" :key="`${ve.variant}-${ae.arch}`"
+                          class="hover:bg-gray-50 dark:hover:bg-gray-750/50 transition-colors"
+                        >
+                          <td v-if="ai === 0" :rowspan="ve.archs.length" class="py-2 px-4 text-gray-900 dark:text-gray-200 font-medium align-top border-r border-gray-100 dark:border-gray-700/50">
+                            {{ ve.variant }}
+                          </td>
+                          <td class="py-2 px-4 text-gray-600 dark:text-gray-400">{{ ae.arch }}</td>
+                          <td v-for="stage in STAGE_ORDER" :key="stage" class="py-2 px-2 text-center">
+                            <template v-if="ae.stages[stage]">
+                              <a :href="ae.stages[stage].web_url" target="_blank" rel="noopener noreferrer"
+                                class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors hover:ring-1 hover:ring-offset-1 dark:hover:ring-offset-gray-800"
+                                :class="ae.stages[stage].status === 'success'
+                                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:ring-green-400'
+                                  : ae.stages[stage].status === 'failed'
+                                    ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:ring-red-400'
+                                    : ae.stages[stage].status === 'skipped'
+                                      ? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400 hover:ring-gray-400'
+                                      : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:ring-gray-400'"
+                                :title="`${ae.stages[stage].status}${ae.stages[stage].duration ? ' · ' + formatDurationSec(ae.stages[stage].duration) : ''} — click to view job`"
+                              >
+                                <svg v-if="ae.stages[stage].status === 'success'" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+                                </svg>
+                                <svg v-else-if="ae.stages[stage].status === 'failed'" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                <span v-else-if="ae.stages[stage].status === 'skipped'" class="w-3 text-center">-</span>
+                                <span v-else class="w-3 text-center">?</span>
+                                {{ ae.stages[stage].status === 'success' ? 'Pass' : ae.stages[stage].status === 'failed' ? 'Fail' : ae.stages[stage].status }}
+                              </a>
+                            </template>
+                            <span v-else class="text-gray-300 dark:text-gray-600">&mdash;</span>
+                          </td>
+                        </tr>
+                      </template>
+                    </tbody>
+                  </table>
+                </div>
+              </details>
+            </div>
+          </details>
+        </div>
+
+        <!-- Special Jobs -->
+        <div v-if="jobs.special_jobs.length > 0" class="mt-4 text-xs text-gray-500 dark:text-gray-400">
+          <span class="font-medium">Utility jobs:</span>
+          <span v-for="(sj, i) in jobs.special_jobs" :key="sj.name">
+            {{ i > 0 ? ', ' : ' ' }}
+            <a :href="sj.web_url" target="_blank" rel="noopener noreferrer" class="hover:underline">{{ sj.name }}</a>
+            (<span :class="sj.status === 'success' ? 'text-green-600 dark:text-green-400' : sj.status === 'failed' ? 'text-red-600 dark:text-red-400' : ''">{{ sj.status }}</span>)
+          </span>
+        </div>
+      </template>
+    </template>
+
+    <!-- Empty state -->
+    <div v-else-if="!loading" class="text-center py-12 text-gray-500 dark:text-gray-400">
+      No nightly pipeline data available.
+    </div>
+  </div>
+</template>

--- a/modules/product-builds/client/views/PackageAnalysisView.vue
+++ b/modules/product-builds/client/views/PackageAnalysisView.vue
@@ -4,6 +4,7 @@ import { apiRequest } from '@shared/client/services/api'
 import { useAuth } from '@shared/client/composables/useAuth'
 
 const PackageSearchView = defineAsyncComponent(() => import('./PackageSearchView.vue'))
+const NightlyAnalysisView = defineAsyncComponent(() => import('./NightlyAnalysisView.vue'))
 
 const { isAdmin } = useAuth()
 
@@ -60,7 +61,8 @@ function getInitialTab() {
   const qIdx = hash.indexOf('?')
   if (qIdx !== -1) {
     const params = new URLSearchParams(hash.slice(qIdx + 1))
-    if (params.get('tab') === 'search') return 'search'
+    const tab = params.get('tab')
+    if (tab === 'search' || tab === 'nightly') return tab
   }
   return 'onboarded'
 }
@@ -364,6 +366,15 @@ onMounted(() => {
           >
             Package Search
           </button>
+          <button
+            @click="activeTab = 'nightly'"
+            class="py-2.5 text-sm font-medium border-b-2 transition-colors flex items-center gap-2"
+            :class="activeTab === 'nightly'
+              ? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+          >
+            Nightly Analysis
+          </button>
         </nav>
       </div>
 
@@ -479,6 +490,11 @@ onMounted(() => {
       <!-- ==================== PACKAGE SEARCH TAB ==================== -->
       <div v-if="activeTab === 'search'">
         <PackageSearchView />
+      </div>
+
+      <!-- ==================== NIGHTLY ANALYSIS TAB ==================== -->
+      <div v-if="activeTab === 'nightly'">
+        <NightlyAnalysisView />
       </div>
 
       <!-- ==================== DAILY REPORT TAB ==================== -->

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -33,6 +33,21 @@
         "key": "NIGHTLY_PIPELINE_GITLAB_TOKEN",
         "description": "GitLab PAT for nightly pipeline schedule queries (overrides GITLAB_TOKEN)",
         "required": false
+      },
+      {
+        "key": "NIGHTLY_PIPELINE_GITLAB_BASE_URL",
+        "description": "GitLab instance base URL (defaults to https://gitlab.com)",
+        "required": false
+      },
+      {
+        "key": "NIGHTLY_PIPELINE_GITLAB_PROJECT",
+        "description": "URL-encoded GitLab project path (defaults to redhat%2Frhel-ai%2Frhai%2Fpipeline)",
+        "required": false
+      },
+      {
+        "key": "NIGHTLY_PIPELINE_SCHEDULE_ID",
+        "description": "GitLab pipeline schedule ID (defaults to 4256496)",
+        "required": false
       }
     ]
   },

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -27,8 +27,14 @@
     "entry": "./server/index.js"
   },
   "secrets": {
-    "platform": ["jira"],
-    "module": []
+    "platform": ["jira", "gitlab"],
+    "module": [
+      {
+        "key": "NIGHTLY_PIPELINE_GITLAB_TOKEN",
+        "description": "GitLab PAT for nightly pipeline schedule queries (overrides GITLAB_TOKEN)",
+        "required": false
+      }
+    ]
   },
   "export": {
     "files": [

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -916,6 +916,9 @@ module.exports = function registerRoutes(router, context) {
     });
   });
 
+  // --- Nightly Pipeline Analysis ---
+  require('./nightly-pipeline')(router, context);
+
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
       const index = readFromStorage(PKG_INDEX_PATH);

--- a/modules/product-builds/server/nightly-pipeline.js
+++ b/modules/product-builds/server/nightly-pipeline.js
@@ -30,44 +30,32 @@ async function gitlabApi(path, token) {
 
 const STAGE_SUFFIXES = ['bootstrap-and-onboard', 'build-wheels', 'publish-wheels', 'release-tarball'];
 const SPECIAL_JOB_PREFIXES = ['slack-notify-', 'update-publish-config'];
+const KNOWN_VARIANTS = ['cpu', 'cuda12.9', 'cuda13.0', 'rocm7.1', 'rocm7.14', 'spyre'];
 
 function parseJobName(name) {
   if (SPECIAL_JOB_PREFIXES.some(p => name.startsWith(p))) return null;
 
+  let stage = null, rest = null;
   for (const suffix of STAGE_SUFFIXES) {
-    if (!name.endsWith(suffix)) continue;
-    const prefix = name.slice(0, -(suffix.length + 1));
-    const ubi9Idx = prefix.lastIndexOf('-ubi9');
-    if (ubi9Idx === -1) continue;
-
-    const collectionAndVariant = prefix.slice(0, ubi9Idx);
-    const arch = prefix.slice(ubi9Idx + 5);
-
-    const lastDash = collectionAndVariant.lastIndexOf('-');
-    if (lastDash === -1) continue;
-
-    const possibleVariant = collectionAndVariant.slice(lastDash + 1);
-    const KNOWN_VARIANTS = ['cpu', 'cuda12.9', 'cuda13.0', 'rocm7.1', 'rocm7.14', 'spyre'];
-
-    let collection, variant;
-    if (KNOWN_VARIANTS.includes(possibleVariant)) {
-      collection = collectionAndVariant.slice(0, lastDash);
-      variant = possibleVariant;
-    } else {
-      const secondLastDash = collectionAndVariant.lastIndexOf('-', lastDash - 1);
-      if (secondLastDash === -1) continue;
-      const twoPartVariant = collectionAndVariant.slice(secondLastDash + 1);
-      if (KNOWN_VARIANTS.includes(twoPartVariant)) {
-        collection = collectionAndVariant.slice(0, secondLastDash);
-        variant = twoPartVariant;
-      } else {
-        continue;
-      }
+    if (name.endsWith('-' + suffix)) {
+      stage = suffix;
+      rest = name.slice(0, -(suffix.length + 1));
+      break;
     }
-
-    return { collection, variant, arch, stage: suffix };
   }
+  if (!stage) return null;
 
+  const ubi9Pos = rest.lastIndexOf('-ubi9-');
+  if (ubi9Pos === -1) return null;
+
+  const collVar = rest.slice(0, ubi9Pos);
+  const arch = rest.slice(ubi9Pos + 6);
+
+  for (const v of KNOWN_VARIANTS) {
+    if (collVar.endsWith('-' + v)) {
+      return { collection: collVar.slice(0, -(v.length + 1)), variant: v, arch, stage };
+    }
+  }
   return null;
 }
 
@@ -127,29 +115,28 @@ function structureJobs(jobs) {
   }
 
   const collectionSummaries = {};
+  let totalCount = 0, successCount = 0, failedCount = 0, skippedCount = 0;
   for (const [name, variants] of Object.entries(collections)) {
-    const allStatuses = [];
+    const statuses = [];
     for (const archs of Object.values(variants)) {
       for (const stages of Object.values(archs)) {
         for (const job of Object.values(stages)) {
-          allStatuses.push(job.status);
+          statuses.push(job.status);
+          totalCount++;
+          if (job.status === 'success') successCount++;
+          else if (job.status === 'failed') failedCount++;
+          else if (job.status === 'skipped') skippedCount++;
         }
       }
     }
     collectionSummaries[name] = {
-      status: rollUpStatus(allStatuses),
+      status: rollUpStatus(statuses),
       variants,
     };
   }
 
-  const allStatuses = jobs.filter(j => parseJobName(j.name)).map(j => j.status);
   return {
-    summary: {
-      total: allStatuses.length,
-      success: allStatuses.filter(s => s === 'success').length,
-      failed: allStatuses.filter(s => s === 'failed').length,
-      skipped: allStatuses.filter(s => s === 'skipped').length,
-    },
+    summary: { total: totalCount, success: successCount, failed: failedCount, skipped: skippedCount },
     failed_jobs: failedJobs,
     collections: collectionSummaries,
     special_jobs: specialJobs,
@@ -299,23 +286,20 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
     try {
       const limit = Math.min(Math.max(parseInt(req.query.limit) || 14, 1), 100);
 
-      const [schedule, ...pipelinePages] = await Promise.all([
+      const [schedule, firstPage] = await Promise.all([
         gitlabApi(`/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}`, token),
         gitlabApi(`/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}/pipelines?per_page=100&page=1`, token),
       ]);
 
-      let allPipelines = pipelinePages[0];
-      if (allPipelines.length === 100) {
-        let page = 2;
-        while (allPipelines.length < limit) {
+      const allPipelines = [...firstPage];
+      if (firstPage.length === 100) {
+        for (let page = 2; page <= 50; page++) {
           const batch = await gitlabApi(
             `/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}/pipelines?per_page=100&page=${page}`,
             token
           );
-          if (!batch.length) break;
           allPipelines.push(...batch);
           if (batch.length < 100) break;
-          page++;
         }
       }
 

--- a/modules/product-builds/server/nightly-pipeline.js
+++ b/modules/product-builds/server/nightly-pipeline.js
@@ -3,18 +3,24 @@ const JOBS_PER_PAGE = 100;
 const PACKAGES_CONCURRENCY = 5;
 const PREFERRED_VARIANT = 'cpu-ubi9';
 
+const PACKAGES_CACHE_MAX = 200;
 const packagesCache = new Map();
+const SAFE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
 
-let GITLAB_BASE_URL = 'https://gitlab.com';
-let GITLAB_PROJECT = 'redhat%2Frhel-ai%2Frhai%2Fpipeline';
-let SCHEDULE_ID = '4256496';
+const DEFAULTS = {
+  gitlabBaseUrl: 'https://gitlab.com',
+  gitlabProject: 'redhat%2Frhel-ai%2Frhai%2Fpipeline',
+  scheduleId: '4256496',
+};
 
 function getToken(secrets) {
   return secrets.NIGHTLY_PIPELINE_GITLAB_TOKEN || secrets.GITLAB_TOKEN || null;
 }
 
+let _cfg = { ...DEFAULTS };
+
 async function gitlabApi(path, token) {
-  const url = `${GITLAB_BASE_URL}/api/v4${path}`;
+  const url = `${_cfg.gitlabBaseUrl}/api/v4${path}`;
   const res = await fetch(url, {
     headers: { 'PRIVATE-TOKEN': token, 'Accept': 'application/json' },
     signal: AbortSignal.timeout(API_TIMEOUT),
@@ -177,7 +183,7 @@ async function concurrentMap(items, fn, limit) {
 }
 
 async function fetchPipelineSha(token, pipelineId) {
-  const pipeline = await gitlabApi(`/projects/${GITLAB_PROJECT}/pipelines/${pipelineId}`, token);
+  const pipeline = await gitlabApi(`/projects/${_cfg.gitlabProject}/pipelines/${pipelineId}`, token);
   return pipeline.sha;
 }
 
@@ -186,7 +192,7 @@ async function fetchTreeListing(token, path, ref) {
   let page = 1;
   while (true) {
     const entries = await gitlabApi(
-      `/projects/${GITLAB_PROJECT}/repository/tree?path=${encodeURIComponent(path)}&ref=${ref}&per_page=100&page=${page}`,
+      `/projects/${_cfg.gitlabProject}/repository/tree?path=${encodeURIComponent(path)}&ref=${ref}&per_page=100&page=${page}`,
       token
     );
     allEntries.push(...entries);
@@ -197,8 +203,8 @@ async function fetchTreeListing(token, path, ref) {
 }
 
 async function fetchFileRaw(token, filePath, ref) {
-  const url = `/projects/${GITLAB_PROJECT}/repository/files/${encodeURIComponent(filePath)}/raw?ref=${ref}`;
-  const res = await fetch(`${GITLAB_BASE_URL}/api/v4${url}`, {
+  const url = `/projects/${_cfg.gitlabProject}/repository/files/${encodeURIComponent(filePath)}/raw?ref=${ref}`;
+  const res = await fetch(`${_cfg.gitlabBaseUrl}/api/v4${url}`, {
     headers: { 'PRIVATE-TOKEN': token, 'Accept': 'text/plain' },
     signal: AbortSignal.timeout(API_TIMEOUT),
   });
@@ -208,7 +214,12 @@ async function fetchFileRaw(token, filePath, ref) {
 
 async function fetchCollectionPackages(token, sha, collection, variant) {
   const cacheKey = `${sha}:${collection}:${variant}`;
-  if (packagesCache.has(cacheKey)) return packagesCache.get(cacheKey);
+  if (packagesCache.has(cacheKey)) {
+    const cached = packagesCache.get(cacheKey);
+    packagesCache.delete(cacheKey);
+    packagesCache.set(cacheKey, cached);
+    return cached;
+  }
 
   const reqPath = `collections/${collection}/${variant}/requirements`;
   let tree;
@@ -237,6 +248,10 @@ async function fetchCollectionPackages(token, sha, collection, variant) {
   for (const g of validGroups) g.packages.forEach(p => allPkgs.add(p));
 
   const result = { collection, variant, sha, groups: validGroups, totalCount: allPkgs.size };
+  if (packagesCache.size >= PACKAGES_CACHE_MAX) {
+    const oldest = packagesCache.keys().next().value;
+    packagesCache.delete(oldest);
+  }
   packagesCache.set(cacheKey, result);
   return result;
 }
@@ -259,7 +274,7 @@ async function fetchAllJobs(token, pipelineId) {
   let page = 1;
   while (true) {
     const jobs = await gitlabApi(
-      `/projects/${GITLAB_PROJECT}/pipelines/${pipelineId}/jobs?per_page=${JOBS_PER_PAGE}&page=${page}`,
+      `/projects/${_cfg.gitlabProject}/pipelines/${pipelineId}/jobs?per_page=${JOBS_PER_PAGE}&page=${page}`,
       token
     );
     allJobs.push(...jobs);
@@ -273,11 +288,34 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
   const secrets = context.secrets || {};
 
   if (context.resolveSecret) {
-    GITLAB_BASE_URL = (context.resolveSecret('NIGHTLY_PIPELINE_GITLAB_BASE_URL') || GITLAB_BASE_URL).replace(/\/+$/, '');
-    GITLAB_PROJECT = context.resolveSecret('NIGHTLY_PIPELINE_GITLAB_PROJECT') || GITLAB_PROJECT;
-    SCHEDULE_ID = context.resolveSecret('NIGHTLY_PIPELINE_SCHEDULE_ID') || SCHEDULE_ID;
+    _cfg = {
+      gitlabBaseUrl: (context.resolveSecret('NIGHTLY_PIPELINE_GITLAB_BASE_URL') || DEFAULTS.gitlabBaseUrl).replace(/\/+$/, ''),
+      gitlabProject: context.resolveSecret('NIGHTLY_PIPELINE_GITLAB_PROJECT') || DEFAULTS.gitlabProject,
+      scheduleId: context.resolveSecret('NIGHTLY_PIPELINE_SCHEDULE_ID') || DEFAULTS.scheduleId,
+    };
   }
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/nightly-pipelines:
+   *   get:
+   *     tags: [Nightly Pipelines]
+   *     summary: List nightly pipeline runs with schedule metadata
+   *     parameters:
+   *       - name: limit
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 100
+   *           default: 14
+   *         description: Number of most recent pipelines to return
+   *     responses:
+   *       200:
+   *         description: Schedule metadata and sorted pipeline list
+   *       503:
+   *         description: GitLab token not configured
+   */
   router.get('/nightly-pipelines', async (req, res) => {
     const token = getToken(secrets);
     if (!token) {
@@ -287,15 +325,15 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
       const limit = Math.min(Math.max(parseInt(req.query.limit) || 14, 1), 100);
 
       const [schedule, firstPage] = await Promise.all([
-        gitlabApi(`/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}`, token),
-        gitlabApi(`/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}/pipelines?per_page=100&page=1`, token),
+        gitlabApi(`/projects/${_cfg.gitlabProject}/pipeline_schedules/${_cfg.scheduleId}`, token),
+        gitlabApi(`/projects/${_cfg.gitlabProject}/pipeline_schedules/${_cfg.scheduleId}/pipelines?per_page=100&page=1`, token),
       ]);
 
       const allPipelines = [...firstPage];
       if (firstPage.length === 100) {
         for (let page = 2; page <= 50; page++) {
           const batch = await gitlabApi(
-            `/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}/pipelines?per_page=100&page=${page}`,
+            `/projects/${_cfg.gitlabProject}/pipeline_schedules/${_cfg.scheduleId}/pipelines?per_page=100&page=${page}`,
             token
           );
           allPipelines.push(...batch);
@@ -318,8 +356,8 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
         .slice(0, limit);
 
       res.json({
-        schedule_id: Number(SCHEDULE_ID),
-        project_web_url: `${GITLAB_BASE_URL}/${decodeURIComponent(GITLAB_PROJECT)}`,
+        schedule_id: Number(_cfg.scheduleId),
+        project_web_url: `${_cfg.gitlabBaseUrl}/${decodeURIComponent(_cfg.gitlabProject)}`,
         schedule: {
           description: schedule.description,
           cron: schedule.cron,
@@ -336,6 +374,27 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
     }
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/nightly-pipelines/{pipelineId}/jobs:
+   *   get:
+   *     tags: [Nightly Pipelines]
+   *     summary: Get structured job data for a nightly pipeline run
+   *     parameters:
+   *       - name: pipelineId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: integer
+   *         description: GitLab pipeline ID
+   *     responses:
+   *       200:
+   *         description: Jobs grouped by collection/variant/arch/stage with summary counts
+   *       400:
+   *         description: Invalid pipeline ID
+   *       503:
+   *         description: GitLab token not configured
+   */
   router.get('/nightly-pipelines/:pipelineId/jobs', async (req, res) => {
     const token = getToken(secrets);
     if (!token) {
@@ -358,6 +417,38 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
     }
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/nightly-pipelines/{pipelineId}/packages:
+   *   get:
+   *     tags: [Nightly Pipelines]
+   *     summary: Get package list for a collection at a pipeline commit
+   *     parameters:
+   *       - name: pipelineId
+   *         in: path
+   *         required: true
+   *         schema:
+   *           type: integer
+   *         description: GitLab pipeline ID
+   *       - name: collection
+   *         in: query
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Collection name from job parsing
+   *       - name: variant
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Build variant (defaults to cpu-ubi9 or first available)
+   *     responses:
+   *       200:
+   *         description: Package groups by source file with total count
+   *       400:
+   *         description: Invalid pipeline ID or missing/invalid collection
+   *       503:
+   *         description: GitLab token not configured
+   */
   router.get('/nightly-pipelines/:pipelineId/packages', async (req, res) => {
     const token = getToken(secrets);
     if (!token) {
@@ -370,6 +461,9 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
     const { collection, variant } = req.query;
     if (!collection) {
       return res.status(400).json({ error: 'collection query parameter is required' });
+    }
+    if (!SAFE_NAME_RE.test(collection) || (variant && !SAFE_NAME_RE.test(variant))) {
+      return res.status(400).json({ error: 'Invalid collection or variant name' });
     }
     try {
       const sha = await fetchPipelineSha(token, pipelineId);

--- a/modules/product-builds/server/nightly-pipeline.js
+++ b/modules/product-builds/server/nightly-pipeline.js
@@ -1,0 +1,407 @@
+const API_TIMEOUT = 30_000;
+const JOBS_PER_PAGE = 100;
+const PACKAGES_CONCURRENCY = 5;
+const PREFERRED_VARIANT = 'cpu-ubi9';
+
+const packagesCache = new Map();
+
+let GITLAB_BASE_URL = 'https://gitlab.com';
+let GITLAB_PROJECT = 'redhat%2Frhel-ai%2Frhai%2Fpipeline';
+let SCHEDULE_ID = '4256496';
+
+function getToken(secrets) {
+  return secrets.NIGHTLY_PIPELINE_GITLAB_TOKEN || secrets.GITLAB_TOKEN || null;
+}
+
+async function gitlabApi(path, token) {
+  const url = `${GITLAB_BASE_URL}/api/v4${path}`;
+  const res = await fetch(url, {
+    headers: { 'PRIVATE-TOKEN': token, 'Accept': 'application/json' },
+    signal: AbortSignal.timeout(API_TIMEOUT),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    const err = new Error(`GitLab API ${res.status}: ${body.slice(0, 200)}`);
+    err.upstreamStatus = res.status;
+    throw err;
+  }
+  return res.json();
+}
+
+const STAGE_SUFFIXES = ['bootstrap-and-onboard', 'build-wheels', 'publish-wheels', 'release-tarball'];
+const SPECIAL_JOB_PREFIXES = ['slack-notify-', 'update-publish-config'];
+
+function parseJobName(name) {
+  if (SPECIAL_JOB_PREFIXES.some(p => name.startsWith(p))) return null;
+
+  for (const suffix of STAGE_SUFFIXES) {
+    if (!name.endsWith(suffix)) continue;
+    const prefix = name.slice(0, -(suffix.length + 1));
+    const ubi9Idx = prefix.lastIndexOf('-ubi9');
+    if (ubi9Idx === -1) continue;
+
+    const collectionAndVariant = prefix.slice(0, ubi9Idx);
+    const arch = prefix.slice(ubi9Idx + 5);
+
+    const lastDash = collectionAndVariant.lastIndexOf('-');
+    if (lastDash === -1) continue;
+
+    const possibleVariant = collectionAndVariant.slice(lastDash + 1);
+    const KNOWN_VARIANTS = ['cpu', 'cuda12.9', 'cuda13.0', 'rocm7.1', 'rocm7.14', 'spyre'];
+
+    let collection, variant;
+    if (KNOWN_VARIANTS.includes(possibleVariant)) {
+      collection = collectionAndVariant.slice(0, lastDash);
+      variant = possibleVariant;
+    } else {
+      const secondLastDash = collectionAndVariant.lastIndexOf('-', lastDash - 1);
+      if (secondLastDash === -1) continue;
+      const twoPartVariant = collectionAndVariant.slice(secondLastDash + 1);
+      if (KNOWN_VARIANTS.includes(twoPartVariant)) {
+        collection = collectionAndVariant.slice(0, secondLastDash);
+        variant = twoPartVariant;
+      } else {
+        continue;
+      }
+    }
+
+    return { collection, variant, arch, stage: suffix };
+  }
+
+  return null;
+}
+
+function rollUpStatus(statuses) {
+  if (statuses.includes('failed')) return 'failed';
+  if (statuses.includes('running')) return 'running';
+  if (statuses.includes('canceled')) return 'canceled';
+  if (statuses.includes('skipped') && statuses.every(s => s === 'skipped' || s === 'success' || s === 'manual')) return 'success';
+  if (statuses.every(s => s === 'success' || s === 'manual')) return 'success';
+  if (statuses.includes('skipped')) return 'skipped';
+  return 'unknown';
+}
+
+function structureJobs(jobs) {
+  const collections = {};
+  const specialJobs = [];
+  const failedJobs = [];
+
+  for (const job of jobs) {
+    const parsed = parseJobName(job.name);
+    if (!parsed) {
+      if (SPECIAL_JOB_PREFIXES.some(p => job.name.startsWith(p))) {
+        specialJobs.push({
+          name: job.name,
+          status: job.status,
+          web_url: job.web_url,
+        });
+      }
+      continue;
+    }
+
+    const { collection, variant, arch, stage } = parsed;
+    collections[collection] ??= {};
+    collections[collection][variant] ??= {};
+    collections[collection][variant][arch] ??= {};
+    collections[collection][variant][arch][stage] = {
+      id: job.id,
+      status: job.status,
+      web_url: job.web_url,
+      duration: job.duration,
+      failure_reason: job.failure_reason || null,
+    };
+
+    if (job.status === 'failed') {
+      failedJobs.push({
+        name: job.name,
+        id: job.id,
+        status: job.status,
+        web_url: job.web_url,
+        collection,
+        variant,
+        arch,
+        stage,
+        failure_reason: job.failure_reason || null,
+      });
+    }
+  }
+
+  const collectionSummaries = {};
+  for (const [name, variants] of Object.entries(collections)) {
+    const allStatuses = [];
+    for (const archs of Object.values(variants)) {
+      for (const stages of Object.values(archs)) {
+        for (const job of Object.values(stages)) {
+          allStatuses.push(job.status);
+        }
+      }
+    }
+    collectionSummaries[name] = {
+      status: rollUpStatus(allStatuses),
+      variants,
+    };
+  }
+
+  const allStatuses = jobs.filter(j => parseJobName(j.name)).map(j => j.status);
+  return {
+    summary: {
+      total: allStatuses.length,
+      success: allStatuses.filter(s => s === 'success').length,
+      failed: allStatuses.filter(s => s === 'failed').length,
+      skipped: allStatuses.filter(s => s === 'skipped').length,
+    },
+    failed_jobs: failedJobs,
+    collections: collectionSummaries,
+    special_jobs: specialJobs,
+  };
+}
+
+function parsePackageName(line) {
+  let s = line.split('#')[0].trim();
+  if (!s) return null;
+  s = s.split(';')[0].trim();
+  s = s.replace(/\[.*?\]/g, '');
+  s = s.replace(/[><=!~].*$/, '').trim();
+  return s.toLowerCase().replace(/[._]+/g, '-') || null;
+}
+
+function parseRequirementsFile(content) {
+  const packages = [];
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const name = parsePackageName(line);
+    if (name) packages.push(name);
+  }
+  return [...new Set(packages)].sort();
+}
+
+async function concurrentMap(items, fn, limit) {
+  const results = [];
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return results;
+}
+
+async function fetchPipelineSha(token, pipelineId) {
+  const pipeline = await gitlabApi(`/projects/${GITLAB_PROJECT}/pipelines/${pipelineId}`, token);
+  return pipeline.sha;
+}
+
+async function fetchTreeListing(token, path, ref) {
+  const allEntries = [];
+  let page = 1;
+  while (true) {
+    const entries = await gitlabApi(
+      `/projects/${GITLAB_PROJECT}/repository/tree?path=${encodeURIComponent(path)}&ref=${ref}&per_page=100&page=${page}`,
+      token
+    );
+    allEntries.push(...entries);
+    if (entries.length < 100) break;
+    page++;
+  }
+  return allEntries;
+}
+
+async function fetchFileRaw(token, filePath, ref) {
+  const url = `/projects/${GITLAB_PROJECT}/repository/files/${encodeURIComponent(filePath)}/raw?ref=${ref}`;
+  const res = await fetch(`${GITLAB_BASE_URL}/api/v4${url}`, {
+    headers: { 'PRIVATE-TOKEN': token, 'Accept': 'text/plain' },
+    signal: AbortSignal.timeout(API_TIMEOUT),
+  });
+  if (!res.ok) return null;
+  return res.text();
+}
+
+async function fetchCollectionPackages(token, sha, collection, variant) {
+  const cacheKey = `${sha}:${collection}:${variant}`;
+  if (packagesCache.has(cacheKey)) return packagesCache.get(cacheKey);
+
+  const reqPath = `collections/${collection}/${variant}/requirements`;
+  let tree;
+  try {
+    tree = await fetchTreeListing(token, reqPath, sha);
+  } catch (err) {
+    if (err.upstreamStatus === 404) {
+      const result = { collection, variant, sha, groups: [], totalCount: 0 };
+      packagesCache.set(cacheKey, result);
+      return result;
+    }
+    throw err;
+  }
+  const txtFiles = tree.filter(e => e.type === 'blob' && e.name.endsWith('.txt') && e.name !== 'onboarded.txt');
+
+  const groups = await concurrentMap(txtFiles, async (entry) => {
+    const content = await fetchFileRaw(token, `${reqPath}/${entry.name}`, sha);
+    if (!content) return null;
+    const packages = parseRequirementsFile(content);
+    const source = entry.name.replace(/\.txt$/, '');
+    return packages.length > 0 ? { source, packages } : null;
+  }, PACKAGES_CONCURRENCY);
+
+  const validGroups = groups.filter(Boolean).sort((a, b) => a.source.localeCompare(b.source));
+  const allPkgs = new Set();
+  for (const g of validGroups) g.packages.forEach(p => allPkgs.add(p));
+
+  const result = { collection, variant, sha, groups: validGroups, totalCount: allPkgs.size };
+  packagesCache.set(cacheKey, result);
+  return result;
+}
+
+async function resolveVariant(token, sha, collection, requestedVariant) {
+  if (requestedVariant) return requestedVariant;
+  try {
+    const tree = await fetchTreeListing(token, `collections/${collection}`, sha);
+    const dirs = tree.filter(e => e.type === 'tree' && e.name.endsWith('-ubi9')).map(e => e.name);
+    if (!dirs.length) return null;
+    return dirs.includes(PREFERRED_VARIANT) ? PREFERRED_VARIANT : dirs.sort()[0];
+  } catch (err) {
+    if (err.upstreamStatus === 404) return null;
+    throw err;
+  }
+}
+
+async function fetchAllJobs(token, pipelineId) {
+  const allJobs = [];
+  let page = 1;
+  while (true) {
+    const jobs = await gitlabApi(
+      `/projects/${GITLAB_PROJECT}/pipelines/${pipelineId}/jobs?per_page=${JOBS_PER_PAGE}&page=${page}`,
+      token
+    );
+    allJobs.push(...jobs);
+    if (jobs.length < JOBS_PER_PAGE) break;
+    page++;
+  }
+  return allJobs;
+}
+
+module.exports = function registerNightlyPipelineRoutes(router, context) {
+  const secrets = context.secrets || {};
+
+  if (context.resolveSecret) {
+    GITLAB_BASE_URL = (context.resolveSecret('NIGHTLY_PIPELINE_GITLAB_BASE_URL') || GITLAB_BASE_URL).replace(/\/+$/, '');
+    GITLAB_PROJECT = context.resolveSecret('NIGHTLY_PIPELINE_GITLAB_PROJECT') || GITLAB_PROJECT;
+    SCHEDULE_ID = context.resolveSecret('NIGHTLY_PIPELINE_SCHEDULE_ID') || SCHEDULE_ID;
+  }
+
+  router.get('/nightly-pipelines', async (req, res) => {
+    const token = getToken(secrets);
+    if (!token) {
+      return res.status(503).json({ error: 'GitLab token not configured' });
+    }
+    try {
+      const limit = Math.min(Math.max(parseInt(req.query.limit) || 14, 1), 100);
+
+      const [schedule, ...pipelinePages] = await Promise.all([
+        gitlabApi(`/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}`, token),
+        gitlabApi(`/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}/pipelines?per_page=100&page=1`, token),
+      ]);
+
+      let allPipelines = pipelinePages[0];
+      if (allPipelines.length === 100) {
+        let page = 2;
+        while (allPipelines.length < limit) {
+          const batch = await gitlabApi(
+            `/projects/${GITLAB_PROJECT}/pipeline_schedules/${SCHEDULE_ID}/pipelines?per_page=100&page=${page}`,
+            token
+          );
+          if (!batch.length) break;
+          allPipelines.push(...batch);
+          if (batch.length < 100) break;
+          page++;
+        }
+      }
+
+      const sorted = allPipelines
+        .map(p => ({
+          id: p.id,
+          iid: p.iid,
+          status: p.status,
+          ref: p.ref,
+          sha: p.sha,
+          created_at: p.created_at,
+          updated_at: p.updated_at,
+          web_url: p.web_url,
+        }))
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+        .slice(0, limit);
+
+      res.json({
+        schedule_id: Number(SCHEDULE_ID),
+        project_web_url: `${GITLAB_BASE_URL}/${decodeURIComponent(GITLAB_PROJECT)}`,
+        schedule: {
+          description: schedule.description,
+          cron: schedule.cron,
+          cron_timezone: schedule.cron_timezone,
+          next_run_at: schedule.next_run_at,
+          ref: (schedule.ref || '').replace('refs/heads/', ''),
+          active: schedule.active,
+        },
+        pipelines: sorted,
+      });
+    } catch (err) {
+      const status = err.upstreamStatus || 500;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  router.get('/nightly-pipelines/:pipelineId/jobs', async (req, res) => {
+    const token = getToken(secrets);
+    if (!token) {
+      return res.status(503).json({ error: 'GitLab token not configured' });
+    }
+    const { pipelineId } = req.params;
+    if (!/^\d+$/.test(pipelineId)) {
+      return res.status(400).json({ error: 'Invalid pipeline ID' });
+    }
+    try {
+      const jobs = await fetchAllJobs(token, pipelineId);
+      const structured = structureJobs(jobs);
+      res.json({
+        pipeline_id: Number(pipelineId),
+        ...structured,
+      });
+    } catch (err) {
+      const status = err.upstreamStatus || 500;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  router.get('/nightly-pipelines/:pipelineId/packages', async (req, res) => {
+    const token = getToken(secrets);
+    if (!token) {
+      return res.status(503).json({ error: 'GitLab token not configured' });
+    }
+    const { pipelineId } = req.params;
+    if (!/^\d+$/.test(pipelineId)) {
+      return res.status(400).json({ error: 'Invalid pipeline ID' });
+    }
+    const { collection, variant } = req.query;
+    if (!collection) {
+      return res.status(400).json({ error: 'collection query parameter is required' });
+    }
+    try {
+      const sha = await fetchPipelineSha(token, pipelineId);
+      const resolvedVariant = await resolveVariant(token, sha, collection, variant);
+      if (!resolvedVariant) {
+        return res.json({ collection, variant: null, sha, groups: [], totalCount: 0 });
+      }
+      const result = await fetchCollectionPackages(token, sha, collection, resolvedVariant);
+      res.json(result);
+    } catch (err) {
+      const status = err.upstreamStatus || 500;
+      res.status(status).json({ error: err.message });
+    }
+  });
+};
+
+module.exports.parseJobName = parseJobName;
+module.exports.structureJobs = structureJobs;
+module.exports.rollUpStatus = rollUpStatus;


### PR DESCRIPTION
## Summary
- Adds a **Nightly Analysis** tab to the Package Analysis page, showing pass/fail results from the RHAI nightly CI pipeline schedule
- Three new server endpoints proxy GitLab schedule/pipeline/jobs/packages APIs with structured job parsing and SHA-based package caching
- Vue composable + view with hero status banner, interactive pipeline timeline, collapsible collection cards with packages and jobs matrix

## Key design decisions
- Packages fetched on-demand per collection (not on page load) and cached by commit SHA (immutable)
- Job names parsed into collection/variant/arch/stage structure; collections sorted with failures first
- Schedule metadata uses API response with hardcoded fallback
- Status colors use a theme map to avoid ternary duplication across the template

## Test plan
- [ ] Verify Nightly Analysis tab loads at `/#/product-builds/package-analysis?tab=nightly`
- [ ] Confirm hero banner shows correct pass/fail status for latest pipeline
- [ ] Click pipeline tiles in timeline and verify job details load
- [ ] Expand collection cards and verify packages load on first expand
- [ ] Verify jobs matrix shows correct variant × arch × stage grid with GitLab links
- [ ] Test with a failing pipeline to confirm failed jobs alert and red styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)