### PR TITLE
feat(jira-taxonomy): add component browse view

### DIFF
--- a/platform/jira-taxonomy/__tests__/client/JiraTaxonomyView.test.js
+++ b/platform/jira-taxonomy/__tests__/client/JiraTaxonomyView.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import JiraTaxonomyView from '../../client/JiraTaxonomyView.vue'
+
+const mockApiRequest = vi.fn()
+vi.mock('@shared/client/services/api', () => ({
+  apiRequest: (...args) => mockApiRequest(...args)
+}))
+
+const sampleComponents = {
+  fetchedAt: '2026-07-01T12:00:00.000Z',
+  project: 'RHAI',
+  source: 'jira',
+  components: [
+    { id: '1', name: 'Authorino', description: 'Auth service', lead: { displayName: 'Alice', emailAddress: 'alice@redhat.com' }, assigneeType: 'COMPONENT_LEAD' },
+    { id: '2', name: 'CodeFlare', description: 'Distributed computing', lead: null, assigneeType: 'PROJECT_DEFAULT' },
+    { id: '3', name: 'Dashboard', description: 'Web console', lead: { displayName: 'Charlie', emailAddress: 'charlie@redhat.com' }, assigneeType: 'COMPONENT_LEAD' }
+  ]
+}
+
+function mountView() {
+  return mount(JiraTaxonomyView, {
+    global: {
+      provide: {
+        moduleNav: {
+          params: ref({}),
+          navigateTo: vi.fn(),
+          updateParams: vi.fn()
+        }
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  mockApiRequest.mockReset()
+  mockApiRequest.mockResolvedValue(sampleComponents)
+})
+
+describe('JiraTaxonomyView', () => {
+  it('renders component table with data', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(mockApiRequest).toHaveBeenCalledWith('/modules/team-tracker/jira-components')
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(3)
+    expect(wrapper.text()).toContain('Authorino')
+    expect(wrapper.text()).toContain('CodeFlare')
+    expect(wrapper.text()).toContain('Dashboard')
+  })
+
+  it('shows component count', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.text()).toContain('3 components')
+  })
+
+  it('filters components by search query', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const input = wrapper.find('input[type="text"][placeholder="Search by name, description, or lead..."]')
+    await input.setValue('auth')
+    expect(wrapper.findAll('tbody tr')).toHaveLength(1)
+    expect(wrapper.text()).toContain('Authorino')
+  })
+
+  it('filters components by lead name', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const input = wrapper.find('input[type="text"][placeholder="Search by name, description, or lead..."]')
+    await input.setValue('Alice')
+    expect(wrapper.findAll('tbody tr')).toHaveLength(1)
+    expect(wrapper.text()).toContain('Authorino')
+  })
+
+  it('shows no results message when search matches nothing', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const input = wrapper.find('input[type="text"][placeholder="Search by name, description, or lead..."]')
+    await input.setValue('nonexistent')
+    expect(wrapper.text()).toContain('No components match your search')
+  })
+
+  it('shows error state when API fails', async () => {
+    mockApiRequest.mockRejectedValue(new Error('Network error'))
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.text()).toContain('Network error')
+  })
+
+  it('shows empty state when no components exist', async () => {
+    mockApiRequest.mockResolvedValue({ fetchedAt: null, project: null, components: [], source: null })
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.text()).toContain('No components found')
+  })
+
+  it('displays project link and sync date', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.text()).toContain('RHAI')
+    expect(wrapper.text()).toContain('Last synced')
+  })
+
+  it('shows dash for components without lead', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const rows = wrapper.findAll('tbody tr')
+    // CodeFlare (index 1 in sorted order) has no lead
+    const codeflareRow = rows.find(r => r.text().includes('CodeFlare'))
+    expect(codeflareRow.text()).toContain('\u2014')
+  })
+
+  it('sorts components by name ascending by default', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const rows = wrapper.findAll('tbody tr')
+    const names = rows.map(r => r.findAll('td')[0].text())
+    expect(names).toEqual(['Authorino', 'CodeFlare', 'Dashboard'])
+  })
+
+  it('toggles sort direction on column click', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    // Click Name header to toggle to descending
+    const nameHeader = wrapper.findAll('th')[0]
+    await nameHeader.trigger('click')
+    const rows = wrapper.findAll('tbody tr')
+    const names = rows.map(r => r.findAll('td')[0].text())
+    expect(names).toEqual(['Dashboard', 'CodeFlare', 'Authorino'])
+  })
+})

