### PR TITLE
feat(ai-impact): add TargetVersion filter and New status to Build & Release report

### DIFF
--- a/fixtures/ai-impact/component-onboarding-data.json
+++ b/fixtures/ai-impact/component-onboarding-data.json
@@ -1,6 +1,6 @@
 {
   "fetchedAt": "2026-05-10T11:01:55.980Z",
-  "totalComponents": 15,
+  "totalComponents": 16,
   "components": {
     "RHOAIENG-61528": {
       "latest": {
@@ -53,6 +53,7 @@
         },
         "onboardingMethod": "automated",
         "firstCommentDate": null,
+        "targetVersion": "rhoai-2.20",
         "syncedAt": "2026-05-10T11:01:55.977Z",
         "resolution": "Done"
       },
@@ -109,6 +110,7 @@
         },
         "onboardingMethod": "automated",
         "firstCommentDate": null,
+        "targetVersion": "rhoai-2.20",
         "syncedAt": "2026-05-10T11:01:55.980Z",
         "resolution": null
       },
@@ -170,6 +172,7 @@
         },
         "onboardingMethod": "automated",
         "firstCommentDate": null,
+        "targetVersion": "rhoai-2.20",
         "syncedAt": "2026-05-10T11:01:55.980Z",
         "resolution": "Done"
       },
@@ -801,6 +804,54 @@
         "firstCommentDate": "2024-09-18T11:05:47.220+0000",
         "syncedAt": "2026-05-10T11:01:55.980Z",
         "resolution": "Won't Do"
+      },
+      "history": []
+    },
+    "RHOAIENG-62100": {
+      "latest": {
+        "key": "RHOAIENG-62100",
+        "summary": "RHOAI Konflux Onboarding odh-model-registry",
+        "status": "New",
+        "completionStatus": "new",
+        "productContext": "RHOAI",
+        "componentName": "odh-model-registry",
+        "repoUrl": "",
+        "branch": "",
+        "dockerfilePath": "",
+        "contextPath": "",
+        "isOperator": false,
+        "linkedFeatures": [
+          "RHAISTRAT-853"
+        ],
+        "featureTitles": {
+          "RHAISTRAT-853": "Implement Model Cache in RHOAI"
+        },
+        "labels": [
+          "component-onboarding",
+          "yaml-attached"
+        ],
+        "created": "2026-05-12T09:15:30.450+0000",
+        "resolved": null,
+        "validationDate": null,
+        "onboardingSteps": {
+          "yamlValidated": false,
+          "quayRepoCreated": false,
+          "deliveryRepoProvisioned": false,
+          "konfluxOnboarded": false,
+          "pushPipelineConfigured": false,
+          "pullPipelineConfigured": false,
+          "odhKonfluxOnboarded": false,
+          "operatorIntegrated": false,
+          "bundleConfigured": false,
+          "productListingUpdated": false,
+          "autoMergeSetup": false,
+          "renovateSetup": false
+        },
+        "onboardingMethod": "automated",
+        "firstCommentDate": null,
+        "targetVersion": "rhoai-2.21",
+        "syncedAt": "2026-05-12T09:15:30.450Z",
+        "resolution": null
       },
       "history": []
     }

