### PR TITLE
fix(ci): detect platform server changes as backend changes

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,6 +13,7 @@ on:
       # Backend
       - 'server/index.js'
       - 'modules/*/server/**'
+      - 'platform/*/server/**'
       - 'deploy/ai-eng.backend.Dockerfile'
       # Frontend
       - 'public/**'
@@ -60,8 +61,8 @@ jobs:
           BACKEND=false
           FRONTEND=false
 
-          # Check backend paths
-          if echo "$CHANGED" | grep -qE '^(server/index\.js|modules/[^/]+/server/|modules/[^/]+/module\.json|deploy/ai-eng\.backend\.Dockerfile|package)'; then
+          # Check backend paths (platform extensions can have server routes)
+          if echo "$CHANGED" | grep -qE '^(server/index\.js|modules/[^/]+/server/|modules/[^/]+/module\.json|platform/[^/]+/server/|platform/[^/]+/manifest\.json|deploy/ai-eng\.backend\.Dockerfile|package)'; then
             BACKEND=true
           fi
 


### PR DESCRIPTION
## Summary

- Platform extensions (`platform/*/server/`) can register Express routes on the backend, but the `build-images` change detection only categorized `platform/` as a frontend change
- This caused the jira-taxonomy server route (`GET /jira-components`) to not trigger a backend image rebuild when PR #1179 merged — only the frontend image was updated
- The Jira Taxonomy nav item appears in the sidebar but the API returns 404 because the backend doesn't have the route

## Fix

- Add `platform/[^/]+/server/` and `platform/[^/]+/manifest\.json` to the backend detection regex
- Add `platform/*/server/**` to the top-level `paths` trigger for clarity

## Test plan

- [ ] Merge this PR — it will trigger a backend rebuild since `build-images.yml` itself changed via `package` match
- [ ] After deploy, verify `GET /api/modules/team-tracker/jira-components` returns data
- [ ] Verify the Jira Taxonomy page populates in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)