### PR TITLE
feat(releases): add draft plans data ingestion from GitLab

### DIFF
--- a/modules/releases/__tests__/server/draft-plans/fetch.test.js
+++ b/modules/releases/__tests__/server/draft-plans/fetch.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { fetchDraftPlans, DATA_PREFIX, _setFetch } = require('../../../server/draft-plans/fetch')
+
+const mockFetch = vi.fn()
+
+function makeStorage() {
+  const written = {}
+  return {
+    writeToStorage(key, data) { written[key] = data },
+    readFromStorage(key) { return written[key] || null },
+    _written: written
+  }
+}
+
+const baseConfig = {
+  gitlabBaseUrl: 'https://gitlab.com',
+  projectId: '81798612',
+  branch: 'main'
+}
+
+function mockJsonResponse(data) {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data))
+  }
+}
+
+const PLAN_DATA = {
+  generatedAt: '2026-07-08T11:00:00Z',
+  product: 'RHOAI',
+  summary: { totalFeatures: 100 },
+  releases: [
+    { version: '3.5', events: { EA1: { features: [] }, GA: { features: [] } } },
+    { version: '3.6', events: { EA1: { features: [] } } }
+  ]
+}
+
+const HEALTH_DATA = {
+  generatedAt: '2026-07-08',
+  releases: [
+    { version: '3.5', totalFeatures: 156, healthStatus: 'critical', featureHealth: { ready: 127 } },
+    { version: '3.6', totalFeatures: 80, healthStatus: 'healthy', featureHealth: { ready: 75 } }
+  ]
+}
+
+describe('fetchDraftPlans', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _setFetch(mockFetch)
+  })
+
+  it('fetches and stores both JSON files for each product', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockJsonResponse(PLAN_DATA))
+      .mockResolvedValueOnce(mockJsonResponse(HEALTH_DATA))
+
+    const storage = makeStorage()
+    const result = await fetchDraftPlans(storage, baseConfig, 'test-token')
+
+    expect(result.status).toBe('success')
+    expect(result.fileCount).toBe(2)
+    expect(storage._written[`${DATA_PREFIX}/RHOAI/release-plan.json`]).toEqual(PLAN_DATA)
+    expect(storage._written[`${DATA_PREFIX}/RHOAI/release-health.json`]).toEqual(HEALTH_DATA)
+  })
+
+  it('constructs correct GitLab Repository Files API URLs', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockJsonResponse(PLAN_DATA))
+      .mockResolvedValueOnce(mockJsonResponse(HEALTH_DATA))
+
+    const storage = makeStorage()
+    await fetchDraftPlans(storage, baseConfig, 'my-token')
+
+    const planUrl = mockFetch.mock.calls[0][0]
+    expect(planUrl).toBe('https://gitlab.com/api/v4/projects/81798612/repository/files/RHOAI%2Flatest%2Frelease-plan.json/raw?ref=main')
+
+    const healthUrl = mockFetch.mock.calls[1][0]
+    expect(healthUrl).toBe('https://gitlab.com/api/v4/projects/81798612/repository/files/RHOAI%2Flatest%2Frelease-health.json/raw?ref=main')
+  })
+
+  it('sends Bearer token in Authorization header', async () => {
+    mockFetch.mockResolvedValue(mockJsonResponse(PLAN_DATA))
+
+    const storage = makeStorage()
+    await fetchDraftPlans(storage, baseConfig, 'secret-token')
+
+    const opts = mockFetch.mock.calls[0][1]
+    expect(opts.headers.Authorization).toBe('Bearer secret-token')
+  })
+
+  it('writes last-fetch.json metadata', async () => {
+    mockFetch.mockResolvedValue(mockJsonResponse(PLAN_DATA))
+
+    const storage = makeStorage()
+    await fetchDraftPlans(storage, baseConfig, 'token')
+
+    const lastFetch = storage._written[`${DATA_PREFIX}/last-fetch.json`]
+    expect(lastFetch).toBeDefined()
+    expect(lastFetch.status).toBe('success')
+    expect(lastFetch.timestamp).toBeDefined()
+    expect(lastFetch.duration).toBeGreaterThanOrEqual(0)
+    expect(lastFetch.products.RHOAI).toBeDefined()
+  })
+
+  it('throws on 401 (authentication failure)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401, text: () => Promise.resolve('') })
+
+    const storage = makeStorage()
+    await expect(fetchDraftPlans(storage, baseConfig, 'bad-token'))
+      .rejects.toThrow('authentication failed')
+  })
+
+  it('throws on 429 (rate limited)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429, text: () => Promise.resolve('') })
+
+    const storage = makeStorage()
+    await expect(fetchDraftPlans(storage, baseConfig, 'token'))
+      .rejects.toThrow('rate limited')
+  })
+
+  it('skips product on 404 and records warning', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, text: () => Promise.resolve('') })
+
+    const storage = makeStorage()
+    const result = await fetchDraftPlans(storage, baseConfig, 'token')
+
+    expect(result.status).toBe('no_data')
+    expect(result.fileCount).toBe(0)
+    expect(result.warnings).toBeDefined()
+    expect(result.warnings.some(w => w.includes('not found (404)'))).toBe(true)
+  })
+
+  it('handles invalid JSON response gracefully', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('not valid json {{{')
+    })
+
+    const storage = makeStorage()
+    const result = await fetchDraftPlans(storage, baseConfig, 'token')
+
+    expect(result.fileCount).toBe(0)
+    expect(result.warnings).toBeDefined()
+    expect(result.warnings.some(w => w.includes('Failed to parse'))).toBe(true)
+  })
+
+  it('requires projectId', async () => {
+    const storage = makeStorage()
+    await expect(fetchDraftPlans(storage, { ...baseConfig, projectId: '' }, 'token'))
+      .rejects.toThrow('projectId is required')
+  })
+
+  it('rejects invalid gitlabBaseUrl protocol', async () => {
+    const storage = makeStorage()
+    await expect(fetchDraftPlans(storage, { ...baseConfig, gitlabBaseUrl: 'ftp://evil.com' }, 'token'))
+      .rejects.toThrow('gitlabBaseUrl must use http or https')
+  })
+
+  it('rejects completely invalid gitlabBaseUrl', async () => {
+    const storage = makeStorage()
+    await expect(fetchDraftPlans(storage, { ...baseConfig, gitlabBaseUrl: 'not-a-url' }, 'token'))
+      .rejects.toThrow('Invalid gitlabBaseUrl')
+  })
+
+  it('succeeds when one file fetches but the other 404s', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockJsonResponse(PLAN_DATA))
+      .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve('') })
+
+    const storage = makeStorage()
+    const result = await fetchDraftPlans(storage, baseConfig, 'token')
+
+    expect(result.status).toBe('success')
+    expect(result.fileCount).toBe(1)
+    expect(storage._written[`${DATA_PREFIX}/RHOAI/release-plan.json`]).toEqual(PLAN_DATA)
+    expect(storage._written[`${DATA_PREFIX}/RHOAI/release-health.json`]).toBeUndefined()
+  })
+
+  it('uses custom branch in API URL', async () => {
+    mockFetch.mockResolvedValue(mockJsonResponse(PLAN_DATA))
+
+    const storage = makeStorage()
+    await fetchDraftPlans(storage, { ...baseConfig, branch: 'staging' }, 'token')
+
+    const url = mockFetch.mock.calls[0][0]
+    expect(url).toContain('ref=staging')
+  })
+})