--- a/modules/ai-impact/client/components/ComponentOnboardingContent.vue
+++ b/modules/ai-impact/client/components/ComponentOnboardingContent.vue
@@ -54,6 +54,7 @@ const metrics = computed(() => {
   const completedAutomated = automated.filter(c => c.completionStatus === 'completed')
   const completedManual = manual.filter(c => c.completionStatus === 'completed')
   const inProgressAutomated = automated.filter(c => c.completionStatus === 'in-progress')
+  const newAutomated = automated.filter(c => c.completionStatus === 'new')
 
   const avgDaysAutomated = calcAvgDaysAutomated(completedAutomated)
   const avgDaysManual = calcAvgDaysManual(completedManual)
@@ -64,6 +65,7 @@ const metrics = computed(() => {
   return {
     totalOnboarded: completedAutomated.length,
     totalInProgress: inProgressAutomated.length,
+    totalNew: newAutomated.length,
     completionRate: automated.length ? Math.round((completedAutomated.length / automated.length) * 100) : 0,
     rhoaiCount: automated.filter(c => c.productContext === 'RHOAI').length,
     odhCount: automated.filter(c => c.productContext === 'ODH').length,

--- a/modules/ai-impact/client/components/ComponentOnboardingTable.vue
+++ b/modules/ai-impact/client/components/ComponentOnboardingTable.vue
@@ -46,6 +46,7 @@ const targetVersionOptions = computed(() => {
   })
   return [...versions].sort()
 })
+
 // ── Derived list ──────────────────────────────────────────────────────────────
 const selectedKey = ref(null)
 

--- a/modules/ai-impact/client/components/ComponentOnboardingTable.vue
+++ b/modules/ai-impact/client/components/ComponentOnboardingTable.vue
@@ -420,9 +420,11 @@ function stepsDone(component) {
                         <span class="text-gray-400 dark:text-gray-500">{{ new Date(h.syncedAt).toLocaleDateString() }}</span>
                         <span
                           class="px-1.5 py-0.5 rounded-full"
-                          :class="h.completionStatus === 'completed'
-                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'"
+                          :class="{
+                            'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400': h.completionStatus === 'completed',
+                            'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400': h.completionStatus === 'in-progress',
+                            'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400': h.completionStatus === 'new'
+                          }"
                         >{{ h.completionStatus }}</span>
                         <span class="text-gray-400">{{ Object.values(h.onboardingSteps || {}).filter(Boolean).length }}/{{ STEPS.length }} steps</span>
                       </div>

--- a/modules/ai-impact/client/components/ComponentOnboardingTable.vue
+++ b/modules/ai-impact/client/components/ComponentOnboardingTable.vue
@@ -37,6 +37,15 @@ function sortIcon(key) {
 const search = ref('')
 const completionFilter = ref('all')
 const productFilter = ref('all')
+const targetVersionFilter = ref('all')
+
+const targetVersionOptions = computed(() => {
+  const versions = new Set()
+  Object.values(props.components).forEach(c => {
+    if (c.targetVersion) versions.add(c.targetVersion)
+  })
+  return [...versions].sort()
+})
 // ── Derived list ──────────────────────────────────────────────────────────────
 const selectedKey = ref(null)
 
@@ -61,6 +70,7 @@ const componentList = computed(() => {
     .filter(c => {
       if (completionFilter.value !== 'all' && c.completionStatus !== completionFilter.value) return false
       if (productFilter.value !== 'all' && c.productContext !== productFilter.value) return false
+      if (targetVersionFilter.value !== 'all' && (c.targetVersion || '') !== targetVersionFilter.value) return false
       if (!q) return true
       return (
         c.key.toLowerCase().includes(q) ||
@@ -162,6 +172,7 @@ function stepsDone(component) {
         <option value="all">All statuses</option>
         <option value="completed">Completed</option>
         <option value="in-progress">In Progress</option>
+        <option value="new">New</option>
       </select>
 
       <!-- Product filter -->
@@ -172,6 +183,15 @@ function stepsDone(component) {
         <option value="all">All products</option>
         <option value="RHOAI">RHOAI</option>
         <option value="ODH">ODH</option>
+      </select>
+
+      <!-- Target Version filter -->
+      <select
+        v-model="targetVersionFilter"
+        class="text-sm border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        <option value="all">All versions</option>
+        <option v-for="v in targetVersionOptions" :key="v" :value="v">{{ v }}</option>
       </select>
 
       <span class="ml-auto text-xs text-gray-400 dark:text-gray-500">
@@ -262,14 +282,20 @@ function stepsDone(component) {
             <td class="px-4 py-3">
               <span
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                :class="component.completionStatus === 'completed'
-                  ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-                  : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'"
+                :class="{
+                  'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300': component.completionStatus === 'completed',
+                  'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300': component.completionStatus === 'in-progress',
+                  'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300': component.completionStatus === 'new'
+                }"
               >
                 <span class="h-1.5 w-1.5 rounded-full"
-                  :class="component.completionStatus === 'completed' ? 'bg-green-500' : 'bg-amber-500'"
+                  :class="{
+                    'bg-green-500': component.completionStatus === 'completed',
+                    'bg-amber-500': component.completionStatus === 'in-progress',
+                    'bg-blue-500': component.completionStatus === 'new'
+                  }"
                 />
-                {{ component.completionStatus === 'completed' ? 'Completed' : 'In Progress' }}
+                {{ component.completionStatus === 'completed' ? 'Completed' : component.completionStatus === 'new' ? 'New' : 'In Progress' }}
               </span>
             </td>
             <td class="px-4 py-3">

--- a/modules/ai-impact/client/components/OnboardingCharts.vue
+++ b/modules/ai-impact/client/components/OnboardingCharts.vue
@@ -74,11 +74,12 @@ const automatedList = computed(() => componentList.value.filter(c => (c.onboardi
 const statusChartData = computed(() => {
   const completed = automatedList.value.filter(c => c.completionStatus === 'completed').length
   const inProgress = automatedList.value.filter(c => c.completionStatus === 'in-progress').length
+  const newCount = automatedList.value.filter(c => c.completionStatus === 'new').length
   return {
-    labels: ['Completed', 'In Progress'],
+    labels: ['Completed', 'In Progress', 'New'],
     datasets: [{
-      data: [completed, inProgress],
-      backgroundColor: ['#10b981', '#f59e0b'],
+      data: [completed, inProgress, newCount],
+      backgroundColor: ['#10b981', '#f59e0b', '#3b82f6'],
       borderWidth: 0
     }]
   }
@@ -96,13 +97,16 @@ const statusChartOptions = computed(() => ({
 const productChartData = computed(() => {
   const rhoaiCompleted = automatedList.value.filter(c => c.productContext === 'RHOAI' && c.completionStatus === 'completed').length
   const rhoaiInProgress = automatedList.value.filter(c => c.productContext === 'RHOAI' && c.completionStatus === 'in-progress').length
+  const rhoaiNew = automatedList.value.filter(c => c.productContext === 'RHOAI' && c.completionStatus === 'new').length
   const odhCompleted = automatedList.value.filter(c => c.productContext === 'ODH' && c.completionStatus === 'completed').length
   const odhInProgress = automatedList.value.filter(c => c.productContext === 'ODH' && c.completionStatus === 'in-progress').length
+  const odhNew = automatedList.value.filter(c => c.productContext === 'ODH' && c.completionStatus === 'new').length
   return {
     labels: ['RHOAI', 'ODH'],
     datasets: [
       { label: 'Completed', data: [rhoaiCompleted, odhCompleted], backgroundColor: '#10b981' },
-      { label: 'In Progress', data: [rhoaiInProgress, odhInProgress], backgroundColor: '#f59e0b' }
+      { label: 'In Progress', data: [rhoaiInProgress, odhInProgress], backgroundColor: '#f59e0b' },
+      { label: 'New', data: [rhoaiNew, odhNew], backgroundColor: '#3b82f6' }
     ]
   }
 })
@@ -169,10 +173,12 @@ const featureChartData = computed(() => {
   for (const comp of automatedList.value) {
     for (const feat of (comp.linkedFeatures || [])) {
       if (!featureMap[feat]) {
-        featureMap[feat] = { completed: 0, inProgress: 0, latestCreated: '' }
+        featureMap[feat] = { completed: 0, inProgress: 0, new: 0, latestCreated: '' }
       }
       if (comp.completionStatus === 'completed') {
         featureMap[feat].completed++
+      } else if (comp.completionStatus === 'new') {
+        featureMap[feat].new++
       } else {
         featureMap[feat].inProgress++
       }
@@ -202,6 +208,11 @@ const featureChartData = computed(() => {
         label: 'In Progress',
         data: sorted.map(([, v]) => v.inProgress),
         backgroundColor: '#f59e0b'
+      },
+      {
+        label: 'New',
+        data: sorted.map(([, v]) => v.new),
+        backgroundColor: '#3b82f6'
       }
     ]
   }

--- a/modules/ai-impact/client/components/OnboardingMetricsRow.vue
+++ b/modules/ai-impact/client/components/OnboardingMetricsRow.vue
@@ -6,7 +6,7 @@ defineProps({
 
 <template>
   <div v-if="metrics" class="p-6 border-b border-gray-200 dark:border-gray-700">
-    <div class="grid gap-6 grid-cols-2 lg:grid-cols-6">
+    <div class="grid gap-6 grid-cols-2 lg:grid-cols-7">
       <!-- Total Onboarded -->
       <div class="space-y-1">
         <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
@@ -32,6 +32,20 @@ defineProps({
         <div class="flex items-baseline gap-2">
           <span class="text-3xl font-bold text-amber-600 dark:text-amber-400">{{ metrics.totalInProgress }}</span>
           <span class="text-xs text-gray-400 dark:text-gray-500">ongoing</span>
+        </div>
+      </div>
+
+      <!-- New -->
+      <div class="space-y-1">
+        <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+          <svg class="h-3.5 w-3.5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+          </svg>
+          New
+        </p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold text-blue-600 dark:text-blue-400">{{ metrics.totalNew ?? 0 }}</span>
+          <span class="text-xs text-gray-400 dark:text-gray-500">pending start</span>
         </div>
       </div>
 

--- a/modules/ai-impact/server/component-onboarding/storage.js
+++ b/modules/ai-impact/server/component-onboarding/storage.js
@@ -88,6 +88,7 @@ function getLatestProjection(data) {
       onboardingMethod: entry.latest.onboardingMethod || 'automated',
       firstCommentDate: entry.latest.firstCommentDate || null,
       contextPath: entry.latest.contextPath || '',
+      targetVersion: entry.latest.targetVersion || null,
       syncedAt: entry.latest.syncedAt
     };
   }

--- a/modules/ai-impact/server/component-onboarding/validation.js
+++ b/modules/ai-impact/server/component-onboarding/validation.js
@@ -1,4 +1,4 @@
-const VALID_COMPLETION_STATUSES = ['completed', 'in-progress'];
+const VALID_COMPLETION_STATUSES = ['completed', 'in-progress', 'new'];
 const VALID_PRODUCT_CONTEXTS = ['RHOAI', 'ODH'];
 const VALID_ONBOARDING_METHODS = ['automated', 'manual'];
 const VALID_KEY_PREFIXES = ['RHOAIENG-'];
@@ -167,6 +167,11 @@ function validateComponentOnboarding(body) {
     errors.push('contextPath must be a string');
   }
 
+  // targetVersion: optional string (Jira Target Version / customfield_10855)
+  if (body.targetVersion !== undefined && body.targetVersion !== null && typeof body.targetVersion !== 'string') {
+    errors.push('targetVersion must be a string or null');
+  }
+
   if (errors.length > 0) {
     return { valid: false, errors };
   }
@@ -195,7 +200,8 @@ function validateComponentOnboarding(body) {
       validationDate: body.validationDate || null,
       onboardingMethod: body.onboardingMethod || 'automated',
       firstCommentDate: body.firstCommentDate || null,
-      contextPath: body.contextPath || ''
+      contextPath: body.contextPath || '',
+      targetVersion: body.targetVersion || null
     }
   };
 }

--- a/tests/integration/ai-impact.spec.js
+++ b/tests/integration/ai-impact.spec.js
@@ -253,3 +253,84 @@ test.describe('AI Impact Views @ai-impact', () => {
     expect(unexpectedErrors).toHaveLength(0);
   });
 });
+
+/**
+ * Build & Release (Component Onboarding) — status badges, filters, metrics
+ */
+test.describe('AI Impact Build & Release @ai-impact', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+    await page.goto('/#/ai-impact/build-release');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('"New" metric card renders in the header', async ({ page }) => {
+    const newCard = page.locator('text=New').first();
+    await expect(newCard).toBeVisible();
+
+    const pendingLabel = page.locator('text=pending start');
+    await expect(pendingLabel).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('"New" status badge displays with blue styling', async ({ page }) => {
+    const newBadge = page.locator('.rounded-full:has-text("New")').first();
+    await expect(newBadge).toBeVisible();
+
+    const hasBlueStyling = await newBadge.evaluate(el => {
+      return el.className.includes('bg-blue-100') || el.className.includes('blue');
+    });
+    expect(hasBlueStyling).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('target version dropdown appears and filters correctly', async ({ page }) => {
+    const versionSelect = page.locator('select').filter({ hasText: 'All versions' });
+    await expect(versionSelect).toBeVisible();
+
+    const options = await versionSelect.locator('option').allTextContents();
+    expect(options).toContain('All versions');
+    expect(options.length).toBeGreaterThan(1);
+
+    await versionSelect.selectOption({ index: 1 });
+    await page.waitForTimeout(500);
+
+    const countText = page.locator('text=/\\d+ components?/');
+    await expect(countText).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('status filter includes "New" option and filters correctly', async ({ page }) => {
+    const statusSelect = page.locator('select').filter({ hasText: 'All statuses' });
+    await expect(statusSelect).toBeVisible();
+
+    const options = await statusSelect.locator('option').allTextContents();
+    expect(options).toContain('New');
+
+    await statusSelect.selectOption('new');
+    await page.waitForTimeout(500);
+
+    const rows = page.locator('table tbody tr');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThan(0);
+
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i);
+      const badge = row.locator('.rounded-full');
+      if (await badge.count() > 0) {
+        const text = await badge.first().textContent();
+        expect(text.trim()).toBe('New');
+      }
+    }
+
+    expect(page.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **TargetVersion filter**: Added `targetVersion` (Jira `customfield_10855`) as a new filterable field in the Build & Release Component Onboarding table. Includes server-side validation, storage projection, and a client-side "All versions" dropdown that dynamically populates from available data.
- **New completion status**: Introduced `"new"` as a third `completionStatus` value alongside `"completed"` and `"in-progress"`. Updated all affected layers: validation enum, metrics header (new blue card), all three status-aware charts (doughnut, product bar, feature bar), table status badge (blue pill), and the status filter dropdown.

## Test plan

- [ ] Verify `POST /api/modules/ai-impact/component-onboarding/bulk` accepts `completionStatus: "new"` and `targetVersion: "rhoai-3.5"`
- [ ] Verify the "New" metric card appears in the header row with correct count
- [ ] Verify all three charts (Status Distribution, By Product Context, Components by Feature) show a blue "New" segment
- [ ] Verify the table status badge renders a blue pill for "New" components
- [ ] Verify the "All statuses" dropdown includes a "New" option and filters correctly
- [ ] Verify the "All versions" dropdown appears when components have `targetVersion` values
- [ ] Confirm no regressions for existing "Completed" and "In Progress" flows

Made with [Cursor](https://cursor.com)