### PR TITLE
feat(releases): AIPCC-19986 feature readiness filters and CSV export

### DIFF
--- a/modules/releases/__tests__/client/plan/feature-readiness-export.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-export.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  featureMatchesProduct,
+  featureFailsSelectedFpdorItems,
+  failedFpdorNames
+} from '../../../client/plan/utils/feature-readiness-export.js'
+
+describe('feature-readiness-export helpers', function() {
+  describe('featureMatchesProduct', function() {
+    it('matches product from targetVersions', function() {
+      var feature = { targetVersions: ['RHOAI 3.5'], fixVersion: null }
+      expect(featureMatchesProduct(feature, ['RHOAI'])).toBe(true)
+      expect(featureMatchesProduct(feature, ['RHAIIS'])).toBe(false)
+    })
+
+    it('matches product from fixVersion', function() {
+      var feature = { targetVersions: [], fixVersion: 'RHAIIS-3.0' }
+      expect(featureMatchesProduct(feature, ['RHAIIS'])).toBe(true)
+    })
+
+    it('passes when no product filter set', function() {
+      expect(featureMatchesProduct({ targetVersions: [] }, [])).toBe(true)
+    })
+  })
+
+  describe('featureFailsSelectedFpdorItems', function() {
+    var feature = {
+      fpdor: {
+        items: [
+          { name: 'Acceptance Criteria', pass: false },
+          { name: 'RICE Score', pass: true },
+          { name: 'Assignee', pass: false }
+        ]
+      }
+    }
+
+    it('matches when feature fails a selected item', function() {
+      expect(featureFailsSelectedFpdorItems(feature, ['Acceptance Criteria'])).toBe(true)
+    })
+
+    it('does not match when selected item passes', function() {
+      expect(featureFailsSelectedFpdorItems(feature, ['RICE Score'])).toBe(false)
+    })
+
+    it('passes when no item filter set', function() {
+      expect(featureFailsSelectedFpdorItems(feature, [])).toBe(true)
+    })
+  })
+
+  describe('failedFpdorNames', function() {
+    it('returns failed item names', function() {
+      var feature = {
+        fpdor: {
+          items: [
+            { name: 'Acceptance Criteria', pass: false },
+            { name: 'RICE Score', pass: true }
+          ]
+        }
+      }
+      expect(failedFpdorNames(feature)).toEqual(['Acceptance Criteria'])
+    })
+  })
+})

--- a/modules/releases/__tests__/client/plan/feature-readiness-export.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-export.test.js
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest'
 import {
   featureMatchesProduct,
   featureFailsSelectedFpdorItems,
-  failedFpdorNames
+  failedFpdorNames,
+  featureMatchesSharedFilters
 } from '../../../client/plan/utils/feature-readiness-export.js'
 
 describe('feature-readiness-export helpers', function() {
@@ -58,6 +58,56 @@ describe('feature-readiness-export helpers', function() {
         }
       }
       expect(failedFpdorNames(feature)).toEqual(['Acceptance Criteria'])
+    })
+  })
+
+  describe('featureMatchesSharedFilters', function() {
+    var base = {
+      bigRock: 'Rock A',
+      targetVersions: ['RHOAI 3.5'],
+      fixVersion: 'RHOAI-3.5',
+      components: ['Dashboard'],
+      priority: 'Major',
+      team: 'DW Team',
+      confidence: 'ready',
+      fpdor: {
+        items: [
+          { name: 'Acceptance Criteria', pass: false },
+          { name: 'RICE Score', pass: true }
+        ]
+      }
+    }
+
+    it('applies readiness when enabled', function() {
+      var filters = {
+        outcome: [], targetVersion: [], fixVersion: [], component: [],
+        priority: [], team: [], product: [], fpdorItems: [], readiness: 'not-ready'
+      }
+      expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: true })).toBe(false)
+      expect(featureMatchesSharedFilters(
+        Object.assign({}, base, { confidence: 'not-ready' }),
+        filters,
+        '',
+        { applyReadiness: true }
+      )).toBe(true)
+    })
+
+    it('skips readiness when disabled for counts', function() {
+      var filters = {
+        outcome: [], targetVersion: [], fixVersion: [], component: [],
+        priority: [], team: [], product: [], fpdorItems: [], readiness: 'not-ready'
+      }
+      expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: false })).toBe(true)
+    })
+
+    it('applies product and fpdor filters', function() {
+      var filters = {
+        outcome: [], targetVersion: [], fixVersion: [], component: [],
+        priority: [], team: [], product: ['RHOAI'], fpdorItems: ['Acceptance Criteria'], readiness: null
+      }
+      expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: true })).toBe(true)
+      filters.product = ['RHAIIS']
+      expect(featureMatchesSharedFilters(base, filters, '', { applyReadiness: true })).toBe(false)
     })
   })
 })

