### PR TITLE
fix(releases): require both Documentation and UXD for cross-functional FPDoR item

### DIFF
--- a/modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js
+++ b/modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js
@@ -206,7 +206,20 @@ describe('FPDoR in health pipeline', function() {
     expect(tvItem.pass).toBe(true)
   })
 
-  it('passes cross-functional check when Documentation component present', async function() {
+  it('passes cross-functional check when Documentation and UXD components present', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      {
+        issueKey: 'T-1', summary: 'F1', status: 'In Progress',
+        components: ['Dashboard', 'Documentation', 'UXD'], fixVersion: '', deliveryOwner: 'Jane', tier: 1
+      }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    var items = result.features[0].fpdor.items
+    var cfItem = items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+    expect(cfItem.pass).toBe(true)
+  })
+
+  it('fails cross-functional check when only Documentation present, no UXD', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
@@ -216,14 +229,14 @@ describe('FPDoR in health pipeline', function() {
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
     var cfItem = items.find(function(i) { return i.name === 'Cross-functional Engagement' })
-    expect(cfItem.pass).toBe(true)
+    expect(cfItem.pass).toBe(false)
   })
 
   it('passes 4 of 6 jira items with correct candidate data (no enrichment)', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
-        components: ['Dashboard', 'Documentation'], fixVersion: '', deliveryOwner: 'Jane',
+        components: ['Dashboard', 'Documentation', 'UXD'], fixVersion: '', deliveryOwner: 'Jane',
         pm: 'Rick', tier: 1, targetRelease: '3.5', phase: 'GA'
       }
     ]))
@@ -245,7 +258,7 @@ describe('FPDoR in health pipeline', function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
-        components: ['Dashboard', 'Documentation'], fixVersion: '', deliveryOwner: 'Jane',
+        components: ['Dashboard', 'Documentation', 'UXD'], fixVersion: '', deliveryOwner: 'Jane',
         pm: 'Rick', tier: 1, targetRelease: '3.5', phase: 'GA'
       },
       {

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -34,7 +34,7 @@ function makeLatest(overrides) {
     scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2 },
     reviewers: { feasibility: 'approve', testability: 'approve', scope: 'approve', architecture: 'approve' },
     reviewedAt: '2026-01-01T00:00:00.000Z',
-    components: ['Documentation', 'Platform'],
+    components: ['Documentation', 'UXD', 'Platform'],
     approvedBy: null,
     approvedAt: null,
     riceScore: 100,
@@ -656,7 +656,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -719,7 +719,7 @@ describe('buildFeatureReadiness', function() {
       var candidateCache = {
         data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, fixVersion: '3.6.0', targetRelease: 'rhoai-3.6' }] }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -734,7 +734,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -800,7 +800,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -840,7 +840,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -963,7 +963,7 @@ describe('buildFeatureReadiness', function() {
           ]
         }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -1061,7 +1061,7 @@ describe('buildFeatureReadiness', function() {
           storyPoints: 5,
           epicCount: 3,
           releaseType: 'GA',
-          components: ['Documentation', 'Platform'],
+          components: ['Documentation', 'UXD', 'Platform'],
           docsRequired: 'Required'
         }]
       }
