### PR TITLE
feat(ai-impact): add autofix impact metrics: effort scoring, priority breakdown, time-to-fix

### DIFF
--- a/fixtures/ai-impact/autofix-data.json
+++ b/fixtures/ai-impact/autofix-data.json
@@ -19,7 +19,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59198",
@@ -38,7 +43,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59193",
@@ -59,7 +69,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-pending",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14654",
@@ -78,7 +93,12 @@
       ],
       "assignee": "Lance Barto",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59101",
@@ -98,7 +118,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14633",
@@ -115,7 +140,12 @@
       "components": [],
       "assignee": "Unassigned",
       "pipelineState": "autofix-pending",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59075",
@@ -135,7 +165,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T17:30:05.162+0000"
+      "terminalAt": "2026-04-21T17:30:05.162+0000",
+      "ciFailureCount": 0,
+      "reviewRoundCount": 1,
+      "wasBlocked": false,
+      "effortScore": 1,
+      "effortTier": "Quick Win"
     },
     {
       "key": "RHOAIENG-59073",
@@ -156,7 +191,12 @@
       ],
       "assignee": "Gowtham Shanmugasundaram",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59067",
@@ -176,7 +216,12 @@
       ],
       "assignee": "Vath Sok",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59066",
@@ -195,7 +240,12 @@
       ],
       "assignee": "Vath Sok",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59060",
@@ -214,7 +264,12 @@
       ],
       "assignee": "Vath Sok",
       "pipelineState": "triage-not-fixable",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14624",
@@ -233,7 +288,12 @@
       ],
       "assignee": "Doug Hellmann",
       "pipelineState": "autofix-review",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-59055",
@@ -252,7 +312,12 @@
       ],
       "assignee": "Gowtham Shanmugasundaram",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58992",
@@ -271,7 +336,12 @@
       ],
       "assignee": "Davide Bianchi",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58984",
@@ -293,7 +363,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58983",
@@ -313,7 +388,12 @@
       ],
       "assignee": "Christian Vogt",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58940",
@@ -333,7 +413,12 @@
       ],
       "assignee": "Claudia Alphonse",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58933",
@@ -353,7 +438,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58847",
@@ -372,7 +462,12 @@
       ],
       "assignee": "Manaswini Das",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58830",
@@ -391,7 +486,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58829",
@@ -411,7 +511,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14469",
@@ -432,7 +537,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58758",
@@ -452,7 +562,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58747",
@@ -473,7 +588,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58734",
@@ -494,7 +614,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14461",
@@ -514,7 +639,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:05.510+0000"
+      "terminalAt": "2026-04-21T14:33:05.510+0000",
+      "ciFailureCount": 0,
+      "reviewRoundCount": 1,
+      "wasBlocked": false,
+      "effortScore": 1,
+      "effortTier": "Quick Win"
     },
     {
       "key": "AIPCC-14460",
@@ -534,7 +664,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:05.973+0000"
+      "terminalAt": "2026-04-21T14:33:05.973+0000",
+      "ciFailureCount": 0,
+      "reviewRoundCount": 1,
+      "wasBlocked": false,
+      "effortScore": 1,
+      "effortTier": "Quick Win"
     },
     {
       "key": "AIPCC-14459",
@@ -554,7 +689,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:06.540+0000"
+      "terminalAt": "2026-04-21T14:33:06.540+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 1,
+      "wasBlocked": false,
+      "effortScore": 2,
+      "effortTier": "Quick Win"
     },
     {
       "key": "AIPCC-14458",
@@ -574,7 +714,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:07.030+0000"
+      "terminalAt": "2026-04-21T14:33:07.030+0000",
+      "ciFailureCount": 0,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": 2,
+      "effortTier": "Quick Win"
     },
     {
       "key": "AIPCC-14457",
@@ -594,7 +739,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:07.452+0000"
+      "terminalAt": "2026-04-21T14:33:07.452+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": 3,
+      "effortTier": "Standard Fix"
     },
     {
       "key": "AIPCC-14456",
@@ -614,7 +764,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14455",
@@ -634,7 +789,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:07.890+0000"
+      "terminalAt": "2026-04-21T14:33:07.890+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 3,
+      "wasBlocked": false,
+      "effortScore": 4,
+      "effortTier": "Standard Fix"
     },
     {
       "key": "AIPCC-14454",
@@ -654,7 +814,12 @@
       ],
       "assignee": "Ryan Petrello",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58730",
@@ -674,7 +839,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58729",
@@ -694,7 +864,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58728",
@@ -714,7 +889,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58724",
@@ -735,7 +915,12 @@
       ],
       "assignee": "Moulali Shikalwadi",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58678",
@@ -754,7 +939,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58677",
@@ -773,7 +963,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58676",
@@ -792,7 +987,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58655",
@@ -811,7 +1011,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14433",
@@ -831,7 +1036,12 @@
       ],
       "assignee": "Sean Johnston",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58577",
@@ -851,7 +1061,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58544",
@@ -870,7 +1085,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58513",
@@ -889,7 +1109,12 @@
       ],
       "assignee": "Claudia Alphonse",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14345",
@@ -908,7 +1133,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:10.934+0000"
+      "terminalAt": "2026-04-21T14:33:10.934+0000",
+      "ciFailureCount": 2,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": 3,
+      "effortTier": "Standard Fix"
     },
     {
       "key": "AIPCC-14342",
@@ -927,7 +1157,12 @@
       ],
       "assignee": "Lance Barto",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T20:13:13.938+0000"
+      "terminalAt": "2026-04-21T20:13:13.938+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": 3,
+      "effortTier": "Standard Fix"
     },
     {
       "key": "AIPCC-14341",
@@ -946,7 +1181,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-rejected",
-      "terminalAt": "2026-04-21T14:33:11.560+0000"
+      "terminalAt": "2026-04-21T14:33:11.560+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58426",
@@ -966,7 +1206,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58425",
@@ -986,7 +1231,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-not-fixable",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58424",
@@ -1007,7 +1257,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-ci-failing",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58423",
@@ -1028,7 +1283,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-ci-failing",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58422",
@@ -1049,7 +1309,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-ci-failing",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58413",
@@ -1069,7 +1334,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14332",
@@ -1088,7 +1358,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-not-fixable",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58388",
@@ -1109,7 +1384,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58373",
@@ -1128,7 +1408,12 @@
       ],
       "assignee": "Jakub Walaszczyk",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14329",
@@ -1147,7 +1432,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-review",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14320",
@@ -1166,7 +1456,12 @@
       ],
       "assignee": "Anu Oguntayo",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:08.401+0000"