--- a/modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js
+++ b/modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js
@@ -19,6 +19,8 @@ function defaultModelValue() {
     component: [],
     priority: [],
     team: [],
+    product: [],
+    fpdorItems: [],
     readiness: null
   }
 }
@@ -356,5 +358,50 @@ describe('FeatureReadinessFilterBar', function() {
     var classes = outcomeBtn[0].classes().join(' ')
     expect(classes).toContain('border-gray-300')
     expect(classes).not.toContain('border-primary-400')
+  })
+
+  it('renders product and failed FPDoR filters', function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() }
+    })
+    expect(wrapper.text()).toContain('All products')
+    expect(wrapper.text()).toContain('Any failed item')
+  })
+
+  it('emits product selection', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var productBtn = findButtonByText(wrapper, 'All products')
+    expect(productBtn.length).toBe(1)
+    await productBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('RHOAI')
+    expect(wrapper.text()).toContain('RHAIIS')
+    expect(wrapper.text()).toContain('RHELAI')
+    var labels = wrapper.findAll('label').filter(function(l) { return l.text().includes('RHOAI') })
+    expect(labels.length).toBeGreaterThan(0)
+    await labels[0].find('input').setValue(true)
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeDefined()
+    expect(emitted[emitted.length - 1][0].product).toContain('RHOAI')
+    wrapper.unmount()
+  })
+
+  it('emits failed FPDoR item selection', async function() {
+    var wrapper = mount(FeatureReadinessFilterBar, {
+      props: { filterMeta: FILTER_META, modelValue: defaultModelValue() },
+      attachTo: document.body
+    })
+    var fpdorBtn = findButtonByText(wrapper, 'Any failed item')
+    expect(fpdorBtn.length).toBe(1)
+    await fpdorBtn[0].trigger('click')
+    expect(wrapper.text()).toContain('Acceptance Criteria')
+    var labels = wrapper.findAll('label').filter(function(l) { return l.text().includes('Acceptance Criteria') })
+    expect(labels.length).toBeGreaterThan(0)
+    await labels[0].find('input').setValue(true)
+    var emitted = wrapper.emitted('update:modelValue')
+    expect(emitted[emitted.length - 1][0].fpdorItems).toContain('Acceptance Criteria')
+    wrapper.unmount()
   })
 })

