### PR TITLE
fix(releases): allow spaces in draft-plans version validation

### DIFF
--- a/modules/releases/__tests__/server/draft-plans/routes.test.js
+++ b/modules/releases/__tests__/server/draft-plans/routes.test.js
@@ -166,6 +166,12 @@ describe('draft-plans routes', () => {
       expect(res._status).toBe(400)
     })
 
+    it('accepts version names with spaces', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/:version', { params: { version: 'RHOAI 3.5' } })
+      expect(res._status).not.toBe(400)
+    })
+
     it('returns 404 when no data stored', async () => {
       const { router } = setupRouter()
       const res = await callRoute(router, 'get', '/:version', { params: { version: '3.5' } })
@@ -202,6 +208,12 @@ describe('draft-plans routes', () => {
       const { router } = setupRouter()
       const res = await callRoute(router, 'get', '/:version/health', { params: { version: 'a'.repeat(51) } })
       expect(res._status).toBe(400)
+    })
+
+    it('accepts version names with spaces', async () => {
+      const { router } = setupRouter()
+      const res = await callRoute(router, 'get', '/:version/health', { params: { version: 'RHOAI 3.5' } })
+      expect(res._status).not.toBe(400)
     })
   })
 

--- a/modules/releases/server/draft-plans/routes.js
+++ b/modules/releases/server/draft-plans/routes.js
@@ -321,7 +321,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    */
   router.get('/:version', requireAuth, requireScope('releases:read'), function(req, res) {
     var version = req.params.version;
-    if (!/^[a-zA-Z0-9._-]{1,50}$/.test(version)) {
+    if (!/^[a-zA-Z0-9 ._-]{1,50}$/.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
     }
 
@@ -386,7 +386,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    */
   router.get('/:version/health', requireAuth, requireScope('releases:read'), function(req, res) {
     var version = req.params.version;
-    if (!/^[a-zA-Z0-9._-]{1,50}$/.test(version)) {
+    if (!/^[a-zA-Z0-9 ._-]{1,50}$/.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
     }
 


### PR DESCRIPTION
## Summary
- Align draft-plans \`/:version\` and \`/:version/health\` validation with planning routes so version names with spaces (e.g. \`RHOAI 3.5\`) are accepted
- Add regression tests for spaced version names

## Test plan
- [x] \`npx vitest run modules/releases/__tests__/server/draft-plans/routes.test.js\` (30 passed)
- [ ] Confirm draft-plans API accepts \`RHOAI 3.5\` without 400


Made with [Cursor](https://cursor.com)