--- a/platform/jira-taxonomy/__tests__/server/index.test.js
+++ b/platform/jira-taxonomy/__tests__/server/index.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+function makeStorage(initial = {}) {
+  const data = { ...initial }
+  return {
+    readFromStorage: vi.fn((key) => data[key] ? JSON.parse(JSON.stringify(data[key])) : null),
+    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    _data: data
+  }
+}
+
+function setupRoutes(storageData = {}) {
+  const handlers = {}
+  const mockRouter = {
+    get(path, ...args) { handlers[`GET ${path}`] = args },
+    post(path, ...args) { handlers[`POST ${path}`] = args },
+    put(path, ...args) { handlers[`PUT ${path}`] = args },
+    delete(path, ...args) { handlers[`DELETE ${path}`] = args }
+  }
+
+  const storage = makeStorage(storageData)
+  const context = {
+    storage,
+    requireAdmin: (req, res, next) => next(),
+    requireScope: () => (req, res, next) => next()
+  }
+
+  const registerRoutes = require('../../server/index')
+  registerRoutes(mockRouter, context)
+
+  return { handlers, storage }
+}
+
+function callHandler(handlerArgs, req) {
+  const handler = handlerArgs[handlerArgs.length - 1]
+  const res = {
+    _status: 200,
+    _body: null,
+    _headers: {},
+    status(code) { res._status = code; return res },
+    json(body) { res._body = body; return res },
+    set(key, val) { res._headers[key] = val; return res }
+  }
+  const result = handler(req, res)
+  if (result && typeof result.then === 'function') {
+    return result.then(() => res).catch(() => res)
+  }
+  return Promise.resolve(res)
+}
+
+const sampleFieldOptions = {
+  name: 'components',
+  label: 'Components',
+  values: ['Authorino', 'Dashboard', 'Notebooks'],
+  source: 'jira',
+  sourceProject: 'RHAI',
+  syncedAt: '2026-07-01T12:00:00.000Z',
+  richValues: {
+    Authorino: { id: '10001', description: 'Auth service', lead: { displayName: 'Alice', emailAddress: 'alice@redhat.com' }, assigneeType: 'COMPONENT_LEAD' },
+    Dashboard: { id: '10003', description: 'Web console', lead: { displayName: 'Charlie', emailAddress: 'charlie@redhat.com' }, assigneeType: 'COMPONENT_LEAD' },
+    Notebooks: { id: '10008', description: 'Jupyter notebooks', lead: null, assigneeType: 'PROJECT_DEFAULT' }
+  }
+}
+
+describe('GET /jira-components', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns components from field-options store', async () => {
+    const { handlers } = setupRoutes({ 'team-data/field-options/component.json': sampleFieldOptions })
+    const res = await callHandler(handlers['GET /jira-components'], {})
+    expect(res._status).toBe(200)
+    expect(res._body.components).toHaveLength(3)
+    expect(res._body.components[0].name).toBe('Authorino')
+    expect(res._body.components[0].description).toBe('Auth service')
+    expect(res._body.components[0].lead.displayName).toBe('Alice')
+    expect(res._body.project).toBe('RHAI')
+    expect(res._body.fetchedAt).toBe('2026-07-01T12:00:00.000Z')
+    expect(res._body.source).toBe('jira')
+  })
+
+  it('returns empty response when field-options file is missing', async () => {
+    const { handlers } = setupRoutes({})
+    const res = await callHandler(handlers['GET /jira-components'], {})
+    expect(res._status).toBe(200)
+    expect(res._body.components).toEqual([])
+    expect(res._body.fetchedAt).toBeNull()
+    expect(res._body.project).toBeNull()
+  })
+
+  it('handles components without rich values', async () => {
+    const minimal = {
+      name: 'components',
+      values: ['Alpha', 'Beta'],
+      source: 'jira',
+      sourceProject: 'DEMO',
+      syncedAt: '2026-07-01T00:00:00Z'
+    }
+    const { handlers } = setupRoutes({ 'team-data/field-options/component.json': minimal })
+    const res = await callHandler(handlers['GET /jira-components'], {})
+    expect(res._status).toBe(200)
+    expect(res._body.components).toHaveLength(2)
+    expect(res._body.components[0].name).toBe('Alpha')
+    expect(res._body.components[0].description).toBe('')
+    expect(res._body.components[0].lead).toBeNull()
+  })
+
+  it('uses updatedAt as fetchedAt when syncedAt is absent', async () => {
+    const noSync = {
+      name: 'components',
+      values: ['A'],
+      updatedAt: '2026-06-15T00:00:00Z'
+    }
+    const { handlers } = setupRoutes({ 'team-data/field-options/component.json': noSync })
+    const res = await callHandler(handlers['GET /jira-components'], {})
+    expect(res._body.fetchedAt).toBe('2026-06-15T00:00:00Z')
+  })
+})