--- a/modules/releases/client/plan/components/FeatureReadinessFilterBar.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessFilterBar.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { FPDOR_ITEM_NAMES, KNOWN_PRODUCTS } from '../utils/feature-readiness-export.js'
 
 const props = defineProps({
   filterMeta: {
@@ -15,6 +16,8 @@ const props = defineProps({
       component: [],
       priority: [],
       team: [],
+      product: [],
+      fpdorItems: [],
       readiness: null
     })
   }
@@ -28,6 +31,8 @@ const fixVersionOpen = ref(false)
 const componentOpen = ref(false)
 const teamOpen = ref(false)
 const priorityOpen = ref(false)
+const productOpen = ref(false)
+const fpdorItemsOpen = ref(false)
 
 const outcomeRef = ref(null)
 const targetVersionRef = ref(null)
@@ -35,6 +40,8 @@ const fixVersionRef = ref(null)
 const componentRef = ref(null)
 const teamRef = ref(null)
 const priorityRef = ref(null)
+const productRef = ref(null)
+const fpdorItemsRef = ref(null)
 
 function closeAll() {
   outcomeOpen.value = false
@@ -43,17 +50,28 @@ function closeAll() {
   componentOpen.value = false
   teamOpen.value = false
   priorityOpen.value = false
+  productOpen.value = false
+  fpdorItemsOpen.value = false
 }
 
 function toggleDropdown(name) {
-  var map = { outcome: outcomeOpen, targetVersion: targetVersionOpen, fixVersion: fixVersionOpen, component: componentOpen, team: teamOpen, priority: priorityOpen }
+  var map = {
+    outcome: outcomeOpen,
+    targetVersion: targetVersionOpen,
+    fixVersion: fixVersionOpen,
+    component: componentOpen,
+    team: teamOpen,
+    priority: priorityOpen,
+    product: productOpen,
+    fpdorItems: fpdorItemsOpen
+  }
   var wasOpen = map[name].value
   closeAll()
   if (!wasOpen) map[name].value = true
 }
 
 function handleClickOutside(event) {
-  var refs = [outcomeRef, targetVersionRef, fixVersionRef, componentRef, teamRef, priorityRef]
+  var refs = [outcomeRef, targetVersionRef, fixVersionRef, componentRef, teamRef, priorityRef, productRef, fpdorItemsRef]
   for (var i = 0; i < refs.length; i++) {
     if (refs[i].value && refs[i].value.contains(event.target)) return
   }
@@ -83,6 +101,8 @@ function clearFilters() {
     component: [],
     priority: [],
     team: [],
+    product: [],
+    fpdorItems: [],
     readiness: null
   })
 }
@@ -96,6 +116,8 @@ const hasActiveFilters = computed(() => {
     (f.component && f.component.length) ||
     (f.priority && f.priority.length) ||
     (f.team && f.team.length) ||
+    (f.product && f.product.length) ||
+    (f.fpdorItems && f.fpdorItems.length) ||
     f.readiness
   )
 })
@@ -112,6 +134,8 @@ const fixVersions = computed(() => props.filterMeta.fixVersions || [])
 const components = computed(() => props.filterMeta.components || [])
 const priorities = computed(() => props.filterMeta.priorities || [])
 const teams = computed(() => props.filterMeta.teams || [])
+const products = KNOWN_PRODUCTS
+const fpdorItems = FPDOR_ITEM_NAMES
 
 const btnClass = 'flex items-center gap-1.5 cursor-pointer text-xs rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400'
 const btnActiveClass = 'flex items-center gap-1.5 cursor-pointer text-xs rounded-md border border-primary-400 dark:border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:focus:ring-primary-400'
@@ -233,6 +257,40 @@ const optionClass = 'flex items-center gap-2 px-3 py-1.5 text-xs text-gray-900 d
           <label v-for="p in priorities" :key="p" :class="optionClass">
             <input type="checkbox" :checked="(modelValue.priority || []).includes(p)" @change="toggleValue('priority', p)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
             <span class="truncate">{{ p }}</span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <!-- Product -->
+    <div class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Product</label>
+      <div ref="productRef" class="relative">
+        <button type="button" @click="toggleDropdown('product')" @keydown.escape="productOpen = false" :aria-expanded="productOpen" aria-haspopup="listbox" :class="(modelValue.product || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[140px]">{{ multiLabel(modelValue.product, 'All products') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="productOpen" role="group" :class="dropdownClass" @keydown.escape="productOpen = false">
+          <label v-for="p in products" :key="p" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.product || []).includes(p)" @change="toggleValue('product', p)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ p }}</span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <!-- Failed FPDoR items -->
+    <div class="flex flex-col gap-0.5">
+      <label class="text-xs font-medium text-gray-600 dark:text-gray-400">Failed FPDoR</label>
+      <div ref="fpdorItemsRef" class="relative">
+        <button type="button" @click="toggleDropdown('fpdorItems')" @keydown.escape="fpdorItemsOpen = false" :aria-expanded="fpdorItemsOpen" aria-haspopup="listbox" :class="(modelValue.fpdorItems || []).length ? btnActiveClass : btnClass">
+          <span class="truncate max-w-[160px]">{{ multiLabel(modelValue.fpdorItems, 'Any failed item') }}</span>
+          <svg class="w-3.5 h-3.5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+        </button>
+        <div v-if="fpdorItemsOpen" role="group" :class="dropdownClass" @keydown.escape="fpdorItemsOpen = false">
+          <label v-for="item in fpdorItems" :key="item" :class="optionClass">
+            <input type="checkbox" :checked="(modelValue.fpdorItems || []).includes(item)" @change="toggleValue('fpdorItems', item)" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+            <span class="truncate">{{ item }}</span>
           </label>
         </div>
       </div>

