### PR TITLE
feat(releases): add filter toolbar to Feature Tracking view

### DIFF
--- a/modules/releases/client/execute/components/FeatureTrackingTable.vue
+++ b/modules/releases/client/execute/components/FeatureTrackingTable.vue
@@ -5,7 +5,8 @@ const props = defineProps({
   groups: { type: Array, default: () => [] },
   portfolioVersion: { type: String, default: '' },
   featureFreezeDate: { type: String, default: null },
-  totalUniqueFeatures: { type: Number, default: null }
+  totalUniqueFeatures: { type: Number, default: null },
+  filteredFeatureCount: { type: Number, default: null }
 })
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse'
@@ -159,7 +160,7 @@ defineExpose({ expandAll, collapseAll })
               </svg>
               <span class="font-bold text-gray-900 dark:text-gray-100">RHAI {{ portfolioVersion }}</span>
               <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">
-                {{ totalFeatureCount() }} features
+                <template v-if="filteredFeatureCount != null && filteredFeatureCount !== totalFeatureCount()">{{ filteredFeatureCount }} of </template>{{ totalFeatureCount() }} features
               </span>
               <span
                 v-if="featureFreezeDate"

--- a/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
+++ b/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
@@ -324,26 +324,27 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     _suspendSave = true
     try {
       var raw = sessionStorage.getItem(FILTER_STORAGE_KEY + ':' + version)
-      if (!raw) return
-      var saved = JSON.parse(raw)
-      if (saved.searchQuery && typeof saved.searchQuery === 'string') {
-        searchQuery.value = saved.searchQuery.slice(0, 2000)
-      }
-      var prods = availableProducts.value
-      var stats = availableStatuses.value
-      var comps = availableComponents.value
-      var owners = availableOwners.value
-      if (Array.isArray(saved.selectedProducts)) {
-        selectedProducts.value = saved.selectedProducts.filter(function (v) { return prods.includes(v) })
-      }
-      if (Array.isArray(saved.selectedStatuses)) {
-        selectedStatuses.value = saved.selectedStatuses.filter(function (v) { return stats.includes(v) })
-      }
-      if (Array.isArray(saved.selectedComponents)) {
-        selectedComponents.value = saved.selectedComponents.filter(function (v) { return comps.includes(v) })
-      }
-      if (Array.isArray(saved.selectedOwners)) {
-        selectedOwners.value = saved.selectedOwners.filter(function (v) { return owners.includes(v) })
+      if (raw) {
+        var saved = JSON.parse(raw)
+        if (saved.searchQuery && typeof saved.searchQuery === 'string') {
+          searchQuery.value = saved.searchQuery.slice(0, 2000)
+        }
+        var prods = availableProducts.value
+        var stats = availableStatuses.value
+        var comps = availableComponents.value
+        var owners = availableOwners.value
+        if (Array.isArray(saved.selectedProducts)) {
+          selectedProducts.value = saved.selectedProducts.filter(function (v) { return prods.includes(v) })
+        }
+        if (Array.isArray(saved.selectedStatuses)) {
+          selectedStatuses.value = saved.selectedStatuses.filter(function (v) { return stats.includes(v) })
+        }
+        if (Array.isArray(saved.selectedComponents)) {
+          selectedComponents.value = saved.selectedComponents.filter(function (v) { return comps.includes(v) })
+        }
+        if (Array.isArray(saved.selectedOwners)) {
+          selectedOwners.value = saved.selectedOwners.filter(function (v) { return owners.includes(v) })
+        }
       }
     } catch { /* ignore corrupt JSON */ }
     nextTick(function () { _suspendSave = false })

--- a/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
+++ b/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
@@ -1,4 +1,4 @@
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 
 var FILTER_STORAGE_KEY = 'releases:feature-tracking-filters'
 
@@ -357,7 +357,7 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
     selectedComponents.value = []
     selectedOwners.value = []
     activeCardFilter.value = null
-    _suspendSave = false
+    nextTick(function () { _suspendSave = false })
   }
 
   watch(

--- a/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
+++ b/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
@@ -1,0 +1,399 @@
+import { ref, computed, watch } from 'vue'
+
+var FILTER_STORAGE_KEY = 'releases:feature-tracking-filters'
+
+export function useFeatureTrackingFilters(groups, selectedVersion) {
+  var searchQuery = ref('')
+  var selectedProducts = ref([])
+  var selectedStatuses = ref([])
+  var selectedComponents = ref([])
+  var selectedOwners = ref([])
+  var activeCardFilter = ref(null)
+
+  // --- Derived option lists from FULL unfiltered groups (Risk 3 mitigation) ---
+
+  var availableProducts = computed(function () {
+    var seen = {}
+    var result = []
+    for (var i = 0; i < groups.value.length; i++) {
+      var p = groups.value[i].product
+      if (p && !seen[p]) {
+        seen[p] = true
+        result.push(p)
+      }
+    }
+    result.sort()
+    return result
+  })
+
+  var availableStatuses = computed(function () {
+    var seen = {}
+    var result = []
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        var s = features[j].colorStatus
+        if (s && !seen[s]) {
+          seen[s] = true
+          result.push(s)
+        }
+      }
+    }
+    var order = { Red: 0, Yellow: 1, Green: 2 }
+    result.sort(function (a, b) {
+      var oa = order[a] != null ? order[a] : 99
+      var ob = order[b] != null ? order[b] : 99
+      return oa - ob
+    })
+    return result
+  })
+
+  var availableComponents = computed(function () {
+    var seen = {}
+    var result = []
+    var hasEmpty = false
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        var comps = features[j].components || []
+        if (comps.length === 0) {
+          hasEmpty = true
+        }
+        for (var k = 0; k < comps.length; k++) {
+          if (!seen[comps[k]]) {
+            seen[comps[k]] = true
+            result.push(comps[k])
+          }
+        }
+      }
+    }
+    result.sort()
+    if (hasEmpty) result.push('No component')
+    return result
+  })
+
+  var availableOwners = computed(function () {
+    var seen = {}
+    var result = []
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        var a = features[j].assignee
+        var p = features[j].pmOwner
+        if (a && !seen[a]) { seen[a] = true; result.push(a) }
+        if (p && !seen[p]) { seen[p] = true; result.push(p) }
+      }
+    }
+    result.sort()
+    return result
+  })
+
+  // --- Total (unfiltered) counts for summary cards (Risk 2 mitigation) ---
+
+  var totalFeatures = computed(function () {
+    var keys = {}
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        if (features[j].scopeChange !== 'dropped') {
+          keys[features[j].key] = true
+        }
+      }
+    }
+    return Object.keys(keys).length
+  })
+
+  var totalAddedCount = computed(function () {
+    var count = 0
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        if (features[j].scopeChange === 'added') count++
+      }
+    }
+    return count
+  })
+
+  var totalDroppedCount = computed(function () {
+    var count = 0
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        if (features[j].scopeChange === 'dropped') count++
+      }
+    }
+    return count
+  })
+
+  var totalBlockedCount = computed(function () {
+    var count = 0
+    for (var i = 0; i < groups.value.length; i++) {
+      var features = groups.value[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        if (features[j].isBlocked && features[j].scopeChange !== 'dropped') count++
+      }
+    }
+    return count
+  })
+
+  // --- Filter pipeline ---
+
+  function applyToolbarFilters(rawGroups) {
+    var result = rawGroups
+
+    if (selectedProducts.value.length > 0) {
+      result = result.filter(function (g) {
+        return selectedProducts.value.includes(g.product)
+      })
+    }
+
+    var hasFeatureFilters = searchQuery.value ||
+      selectedStatuses.value.length > 0 ||
+      selectedComponents.value.length > 0 ||
+      selectedOwners.value.length > 0
+
+    if (!hasFeatureFilters) return result
+
+    var q = searchQuery.value ? searchQuery.value.toLowerCase() : ''
+
+    return result.map(function (g) {
+      var filtered = (g.features || []).filter(function (f) {
+        if (q) {
+          var matchKey = f.key && f.key.toLowerCase().includes(q)
+          var matchSummary = f.summary && f.summary.toLowerCase().includes(q)
+          if (!matchKey && !matchSummary) return false
+        }
+        if (selectedStatuses.value.length > 0) {
+          if (!f.colorStatus || !selectedStatuses.value.includes(f.colorStatus)) return false
+        }
+        if (selectedComponents.value.length > 0) {
+          var comps = f.components || []
+          if (comps.length === 0) {
+            if (!selectedComponents.value.includes('No component')) return false
+          } else {
+            var hasMatch = false
+            for (var k = 0; k < comps.length; k++) {
+              if (selectedComponents.value.includes(comps[k])) { hasMatch = true; break }
+            }
+            if (!hasMatch) return false
+          }
+        }
+        if (selectedOwners.value.length > 0) {
+          var ownerMatch = (f.assignee && selectedOwners.value.includes(f.assignee)) ||
+            (f.pmOwner && selectedOwners.value.includes(f.pmOwner))
+          if (!ownerMatch) return false
+        }
+        return true
+      })
+      return {
+        ...g,
+        features: filtered,
+        featureCount: filtered.filter(function (f) { return f.scopeChange !== 'dropped' }).length
+      }
+    }).filter(function (g) { return g.features.length > 0 })
+  }
+
+  var toolbarFilteredGroups = computed(function () {
+    return applyToolbarFilters(groups.value)
+  })
+
+  var filteredGroups = computed(function () {
+    var base = toolbarFilteredGroups.value
+    if (!activeCardFilter.value) return base
+
+    return base.map(function (g) {
+      var filtered = (g.features || []).filter(function (f) {
+        if (activeCardFilter.value === 'added') return f.scopeChange === 'added'
+        if (activeCardFilter.value === 'dropped') return f.scopeChange === 'dropped'
+        if (activeCardFilter.value === 'blocked') return f.isBlocked && f.scopeChange !== 'dropped'
+        return true
+      })
+      return {
+        ...g,
+        features: filtered,
+        featureCount: filtered.filter(function (f) { return f.scopeChange !== 'dropped' }).length
+      }
+    }).filter(function (g) { return g.features.length > 0 })
+  })
+
+  // --- Filtered feature count (deduplicated, Risk 4 mitigation) ---
+
+  var filteredFeatureCount = computed(function () {
+    var keys = {}
+    var fg = filteredGroups.value
+    for (var i = 0; i < fg.length; i++) {
+      var features = fg[i].features || []
+      for (var j = 0; j < features.length; j++) {
+        if (features[j].scopeChange !== 'dropped') {
+          keys[features[j].key] = true
+        }
+      }
+    }
+    return Object.keys(keys).length
+  })
+
+  // --- State helpers ---
+
+  var isToolbarFiltered = computed(function () {
+    return !!(searchQuery.value ||
+      selectedProducts.value.length > 0 ||
+      selectedStatuses.value.length > 0 ||
+      selectedComponents.value.length > 0 ||
+      selectedOwners.value.length > 0)
+  })
+
+  var isFiltered = computed(function () {
+    return isToolbarFiltered.value || !!activeCardFilter.value
+  })
+
+  var activeFilterLabels = computed(function () {
+    var labels = []
+    if (selectedProducts.value.length > 0) {
+      labels.push({ type: 'product', label: 'Product: ' + selectedProducts.value.map(function (p) { return p.toUpperCase() }).join(', ') })
+    }
+    if (selectedStatuses.value.length > 0) {
+      labels.push({ type: 'status', label: 'Status: ' + selectedStatuses.value.join(', ') })
+    }
+    if (selectedComponents.value.length > 0) {
+      labels.push({ type: 'components', label: 'Components: ' + selectedComponents.value.join(', ') })
+    }
+    if (selectedOwners.value.length > 0) {
+      labels.push({ type: 'owners', label: 'Owner: ' + selectedOwners.value.join(', ') })
+    }
+    if (searchQuery.value) {
+      labels.push({ type: 'search', label: 'Search: "' + searchQuery.value + '"' })
+    }
+    if (activeCardFilter.value) {
+      var cardLabels = { added: 'Late Added', dropped: 'Dropped', blocked: 'Blocked' }
+      labels.push({ type: 'card', label: cardLabels[activeCardFilter.value] || activeCardFilter.value })
+    }
+    return labels
+  })
+
+  function setCardFilter(type) {
+    if (type === null || activeCardFilter.value === type) {
+      activeCardFilter.value = null
+    } else {
+      activeCardFilter.value = type
+    }
+  }
+
+  function removeFilter(type) {
+    if (type === 'product') selectedProducts.value = []
+    else if (type === 'status') selectedStatuses.value = []
+    else if (type === 'components') selectedComponents.value = []
+    else if (type === 'owners') selectedOwners.value = []
+    else if (type === 'search') searchQuery.value = ''
+    else if (type === 'card') activeCardFilter.value = null
+  }
+
+  function clearAllFilters() {
+    searchQuery.value = ''
+    selectedProducts.value = []
+    selectedStatuses.value = []
+    selectedComponents.value = []
+    selectedOwners.value = []
+    activeCardFilter.value = null
+  }
+
+  // --- sessionStorage persistence ---
+
+  var _suspendSave = false
+
+  function saveFilters() {
+    if (_suspendSave) return
+    var version = selectedVersion.value
+    if (!version) return
+    try {
+      sessionStorage.setItem(
+        FILTER_STORAGE_KEY + ':' + version,
+        JSON.stringify({
+          searchQuery: searchQuery.value,
+          selectedProducts: selectedProducts.value,
+          selectedStatuses: selectedStatuses.value,
+          selectedComponents: selectedComponents.value,
+          selectedOwners: selectedOwners.value
+        })
+      )
+    } catch { /* quota / private mode */ }
+  }
+
+  function restoreFilters() {
+    var version = selectedVersion.value
+    if (!version) return
+    _suspendSave = true
+    try {
+      var raw = sessionStorage.getItem(FILTER_STORAGE_KEY + ':' + version)
+      if (!raw) return
+      var saved = JSON.parse(raw)
+      if (saved.searchQuery && typeof saved.searchQuery === 'string') {
+        searchQuery.value = saved.searchQuery.slice(0, 2000)
+      }
+      var prods = availableProducts.value
+      var stats = availableStatuses.value
+      var comps = availableComponents.value
+      var owners = availableOwners.value
+      if (Array.isArray(saved.selectedProducts)) {
+        selectedProducts.value = saved.selectedProducts.filter(function (v) { return prods.includes(v) })
+      }
+      if (Array.isArray(saved.selectedStatuses)) {
+        selectedStatuses.value = saved.selectedStatuses.filter(function (v) { return stats.includes(v) })
+      }
+      if (Array.isArray(saved.selectedComponents)) {
+        selectedComponents.value = saved.selectedComponents.filter(function (v) { return comps.includes(v) })
+      }
+      if (Array.isArray(saved.selectedOwners)) {
+        selectedOwners.value = saved.selectedOwners.filter(function (v) { return owners.includes(v) })
+      }
+    } catch { /* ignore corrupt JSON */ }
+    _suspendSave = false
+  }
+
+  function resetFilters() {
+    _suspendSave = true
+    searchQuery.value = ''
+    selectedProducts.value = []
+    selectedStatuses.value = []
+    selectedComponents.value = []
+    selectedOwners.value = []
+    activeCardFilter.value = null
+    _suspendSave = false
+  }
+
+  watch(
+    [searchQuery, selectedProducts, selectedStatuses, selectedComponents, selectedOwners],
+    saveFilters,
+    { deep: true }
+  )
+
+  return {
+    searchQuery,
+    selectedProducts,
+    selectedStatuses,
+    selectedComponents,
+    selectedOwners,
+    activeCardFilter,
+
+    availableProducts,
+    availableStatuses,
+    availableComponents,
+    availableOwners,
+
+    totalFeatures,
+    totalAddedCount,
+    totalDroppedCount,
+    totalBlockedCount,
+
+    filteredGroups,
+    filteredFeatureCount,
+    isToolbarFiltered,
+    isFiltered,
+    activeFilterLabels,
+
+    setCardFilter,
+    removeFilter,
+    clearAllFilters,
+    restoreFilters,
+    resetFilters
+  }
+}