+      "terminalAt": "2026-04-21T14:33:08.401+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": 3,
+      "effortTier": "Standard Fix"
     },
     {
       "key": "RHOAIENG-58326",
@@ -1187,7 +1482,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-missing-info",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14318",
@@ -1206,7 +1506,12 @@
       ],
       "assignee": "Unassigned",
       "pipelineState": "triage-not-fixable",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "RHOAIENG-58288",
@@ -1228,7 +1533,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14272",
@@ -1246,7 +1556,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-ready",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14220",
@@ -1263,7 +1578,12 @@
       "components": [],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-review",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-14216",
@@ -1282,7 +1602,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:08.929+0000"
+      "terminalAt": "2026-04-21T14:33:08.929+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 2,
+      "wasBlocked": false,
+      "effortScore": 4,
+      "effortTier": "Standard Fix"
     },
     {
       "key": "AIPCC-14188",
@@ -1301,7 +1626,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:09.420+0000"
+      "terminalAt": "2026-04-21T14:33:09.420+0000",
+      "ciFailureCount": 2,
+      "reviewRoundCount": 3,
+      "wasBlocked": true,
+      "effortScore": 7,
+      "effortTier": "Complex Fix"
     },
     {
       "key": "AIPCC-14074",
@@ -1320,7 +1650,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:09.858+0000"
+      "terminalAt": "2026-04-21T14:33:09.858+0000",
+      "ciFailureCount": 1,
+      "reviewRoundCount": 2,
+      "wasBlocked": true,
+      "effortScore": 6,
+      "effortTier": "Complex Fix"
     },
     {
       "key": "AIPCC-14062",
@@ -1339,7 +1674,12 @@
       ],
       "assignee": "AIPCC JIRABOT",
       "pipelineState": "autofix-merged",
-      "terminalAt": "2026-04-21T14:33:10.434+0000"
+      "terminalAt": "2026-04-21T14:33:10.434+0000",
+      "ciFailureCount": 2,
+      "reviewRoundCount": 3,
+      "wasBlocked": true,
+      "effortScore": 7,
+      "effortTier": "Complex Fix"
     },
     {
       "key": "AIPCC-14049",
@@ -1359,7 +1699,12 @@
       ],
       "assignee": "Emilien Macchi",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-12897",
@@ -1376,7 +1721,12 @@
       "components": [],
       "assignee": "Martin Prpic",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     },
     {
       "key": "AIPCC-12895",
@@ -1396,7 +1746,12 @@
       ],
       "assignee": "Emilien Macchi",
       "pipelineState": "autofix-blocked",
-      "terminalAt": null
+      "terminalAt": null,
+      "ciFailureCount": 0,
+      "reviewRoundCount": 0,
+      "wasBlocked": false,
+      "effortScore": null,
+      "effortTier": null
     }
   ]
 }

--- a/modules/ai-impact/__tests__/client/AutofixContent.test.js
+++ b/modules/ai-impact/__tests__/client/AutofixContent.test.js
@@ -15,7 +15,11 @@ const MOCK_DATA = {
     autofixTotal: 6,
     successRate: 100,
     windowTotal: 10,
-    totalIssues: 10
+    totalIssues: 10,
+    priorityBreakdown: { Major: 1, Normal: 1, Blocker: 1 },
+    medianTimeToFixDays: 2.5,
+    effortBreakdown: { quickWin: 1, standardFix: 1, complexFix: 0 },
+    totalImpactScore: 4
   },
   trendData: [
     { date: daysAgo(7).slice(0, 10), triaged: 3, autofixed: 2, merged: 1, total: 3, review: 1, ciFailing: 0, blocked: 0, maxRetries: 0, missingInfo: 1, stale: 0, external: 0, securityReview: 0 },
@@ -33,10 +37,28 @@ const MOCK_DATA = {
       priority: 'Major',
       created: daysAgo(2),
       updated: daysAgo(1),
-      labels: ['jira-autofix-review'],
+      terminalAt: daysAgo(0),
+      labels: ['jira-autofix-merged'],
       components: ['Model Server'],
       assignee: 'Jane Doe',
-      pipelineState: 'autofix-review'
+      pipelineState: 'autofix-merged',
+      effortScore: 1,
+      effortTier: 'Quick Win'
+    },
+    {
+      key: 'AIPCC-101',
+      summary: 'Fix auth bypass',
+      status: 'Closed',
+      priority: 'Blocker',
+      created: daysAgo(5),
+      updated: daysAgo(1),
+      terminalAt: daysAgo(1),
+      labels: ['jira-autofix-merged'],
+      components: ['Model Server'],
+      assignee: 'John Smith',
+      pipelineState: 'autofix-merged',
+      effortScore: 3,
+      effortTier: 'Standard Fix'
     },
     {
       key: 'RHOAIENG-200',
@@ -45,10 +67,13 @@ const MOCK_DATA = {
       priority: 'Normal',
       created: daysAgo(3),
       updated: daysAgo(3),
+      terminalAt: null,
       labels: ['jira-triage-not-fixable'],
       components: ['Notebooks'],
       assignee: null,
-      pipelineState: 'triage-not-fixable'
+      pipelineState: 'triage-not-fixable',
+      effortScore: null,
+      effortTier: null
     }
   ]
 }