--- a/modules/releases/client/plan/utils/feature-readiness-export.js
+++ b/modules/releases/client/plan/utils/feature-readiness-export.js
@@ -87,11 +87,44 @@ function exportFeatureReadinessCsv(features) {
   triggerDownload(blob, 'feature-readiness-' + today + '.csv')
 }
 
+function featureMatchesSharedFilters(feature, filterState, selectedVersion, options) {
+  var opts = options || {}
+  var applyReadiness = opts.applyReadiness !== false
+  var f = filterState
+
+  if (f.outcome && f.outcome.length) {
+    var featureRocks = feature.bigRock ? feature.bigRock.split(', ') : []
+    if (!featureRocks.some(function(r) { return f.outcome.indexOf(r) !== -1 })) return false
+  }
+  if (f.targetVersion && f.targetVersion.length && !(feature.targetVersions || []).some(function(tv) {
+    return f.targetVersion.indexOf(tv) !== -1
+  })) return false
+  if (f.fixVersion && f.fixVersion.length && f.fixVersion.indexOf(feature.fixVersion) === -1) return false
+  if (f.component && f.component.length && !(feature.components || []).some(function(c) {
+    return f.component.indexOf(c) !== -1
+  })) return false
+  if (f.priority && f.priority.length && f.priority.indexOf(feature.priority) === -1) return false
+  if (f.team && f.team.length && f.team.indexOf(feature.team) === -1) return false
+  if (f.product && f.product.length && !featureMatchesProduct(feature, f.product)) return false
+  if (f.fpdorItems && f.fpdorItems.length && !featureFailsSelectedFpdorItems(feature, f.fpdorItems)) return false
+  if (applyReadiness) {
+    if (f.readiness === 'ready' && feature.confidence === 'not-ready') return false
+    if (f.readiness === 'not-ready' && feature.confidence !== 'not-ready') return false
+  }
+  if (selectedVersion) {
+    if (!(feature.targetVersions || []).some(function(tv) {
+      return tv === selectedVersion || tv.indexOf(selectedVersion) !== -1 || selectedVersion.indexOf(tv) !== -1
+    })) return false
+  }
+  return true
+}
+
 export {
   FPDOR_ITEM_NAMES,
   KNOWN_PRODUCTS,
   featureMatchesProduct,
   featureFailsSelectedFpdorItems,
   failedFpdorNames,
+  featureMatchesSharedFilters,
   exportFeatureReadinessCsv
 }

