### PR TITLE
fix: use API_PUBLIC_URL for Google OAuth callback in production

### DIFF
--- a/eslint-rules/no-module-process-env.js
+++ b/eslint-rules/no-module-process-env.js
@@ -48,7 +48,8 @@ const ALLOWED = new Set([
   // AI Eng: customer-insights module
   'SHEETS_CACHE_TTL_MS',
   'GOOGLE_OAUTH_CALLBACK_URL',
-  'VITE_API_BASE_URL'
+  'VITE_API_BASE_URL',
+  'API_PUBLIC_URL'
 ])
 
 module.exports = {

--- a/modules/customer-insights/server/routes/googleDriveAuth.js
+++ b/modules/customer-insights/server/routes/googleDriveAuth.js
@@ -22,7 +22,7 @@ module.exports = function registerGoogleDriveAuthRoutes(router, context) {
     const clientSecret = secrets.GOOGLE_OAUTH_CLIENT_SECRET
 
     const callbackUrl = process.env.GOOGLE_OAUTH_CALLBACK_URL ||
-                       `${process.env.VITE_API_BASE_URL || 'http://localhost:3001'}/api/modules/customer-insights/auth/google/callback`
+                       `${process.env.API_PUBLIC_URL || process.env.VITE_API_BASE_URL || 'http://localhost:3001'}/api/modules/customer-insights/auth/google/callback`
 
     if (!clientId || !clientSecret) {
       throw new Error('Google OAuth credentials not configured. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET.')


### PR DESCRIPTION
## Summary

- Google OAuth callback URL was falling back to `http://localhost:3001` in production because neither `GOOGLE_OAUTH_CALLBACK_URL` nor `VITE_API_BASE_URL` are set
- Added `API_PUBLIC_URL` as a fallback — it's already configured in the production ConfigMap and points to the direct backend route, which bypasses the OAuth proxy (necessary since the callback endpoint doesn't use `requireAuth`)
- Added `API_PUBLIC_URL` to the ESLint `no-module-process-env` allowed list (it's config, not a secret)

## Test plan

- [ ] Verify Google OAuth flow works in production (initiate from Customer Insights, confirm callback redirects correctly)
- [ ] Verify local dev still works (falls back to `localhost:3001` when `API_PUBLIC_URL` is unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)