### PR TITLE
feat(product-builds): nightly analysis — auto-load, variant filter, UI redesign

### DIFF
--- a/deploy/ai-eng.backend.Dockerfile
+++ b/deploy/ai-eng.backend.Dockerfile
@@ -10,7 +10,7 @@ FROM quay.io/org-pulse/org-pulse-core-backend:${CORE_TAG}
 USER 0
 
 # Install AI Eng-specific runtime dependencies not in core
-RUN npm install --no-save @octokit/rest
+RUN npm install --no-save @octokit/rest js-yaml
 
 # Add all non-core modules (core image already has team-tracker)
 COPY modules/ ./modules/

--- a/modules/product-builds/client/composables/useNightlyPipelines.js
+++ b/modules/product-builds/client/composables/useNightlyPipelines.js
@@ -13,7 +13,6 @@ export function useNightlyPipelines() {
   const error = ref(null)
   const packages = ref({})
   const packagesLoading = ref(new Set())
-  const collectionStats = ref({})
 
   async function loadPipelines(limit = 14) {
     loading.value = true
@@ -38,14 +37,7 @@ export function useNightlyPipelines() {
     packages.value = {}
     packagesLoading.value = new Set()
     try {
-      const data = await apiRequest(`${BASE}/${pipelineId}/jobs`)
-      jobs.value = data
-      if (data?.collections) {
-        const entries = Object.values(data.collections)
-        const total = entries.length
-        const passed = entries.filter(c => c.status === 'success').length
-        collectionStats.value = { ...collectionStats.value, [pipelineId]: { total, passed, failed: total - passed } }
-      }
+      jobs.value = await apiRequest(`${BASE}/${pipelineId}/jobs`)
     } catch (e) {
       error.value = e.message
       jobs.value = null
@@ -102,7 +94,6 @@ export function useNightlyPipelines() {
     error,
     packages,
     packagesLoading,
-    collectionStats,
     loadPipelines,
     loadPipelineJobs,
     loadCollectionPackages,

--- a/modules/product-builds/client/composables/useNightlyPipelines.js
+++ b/modules/product-builds/client/composables/useNightlyPipelines.js
@@ -13,6 +13,7 @@ export function useNightlyPipelines() {
   const error = ref(null)
   const packages = ref({})
   const packagesLoading = ref(new Set())
+  const collectionStats = ref({})
 
   async function loadPipelines(limit = 14) {
     loading.value = true
@@ -37,7 +38,14 @@ export function useNightlyPipelines() {
     packages.value = {}
     packagesLoading.value = new Set()
     try {
-      jobs.value = await apiRequest(`${BASE}/${pipelineId}/jobs`)
+      const data = await apiRequest(`${BASE}/${pipelineId}/jobs`)
+      jobs.value = data
+      if (data?.collections) {
+        const entries = Object.values(data.collections)
+        const total = entries.length
+        const passed = entries.filter(c => c.status === 'success').length
+        collectionStats.value = { ...collectionStats.value, [pipelineId]: { total, passed, failed: total - passed } }
+      }
     } catch (e) {
       error.value = e.message
       jobs.value = null
@@ -94,6 +102,7 @@ export function useNightlyPipelines() {
     error,
     packages,
     packagesLoading,
+    collectionStats,
     loadPipelines,
     loadPipelineJobs,
     loadCollectionPackages,

--- a/modules/product-builds/client/views/NightlyAnalysisView.vue
+++ b/modules/product-builds/client/views/NightlyAnalysisView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useNightlyPipelines } from '../composables/useNightlyPipelines.js'
 
 const STAGE_ORDER = ['bootstrap-and-onboard', 'build-wheels', 'publish-wheels', 'release-tarball']
@@ -110,7 +110,26 @@ const selectedPipeline = computed(() =>
   pipelines.value.find(p => p.id === jobs.value?.pipeline_id) || null
 )
 
+const chartView = ref('chart')
 const timelinePipelines = computed(() => [...pipelines.value].reverse())
+
+const chartLayout = computed(() => {
+  const pts = timelinePipelines.value
+  if (!pts.length) return null
+  const pad = { left: 44, right: 16, top: 16, bottom: 32 }
+  const w = Math.max(pts.length * 56, 300)
+  const h = 100
+  const yPass = pad.top + 14
+  const yFail = h - pad.bottom - 14
+  const plotW = w - pad.left - pad.right
+  const points = pts.map((p, i) => {
+    const x = pad.left + (pts.length === 1 ? plotW / 2 : (i / (pts.length - 1)) * plotW)
+    const y = p.status === 'success' ? yPass : yFail
+    const { day, month } = dateParts(p.created_at)
+    return { id: p.id, status: p.status, x, y, day, month, label: `${month} ${day}` }
+  })
+  return { w, h, yPass, yFail, yMid: (yPass + yFail) / 2, padLeft: pad.left, points }
+})
 
 const sortedCollections = computed(() => {
   if (!jobs.value?.collections) return []
@@ -256,10 +275,24 @@ onMounted(async () => {
         >View on GitLab &rarr;</a>
       </div>
 
-      <!-- ===== TIER 2: Pipeline Timeline ===== -->
-      <div class="mb-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-        <div class="flex items-center justify-between mb-4">
-          <div class="text-sm font-semibold text-gray-700 dark:text-gray-300">Pipeline History</div>
+      <!-- ===== TIER 2: Pipeline History ===== -->
+      <div v-if="chartLayout" class="mb-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <div class="flex items-center justify-between mb-3">
+          <div class="flex items-center gap-3">
+            <div class="text-sm font-semibold text-gray-700 dark:text-gray-300">Pipeline History</div>
+            <div class="inline-flex rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden">
+              <button
+                :class="chartView === 'chart' ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-750'"
+                class="px-2 py-1 text-[11px] font-medium transition-colors"
+                @click="chartView = 'chart'"
+              >Chart</button>
+              <button
+                :class="chartView === 'strip' ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-750'"
+                class="px-2 py-1 text-[11px] font-medium border-l border-gray-200 dark:border-gray-600 transition-colors"
+                @click="chartView = 'strip'"
+              >Strip</button>
+            </div>
+          </div>
           <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
             <span>{{ successRate }}% pass rate</span>
             <span v-if="lastSuccess && latestPipeline?.status !== 'success'">
@@ -268,30 +301,65 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div class="flex gap-1.5 overflow-x-auto pb-1">
+        <!-- Chart view -->
+        <svg v-if="chartView === 'chart'" :viewBox="`0 0 ${chartLayout.w} ${chartLayout.h}`" class="w-full" preserveAspectRatio="xMidYMid meet">
+          <line :x1="chartLayout.padLeft" :x2="chartLayout.w - 16"
+            :y1="chartLayout.yMid" :y2="chartLayout.yMid"
+            class="stroke-gray-200 dark:stroke-gray-700" stroke-width="1" />
+
+          <text :x="chartLayout.padLeft - 8" :y="chartLayout.yPass + 1"
+            text-anchor="end" dominant-baseline="middle"
+            class="fill-green-600 dark:fill-green-400 text-[11px] font-medium" style="font-family: system-ui, sans-serif">Pass</text>
+          <text :x="chartLayout.padLeft - 8" :y="chartLayout.yFail + 1"
+            text-anchor="end" dominant-baseline="middle"
+            class="fill-red-500 dark:fill-red-400 text-[11px] font-medium" style="font-family: system-ui, sans-serif">Fail</text>
+
+          <template v-for="pt in chartLayout.points" :key="pt.id">
+            <line :x1="pt.x" :x2="pt.x" :y1="chartLayout.yMid" :y2="pt.y"
+              :class="pt.status === 'success' ? 'stroke-green-400 dark:stroke-green-600' : 'stroke-red-300 dark:stroke-red-700'"
+              stroke-width="2" stroke-linecap="round" />
+
+            <circle v-if="selectedPipelineId === pt.id"
+              :cx="pt.x" :cy="pt.y" r="10"
+              :class="pt.status === 'success' ? 'fill-green-100 dark:fill-green-900/40' : 'fill-red-100 dark:fill-red-900/40'" />
+
+            <circle :cx="pt.x" :cy="pt.y" r="6"
+              :class="pt.status === 'success' ? 'fill-green-500 dark:fill-green-400' : 'fill-red-500 dark:fill-red-400'"
+              class="cursor-pointer transition-all"
+              @click="selectPipeline(timelinePipelines[chartLayout.points.indexOf(pt)])" />
+
+            <circle :cx="pt.x" :cy="pt.y" r="16" fill="transparent" class="cursor-pointer"
+              @click="selectPipeline(timelinePipelines[chartLayout.points.indexOf(pt)])">
+              <title>{{ pt.label }} — {{ pt.status === 'success' ? 'Passed' : 'Failed' }}</title>
+            </circle>
+
+            <text :x="pt.x" :y="chartLayout.h - 4"
+              text-anchor="middle" dominant-baseline="auto"
+              class="fill-gray-500 dark:fill-gray-400 text-[10px]" style="font-family: system-ui, sans-serif">{{ pt.label }}</text>
+          </template>
+        </svg>
+
+        <!-- Strip view -->
+        <div v-else class="flex gap-1.5">
           <button
             v-for="p in timelinePipelines" :key="p.id"
-            :class="[theme(p.status).tile, selectedPipelineId === p.id ? theme(p.status).tileSelected : 'border-transparent']"
-            class="flex-shrink-0 w-16 rounded-lg pt-1.5 pb-2 text-center cursor-pointer transition-all border-2"
+            :class="[
+              p.status === 'success' ? 'bg-green-500 dark:bg-green-500' : 'bg-red-500 dark:bg-red-500',
+              selectedPipelineId === p.id ? 'ring-2 ring-offset-2 dark:ring-offset-gray-800' : '',
+              selectedPipelineId === p.id && p.status === 'success' ? 'ring-green-400' : '',
+              selectedPipelineId === p.id && p.status !== 'success' ? 'ring-red-400' : '',
+            ]"
+            class="flex-1 h-10 rounded cursor-pointer transition-all hover:opacity-80 relative group"
+            :title="`${dateParts(p.created_at).month} ${dateParts(p.created_at).day} — ${p.status === 'success' ? 'Passed' : 'Failed'}`"
             @click="selectPipeline(p)"
           >
-            <div :class="theme(p.status).tileLabel" class="text-[10px] leading-tight font-medium">{{ dateParts(p.created_at).dow }}</div>
-            <div :class="theme(p.status).tileDay" class="text-xl font-bold leading-tight mt-0.5">{{ dateParts(p.created_at).day }}</div>
-            <div :class="theme(p.status).tileLabel" class="text-[10px] leading-tight">{{ dateParts(p.created_at).month }}</div>
-            <div class="mt-1">
-              <svg v-if="p.status === 'success'" :class="theme(p.status).icon" class="w-4 h-4 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
-              </svg>
-              <svg v-else-if="p.status === 'failed'" :class="theme(p.status).icon" class="w-4 h-4 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-              <svg v-else class="w-4 h-4 mx-auto animate-spin" :class="theme(p.status).icon" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-            </div>
+            <span class="absolute inset-x-0 -bottom-5 text-[10px] text-gray-500 dark:text-gray-400 text-center opacity-0 group-hover:opacity-100 transition-opacity">
+              {{ dateParts(p.created_at).month }} {{ dateParts(p.created_at).day }}
+            </span>
           </button>
         </div>
+        <!-- Spacer for strip hover labels -->
+        <div v-if="chartView === 'strip'" class="h-5"></div>
       </div>
 
       <!-- ===== TIER 3: Pipeline Detail ===== -->
@@ -305,51 +373,85 @@ onMounted(async () => {
       </div>
 
       <template v-else-if="jobs && selectedPipeline">
-        <!-- Pipeline header -->
-        <div class="mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg">
-          <div class="flex items-center gap-3 flex-wrap">
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="badgeClass(jobs.status)">
+        <!-- Pipeline Stats Hero -->
+        <div class="mb-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          <div class="px-5 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center gap-3 flex-wrap">
+            <span class="inline-flex items-center px-2.5 py-1 rounded text-xs font-semibold" :class="badgeClass(jobs.status)">
               {{ jobs.status }}
             </span>
             <span class="text-sm font-semibold text-gray-900 dark:text-white">
               {{ formatDateFull(selectedPipeline.created_at) }}
             </span>
             <span class="text-xs text-gray-400 dark:text-gray-500">Pipeline #{{ jobs.pipeline_id }}</span>
-            <span class="text-sm text-gray-500 dark:text-gray-400 ml-auto">
-              {{ jobs.summary.total }} jobs &middot; {{ jobs.summary.success }} passed &middot; {{ jobs.summary.failed }} failed &middot; {{ jobs.summary.skipped }} skipped
-            </span>
             <a :href="selectedPipeline.web_url" target="_blank" rel="noopener noreferrer"
-              class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+              class="text-sm text-blue-600 dark:text-blue-400 hover:underline ml-auto">
               View on GitLab &rarr;
             </a>
           </div>
-        </div>
-
-        <!-- Failed Jobs Alert -->
-        <div v-if="jobs.failed_jobs.length > 0" class="mb-4 border border-red-200 dark:border-red-800/50 rounded-lg overflow-hidden">
-          <div class="px-4 py-3 bg-red-50 dark:bg-red-900/10 border-b border-red-200 dark:border-red-800/50">
-            <span class="text-sm font-semibold text-red-800 dark:text-red-300">
-              {{ jobs.failed_jobs.length }} Failed Job{{ jobs.failed_jobs.length !== 1 ? 's' : '' }}
-            </span>
-          </div>
-          <div class="divide-y divide-red-100 dark:divide-red-900/20">
-            <div v-for="fj in jobs.failed_jobs" :key="fj.id" class="px-4 py-2.5 flex items-center gap-3 bg-white dark:bg-gray-800">
-              <svg class="w-4 h-4 text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-              </svg>
-              <div class="flex-1 min-w-0">
-                <a :href="fj.web_url" target="_blank" rel="noopener noreferrer"
-                  class="text-sm font-medium text-red-700 dark:text-red-400 hover:underline">
-                  {{ fj.name }}
-                </a>
-                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  {{ fj.collection }} &middot; {{ fj.variant }} &middot; {{ fj.arch }} &middot; {{ STAGE_LABELS[fj.stage] || fj.stage }}
-                </div>
-              </div>
-              <span v-if="fj.failure_reason" class="text-xs text-gray-400 dark:text-gray-500">{{ fj.failure_reason }}</span>
+          <div class="grid grid-cols-4 divide-x divide-gray-200 dark:divide-gray-700">
+            <div class="px-5 py-4 text-center">
+              <div class="text-2xl font-semibold text-gray-900 dark:text-white">{{ jobs.summary.total }}</div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Total Jobs</div>
+            </div>
+            <div class="px-5 py-4 text-center">
+              <div class="text-2xl font-semibold text-green-600 dark:text-green-400">{{ jobs.summary.success }}</div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Passed</div>
+            </div>
+            <div class="px-5 py-4 text-center">
+              <div class="text-2xl font-semibold" :class="jobs.summary.failed > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'">{{ jobs.summary.failed }}</div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Failed</div>
+            </div>
+            <div class="px-5 py-4 text-center">
+              <div class="text-2xl font-semibold text-gray-400 dark:text-gray-500">{{ jobs.summary.skipped }}</div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Skipped</div>
             </div>
           </div>
         </div>
+
+        <!-- Failed Jobs Overview -->
+        <details v-if="jobs.failed_jobs.length > 0" class="mb-4 rounded-xl border border-red-200 dark:border-red-800/50 shadow-sm overflow-hidden group/failed">
+          <summary class="px-4 py-3 bg-red-50 dark:bg-red-900/10 cursor-pointer flex items-center gap-3 hover:bg-red-100 dark:hover:bg-red-900/20 transition-colors list-none [&::-webkit-details-marker]:hidden">
+            <svg class="w-3.5 h-3.5 text-red-400 transition-transform group-open/failed:rotate-90 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+            </svg>
+            <svg class="w-4 h-4 text-red-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+            <span class="text-sm font-semibold text-red-800 dark:text-red-300">Overview of Failed Jobs</span>
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">
+              {{ jobs.failed_jobs.length }}
+            </span>
+          </summary>
+          <div class="border-t border-red-200 dark:border-red-800/50">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="bg-red-50/50 dark:bg-red-900/5 border-b border-red-100 dark:border-red-900/20">
+                  <th class="text-left py-2 px-4 font-medium text-red-700 dark:text-red-400">Job Name</th>
+                  <th class="text-left py-2 px-4 font-medium text-red-700 dark:text-red-400">Collection</th>
+                  <th class="text-left py-2 px-4 font-medium text-red-700 dark:text-red-400">Variant</th>
+                  <th class="text-left py-2 px-4 font-medium text-red-700 dark:text-red-400">Arch</th>
+                  <th class="text-left py-2 px-4 font-medium text-red-700 dark:text-red-400">Stage</th>
+                  <th class="text-left py-2 px-4 font-medium text-red-700 dark:text-red-400">Reason</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-red-100 dark:divide-red-900/20">
+                <tr v-for="fj in jobs.failed_jobs" :key="fj.id" class="bg-white dark:bg-gray-800 hover:bg-red-50/50 dark:hover:bg-red-900/5 transition-colors">
+                  <td class="py-2 px-4">
+                    <a :href="fj.web_url" target="_blank" rel="noopener noreferrer"
+                      class="text-sm font-medium text-red-700 dark:text-red-400 hover:underline">
+                      {{ fj.name }}
+                    </a>
+                  </td>
+                  <td class="py-2 px-4 text-gray-700 dark:text-gray-300">{{ fj.collection }}</td>
+                  <td class="py-2 px-4 text-gray-700 dark:text-gray-300">{{ fj.variant }}</td>
+                  <td class="py-2 px-4 text-gray-600 dark:text-gray-400">{{ fj.arch }}</td>
+                  <td class="py-2 px-4 text-gray-600 dark:text-gray-400">{{ STAGE_LABELS[fj.stage] || fj.stage }}</td>
+                  <td class="py-2 px-4 text-gray-400 dark:text-gray-500 text-xs">{{ fj.failure_reason || '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </details>
 
         <!-- Collection Grid -->
         <div class="space-y-3">

--- a/modules/product-builds/client/views/NightlyAnalysisView.vue
+++ b/modules/product-builds/client/views/NightlyAnalysisView.vue
@@ -280,15 +280,15 @@ onMounted(async () => {
         <div class="flex items-center justify-between mb-3">
           <div class="flex items-center gap-3">
             <div class="text-sm font-semibold text-gray-700 dark:text-gray-300">Pipeline History</div>
-            <div class="inline-flex rounded-md border border-gray-200 dark:border-gray-600 overflow-hidden">
+            <div class="inline-flex rounded-md overflow-hidden border border-gray-300 dark:border-gray-500">
               <button
-                :class="chartView === 'chart' ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-750'"
-                class="px-2 py-1 text-[11px] font-medium transition-colors"
+                :class="chartView === 'chart' ? 'bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900' : 'bg-white dark:bg-gray-800 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'"
+                class="px-2.5 py-1 text-[11px] font-semibold transition-colors"
                 @click="chartView = 'chart'"
               >Chart</button>
               <button
-                :class="chartView === 'strip' ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white' : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-750'"
-                class="px-2 py-1 text-[11px] font-medium border-l border-gray-200 dark:border-gray-600 transition-colors"
+                :class="chartView === 'strip' ? 'bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900' : 'bg-white dark:bg-gray-800 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'"
+                class="px-2.5 py-1 text-[11px] font-semibold border-l border-gray-300 dark:border-gray-500 transition-colors"
                 @click="chartView = 'strip'"
               >Strip</button>
             </div>
@@ -341,25 +341,23 @@ onMounted(async () => {
 
         <!-- Strip view -->
         <div v-else class="flex gap-1.5">
-          <button
-            v-for="p in timelinePipelines" :key="p.id"
-            :class="[
-              p.status === 'success' ? 'bg-green-500 dark:bg-green-500' : 'bg-red-500 dark:bg-red-500',
-              selectedPipelineId === p.id ? 'ring-2 ring-offset-2 dark:ring-offset-gray-800' : '',
-              selectedPipelineId === p.id && p.status === 'success' ? 'ring-green-400' : '',
-              selectedPipelineId === p.id && p.status !== 'success' ? 'ring-red-400' : '',
-            ]"
-            class="flex-1 h-10 rounded cursor-pointer transition-all hover:opacity-80 relative group"
-            :title="`${dateParts(p.created_at).month} ${dateParts(p.created_at).day} — ${p.status === 'success' ? 'Passed' : 'Failed'}`"
-            @click="selectPipeline(p)"
-          >
-            <span class="absolute inset-x-0 -bottom-5 text-[10px] text-gray-500 dark:text-gray-400 text-center opacity-0 group-hover:opacity-100 transition-opacity">
+          <div v-for="p in timelinePipelines" :key="p.id" class="flex-1 flex flex-col items-center gap-1">
+            <button
+              :class="[
+                p.status === 'success' ? 'bg-green-500' : 'bg-red-500',
+                selectedPipelineId === p.id ? 'ring-2 ring-offset-2 dark:ring-offset-gray-800' : '',
+                selectedPipelineId === p.id && p.status === 'success' ? 'ring-green-400' : '',
+                selectedPipelineId === p.id && p.status !== 'success' ? 'ring-red-400' : '',
+              ]"
+              class="w-full h-10 rounded cursor-pointer transition-all hover:opacity-80"
+              :title="`${dateParts(p.created_at).month} ${dateParts(p.created_at).day} — ${p.status === 'success' ? 'Passed' : 'Failed'}`"
+              @click="selectPipeline(p)"
+            ></button>
+            <span class="text-[9px] text-gray-500 dark:text-gray-400 leading-tight">
               {{ dateParts(p.created_at).month }} {{ dateParts(p.created_at).day }}
             </span>
-          </button>
+          </div>
         </div>
-        <!-- Spacer for strip hover labels -->
-        <div v-if="chartView === 'strip'" class="h-5"></div>
       </div>
 
       <!-- ===== TIER 3: Pipeline Detail ===== -->
@@ -404,6 +402,22 @@ onMounted(async () => {
             <div class="px-5 py-4 text-center">
               <div class="text-2xl font-semibold text-gray-400 dark:text-gray-500">{{ jobs.summary.skipped }}</div>
               <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Skipped</div>
+            </div>
+          </div>
+          <div v-if="sortedCollections.length" class="px-5 py-3 border-t border-gray-200 dark:border-gray-700">
+            <div class="flex items-center gap-3 mb-2">
+              <span class="text-xs font-medium text-gray-500 dark:text-gray-400">Collections</span>
+              <span class="text-xs text-gray-400 dark:text-gray-500">
+                {{ sortedCollections.filter(c => c.status === 'success').length }} passed,
+                {{ sortedCollections.filter(c => c.status !== 'success').length }} failed
+              </span>
+            </div>
+            <div class="flex gap-0.5 h-3 rounded-full overflow-hidden">
+              <div v-for="col in sortedCollections" :key="col.name"
+                class="flex-1 first:rounded-l-full last:rounded-r-full"
+                :class="col.status === 'success' ? 'bg-green-500' : 'bg-red-500'"
+                :title="`${col.name} — ${col.status}`"
+              ></div>
             </div>
           </div>
         </div>
@@ -473,10 +487,20 @@ onMounted(async () => {
 
               <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ col.name }}</span>
               <span class="text-xs text-gray-500 dark:text-gray-400">{{ col.jobCount }} jobs</span>
-              <span v-if="col.failCount > 0" class="text-xs text-red-600 dark:text-red-400 font-medium">{{ col.failCount }} failed</span>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ml-auto" :class="badgeClass(col.status)">
-                {{ col.status }}
-              </span>
+
+              <div class="flex items-center gap-2 ml-auto">
+                <span v-if="col.failCount > 0" class="text-xs text-red-600 dark:text-red-400 font-medium">{{ col.failCount }} failed</span>
+                <div class="w-10 h-1.5 rounded-full overflow-hidden bg-green-500 dark:bg-green-500 flex"
+                  :title="`${col.jobCount - col.failCount} passed, ${col.failCount} failed`">
+                  <div v-if="col.failCount > 0"
+                    class="h-full bg-red-500 dark:bg-red-500 rounded-l-full"
+                    :style="{ width: (col.failCount / col.jobCount * 100) + '%' }"
+                  ></div>
+                </div>
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="badgeClass(col.status)">
+                  {{ col.status }}
+                </span>
+              </div>
             </summary>
 
             <div class="bg-white dark:bg-gray-800">

--- a/modules/product-builds/client/views/NightlyAnalysisView.vue
+++ b/modules/product-builds/client/views/NightlyAnalysisView.vue
@@ -87,7 +87,14 @@ const {
   latestPipeline, successRate, currentStreak, lastSuccess,
 } = useNightlyPipelines()
 
-const heroTheme = computed(() => theme(latestPipeline.value?.status))
+const heroStatus = computed(() => {
+  if (selectedPipelineId.value === latestPipeline.value?.id && jobs.value?.status) {
+    return jobs.value.status
+  }
+  return latestPipeline.value?.status
+})
+
+const heroTheme = computed(() => theme(heroStatus.value))
 
 const scheduleInfo = computed(() => {
   const s = schedule.value
@@ -180,7 +187,12 @@ function jobTitle(job) {
   return parts.join(' · ')
 }
 
-onMounted(() => loadPipelines())
+onMounted(async () => {
+  await loadPipelines()
+  if (latestPipeline.value) {
+    loadPipelineJobs(latestPipeline.value.id)
+  }
+})
 </script>
 
 <template>
@@ -203,10 +215,10 @@ onMounted(() => loadPipelines())
       <!-- ===== TIER 1: Hero Status Banner ===== -->
       <div v-if="latestPipeline" :class="heroTheme.banner" class="mb-6 p-5 rounded-lg border flex items-center gap-4">
         <div :class="heroTheme.iconBg" class="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center">
-          <svg v-if="latestPipeline.status === 'success'" :class="heroTheme.icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-if="heroStatus === 'success'" :class="heroTheme.icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
           </svg>
-          <svg v-else-if="latestPipeline.status === 'failed'" :class="heroTheme.icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-else-if="heroStatus === 'failed'" :class="heroTheme.icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
           </svg>
           <svg v-else :class="heroTheme.icon" class="w-6 h-6 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -218,7 +230,7 @@ onMounted(() => loadPipelines())
         <div class="flex-1 min-w-0">
           <div :class="heroTheme.title" class="text-lg font-bold">{{ scheduleInfo.description }}</div>
           <div :class="heroTheme.subtitle" class="text-sm font-semibold mt-1">
-            {{ theme(latestPipeline.status).label || latestPipeline.status.toUpperCase() }}
+            {{ theme(heroStatus).label || heroStatus.toUpperCase() }}
           </div>
           <div :class="heroTheme.info" class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs">
             <span>{{ formatDateFull(latestPipeline.created_at) }}</span>
@@ -283,15 +295,6 @@ onMounted(() => loadPipelines())
       </div>
 
       <!-- ===== TIER 3: Pipeline Detail ===== -->
-      <!-- Prompt to select -->
-      <div v-if="!selectedPipelineId && !jobsLoading && !jobs" class="text-center py-10 bg-gray-50 dark:bg-gray-800/50 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
-        <svg class="w-8 h-8 text-gray-400 dark:text-gray-500 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
-        </svg>
-        <div class="text-sm font-medium text-gray-600 dark:text-gray-400">Click a pipeline above to view job details</div>
-        <div class="text-xs text-gray-400 dark:text-gray-500 mt-1">Each tile represents one nightly pipeline run</div>
-      </div>
-
       <!-- Jobs loading -->
       <div v-if="jobsLoading" class="text-center py-12">
         <svg class="animate-spin h-8 w-8 text-gray-400 mx-auto" fill="none" viewBox="0 0 24 24">
@@ -305,8 +308,8 @@ onMounted(() => loadPipelines())
         <!-- Pipeline header -->
         <div class="mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg">
           <div class="flex items-center gap-3 flex-wrap">
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="badgeClass(selectedPipeline.status)">
-              {{ selectedPipeline.status }}
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium" :class="badgeClass(jobs.status)">
+              {{ jobs.status }}
             </span>
             <span class="text-sm font-semibold text-gray-900 dark:text-white">
               {{ formatDateFull(selectedPipeline.created_at) }}

--- a/modules/product-builds/server/nightly-pipeline.js
+++ b/modules/product-builds/server/nightly-pipeline.js
@@ -1,3 +1,5 @@
+const yaml = require('js-yaml');
+
 const API_TIMEOUT = 30_000;
 const JOBS_PER_PAGE = 100;
 const PACKAGES_CONCURRENCY = 5;
@@ -6,6 +8,10 @@ const PREFERRED_VARIANT = 'cpu-ubi9';
 const PACKAGES_CACHE_MAX = 200;
 const packagesCache = new Map();
 const SAFE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
+
+const SUPPORTED_VARIANTS_CACHE_TTL = 3600_000;
+let _supportedVariantsCache = null;
+let _supportedVariantsCacheTime = 0;
 
 const DEFAULTS = {
   gitlabBaseUrl: 'https://gitlab.com',
@@ -269,6 +275,67 @@ async function resolveVariant(token, sha, collection, requestedVariant) {
   }
 }
 
+async function fetchSupportedVariants(token, ref = 'main') {
+  const now = Date.now();
+  if (_supportedVariantsCache && (now - _supportedVariantsCacheTime) < SUPPORTED_VARIANTS_CACHE_TTL) {
+    return _supportedVariantsCache;
+  }
+  const content = await fetchFileRaw(token, 'supported_versions.yml', ref);
+  if (!content) return null;
+  const data = yaml.load(content);
+  const entry = data?.supported_versions?.find(v => v.release_branch === ref);
+  if (!entry?.variants) return null;
+  const variants = new Set(entry.variants.map(v => v.replace(/-ubi9$/, '')));
+  _supportedVariantsCache = variants;
+  _supportedVariantsCacheTime = now;
+  return variants;
+}
+
+function filterBySupported(structured, supportedVariants) {
+  if (!supportedVariants) return structured;
+
+  const filteredCollections = {};
+  let totalCount = 0, successCount = 0, failedCount = 0, skippedCount = 0;
+
+  for (const [name, col] of Object.entries(structured.collections)) {
+    const filteredVariants = {};
+    const statuses = [];
+    for (const [variant, archs] of Object.entries(col.variants)) {
+      if (!supportedVariants.has(variant)) continue;
+      filteredVariants[variant] = archs;
+      for (const stages of Object.values(archs)) {
+        for (const job of Object.values(stages)) {
+          statuses.push(job.status);
+          totalCount++;
+          if (job.status === 'success') successCount++;
+          else if (job.status === 'failed') failedCount++;
+          else if (job.status === 'skipped') skippedCount++;
+        }
+      }
+    }
+    if (Object.keys(filteredVariants).length > 0) {
+      filteredCollections[name] = { status: rollUpStatus(statuses), variants: filteredVariants };
+    }
+  }
+
+  const allStatuses = [];
+  for (const col of Object.values(filteredCollections)) {
+    for (const archs of Object.values(col.variants)) {
+      for (const stages of Object.values(archs)) {
+        for (const job of Object.values(stages)) allStatuses.push(job.status);
+      }
+    }
+  }
+
+  return {
+    status: rollUpStatus(allStatuses),
+    summary: { total: totalCount, success: successCount, failed: failedCount, skipped: skippedCount },
+    failed_jobs: structured.failed_jobs.filter(j => supportedVariants.has(j.variant)),
+    collections: filteredCollections,
+    special_jobs: structured.special_jobs,
+  };
+}
+
 async function fetchAllJobs(token, pipelineId) {
   const allJobs = [];
   let page = 1;
@@ -341,7 +408,16 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
         }
       }
 
-      const sorted = allPipelines
+      const deduped = new Map();
+      for (const p of allPipelines) {
+        const date = p.created_at.slice(0, 10);
+        const existing = deduped.get(date);
+        if (!existing || new Date(p.created_at) > new Date(existing.created_at)) {
+          deduped.set(date, p);
+        }
+      }
+
+      const sorted = [...deduped.values()]
         .map(p => ({
           id: p.id,
           iid: p.iid,
@@ -354,6 +430,22 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
         }))
         .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
         .slice(0, limit);
+
+      const supportedVariants = await fetchSupportedVariants(token).catch(() => null);
+      if (supportedVariants) {
+        const failedPipelines = sorted.filter(p => p.status === 'failed');
+        await concurrentMap(failedPipelines, async (p) => {
+          const failedJobs = await gitlabApi(
+            `/projects/${_cfg.gitlabProject}/pipelines/${p.id}/jobs?scope[]=failed&per_page=100`,
+            token
+          ).catch(() => []);
+          const hasRelevantFailure = failedJobs.some(j => {
+            const parsed = parseJobName(j.name);
+            return parsed && supportedVariants.has(parsed.variant);
+          });
+          if (!hasRelevantFailure) p.status = 'success';
+        }, 5);
+      }
 
       res.json({
         schedule_id: Number(_cfg.scheduleId),
@@ -405,11 +497,15 @@ module.exports = function registerNightlyPipelineRoutes(router, context) {
       return res.status(400).json({ error: 'Invalid pipeline ID' });
     }
     try {
-      const jobs = await fetchAllJobs(token, pipelineId);
+      const [jobs, supportedVariants] = await Promise.all([
+        fetchAllJobs(token, pipelineId),
+        fetchSupportedVariants(token).catch(() => null),
+      ]);
       const structured = structureJobs(jobs);
+      const filtered = filterBySupported(structured, supportedVariants);
       res.json({
         pipeline_id: Number(pipelineId),
-        ...structured,
+        ...filtered,
       });
     } catch (err) {
       const status = err.upstreamStatus || 500;

--- a/modules/product-builds/server/nightly-pipeline.js
+++ b/modules/product-builds/server/nightly-pipeline.js
@@ -127,6 +127,7 @@ function structureJobs(jobs) {
   }
 
   const collectionSummaries = {};
+  const allStatuses = [];
   let totalCount = 0, successCount = 0, failedCount = 0, skippedCount = 0;
   for (const [name, variants] of Object.entries(collections)) {
     const statuses = [];
@@ -134,6 +135,7 @@ function structureJobs(jobs) {
       for (const stages of Object.values(archs)) {
         for (const job of Object.values(stages)) {
           statuses.push(job.status);
+          allStatuses.push(job.status);
           totalCount++;
           if (job.status === 'success') successCount++;
           else if (job.status === 'failed') failedCount++;
@@ -148,6 +150,7 @@ function structureJobs(jobs) {
   }
 
   return {
+    status: rollUpStatus(allStatuses),
     summary: { total: totalCount, success: successCount, failed: failedCount, skipped: skippedCount },
     failed_jobs: failedJobs,
     collections: collectionSummaries,
@@ -295,6 +298,7 @@ function filterBySupported(structured, supportedVariants) {
   if (!supportedVariants) return structured;
 
   const filteredCollections = {};
+  const allStatuses = [];
   let totalCount = 0, successCount = 0, failedCount = 0, skippedCount = 0;
 
   for (const [name, col] of Object.entries(structured.collections)) {
@@ -306,6 +310,7 @@ function filterBySupported(structured, supportedVariants) {
       for (const stages of Object.values(archs)) {
         for (const job of Object.values(stages)) {
           statuses.push(job.status);
+          allStatuses.push(job.status);
           totalCount++;
           if (job.status === 'success') successCount++;
           else if (job.status === 'failed') failedCount++;
@@ -315,15 +320,6 @@ function filterBySupported(structured, supportedVariants) {
     }
     if (Object.keys(filteredVariants).length > 0) {
       filteredCollections[name] = { status: rollUpStatus(statuses), variants: filteredVariants };
-    }
-  }
-
-  const allStatuses = [];
-  for (const col of Object.values(filteredCollections)) {
-    for (const archs of Object.values(col.variants)) {
-      for (const stages of Object.values(archs)) {
-        for (const job of Object.values(stages)) allStatuses.push(job.status);
-      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@vue-flow/minimap": "^1.5.4",
         "@vueuse/core": "^14.3.0",
         "express": "^5.2.1",
+        "js-yaml": "^5.2.1",
         "mermaid": "^11.16.0"
       },
       "devDependencies": {
@@ -87,6 +88,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -6082,15 +6105,25 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vue-flow/minimap": "^1.5.4",
     "@vueuse/core": "^14.3.0",
     "express": "^5.2.1",
+    "js-yaml": "^5.2.1",
     "mermaid": "^11.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- **Auto-load latest pipeline** on tab mount so tonight's results are visible immediately — no click required
- **Filter unsupported variants** by fetching `supported_versions.yml` from the pipeline repo, hiding variants not in the current release (e.g., `rocm7.1`). Derives filtered status so the UI accurately reflects supported-variant health
- **Deduplicate pipelines by date** — manual retriggers no longer create duplicate tiles; newest pipeline per day wins
- **Redesigned Pipeline History** — SVG lollipop chart (Pass/Fail y-axis) with a compact strip view toggle
- **Stats hero box** — replaces the single-line header with large job count numbers and a collections pass/fail strip
- **Failed jobs overview** — collapsible table with Job Name, Collection, Variant, Arch, Stage, Reason columns
- **Collection pass/fail strips** — small proportional bar in each collection header

## Test plan

- [ ] Open Nightly Analysis tab — latest pipeline details should auto-load (no "click to view" prompt)
- [ ] Verify `rocm7.1` variant does not appear in any collection's jobs matrix
- [ ] Check that the hero banner shows PASSING when all supported variant jobs pass (even if raw GitLab pipeline status is "failed")
- [ ] Toggle between Chart and Strip views in Pipeline History
- [ ] Click different pipeline dates and verify stats hero box updates
- [ ] Expand a collection — verify proportional pass/fail strip in header matches job counts
- [ ] Click a day with failures — verify the Failed Jobs Overview table is collapsible and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)