--- a/modules/releases/client/plan/utils/feature-readiness-export.js
+++ b/modules/releases/client/plan/utils/feature-readiness-export.js
@@ -1,0 +1,97 @@
+import { escapeCsv, triggerDownload } from './health-export.js'
+
+var FPDOR_ITEM_NAMES = [
+  'Requirements Clarity',
+  'Acceptance Criteria',
+  'Scope Defined',
+  'RICE Score',
+  'Cross-functional Engagement',
+  'Architectural Alignment',
+  'Risks & Assumptions',
+  'Release Type',
+  'Target Version',
+  'Assignee',
+  'PM Assigned'
+]
+
+var KNOWN_PRODUCTS = ['RHOAI', 'RHAIIS', 'RHELAI']
+
+function featureMatchesProduct(feature, products) {
+  if (!products || products.length === 0) return true
+  var versions = (feature.targetVersions || []).slice()
+  if (feature.fixVersion) versions.push(feature.fixVersion)
+  var haystack = versions.join(' ').toUpperCase()
+  for (var i = 0; i < products.length; i++) {
+    if (haystack.indexOf(String(products[i]).toUpperCase()) !== -1) return true
+  }
+  return false
+}
+
+function featureFailsSelectedFpdorItems(feature, itemNames) {
+  if (!itemNames || itemNames.length === 0) return true
+  var items = feature.fpdor && feature.fpdor.items ? feature.fpdor.items : []
+  for (var i = 0; i < items.length; i++) {
+    if (items[i].pass === false && itemNames.indexOf(items[i].name) !== -1) return true
+  }
+  return false
+}
+
+function failedFpdorNames(feature) {
+  var items = feature.fpdor && feature.fpdor.items ? feature.fpdor.items : []
+  var failed = []
+  for (var i = 0; i < items.length; i++) {
+    if (items[i].pass === false) failed.push(items[i].name)
+  }
+  return failed
+}
+
+function exportFeatureReadinessCsv(features) {
+  var columns = [
+    { label: 'Rank', getter: function(f) { return f.rank != null ? f.rank : '' } },
+    { label: 'Key', getter: function(f) { return f.key || '' } },
+    { label: 'Title', getter: function(f) { return f.title || '' } },
+    { label: 'Score', getter: function(f) { return f.effectivePriorityScore != null ? f.effectivePriorityScore : '' } },
+    {
+      label: 'FPDoR',
+      getter: function(f) {
+        if (!f.fpdor) return ''
+        return f.fpdor.passedCount + '/' + f.fpdor.totalCount
+      }
+    },
+    { label: 'Failed FPDoR Items', getter: function(f) { return failedFpdorNames(f).join('; ') } },
+    { label: 'Outcome', getter: function(f) { return f.bigRock || '' } },
+    {
+      label: 'Target Versions',
+      getter: function(f) { return (f.targetVersions || []).join('; ') }
+    },
+    { label: 'Fix Version', getter: function(f) { return f.fixVersion || '' } },
+    {
+      label: 'Components',
+      getter: function(f) {
+        return Array.isArray(f.components) ? f.components.join('; ') : (f.components || '')
+      }
+    },
+    { label: 'Team', getter: function(f) { return f.team || '' } },
+    { label: 'Status', getter: function(f) { return f.status || '' } },
+    { label: 'Priority', getter: function(f) { return f.priority || '' } },
+    { label: 'Confidence', getter: function(f) { return f.confidence || '' } }
+  ]
+
+  var header = columns.map(function(c) { return escapeCsv(c.label) }).join(',')
+  var rows = features.map(function(f) {
+    return columns.map(function(c) { return escapeCsv(c.getter(f)) }).join(',')
+  })
+  var csv = header + '\n' + rows.join('\n')
+  var blob = new Blob([csv + '\n'], { type: 'text/csv' })
+  var today = new Date().toISOString().split('T')[0]
+  triggerDownload(blob, 'feature-readiness-' + today + '.csv')
+}
+
+export {
+  FPDOR_ITEM_NAMES,
+  KNOWN_PRODUCTS,
+  featureMatchesProduct,
+  featureFailsSelectedFpdorItems,
+  failedFpdorNames,
+  exportFeatureReadinessCsv
+}

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -8,8 +8,7 @@ import FeatureReadinessFilterBar from '../components/FeatureReadinessFilterBar.v
 import FeatureReadinessRow from '../components/FeatureReadinessRow.vue'
 import FeatureReadinessDrawer from '../components/FeatureReadinessDrawer.vue'
 import {
-  featureMatchesProduct,
-  featureFailsSelectedFpdorItems,
+  featureMatchesSharedFilters,
   exportFeatureReadinessCsv
 } from '../utils/feature-readiness-export.js'
 
