### PR TITLE
feat(releases): add feature freeze milestone to schedule

### DIFF
--- a/fixtures/releases/registry.json
+++ b/fixtures/releases/registry.json
@@ -9,6 +9,7 @@
       "productPagesVersion": "2.14",
       "milestones": {
         "planningFreeze": "2026-04-15",
+        "featureFreeze": "2026-05-15",
         "codeFreeze": "2026-06-01",
         "ea1": "2026-06-15",
         "ga": "2026-07-01"
@@ -26,6 +27,7 @@
       "productPagesVersion": "2.15",
       "milestones": {
         "planningFreeze": "2026-06-15",
+        "featureFreeze": "2026-07-15",
         "codeFreeze": "2026-08-01",
         "ga": "2026-09-01"
       },

--- a/modules/releases/__tests__/client/schedule-view.test.js
+++ b/modules/releases/__tests__/client/schedule-view.test.js
@@ -16,6 +16,7 @@ function makeRelease(id, opts = {}) {
     productPagesShortname: opts.shortname || 'rhoai',
     milestones: {
       ga: opts.ga || null,
+      featureFreeze: opts.featureFreeze || null,
       codeFreeze: opts.codeFreeze || null,
       planningFreeze: opts.planningFreeze || null
     }
@@ -45,6 +46,7 @@ describe('ScheduleView', () => {
       releases: [
         makeRelease('rhoai-3.5', {
           ga: '2026-09-15',
+          featureFreeze: '2026-08-01',
           codeFreeze: '2026-08-20',
           planningFreeze: '2026-07-10'
         })
@@ -72,7 +74,7 @@ describe('ScheduleView', () => {
     const cells = wrapper.findAll('td')
     const cellTexts = cells.map(c => c.text())
     const dashCells = cellTexts.filter(t => t === '—')
-    expect(dashCells.length).toBe(2)
+    expect(dashCells.length).toBe(3)
   })
 
   it('sorts releases by GA date', async () => {

--- a/modules/releases/__tests__/client/schedule-widget.test.js
+++ b/modules/releases/__tests__/client/schedule-widget.test.js
@@ -24,6 +24,7 @@ function makeRelease(id, opts = {}) {
     milestones: {
       ga: opts.ga || null,
       codeFreeze: opts.codeFreeze || null,
+      featureFreeze: opts.featureFreeze || null,
       planningFreeze: opts.planningFreeze || null
     }
   }

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -105,6 +105,7 @@
               <tr class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/50">
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Plan Freeze</th>
+                <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Feature Freeze</th>
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Code Freeze</th>
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release Date</th>
               </tr>
@@ -121,6 +122,9 @@
                 </td>
                 <td class="px-4 py-3">
                   <MilestoneCell :date="r.milestones?.planningFreeze" :muted="isReleased(r)" />
+                </td>
+                <td class="px-4 py-3">
+                  <MilestoneCell :date="r.milestones?.featureFreeze" :muted="isReleased(r)" />
                 </td>
                 <td class="px-4 py-3">
                   <MilestoneCell :date="r.milestones?.codeFreeze" :muted="isReleased(r)" />
@@ -206,6 +210,7 @@ function nextMilestone(release) {
   const ms = release.milestones || {}
   const milestones = [
     { key: 'planningFreeze', label: 'Plan Freeze', date: ms.planningFreeze },
+    { key: 'featureFreeze', label: 'Feature Freeze', date: ms.featureFreeze },
     { key: 'codeFreeze', label: 'Code Freeze', date: ms.codeFreeze },
     { key: 'ga', label: 'Release Date', date: ms.ga }
   ]

--- a/modules/releases/client/widgets/ScheduleWidget.vue
+++ b/modules/releases/client/widgets/ScheduleWidget.vue
@@ -76,6 +76,7 @@ const filteredReleases = computed(() => {
 
 const milestoneTypes = [
   { key: 'planningFreeze', label: 'Plan Freeze' },
+  { key: 'featureFreeze', label: 'Feature Freeze' },
   { key: 'codeFreeze', label: 'Code Freeze' },
   { key: 'ga', label: 'Release' }
 ]

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -407,6 +407,7 @@ async function runRegistrySync(storage, options) {
           ...(existing.milestones || {}),
           ga: ppRelease.dueDate || existing.milestones?.ga || null,
           codeFreeze: ppRelease.codeFreezeDate || existing.milestones?.codeFreeze || null,
+          featureFreeze: ppRelease.featureFreezeDate || existing.milestones?.featureFreeze || null,
           planningFreeze: ppRelease.planningFreezeDate || existing.milestones?.planningFreeze || null
         };
         existing.updatedAt = new Date().toISOString();
@@ -421,6 +422,7 @@ async function runRegistrySync(storage, options) {
         milestones: {
           ga: ppRelease.dueDate || null,
           codeFreeze: ppRelease.codeFreezeDate || null,
+          featureFreeze: ppRelease.featureFreezeDate || null,
           planningFreeze: ppRelease.planningFreezeDate || null
         },
         source: 'product-pages',


### PR DESCRIPTION
## Summary
- Wire `featureFreezeDate` (already extracted from Product Pages API) through the registry sync into the `milestones` object
- Display Feature Freeze in both the dashboard Schedule widget and the full Schedule view (table column + next-milestone banner)
- Add fixture data and update test helper for the new milestone

## Test plan
- [ ] CI passes lint + tests
- [ ] In demo mode, verify Feature Freeze appears in the Schedule widget with countdown
- [ ] In demo mode, verify Feature Freeze column appears in the Schedule full view
- [ ] After a Product Pages sync, confirm `featureFreeze` is populated in `data/releases/registry.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)