### PR TITLE
Align FPDoR readiness display across all views

### DIFF
--- a/modules/releases/client/plan/components/FPDoRPopover.vue
+++ b/modules/releases/client/plan/components/FPDoRPopover.vue
@@ -13,16 +13,6 @@ var hasContent = computed(function() {
   return props.fpdor && props.fpdor.items && props.fpdor.items.length > 0
 })
 
-var jiraItems = computed(function() {
-  if (!props.fpdor || !props.fpdor.items) return []
-  return props.fpdor.items.filter(function(item) { return item.source === 'jira' })
-})
-
-var rubricItems = computed(function() {
-  if (!props.fpdor || !props.fpdor.items) return []
-  return props.fpdor.items.filter(function(item) { return item.source === 'strat-pipeline' })
-})
-
 var badgeLabel = computed(function() {
   if (!props.fpdor) return '—'
   return props.fpdor.passedCount + '/' + props.fpdor.totalCount
@@ -45,24 +35,6 @@ var confidenceLabel = computed(function() {
     default:          return '—'
   }
 })
-
-function stateClass(state) {
-  switch (state) {
-    case 'passed':        return 'text-green-600 dark:text-green-400'
-    case 'failed':        return 'text-red-500 dark:text-red-400'
-    case 'not-evaluated': return 'text-gray-400 dark:text-gray-500'
-    default:              return 'text-gray-400 dark:text-gray-500'
-  }
-}
-
-function stateLabel(state) {
-  switch (state) {
-    case 'passed':        return 'Passed'
-    case 'failed':        return 'Failed'
-    case 'not-evaluated': return 'Not evaluated'
-    default:              return '—'
-  }
-}
 </script>
 
 <template>
@@ -115,33 +87,20 @@ function stateLabel(state) {
         </button>
       </div>
 
-      <!-- Body -->
-      <div class="px-3 py-2 max-h-64 overflow-y-auto space-y-3">
-        <!-- Jira Fields group -->
-        <div v-if="jiraItems.length">
-          <p class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1.5">Jira Fields</p>
-          <div class="space-y-1">
-            <div v-for="item in jiraItems" :key="item.name" class="flex items-center gap-2">
-              <span :class="stateClass(item.state)" class="shrink-0">
-                {{ item.state === 'passed' ? '●' : '○' }}
-              </span>
-              <span class="text-gray-700 dark:text-gray-300 flex-1">{{ item.name }}</span>
-              <span :class="stateClass(item.state)" class="shrink-0 text-[10px]">{{ stateLabel(item.state) }}</span>
-            </div>
-          </div>
-        </div>
-
-        <!-- Strategy Rubric group -->
-        <div v-if="rubricItems.length">
-          <p class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1.5">Strategy Rubric</p>
-          <div class="space-y-1">
-            <div v-for="item in rubricItems" :key="item.name" class="flex items-center gap-2">
-              <span :class="stateClass(item.state)" class="shrink-0">
-                {{ item.state === 'passed' ? '●' : '○' }}
-              </span>
-              <span class="text-gray-700 dark:text-gray-300 flex-1">{{ item.name }}</span>
-              <span :class="stateClass(item.state)" class="shrink-0 text-[10px]">{{ stateLabel(item.state) }}</span>
-            </div>
+      <!-- Body — flat checklist -->
+      <div class="px-3 py-2 max-h-64 overflow-y-auto">
+        <div class="space-y-1">
+          <div v-for="item in fpdor.items" :key="item.name" class="flex items-center gap-2">
+            <svg v-if="item.pass === true" class="w-3.5 h-3.5 text-green-500 dark:text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg v-else-if="item.pass === false" class="w-3.5 h-3.5 text-red-500 dark:text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            <svg v-else class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
+            </svg>
+            <span :class="item.pass === true ? 'text-gray-700 dark:text-gray-300' : item.pass === false ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400 dark:text-gray-500'">{{ item.name }}</span>
           </div>
         </div>
       </div>
@@ -151,7 +110,7 @@ function stateLabel(state) {
         v-if="confidence"
         class="px-3 py-1.5 border-t border-gray-100 dark:border-gray-700 text-[10px] text-gray-400 dark:text-gray-500"
       >
-        Confidence: <span class="font-medium" :class="stateClass(confidence === 'not-ready' ? 'failed' : 'passed')">{{ confidenceLabel }}</span>
+        Confidence: <span class="font-medium" :class="confidence === 'not-ready' ? 'text-red-500 dark:text-red-400' : 'text-green-600 dark:text-green-400'">{{ confidenceLabel }}</span>
       </div>
     </div>
   </span>

--- a/modules/releases/client/plan/components/PlanningGateStatus.vue
+++ b/modules/releases/client/plan/components/PlanningGateStatus.vue
@@ -100,18 +100,21 @@ function stratBadgeLabel(detail) {
         FPDoR Readiness
         <span class="font-normal ml-1" :class="fpdor.passedCount === fpdor.evaluatedCount ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400'">({{ fpdor.passedCount }}/{{ fpdor.evaluatedCount }} passed)</span>
       </div>
-      <div v-for="item in fpdor.items" :key="item.name" class="flex items-center gap-2 py-0.5 text-xs">
-        <svg v-if="item.pass === true" class="w-3.5 h-3.5 text-green-500 dark:text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+      <div v-for="item in fpdor.items" :key="item.name" class="flex items-start gap-2 py-0.5 text-xs">
+        <svg v-if="item.pass === true" class="w-3.5 h-3.5 text-green-500 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
         </svg>
-        <svg v-else-if="item.pass === false" class="w-3.5 h-3.5 text-red-500 dark:text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <svg v-else-if="item.pass === false" class="w-3.5 h-3.5 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
         </svg>
-        <svg v-else class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <svg v-else class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
         </svg>
-        <span :class="item.pass === true ? 'text-gray-700 dark:text-gray-300' : item.pass === false ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400 dark:text-gray-500'">{{ item.name }}</span>
-        <span v-if="item.state === 'not-evaluated'" class="text-[10px] text-gray-400 dark:text-gray-500">(not evaluated)</span>
+        <div class="flex-1 min-w-0">
+          <span :class="item.pass === true ? 'text-gray-700 dark:text-gray-300' : item.pass === false ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400 dark:text-gray-500'">{{ item.name }}</span>
+          <span v-if="item.state === 'not-evaluated'" class="text-[10px] text-gray-400 dark:text-gray-500 ml-1">(not evaluated)</span>
+          <div v-if="item.detail && item.pass !== true" class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5 truncate">{{ item.detail }}</div>
+        </div>
       </div>
     </div>
     <div v-if="hasActiveBlockers">
@@ -176,25 +179,6 @@ function stratBadgeLabel(detail) {
         </svg>
         <span :class="check.passed ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'">{{ check.label }}</span>
         <span v-if="check.detail && !check.passed" class="text-gray-400 dark:text-gray-500 truncate">{{ check.detail }}</span>
-      </div>
-    </div>
-
-    <!-- Planning Readiness Checks (DoR-P series) -->
-    <div v-if="planningChecks && planningChecks.checks" class="border-t border-gray-100 dark:border-gray-700 pt-2">
-      <div class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">
-        Planning Readiness
-        <span v-if="planningChecks.hasHardBlockers" class="text-red-600 dark:text-red-400 font-normal ml-1">({{ planningChecks.hardBlockersFailed.length }} blocker{{ planningChecks.hardBlockersFailed.length !== 1 ? 's' : '' }})</span>
-        <span v-else class="text-green-600 dark:text-green-400 font-normal ml-1">({{ planningChecks.passedCount }}/{{ planningChecks.totalCount }} passed)</span>
-      </div>
-      <div v-for="check in planningChecks.checks" :key="check.id" class="flex items-center gap-2 py-0.5 text-xs">
-        <svg v-if="check.passed" class="w-3.5 h-3.5 text-green-500 dark:text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-        </svg>
-        <svg v-else class="w-3.5 h-3.5 text-red-500 dark:text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-        <span :class="check.passed ? 'text-gray-700 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'">{{ check.label }}</span>
-        <span v-if="check.detail" class="text-gray-400 dark:text-gray-500 truncate">{{ check.detail }}</span>
       </div>
     </div>
   </div>

--- a/modules/releases/client/views/FeatureDetailView.vue
+++ b/modules/releases/client/views/FeatureDetailView.vue
@@ -22,6 +22,27 @@ const hygieneViolations = ref([])
 const hygieneAvailable = ref(true)
 const hygieneExpanded = ref(false)
 
+// --- FPDoR Readiness ---
+const fpdorData = ref(null)
+const fpdorLoading = ref(false)
+
+async function loadFPDoR(version, key) {
+  if (!version || !key) return
+  fpdorLoading.value = true
+  try {
+    const data = await apiRequest(`/modules/releases/planning/releases/${encodeURIComponent(version)}/health/feature/${encodeURIComponent(key)}`)
+    if (data && data.fpdor) {
+      fpdorData.value = data.fpdor
+    } else {
+      fpdorData.value = null
+    }
+  } catch {
+    fpdorData.value = null
+  } finally {
+    fpdorLoading.value = false
+  }
+}
+
 async function loadHygiene(version) {
   if (!version) { hygieneAvailable.value = false; return }
   hygieneLoading.value = true
@@ -345,6 +366,7 @@ watch(feature, (feat) => {
   const version = versionParam || (feat?.fixVersions?.length ? feat.fixVersions[0] : null)
   if (version) {
     loadHygiene(version)
+    if (featureKey.value) loadFPDoR(version, featureKey.value)
   } else if (feat) {
     hygieneAvailable.value = false
   }
@@ -439,6 +461,40 @@ onMounted(() => {
 
         <!-- Release signoff: summary row in header; full panel expands on click -->
         <SignoffSection v-if="signoffValidation" collapsible :validation="signoffValidation" />
+      </div>
+
+      <!-- FPDoR Readiness Section -->
+      <div
+        v-if="fpdorData && fpdorData.items"
+        class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5"
+      >
+        <div class="flex items-center gap-3 mb-3">
+          <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">FPDoR Readiness</span>
+          <span
+            class="inline-flex items-center px-2 py-0.5 rounded text-xs font-bold"
+            :class="fpdorData.passedCount === fpdorData.evaluatedCount ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'"
+          >{{ fpdorData.passedCount }}/{{ fpdorData.totalCount }}</span>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-1">
+          <div v-for="item in fpdorData.items" :key="item.name" class="flex items-start gap-2 py-1 text-sm">
+            <svg v-if="item.pass === true" class="w-4 h-4 text-green-500 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg v-else-if="item.pass === false" class="w-4 h-4 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            <svg v-else class="w-4 h-4 text-gray-300 dark:text-gray-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
+            </svg>
+            <div class="min-w-0">
+              <span :class="item.pass === true ? 'text-gray-700 dark:text-gray-300' : item.pass === false ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400 dark:text-gray-500'">{{ item.name }}</span>
+              <div v-if="item.detail && item.pass !== true" class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate">{{ item.detail }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-else-if="fpdorLoading" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <span class="text-sm text-gray-500 dark:text-gray-400">Loading readiness data...</span>
       </div>
 
       <!-- Hygiene Section (collapsible) -->

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -128,6 +128,36 @@ module.exports = function registerHygieneRoutes(router, context) {
     return DATA_PREFIX + '/features-' + version + '.json';
   }
 
+  function resolveHygieneVersion(version) {
+    var data = storage.readFromStorage(storageKey(version));
+    if (data) return { data: data, resolvedVersion: version };
+
+    var registry = readRegistry(storage.readFromStorage);
+    var registryReleases = registry.releases || [];
+    for (var ri = 0; ri < registryReleases.length; ri++) {
+      var rel = registryReleases[ri];
+      var aliases = [rel.displayName, rel.id].concat(rel.fixVersions || []).filter(Boolean);
+      var isMatch = false;
+      for (var ai = 0; ai < aliases.length; ai++) {
+        if (aliases[ai] === version) { isMatch = true; break; }
+      }
+      if (!isMatch) {
+        for (var ai2 = 0; ai2 < aliases.length; ai2++) {
+          if (aliases[ai2].indexOf(version) !== -1 || version.indexOf(aliases[ai2]) !== -1) { isMatch = true; break; }
+        }
+      }
+      if (isMatch) {
+        for (var ai3 = 0; ai3 < aliases.length; ai3++) {
+          if (aliases[ai3] !== version) {
+            var aliasData = storage.readFromStorage(storageKey(aliases[ai3]));
+            if (aliasData) return { data: aliasData, resolvedVersion: aliases[ai3] };
+          }
+        }
+      }
+    }
+    return { data: null, resolvedVersion: version };
+  }
+
   async function runHygieneRefreshAll(options) {
     options = options || {};
     if (refreshState.running) return { status: 'already_running' };
@@ -259,7 +289,8 @@ module.exports = function registerHygieneRoutes(router, context) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
 
-    var data = storage.readFromStorage(storageKey(version));
+    var resolved = resolveHygieneVersion(version);
+    var data = resolved.data;
     if (!data) {
       return res.json({ features: {}, fetchedAt: null, version: version });
     }
@@ -283,7 +314,8 @@ module.exports = function registerHygieneRoutes(router, context) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
 
-    var data = storage.readFromStorage(storageKey(version));
+    var resolved = resolveHygieneVersion(version);
+    var data = resolved.data;
     if (!data || !data.features) {
       return res.json({
         version: version,

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -284,7 +284,7 @@ module.exports = function registerHygieneRoutes(router, context) {
 
   // GET /features — hygiene features for a release version
   router.get('/features', requireAuth, requireScope('releases:read'), function(req, res) {
-    var version = req.query.version;
+    var version = Array.isArray(req.query.version) ? req.query.version[0] : req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
@@ -309,7 +309,7 @@ module.exports = function registerHygieneRoutes(router, context) {
 
   // GET /summary — aggregate violation summary
   router.get('/summary', requireAuth, requireScope('releases:read'), function(req, res) {
-    var version = req.query.version;
+    var version = Array.isArray(req.query.version) ? req.query.version[0] : req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
@@ -364,7 +364,7 @@ module.exports = function registerHygieneRoutes(router, context) {
 
   // POST /refresh — trigger Jira data refresh (fire-and-forget)
   router.post('/refresh', requirePlanningManager, requireScope('releases:write'), function(req, res) {
-    var version = req.query.version;
+    var version = Array.isArray(req.query.version) ? req.query.version[0] : req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }

--- a/modules/releases/server/planning/fpdor.js
+++ b/modules/releases/server/planning/fpdor.js
@@ -50,26 +50,58 @@ function extractRubricData(feature) {
   }
 }
 
-function evalRubricItem(name, rubricData, dimension) {
+function evalRubricItem(name, rubricData, dimension, detail) {
   if (!rubricData || !rubricData.scored || rubricData[dimension] == null) {
-    return { name: name, pass: null, source: 'strat-pipeline', state: 'not-evaluated' }
+    return { name: name, pass: null, source: 'strat-pipeline', state: 'not-evaluated', detail: 'No rubric data available' }
   }
   var passed = rubricData[dimension] >= RUBRIC_PASS_THRESHOLD
-  return { name: name, pass: passed, source: 'strat-pipeline', state: passed ? 'passed' : 'failed' }
+  return { name: name, pass: passed, source: 'strat-pipeline', state: passed ? 'passed' : 'failed', detail: passed ? null : (detail || 'Score below threshold (' + rubricData[dimension] + '/' + RUBRIC_PASS_THRESHOLD + ')') }
 }
 
-function evalJiraItem(name, passed) {
-  return { name: name, pass: passed, source: 'jira', state: passed ? 'passed' : 'failed' }
+function evalJiraItem(name, passed, detail) {
+  return { name: name, pass: passed, source: 'jira', state: passed ? 'passed' : 'failed', detail: passed ? null : (detail || null) }
+}
+
+function riceDetail(feature) {
+  if (feature.riceScore == null) return 'No RICE score in Jira'
+  if (feature.riceScore === 0) return 'RICE score is 0'
+  return null
+}
+
+function sizingDetail(feature) {
+  var parts = []
+  if (feature.storyPoints == null || feature.storyPoints <= 0) parts.push('no story points')
+  if (feature.epicCount == null || feature.epicCount <= 0) parts.push('no child epics')
+  return parts.length === 2 ? 'No story points or child epics' : null
+}
+
+function targetDetail(feature) {
+  var tvs = feature.targetVersions || []
+  var hasTarget = tvs.length > 0
+  var hasReleaseType = !!(feature.releaseType || feature.phase)
+  var parts = []
+  if (!hasTarget) parts.push('missing target version')
+  if (!hasReleaseType) parts.push('missing release type')
+  return parts.join(', ') || null
+}
+
+function ownersDetail(feature) {
+  var hasDelivery = !!(feature.deliveryOwner || feature.assignee)
+  var hasPM = !!(feature.pmOwner || feature.pm)
+  var parts = []
+  if (!hasDelivery) parts.push('no assignee')
+  if (!hasPM) parts.push('no PM assigned')
+  return parts.join(', ') || null
 }
 
 function computeFPDoRReadiness(feature, rubricData) {
   var items = [
-    evalJiraItem('RICE Score', hasRiceScore(feature)),
-    evalJiraItem('Sizing & Breakdown', hasSizing(feature)),
-    evalJiraItem('Target Version + Release Type', hasTargetAndReleaseType(feature)),
-    evalJiraItem('Assignee + PM', hasOwners(feature)),
-    evalJiraItem('Components', hasComponents(feature)),
-    evalJiraItem('Cross-functional Engagement', hasCrossFunctional(feature)),
+    evalJiraItem('RICE Score', hasRiceScore(feature), riceDetail(feature)),
+    evalJiraItem('Sizing & Breakdown', hasSizing(feature), sizingDetail(feature)),
+    evalJiraItem('Target Version + Release Type', hasTargetAndReleaseType(feature), targetDetail(feature)),
+    evalJiraItem('Assignee + PM', hasOwners(feature), ownersDetail(feature)),
+    evalJiraItem('Components', hasComponents(feature), 'No components set'),
+    evalJiraItem('Cross-functional Engagement', hasCrossFunctional(feature), 'Missing docs/UXD engagement'),
     evalRubricItem('Acceptance Criteria', rubricData, 'testability'),
     evalRubricItem('Architecture Review', rubricData, 'architecture'),
     evalRubricItem('Risks & Assumptions', rubricData, 'feasibility')


### PR DESCRIPTION
## Summary
- **FPDoRPopover**: Flatten to simple 9-item checklist with checkmark/X icons — remove "Jira Fields" vs "Strategy Rubric" source grouping
- **PlanningGateStatus**: Remove redundant DoR-P planning checks section (DoR-P1–P5), add failure detail strings to FPDoR items explaining WHY each check failed
- **FeatureDetailView**: Add FPDoR readiness section with detail strings (was completely missing), load from health API
- **fpdor.js (server)**: Add `detail` field to each FPDoR item with human-readable failure reasons (e.g., "No RICE score in Jira", "missing target version, missing release type")
- **hygiene/routes.js (server)**: Add version alias fallback so hygiene endpoints resolve version mismatches the same way `buildFeatureReadiness()` does — fixes false "all clear" on FeatureDetailView

## Test plan
- [ ] Verify FPDoR popover on feature health table shows flat 9-item list with green check / red X
- [ ] Verify expanded panel no longer shows DoR-P planning checks section
- [ ] Verify expanded panel FPDoR items show failure detail strings for failed items
- [ ] Verify FeatureDetailView shows FPDoR readiness section for a feature (e.g., RHAISTRAT-1519)
- [ ] Verify FeatureDetailView hygiene section matches FeatureReadinessDrawer hygiene for the same feature
- [ ] All 3544 tests pass, ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)