--- a/modules/releases/__tests__/server/draft-plans/routes.test.js
+++ b/modules/releases/__tests__/server/draft-plans/routes.test.js
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { _setFetch, DATA_PREFIX } = require('../../../server/draft-plans/fetch')
+
+const mockFetch = vi.fn()
+
+const PLAN_DATA = {
+  generatedAt: '2026-07-08T11:00:00Z',
+  product: 'RHOAI',
+  summary: { totalFeatures: 100 },
+  capacity: { conservative_max: 31 },
+  releases: [
+    { version: '3.5', events: { EA1: { features: [{ key: 'F-1' }] }, GA: { features: [] } } },
+    { version: '3.6', events: { EA1: { features: [] } } }
+  ]
+}
+
+const HEALTH_DATA = {
+  generatedAt: '2026-07-08',
+  historicalCapacity: { typical: 12 },
+  velocitySource: 'live',
+  releases: [
+    { version: '3.5', totalFeatures: 156, committed: 118, planned: 38, healthStatus: 'critical', featureHealth: { ready: 127 }, overcommitRatio: 9.2 },
+    { version: '3.6', totalFeatures: 80, committed: 60, planned: 20, healthStatus: 'healthy', featureHealth: { ready: 75 }, overcommitRatio: 1.1 }
+  ]
+}
+
+function makeStorage(data = {}) {
+  const store = { ...data }
+  return {
+    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null },
+    writeToStorage(key, value) { store[key] = value },
+    _store: store
+  }
+}
+
+function makeRouter() {
+  const routes = { get: {}, post: {} }
+  return {
+    get: vi.fn(function(path, ...handlers) { routes.get[path] = handlers }),
+    post: vi.fn(function(path, ...handlers) { routes.post[path] = handlers }),
+    _routes: routes
+  }
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: null,
+    status(code) { res._status = code; return res },
+    json(data) { res._json = data; return res }
+  }
+  return res
+}
+
+function passthrough(req, res, next) { if (next) next(); }
+
+function setupRouter(storageData = {}, secretsOverride = null) {
+  const storage = makeStorage(storageData)
+  const router = makeRouter()
+  const refreshHandlers = {}
+  const diagnosticsFn = vi.fn()
+
+  const registerDraftPlanRoutes = require('../../../server/draft-plans/routes')
+  registerDraftPlanRoutes(router, {
+    storage,
+    requireAuth: passthrough,
+    requireScope: () => passthrough,
+    secrets: secretsOverride !== null ? secretsOverride : { GITLAB_TOKEN: 'test-token' },
+    registerRefresh: (name, opts) => { refreshHandlers[name] = opts },
+    isRefreshRunning: () => false,
+    registerDiagnostics: diagnosticsFn
+  })
+
+  return { storage, router, refreshHandlers, diagnosticsFn }
+}
+
+async function callRoute(router, method, path, req = {}) {
+  const routes = router._routes[method]
+  const handlers = routes[path]
+  if (!handlers) throw new Error(`No route registered for ${method.toUpperCase()} ${path}`)
+
+  const finalHandler = handlers[handlers.length - 1]
+  const res = makeRes()
+  const fullReq = { query: {}, params: {}, body: {}, ...req }
+  await finalHandler(fullReq, res)
+  return res
+}
+
+describe('draft-plans routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _setFetch(mockFetch)
+    vi.resetModules()
+  })
+
+  describe('GET /releases', () => {
+    it('returns empty products when no data stored', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/releases')
+
+      expect(res._json.products).toEqual([])
+      expect(res._json.fetchedAt).toBeNull()
+    })
+
+    it('returns release list with health summary when data is stored', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA,
+        [`${DATA_PREFIX}/RHOAI/release-health.json`]: HEALTH_DATA,
+        [`${DATA_PREFIX}/last-fetch.json`]: { timestamp: '2026-07-08T12:00:00Z' }
+      })
+
+      const res = await callRoute(router, 'get', '/releases')
+
+      expect(res._json.fetchedAt).toBe('2026-07-08T12:00:00Z')
+      expect(res._json.products).toHaveLength(1)
+      expect(res._json.products[0].product).toBe('RHOAI')
+      expect(res._json.products[0].releases).toHaveLength(2)
+
+      const v35 = res._json.products[0].releases[0]
+      expect(v35.version).toBe('3.5')
+      expect(v35.totalFeatures).toBe(156)
+      expect(v35.healthStatus).toBe('critical')
+      expect(v35.overcommitRatio).toBe(9.2)
+    })
+
+    it('filters by product query param', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA
+      })
+
+      const res = await callRoute(router, 'get', '/releases', { query: { product: 'RHAIIS' } })
+      expect(res._json.products).toEqual([])
+    })
+  })
+
+  describe('GET /:version', () => {
+    it('returns full version plan data', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA
+      })
+
+      const res = await callRoute(router, 'get', '/:version', { params: { version: '3.5' } })
+
+      expect(res._status).toBe(200)
+      expect(res._json.version).toBe('3.5')
+      expect(res._json.products.RHOAI).toBeDefined()
+      expect(res._json.products.RHOAI.release.version).toBe('3.5')
+      expect(res._json.products.RHOAI.release.events).toBeDefined()
+      expect(res._json.products.RHOAI.summary).toEqual({ totalFeatures: 100 })
+      expect(res._json.products.RHOAI.capacity).toEqual({ conservative_max: 31 })
+    })
+
+    it('returns 404 for unknown version', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA
+      })
+
+      const res = await callRoute(router, 'get', '/:version', { params: { version: '9.9' } })
+      expect(res._status).toBe(404)
+    })
+
+    it('returns 400 for invalid version format', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/:version', { params: { version: '../etc/passwd' } })
+      expect(res._status).toBe(400)
+    })
+
+    it('returns 404 when no data stored', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/:version', { params: { version: '3.5' } })
+      expect(res._status).toBe(404)
+    })
+  })
+
+  describe('GET /:version/health', () => {
+    it('returns health data for a version', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/RHOAI/release-health.json`]: HEALTH_DATA
+      })
+
+      const res = await callRoute(router, 'get', '/:version/health', { params: { version: '3.5' } })
+
+      expect(res._status).toBe(200)
+      expect(res._json.version).toBe('3.5')
+      expect(res._json.products.RHOAI.release.healthStatus).toBe('critical')
+      expect(res._json.products.RHOAI.release.totalFeatures).toBe(156)
+      expect(res._json.products.RHOAI.historicalCapacity).toEqual({ typical: 12 })
+      expect(res._json.products.RHOAI.velocitySource).toBe('live')
+    })
+
+    it('returns 404 for unknown version', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/RHOAI/release-health.json`]: HEALTH_DATA
+      })
+
+      const res = await callRoute(router, 'get', '/:version/health', { params: { version: '9.9' } })
+      expect(res._status).toBe(404)
+    })
+
+    it('returns 400 for invalid version format', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/:version/health', { params: { version: 'a'.repeat(51) } })
+      expect(res._status).toBe(400)
+    })
+  })
+
+  describe('GET /config', () => {
+    it('returns default config with token status', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/config')
+
+      expect(res._json.enabled).toBe(false)
+      expect(res._json.projectId).toBe('81798612')
+      expect(res._json.tokenConfigured).toBe(true)
+      expect(res._json.tokenSource).toBe('GITLAB_TOKEN')
+    })
+
+    it('reports DRAFT_PLANS_GITLAB_TOKEN as preferred source', async () => {
+      const { router } = setupRouter({}, { DRAFT_PLANS_GITLAB_TOKEN: 'dp-token', GITLAB_TOKEN: 'gl-token' })
+      const res = await callRoute(router, 'get', '/config')
+
+      expect(res._json.tokenConfigured).toBe(true)
+      expect(res._json.tokenSource).toBe('DRAFT_PLANS_GITLAB_TOKEN')
+    })
+
+    it('reports no token when secrets are empty', async () => {
+      const { router } = setupRouter({}, {})
+      const res = await callRoute(router, 'get', '/config')
+
+      expect(res._json.tokenConfigured).toBe(false)
+      expect(res._json.tokenSource).toBeNull()
+    })
+  })
+
+  describe('POST /config', () => {
+    it('saves valid config without enabling', async () => {
+      const { router, storage } = setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        body: { projectId: '12345', refreshIntervalHours: 12 }
+      })
+
+      expect(res._json.status).toBe('saved')
+      const saved = storage._store[`${DATA_PREFIX}/config.json`]
+      expect(saved.projectId).toBe('12345')
+      expect(saved.refreshIntervalHours).toBe(12)
+    })
+
+    it('auto-fetches when enabling for the first time', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(PLAN_DATA))
+      })
+
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        body: { enabled: true, projectId: '12345' }
+      })
+
+      expect(res._json.status).toBe('saved_and_fetched')
+      expect(res._json.fetchResult).toBeDefined()
+    })
+
+    it('rejects invalid projectId', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        body: { projectId: 'not-a-number' }
+      })
+
+      expect(res._status).toBe(400)
+      expect(res._json.message).toContain('projectId must be a numeric string')
+    })
+
+    it('rejects non-https gitlabBaseUrl', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        body: { gitlabBaseUrl: 'http://gitlab.internal' }
+      })
+
+      expect(res._status).toBe(400)
+      expect(res._json.message).toContain('must start with https://')
+    })
+
+    it('rejects refreshIntervalHours out of range', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'post', '/config', {
+        body: { refreshIntervalHours: 0 }
+      })
+
+      expect(res._status).toBe(400)
+    })
+  })
+
+  describe('POST /refresh', () => {
+    it('returns 500 when no token configured', async () => {
+      const { router } = setupRouter(
+        { [`${DATA_PREFIX}/config.json`]: { ...PLAN_DATA, enabled: true } },
+        {}
+      )
+
+      const res = await callRoute(router, 'post', '/refresh')
+      expect(res._status).toBe(500)
+      expect(res._json.message).toContain('No GitLab token')
+    })
+
+    it('returns 400 when fetch is disabled', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'post', '/refresh')
+
+      expect(res._status).toBe(400)
+      expect(res._json.message).toContain('disabled')
+    })
+
+    it('performs fetch when enabled and token present', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(PLAN_DATA))
+      })
+
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/config.json`]: { enabled: true, projectId: '81798612', branch: 'main', gitlabBaseUrl: 'https://gitlab.com' }
+      })
+
+      const res = await callRoute(router, 'post', '/refresh', { userEmail: 'test@example.com' })
+      expect(res._json.status).toBe('success')
+      expect(res._json.fileCount).toBeGreaterThan(0)
+    })
+  })
+
+  describe('GET /refresh/status', () => {
+    it('returns status with no prior fetch', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/refresh/status')
+
+      expect(res._json.running).toBe(false)
+      expect(res._json.lastFetch).toBeNull()
+    })
+
+    it('returns last fetch info when available', async () => {
+      const { router } = setupRouter({
+        [`${DATA_PREFIX}/last-fetch.json`]: { status: 'success', timestamp: '2026-07-08T12:00:00Z', fileCount: 2 }
+      })
+
+      const res = await callRoute(router, 'get', '/refresh/status')
+      expect(res._json.lastFetch.status).toBe('success')
+      expect(res._json.lastFetch.fileCount).toBe(2)
+    })
+  })
+
+  describe('registerRefresh', () => {
+    it('registers a draft-plans refresh handler', () => {
+      const { refreshHandlers } = setupRouter()
+
+      expect(refreshHandlers['draft-plans']).toBeDefined()
+      expect(refreshHandlers['draft-plans'].order).toBe(80)
+      expect(refreshHandlers['draft-plans'].timeout).toBe(300000)
+      expect(refreshHandlers['draft-plans'].handler).toBeTypeOf('function')
+    })
+
+    it('refresh handler skips when disabled', async () => {
+      const { refreshHandlers } = setupRouter()
+      const result = await refreshHandlers['draft-plans'].handler()
+
+      expect(result.status).toBe('skipped')
+    })
+
+    it('refresh handler skips when no token', async () => {
+      const { refreshHandlers } = setupRouter(
+        { [`${DATA_PREFIX}/config.json`]: { enabled: true, projectId: '81798612' } },
+        {}
+      )
+
+      const result = await refreshHandlers['draft-plans'].handler()
+      expect(result.status).toBe('error')
+      expect(result.message).toContain('No GitLab token')
+    })
+  })
+
+  describe('registerDiagnostics', () => {
+    it('registers a diagnostics function', () => {
+      const { diagnosticsFn } = setupRouter()
+      expect(diagnosticsFn).toHaveBeenCalledOnce()
+      expect(diagnosticsFn.mock.calls[0][0]).toBeTypeOf('function')
+    })
+
+    it('diagnostics returns status info', async () => {
+      const { diagnosticsFn } = setupRouter({
+        [`${DATA_PREFIX}/last-fetch.json`]: { status: 'success', timestamp: '2026-07-08T12:00:00Z', fileCount: 2 }
+      })
+
+      const diagFn = diagnosticsFn.mock.calls[0][0]
+      const result = await diagFn()
+
+      expect(result.lastFetchStatus).toBe('success')
+      expect(result.lastFetchTimestamp).toBe('2026-07-08T12:00:00Z')
+      expect(result.fileCount).toBe(2)
+      expect(result.tokenSource).toBe('GITLAB_TOKEN')
+    })
+  })
+})

--- a/modules/releases/module.json
+++ b/modules/releases/module.json
@@ -66,6 +66,11 @@
         "key": "SMARTSHEET_API_TOKEN",
         "description": "SmartSheet API token for release discovery",
         "required": false
+      },
+      {
+        "key": "DRAFT_PLANS_GITLAB_TOKEN",
+        "description": "GitLab PAT for draft plans data fetching (overrides GITLAB_TOKEN)",
+        "required": false
       }
     ]
   },

--- a/modules/releases/server/draft-plans/fetch.js
+++ b/modules/releases/server/draft-plans/fetch.js
@@ -1,0 +1,124 @@
+let _fetch = globalThis.fetch;
+
+const DATA_PREFIX = 'releases/draft-plans';
+
+const KNOWN_PRODUCTS = ['RHOAI'];
+
+const FILES_TO_FETCH = ['release-plan.json', 'release-health.json'];
+
+const DEFAULT_CONFIG = {
+  gitlabBaseUrl: 'https://gitlab.com',
+  projectId: '81798612',
+  branch: 'main',
+  refreshIntervalHours: 24,
+  enabled: false
+};
+
+async function fetchDraftPlans(storage, config, token) {
+  const {
+    gitlabBaseUrl = 'https://gitlab.com',
+    projectId,
+    branch = 'main'
+  } = config;
+
+  if (!projectId) {
+    throw new Error('projectId is required');
+  }
+
+  let parsedBase;
+  try {
+    parsedBase = new URL(gitlabBaseUrl);
+  } catch {
+    throw new Error('Invalid gitlabBaseUrl');
+  }
+  if (!['https:', 'http:'].includes(parsedBase.protocol)) {
+    throw new Error('gitlabBaseUrl must use http or https');
+  }
+
+  console.log(`[releases/draft-plans] Fetching draft plans from project ${projectId} (branch: ${branch})`);
+  const startTime = Date.now();
+  const warnings = [];
+  const productResults = {};
+  let fileCount = 0;
+
+  for (const product of KNOWN_PRODUCTS) {
+    productResults[product] = { files: 0, errors: [] };
+
+    for (const fileName of FILES_TO_FETCH) {
+      const filePath = encodeURIComponent(`${product}/latest/${fileName}`);
+      const url = `${parsedBase.origin}/api/v4/projects/${projectId}/repository/files/${filePath}/raw?ref=${encodeURIComponent(branch)}`;
+
+      try {
+        const response = await _fetch(url, {
+          headers: { 'Authorization': `Bearer ${token}` },
+          signal: AbortSignal.timeout(30000)
+        });
+
+        if (!response.ok) {
+          const status = response.status;
+          if (status === 401) {
+            throw new Error('GitLab API authentication failed (401). Check your token.');
+          }
+          if (status === 404) {
+            warnings.push(`${product}/latest/${fileName} not found (404)`);
+            productResults[product].errors.push(`${fileName}: not found`);
+            continue;
+          }
+          if (status === 429) {
+            throw new Error('GitLab API rate limited (429). Try again later.');
+          }
+          throw new Error(`GitLab API returned ${status} for ${product}/${fileName}`);
+        }
+
+        const text = await response.text();
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch (err) {
+          warnings.push(`Failed to parse ${product}/latest/${fileName}: ${err.message}`);
+          productResults[product].errors.push(`${fileName}: invalid JSON`);
+          continue;
+        }
+
+        storage.writeToStorage(`${DATA_PREFIX}/${product}/${fileName}`, parsed);
+        productResults[product].files++;
+        fileCount++;
+      } catch (err) {
+        if (err.message.includes('401') || err.message.includes('429')) {
+          throw err;
+        }
+        warnings.push(`Failed to fetch ${product}/latest/${fileName}: ${err.message}`);
+        productResults[product].errors.push(`${fileName}: ${err.message}`);
+      }
+    }
+  }
+
+  const duration = Date.now() - startTime;
+  console.log(`[releases/draft-plans] Fetch complete: ${fileCount} files in ${duration}ms`);
+
+  if (warnings.length > 0) {
+    console.warn('[releases/draft-plans] Warnings:', warnings);
+  }
+
+  const result = {
+    status: fileCount > 0 ? 'success' : 'no_data',
+    timestamp: new Date().toISOString(),
+    duration,
+    fileCount,
+    products: productResults,
+    warnings: warnings.length > 0 ? warnings : undefined
+  };
+
+  storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
+
+  return result;
+}
+
+module.exports = {
+  fetchDraftPlans,
+  DATA_PREFIX,
+  DEFAULT_CONFIG,
+  KNOWN_PRODUCTS,
+  FILES_TO_FETCH,
+  _setFetch(fn) { _fetch = fn; }
+};

--- a/modules/releases/server/draft-plans/routes.js
+++ b/modules/releases/server/draft-plans/routes.js
@@ -85,6 +85,21 @@ module.exports = function registerDraftPlanRoutes(router, context) {
 
   // ─── Fixed-path routes (before parameterized) ──────────────────────
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/releases:
+   *   get:
+   *     tags: [Releases]
+   *     summary: List draft plan versions with health summary
+   *     parameters:
+   *       - in: query
+   *         name: product
+   *         schema: { type: string }
+   *         description: Filter by product (e.g. RHOAI)
+   *     responses:
+   *       200:
+   *         description: Draft plan releases with health data
+   */
   router.get('/releases', requireAuth, requireScope('releases:read'), function(req, res) {
     var productFilter = req.query.product || null;
     var results = [];
@@ -138,6 +153,24 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     });
   });
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/refresh:
+   *   post:
+   *     tags: [Releases]
+   *     summary: Trigger draft plans data refresh from GitLab
+   *     responses:
+   *       200:
+   *         description: Refresh result
+   *       400:
+   *         description: Fetch is disabled
+   *       409:
+   *         description: Global refresh already in progress
+   *       429:
+   *         description: Cooldown active
+   *       500:
+   *         description: No token configured or fetch error
+   */
   router.post('/refresh', requireAuth, requireScope('releases:write'), async function(req, res) {
     if (isRefreshRunning && isRefreshRunning()) {
       return res.status(409).json({ status: 'error', message: 'A global refresh is already in progress' });
@@ -179,6 +212,16 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     }
   });
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/refresh/status:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get draft plans refresh progress and last fetch info
+   *     responses:
+   *       200:
+   *         description: Refresh status
+   */
   router.get('/refresh/status', requireAuth, requireScope('releases:read'), function(req, res) {
     var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
     res.json({
@@ -189,6 +232,16 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     });
   });
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/config:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get draft plans fetch configuration
+   *     responses:
+   *       200:
+   *         description: Current configuration with token status
+   */
   router.get('/config', requireAuth, requireScope('releases:write'), function(req, res) {
     var config = loadConfig();
     res.json(Object.assign({}, config, {
@@ -197,11 +250,23 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     }));
   });
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/config:
+   *   post:
+   *     tags: [Releases]
+   *     summary: Update draft plans fetch configuration
+   *     responses:
+   *       200:
+   *         description: Configuration saved (optionally triggers fetch if newly enabled)
+   *       400:
+   *         description: Invalid configuration values
+   */
   router.post('/config', requireAuth, requireScope('releases:write'), async function(req, res) {
     try {
       validateConfig(req.body);
       var oldConfig = loadConfig();
-      var config = Object.assign({}, DEFAULT_CONFIG, req.body);
+      var config = Object.assign({}, oldConfig, req.body);
       saveConfig(config);
 
       logAudit(storage.readFromStorage, storage.writeToStorage, {
@@ -230,6 +295,30 @@ module.exports = function registerDraftPlanRoutes(router, context) {
 
   // ─── Parameterized routes ──────────────────────────────────────────
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/{version}:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get full draft plan for a specific version
+   *     parameters:
+   *       - in: path
+   *         name: version
+   *         required: true
+   *         schema: { type: string }
+   *         description: Release version (e.g. 3.5)
+   *       - in: query
+   *         name: product
+   *         schema: { type: string }
+   *         description: Filter by product
+   *     responses:
+   *       200:
+   *         description: Draft plan data for the version
+   *       400:
+   *         description: Invalid version format
+   *       404:
+   *         description: No data found for version
+   */
   router.get('/:version', requireAuth, requireScope('releases:read'), function(req, res) {
     var version = req.params.version;
     if (!/^[a-zA-Z0-9._-]{1,50}$/.test(version)) {
@@ -271,6 +360,30 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     res.json(result);
   });
 
+  /**
+   * @openapi
+   * /api/modules/releases/draft-plans/{version}/health:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Get health details for a specific version
+   *     parameters:
+   *       - in: path
+   *         name: version
+   *         required: true
+   *         schema: { type: string }
+   *         description: Release version (e.g. 3.5)
+   *       - in: query
+   *         name: product
+   *         schema: { type: string }
+   *         description: Filter by product
+   *     responses:
+   *       200:
+   *         description: Health data for the version
+   *       400:
+   *         description: Invalid version format
+   *       404:
+   *         description: No health data found for version
+   */
   router.get('/:version/health', requireAuth, requireScope('releases:read'), function(req, res) {
     var version = req.params.version;
     if (!/^[a-zA-Z0-9._-]{1,50}$/.test(version)) {

--- a/modules/releases/server/draft-plans/routes.js
+++ b/modules/releases/server/draft-plans/routes.js
@@ -1,0 +1,362 @@
+const { fetchDraftPlans, DATA_PREFIX, DEFAULT_CONFIG, KNOWN_PRODUCTS } = require('./fetch');
+const { logAudit } = require('../planning/audit-log');
+
+const COOLDOWN_MS = 5 * 60 * 1000;
+
+module.exports = function registerDraftPlanRoutes(router, context) {
+  const { storage, requireAuth, requireScope, secrets, registerRefresh, isRefreshRunning } = context;
+
+  let fetchInProgress = false;
+  let lastSuccessfulFetch = 0;
+  let refreshState = { running: false, lastResult: null };
+
+  function getToken() {
+    if (!secrets) return null;
+    return secrets.DRAFT_PLANS_GITLAB_TOKEN || secrets.GITLAB_TOKEN || null;
+  }
+
+  function getTokenSource() {
+    if (!secrets) return null;
+    if (secrets.DRAFT_PLANS_GITLAB_TOKEN) return 'DRAFT_PLANS_GITLAB_TOKEN';
+    if (secrets.GITLAB_TOKEN) return 'GITLAB_TOKEN';
+    return null;
+  }
+
+  function loadConfig() {
+    var stored = storage.readFromStorage(DATA_PREFIX + '/config.json');
+    return Object.assign({}, DEFAULT_CONFIG, stored || {});
+  }
+
+  function saveConfig(config) {
+    storage.writeToStorage(DATA_PREFIX + '/config.json', config);
+  }
+
+  function validateConfig(input) {
+    if (input.gitlabBaseUrl !== undefined) {
+      if (typeof input.gitlabBaseUrl !== 'string' || !input.gitlabBaseUrl.startsWith('https://')) {
+        throw new Error('gitlabBaseUrl must start with https://');
+      }
+    }
+    if (input.projectId !== undefined) {
+      if (typeof input.projectId !== 'string' || !/^\d+$/.test(input.projectId)) {
+        throw new Error('projectId must be a numeric string');
+      }
+    }
+    if (input.refreshIntervalHours !== undefined) {
+      if (typeof input.refreshIntervalHours !== 'number' || input.refreshIntervalHours < 1 || input.refreshIntervalHours > 168) {
+        throw new Error('refreshIntervalHours must be between 1 and 168');
+      }
+    }
+    if (input.branch !== undefined && typeof input.branch !== 'string') {
+      throw new Error('branch must be a string');
+    }
+    if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
+      throw new Error('enabled must be a boolean');
+    }
+  }
+
+  async function doFetch() {
+    var token = getToken();
+    if (!token) {
+      return { status: 'error', message: 'No GitLab token configured. Set DRAFT_PLANS_GITLAB_TOKEN or GITLAB_TOKEN.' };
+    }
+    var config = loadConfig();
+    if (!config.enabled) {
+      return { status: 'skipped', message: 'Draft plans fetch is disabled' };
+    }
+    fetchInProgress = true;
+    refreshState = { running: true, startedAt: new Date().toISOString(), lastResult: refreshState.lastResult };
+    try {
+      var result = await fetchDraftPlans(storage, config, token);
+      if (result.status === 'success') {
+        lastSuccessfulFetch = Date.now();
+      }
+      refreshState = { running: false, lastResult: result };
+      return result;
+    } catch (err) {
+      var errorResult = { status: 'error', message: err.message, timestamp: new Date().toISOString() };
+      storage.writeToStorage(DATA_PREFIX + '/last-fetch.json', errorResult);
+      refreshState = { running: false, lastResult: errorResult };
+      throw err;
+    } finally {
+      fetchInProgress = false;
+    }
+  }
+
+  // ─── Fixed-path routes (before parameterized) ──────────────────────
+
+  router.get('/releases', requireAuth, requireScope('releases:read'), function(req, res) {
+    var productFilter = req.query.product || null;
+    var results = [];
+
+    for (var i = 0; i < KNOWN_PRODUCTS.length; i++) {
+      var product = KNOWN_PRODUCTS[i];
+      if (productFilter && product !== productFilter) continue;
+
+      var plan = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-plan.json');
+      var health = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-health.json');
+
+      if (!plan && !health) continue;
+
+      var releases = [];
+      var healthByVersion = {};
+
+      if (health && Array.isArray(health.releases)) {
+        for (var h = 0; h < health.releases.length; h++) {
+          var hr = health.releases[h];
+          healthByVersion[hr.version] = hr;
+        }
+      }
+
+      if (plan && Array.isArray(plan.releases)) {
+        for (var p = 0; p < plan.releases.length; p++) {
+          var pr = plan.releases[p];
+          var hv = healthByVersion[pr.version] || {};
+          releases.push({
+            version: pr.version,
+            totalFeatures: hv.totalFeatures || null,
+            committed: hv.committed || null,
+            planned: hv.planned || null,
+            healthStatus: hv.healthStatus || null,
+            featureHealth: hv.featureHealth || null,
+            overcommitRatio: hv.overcommitRatio || null
+          });
+        }
+      }
+
+      results.push({
+        product: product,
+        generatedAt: (plan && plan.generatedAt) || (health && health.generatedAt) || null,
+        releases: releases
+      });
+    }
+
+    var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
+    res.json({
+      fetchedAt: lastFetch ? lastFetch.timestamp : null,
+      products: results
+    });
+  });
+
+  router.post('/refresh', requireAuth, requireScope('releases:write'), async function(req, res) {
+    if (isRefreshRunning && isRefreshRunning()) {
+      return res.status(409).json({ status: 'error', message: 'A global refresh is already in progress' });
+    }
+
+    var now = Date.now();
+    var elapsed = now - lastSuccessfulFetch;
+    if (lastSuccessfulFetch > 0 && elapsed < COOLDOWN_MS) {
+      var retryAfter = Math.ceil((COOLDOWN_MS - elapsed) / 1000);
+      return res.status(429).json({ status: 'cooldown', retryAfter: retryAfter });
+    }
+
+    if (fetchInProgress) {
+      return res.json({ status: 'already_running' });
+    }
+
+    var token = getToken();
+    if (!token) {
+      return res.status(500).json({ status: 'error', message: 'No GitLab token configured. Set DRAFT_PLANS_GITLAB_TOKEN or GITLAB_TOKEN.' });
+    }
+
+    var config = loadConfig();
+    if (!config.enabled) {
+      return res.status(400).json({ status: 'error', message: 'Draft plans fetch is disabled. Enable it in config.' });
+    }
+
+    try {
+      var result = await doFetch();
+      logAudit(storage.readFromStorage, storage.writeToStorage, {
+        domain: 'draft-plans',
+        action: 'manual_refresh',
+        user: req.userEmail || 'unknown',
+        summary: 'Manual draft plans data refresh: ' + (result.status || 'unknown'),
+        details: { status: result.status, fileCount: result.fileCount }
+      });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ status: 'error', message: err.message, timestamp: new Date().toISOString() });
+    }
+  });
+
+  router.get('/refresh/status', requireAuth, requireScope('releases:read'), function(req, res) {
+    var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
+    res.json({
+      running: refreshState.running,
+      startedAt: refreshState.startedAt || null,
+      lastResult: refreshState.lastResult,
+      lastFetch: lastFetch || null
+    });
+  });
+
+  router.get('/config', requireAuth, requireScope('releases:write'), function(req, res) {
+    var config = loadConfig();
+    res.json(Object.assign({}, config, {
+      tokenConfigured: !!getToken(),
+      tokenSource: getTokenSource()
+    }));
+  });
+
+  router.post('/config', requireAuth, requireScope('releases:write'), async function(req, res) {
+    try {
+      validateConfig(req.body);
+      var oldConfig = loadConfig();
+      var config = Object.assign({}, DEFAULT_CONFIG, req.body);
+      saveConfig(config);
+
+      logAudit(storage.readFromStorage, storage.writeToStorage, {
+        domain: 'draft-plans',
+        action: 'config_save',
+        user: req.userEmail || 'unknown',
+        summary: 'Updated draft plans fetch configuration',
+        details: { enabled: config.enabled, projectId: config.projectId }
+      });
+
+      if (config.enabled && !oldConfig.enabled && getToken()) {
+        try {
+          var result = await doFetch();
+          return res.json({ status: 'saved_and_fetched', fetchResult: result });
+        } catch (err) {
+          return res.json({ status: 'saved', fetchError: err.message });
+        }
+      }
+
+      res.json({ status: 'saved' });
+    } catch (err) {
+      var status = (err.message && (err.message.includes('must be') || err.message.includes('must start'))) ? 400 : 500;
+      res.status(status).json({ status: 'error', message: err.message });
+    }
+  });
+
+  // ─── Parameterized routes ──────────────────────────────────────────
+
+  router.get('/:version', requireAuth, requireScope('releases:read'), function(req, res) {
+    var version = req.params.version;
+    if (!/^[a-zA-Z0-9._-]{1,50}$/.test(version)) {
+      return res.status(400).json({ error: 'Invalid version format' });
+    }
+
+    var productFilter = req.query.product || null;
+    var result = { version: version, products: {} };
+
+    for (var i = 0; i < KNOWN_PRODUCTS.length; i++) {
+      var product = KNOWN_PRODUCTS[i];
+      if (productFilter && product !== productFilter) continue;
+
+      var plan = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-plan.json');
+      if (!plan || !Array.isArray(plan.releases)) continue;
+
+      var match = null;
+      for (var p = 0; p < plan.releases.length; p++) {
+        if (plan.releases[p].version === version) {
+          match = plan.releases[p];
+          break;
+        }
+      }
+
+      if (match) {
+        result.products[product] = {
+          generatedAt: plan.generatedAt || null,
+          summary: plan.summary || null,
+          capacity: plan.capacity || null,
+          release: match
+        };
+      }
+    }
+
+    if (Object.keys(result.products).length === 0) {
+      return res.status(404).json({ error: 'No draft plan data found for version ' + version });
+    }
+
+    res.json(result);
+  });
+
+  router.get('/:version/health', requireAuth, requireScope('releases:read'), function(req, res) {
+    var version = req.params.version;
+    if (!/^[a-zA-Z0-9._-]{1,50}$/.test(version)) {
+      return res.status(400).json({ error: 'Invalid version format' });
+    }
+
+    var productFilter = req.query.product || null;
+    var result = { version: version, products: {} };
+
+    for (var i = 0; i < KNOWN_PRODUCTS.length; i++) {
+      var product = KNOWN_PRODUCTS[i];
+      if (productFilter && product !== productFilter) continue;
+
+      var health = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-health.json');
+      if (!health || !Array.isArray(health.releases)) continue;
+
+      var match = null;
+      for (var h = 0; h < health.releases.length; h++) {
+        if (health.releases[h].version === version) {
+          match = health.releases[h];
+          break;
+        }
+      }
+
+      if (match) {
+        result.products[product] = {
+          generatedAt: health.generatedAt || null,
+          historicalCapacity: health.historicalCapacity || null,
+          velocitySource: health.velocitySource || null,
+          release: match
+        };
+      }
+    }
+
+    if (Object.keys(result.products).length === 0) {
+      return res.status(404).json({ error: 'No health data found for version ' + version });
+    }
+
+    res.json(result);
+  });
+
+  // ─── registerRefresh ──────────────────────────────────────────────
+
+  if (registerRefresh) {
+    var initialConfig = loadConfig();
+
+    registerRefresh('draft-plans', {
+      order: 80,
+      timeout: 300000,
+      description: 'Fetches draft release plan data from the release-planning-data GitLab repository.',
+      cadence: initialConfig.refreshIntervalHours + 'h',
+      handler: async function() {
+        var config = loadConfig();
+        if (!config.enabled) {
+          return { status: 'skipped', message: 'Draft plans fetch is disabled' };
+        }
+        var token = getToken();
+        if (!token) {
+          return { status: 'error', message: 'No GitLab token configured' };
+        }
+        var elapsed = Date.now() - lastSuccessfulFetch;
+        if (lastSuccessfulFetch > 0 && elapsed < COOLDOWN_MS) {
+          return { status: 'cooldown', retryAfter: Math.ceil((COOLDOWN_MS - elapsed) / 1000) };
+        }
+        try {
+          return await doFetch();
+        } catch (err) {
+          return { status: 'error', message: err.message, timestamp: new Date().toISOString() };
+        }
+      }
+    });
+  }
+
+  // ─── registerDiagnostics ──────────────────────────────────────────
+
+  if (context.registerDiagnostics) {
+    context.registerDiagnostics(async function() {
+      var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
+      var config = loadConfig();
+      return {
+        lastFetchStatus: lastFetch ? lastFetch.status : null,
+        lastFetchTimestamp: lastFetch ? lastFetch.timestamp : null,
+        fileCount: lastFetch ? lastFetch.fileCount : 0,
+        configured: config.enabled && !!getToken(),
+        tokenSource: getTokenSource()
+      };
+    });
+  }
+};

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -16,6 +16,7 @@ const registerHygieneRoutes = require('./hygiene/routes');
 const registerTvFvDeltaRoutes = require('./tv-fv-delta/routes');
 const registerFeaturePressureRoutes = require('./feature-pressure/routes');
 const registerPmHubRoutes = require('./pm-hub/routes');
+const registerDraftPlanRoutes = require('./draft-plans/routes');
 const { getAuditLog } = require('./planning/audit-log');
 
 /**
@@ -283,6 +284,19 @@ module.exports = function registerRoutes(router, context) {
     storage
   });
   router.use('/pm-hub', pmHubRouter);
+
+  // Draft Plans sub-router (mounted at /api/modules/releases/draft-plans/)
+  var draftPlansRouter = express.Router();
+  registerDraftPlanRoutes(draftPlansRouter, {
+    storage,
+    requireAuth,
+    requireScope,
+    secrets,
+    registerDiagnostics: context.registerDiagnostics || null,
+    registerRefresh: context.registerRefresh || null,
+    isRefreshRunning: context.isRefreshRunning || null
+  });
+  router.use('/draft-plans', draftPlansRouter);
 
   // ─── Unified Audit Routes ───
 


### PR DESCRIPTION
## Summary

- Adds server module (WI-6) to fetch draft release plan and health data from the `release-planning-data` GitLab repository via the Repository Files API
- Creates `fetch.js` — fetches `release-plan.json` and `release-health.json` from `RHOAI/latest/` (project 81798612), with SSRF protection, 401/404/429 handling, and storage write
- Creates `routes.js` — 7 REST endpoints under `/api/modules/releases/draft-plans/`:
  - `GET /releases` — list versions with health summary
  - `POST /refresh` — trigger fetch with 5-min cooldown and mutex
  - `GET /refresh/status` — refresh progress and last fetch info
  - `GET /config` / `POST /config` — fetch configuration management
  - `GET /:version` — full draft plan for a specific version
  - `GET /:version/health` — health details for a specific version
- Mounts `/draft-plans` sub-router in `index.js` after pm-hub

## Test plan

- [x] ESLint clean on all files
- [x] 41 automated tests (13 fetch + 28 routes) covering:
  - API URL construction and Bearer auth
  - Storage writes for both plan and health files
  - Error handling: 401, 404, 429, invalid JSON, SSRF
  - All 7 route endpoints: releases list, version detail, health detail, config, refresh
  - Config validation (projectId, gitlabBaseUrl, refreshIntervalHours)
  - Auto-fetch on first enable, token source detection
  - registerRefresh handler (skip when disabled, skip when no token)
  - registerDiagnostics status reporting
- [x] Full test suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)