### PR TITLE
fix(fpdor): realign FPDoR to 11-item discrete checklist

### DIFF
--- a/modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js
+++ b/modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js
@@ -44,38 +44,40 @@ describe('FPDoR in health pipeline', function() {
     expect(result.features).toHaveLength(1)
     var f = result.features[0]
     expect(f.fpdor).toBeDefined()
-    expect(f.fpdor.items).toHaveLength(10)
-    expect(f.fpdor.totalCount).toBe(10)
+    expect(f.fpdor.items).toHaveLength(11)
+    expect(f.fpdor.totalCount).toBe(11)
     expect(typeof f.fpdor.passedCount).toBe('number')
     expect(typeof f.fpdor.evaluatedCount).toBe('number')
   })
 
-  it('has 6 jira items and 3 strat-pipeline items', async function() {
+  it('all 11 items have source jira', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
     var jiraItems = items.filter(function(i) { return i.source === 'jira' })
-    var rubricItems = items.filter(function(i) { return i.source === 'strat-pipeline' })
-    expect(jiraItems).toHaveLength(7)
-    expect(rubricItems).toHaveLength(3)
+    expect(jiraItems).toHaveLength(11)
   })
 
-  it('marks rubric items as not-evaluated when no execution detail has scores', async function() {
+  it('pipeline-backed items fail when no execution detail has scores', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var rubricItems = items.filter(function(i) { return i.source === 'strat-pipeline' })
-    for (var i = 0; i < rubricItems.length; i++) {
-      expect(rubricItems[i].state).toBe('not-evaluated')
-      expect(rubricItems[i].pass).toBeNull()
-    }
+    var acItem = items.find(function(i) { return i.name === 'Acceptance Criteria' })
+    var archItem = items.find(function(i) { return i.name === 'Architectural Alignment' })
+    var riskItem = items.find(function(i) { return i.name === 'Risks & Assumptions' })
+    expect(acItem.state).toBe('failed')
+    expect(acItem.pass).toBe(false)
+    expect(archItem.state).toBe('failed')
+    expect(archItem.pass).toBe(false)
+    expect(riskItem.state).toBe('failed')
+    expect(riskItem.pass).toBe(false)
   })
 
-  it('evaluates rubric items when execution detail file has aiReview.scores', async function() {
+  it('pipeline-backed items pass when execution detail has high scores', async function() {
     var candidatesData = makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: ['Dashboard'], fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ])
@@ -92,11 +94,15 @@ describe('FPDoR in health pipeline', function() {
     var storage = makeStorage(candidatesData)
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var rubricItems = items.filter(function(i) { return i.source === 'strat-pipeline' })
-    for (var i = 0; i < rubricItems.length; i++) {
-      expect(rubricItems[i].state).toBe('passed')
-      expect(rubricItems[i].pass).toBe(true)
-    }
+    var acItem = items.find(function(i) { return i.name === 'Acceptance Criteria' })
+    var archItem = items.find(function(i) { return i.name === 'Architectural Alignment' })
+    var riskItem = items.find(function(i) { return i.name === 'Risks & Assumptions' })
+    expect(acItem.state).toBe('passed')
+    expect(acItem.pass).toBe(true)
+    expect(archItem.state).toBe('passed')
+    expect(archItem.pass).toBe(true)
+    expect(riskItem.state).toBe('passed')
+    expect(riskItem.pass).toBe(true)
   })
 
   it('includes scores in health cache output when bridged from execution', async function() {
@@ -119,7 +125,7 @@ describe('FPDoR in health pipeline', function() {
     expect(f.scores).toEqual({ feasibility: 1, testability: 0, scope: 2, architecture: 1 })
   })
 
-  it('fails rubric items when execution scores are below threshold', async function() {
+  it('fails pipeline-backed items when execution scores are below threshold', async function() {
     var candidatesData = makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: ['Dashboard'], fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ])
@@ -137,14 +143,14 @@ describe('FPDoR in health pipeline', function() {
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
     var acItem = items.find(function(i) { return i.name === 'Acceptance Criteria' })
-    var archItem = items.find(function(i) { return i.name === 'Architecture Review' })
+    var archItem = items.find(function(i) { return i.name === 'Architectural Alignment' })
     var riskItem = items.find(function(i) { return i.name === 'Risks & Assumptions' })
     expect(acItem.pass).toBe(false)
     expect(archItem.pass).toBe(false)
     expect(riskItem.pass).toBe(false)
   })
 
-  it('passes components check when components are set', async function() {
+  it('passes cross-functional check when multiple non-doc components', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
@@ -153,23 +159,23 @@ describe('FPDoR in health pipeline', function() {
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var compItem = items.find(function(i) { return i.name === 'Components' })
-    expect(compItem.pass).toBe(true)
-    expect(compItem.state).toBe('passed')
+    var cfItem = items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+    expect(cfItem.pass).toBe(true)
+    expect(cfItem.state).toBe('passed')
   })
 
-  it('fails components check when components empty', async function() {
+  it('fails cross-functional check when single component', async function() {
     var storage = makeStorage(makeCandidatesCache([
-      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
+      { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: ['Dashboard'], fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var compItem = items.find(function(i) { return i.name === 'Components' })
-    expect(compItem.pass).toBe(false)
-    expect(compItem.state).toBe('failed')
+    var cfItem = items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+    expect(cfItem.pass).toBe(false)
+    expect(cfItem.state).toBe('failed')
   })
 
-  it('passes owner check when both delivery owner and PM are set', async function() {
+  it('passes assignee check when deliveryOwner is set', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
@@ -178,39 +184,66 @@ describe('FPDoR in health pipeline', function() {
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var ownerItem = items.find(function(i) { return i.name === 'Assignee + PM' })
-    expect(ownerItem.pass).toBe(true)
+    var assigneeItem = items.find(function(i) { return i.name === 'Assignee' })
+    expect(assigneeItem.pass).toBe(true)
   })
 
-  it('fails owner check when PM is missing', async function() {
+  it('passes PM check when pm is set', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      {
+        issueKey: 'T-1', summary: 'F1', status: 'In Progress',
+        components: '', fixVersion: '', deliveryOwner: 'Jane', pm: 'Rick', tier: 1
+      }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    var items = result.features[0].fpdor.items
+    var pmItem = items.find(function(i) { return i.name === 'PM Assigned' })
+    expect(pmItem.pass).toBe(true)
+  })
+
+  it('fails PM check when pm is missing', async function() {
     var storage = makeStorage(makeCandidatesCache([
       { issueKey: 'T-1', summary: 'F1', status: 'In Progress', components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1 }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var ownerItem = items.find(function(i) { return i.name === 'Assignee + PM' })
-    expect(ownerItem.pass).toBe(false)
+    var pmItem = items.find(function(i) { return i.name === 'PM Assigned' })
+    expect(pmItem.pass).toBe(false)
   })
 
-  it('passes target version check when targetRelease and phase are set', async function() {
+  it('passes target version check when targetRelease is set', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
         components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1,
-        targetRelease: '3.5', phase: 'GA'
+        targetRelease: '3.5'
       }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var items = result.features[0].fpdor.items
-    var tvItem = items.find(function(i) { return i.name === 'Target Version + Release Type' })
+    var tvItem = items.find(function(i) { return i.name === 'Target Version' })
     expect(tvItem.pass).toBe(true)
   })
 
-  it('passes cross-functional check when Documentation component present', async function() {
+  it('passes release type check when phase is set', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
-        components: ['Dashboard', 'Documentation'], fixVersion: '', deliveryOwner: 'Jane', tier: 1
+        components: '', fixVersion: '', deliveryOwner: 'Jane', tier: 1,
+        phase: 'GA'
+      }
+    ]))
+    var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
+    var items = result.features[0].fpdor.items
+    var rtItem = items.find(function(i) { return i.name === 'Release Type' })
+    expect(rtItem.pass).toBe(true)
+  })
+
+  it('passes cross-functional check when Documentation present with >= 3 components', async function() {
+    var storage = makeStorage(makeCandidatesCache([
+      {
+        issueKey: 'T-1', summary: 'F1', status: 'In Progress',
+        components: ['Dashboard', 'Documentation', 'API'], fixVersion: '', deliveryOwner: 'Jane', tier: 1
       }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
@@ -219,25 +252,25 @@ describe('FPDoR in health pipeline', function() {
     expect(cfItem.pass).toBe(true)
   })
 
-  it('passes 4 of 6 jira items with correct candidate data (no enrichment)', async function() {
+  it('passes 5 of 11 jira items with correct candidate data (no enrichment)', async function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
-        components: ['Dashboard', 'Documentation'], fixVersion: '', deliveryOwner: 'Jane',
+        components: ['Dashboard', 'Documentation', 'API'], fixVersion: '', deliveryOwner: 'Jane',
         pm: 'Rick', tier: 1, targetRelease: '3.5', phase: 'GA'
       }
     ]))
     var result = await runHealthPipeline('3.5', storage.readFromStorage, storage.writeToStorage, vi.fn(), vi.fn())
     var fpdor = result.features[0].fpdor
-    expect(fpdor.evaluatedCount).toBe(7)
-    expect(fpdor.passedCount).toBe(4)
+    expect(fpdor.evaluatedCount).toBe(11)
     var passed = fpdor.items.filter(function(i) { return i.pass === true })
     var passedNames = passed.map(function(i) { return i.name }).sort()
     expect(passedNames).toEqual([
-      'Assignee + PM',
-      'Components',
+      'Assignee',
       'Cross-functional Engagement',
-      'Target Version + Release Type'
+      'PM Assigned',
+      'Release Type',
+      'Target Version'
     ])
   })
 
@@ -245,7 +278,7 @@ describe('FPDoR in health pipeline', function() {
     var storage = makeStorage(makeCandidatesCache([
       {
         issueKey: 'T-1', summary: 'F1', status: 'In Progress',
-        components: ['Dashboard', 'Documentation'], fixVersion: '', deliveryOwner: 'Jane',
+        components: ['Dashboard', 'Documentation', 'API'], fixVersion: '', deliveryOwner: 'Jane',
         pm: 'Rick', tier: 1, targetRelease: '3.5', phase: 'GA'
       },
       {

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -34,7 +34,7 @@ function makeLatest(overrides) {
     scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2 },
     reviewers: { feasibility: 'approve', testability: 'approve', scope: 'approve', architecture: 'approve' },
     reviewedAt: '2026-01-01T00:00:00.000Z',
-    components: ['Documentation', 'Platform'],
+    components: ['Platform', 'Serving'],
     approvedBy: null,
     approvedAt: null,
     riceScore: 100,
@@ -656,7 +656,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -719,7 +719,7 @@ describe('buildFeatureReadiness', function() {
       var candidateCache = {
         data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, fixVersion: '3.6.0', targetRelease: 'rhoai-3.6' }] }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -734,7 +734,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -800,7 +800,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -840,7 +840,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -963,7 +963,7 @@ describe('buildFeatureReadiness', function() {
           ]
         }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6,
@@ -1061,7 +1061,7 @@ describe('buildFeatureReadiness', function() {
           storyPoints: 5,
           epicCount: 3,
           releaseType: 'GA',
-          components: ['Documentation', 'Platform'],
+          components: ['Platform', 'Serving'],
           docsRequired: 'Required'
         }]
       }
@@ -1087,7 +1087,7 @@ describe('buildFeatureReadiness', function() {
         data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'AI Speed', targetRelease: 'rhoai-3.6-cand', fixVersion: '3.6.0-cand' }] }
       }
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', tier: 'T3', bigRock: 'Platform', targetRelease: 'rhoai-3.6-health', fixVersions: '3.6.0-health', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', tier: 'T3', bigRock: 'Platform', targetRelease: 'rhoai-3.6-health', fixVersions: '3.6.0-health', deliveryOwner: 'Alice', pmOwner: 'Jane', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1129,7 +1129,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 87, priorityBreakdown: { rice: 50, bigRock: 100 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 87, priorityBreakdown: { rice: 50, bigRock: 100 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1171,7 +1171,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: { rice: 60 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', priorityScore: 70, priorityBreakdown: { rice: 60 }, deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1246,7 +1246,7 @@ describe('buildFeatureReadiness', function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'wrong-owner', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'wrong-owner', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var hygieneCache = { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Real Team' } } }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1270,7 +1270,7 @@ describe('buildFeatureReadiness', function() {
       })
       var healthCache = {
         features: [
-          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' },
+          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' },
           { key: 'RHAISTRAT-2', priorityScore: null },
           { key: 'RHAISTRAT-3', priorityScore: null }
         ]
@@ -1421,8 +1421,8 @@ describe('buildFeatureReadiness', function() {
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': config,
-        'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.5', priorityScore: 80, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] },
-        'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', deliveryOwner: 'Bob', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 60, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+        'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.5', priorityScore: 80, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] },
+        'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', deliveryOwner: 'Bob', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 60, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       })
       var result = buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(2)
@@ -1475,11 +1475,11 @@ describe('buildFeatureReadiness', function() {
         releaseType: 'GA',
         deliveryOwner: 'Alice',
         pmOwner: 'Jane',
-        components: ['Documentation', 'Platform'],
+        components: ['Platform', 'Serving'],
         docsRequired: 'Required',
         effort: 5,
         scores: { testability: 2, architecture: 2, feasibility: 2, scope: 2 },
-        descriptionSignals: { hasContent: true, signalCount: 3, hasAcceptanceCriteria: true, hasUseCases: true, hasScopeDefinition: true, hasRequirements: false, hasRisks: false },
+        descriptionSignals: { hasContent: true, signalCount: 3, hasAcceptanceCriteria: true, hasUseCases: true, hasScopeDefinition: true, hasRequirements: false, hasRisks: true, hasArchitectureSignal: true },
         status: 'In Progress',
         violations: null
       }, overrides)
@@ -1503,8 +1503,8 @@ describe('buildFeatureReadiness', function() {
       expect(result.gates.fpDorPassed).toBeLessThan(result.gates.fpDorEvaluated)
     })
 
-    it('returns isReady=false when no sizing (storyPoints=0 and epicCount=0)', function() {
-      var result = computeReadiness(readyFeature({ storyPoints: 0, epicCount: 0 }))
+    it('returns isReady=false when scope not defined (no sizing, no breakdown)', function() {
+      var result = computeReadiness(readyFeature({ storyPoints: 0, epicCount: 0, effort: null, tshirtSize: null, scores: {} }))
       expect(result.isReady).toBe(false)
     })
 
@@ -1590,48 +1590,66 @@ describe('buildFeatureReadiness', function() {
       }
     })
 
-    // --- Sizing AND logic tests ---
+    // --- Scope Defined tests ---
 
-    it('sizing fails when has storyPoints but no epicCount (AND logic)', function() {
-      var result = computeReadiness(readyFeature({ storyPoints: 5, epicCount: 0 }))
-      expect(result.isReady).toBe(false)
-      var sizingItem = result.fpdor.items.find(function(i) { return i.name === 'Sizing & Breakdown' })
-      expect(sizingItem.pass).toBe(false)
-      expect(sizingItem.detail).toContain('child work items')
+    it('scope defined passes with epicCount > 0 (no pipeline)', function() {
+      var result = computeReadiness(readyFeature({ scores: {}, epicCount: 3, storyPoints: 0 }))
+      var scopeItem = result.fpdor.items.find(function(i) { return i.name === 'Scope Defined' })
+      expect(scopeItem.pass).toBe(true)
     })
 
-    it('sizing passes with effort + epicCount', function() {
-      var result = computeReadiness(readyFeature({ storyPoints: 0, effort: 5, epicCount: 3 }))
-      expect(result.isReady).toBe(true)
-      var sizingItem = result.fpdor.items.find(function(i) { return i.name === 'Sizing & Breakdown' })
-      expect(sizingItem.pass).toBe(true)
+    it('scope defined passes with storyPoints > 0 (no pipeline)', function() {
+      var result = computeReadiness(readyFeature({ scores: {}, epicCount: 0, storyPoints: 5 }))
+      var scopeItem = result.fpdor.items.find(function(i) { return i.name === 'Scope Defined' })
+      expect(scopeItem.pass).toBe(true)
     })
 
-    it('sizing passes with tshirtSize + epicCount', function() {
-      var result = computeReadiness(readyFeature({ storyPoints: 0, tshirtSize: 'L', epicCount: 2 }))
-      expect(result.isReady).toBe(true)
-      var sizingItem = result.fpdor.items.find(function(i) { return i.name === 'Sizing & Breakdown' })
-      expect(sizingItem.pass).toBe(true)
+    it('scope defined passes with effort > 0 (no pipeline)', function() {
+      var result = computeReadiness(readyFeature({ scores: {}, epicCount: 0, storyPoints: 0, effort: 5 }))
+      var scopeItem = result.fpdor.items.find(function(i) { return i.name === 'Scope Defined' })
+      expect(scopeItem.pass).toBe(true)
     })
 
-    it('sizing detail shows both missing when no size and no breakdown', function() {
-      var result = computeReadiness(readyFeature({ storyPoints: 0, effort: null, tshirtSize: null, epicCount: 0 }))
-      var sizingItem = result.fpdor.items.find(function(i) { return i.name === 'Sizing & Breakdown' })
-      expect(sizingItem.detail).toContain('No sizing and no child work items')
+    it('scope defined passes with tshirtSize (no pipeline)', function() {
+      var result = computeReadiness(readyFeature({ scores: {}, epicCount: 0, storyPoints: 0, tshirtSize: 'L' }))
+      var scopeItem = result.fpdor.items.find(function(i) { return i.name === 'Scope Defined' })
+      expect(scopeItem.pass).toBe(true)
+    })
+
+    it('scope defined fails when no epicCount and no sizing (no pipeline)', function() {
+      var result = computeReadiness(readyFeature({ scores: {}, epicCount: 0, storyPoints: 0, effort: null, tshirtSize: null }))
+      var scopeItem = result.fpdor.items.find(function(i) { return i.name === 'Scope Defined' })
+      expect(scopeItem.pass).toBe(false)
+    })
+
+    it('scope defined passes with scope score >= 2 (pipeline)', function() {
+      var result = computeReadiness(readyFeature({ scores: { scope: 2, testability: 2, architecture: 2, feasibility: 2 } }))
+      var scopeItem = result.fpdor.items.find(function(i) { return i.name === 'Scope Defined' })
+      expect(scopeItem.pass).toBe(true)
     })
 
     // --- Cross-functional tests ---
 
-    it('cross-functional passes with docsRequired', function() {
-      var result = computeReadiness(readyFeature({ components: ['Platform'], docsRequired: 'Required' }))
-      expect(result.isReady).toBe(true)
+    it('cross-functional passes with 2 non-doc components', function() {
+      var result = computeReadiness(readyFeature({ components: ['Platform', 'Serving'] }))
       var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
       expect(cfItem.pass).toBe(true)
     })
 
-    it('cross-functional passes with doc component', function() {
-      var result = computeReadiness(readyFeature({ components: ['Documentation'], docsRequired: null }))
-      expect(result.isReady).toBe(true)
+    it('cross-functional fails with single component', function() {
+      var result = computeReadiness(readyFeature({ components: ['Platform'] }))
+      var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+      expect(cfItem.pass).toBe(false)
+    })
+
+    it('cross-functional fails with Documentation + 1 other (need >= 3)', function() {
+      var result = computeReadiness(readyFeature({ components: ['Documentation', 'Platform'] }))
+      var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
+      expect(cfItem.pass).toBe(false)
+    })
+
+    it('cross-functional passes with Documentation + 2 others (>= 3)', function() {
+      var result = computeReadiness(readyFeature({ components: ['Documentation', 'Platform', 'Serving'] }))
       var cfItem = result.fpdor.items.find(function(i) { return i.name === 'Cross-functional Engagement' })
       expect(cfItem.pass).toBe(true)
     })
@@ -1662,10 +1680,10 @@ describe('buildFeatureReadiness', function() {
       expect(reqItem.pass).toBe(false)
     })
 
-    it('FPDoR has 10 items total', function() {
+    it('FPDoR has 11 items total', function() {
       var result = computeReadiness(readyFeature())
-      expect(result.fpdor.items.length).toBe(10)
-      expect(result.fpdor.totalCount).toBe(10)
+      expect(result.fpdor.items.length).toBe(11)
+      expect(result.fpdor.totalCount).toBe(11)
     })
   })
 
@@ -1734,7 +1752,7 @@ describe('buildFeatureReadiness', function() {
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var healthCache = {
-        features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }]
+        features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }]
       }
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store),
@@ -1856,7 +1874,7 @@ describe('buildFeatureReadiness', function() {
       })
       var healthCache = {
         features: [
-          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' },
+          { key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 70, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' },
           { key: 'AIPCC-1000', summary: 'AIPCC Ready', status: 'In Progress', priority: 'Major', deliveryOwner: 'Alice', blockerCount: 0, targetRelease: 'rhoai-3.6' }
         ]
       }
@@ -1880,7 +1898,7 @@ describe('buildFeatureReadiness', function() {
       var hygieneCache = {
         features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha', violations: violations } }
       }
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var registryData = {
         releases: [
           { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: ['RHOAI-3.6'], state: 'active', milestones: {} }
@@ -1930,7 +1948,7 @@ describe('buildFeatureReadiness', function() {
       })
       var directViolations = [{ id: 'stale-status-summary', name: 'Direct', category: 'timeliness', message: 'Direct' }]
       var aliasViolations = [{ id: 'missing-assignee', name: 'Alias', category: 'ownership', message: 'Alias' }]
-      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Documentation', 'Platform'], docsRequired: 'Required' }] }
+      var healthCache = { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: null, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving'], docsRequired: 'Required' }] }
       var registryData = {
         releases: [
           { id: 'rhoai-3.6', displayName: 'RHOAI 3.6', fixVersions: [], state: 'active', milestones: {} }

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -105,7 +105,7 @@ function computeReadiness(feature) {
   var noBlockingViolations = !hasBlockingViolations(feature.violations)
 
   var isReady = fpdor.passedCount === fpdor.evaluatedCount
-    && fpdor.evaluatedCount >= 6
+    && fpdor.evaluatedCount >= 7
     && pastRefinement
     && noBlockingViolations
 

--- a/modules/releases/server/planning/fpdor.js
+++ b/modules/releases/server/planning/fpdor.js
@@ -4,43 +4,6 @@ function hasRiceScore(feature) {
   return feature.riceScore != null && feature.riceScore > 0
 }
 
-function hasSizing(feature) {
-  var hasSize = (feature.storyPoints != null && feature.storyPoints > 0)
-    || !!feature.tshirtSize
-    || (feature.effort != null && feature.effort > 0)
-  var hasBreakdown = feature.epicCount != null && feature.epicCount > 0
-  return hasSize && hasBreakdown
-}
-
-function hasTargetAndReleaseType(feature) {
-  var tvs = feature.targetVersions || []
-  var hasTarget = tvs.length > 0
-  var hasReleaseType = !!(feature.releaseType || feature.phase)
-  return hasTarget && hasReleaseType
-}
-
-function hasOwners(feature) {
-  var hasDelivery = !!(feature.deliveryOwner || feature.assignee)
-  var hasPM = !!(feature.pmOwner || feature.pm)
-  return hasDelivery && hasPM
-}
-
-function hasComponents(feature) {
-  var comps = feature.components || []
-  return Array.isArray(comps) ? comps.length > 0 : !!(comps && String(comps).trim())
-}
-
-function hasCrossFunctional(feature) {
-  if (feature.docsRequired && feature.docsRequired !== 'No') return true
-  var comps = feature.components || []
-  if (!Array.isArray(comps)) return false
-  if (comps.length > 1) return true
-  for (var i = 0; i < comps.length; i++) {
-    if (comps[i] && comps[i].toLowerCase().indexOf('doc') !== -1) return true
-  }
-  return false
-}
-
 function hasRequirementsClarity(feature, rubricData) {
   if (rubricData && rubricData.scored && rubricData.scope != null) {
     return rubricData.scope >= RUBRIC_PASS_THRESHOLD
@@ -50,6 +13,78 @@ function hasRequirementsClarity(feature, rubricData) {
     return signals.signalCount >= 2
   }
   return false
+}
+
+function hasAcceptanceCriteria(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.testability != null) {
+    return rubricData.testability >= RUBRIC_PASS_THRESHOLD
+  }
+  var signals = feature.descriptionSignals
+  if (signals && signals.hasContent) {
+    return !!signals.hasAcceptanceCriteria
+  }
+  return false
+}
+
+function hasScopeDefined(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.scope != null) {
+    return rubricData.scope >= RUBRIC_PASS_THRESHOLD
+  }
+  var hasBreakdown = feature.epicCount != null && feature.epicCount > 0
+  var hasSizing = (feature.storyPoints != null && feature.storyPoints > 0)
+    || !!feature.tshirtSize
+    || (feature.effort != null && feature.effort > 0)
+  return hasBreakdown || hasSizing
+}
+
+function hasArchitecturalAlignment(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.architecture != null) {
+    return rubricData.architecture >= RUBRIC_PASS_THRESHOLD
+  }
+  var signals = feature.descriptionSignals
+  if (signals && signals.hasContent) {
+    return !!signals.hasArchitectureSignal
+  }
+  return false
+}
+
+function hasRisksAndAssumptions(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.feasibility != null) {
+    return rubricData.feasibility >= RUBRIC_PASS_THRESHOLD
+  }
+  var signals = feature.descriptionSignals
+  if (signals && signals.hasContent) {
+    return !!signals.hasRisks
+  }
+  return false
+}
+
+function hasCrossFunctionalEngagement(feature) {
+  var comps = feature.components || []
+  if (!Array.isArray(comps)) return false
+  var hasDocumentation = false
+  for (var i = 0; i < comps.length; i++) {
+    if (comps[i] && comps[i] === 'Documentation') hasDocumentation = true
+  }
+  if (hasDocumentation) return comps.length >= 3
+  return comps.length > 1
+}
+
+function hasReleaseType(feature) {
+  return !!(feature.releaseType || feature.phase)
+}
+
+function hasTargetVersion(feature) {
+  var tvs = feature.targetVersions || []
+  return tvs.length > 0
+}
+
+function hasAssignee(feature) {
+  return !!(feature.deliveryOwner || feature.assignee)
+}
+
+function hasPmAssigned(feature) {
+  return !!(feature.pmOwner || feature.pm)
 }
 
 function extractRubricData(feature) {
@@ -67,14 +102,6 @@ function extractRubricData(feature) {
   }
 }
 
-function evalRubricItem(name, rubricData, dimension, detail) {
-  if (!rubricData || !rubricData.scored || rubricData[dimension] == null) {
-    return { name: name, pass: null, source: 'strat-pipeline', state: 'not-evaluated', detail: 'No rubric data available' }
-  }
-  var passed = rubricData[dimension] >= RUBRIC_PASS_THRESHOLD
-  return { name: name, pass: passed, source: 'strat-pipeline', state: passed ? 'passed' : 'failed', detail: passed ? null : (detail || 'Score below threshold (' + rubricData[dimension] + '/' + RUBRIC_PASS_THRESHOLD + ')') }
-}
-
 function evalJiraItem(name, passed, detail) {
   return { name: name, pass: passed, source: 'jira', state: passed ? 'passed' : 'failed', detail: passed ? null : (detail || null) }
 }
@@ -85,38 +112,16 @@ function riceDetail(feature) {
   return null
 }
 
-function sizingDetail(feature) {
-  var hasSize = (feature.storyPoints != null && feature.storyPoints > 0)
+function scopeDetail(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.scope != null) {
+    return 'Scope score below threshold (' + rubricData.scope + '/' + RUBRIC_PASS_THRESHOLD + ')'
+  }
+  var hasBreakdown = feature.epicCount != null && feature.epicCount > 0
+  var hasSizing = (feature.storyPoints != null && feature.storyPoints > 0)
     || !!feature.tshirtSize
     || (feature.effort != null && feature.effort > 0)
-  var hasBreakdown = feature.epicCount != null && feature.epicCount > 0
-  if (!hasSize && !hasBreakdown) return 'No sizing and no child work items'
-  if (!hasSize) return 'No sizing (set story points, t-shirt size, or effort)'
-  if (!hasBreakdown) return 'No child work items (create child epics)'
+  if (!hasBreakdown && !hasSizing) return 'No child epics and no sizing (story points, t-shirt size, or effort)'
   return null
-}
-
-function targetDetail(feature) {
-  var tvs = feature.targetVersions || []
-  var hasTarget = tvs.length > 0
-  var hasReleaseType = !!(feature.releaseType || feature.phase)
-  var parts = []
-  if (!hasTarget) parts.push('missing target version')
-  if (!hasReleaseType) parts.push('missing release type')
-  return parts.join(', ') || null
-}
-
-function ownersDetail(feature) {
-  var hasDelivery = !!(feature.deliveryOwner || feature.assignee)
-  var hasPM = !!(feature.pmOwner || feature.pm)
-  var parts = []
-  if (!hasDelivery) parts.push('no assignee')
-  if (!hasPM) parts.push('no PM assigned')
-  return parts.join(', ') || null
-}
-
-function crossFunctionalDetail(_feature) {
-  return 'No cross-functional engagement (add docs component, set docsRequired, or add multiple components)'
 }
 
 function requirementsDetail(feature, rubricData) {
@@ -130,18 +135,52 @@ function requirementsDetail(feature, rubricData) {
   return 'No requirements clarity data available'
 }
 
+function acceptanceCriteriaDetail(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.testability != null) {
+    return 'Testability score below threshold (' + rubricData.testability + '/' + RUBRIC_PASS_THRESHOLD + ')'
+  }
+  return 'No acceptance criteria found in description'
+}
+
+function architectureDetail(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.architecture != null) {
+    return 'Architecture score below threshold (' + rubricData.architecture + '/' + RUBRIC_PASS_THRESHOLD + ')'
+  }
+  return 'No architecture review signals in description'
+}
+
+function risksDetail(feature, rubricData) {
+  if (rubricData && rubricData.scored && rubricData.feasibility != null) {
+    return 'Feasibility score below threshold (' + rubricData.feasibility + '/' + RUBRIC_PASS_THRESHOLD + ')'
+  }
+  return 'No risks or assumptions documented in description'
+}
+
+function crossFunctionalDetail(feature) {
+  var comps = feature.components || []
+  if (!Array.isArray(comps) || comps.length === 0) return 'No components assigned'
+  var hasDocumentation = false
+  for (var i = 0; i < comps.length; i++) {
+    if (comps[i] && comps[i] === 'Documentation') hasDocumentation = true
+  }
+  if (hasDocumentation && comps.length < 3) return 'Documentation present but need at least 3 components (have ' + comps.length + ')'
+  if (comps.length <= 1) return 'Only 1 component assigned; need more than 1 for cross-functional engagement'
+  return null
+}
+
 function computeFPDoRReadiness(feature, rubricData) {
   var items = [
     evalJiraItem('Requirements Clarity', hasRequirementsClarity(feature, rubricData), requirementsDetail(feature, rubricData)),
+    evalJiraItem('Acceptance Criteria', hasAcceptanceCriteria(feature, rubricData), acceptanceCriteriaDetail(feature, rubricData)),
+    evalJiraItem('Scope Defined', hasScopeDefined(feature, rubricData), scopeDetail(feature, rubricData)),
     evalJiraItem('RICE Score', hasRiceScore(feature), riceDetail(feature)),
-    evalJiraItem('Sizing & Breakdown', hasSizing(feature), sizingDetail(feature)),
-    evalJiraItem('Target Version + Release Type', hasTargetAndReleaseType(feature), targetDetail(feature)),
-    evalJiraItem('Assignee + PM', hasOwners(feature), ownersDetail(feature)),
-    evalJiraItem('Components', hasComponents(feature), 'No components set'),
-    evalJiraItem('Cross-functional Engagement', hasCrossFunctional(feature), crossFunctionalDetail(feature)),
-    evalRubricItem('Acceptance Criteria', rubricData, 'testability'),
-    evalRubricItem('Architecture Review', rubricData, 'architecture'),
-    evalRubricItem('Risks & Assumptions', rubricData, 'feasibility')
+    evalJiraItem('Cross-functional Engagement', hasCrossFunctionalEngagement(feature), crossFunctionalDetail(feature)),
+    evalJiraItem('Architectural Alignment', hasArchitecturalAlignment(feature, rubricData), architectureDetail(feature, rubricData)),
+    evalJiraItem('Risks & Assumptions', hasRisksAndAssumptions(feature, rubricData), risksDetail(feature, rubricData)),
+    evalJiraItem('Release Type', hasReleaseType(feature), 'No release type set'),
+    evalJiraItem('Target Version', hasTargetVersion(feature), 'No target version set'),
+    evalJiraItem('Assignee', hasAssignee(feature), 'No assignee set'),
+    evalJiraItem('PM Assigned', hasPmAssigned(feature), 'No PM assigned')
   ]
 
   var passedCount = 0
@@ -154,7 +193,7 @@ function computeFPDoRReadiness(feature, rubricData) {
   return {
     items: items,
     passedCount: passedCount,
-    totalCount: 10,
+    totalCount: 11,
     evaluatedCount: evaluatedCount
   }
 }
@@ -162,14 +201,16 @@ function computeFPDoRReadiness(feature, rubricData) {
 module.exports = {
   computeFPDoRReadiness: computeFPDoRReadiness,
   extractRubricData: extractRubricData,
-  evalRubricItem: evalRubricItem,
   hasRiceScore: hasRiceScore,
-  hasSizing: hasSizing,
-  hasTargetAndReleaseType: hasTargetAndReleaseType,
-  hasOwners: hasOwners,
-  hasComponents: hasComponents,
-  hasCrossFunctional: hasCrossFunctional,
+  hasScopeDefined: hasScopeDefined,
   hasRequirementsClarity: hasRequirementsClarity,
+  hasAcceptanceCriteria: hasAcceptanceCriteria,
+  hasArchitecturalAlignment: hasArchitecturalAlignment,
+  hasRisksAndAssumptions: hasRisksAndAssumptions,
+  hasCrossFunctionalEngagement: hasCrossFunctionalEngagement,
+  hasReleaseType: hasReleaseType,
+  hasTargetVersion: hasTargetVersion,
+  hasAssignee: hasAssignee,
+  hasPmAssigned: hasPmAssigned,
   RUBRIC_PASS_THRESHOLD: RUBRIC_PASS_THRESHOLD
 }
-

--- a/modules/releases/server/planning/health/description-scanner.js
+++ b/modules/releases/server/planning/health/description-scanner.js
@@ -5,9 +5,10 @@ var USE_CASE_PATTERN = /\b(use\s+case|user\s+stor|as\s+a\s+.*?\bso\s+that\b)/i
 var SCOPE_PATTERN = /\b(in\s+scope|out\s+of\s+scope|\bscope\b\s*[:=-])/i
 var REQUIREMENTS_PATTERN = /\b(requirement|HLR|NFR|non[\s-]?functional)/i
 var RISKS_PATTERN = /\b(risk|assumption|constraint|dependency|blocker)\s*[:=-]/i
+var ARCHITECTURE_PATTERN = /\b(architect|arch[\s-]?review|technical\s+design|system\s+design)\b/i
 
 function parseDescriptionSignals(description) {
-  if (!description) return { hasContent: false, hasAcceptanceCriteria: false, hasUseCases: false, hasScopeDefinition: false, hasRequirements: false, hasRisks: false, signalCount: 0 }
+  if (!description) return { hasContent: false, hasAcceptanceCriteria: false, hasUseCases: false, hasScopeDefinition: false, hasRequirements: false, hasRisks: false, hasArchitectureSignal: false, signalCount: 0 }
 
   var text
   if (typeof description === 'string') {
@@ -15,17 +16,18 @@ function parseDescriptionSignals(description) {
   } else if (description.type === 'doc') {
     text = adfToText(description)
   } else {
-    return { hasContent: false, hasAcceptanceCriteria: false, hasUseCases: false, hasScopeDefinition: false, hasRequirements: false, hasRisks: false, signalCount: 0 }
+    return { hasContent: false, hasAcceptanceCriteria: false, hasUseCases: false, hasScopeDefinition: false, hasRequirements: false, hasRisks: false, hasArchitectureSignal: false, signalCount: 0 }
   }
 
   var hasContent = text.trim().length > 0
-  if (!hasContent) return { hasContent: false, hasAcceptanceCriteria: false, hasUseCases: false, hasScopeDefinition: false, hasRequirements: false, hasRisks: false, signalCount: 0 }
+  if (!hasContent) return { hasContent: false, hasAcceptanceCriteria: false, hasUseCases: false, hasScopeDefinition: false, hasRequirements: false, hasRisks: false, hasArchitectureSignal: false, signalCount: 0 }
 
   var hasAcceptanceCriteria = AC_PATTERN.test(text)
   var hasUseCases = USE_CASE_PATTERN.test(text)
   var hasScopeDefinition = SCOPE_PATTERN.test(text)
   var hasRequirements = REQUIREMENTS_PATTERN.test(text)
   var hasRisks = RISKS_PATTERN.test(text)
+  var hasArchitectureSignal = ARCHITECTURE_PATTERN.test(text)
 
   var signalCount = 0
   if (hasAcceptanceCriteria) signalCount++
@@ -41,6 +43,7 @@ function parseDescriptionSignals(description) {
     hasScopeDefinition: hasScopeDefinition,
     hasRequirements: hasRequirements,
     hasRisks: hasRisks,
+    hasArchitectureSignal: hasArchitectureSignal,
     signalCount: signalCount
   }
 }

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -598,16 +598,16 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     expect(sample.fpdor).toHaveProperty('totalCount');
     expect(sample.fpdor).toHaveProperty('evaluatedCount');
     expect(Array.isArray(sample.fpdor.items)).toBe(true);
-    expect(sample.fpdor.totalCount).toBe(10);
-    expect(sample.fpdor.items.length).toBe(10);
+    expect(sample.fpdor.totalCount).toBe(11);
+    expect(sample.fpdor.items.length).toBe(11);
 
     var item = sample.fpdor.items[0];
     expect(item).toHaveProperty('name');
     expect(item).toHaveProperty('pass');
     expect(item).toHaveProperty('source');
     expect(item).toHaveProperty('state');
-    expect(['jira', 'strat-pipeline']).toContain(item.source);
-    expect(['passed', 'failed', 'not-evaluated']).toContain(item.state);
+    expect(item.source).toBe('jira');
+    expect(['passed', 'failed']).toContain(item.state);
 
     expect(sample).toHaveProperty('readinessGates');
     expect(sample.readinessGates).toHaveProperty('fpDorPassed');


### PR DESCRIPTION
## Summary
- Realigns FPDoR from 10 conflated items to 11 discrete 1:1 checks matching the governance document
- Replaces "Sizing & Breakdown" (AND logic) with "Scope Defined" (scope score ≥ 2 OR epicCount > 0 OR sizing indicators)
- Splits "Assignee + PM" and "Target Version + Release Type" into separate items
- Replaces cross-functional Documentation+UXD OR logic with component count > 1 (or ≥ 3 if Documentation present)
- Adds architecture keyword fallback to description-scanner.js for Architectural Alignment
- All items now use evalJiraItem() with Jira/description fallbacks — no items are ever "not-evaluated"
- Supersedes PR #1189

## Changed Files
- `modules/releases/server/planning/fpdor.js` — complete rewrite with 11 items
- `modules/releases/server/planning/health/description-scanner.js` — add ARCHITECTURE_PATTERN
- `modules/releases/server/planning/feature-readiness.js` — evaluatedCount threshold 6→7
- `modules/releases/server/planning/__tests__/feature-readiness.test.js` — updated tests
- `modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js` — updated tests

## Test plan
- [x] 222 feature-readiness tests pass
- [x] 19 health-pipeline-fpdor tests pass
- [x] 3680 total tests pass across 167 test files
- [x] Zero ESLint errors
- [x] Vue components are data-driven — no client changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)