--- a/platform/jira-taxonomy/client/JiraTaxonomyView.vue
+++ b/platform/jira-taxonomy/client/JiraTaxonomyView.vue
@@ -78,7 +78,7 @@
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
               <tr
                 v-for="comp in filteredComponents"
-                :key="comp.id"
+                :key="comp.name"
                 class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
               >
                 <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
@@ -126,7 +126,7 @@ const filteredComponents = computed(() => {
   const q = searchQuery.value.toLowerCase().trim()
   if (q) {
     result = result.filter(c =>
-      c.name.toLowerCase().includes(q) || (c.description || '').toLowerCase().includes(q) || (c.lead && c.lead.displayName || '').toLowerCase().includes(q)
+      c.name.toLowerCase().includes(q) || (c.description || '').toLowerCase().includes(q) || (c.lead?.displayName || '').toLowerCase().includes(q)
     )
   }
 

--- a/platform/jira-taxonomy/client/JiraTaxonomyView.vue
+++ b/platform/jira-taxonomy/client/JiraTaxonomyView.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="max-w-7xl mx-auto px-4 py-6">
+    <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Jira Taxonomy</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">Browse Jira classification systems</p>
+
+    <!-- Info card -->
+    <div
+      v-if="project && !loading"
+      class="mb-4 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-3 flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400"
+    >
+      <svg class="h-5 w-5 text-gray-400 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span>
+        This list is sourced from the
+        <a :href="`https://redhat.atlassian.net/projects/${project}/components`" target="_blank" rel="noopener noreferrer" class="font-medium text-primary-600 dark:text-primary-400 hover:underline">{{ project }}</a>
+        Jira project's component registry.
+        <template v-if="fetchedAt">Last synced {{ formatDate(fetchedAt) }}.</template>
+        Components are synced automatically from Jira.
+      </span>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error && !components.length" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-4">
+      <p class="text-red-700 dark:text-red-400 text-sm">{{ error }}</p>
+    </div>
+
+    <template v-else>
+      <!-- Component Browser -->
+      <div class="mb-8">
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center gap-3">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Components</h3>
+            <span class="text-sm text-gray-500 dark:text-gray-400">{{ filteredComponents.length }} component{{ filteredComponents.length !== 1 ? 's' : '' }}</span>
+          </div>
+          <div class="relative">
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search by name, description, or lead..."
+              class="pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 w-80"
+            />
+            <svg class="absolute left-3 top-2.5 h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th
+                  @click="toggleSort('name')"
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none"
+                >
+                  Name {{ sortColumn === 'name' ? (sortAsc ? '\u25B2' : '\u25BC') : '' }}
+                </th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Description
+                </th>
+                <th
+                  @click="toggleSort('lead')"
+                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none"
+                >
+                  Lead {{ sortColumn === 'lead' ? (sortAsc ? '\u25B2' : '\u25BC') : '' }}
+                </th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Assignee Type
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="comp in filteredComponents"
+                :key="comp.id"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                  {{ comp.name }}
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-md truncate" :title="comp.description">
+                  {{ comp.description || '\u2014' }}
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                  {{ comp.lead ? comp.lead.displayName : '\u2014' }}
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {{ formatAssigneeType(comp.assigneeType) }}
+                </td>
+              </tr>
+              <tr v-if="filteredComponents.length === 0">
+                <td colspan="4" class="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                  {{ searchQuery ? 'No components match your search.' : 'No components found.' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+// Component browser state
+const loading = ref(false)
+const error = ref(null)
+const components = ref([])
+const project = ref('')
+const fetchedAt = ref(null)
+const searchQuery = ref('')
+const sortColumn = ref('name')
+const sortAsc = ref(true)
+
+const filteredComponents = computed(() => {
+  let result = components.value
+  const q = searchQuery.value.toLowerCase().trim()
+  if (q) {
+    result = result.filter(c =>
+      c.name.toLowerCase().includes(q) || (c.description || '').toLowerCase().includes(q) || (c.lead && c.lead.displayName || '').toLowerCase().includes(q)
+    )
+  }
+
+  const col = sortColumn.value
+  const asc = sortAsc.value
+  return [...result].sort((a, b) => {
+    let aVal, bVal
+    if (col === 'lead') {
+      aVal = a.lead ? a.lead.displayName.toLowerCase() : ''
+      bVal = b.lead ? b.lead.displayName.toLowerCase() : ''
+    } else {
+      aVal = (a[col] || '').toLowerCase()
+      bVal = (b[col] || '').toLowerCase()
+    }
+    if (aVal < bVal) return asc ? -1 : 1
+    if (aVal > bVal) return asc ? 1 : -1
+    return 0
+  })
+})
+
+function toggleSort(col) {
+  if (sortColumn.value === col) {
+    sortAsc.value = !sortAsc.value
+  } else {
+    sortColumn.value = col
+    sortAsc.value = true
+  }
+}
+
+function formatAssigneeType(type) {
+  if (!type) return '\u2014'
+  return type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+async function fetchComponents() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await apiRequest('/modules/team-tracker/jira-components')
+    components.value = data.components || []
+    project.value = data.project || ''
+    fetchedAt.value = data.fetchedAt || null
+  } catch (err) {
+    error.value = err.message || 'Failed to load components'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchComponents)
+</script>

--- a/platform/jira-taxonomy/manifest.json
+++ b/platform/jira-taxonomy/manifest.json
@@ -1,0 +1,20 @@
+{
+  "type": "module-views",
+  "targetModule": "team-tracker",
+  "navItems": [
+    {
+      "id": "jira-taxonomy",
+      "label": "Jira Taxonomy",
+      "icon": "Layers",
+      "order": 150
+    }
+  ],
+  "client": {
+    "views": {
+      "jira-taxonomy": "./client/JiraTaxonomyView.vue"
+    }
+  },
+  "server": {
+    "entry": "./server/index.js"
+  }
+}

--- a/platform/jira-taxonomy/server/index.js
+++ b/platform/jira-taxonomy/server/index.js
@@ -10,12 +10,12 @@
  * data into the browse-friendly format.
  */
 
-var COMPONENT_OPTIONS_NAME = 'component';
+const COMPONENT_OPTIONS_NAME = 'component';
 
 module.exports = function registerJiraTaxonomyRoutes(router, context) {
-  var storage = context.storage;
-  var requireScope = context.requireScope;
-  var readFromStorage = storage.readFromStorage;
+  const storage = context.storage;
+  const requireScope = context.requireScope;
+  const readFromStorage = storage.readFromStorage;
 
   /**
    * Build the component browse response from the field-options store.
@@ -23,14 +23,14 @@ module.exports = function registerJiraTaxonomyRoutes(router, context) {
    * component array format expected by the taxonomy browse UI.
    */
   function buildComponentResponse() {
-    var data = readFromStorage('team-data/field-options/' + COMPONENT_OPTIONS_NAME + '.json');
+    const data = readFromStorage('team-data/field-options/' + COMPONENT_OPTIONS_NAME + '.json');
     if (!data || !data.values) {
       return { fetchedAt: null, project: null, components: [], source: null };
     }
 
-    var richValues = data.richValues || {};
-    var components = data.values.map(function(name) {
-      var rich = richValues[name] || {};
+    const richValues = data.richValues || {};
+    const components = data.values.map(function(name) {
+      const rich = richValues[name] || {};
       return {
         id: rich.id || '',
         name: name,

--- a/platform/jira-taxonomy/server/index.js
+++ b/platform/jira-taxonomy/server/index.js
@@ -1,0 +1,73 @@
+/**
+ * Jira Taxonomy platform extension — server routes.
+ * Browse components sourced from the field-options store.
+ *
+ * Mounted as a module-views extension targeting team-tracker.
+ * Routes are served at /api/modules/team-tracker/jira-components*.
+ *
+ * The Jira component sync itself lives in core's field-options-sync engine.
+ * This extension provides a read endpoint that reshapes rich field-options
+ * data into the browse-friendly format.
+ */
+
+var COMPONENT_OPTIONS_NAME = 'component';
+
+module.exports = function registerJiraTaxonomyRoutes(router, context) {
+  var storage = context.storage;
+  var requireScope = context.requireScope;
+  var readFromStorage = storage.readFromStorage;
+
+  /**
+   * Build the component browse response from the field-options store.
+   * Reads the "component" option set and reshapes richValues into the
+   * component array format expected by the taxonomy browse UI.
+   */
+  function buildComponentResponse() {
+    var data = readFromStorage('team-data/field-options/' + COMPONENT_OPTIONS_NAME + '.json');
+    if (!data || !data.values) {
+      return { fetchedAt: null, project: null, components: [], source: null };
+    }
+
+    var richValues = data.richValues || {};
+    var components = data.values.map(function(name) {
+      var rich = richValues[name] || {};
+      return {
+        id: rich.id || '',
+        name: name,
+        description: rich.description || '',
+        lead: rich.lead || null,
+        assigneeType: rich.assigneeType || 'PROJECT_DEFAULT'
+      };
+    });
+
+    return {
+      fetchedAt: data.syncedAt || data.updatedAt || null,
+      project: data.sourceProject || null,
+      components: components,
+      source: data.source || null
+    };
+  }
+
+  // ─── GET /jira-components ───
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/jira-components:
+   *   get:
+   *     tags: ['TT: Jira Taxonomy']
+   *     summary: List Jira components for the taxonomy browser
+   *     description: Returns components from the field-options store, enriched with descriptions and leads from Jira sync.
+   *     responses:
+   *       200:
+   *         description: Component list
+   */
+  router.get('/jira-components', requireScope('team-tracker:read'), function(req, res) {
+    try {
+      var result = buildComponentResponse();
+      res.json(result);
+    } catch (err) {
+      console.error('[jira-taxonomy] Error building component response:', err.message);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+};


### PR DESCRIPTION
## Summary

- Adds a **Jira Taxonomy** platform extension (`module-views` targeting `team-tracker`) with a searchable, sortable component browser
- Reads from core's field-options store (synced from the RHAI Jira project by the field-options sync engine in [org-pulse-core#16](https://github.com/red-hat-data-services/org-pulse-core/pull/16))
- Displays component name, description, lead, and assignee type in a table with search filtering and column sorting
- The "Request Component" tab is intentionally deferred to a follow-up PR

## What's included

| File | Purpose |
|------|---------|
| `platform/jira-taxonomy/manifest.json` | `module-views` manifest targeting team-tracker |
| `platform/jira-taxonomy/client/JiraTaxonomyView.vue` | Browse UI — table with search + sort |
| `platform/jira-taxonomy/server/index.js` | `GET /jira-components` — reshapes field-options store data |
| `platform/jira-taxonomy/__tests__/client/` | 11 Vue component tests |
| `platform/jira-taxonomy/__tests__/server/` | 4 server route tests |

## How it works

The server route reads `data/team-data/field-options/component.json` (written by core's field-options sync engine) and reshapes the `richValues` map into a flat component array with `id`, `name`, `description`, `lead`, and `assigneeType` fields.

## Test plan

- [x] `npx vitest run platform/jira-taxonomy` — 15 tests pass
- [x] `npx eslint platform/jira-taxonomy/` — no lint errors
- [ ] CI passes (Test & Build)
- [ ] Visual verification: navigate to Jira Taxonomy in sidebar, verify component table populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)