### PR TITLE
fix(ci): rename deprecated app-id to client-id in GitHub App token action

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -116,7 +116,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7
@@ -331,7 +331,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7
@@ -394,7 +394,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -143,7 +143,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code

--- a/.github/workflows/core-upgrade.yml
+++ b/.github/workflows/core-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7

--- a/.github/workflows/guard-ai-configs.yml
+++ b/.github/workflows/guard-ai-configs.yml
@@ -153,7 +153,7 @@ jobs:
         if: steps.check_sensitive_files.outputs.detected == 'true'
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check for team approval and set status

--- a/.github/workflows/sync-preprod.yml
+++ b/.github/workflows/sync-preprod.yml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token@v3` deprecated `app-id` in favor of `client-id`
- This broke the `sync-preprod` scheduled workflow and will eventually break others
- Updated all 5 workflow files: `sync-preprod`, `build-images` (3 uses), `claude-review`, `guard-ai-configs`, `core-upgrade`

## Test plan
- [ ] `sync-preprod` workflow passes on next scheduled/manual run
- [ ] `build-images` workflow passes on next main push
- [ ] No more deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)