### PR TITLE
feat(autofix): add calendar and rolling time window filters

### DIFF
--- a/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
+++ b/modules/ai-impact/__tests__/server/autofix-fetcher.test.js
@@ -9,6 +9,7 @@ const {
   computePriorityBreakdown,
   computeMedianTimeToFix,
   getLastWeekBounds,
+  getWindowBounds,
   computeAutofixMetrics,
   buildTrendData
 } = require('../../server/jira/autofix-fetcher')
@@ -153,8 +154,8 @@ describe('computeAutofixMetrics', () => {
     { created: old, pipelineState: 'autofix-merged', components: ['A'] }
   ]
 
-  it('computes metrics for a week window', () => {
-    const m = computeAutofixMetrics(issues, 'week')
+  it('computes metrics for a last7 rolling window', () => {
+    const m = computeAutofixMetrics(issues, 'last7')
     expect(m.windowTotal).toBe(7)
     expect(m.triageVerdicts.ready).toBe(3)
     expect(m.triageVerdicts.missingInfo).toBe(1)
@@ -168,13 +169,13 @@ describe('computeAutofixMetrics', () => {
   })
 
   it('computes success rate from terminal states (merged / (merged + rejected + maxRetries))', () => {
-    const m = computeAutofixMetrics(issues, 'week')
+    const m = computeAutofixMetrics(issues, 'last7')
     // merged=1, rejected=1, maxRetries=0 → terminal=2, successRate = 1/2 = 50%
     expect(m.successRate).toBe(50)
   })
 
   it('returns zero success rate when no terminal autofix issues in window', () => {
-    const m = computeAutofixMetrics([], 'week')
+    const m = computeAutofixMetrics([], 'last7')
     expect(m.successRate).toBe(0)
   })
 })
@@ -184,7 +185,7 @@ describe('buildTrendData', () => {
     const issues = [
       { created: new Date().toISOString(), pipelineState: 'autofix-merged', components: [] }
     ]
-    const trend = buildTrendData(issues, 'week')
+    const trend = buildTrendData(issues, 'last7')
     expect(trend).toHaveLength(4)
     expect(trend[0]).toHaveProperty('date')
     expect(trend[0]).toHaveProperty('triaged')
@@ -200,8 +201,8 @@ describe('buildTrendData', () => {
     expect(trend[0]).toHaveProperty('securityReview')
   })
 
-  it('returns 13 points for 3months window', () => {
-    const trend = buildTrendData([], '3months')
+  it('returns 13 points for last90 window', () => {
+    const trend = buildTrendData([], 'last90')
     expect(trend).toHaveLength(13)
   })
 
@@ -220,7 +221,7 @@ describe('buildTrendData', () => {
       { created: recent, pipelineState: 'triage-external', components: [] },
       { created: recent, pipelineState: 'triage-security-review', components: [] }
     ]
-    const trend = buildTrendData(issues, 'week')
+    const trend = buildTrendData(issues, 'last7')
     const lastPoint = trend[trend.length - 1]
     expect(lastPoint.review).toBe(2)
     expect(lastPoint.ciFailing).toBe(1)
@@ -252,13 +253,13 @@ describe('buildTrendData', () => {
     expect(lastBucket.review).toBe(1)
   })
 
-  it('does not use terminalAt for existing time windows', () => {
+  it('does not use terminalAt for rolling time windows', () => {
     const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
     const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString()
     const issues = [
       { created: old, terminalAt: recent, pipelineState: 'autofix-merged' }
     ]
-    const trend = buildTrendData(issues, 'week')
+    const trend = buildTrendData(issues, 'last7')
     const lastBucket = trend[trend.length - 1]
     expect(lastBucket.merged).toBe(0)
   })
@@ -549,6 +550,117 @@ describe('computeMedianTimeToFix', () => {
   })
 })
 
+describe('getWindowBounds', () => {
+  it('returns calendar week bounds for week', () => {
+    const { start, end, useTerminalDate } = getWindowBounds('week')
+    const startDate = new Date(start)
+    expect(startDate.getUTCDay()).toBe(1)
+    expect(end).toBeLessThanOrEqual(Date.now() + 1000)
+    expect(end).toBeGreaterThan(start)
+    expect(useTerminalDate).toBe(false)
+  })
+
+  it('returns rolling 7-day bounds for last7', () => {
+    const { start, end, useTerminalDate } = getWindowBounds('last7')
+    const diff = end - start
+    expect(Math.abs(diff - 7 * 24 * 60 * 60 * 1000)).toBeLessThan(1000)
+    expect(useTerminalDate).toBe(false)
+  })
+
+  it('returns calendar month bounds for month', () => {
+    const { start, end, useTerminalDate } = getWindowBounds('month')
+    const startDate = new Date(start)
+    expect(startDate.getUTCDate()).toBe(1)
+    expect(end).toBeLessThanOrEqual(Date.now() + 1000)
+    expect(useTerminalDate).toBe(false)
+  })
+
+  it('returns previous calendar month bounds for lastMonth', () => {
+    const { start, end, useTerminalDate } = getWindowBounds('lastMonth')
+    const startDate = new Date(start)
+    const endDate = new Date(end)
+    expect(startDate.getUTCDate()).toBe(1)
+    expect(endDate.getUTCDate()).toBe(1)
+    expect(endDate.getUTCMonth()).toBe(new Date().getUTCMonth())
+    expect(useTerminalDate).toBe(true)
+  })
+
+  it('returns rolling 30-day bounds for last30', () => {
+    const { start, end, useTerminalDate } = getWindowBounds('last30')
+    const diff = end - start
+    expect(Math.abs(diff - 30 * 24 * 60 * 60 * 1000)).toBeLessThan(1000)
+    expect(useTerminalDate).toBe(false)
+  })
+
+  it('returns rolling 90-day bounds for last90', () => {
+    const { start, end, useTerminalDate } = getWindowBounds('last90')
+    const diff = end - start
+    expect(Math.abs(diff - 90 * 24 * 60 * 60 * 1000)).toBeLessThan(1000)
+    expect(useTerminalDate).toBe(false)
+  })
+
+  it('uses terminalDate for lastWeek', () => {
+    const { useTerminalDate } = getWindowBounds('lastWeek')
+    expect(useTerminalDate).toBe(true)
+  })
+})
+
+describe('computeAutofixMetrics with lastMonth', () => {
+  it('uses terminalAt for terminal issues in lastMonth window', () => {
+    const { start, end } = getWindowBounds('lastMonth')
+    const midLastMonth = new Date(start + (end - start) / 2).toISOString()
+    const sixMonthsAgo = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created: sixMonthsAgo, terminalAt: midLastMonth, pipelineState: 'autofix-merged' },
+      { created: midLastMonth, terminalAt: null, pipelineState: 'autofix-review' },
+      { created: sixMonthsAgo, terminalAt: null, pipelineState: 'autofix-merged' }
+    ]
+    const m = computeAutofixMetrics(issues, 'lastMonth')
+    expect(m.autofixStates.merged).toBe(1)
+    expect(m.autofixStates.review).toBe(1)
+    expect(m.windowTotal).toBe(2)
+  })
+})
+
+describe('buildTrendData with new windows', () => {
+  it('returns 4 points for last7 window', () => {
+    const trend = buildTrendData([], 'last7')
+    expect(trend).toHaveLength(4)
+  })
+
+  it('returns 8 points for last30 window', () => {
+    const trend = buildTrendData([], 'last30')
+    expect(trend).toHaveLength(8)
+  })
+
+  it('returns 8 points for lastMonth window', () => {
+    const trend = buildTrendData([], 'lastMonth')
+    expect(trend).toHaveLength(8)
+  })
+
+  it('returns 8 points for calendar month window', () => {
+    const trend = buildTrendData([], 'month')
+    expect(trend).toHaveLength(8)
+  })
+
+  it('returns 4 points for calendar week window', () => {
+    const trend = buildTrendData([], 'week')
+    expect(trend).toHaveLength(4)
+  })
+
+  it('uses terminalAt for lastMonth window', () => {
+    const { start, end } = getWindowBounds('lastMonth')
+    const midLastMonth = new Date(start + (end - start) / 2).toISOString()
+    const sixMonthsAgo = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      { created: sixMonthsAgo, terminalAt: midLastMonth, pipelineState: 'autofix-merged' }
+    ]
+    const trend = buildTrendData(issues, 'lastMonth')
+    const totalMerged = trend.reduce((s, p) => s + p.merged, 0)
+    expect(totalMerged).toBe(1)
+  })
+})
+
 describe('computeAutofixMetrics new fields', () => {
   const now = new Date()
   const recent = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString()
@@ -559,7 +671,7 @@ describe('computeAutofixMetrics new fields', () => {
       { created: recent, pipelineState: 'autofix-merged', priority: 'Blocker', terminalAt: mergedAt, effortScore: 3, effortTier: 'Standard Fix' },
       { created: recent, pipelineState: 'triage-missing-info', priority: 'Major' }
     ]
-    const m = computeAutofixMetrics(issues, 'week')
+    const m = computeAutofixMetrics(issues, 'last7')
     expect(m.priorityBreakdown).toEqual({ Blocker: 1, Major: 1 })
   })
 
@@ -568,7 +680,7 @@ describe('computeAutofixMetrics new fields', () => {
     const issues = [
       { created, pipelineState: 'autofix-merged', priority: 'Major', terminalAt: mergedAt, effortScore: 1, effortTier: 'Quick Win' }
     ]
-    const m = computeAutofixMetrics(issues, 'week')
+    const m = computeAutofixMetrics(issues, 'last7')
     expect(m.medianTimeToFixDays).toBeGreaterThan(0)
   })
 
@@ -578,7 +690,7 @@ describe('computeAutofixMetrics new fields', () => {
       { created: recent, pipelineState: 'autofix-merged', priority: 'Blocker', terminalAt: mergedAt, effortScore: 4, effortTier: 'Standard Fix' },
       { created: recent, pipelineState: 'autofix-merged', priority: 'Critical', terminalAt: mergedAt, effortScore: 6, effortTier: 'Complex Fix' }
     ]
-    const m = computeAutofixMetrics(issues, 'week')
+    const m = computeAutofixMetrics(issues, 'last7')
     expect(m.effortBreakdown).toEqual({ quickWin: 1, standardFix: 1, complexFix: 1 })
     expect(m.totalImpactScore).toBe(11)
   })

--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -70,8 +70,41 @@ function getLastWeekBounds() {
   return { start: lastMonday.getTime(), end: thisMonday.getTime() }
 }
 
-function issueTimestamp(issue, isLastWeek) {
-  if (isLastWeek && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
+function getWindowBounds(timeWindow) {
+  const now = new Date()
+  switch (timeWindow) {
+    case 'week': {
+      const day = now.getUTCDay()
+      const diffToMonday = day === 0 ? 6 : day - 1
+      const thisMonday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - diffToMonday))
+      return { start: thisMonday.getTime(), end: Date.now(), useTerminalDate: false }
+    }
+    case 'lastWeek': {
+      const bounds = getLastWeekBounds()
+      return { start: bounds.start, end: bounds.end, useTerminalDate: true }
+    }
+    case 'last7':
+      return { start: Date.now() - 7 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
+    case 'month': {
+      const firstOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+      return { start: firstOfMonth.getTime(), end: Date.now(), useTerminalDate: false }
+    }
+    case 'lastMonth': {
+      const firstOfThisMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+      const firstOfLastMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+      return { start: firstOfLastMonth.getTime(), end: firstOfThisMonth.getTime(), useTerminalDate: true }
+    }
+    case 'last30':
+      return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
+    case 'last90':
+      return { start: Date.now() - 90 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
+    default:
+      return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
+  }
+}
+
+function issueTimestamp(issue, useTerminalDate) {
+  if (useTerminalDate && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
     return new Date(issue.terminalAt).getTime()
   }
   return new Date(issue.created).getTime()
@@ -83,16 +116,18 @@ function formatUTCShortDate(d) {
 }
 
 const windowDateRange = computed(() => {
+  const { start, end } = getWindowBounds(props.timeWindow)
   if (props.timeWindow === 'lastWeek') {
-    const { start, end } = getLastWeekBounds()
     const s = new Date(start)
     const e = new Date(end - 86400000)
     return 'Mon ' + formatUTCShortDate(s) + ' – Sun ' + formatUTCShortDate(e)
   }
-  const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-  const endDate = new Date()
-  const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-  return formatUTCShortDate(startDate) + ' – ' + formatUTCShortDate(endDate)
+  if (props.timeWindow === 'lastMonth') {
+    const s = new Date(start)
+    const e = new Date(end - 86400000)
+    return formatUTCShortDate(s) + ' – ' + formatUTCShortDate(e)
+  }
+  return formatUTCShortDate(new Date(start)) + ' – ' + formatUTCShortDate(new Date(end))
 })
 
 const jiraHost = computed(() => props.autofixData?.jiraHost || 'https://redhat.atlassian.net')
@@ -205,21 +240,10 @@ const metrics = computed(() => {
   if (!hasActiveFilter.value) return props.autofixData.metrics
 
   const issues = projectFilteredIssues.value
-  const isLastWeek = props.timeWindow === 'lastWeek'
-  let windowStart, windowEnd
-
-  if (isLastWeek) {
-    const bounds = getLastWeekBounds()
-    windowStart = bounds.start
-    windowEnd = bounds.end
-  } else {
-    const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-    windowEnd = Date.now()
-    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
-  }
+  const { start: windowStart, end: windowEnd, useTerminalDate } = getWindowBounds(props.timeWindow)
 
   const windowIssues = issues.filter(i => {
-    const ts = issueTimestamp(i, isLastWeek)
+    const ts = issueTimestamp(i, useTerminalDate)
     return ts >= windowStart && ts < windowEnd
   })
 
@@ -285,13 +309,16 @@ const trendData = computed(() => {
   if (!hasActiveFilter.value) return props.autofixData?.trendData || []
 
   const issues = projectFilteredIssues.value
-  const isLW = props.timeWindow === 'lastWeek'
-  const weekCounts = (props.timeWindow === 'week' || isLW) ? 4 : props.timeWindow === 'month' ? 8 : 13
+  const { useTerminalDate } = getWindowBounds(props.timeWindow)
+  const tw = props.timeWindow
+  const weekCounts = (tw === 'week' || tw === 'lastWeek' || tw === 'last7') ? 4 : (tw === 'month' || tw === 'lastMonth' || tw === 'last30') ? 8 : 13
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
   let anchor
-  if (isLW) {
-    const { end: thisMonday } = getLastWeekBounds()
-    anchor = thisMonday
+  if (tw === 'lastWeek') {
+    anchor = getLastWeekBounds().end
+  } else if (tw === 'lastMonth') {
+    const now = new Date()
+    anchor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).getTime()
   } else {
     anchor = Date.now()
   }
@@ -300,7 +327,7 @@ const trendData = computed(() => {
     const weekEnd = new Date(anchor - w * MS_PER_WEEK)
     const weekStart = new Date(weekEnd.getTime() - MS_PER_WEEK)
     const weekIssues = issues.filter(i => {
-      const ts = issueTimestamp(i, isLW)
+      const ts = issueTimestamp(i, useTerminalDate)
       return ts >= weekStart.getTime() && ts < weekEnd.getTime()
     })
     const triaged = weekIssues.filter(i => i.pipelineState.startsWith('triage-') || i.pipelineState.startsWith('autofix-')).length
@@ -344,21 +371,10 @@ const stateFilterOptions = STATE_OPTIONS.filter(o => o.value !== 'all')
 
 const timeFilteredIssues = computed(() => {
   if (!projectFilteredIssues.value.length) return []
-  const isLastWeek = props.timeWindow === 'lastWeek'
-  let windowStart, windowEnd
-
-  if (isLastWeek) {
-    const bounds = getLastWeekBounds()
-    windowStart = bounds.start
-    windowEnd = bounds.end
-  } else {
-    const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-    windowEnd = Date.now()
-    windowStart = windowEnd - days * 24 * 60 * 60 * 1000
-  }
+  const { start: windowStart, end: windowEnd, useTerminalDate } = getWindowBounds(props.timeWindow)
 
   return projectFilteredIssues.value.filter(i => {
-    const ts = issueTimestamp(i, isLastWeek)
+    const ts = issueTimestamp(i, useTerminalDate)
     return ts >= windowStart && ts < windowEnd
   })
 })
@@ -602,8 +618,9 @@ const effortSegmentTotal = computed(() => effortSegments.value.reduce((s, v) => 
 
 function buildJiraLabelUrl(jiraLabels, excludeLabels) {
   const host = jiraHost.value
+  const { start: windowStart, end: windowEnd, useTerminalDate } = getWindowBounds(props.timeWindow)
 
-  if (props.timeWindow === 'lastWeek') {
+  if (useTerminalDate) {
     const isTerminalLabel = jiraLabels.some(l =>
       l === 'jira-autofix-merged' || l === 'jira-autofix-rejected' ||
       l === 'jira-autofix-max-retries'
@@ -642,14 +659,12 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
   if (selectedComponent.value !== 'all') {
     jql += ` AND component = "${selectedComponent.value}"`
   }
-  if (props.timeWindow === 'lastWeek') {
-    const { start, end } = getLastWeekBounds()
-    jql += ` AND created >= "${new Date(start).toISOString().slice(0, 10)}"`
-    jql += ` AND created < "${new Date(end).toISOString().slice(0, 10)}"`
+  if (useTerminalDate) {
+    jql += ` AND created >= "${new Date(windowStart).toISOString().slice(0, 10)}"`
+    jql += ` AND created < "${new Date(windowEnd).toISOString().slice(0, 10)}"`
     jql += ' ORDER BY created DESC'
   } else {
-    const days = props.timeWindow === 'week' ? 7 : props.timeWindow === 'month' ? 30 : 90
-    const windowCutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    const windowCutoff = new Date(windowStart)
     const earliestIssue = projectFilteredIssues.value.length > 0
       ? projectFilteredIssues.value.reduce((min, i) => i.created < min ? i.created : min, projectFilteredIssues.value[0].created)
       : null
@@ -735,8 +750,11 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
         >
           <option value="week">This Week</option>
           <option value="lastWeek">Last Week</option>
+          <option value="last7">Last 7 Days</option>
           <option value="month">This Month</option>
-          <option value="3months">Last 3 Months</option>
+          <option value="lastMonth">Last Month</option>
+          <option value="last30">Last 30 Days</option>
+          <option value="last90">Last 90 Days</option>
         </select>
       </div>
     </header>

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -113,7 +113,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── Autofix data ───
 
-  const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'lastWeek', 'month', '3months'];
+  const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'lastWeek', 'last7', 'month', 'lastMonth', 'last30', 'last90'];
 
   let autofixDataCache = null;
 
@@ -180,9 +180,9 @@ module.exports = function registerRoutes(router, context) {
    *         name: timeWindow
    *         schema:
    *           type: string
-   *           enum: [week, lastWeek, month, 3months]
+   *           enum: [week, lastWeek, last7, month, lastMonth, last30, last90]
    *           default: month
-   *         description: Time window for metric computation. lastWeek uses calendar week (Mon-Sun) with terminalAt for resolved issues.
+   *         description: Time window for metric computation. Calendar windows (week, lastWeek, month, lastMonth) use fixed boundaries. Rolling windows (last7, last30, last90) count back from now. Past windows (lastWeek, lastMonth) use terminalAt for resolved issues.
    *       - in: query
    *         name: components
    *         schema:

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -190,8 +190,41 @@ function getLastWeekBounds() {
   return { start: lastMonday.getTime(), end: thisMonday.getTime() };
 }
 
-function issueInWindow(issue, windowStart, windowEnd, isLastWeek) {
-  if (isLastWeek && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
+function getWindowBounds(timeWindow) {
+  const now = new Date();
+  switch (timeWindow) {
+    case 'week': {
+      const day = now.getUTCDay();
+      const diffToMonday = day === 0 ? 6 : day - 1;
+      const thisMonday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - diffToMonday));
+      return { start: thisMonday.getTime(), end: Date.now(), useTerminalDate: false };
+    }
+    case 'lastWeek': {
+      const bounds = getLastWeekBounds();
+      return { start: bounds.start, end: bounds.end, useTerminalDate: true };
+    }
+    case 'last7':
+      return { start: Date.now() - 7 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
+    case 'month': {
+      const firstOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      return { start: firstOfMonth.getTime(), end: Date.now(), useTerminalDate: false };
+    }
+    case 'lastMonth': {
+      const firstOfThisMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      const firstOfLastMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+      return { start: firstOfLastMonth.getTime(), end: firstOfThisMonth.getTime(), useTerminalDate: true };
+    }
+    case 'last30':
+      return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
+    case 'last90':
+      return { start: Date.now() - 90 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
+    default:
+      return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
+  }
+}
+
+function issueInWindow(issue, windowStart, windowEnd, useTerminalDate) {
+  if (useTerminalDate && TERMINAL_STATES.has(issue.pipelineState) && issue.terminalAt) {
     const t = new Date(issue.terminalAt).getTime();
     return t >= windowStart && t < windowEnd;
   }
@@ -200,24 +233,13 @@ function issueInWindow(issue, windowStart, windowEnd, isLastWeek) {
 }
 
 function computeAutofixMetrics(issues, timeWindow) {
-  const isLastWeek = timeWindow === 'lastWeek';
-  let windowStart, windowEnd;
-
-  if (isLastWeek) {
-    const bounds = getLastWeekBounds();
-    windowStart = bounds.start;
-    windowEnd = bounds.end;
-  } else {
-    const days = timeWindow === 'week' ? 7 : timeWindow === 'month' ? 30 : 90;
-    windowEnd = Date.now();
-    windowStart = windowEnd - days * 24 * 60 * 60 * 1000;
-  }
+  const { start: windowStart, end: windowEnd, useTerminalDate } = getWindowBounds(timeWindow);
 
   const counts = {};
   let windowTotal = 0;
 
   for (const issue of issues) {
-    if (!issueInWindow(issue, windowStart, windowEnd, isLastWeek)) continue;
+    if (!issueInWindow(issue, windowStart, windowEnd, useTerminalDate)) continue;
     windowTotal++;
     counts[issue.pipelineState] = (counts[issue.pipelineState] || 0) + 1;
   }
@@ -257,11 +279,11 @@ function computeAutofixMetrics(issues, timeWindow) {
     : 0;
 
   const priorityBreakdown = computePriorityBreakdown(
-    issues.filter(function(issue) { return issueInWindow(issue, windowStart, windowEnd, isLastWeek); })
+    issues.filter(function(issue) { return issueInWindow(issue, windowStart, windowEnd, useTerminalDate); })
   );
 
   const mergedWindowIssues = issues.filter(function(issue) {
-    return issue.pipelineState === 'autofix-merged' && issueInWindow(issue, windowStart, windowEnd, isLastWeek);
+    return issue.pipelineState === 'autofix-merged' && issueInWindow(issue, windowStart, windowEnd, useTerminalDate);
   });
 
   const medianTimeToFixDays = computeMedianTimeToFix(mergedWindowIssues);
@@ -298,12 +320,27 @@ function computeAutofixMetrics(issues, timeWindow) {
 // limitation — Jira labels don't carry timestamps for state transitions.
 // The 'lastWeek' time window mitigates this for terminal states by using
 // terminalAt (from the Jira changelog) instead of created.
+function getTrendWeekCount(timeWindow) {
+  if (timeWindow === 'week' || timeWindow === 'lastWeek' || timeWindow === 'last7') return 4;
+  if (timeWindow === 'month' || timeWindow === 'lastMonth' || timeWindow === 'last30') return 8;
+  return 13;
+}
+
+function getTrendAnchor(timeWindow) {
+  if (timeWindow === 'lastWeek') return getLastWeekBounds().end;
+  if (timeWindow === 'lastMonth') {
+    const now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).getTime();
+  }
+  return Date.now();
+}
+
 function buildTrendData(issues, timeWindow) {
-  const isLastWeek = timeWindow === 'lastWeek';
-  const weekCounts = (timeWindow === 'week' || isLastWeek) ? 4 : timeWindow === 'month' ? 8 : 13;
+  const { useTerminalDate } = getWindowBounds(timeWindow);
+  const weekCounts = getTrendWeekCount(timeWindow);
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
-  const anchor = isLastWeek ? getLastWeekBounds().end : Date.now();
+  const anchor = getTrendAnchor(timeWindow);
 
   const buckets = [];
   for (let w = weekCounts - 1; w >= 0; w--) {
@@ -323,7 +360,7 @@ function buildTrendData(issues, timeWindow) {
 
   for (const issue of issues) {
     const state = issue.pipelineState;
-    const useTerminalAt = isLastWeek && TERMINAL_STATES.has(state) && issue.terminalAt;
+    const useTerminalAt = useTerminalDate && TERMINAL_STATES.has(state) && issue.terminalAt;
     const ts = useTerminalAt
       ? new Date(issue.terminalAt).getTime()
       : new Date(issue.created).getTime();
@@ -429,6 +466,7 @@ module.exports = {
   computePriorityBreakdown,
   computeMedianTimeToFix,
   getLastWeekBounds,
+  getWindowBounds,
   computeAutofixMetrics,
   buildTrendData,
   ALL_PIPELINE_LABELS,


### PR DESCRIPTION
## Summary

- **Fix misleading date ranges**: "This Month" was a rolling 30-day window showing "Jun 13 – Jul 13" instead of the actual calendar month. "This Week" was a rolling 7-day window, not the calendar week.
- **Expand from 4 to 7 time window options**, clearly distinguishing calendar periods from rolling windows:
  - This Week (calendar Mon→now), Last Week (Mon–Sun), Last 7 Days (rolling)
  - This Month (calendar 1st→now), Last Month (previous month), Last 30 Days (rolling)
  - Last 90 Days (rolling, renamed from "Last 3 Months")
- **Add `getWindowBounds()` helper** on both server and client, centralizing all date boundary logic and eliminating duplicated date math across computed properties.
- **Extend `terminalAt` filtering** to `lastMonth` (in addition to existing `lastWeek`), so merged fixes appear in the period they were resolved.

## Changes

| File | What changed |
|------|-------------|
| `modules/ai-impact/server/jira/autofix-fetcher.js` | Added `getWindowBounds()`, `getTrendWeekCount()`, `getTrendAnchor()`. Updated `computeAutofixMetrics` and `buildTrendData` to use centralized bounds. Renamed `isLastWeek` → `useTerminalDate`. |
| `modules/ai-impact/server/index.js` | Updated `VALID_AUTOFIX_TIME_WINDOWS` enum and OpenAPI annotation. |
| `modules/ai-impact/client/components/AutofixContent.vue` | Added client-side `getWindowBounds()`. Updated dropdown (7 options), `windowDateRange`, `metrics`, `trendData`, `timeFilteredIssues`, and `buildJiraLabelUrl` computeds. |
| `modules/ai-impact/__tests__/server/autofix-fetcher.test.js` | New test suites for `getWindowBounds` (7 cases), `lastMonth` metrics, and new window trend bucket counts (6 cases). Updated existing tests to use `last7`/`last90` where they relied on rolling behavior. |

## Design notes

- **Calendar vs rolling**: Calendar windows (`week`, `month`) use fixed boundaries (Monday, 1st of month). Rolling windows (`last7`, `last30`, `last90`) count back from now. Past completed periods (`lastWeek`, `lastMonth`) set `useTerminalDate: true` so resolved issues appear in the period they terminated.
- **Default remains `month`**: Now means "calendar month to date" instead of the old "rolling 30 days". Users who want the old behavior can select "Last 30 Days".
- **Old `3months` gracefully degrades**: API calls with `?timeWindow=3months` fall back to `month` (the default). This is an internal API with no external consumers.

## Test plan

- [x] `npm test` — all 87 autofix tests pass (server + client)
- [x] `npm run lint` — clean
- [ ] Verify each dropdown option shows correct date range in the banner
- [ ] Verify "This Month" on July 1 shows "Jul 1 – Jul 1" (not 30-day rolling)
- [ ] Verify "Last Month" shows previous month boundaries with correct data
- [ ] Verify "Last 90 Days" shows same data as old "Last 3 Months"

🤖 Generated with [Claude Code](https://claude.com/claude-code)