@@ -72,26 +71,7 @@ const filters = ref({
 })
 
 function matchesFilters(feature) {
-  const f = filters.value
-  if (f.outcome.length) {
-    var featureRocks = feature.bigRock ? feature.bigRock.split(', ') : []
-    if (!featureRocks.some(function(r) { return f.outcome.includes(r) })) return false
-  }
-  if (f.targetVersion.length && !(feature.targetVersions || []).some(function(tv) { return f.targetVersion.includes(tv) })) return false
-  if (f.fixVersion.length && !f.fixVersion.includes(feature.fixVersion)) return false
-  if (f.component.length && !(feature.components || []).some(function(c) { return f.component.includes(c) })) return false
-  if (f.priority.length && !f.priority.includes(feature.priority)) return false
-  if (f.team.length && !f.team.includes(feature.team)) return false
-  if (f.product.length && !featureMatchesProduct(feature, f.product)) return false
-  if (f.fpdorItems.length && !featureFailsSelectedFpdorItems(feature, f.fpdorItems)) return false
-  if (f.readiness === 'ready' && feature.confidence === 'not-ready') return false
-  if (f.readiness === 'not-ready' && feature.confidence !== 'not-ready') return false
-  if (selectedVersion.value) {
-    if (!(feature.targetVersions || []).some(function(tv) {
-      return tv === selectedVersion.value || tv.indexOf(selectedVersion.value) !== -1 || selectedVersion.value.indexOf(tv) !== -1
-    })) return false
-  }
-  return true
+  return featureMatchesSharedFilters(feature, filters.value, selectedVersion.value, { applyReadiness: true })
 }
 
 const filteredFeatures = computed(() => {
@@ -106,24 +86,7 @@ const filteredFeatures = computed(() => {
 
 const readyCounts = computed(() => {
   var all = pendingReview.value.concat(ready.value).filter(function(f) {
-    const fv = filters.value
-    if (fv.outcome.length) {
-      var countRocks = f.bigRock ? f.bigRock.split(', ') : []
-      if (!countRocks.some(function(r) { return fv.outcome.includes(r) })) return false
-    }
-    if (fv.targetVersion.length && !(f.targetVersions || []).some(function(tv) { return fv.targetVersion.includes(tv) })) return false
-    if (fv.fixVersion.length && !fv.fixVersion.includes(f.fixVersion)) return false
-    if (fv.component.length && !(f.components || []).some(function(c) { return fv.component.includes(c) })) return false
-    if (fv.priority.length && !fv.priority.includes(f.priority)) return false
-    if (fv.team.length && !fv.team.includes(f.team)) return false
-    if (fv.product.length && !featureMatchesProduct(f, fv.product)) return false
-    if (fv.fpdorItems.length && !featureFailsSelectedFpdorItems(f, fv.fpdorItems)) return false
-    if (selectedVersion.value) {
-      if (!(f.targetVersions || []).some(function(tv) {
-        return tv === selectedVersion.value || tv.indexOf(selectedVersion.value) !== -1 || selectedVersion.value.indexOf(tv) !== -1
-      })) return false
-    }
-    return true
+    return featureMatchesSharedFilters(f, filters.value, selectedVersion.value, { applyReadiness: false })
   })
   var readyCount = 0
   var notReadyCount = 0

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -7,6 +7,11 @@ import { apiRequest } from '@shared/client/services/api'
 import FeatureReadinessFilterBar from '../components/FeatureReadinessFilterBar.vue'
 import FeatureReadinessRow from '../components/FeatureReadinessRow.vue'
 import FeatureReadinessDrawer from '../components/FeatureReadinessDrawer.vue'
+import {
+  featureMatchesProduct,
+  featureFailsSelectedFpdorItems,
+  exportFeatureReadinessCsv
+} from '../utils/feature-readiness-export.js'
 
 const nav = inject('moduleNav')
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
@@ -61,6 +66,8 @@ const filters = ref({
   component: [],
   priority: [],
   team: [],
+  product: [],
+  fpdorItems: [],
   readiness: null
 })
 
@@ -75,6 +82,8 @@ function matchesFilters(feature) {
   if (f.component.length && !(feature.components || []).some(function(c) { return f.component.includes(c) })) return false
   if (f.priority.length && !f.priority.includes(feature.priority)) return false
   if (f.team.length && !f.team.includes(feature.team)) return false
+  if (f.product.length && !featureMatchesProduct(feature, f.product)) return false
+  if (f.fpdorItems.length && !featureFailsSelectedFpdorItems(feature, f.fpdorItems)) return false
   if (f.readiness === 'ready' && feature.confidence === 'not-ready') return false
   if (f.readiness === 'not-ready' && feature.confidence !== 'not-ready') return false
   if (selectedVersion.value) {
@@ -107,6 +116,8 @@ const readyCounts = computed(() => {
     if (fv.component.length && !(f.components || []).some(function(c) { return fv.component.includes(c) })) return false
     if (fv.priority.length && !fv.priority.includes(f.priority)) return false
     if (fv.team.length && !fv.team.includes(f.team)) return false
+    if (fv.product.length && !featureMatchesProduct(f, fv.product)) return false
+    if (fv.fpdorItems.length && !featureFailsSelectedFpdorItems(f, fv.fpdorItems)) return false
     if (selectedVersion.value) {
       if (!(f.targetVersions || []).some(function(tv) {
         return tv === selectedVersion.value || tv.indexOf(selectedVersion.value) !== -1 || selectedVersion.value.indexOf(tv) !== -1
@@ -130,6 +141,10 @@ const releaseOptions = computed(() => {
   }
   return opts
 })
+
+function exportCsv() {
+  exportFeatureReadinessCsv(filteredFeatures.value)
+}
 
 const headers = [
   { id: 'h-num',        label: '#',               scope: 'col' },
@@ -186,6 +201,13 @@ function formatSyncDate(dateStr) {
           class="ml-2 px-3 py-1 text-xs font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           :title="refreshing ? refreshStatus : 'Refresh hygiene data from Jira'"
         >{{ refreshing ? 'Refreshing...' : 'Refresh Hygiene' }}</button>
+        <button
+          type="button"
+          @click="exportCsv"
+          :disabled="filteredFeatures.length === 0"
+          class="px-3 py-1 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          title="Export current filtered view as CSV"
+        >Export CSV</button>
       </div>
     </div>
 

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -553,6 +553,20 @@ test.describe('Releases FPDoR Readiness @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 
+  test('Feature List shows Product, Failed FPDoR filters and Export CSV', async ({ page }) => {
+    await page.goto('/#/releases/plan?tab=feature-readiness');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.getByText('Product', { exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /All products/i })).toBeVisible();
+    await expect(page.getByText('Failed FPDoR', { exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /Any failed item/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Export CSV/i })).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
   test('PM Hub view loads with priority scores visible', async ({ page }) => {
     await page.goto('/#/releases/plan');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
- Add **Product** filter (RHOAI / RHAIIS / RHELAI) derived from target/fix versions
- Add **Failed FPDoR** multi-select filter for the 11 checklist items
- Add **Export CSV** for the current filtered Feature Readiness view
- Defer confidence column until pipeline confidence data is available in Org Pulse

Closes / tracks: https://redhat.atlassian.net/browse/AIPCC-19986

## Test plan
- [x] `npx vitest run modules/releases/__tests__/client/plan/feature-readiness-filter-bar.test.js modules/releases/__tests__/client/plan/feature-readiness-export.test.js` (32 passed)
- [ ] Manually verify Product and Failed FPDoR filters change the table
- [ ] Manually verify CSV downloads filtered rows


Made with [Cursor](https://cursor.com)