### PR TITLE
fix: route Google OAuth callback through frontend proxy

### DIFF
--- a/deploy/openshift/overlays/ai-eng-prod/kustomization.yaml
+++ b/deploy/openshift/overlays/ai-eng-prod/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
   literals:
   - API_PUBLIC_URL=https://api-team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com
   - AUTH_EMAIL_DOMAIN=cluster.local
+  - GOOGLE_OAUTH_CALLBACK_URL=https://team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com/api/modules/customer-insights/auth/google/callback
   name: team-tracker-config
 
 patches:

--- a/eslint-rules/no-module-process-env.js
+++ b/eslint-rules/no-module-process-env.js
@@ -48,8 +48,7 @@ const ALLOWED = new Set([
   // AI Eng: customer-insights module
   'SHEETS_CACHE_TTL_MS',
   'GOOGLE_OAUTH_CALLBACK_URL',
-  'VITE_API_BASE_URL',
-  'API_PUBLIC_URL'
+  'VITE_API_BASE_URL'
 ])
 
 module.exports = {

--- a/modules/customer-insights/server/routes/googleDriveAuth.js
+++ b/modules/customer-insights/server/routes/googleDriveAuth.js
@@ -22,7 +22,7 @@ module.exports = function registerGoogleDriveAuthRoutes(router, context) {
     const clientSecret = secrets.GOOGLE_OAUTH_CLIENT_SECRET
 
     const callbackUrl = process.env.GOOGLE_OAUTH_CALLBACK_URL ||
-                       `${process.env.API_PUBLIC_URL || process.env.VITE_API_BASE_URL || 'http://localhost:3001'}/api/modules/customer-insights/auth/google/callback`
+                       `${process.env.VITE_API_BASE_URL || 'http://localhost:3001'}/api/modules/customer-insights/auth/google/callback`
 
     if (!clientId || !clientSecret) {
       throw new Error('Google OAuth credentials not configured. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET.')


### PR DESCRIPTION
## Summary

Fixes the Google OAuth callback for customer-insights in production. Reverts the `API_PUBLIC_URL` approach from PR #1201, which didn't work because:

- **`proxySecretGuard` blocks it** — Google's redirect is a plain browser GET with no `X-Proxy-Secret` header, so the backend rejects it with `{"error":"Unauthorized"}`
- **`postMessage` origin mismatch** — the callback page would be on the backend origin (`api-team-tracker.apps...`) while the SPA is on the frontend origin (`team-tracker.apps...`), so the popup would never notify the parent window

Instead, sets `GOOGLE_OAUTH_CALLBACK_URL` explicitly in the prod ConfigMap to route through the frontend (`team-tracker.apps...`). Nginx proxies `/api/` to the backend with the `X-Proxy-Secret` header, and the user already has an OAuth proxy session cookie from initiating the flow.

### Changes
- **Revert**: Remove `API_PUBLIC_URL` fallback from `googleDriveAuth.js` callback URL chain
- **Revert**: Remove `API_PUBLIC_URL` from ESLint `no-module-process-env` allowed list
- **Add**: `GOOGLE_OAUTH_CALLBACK_URL` to prod kustomize ConfigMap

### Still needed
- Register `https://team-tracker.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com/api/modules/customer-insights/auth/google/callback` as an authorized redirect URI in Google Cloud Console

## Test plan

- [ ] Merge and let ArgoCD deploy
- [ ] Initiate Google OAuth flow from Customer Insights
- [ ] Verify Google redirects to the frontend route, callback completes, and popup notifies the SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)