--- a/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
+++ b/modules/releases/client/execute/composables/useFeatureTrackingFilters.js
@@ -346,7 +346,7 @@ export function useFeatureTrackingFilters(groups, selectedVersion) {
         selectedOwners.value = saved.selectedOwners.filter(function (v) { return owners.includes(v) })
       }
     } catch { /* ignore corrupt JSON */ }
-    _suspendSave = false
+    nextTick(function () { _suspendSave = false })
   }
 
   function resetFilters() {

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -136,6 +136,7 @@ watch(selectedVersion, async (v) => {
   resetFilters()
   if (v) {
     await loadTrackingData(v)
+    if (selectedVersion.value !== v) return
     nextTick(() => restoreFilters())
   }
 })

--- a/modules/releases/client/execute/views/FeatureTrackingView.vue
+++ b/modules/releases/client/execute/views/FeatureTrackingView.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { useFeatureTracking } from '../composables/useFeatureTracking.js'
+import { useFeatureTrackingFilters } from '../composables/useFeatureTrackingFilters.js'
 import FeatureTrackingTable from '../components/FeatureTrackingTable.vue'
 import FeatureTrackingSettingsPanel from '../components/FeatureTrackingSettingsPanel.vue'
+import HygieneSelect from '../components/hygiene/HygieneSelect.vue'
 import { getApiBase } from '@shared/client/services/api'
 
 const {
@@ -18,7 +20,6 @@ const {
 const selectedVersion = ref(null)
 const refreshing = ref(false)
 const tableRef = ref(null)
-const activeFilter = ref(null)
 const settingsOpen = ref(false)
 const trackingConfig = ref({ releases: {} })
 
@@ -35,76 +36,54 @@ const freezeStatus = computed(() => {
   return today >= featureFreezeDate.value ? 'past' : 'future'
 })
 
-const totalFeatures = computed(() => {
-  if (currentData.value && currentData.value.totalUniqueFeatures != null) {
-    return currentData.value.totalUniqueFeatures
-  }
-  var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    count += groups.value[i].featureCount || 0
-  }
-  return count
-})
+const {
+  searchQuery,
+  selectedProducts,
+  selectedStatuses,
+  selectedComponents,
+  selectedOwners,
+  activeCardFilter,
 
-const addedCount = computed(() => {
-  var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    var features = groups.value[i].features || []
-    for (var j = 0; j < features.length; j++) {
-      if (features[j].scopeChange === 'added') count++
-    }
-  }
-  return count
-})
+  availableProducts,
+  availableStatuses,
+  availableComponents,
+  availableOwners,
 
-const droppedCount = computed(() => {
-  var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    var features = groups.value[i].features || []
-    for (var j = 0; j < features.length; j++) {
-      if (features[j].scopeChange === 'dropped') count++
-    }
-  }
-  return count
-})
+  totalFeatures,
+  totalAddedCount,
+  totalDroppedCount,
+  totalBlockedCount,
 
-const blockedCount = computed(() => {
-  var count = 0
-  for (var i = 0; i < groups.value.length; i++) {
-    var features = groups.value[i].features || []
-    for (var j = 0; j < features.length; j++) {
-      if (features[j].isBlocked && features[j].scopeChange !== 'dropped') count++
-    }
-  }
-  return count
-})
+  filteredGroups,
+  filteredFeatureCount,
+  isToolbarFiltered,
+  isFiltered,
+  activeFilterLabels,
 
-function setFilter(type) {
-  if (type === null || activeFilter.value === type) {
-    activeFilter.value = null
-  } else {
-    activeFilter.value = type
+  setCardFilter,
+  removeFilter,
+  clearAllFilters,
+  restoreFilters,
+  resetFilters
+} = useFeatureTrackingFilters(groups, selectedVersion)
+
+function handleCardClick(type) {
+  var counts = { added: totalAddedCount.value, dropped: totalDroppedCount.value, blocked: totalBlockedCount.value }
+  if (counts[type] === 0) return
+  setCardFilter(type)
+  if (activeCardFilter.value === type) {
     nextTick(() => {
       if (tableRef.value) tableRef.value.expandAll()
     })
   }
 }
 
-const filteredGroups = computed(() => {
-  if (!activeFilter.value) return groups.value
-  return groups.value.map(g => {
-    const filtered = (g.features || []).filter(f => {
-      if (activeFilter.value === 'added') return f.scopeChange === 'added'
-      if (activeFilter.value === 'dropped') return f.scopeChange === 'dropped'
-      if (activeFilter.value === 'blocked') return f.isBlocked && f.scopeChange !== 'dropped'
-      return true
-    })
-    return {
-      ...g,
-      features: filtered,
-      featureCount: filtered.filter(f => f.scopeChange !== 'dropped').length
-    }
-  }).filter(g => g.features.length > 0)
+var productOptions = computed(() => {
+  return availableProducts.value.map(p => ({ value: p, label: p.toUpperCase() }))
+})
+
+var statusOptions = computed(() => {
+  return availableStatuses.value.map(s => ({ value: s, label: s }))
 })
 
 function formatDate(dateStr) {
@@ -154,8 +133,11 @@ async function onSettingsSaved(newConfig) {
 }
 
 watch(selectedVersion, async (v) => {
-  activeFilter.value = null
-  if (v) await loadTrackingData(v)
+  resetFilters()
+  if (v) {
+    await loadTrackingData(v)
+    nextTick(() => restoreFilters())
+  }
 })
 
 onMounted(async () => {
@@ -240,13 +222,56 @@ onMounted(async () => {
       </div>
     </div>
 
+    <!-- Filter toolbar -->
+    <div v-if="currentData && !loading" class="flex flex-wrap gap-3 items-center mb-5">
+      <input
+        v-model="searchQuery"
+        type="text"
+        placeholder="Search features..."
+        class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+      />
+      <HygieneSelect
+        :modelValue="selectedProducts"
+        :options="productOptions"
+        placeholder="All Products"
+        @update:modelValue="v => selectedProducts = v"
+      />
+      <HygieneSelect
+        :modelValue="selectedStatuses"
+        :options="statusOptions"
+        placeholder="All Statuses"
+        @update:modelValue="v => selectedStatuses = v"
+      />
+      <HygieneSelect
+        :modelValue="selectedComponents"
+        :options="availableComponents"
+        placeholder="All Components"
+        @update:modelValue="v => selectedComponents = v"
+      />
+      <HygieneSelect
+        :modelValue="selectedOwners"
+        :options="availableOwners"
+        placeholder="All Owners"
+        @update:modelValue="v => selectedOwners = v"
+      />
+      <span
+        v-if="isToolbarFiltered"
+        class="text-xs text-gray-500 dark:text-gray-400"
+      >Showing {{ filteredFeatureCount }} of {{ totalFeatures }}</span>
+      <button
+        v-if="isToolbarFiltered"
+        class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+        @click="clearAllFilters"
+      >Clear Filters</button>
+    </div>
+
     <!-- Summary cards -->
     <div v-if="currentData && !loading" class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
-      <!-- Total features (click = clear filter) -->
+      <!-- Total features (click = clear card filter) -->
       <div
-        @click="setFilter(null)"
+        @click="setCardFilter(null)"
         class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 cursor-pointer transition-all duration-150 hover:shadow-md"
-        :class="!activeFilter
+        :class="!activeCardFilter
           ? 'border-indigo-400 dark:border-indigo-500 ring-2 ring-indigo-200 dark:ring-indigo-800 shadow-sm'
           : 'border-gray-200 dark:border-gray-700 hover:border-indigo-300 dark:hover:border-indigo-600'"
       >
@@ -258,9 +283,11 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Features</span>
-          <span v-if="activeFilter" class="ml-auto text-[10px] text-indigo-500 dark:text-indigo-400 font-medium">Show all</span>
+          <span v-if="activeCardFilter" class="ml-auto text-[10px] text-indigo-500 dark:text-indigo-400 font-medium">Show all</span>
         </div>
-        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">{{ totalFeatures }}</div>
+        <div class="text-2xl font-bold text-gray-900 dark:text-gray-100 ml-7">
+          {{ totalFeatures }}
+        </div>
       </div>
 
       <!-- Feature Freeze date -->
@@ -281,13 +308,13 @@ onMounted(async () => {
 
       <!-- Late additions -->
       <div
-        @click="addedCount > 0 ? setFilter('added') : undefined"
+        @click="handleCardClick('added')"
         class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
         :class="[
-          activeFilter === 'added'
+          activeCardFilter === 'added'
             ? 'border-blue-400 dark:border-blue-500 ring-2 ring-blue-200 dark:ring-blue-800 shadow-sm'
             : 'border-gray-200 dark:border-gray-700',
-          addedCount > 0
+          totalAddedCount > 0
             ? 'cursor-pointer hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600'
             : ''
         ]"
@@ -300,22 +327,22 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Late Added</span>
-          <svg v-if="activeFilter === 'added'" class="ml-auto w-3.5 h-3.5 text-blue-500 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <svg v-if="activeCardFilter === 'added'" class="ml-auto w-3.5 h-3.5 text-blue-500 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="addedCount > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'">{{ addedCount }}</div>
+        <div class="text-2xl font-bold ml-7" :class="totalAddedCount > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'">{{ totalAddedCount }}</div>
       </div>
 
       <!-- Dropped -->
       <div
-        @click="droppedCount > 0 ? setFilter('dropped') : undefined"
+        @click="handleCardClick('dropped')"
         class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
         :class="[
-          activeFilter === 'dropped'
+          activeCardFilter === 'dropped'
             ? 'border-amber-400 dark:border-amber-500 ring-2 ring-amber-200 dark:ring-amber-800 shadow-sm'
             : 'border-gray-200 dark:border-gray-700',
-          droppedCount > 0
+          totalDroppedCount > 0
             ? 'cursor-pointer hover:shadow-md hover:border-amber-300 dark:hover:border-amber-600'
             : ''
         ]"
@@ -328,22 +355,22 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Dropped</span>
-          <svg v-if="activeFilter === 'dropped'" class="ml-auto w-3.5 h-3.5 text-amber-500 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <svg v-if="activeCardFilter === 'dropped'" class="ml-auto w-3.5 h-3.5 text-amber-500 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="droppedCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ droppedCount }}</div>
+        <div class="text-2xl font-bold ml-7" :class="totalDroppedCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ totalDroppedCount }}</div>
       </div>
 
       <!-- Blocked -->
       <div
-        @click="blockedCount > 0 ? setFilter('blocked') : undefined"
+        @click="handleCardClick('blocked')"
         class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border px-4 py-3.5 transition-all duration-150"
         :class="[
-          activeFilter === 'blocked'
+          activeCardFilter === 'blocked'
             ? 'border-red-400 dark:border-red-500 ring-2 ring-red-200 dark:ring-red-800 shadow-sm'
             : 'border-gray-200 dark:border-gray-700',
-          blockedCount > 0
+          totalBlockedCount > 0
             ? 'cursor-pointer hover:shadow-md hover:border-red-300 dark:hover:border-red-600'
             : ''
         ]"
@@ -356,11 +383,11 @@ onMounted(async () => {
             </svg>
           </span>
           <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Blocked</span>
-          <svg v-if="activeFilter === 'blocked'" class="ml-auto w-3.5 h-3.5 text-red-500 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <svg v-if="activeCardFilter === 'blocked'" class="ml-auto w-3.5 h-3.5 text-red-500 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="blockedCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ blockedCount }}</div>
+        <div class="text-2xl font-bold ml-7" :class="totalBlockedCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'">{{ totalBlockedCount }}</div>
       </div>
     </div>
 
@@ -398,26 +425,33 @@ onMounted(async () => {
       <p class="text-xs mt-1">Use the Refresh button to fetch data from Jira.</p>
     </div>
 
-    <!-- Data table (with optional filter indicator) -->
+    <!-- Data table (with active filter chips banner) -->
     <template v-else-if="currentData">
       <div
-        v-if="activeFilter"
-        class="mb-3 flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium"
-        :class="{
-          'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300': activeFilter === 'added',
-          'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300': activeFilter === 'dropped',
-          'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300': activeFilter === 'blocked'
-        }"
+        v-if="isFiltered"
+        class="mb-3 flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium bg-gray-50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700"
       >
-        <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <svg class="w-4 h-4 shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
         </svg>
-        <span>Showing {{ activeFilter === 'added' ? 'late added' : activeFilter }} features only</span>
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="chip in activeFilterLabels"
+            :key="chip.type"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-400"
+          >
+            {{ chip.label }}
+            <button
+              @click.stop="removeFilter(chip.type)"
+              class="hover:text-primary-900 dark:hover:text-primary-200 transition-colors"
+            >&times;</button>
+          </span>
+        </div>
         <button
-          @click="setFilter(null)"
-          class="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold hover:bg-white/50 dark:hover:bg-gray-800/50 transition-colors"
+          @click="clearAllFilters"
+          class="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-semibold text-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors whitespace-nowrap"
         >
-          Clear filter
+          Clear all
           <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -429,6 +463,7 @@ onMounted(async () => {
         :portfolioVersion="selectedVersion"
         :featureFreezeDate="featureFreezeDate"
         :totalUniqueFeatures="totalFeatures"
+        :filteredFeatureCount="isFiltered ? filteredFeatureCount : null"
       />
     </template>
 

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -761,6 +761,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
               assignee: f.assignee || null,
               pmOwner: f.pmOwner || null,
               status: f.status || null,
+              team: f.team || null,
               scopeChange: f.scopeChange || null,
               fixVersionAddedAt: f.fixVersionAddedAt || null,
               fixVersionRemovedAt: f.fixVersionRemovedAt || null


### PR DESCRIPTION
## Summary
Before -
<img width="1235" height="721" alt="Screenshot 2026-07-11 at 3 26 48 PM" src="https://github.com/user-attachments/assets/0115033e-8159-4df4-8107-f97516fef6bc" />


After - 
<img width="1253" height="811" alt="Screenshot 2026-07-11 at 2 36 59 PM" src="https://github.com/user-attachments/assets/1c2b3934-5b5c-4f93-b19d-0ba8a3526887" />

- Adds a full filter toolbar to the Feature Tracking tab (`#/releases/execute?tab=feature-tracking`) with text search, multi-select dropdowns for Product, Status, Components, and Owner — bringing it to parity with the Feature List and Feature Status sibling tabs
- Introduces active filter chips banner with individual remove buttons, session persistence per version, and "X of Y features" count in both toolbar and portfolio table header
- Exposes the `team` field in the feature tracking API response (already fetched from Jira but previously stripped)

## Design Decisions

- **Summary cards always show total (unfiltered) counts** — preserves "truth of the release" context even when toolbar filters are active
- **Dropdown options derived from full unfiltered dataset** — avoids cascading filter traps where selecting one filter narrows options in other dropdowns
- **Auto-expand only on card-filter clicks** — toolbar filters (search, dropdowns) do not trigger expand to prevent jarring layout shifts on every keystroke
- **Filtered counts deduplicated by feature key** — matches the server-side `totalUniqueFeatures` logic for features appearing across multiple product groups
- **Reuses `HygieneSelect`** component from the Feature Status tab (same module, no cross-module import)

## Files Changed

| File | Change |
|------|--------|
| `modules/releases/server/execution/feature-tracking-routes.js` | Add `team` field to API response (1 line) |
| `modules/releases/client/execute/composables/useFeatureTrackingFilters.js` | **New** — filter state, computed pipeline, sessionStorage persistence |
| `modules/releases/client/execute/views/FeatureTrackingView.vue` | Add filter toolbar, rewire summary cards, upgrade filter banner to chips |
| `modules/releases/client/execute/components/FeatureTrackingTable.vue` | Add `filteredFeatureCount` prop for "X of Y features" display |

## Test Plan

- [ ] Select a release version — filter toolbar appears between version chips and summary cards
- [ ] Type in search box — features filter by key and summary instantly
- [ ] Select values in Product, Status, Components, Owner dropdowns — table narrows accordingly
- [ ] "Showing X of Y" counter appears when toolbar filters are active
- [ ] Click Late Added / Dropped / Blocked cards — toggles card filter on top of toolbar filters, auto-expands table
- [ ] Summary card counts remain unchanged (total) regardless of toolbar filters
- [ ] Active filter chips banner appears with individual remove (×) buttons
- [ ] "Clear all" removes all filters at once
- [ ] Switch versions — filters reset cleanly
- [ ] Switch to another tab and back — toolbar filters persist (sessionStorage)
- [ ] Portfolio header badge shows "X of Y features" when filtered


Made with [Cursor](https://cursor.com)