@@ -1087,7 +1087,7 @@ describe('buildFeatureReadiness', function() {
         data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'AI Speed', targetRelease: 'rhoai-3.6-cand', fixVersion: '3.6.0-cand' }] }
       }
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', tier: 'T3', bigRock: 'Platform', targetRelease: 'rhoai-3.6-health', fixVersions: '3.6.0-health', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', tier: 'T3', bigRock: 'Platform', targetRelease: 'rhoai-3.6-health', fixVersions: '3.6.0-health', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1129,7 +1129,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 87, priorityBreakdown: { rice: 50, bigRock: 100 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 87, priorityBreakdown: { rice: 50, bigRock: 100 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1171,7 +1171,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: { rice: 60 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: { rice: 60 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1246,7 +1246,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'wrong-owner', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'wrong-owner', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var hygieneCache = { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Real Team' } } }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1270,7 +1270,7 @@ describe('buildFeatureReadiness', function() {
       })
       var healthCache = {
         features: [
-          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' },
+          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' },
           { key: 'RHAISTRAT-2', priorityScore: null },
           { key: 'RHAISTRAT-3', priorityScore: null }
         ]
@@ -1421,8 +1421,8 @@ describe('buildFeatureReadiness', function() {
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': config,
-        'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.5', priorityScore: 80, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] },
-        'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', deliveryOwner: 'Bob', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 60, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+        'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.5', priorityScore: 80, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] },
+        'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', deliveryOwner: 'Bob', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 60, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(2)
@@ -1475,7 +1475,7 @@ describe('buildFeatureReadiness', function() {
         releaseType: 'GA',
         deliveryOwner: 'Alice',
         pmOwner: 'Jane',
-        components: ['Documentation', 'Platform'],
+        components: ['Documentation', 'UXD', 'Platform'],
         docsRequired: 'Required',
         effort: 5,
         scores: { testability: 2, architecture: 2, feasibility: 2, scope: 2 },
@@ -1533,9 +1533,11 @@ describe('buildFeatureReadiness', function() {
       expect(result.isReady).toBe(false)
     })
 
-    it('cross-functional passes with multiple components even without docs', function() {
+    it('cross-functional fails with multiple components but no Documentation or UXD', function() {
       var result = computeReadiness(readyFeature({ components: ['Platform', 'UI'], docsRequired: null }))
-      expect(result.isReady).toBe(true)
+      expect(result.isReady).toBe(false)
+      var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+      expect(cfItem.pass).toBe(false)
     })
 
     it('cross-functional fails with single non-doc component and no docsRequired', function() {
@@ -1622,18 +1624,40 @@ describe('buildFeatureReadiness', function() {
 
     // --- Cross-functional tests ---
 
-    it('cross-functional passes with docsRequired', function() {
-      var result = computeReadiness(readyFeature({ components: ['Platform'], docsRequired: 'Required' }))
+    it('cross-functional passes with docsRequired and UXD component', function() {
+      var result = computeReadiness(readyFeature({ components: ['UXD', 'Platform'], docsRequired: 'Required' }))
       expect(result.isReady).toBe(true)
       var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
       expect(cfItem.pass).toBe(true)
     })
 
-    it('cross-functional passes with doc component', function() {
-      var result = computeReadiness(readyFeature({ components: ['Documentation'], docsRequired: null }))
+    it('cross-functional passes with Documentation and UXD components', function() {
+      var result = computeReadiness(readyFeature({ components: ['Documentation', 'UXD'], docsRequired: null }))
       expect(result.isReady).toBe(true)
       var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
       expect(cfItem.pass).toBe(true)
+    })
+
+    it('cross-functional fails with only Documentation, no UXD', function() {
+      var result = computeReadiness(readyFeature({ components: ['Documentation', 'Platform'], docsRequired: null }))
+      var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+      expect(cfItem.pass).toBe(false)
+      expect(cfItem.detail).toContain('missing UXD component')
+    })
+
+    it('cross-functional fails with only UXD, no Documentation or docsRequired', function() {
+      var result = computeReadiness(readyFeature({ components: ['UXD', 'Platform'], docsRequired: null }))
+      var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+      expect(cfItem.pass).toBe(false)
+      expect(cfItem.detail).toContain('missing Documentation component')
+    })
+
+    it('cross-functional fails with no Documentation, no UXD, no docsRequired', function() {
+      var result = computeReadiness(readyFeature({ components: ['Platform'], docsRequired: null }))
+      var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+      expect(cfItem.pass).toBe(false)
+      expect(cfItem.detail).toContain('missing Documentation')
+      expect(cfItem.detail).toContain('missing UXD')
     })
 
     // --- Requirements Clarity tests ---
@@ -1734,7 +1758,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1856,7 +1880,7 @@ describe('buildFeatureReadiness', function() {
       })
       var healthCache = {
         features: [
-          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' },
+          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' },
           { key: 'AIPCC-1000', summary: 'AIPCC Ready', status: 'In Progress', priority: 'Major', deliveryOwner: 'Alice', blockerCount: 0, targetRelease: 'rhoai-3.6' }
         ]
       }
@@ -1880,7 +1904,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var registryData = {
         releases: [
           { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: ['RHOAI-3.6'], state: 'active', milestones: {} }
@@ -1930,7 +1954,7 @@ describe('buildFeatureReadiness', function() {
       })
       var directViolations = [{ id: 'stale-status-summary', name: 'Direct', category: 'timeliness', message: 'Direct' }]
       var aliasViolations = [{ id: 'missing-assignee', name: 'Alias', category: 'ownership', message: 'Alias' }]
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'UXD', 'Platform'], docsRequired: 'Required' }] }
       var registryData = {
         releases: [
           { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: [], state: 'active', milestones: {} }

--- a/modules/releases/server/planning/fpdor.js
+++ b/modules/releases/server/planning/fpdor.js
@@ -30,15 +30,27 @@ function hasComponents(feature) {
   return Array.isArray(comps) ? comps.length > 0 : !!(comps && String(comps).trim())
 }
 
-function hasCrossFunctional(feature) {
+function hasDocsEngagement(feature) {
   if (feature.docsRequired && feature.docsRequired !== 'No') return true
   var comps = feature.components || []
   if (!Array.isArray(comps)) return false
-  if (comps.length > 1) return true
   for (var i = 0; i < comps.length; i++) {
-    if (comps[i] && comps[i].toLowerCase().indexOf('doc') !== -1) return true
+    if (comps[i] && comps[i] === 'Documentation') return true
   }
   return false
+}
+
+function hasUxdEngagement(feature) {
+  var comps = feature.components || []
+  if (!Array.isArray(comps)) return false
+  for (var i = 0; i < comps.length; i++) {
+    if (comps[i] && comps[i] === 'UXD') return true
+  }
+  return false
+}
+
+function hasCrossFunctional(feature) {
+  return hasDocsEngagement(feature) && hasUxdEngagement(feature)
 }
 
 function hasRequirementsClarity(feature, rubricData) {
@@ -115,8 +127,13 @@ function ownersDetail(feature) {
   return parts.join(', ') || null
 }
 
-function crossFunctionalDetail(_feature) {
-  return 'No cross-functional engagement (add docs component, set docsRequired, or add multiple components)'
+function crossFunctionalDetail(feature) {
+  var hasDocs = hasDocsEngagement(feature)
+  var hasUxd = hasUxdEngagement(feature)
+  var parts = []
+  if (!hasDocs) parts.push('missing Documentation component or docsRequired')
+  if (!hasUxd) parts.push('missing UXD component')
+  return parts.join('; ') || null
 }
 
 function requirementsDetail(feature, rubricData) {
@@ -169,6 +186,8 @@ module.exports = {
   hasOwners: hasOwners,
   hasComponents: hasComponents,
   hasCrossFunctional: hasCrossFunctional,
+  hasDocsEngagement: hasDocsEngagement,
+  hasUxdEngagement: hasUxdEngagement,
   hasRequirementsClarity: hasRequirementsClarity,
   RUBRIC_PASS_THRESHOLD: RUBRIC_PASS_THRESHOLD
 }


### PR DESCRIPTION
## Summary
- **Cross-functional Engagement** FPDoR checklist item now requires **both** Documentation support AND UXD support to pass (was incorrectly passing with just multiple components or any doc-like component)
- Documentation support: `Documentation` component present OR `docsRequired` field set to a value other than "No"
- UXD support: `UXD` component present
- Detail message now reports which specific engagement is missing (e.g., "missing UXD component" or "missing Documentation component or docsRequired")

## Files Changed
| File | Change |
|------|--------|
| `modules/releases/server/planning/fpdor.js` | Split `hasCrossFunctional` into `hasDocsEngagement` + `hasUxdEngagement` (AND logic), update detail function |
| `modules/releases/server/planning/__tests__/feature-readiness.test.js` | Update `readyFeature` default to include UXD, add 4 new test cases for docs/UXD combinations |
| `modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js` | Add UXD to test fixtures, add test for missing-UXD failure case |

## Test plan
- [x] 3678 tests pass across 167 test files
- [x] ESLint clean on all modified files
- [x] Tests verify: passes with both Documentation+UXD, fails with only Documentation, fails with only UXD, fails with neither, docsRequired+UXD is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)