### PR TITLE
fix: use google platform secret group in customer-insights module

### DIFF
--- a/modules/customer-insights/module.json
+++ b/modules/customer-insights/module.json
@@ -51,7 +51,7 @@
         "required": false
       }
     ],
-    "platform": ["GOOGLE_SERVICE_ACCOUNT_KEY_FILE", "jira"]
+    "platform": ["google", "jira"]
   },
   "defaultEnabled": true,
   "requires": [],


### PR DESCRIPTION
## Summary

- `module.json` had `"GOOGLE_SERVICE_ACCOUNT_KEY_FILE"` in the `secrets.platform` array instead of `"google"` (the platform group ID)
- The secret registry couldn't match the raw env var name to a declared group, causing `[secrets] Module "customer-insights" resolved undeclared secret "GOOGLE_SERVICE_ACCOUNT_KEY_FILE" via resolveSecret()` warnings on every call

## Test plan

- [ ] Verify the undeclared secret warning no longer appears in backend pod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)