@@ -137,6 +162,41 @@ describe('AutofixContent', () => {
     const labelTexts = labels.map(l => l.text())
     expect(labelTexts).toContain('External Reporter')
     expect(labelTexts).toContain('Security Review')
+  })
+
+  it('renders priority distribution section', () => {
+    const wrapper = mount(AutofixContent, {
+      props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
+    })
+    expect(wrapper.text()).toContain('Priority Distribution')
+    expect(wrapper.text()).toContain('Major')
+    expect(wrapper.text()).toContain('Blocker')
+  })
+
+  it('renders effort breakdown section', () => {
+    const wrapper = mount(AutofixContent, {
+      props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
+    })
+    expect(wrapper.text()).toContain('Effort Breakdown')
+    expect(wrapper.text()).toContain('Quick Win')
+    expect(wrapper.text()).toContain('Standard Fix')
+  })
+
+  it('renders median time to fix', () => {
+    const wrapper = mount(AutofixContent, {
+      props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
+    })
+    expect(wrapper.text()).toContain('Time to Fix')
+    expect(wrapper.text()).toContain('2.5 days')
+    expect(wrapper.text()).toContain('Median Time to Fix')
+  })
+
+  it('renders effort tier badge in issue table', () => {
+    const wrapper = mount(AutofixContent, {
+      props: { autofixData: MOCK_DATA, loading: false, timeWindow: 'month' }
+    })
+    expect(wrapper.text()).toContain('Quick Win')
+    expect(wrapper.text()).toContain('Standard Fix')
   })
 
   it('filters issues by state', async () => {

--- a/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
+++ b/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
@@ -4,6 +4,10 @@ const {
   classifyIssue,
   processIssue,
   extractTerminalAt,
+  extractPipelineHistory,
+  computeEffortScore,
+  computePriorityBreakdown,
+  computeMedianTimeToFix,
   getLastWeekBounds,
   computeAutofixMetrics,
   buildTrendData
@@ -368,5 +372,214 @@ describe('getLastWeekBounds', () => {
   it('end is before now', () => {
     const { end } = getLastWeekBounds()
     expect(end).toBeLessThanOrEqual(Date.now())
+  })
+})
+
+describe('extractPipelineHistory', () => {
+  it('counts CI failure label additions', () => {
+    const changelog = {
+      histories: [
+        { created: '2026-06-10T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-ci-failing' }] },
+        { created: '2026-06-11T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-review' }] },
+        { created: '2026-06-12T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-ci-failing' }] },
+        { created: '2026-06-13T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-merged' }] }
+      ]
+    }
+    const h = extractPipelineHistory(changelog, 'autofix-merged')
+    expect(h.ciFailureCount).toBe(2)
+    expect(h.terminalAt).toBe('2026-06-13T10:00:00.000Z')
+  })
+
+  it('counts review round label additions', () => {
+    const changelog = {
+      histories: [
+        { created: '2026-06-10T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-review' }] },
+        { created: '2026-06-11T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-ci-failing' }] },
+        { created: '2026-06-12T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-review' }] },
+        { created: '2026-06-13T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-review' }] },
+        { created: '2026-06-14T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-merged' }] }
+      ]
+    }
+    const h = extractPipelineHistory(changelog, 'autofix-merged')
+    expect(h.reviewRoundCount).toBe(3)
+  })
+
+  it('detects blocked state', () => {
+    const changelog = {
+      histories: [
+        { created: '2026-06-10T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-blocked' }] },
+        { created: '2026-06-12T10:00:00.000Z', items: [{ field: 'labels', toString: 'jira-autofix-merged' }] }
+      ]
+    }
+    const h = extractPipelineHistory(changelog, 'autofix-merged')
+    expect(h.wasBlocked).toBe(true)
+  })
+
+  it('returns defaults for empty changelog', () => {
+    const h = extractPipelineHistory(null, 'autofix-merged')
+    expect(h.terminalAt).toBeNull()
+    expect(h.ciFailureCount).toBe(0)
+    expect(h.reviewRoundCount).toBe(0)
+    expect(h.wasBlocked).toBe(false)
+  })
+
+  it('handles multiple label changes in a single history entry', () => {
+    const changelog = {
+      histories: [
+        {
+          created: '2026-06-10T10:00:00.000Z',
+          items: [
+            { field: 'labels', toString: 'jira-autofix-review' },
+            { field: 'labels', toString: 'jira-autofix-ci-failing' }
+          ]
+        }
+      ]
+    }
+    const h = extractPipelineHistory(changelog, 'autofix-merged')
+    expect(h.reviewRoundCount).toBe(1)
+    expect(h.ciFailureCount).toBe(1)
+  })
+})
+
+describe('computeEffortScore', () => {
+  it('returns base score of 1 for a simple merged issue', () => {
+    const issue = { pipelineState: 'autofix-merged', created: '2026-06-10T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z', priority: 'Normal' }
+    const { effortScore, effortTier } = computeEffortScore(issue)
+    expect(effortScore).toBe(1)
+    expect(effortTier).toBe('Quick Win')
+  })
+
+  it('adds 1 point for CI failures', () => {
+    const issue = { pipelineState: 'autofix-merged', ciFailureCount: 2, created: '2026-06-10T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z', priority: 'Normal' }
+    const { effortScore } = computeEffortScore(issue)
+    expect(effortScore).toBe(2)
+  })
+
+  it('adds 1 point per extra review round beyond the first', () => {
+    const issue = { pipelineState: 'autofix-merged', reviewRoundCount: 3, created: '2026-06-10T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z', priority: 'Normal' }
+    const { effortScore } = computeEffortScore(issue)
+    expect(effortScore).toBe(3)
+  })
+
+  it('adds 2 points for blocked state', () => {
+    const issue = { pipelineState: 'autofix-merged', wasBlocked: true, created: '2026-06-10T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z', priority: 'Normal' }
+    const { effortScore } = computeEffortScore(issue)
+    expect(effortScore).toBe(3)
+  })
+
+  it('adds 1 point for time-to-fix over 7 days', () => {
+    const issue = { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-10T00:00:00Z', priority: 'Normal' }
+    const { effortScore } = computeEffortScore(issue)
+    expect(effortScore).toBe(2)
+  })
+
+  it('adds 2 points for Blocker or Critical priority', () => {
+    const issue = { pipelineState: 'autofix-merged', created: '2026-06-10T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z', priority: 'Blocker' }
+    const { effortScore, effortTier } = computeEffortScore(issue)
+    expect(effortScore).toBe(3)
+    expect(effortTier).toBe('Standard Fix')
+  })
+
+  it('maps tier boundaries correctly', () => {
+    const base = { pipelineState: 'autofix-merged', created: '2026-06-10T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z', priority: 'Normal' }
+
+    expect(computeEffortScore({ ...base }).effortTier).toBe('Quick Win')
+    expect(computeEffortScore({ ...base, ciFailureCount: 1 }).effortTier).toBe('Quick Win')
+    expect(computeEffortScore({ ...base, wasBlocked: true }).effortTier).toBe('Standard Fix')
+    expect(computeEffortScore({ ...base, wasBlocked: true, ciFailureCount: 1 }).effortTier).toBe('Standard Fix')
+    expect(computeEffortScore({ ...base, wasBlocked: true, ciFailureCount: 1, reviewRoundCount: 3 }).effortTier).toBe('Complex Fix')
+  })
+
+  it('returns null for non-merged issues', () => {
+    const issue = { pipelineState: 'autofix-review', priority: 'Major' }
+    const { effortScore, effortTier } = computeEffortScore(issue)
+    expect(effortScore).toBeNull()
+    expect(effortTier).toBeNull()
+  })
+})
+
+describe('computePriorityBreakdown', () => {
+  it('counts issues by priority', () => {
+    const issues = [
+      { priority: 'Blocker' },
+      { priority: 'Major' },
+      { priority: 'Major' },
+      { priority: 'Undefined' }
+    ]
+    const result = computePriorityBreakdown(issues)
+    expect(result).toEqual({ Blocker: 1, Major: 2, Undefined: 1 })
+  })
+
+  it('returns empty object for empty array', () => {
+    expect(computePriorityBreakdown([])).toEqual({})
+  })
+})
+
+describe('computeMedianTimeToFix', () => {
+  it('returns median for odd number of merged issues', () => {
+    const issues = [
+      { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-02T00:00:00Z' },
+      { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-04T00:00:00Z' },
+      { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-11T00:00:00Z' }
+    ]
+    expect(computeMedianTimeToFix(issues)).toBe(3)
+  })
+
+  it('returns median for even number of merged issues', () => {
+    const issues = [
+      { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-03T00:00:00Z' },
+      { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-05T00:00:00Z' }
+    ]
+    expect(computeMedianTimeToFix(issues)).toBe(3)
+  })
+
+  it('returns null when no merged issues', () => {
+    const issues = [
+      { pipelineState: 'autofix-review', created: '2026-06-01T00:00:00Z', terminalAt: null }
+    ]
+    expect(computeMedianTimeToFix(issues)).toBeNull()
+  })
+
+  it('skips non-merged issues', () => {
+    const issues = [
+      { pipelineState: 'autofix-rejected', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-02T00:00:00Z' },
+      { pipelineState: 'autofix-merged', created: '2026-06-01T00:00:00Z', terminalAt: '2026-06-06T00:00:00Z' }
+    ]
+    expect(computeMedianTimeToFix(issues)).toBe(5)
+  })
+})
+
+describe('computeAutofixMetrics new fields', () => {
+  const now = new Date()
+  const recent = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString()
+  const mergedAt = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString()
+
+  it('includes priorityBreakdown in metrics', () => {
+    const issues = [
+      { created: recent, pipelineState: 'autofix-merged', priority: 'Blocker', terminalAt: mergedAt, effortScore: 3, effortTier: 'Standard Fix' },
+      { created: recent, pipelineState: 'triage-missing-info', priority: 'Major' }
+    ]
+    const m = computeAutofixMetrics(issues, 'week')
+    expect(m.priorityBreakdown).toEqual({ Blocker: 1, Major: 1 })
+  })
+
+  it('includes medianTimeToFixDays for merged issues', () => {
+    const created = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created, pipelineState: 'autofix-merged', priority: 'Major', terminalAt: mergedAt, effortScore: 1, effortTier: 'Quick Win' }
+    ]
+    const m = computeAutofixMetrics(issues, 'week')
+    expect(m.medianTimeToFixDays).toBeGreaterThan(0)
+  })
+
+  it('includes effortBreakdown and totalImpactScore', () => {
+    const issues = [
+      { created: recent, pipelineState: 'autofix-merged', priority: 'Major', terminalAt: mergedAt, effortScore: 1, effortTier: 'Quick Win' },
+      { created: recent, pipelineState: 'autofix-merged', priority: 'Blocker', terminalAt: mergedAt, effortScore: 4, effortTier: 'Standard Fix' },
+      { created: recent, pipelineState: 'autofix-merged', priority: 'Critical', terminalAt: mergedAt, effortScore: 6, effortTier: 'Complex Fix' }
+    ]
+    const m = computeAutofixMetrics(issues, 'week')
+    expect(m.effortBreakdown).toEqual({ quickWin: 1, standardFix: 1, complexFix: 1 })
+    expect(m.totalImpactScore).toBe(11)
   })
 })

--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -251,7 +251,34 @@ const metrics = computed(() => {
   const terminalTotal = autofixStates.merged + autofixStates.rejected + autofixStates.maxRetries
   const successRate = terminalTotal > 0 ? Math.round((autofixStates.merged / terminalTotal) * 100) : 0
 
-  return { triageTotal, triageVerdicts, autofixStates, autofixTotal: triageVerdicts.ready, successRate, windowTotal: windowIssues.length, totalIssues: issues.length }
+  const priorityBreakdown = {}
+  for (const issue of windowIssues) {
+    const p = issue.priority || 'Undefined'
+    priorityBreakdown[p] = (priorityBreakdown[p] || 0) + 1
+  }
+
+  const mergedWindowIssues = windowIssues.filter(i => i.pipelineState === 'autofix-merged' && i.terminalAt)
+  let medianTimeToFixDays = null
+  if (mergedWindowIssues.length > 0) {
+    const days = mergedWindowIssues
+      .map(i => (new Date(i.terminalAt).getTime() - new Date(i.created).getTime()) / (24 * 60 * 60 * 1000))
+      .sort((a, b) => a - b)
+    const mid = Math.floor(days.length / 2)
+    medianTimeToFixDays = days.length % 2 === 0
+      ? Math.round(((days[mid - 1] + days[mid]) / 2) * 10) / 10
+      : Math.round(days[mid] * 10) / 10
+  }
+
+  const effortBreakdown = { quickWin: 0, standardFix: 0, complexFix: 0 }
+  let totalImpactScore = 0
+  for (const issue of mergedWindowIssues) {
+    if (issue.effortTier === 'Quick Win') effortBreakdown.quickWin++
+    else if (issue.effortTier === 'Standard Fix') effortBreakdown.standardFix++
+    else if (issue.effortTier === 'Complex Fix') effortBreakdown.complexFix++
+    totalImpactScore += (issue.effortScore || 0)
+  }
+
+  return { triageTotal, triageVerdicts, autofixStates, autofixTotal: triageVerdicts.ready, successRate, windowTotal: windowIssues.length, totalIssues: issues.length, priorityBreakdown, medianTimeToFixDays, effortBreakdown, totalImpactScore }
 })
 
 const trendData = computed(() => {
@@ -489,6 +516,13 @@ function stateColorClass(state) {
   return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
 }
 
+function effortTierColorClass(tier) {
+  if (tier === 'Quick Win') return 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400'
+  if (tier === 'Standard Fix') return 'bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400'
+  if (tier === 'Complex Fix') return 'bg-purple-100 dark:bg-purple-500/20 text-purple-700 dark:text-purple-400'
+  return ''
+}
+
 function formatDate(iso) {
   if (!iso) return ''
   return new Date(iso).toLocaleDateString()
@@ -526,6 +560,44 @@ const autofixSegments = computed(() => {
 })
 
 const autofixSegmentTotal = computed(() => autofixSegments.value.reduce((s, v) => s + v.count, 0))
+
+const PRIORITY_COLORS = {
+  Blocker: { bar: 'bg-red-500', text: 'text-red-600 dark:text-red-400' },
+  Critical: { bar: 'bg-orange-500', text: 'text-orange-600 dark:text-orange-400' },
+  Major: { bar: 'bg-yellow-500', text: 'text-yellow-600 dark:text-yellow-400' },
+  Normal: { bar: 'bg-blue-500', text: 'text-blue-600 dark:text-blue-400' },
+  Minor: { bar: 'bg-green-500', text: 'text-green-600 dark:text-green-400' },
+  Undefined: { bar: 'bg-gray-400', text: 'text-gray-500 dark:text-gray-400' }
+}
+
+const PRIORITY_ORDER = ['Blocker', 'Critical', 'Major', 'Normal', 'Minor', 'Undefined']
+
+const prioritySegments = computed(() => {
+  if (!metrics.value?.priorityBreakdown) return []
+  const pb = metrics.value.priorityBreakdown
+  return PRIORITY_ORDER
+    .filter(p => (pb[p] || 0) > 0)
+    .map(p => ({
+      label: p,
+      count: pb[p] || 0,
+      color: PRIORITY_COLORS[p]?.bar || 'bg-gray-400',
+      textClass: PRIORITY_COLORS[p]?.text || 'text-gray-500'
+    }))
+})
+
+const prioritySegmentTotal = computed(() => prioritySegments.value.reduce((s, v) => s + v.count, 0))
+
+const effortSegments = computed(() => {
+  if (!metrics.value?.effortBreakdown) return []
+  const eb = metrics.value.effortBreakdown
+  return [
+    { label: 'Quick Win', count: eb.quickWin || 0, color: 'bg-green-500', textClass: 'text-green-600 dark:text-green-400' },
+    { label: 'Standard Fix', count: eb.standardFix || 0, color: 'bg-blue-500', textClass: 'text-blue-600 dark:text-blue-400' },
+    { label: 'Complex Fix', count: eb.complexFix || 0, color: 'bg-purple-500', textClass: 'text-purple-600 dark:text-purple-400' }
+  ].filter(s => s.count > 0)
+})
+
+const effortSegmentTotal = computed(() => effortSegments.value.reduce((s, v) => s + v.count, 0))
 
 function buildJiraLabelUrl(jiraLabels, excludeLabels) {
   const host = jiraHost.value
@@ -924,6 +996,124 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
 
         </div>
 
+        <!-- Impact Metrics -->
+        <div class="px-6 pb-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <!-- Priority Distribution -->
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                Priority Distribution
+                <div class="relative group">
+                  <svg class="h-3.5 w-3.5 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <div class="absolute left-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300">
+                    Distribution of Jira priorities across all issues in the selected time window. Priorities are set by the ticket reporter or team lead.
+                  </div>
+                </div>
+              </h3>
+              <span class="text-xs text-gray-400 dark:text-gray-500">{{ prioritySegmentTotal }} issues</span>
+            </div>
+
+            <div class="flex h-6 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 mb-4" v-if="prioritySegmentTotal > 0">
+              <div
+                v-for="seg in prioritySegments"
+                :key="seg.label"
+                class="transition-all duration-500"
+                :class="seg.color"
+                :style="{ width: (seg.count / prioritySegmentTotal * 100) + '%' }"
+                :title="`${seg.label}: ${seg.count}`"
+              />
+            </div>
+
+            <div class="space-y-2.5">
+              <div v-for="seg in prioritySegments" :key="seg.label" class="flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                  <span class="w-2.5 h-2.5 rounded-sm shrink-0" :class="seg.color" />
+                  <span class="text-sm text-gray-600 dark:text-gray-300">{{ seg.label }}</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-sm font-semibold" :class="seg.textClass">{{ seg.count }}</span>
+                  <span class="text-xs text-gray-400 dark:text-gray-500 w-10 text-right">{{ prioritySegmentTotal > 0 ? Math.round(seg.count / prioritySegmentTotal * 100) : 0 }}%</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Effort Breakdown -->
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                Effort Breakdown
+                <div class="relative group">
+                  <svg class="h-3.5 w-3.5 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <div class="absolute left-0 top-6 z-20 hidden group-hover:block w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300">
+                    Effort score measures fix complexity based on observable pipeline signals. Scoring: Base (1 pt), CI failures (+1), Extra review rounds (+1 each), Was blocked (+2), Time-to-fix over 7 days (+1), Blocker/Critical priority (+2). Tiers: Quick Win (1-2 pts), Standard Fix (3-4 pts), Complex Fix (5+ pts).
+                  </div>
+                </div>
+              </h3>
+              <span class="text-xs text-gray-400 dark:text-gray-500">{{ effortSegmentTotal }} issues</span>
+            </div>
+
+            <template v-if="effortSegmentTotal > 0">
+              <div class="flex h-6 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 mb-4">
+                <div
+                  v-for="seg in effortSegments"
+                  :key="seg.label"
+                  class="transition-all duration-500"
+                  :class="seg.color"
+                  :style="{ width: (seg.count / effortSegmentTotal * 100) + '%' }"
+                  :title="`${seg.label}: ${seg.count}`"
+                />
+              </div>
+
+              <div class="space-y-2.5">
+                <div v-for="seg in effortSegments" :key="seg.label" class="flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <span class="w-2.5 h-2.5 rounded-sm shrink-0" :class="seg.color" />
+                    <span class="text-sm text-gray-600 dark:text-gray-300">{{ seg.label }}</span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-semibold" :class="seg.textClass">{{ seg.count }}</span>
+                    <span class="text-xs text-gray-400 dark:text-gray-500 w-10 text-right">{{ effortSegmentTotal > 0 ? Math.round(seg.count / effortSegmentTotal * 100) : 0 }}%</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-700">
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-gray-500 dark:text-gray-400">Total Impact Score</span>
+                  <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ metrics.totalImpactScore }}</span>
+                </div>
+              </div>
+            </template>
+          </div>
+
+          <!-- Time to Fix -->
+          <div class="relative bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Time to Fix</h3>
+              <div class="relative group">
+                <svg class="h-3.5 w-3.5 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div class="absolute left-0 top-6 z-20 hidden group-hover:block w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50 p-3 text-xs text-gray-700 dark:text-gray-300">
+                  Median elapsed time from issue creation to merged fix for successfully resolved issues in the selected time window.
+                </div>
+              </div>
+            </div>
+            <div class="flex flex-col items-center justify-center py-4">
+              <div class="text-4xl font-bold text-gray-900 dark:text-gray-100">
+                {{ metrics.medianTimeToFixDays !== null ? metrics.medianTimeToFixDays + ' days' : 'N/A' }}
+              </div>
+              <div class="text-xs text-gray-500 dark:text-gray-400 mt-2 uppercase tracking-wide">Median Time to Fix</div>
+              <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-1">{{ metrics.autofixStates?.merged || 0 }} merged issues</div>
+            </div>
+          </div>
+        </div>
+
         <!-- Pipeline Trends -->
         <div class="px-6 pb-6 grid grid-cols-1 lg:grid-cols-3 gap-6" v-if="trendData.length > 0 && hasTrendActivity">
           <!-- Waiting on Humans: Triage -->
@@ -1101,6 +1291,7 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Summary</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Status</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">State</th>
+                    <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Effort</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Component</th>
                     <th class="px-5 py-2 text-left text-gray-500 dark:text-gray-400 font-medium">Created</th>
                   </tr>
@@ -1129,13 +1320,17 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
                         :class="stateColorClass(issue.pipelineState)"
                       >{{ stateLabel(issue.pipelineState) }}</span>
                     </td>
+                    <td class="px-5 py-2">
+                      <span v-if="issue.effortTier" class="inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold" :class="effortTierColorClass(issue.effortTier)">{{ issue.effortTier }}</span>
+                      <span v-else class="text-gray-300 dark:text-gray-600">&mdash;</span>
+                    </td>
                     <td class="px-5 py-2 text-gray-600 dark:text-gray-400 text-xs">
                       {{ issue.components.join(', ') || '—' }}
                     </td>
                     <td class="px-5 py-2 text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">{{ formatDate(issue.created) }}</td>
                   </tr>
                   <tr v-if="filteredIssues.length === 0">
-                    <td colspan="6" class="px-5 py-8 text-center text-gray-500 dark:text-gray-400">
+                    <td colspan="7" class="px-5 py-8 text-center text-gray-500 dark:text-gray-400">
                       No issues found matching the current filters.
                     </td>
                   </tr>

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -141,8 +141,8 @@ module.exports = function registerRoutes(router, context) {
       components: issue.components,
       assignee: issue.assignee,
       pipelineState: issue.pipelineState,
-      effortScore: issue.effortScore || null,
-      effortTier: issue.effortTier || null
+      effortScore: issue.effortScore ?? null,
+      effortTier: issue.effortTier ?? null
     };
   }
 

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -140,7 +140,9 @@ module.exports = function registerRoutes(router, context) {
       terminalAt: issue.terminalAt || null,
       components: issue.components,
       assignee: issue.assignee,
-      pipelineState: issue.pipelineState
+      pipelineState: issue.pipelineState,
+      effortScore: issue.effortScore || null,
+      effortTier: issue.effortTier || null
     };
   }
 
@@ -177,7 +179,7 @@ module.exports = function registerRoutes(router, context) {
       return res.json({
         fetchedAt: null,
         jiraHost: JIRA_HOST,
-        metrics: { triageTotal: 0, triageVerdicts: {}, autofixStates: {}, autofixTotal: 0, successRate: 0, windowTotal: 0, totalIssues: 0 },
+        metrics: { triageTotal: 0, triageVerdicts: {}, autofixStates: {}, autofixTotal: 0, successRate: 0, windowTotal: 0, totalIssues: 0, priorityBreakdown: {}, medianTimeToFixDays: null, effortBreakdown: { quickWin: 0, standardFix: 0, complexFix: 0 }, totalImpactScore: 0 },
         trendData: [],
         issues: []
       });

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -117,9 +117,32 @@ module.exports = function registerRoutes(router, context) {
 
   let autofixDataCache = null;
 
+  function shiftAutofixDates(data) {
+    if (!data || !data.fetchedAt) return data;
+    const offset = Date.now() - new Date(data.fetchedAt).getTime();
+    if (Math.abs(offset) < 60 * 60 * 1000) return data;
+
+    function shift(iso) {
+      if (!iso) return iso;
+      return new Date(new Date(iso).getTime() + offset).toISOString();
+    }
+
+    return {
+      ...data,
+      fetchedAt: new Date().toISOString(),
+      issues: data.issues.map(i => ({
+        ...i,
+        created: shift(i.created),
+        updated: shift(i.updated),
+        terminalAt: shift(i.terminalAt)
+      }))
+    };
+  }
+
   function getAutofixData() {
     if (!autofixDataCache) {
-      autofixDataCache = readFromStorage('ai-impact/autofix-data.json');
+      const raw = readFromStorage('ai-impact/autofix-data.json');
+      autofixDataCache = DEMO_MODE ? shiftAutofixDates(raw) : raw;
     }
     return autofixDataCache;
   }

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -127,24 +127,24 @@ function computeEffortScore(issue) {
     return { effortScore: null, effortTier: null };
   }
 
-  var score = 1;
+  let score = 1;
 
   if ((issue.ciFailureCount || 0) > 0) score += 1;
 
-  var reviewRounds = issue.reviewRoundCount || 0;
+  const reviewRounds = issue.reviewRoundCount || 0;
   if (reviewRounds > 1) score += (reviewRounds - 1);
 
   if (issue.wasBlocked) score += 2;
 
   if (issue.terminalAt && issue.created) {
-    var days = (new Date(issue.terminalAt).getTime() - new Date(issue.created).getTime()) / (24 * 60 * 60 * 1000);
+    const days = (new Date(issue.terminalAt).getTime() - new Date(issue.created).getTime()) / (24 * 60 * 60 * 1000);
     if (days > 7) score += 1;
   }
 
-  var priority = issue.priority || '';
+  const priority = issue.priority || '';
   if (priority === 'Blocker' || priority === 'Critical') score += 2;
 
-  var tier;
+  let tier;
   if (score <= 2) tier = 'Quick Win';
   else if (score <= 4) tier = 'Standard Fix';
   else tier = 'Complex Fix';
@@ -153,26 +153,26 @@ function computeEffortScore(issue) {
 }
 
 function computePriorityBreakdown(issues) {
-  var breakdown = {};
-  for (var i = 0; i < issues.length; i++) {
-    var p = issues[i].priority || 'Undefined';
+  const breakdown = {};
+  for (let i = 0; i < issues.length; i++) {
+    const p = issues[i].priority || 'Undefined';
     breakdown[p] = (breakdown[p] || 0) + 1;
   }
   return breakdown;
 }
 
 function computeMedianTimeToFix(issues) {
-  var days = [];
-  for (var i = 0; i < issues.length; i++) {
-    var issue = issues[i];
+  const days = [];
+  for (let i = 0; i < issues.length; i++) {
+    const issue = issues[i];
     if (issue.pipelineState !== 'autofix-merged') continue;
     if (!issue.terminalAt || !issue.created) continue;
-    var d = (new Date(issue.terminalAt).getTime() - new Date(issue.created).getTime()) / (24 * 60 * 60 * 1000);
+    const d = (new Date(issue.terminalAt).getTime() - new Date(issue.created).getTime()) / (24 * 60 * 60 * 1000);
     days.push(d);
   }
   if (days.length === 0) return null;
   days.sort(function(a, b) { return a - b; });
-  var mid = Math.floor(days.length / 2);
+  const mid = Math.floor(days.length / 2);
   if (days.length % 2 === 0) {
     return Math.round(((days[mid - 1] + days[mid]) / 2) * 10) / 10;
   }
@@ -256,20 +256,20 @@ function computeAutofixMetrics(issues, timeWindow) {
     ? Math.round((autofixStates.merged / terminalTotal) * 100)
     : 0;
 
-  var priorityBreakdown = computePriorityBreakdown(
+  const priorityBreakdown = computePriorityBreakdown(
     issues.filter(function(issue) { return issueInWindow(issue, windowStart, windowEnd, isLastWeek); })
   );
 
-  var mergedWindowIssues = issues.filter(function(issue) {
+  const mergedWindowIssues = issues.filter(function(issue) {
     return issue.pipelineState === 'autofix-merged' && issueInWindow(issue, windowStart, windowEnd, isLastWeek);
   });
 
-  var medianTimeToFixDays = computeMedianTimeToFix(mergedWindowIssues);
+  const medianTimeToFixDays = computeMedianTimeToFix(mergedWindowIssues);
 
-  var effortBreakdown = { quickWin: 0, standardFix: 0, complexFix: 0 };
-  var totalImpactScore = 0;
-  for (var j = 0; j < mergedWindowIssues.length; j++) {
-    var tier = mergedWindowIssues[j].effortTier;
+  const effortBreakdown = { quickWin: 0, standardFix: 0, complexFix: 0 };
+  let totalImpactScore = 0;
+  for (let j = 0; j < mergedWindowIssues.length; j++) {
+    const tier = mergedWindowIssues[j].effortTier;
     if (tier === 'Quick Win') effortBreakdown.quickWin++;
     else if (tier === 'Standard Fix') effortBreakdown.standardFix++;
     else if (tier === 'Complex Fix') effortBreakdown.complexFix++;
@@ -396,7 +396,7 @@ async function fetchAutofixData(jiraRequest, config) {
       return jiraRequest(
         '/rest/api/3/issue/' + encodeURIComponent(issue.key) + '?expand=changelog&fields=labels'
       ).then(function(detail) {
-        var history = extractPipelineHistory(detail.changelog, issue.pipelineState);
+        const history = extractPipelineHistory(detail.changelog, issue.pipelineState);
         issue.terminalAt = history.terminalAt;
         issue.ciFailureCount = history.ciFailureCount;
         issue.reviewRoundCount = history.reviewRoundCount;
@@ -411,7 +411,7 @@ async function fetchAutofixData(jiraRequest, config) {
   }
 
   for (let i = 0; i < processed.length; i++) {
-    var scoring = computeEffortScore(processed[i]);
+    const scoring = computeEffortScore(processed[i]);
     processed[i].effortScore = scoring.effortScore;
     processed[i].effortTier = scoring.effortTier;
   }

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -80,21 +80,103 @@ function processIssue(issue) {
   };
 }
 
-function extractTerminalAt(changelog, pipelineState) {
-  if (!changelog || !changelog.histories) return null;
+function extractPipelineHistory(changelog, pipelineState) {
+  const result = {
+    terminalAt: null,
+    ciFailureCount: 0,
+    reviewRoundCount: 0,
+    wasBlocked: false
+  };
+
+  if (!changelog || !changelog.histories) return result;
+
   const targetLabel = 'jira-' + pipelineState;
-  let latest = null;
+  let latestTerminal = null;
+
   for (const history of changelog.histories) {
     for (const item of history.items) {
       if (item.field !== 'labels') continue;
       const after = item.toString || '';
+
       if (after.includes(targetLabel)) {
         const ts = new Date(history.created).getTime();
-        if (latest === null || ts > latest) latest = ts;
+        if (latestTerminal === null || ts > latestTerminal) latestTerminal = ts;
+      }
+      if (after.includes('jira-autofix-ci-failing')) {
+        result.ciFailureCount++;
+      }
+      if (after.includes('jira-autofix-review')) {
+        result.reviewRoundCount++;
+      }
+      if (after.includes('jira-autofix-blocked')) {
+        result.wasBlocked = true;
       }
     }
   }
-  return latest ? new Date(latest).toISOString() : null;
+
+  result.terminalAt = latestTerminal ? new Date(latestTerminal).toISOString() : null;
+  return result;
+}
+
+function extractTerminalAt(changelog, pipelineState) {
+  return extractPipelineHistory(changelog, pipelineState).terminalAt;
+}
+
+function computeEffortScore(issue) {
+  if (issue.pipelineState !== 'autofix-merged') {
+    return { effortScore: null, effortTier: null };
+  }
+
+  var score = 1;
+
+  if ((issue.ciFailureCount || 0) > 0) score += 1;
+
+  var reviewRounds = issue.reviewRoundCount || 0;
+  if (reviewRounds > 1) score += (reviewRounds - 1);
+
+  if (issue.wasBlocked) score += 2;
+
+  if (issue.terminalAt && issue.created) {
+    var days = (new Date(issue.terminalAt).getTime() - new Date(issue.created).getTime()) / (24 * 60 * 60 * 1000);
+    if (days > 7) score += 1;
+  }
+
+  var priority = issue.priority || '';
+  if (priority === 'Blocker' || priority === 'Critical') score += 2;
+
+  var tier;
+  if (score <= 2) tier = 'Quick Win';
+  else if (score <= 4) tier = 'Standard Fix';
+  else tier = 'Complex Fix';
+
+  return { effortScore: score, effortTier: tier };
+}
+
+function computePriorityBreakdown(issues) {
+  var breakdown = {};
+  for (var i = 0; i < issues.length; i++) {
+    var p = issues[i].priority || 'Undefined';
+    breakdown[p] = (breakdown[p] || 0) + 1;
+  }
+  return breakdown;
+}
+
+function computeMedianTimeToFix(issues) {
+  var days = [];
+  for (var i = 0; i < issues.length; i++) {
+    var issue = issues[i];
+    if (issue.pipelineState !== 'autofix-merged') continue;
+    if (!issue.terminalAt || !issue.created) continue;
+    var d = (new Date(issue.terminalAt).getTime() - new Date(issue.created).getTime()) / (24 * 60 * 60 * 1000);
+    days.push(d);
+  }
+  if (days.length === 0) return null;
+  days.sort(function(a, b) { return a - b; });
+  var mid = Math.floor(days.length / 2);
+  if (days.length % 2 === 0) {
+    return Math.round(((days[mid - 1] + days[mid]) / 2) * 10) / 10;
+  }
+  return Math.round(days[mid] * 10) / 10;
 }
 
 function getLastWeekBounds() {
@@ -174,6 +256,26 @@ function computeAutofixMetrics(issues, timeWindow) {
     ? Math.round((autofixStates.merged / terminalTotal) * 100)
     : 0;
 
+  var priorityBreakdown = computePriorityBreakdown(
+    issues.filter(function(issue) { return issueInWindow(issue, windowStart, windowEnd, isLastWeek); })
+  );
+
+  var mergedWindowIssues = issues.filter(function(issue) {
+    return issue.pipelineState === 'autofix-merged' && issueInWindow(issue, windowStart, windowEnd, isLastWeek);
+  });
+
+  var medianTimeToFixDays = computeMedianTimeToFix(mergedWindowIssues);
+
+  var effortBreakdown = { quickWin: 0, standardFix: 0, complexFix: 0 };
+  var totalImpactScore = 0;
+  for (var j = 0; j < mergedWindowIssues.length; j++) {
+    var tier = mergedWindowIssues[j].effortTier;
+    if (tier === 'Quick Win') effortBreakdown.quickWin++;
+    else if (tier === 'Standard Fix') effortBreakdown.standardFix++;
+    else if (tier === 'Complex Fix') effortBreakdown.complexFix++;
+    totalImpactScore += (mergedWindowIssues[j].effortScore || 0);
+  }
+
   return {
     triageTotal,
     triageVerdicts,
@@ -182,7 +284,11 @@ function computeAutofixMetrics(issues, timeWindow) {
     terminalTotal,
     successRate,
     windowTotal,
-    totalIssues: issues.length
+    totalIssues: issues.length,
+    priorityBreakdown,
+    medianTimeToFixDays,
+    effortBreakdown,
+    totalImpactScore
   };
 }
 
@@ -290,7 +396,11 @@ async function fetchAutofixData(jiraRequest, config) {
       return jiraRequest(
         '/rest/api/3/issue/' + encodeURIComponent(issue.key) + '?expand=changelog&fields=labels'
       ).then(function(detail) {
-        issue.terminalAt = extractTerminalAt(detail.changelog, issue.pipelineState);
+        var history = extractPipelineHistory(detail.changelog, issue.pipelineState);
+        issue.terminalAt = history.terminalAt;
+        issue.ciFailureCount = history.ciFailureCount;
+        issue.reviewRoundCount = history.reviewRoundCount;
+        issue.wasBlocked = history.wasBlocked;
       });
     }));
     for (const r of results) {
@@ -298,6 +408,12 @@ async function fetchAutofixData(jiraRequest, config) {
         console.error('[autofix] changelog fetch failed:', r.reason?.message || r.reason);
       }
     }
+  }
+
+  for (let i = 0; i < processed.length; i++) {
+    var scoring = computeEffortScore(processed[i]);
+    processed[i].effortScore = scoring.effortScore;
+    processed[i].effortTier = scoring.effortTier;
   }
 
   return processed;
@@ -308,6 +424,10 @@ module.exports = {
   processIssue,
   classifyIssue,
   extractTerminalAt,
+  extractPipelineHistory,
+  computeEffortScore,
+  computePriorityBreakdown,
+  computeMedianTimeToFix,
   getLastWeekBounds,
   computeAutofixMetrics,
   buildTrendData,

--- a/tests/integration/ai-impact.spec.js
+++ b/tests/integration/ai-impact.spec.js
@@ -222,7 +222,7 @@ test.describe('AI Impact Views @ai-impact', () => {
     const effortHeading = page.locator('text=Effort Breakdown');
     await expect(effortHeading).toBeVisible();
 
-    const ttfHeading = page.locator('text=Time to Fix');
+    const ttfHeading = page.getByRole('heading', { name: 'Time to Fix' });
     await expect(ttfHeading).toBeVisible();
 
     const effortColumn = page.locator('th:has-text("Effort")');

--- a/tests/integration/ai-impact.spec.js
+++ b/tests/integration/ai-impact.spec.js
@@ -211,6 +211,26 @@ test.describe('AI Impact Views @ai-impact', () => {
     await testView(page, 'autofix', 'AutoFix');
   });
 
+  test('Jira AutoFix view renders impact metrics sections', async ({ page }) => {
+    await page.goto('/#/ai-impact/autofix');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const priorityHeading = page.locator('text=Priority Distribution');
+    await expect(priorityHeading).toBeVisible();
+
+    const effortHeading = page.locator('text=Effort Breakdown');
+    await expect(effortHeading).toBeVisible();
+
+    const ttfHeading = page.locator('text=Time to Fix');
+    await expect(ttfHeading).toBeVisible();
+
+    const effortColumn = page.locator('th:has-text("Effort")');
+    await expect(effortColumn).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
   test('should load Test Plan Review view', async ({ page }) => {
     await testView(page, 'test-plan-review', 'Test Plan Review');
   });


### PR DESCRIPTION
## Summary

- **Effort Scoring**: derives complexity tiers (Quick Win / Standard Fix / Complex Fix) from observable pipeline signals (CI failures, review rounds, blocked state, time-to-fix, Jira priority). Scoring methodology documented in an info tooltip.
- **Priority Breakdown**: stacked bar showing Blocker/Critical/Major/Normal/Minor/Undefined distribution across issues in the selected time window.
- **Time-to-Fix**: median elapsed days from issue creation to merged fix, supporting the "weeks to days" release velocity narrative.
- All metrics recompute client-side when filters are active. Effort tier badges appear in the issue table for merged issues.

Motivated by Tom's feedback: raw bug counts aren't compelling for leadership. These metrics provide the data needed to build a business case for autofix adoption across teams.

## Changes

### Server (`autofix-fetcher.js`)
- `extractPipelineHistory()`: extends changelog parsing to count CI failures, review rounds, and blocked state alongside terminalAt
- `computeEffortScore()`: scoring formula + tier assignment for merged issues
- `computePriorityBreakdown()` / `computeMedianTimeToFix()`: new aggregation functions
- `computeAutofixMetrics()`: extended with `priorityBreakdown`, `medianTimeToFixDays`, `effortBreakdown`, `totalImpactScore`

### Client (`AutofixContent.vue`)
- 3 new Impact Metrics panels (Priority Distribution, Effort Breakdown, Time to Fix)
- Effort column added to issue table with tier badges
- Client-side metric recomputation for filtered views

### Fixtures & Tests
- 71 demo issues enriched with pipeline history and effort data (5 Quick Win, 6 Standard Fix, 3 Complex Fix)
- 22 new server unit tests, 4 new client component tests, 1 new integration test
- All 579 ai-impact tests pass

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes (579 ai-impact tests, 60 server + 13 client for autofix)
- [ ] `DEMO_MODE=true npm run dev:full` — autofix view renders all three new panels with fixture data
- [ ] Priority Distribution shows stacked bar with correct colors
- [ ] Effort Breakdown shows tier counts with scoring methodology tooltip
- [ ] Time to Fix shows median days for merged issues
- [ ] Effort tier badges appear on merged issues in the table
- [ ] All sections recompute when project/component/type filters change
- [ ] `make test-module MODULE=ai-impact` — integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)