### PR TITLE
feat(product-builds): add package tracker tab and version map JIRA links

### DIFF
--- a/modules/product-builds/__tests__/server/normalize-release.test.js
+++ b/modules/product-builds/__tests__/server/normalize-release.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+
+const { normalizeRelease } = require('../../lib/normalize-release')
+
+describe('normalizeRelease', () => {
+  it('strips RHAI prefix', () => {
+    expect(normalizeRelease('RHAI 3.5')).toBe('3.5')
+    expect(normalizeRelease('RHAI 3.4 EA1')).toBe('3.4 EA1')
+  })
+
+  it('normalizes GA suffix', () => {
+    expect(normalizeRelease('3.5 GA')).toBe('3.5 GA')
+    expect(normalizeRelease('3.4 GA')).toBe('3.4 GA')
+  })
+
+  it('normalizes EA with hyphen', () => {
+    expect(normalizeRelease('3.5-EA2')).toBe('3.5 EA2')
+  })
+
+  it('normalizes EA stuck to version', () => {
+    expect(normalizeRelease('3.5EA1')).toBe('3.5 EA1')
+  })
+
+  it('normalizes EA with hyphen after', () => {
+    expect(normalizeRelease('3.5EA-1')).toBe('3.5 EA1')
+  })
+
+  it('handles full RHAI prefix with EA', () => {
+    expect(normalizeRelease('RHAI 3.5 EA1')).toBe('3.5 EA1')
+    expect(normalizeRelease('RHAI 3.5 EA2')).toBe('3.5 EA2')
+  })
+
+  it('handles stray dot before space', () => {
+    expect(normalizeRelease('RHAI 3.4. EA2')).toBe('3.4 EA2')
+  })
+
+  it('passes through bare version', () => {
+    expect(normalizeRelease('3.4')).toBe('3.4')
+  })
+})

--- a/modules/product-builds/__tests__/server/package-tracker.test.js
+++ b/modules/product-builds/__tests__/server/package-tracker.test.js
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const registerRoutes = require('../../server/package-tracker')
+const {
+  extractAdfText, extractJiraLinks, parseDescriptionFields,
+  computeRisk, computeLeadTime, extractTargetVersions,
+} = registerRoutes._testExports
+
+describe('package-tracker', () => {
+  describe('extractAdfText', () => {
+    it('returns empty for null', () => {
+      expect(extractAdfText(null)).toBe('')
+    })
+
+    it('extracts text from simple ADF', () => {
+      const adf = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'world' }] }
+        ]
+      }
+      expect(extractAdfText(adf)).toBe('Hello world')
+    })
+
+    it('handles nested content', () => {
+      const adf = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Target Date: 2026-07-01' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Team: Platform' }] }
+        ]
+      }
+      expect(extractAdfText(adf)).toContain('Target Date: 2026-07-01')
+      expect(extractAdfText(adf)).toContain('Team: Platform')
+    })
+  })
+
+  describe('extractJiraLinks', () => {
+    it('returns empty for null', () => {
+      expect(extractJiraLinks(null)).toEqual([])
+    })
+
+    it('extracts from inlineCard', () => {
+      const node = {
+        type: 'inlineCard',
+        attrs: { url: 'https://redhat.atlassian.net/browse/RHEL-5678' }
+      }
+      expect(extractJiraLinks(node)).toEqual(['RHEL-5678'])
+    })
+
+    it('extracts from text with link mark', () => {
+      const node = {
+        type: 'text',
+        text: 'Related ticket',
+        marks: [{ type: 'link', attrs: { href: 'https://redhat.atlassian.net/browse/AIPCC-123' } }]
+      }
+      expect(extractJiraLinks(node)).toEqual(['AIPCC-123'])
+    })
+
+    it('recurses into content', () => {
+      const node = {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [
+            { type: 'inlineCard', attrs: { url: 'https://redhat.atlassian.net/browse/ABC-1' } },
+            { type: 'inlineCard', attrs: { url: 'https://redhat.atlassian.net/browse/DEF-2' } }
+          ]}
+        ]
+      }
+      expect(extractJiraLinks(node)).toEqual(['ABC-1', 'DEF-2'])
+    })
+
+    it('ignores non-atlassian URLs', () => {
+      const node = {
+        type: 'inlineCard',
+        attrs: { url: 'https://github.com/some/repo' }
+      }
+      expect(extractJiraLinks(node)).toEqual([])
+    })
+  })
+
+  describe('parseDescriptionFields', () => {
+    it('returns defaults for null', () => {
+      const result = parseDescriptionFields(null)
+      expect(result).toEqual({ targetDate: null, release: null, relatedTicket: null, team: null, requester: null })
+    })
+
+    it('extracts target date', () => {
+      const adf = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Target Date: 2026-07-15' }] }] }
+      expect(parseDescriptionFields(adf).targetDate).toBe('2026-07-15')
+    })
+
+    it('extracts release commitment', () => {
+      const adf = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Release Commitment: 3.5 EA2 Testing' }] }] }
+      expect(parseDescriptionFields(adf).release).toBe('3.5 EA2')
+    })
+
+    it('extracts related ticket from text', () => {
+      const adf = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Related Jira Ticket: AIPCC-18313' }] }] }
+      expect(parseDescriptionFields(adf).relatedTicket).toBe('AIPCC-18313')
+    })
+
+    it('prefers inlineCard links over text regex', () => {
+      const adf = {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Related Jira Ticket: AIPCC-999' },
+            { type: 'inlineCard', attrs: { url: 'https://redhat.atlassian.net/browse/AIPCC-111' } }
+          ]
+        }]
+      }
+      expect(parseDescriptionFields(adf).relatedTicket).toBe('AIPCC-111')
+    })
+
+    it('extracts team', () => {
+      const adf = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Team: PyTorch Package' }] }] }
+      expect(parseDescriptionFields(adf).team).toBe('PyTorch')
+    })
+
+    it('extracts requester email', () => {
+      const adf = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Requester: user@redhat.com' }] }] }
+      expect(parseDescriptionFields(adf).requester).toBe('user@redhat.com')
+    })
+  })
+
+  describe('computeRisk', () => {
+    it('returns no_date for null', () => {
+      expect(computeRisk(null)).toEqual({ days_overdue: null, risk: 'no_date' })
+    })
+
+    it('returns no_date for invalid date', () => {
+      expect(computeRisk('not-a-date')).toEqual({ days_overdue: null, risk: 'no_date' })
+    })
+
+    it('returns overdue for past dates', () => {
+      const result = computeRisk('2020-01-01')
+      expect(result.risk).toBe('overdue')
+      expect(result.days_overdue).toBeGreaterThan(0)
+    })
+
+    it('returns on_track for far future dates', () => {
+      const result = computeRisk('2099-12-31')
+      expect(result.risk).toBe('on_track')
+      expect(result.days_overdue).toBeLessThan(-7)
+    })
+  })
+
+  describe('computeLeadTime', () => {
+    it('returns null for missing dates', () => {
+      expect(computeLeadTime(null, '2026-01-01')).toEqual({ lead_time: null, lead_time_flag: null })
+      expect(computeLeadTime('2026-01-01', null)).toEqual({ lead_time: null, lead_time_flag: null })
+    })
+
+    it('flags critical for <= 3 days', () => {
+      const result = computeLeadTime('2026-01-03', '2026-01-01')
+      expect(result.lead_time).toBe(2)
+      expect(result.lead_time_flag).toBe('critical')
+    })
+
+    it('flags tight for <= 7 days', () => {
+      const result = computeLeadTime('2026-01-07', '2026-01-01')
+      expect(result.lead_time).toBe(6)
+      expect(result.lead_time_flag).toBe('tight')
+    })
+
+    it('returns null flag for > 7 days', () => {
+      const result = computeLeadTime('2026-01-20', '2026-01-01')
+      expect(result.lead_time).toBe(19)
+      expect(result.lead_time_flag).toBeNull()
+    })
+  })
+
+  describe('extractTargetVersions', () => {
+    it('returns empty for null', () => {
+      expect(extractTargetVersions(null)).toEqual([])
+    })
+
+    it('handles array of objects', () => {
+      expect(extractTargetVersions([{ name: '3.5 GA' }, { name: '3.4' }])).toEqual(['3.5 GA', '3.4'])
+    })
+
+    it('handles single object', () => {
+      expect(extractTargetVersions({ name: '3.5 EA1' })).toEqual(['3.5 EA1'])
+    })
+
+    it('filters empty names', () => {
+      expect(extractTargetVersions([{ name: '' }, { name: '3.5' }])).toEqual(['3.5'])
+    })
+  })
+
+  describe('route registration', () => {
+    it('registers GET and POST routes', () => {
+      const router = { get: vi.fn(), post: vi.fn() }
+      const context = { secrets: {}, requireAdmin: vi.fn() }
+      registerRoutes(router, context)
+      expect(router.get).toHaveBeenCalledWith('/package-tracker', expect.any(Function))
+      expect(router.post).toHaveBeenCalledWith('/package-tracker/refresh', context.requireAdmin, expect.any(Function))
+    })
+  })
+})

--- a/modules/product-builds/__tests__/server/version-map-jira.test.js
+++ b/modules/product-builds/__tests__/server/version-map-jira.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+
+const { _testExports } = require('../../server/version-map')
+const { parseFeatureSummary, extractVariantBase, extractPackageFromEpic } = _testExports
+
+describe('version-map JIRA helpers', () => {
+  describe('parseFeatureSummary', () => {
+    it('parses standard variant feature', () => {
+      expect(parseFeatureSummary('cuda12.9-ubi9 for 3.5 GA')).toEqual({ variant: 'cuda12.9', release: '3.5 GA' })
+    })
+
+    it('parses EA release with hyphen', () => {
+      expect(parseFeatureSummary('cuda12.9-ubi9 for 3.5-EA2')).toEqual({ variant: 'cuda12.9', release: '3.5-EA2' })
+    })
+
+    it('parses EA release stuck to version', () => {
+      expect(parseFeatureSummary('cuda12.9-ubi9 for 3.5EA1')).toEqual({ variant: 'cuda12.9', release: '3.5EA1' })
+    })
+
+    it('parses Google TPU variant', () => {
+      expect(parseFeatureSummary('Google TPU-ubi9 for 3.5-EA2')).toEqual({ variant: 'google tpu', release: '3.5-EA2' })
+    })
+
+    it('parses cpu variant', () => {
+      expect(parseFeatureSummary('cpu-ubi9 for 3.5 GA')).toEqual({ variant: 'cpu', release: '3.5 GA' })
+    })
+
+    it('parses ROCm variant', () => {
+      expect(parseFeatureSummary('rocm7.23-ubi9 for 3.5 GA')).toEqual({ variant: 'rocm7.23', release: '3.5 GA' })
+    })
+
+    it('parses with RHAI prefix in release', () => {
+      expect(parseFeatureSummary('cpu-ubi9 for RHAI 3.5 EA1')).toEqual({ variant: 'cpu', release: 'RHAI 3.5 EA1' })
+    })
+
+    it('returns null for non-variant features', () => {
+      expect(parseFeatureSummary('Delivery Squad work for 3.5 GA')).toBeNull()
+      expect(parseFeatureSummary('Some random feature')).toBeNull()
+    })
+  })
+
+  describe('extractVariantBase', () => {
+    it('extracts alpha prefix', () => {
+      expect(extractVariantBase('cuda12.9')).toBe('cuda')
+      expect(extractVariantBase('rocm7.23')).toBe('rocm')
+    })
+
+    it('handles pure alpha variants', () => {
+      expect(extractVariantBase('cpu')).toBe('cpu')
+      expect(extractVariantBase('gaudi')).toBe('gaudi')
+      expect(extractVariantBase('spyre')).toBe('spyre')
+    })
+
+    it('handles google tpu', () => {
+      expect(extractVariantBase('google tpu')).toBe('google')
+    })
+  })
+
+  describe('extractPackageFromEpic', () => {
+    it('extracts from "Update X to Y" pattern', () => {
+      expect(extractPackageFromEpic('Update vllm to 0.24.0')).toBe('vllm')
+      expect(extractPackageFromEpic('Update torch to 2.11')).toBe('torch')
+    })
+
+    it('extracts from "Upgrade X to Y" pattern', () => {
+      expect(extractPackageFromEpic('Upgrade LLM-D to 0.8 along with its dependencies')).toBe('llm-d')
+    })
+
+    it('extracts from "wheels for X" pattern', () => {
+      expect(extractPackageFromEpic('Deliver cpu-ubi9 wheels for vLLM TBD for 3.5 GA')).toBe('vllm')
+    })
+
+    it('strips -ubi9 suffix from variant names', () => {
+      expect(extractPackageFromEpic('Update cuda12.9-ubi9 base images to 3.5')).toBe('cuda12.9')
+    })
+
+    it('returns null for non-package epics', () => {
+      expect(extractPackageFromEpic('QE: Validate CUDA 12.9 packages for 3.5 GA')).toBeNull()
+      expect(extractPackageFromEpic('SPIKE: ADR & Breakdown of stories')).toBeNull()
+    })
+  })
+})

--- a/modules/product-builds/client/composables/usePackageTracker.js
+++ b/modules/product-builds/client/composables/usePackageTracker.js
@@ -1,0 +1,60 @@
+import { ref, computed } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const BASE = '/modules/product-builds/package-tracker'
+
+export function usePackageTracker() {
+  const data = ref(null)
+  const loading = ref(false)
+  const refreshing = ref(false)
+  const error = ref(null)
+
+  async function load() {
+    loading.value = true
+    error.value = null
+    try {
+      data.value = await apiRequest(BASE)
+    } catch (e) {
+      error.value = e.message || 'Failed to load package tracker'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refresh() {
+    refreshing.value = true
+    error.value = null
+    try {
+      data.value = await apiRequest(`${BASE}/refresh`, { method: 'POST' })
+    } catch (e) {
+      error.value = e.message || 'Failed to refresh package tracker'
+    } finally {
+      refreshing.value = false
+    }
+  }
+
+  const packages = computed(() => data.value ? data.value.packages : [])
+
+  const summary = computed(() => {
+    if (!data.value) return null
+    return {
+      total: data.value.total,
+      overdue: data.value.overdue,
+      at_risk: data.value.at_risk,
+      on_track: data.value.on_track,
+      no_date: data.value.no_date,
+      generated_at: data.value.generated_at,
+    }
+  })
+
+  return {
+    data,
+    loading,
+    refreshing,
+    error,
+    load,
+    refresh,
+    packages,
+    summary,
+  }
+}

--- a/modules/product-builds/client/composables/useVersionMap.js
+++ b/modules/product-builds/client/composables/useVersionMap.js
@@ -58,6 +58,20 @@ export function useVersionMap() {
     return count
   })
 
+  const jiraLinks = ref(null)
+  const jiraLinksLoading = ref(false)
+
+  async function loadJiraLinks() {
+    jiraLinksLoading.value = true
+    try {
+      jiraLinks.value = await apiRequest(`${BASE}/jira-links`)
+    } catch {
+      jiraLinks.value = null
+    } finally {
+      jiraLinksLoading.value = false
+    }
+  }
+
   return {
     data,
     loading,
@@ -70,5 +84,8 @@ export function useVersionMap() {
     source,
     allPackageNames,
     totalVariants,
+    jiraLinks,
+    jiraLinksLoading,
+    loadJiraLinks,
   }
 }

--- a/modules/product-builds/client/views/PackageAnalysisView.vue
+++ b/modules/product-builds/client/views/PackageAnalysisView.vue
@@ -6,6 +6,7 @@ import { useAuth } from '@shared/client/composables/useAuth'
 const PackageSearchView = defineAsyncComponent(() => import('./PackageSearchView.vue'))
 const NightlyAnalysisView = defineAsyncComponent(() => import('./NightlyAnalysisView.vue'))
 const VersionMapView = defineAsyncComponent(() => import('./VersionMapView.vue'))
+const PackageTrackerView = defineAsyncComponent(() => import('./PackageTrackerView.vue'))
 
 const { isAdmin } = useAuth()
 
@@ -63,7 +64,7 @@ function getInitialTab() {
   if (qIdx !== -1) {
     const params = new URLSearchParams(hash.slice(qIdx + 1))
     const tab = params.get('tab')
-    if (tab === 'search' || tab === 'nightly' || tab === 'versions') return tab
+    if (tab === 'search' || tab === 'nightly' || tab === 'versions' || tab === 'tracker') return tab
   }
   return 'onboarded'
 }
@@ -385,6 +386,15 @@ onMounted(() => {
           >
             Version Map
           </button>
+          <button
+            @click="activeTab = 'tracker'"
+            class="py-2.5 text-sm font-medium border-b-2 transition-colors flex items-center gap-2"
+            :class="activeTab === 'tracker'
+              ? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+          >
+            Tracker
+          </button>
         </nav>
       </div>
 
@@ -510,6 +520,11 @@ onMounted(() => {
       <!-- ==================== VERSION MAP TAB ==================== -->
       <div v-if="activeTab === 'versions'">
         <VersionMapView />
+      </div>
+
+      <!-- ==================== PACKAGE TRACKER TAB ==================== -->
+      <div v-if="activeTab === 'tracker'">
+        <PackageTrackerView />
       </div>
 
       <!-- ==================== DAILY REPORT TAB ==================== -->

--- a/modules/product-builds/client/views/PackageTrackerView.vue
+++ b/modules/product-builds/client/views/PackageTrackerView.vue
@@ -1,0 +1,352 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { usePackageTracker } from '../composables/usePackageTracker'
+import { useAuth } from '@shared/client/composables/useAuth'
+
+const { isAdmin } = useAuth()
+const { loading, refreshing, error, load, refresh, packages, summary } = usePackageTracker()
+
+const JIRA_BASE = 'https://redhat.atlassian.net/browse'
+
+const RISK_CONFIG = {
+  overdue:  { label: 'Overdue',  icon: '●', color: '#c42f2f', bg: '#faeae8', border: 'border-red-300 dark:border-red-800', cardBorder: '#c42f2f' },
+  at_risk:  { label: 'At Risk',  icon: '▲', color: '#8a6500', bg: '#fdf7e7', border: 'border-amber-300 dark:border-amber-800', cardBorder: '#8a6500' },
+  on_track: { label: 'On Track', icon: '✓', color: '#006300', bg: '#f3faf2', border: 'border-green-300 dark:border-green-800', cardBorder: '#006300' },
+  no_date:  { label: 'No Date',  icon: '—', color: '#6a6e73', bg: '#f5f5f5', border: 'border-gray-300 dark:border-gray-700', cardBorder: '#6a6e73' },
+}
+
+const STATUS_CATEGORY_COLORS = {
+  'new':           'bg-gray-500',
+  'indeterminate': 'bg-blue-600',
+  'done':          'bg-green-600',
+  'undefined':     'bg-gray-400',
+}
+
+const SUMMARY_CARDS = [
+  { key: 'total',   label: 'Total Packages', color: '#2563eb' },
+  { key: 'overdue', label: 'Overdue',        color: '#c42f2f', riskFilter: 'overdue' },
+  { key: 'at_risk', label: 'At Risk',        color: '#8a6500', riskFilter: 'at_risk' },
+  { key: 'on_track',label: 'On Track',       color: '#006300', riskFilter: 'on_track' },
+]
+
+const SORTABLE_COLUMNS = [
+  { field: 'key',            label: 'EPIC',           width: 'w-[110px]' },
+  { field: 'package',        label: 'Package',        width: 'min-w-[140px]' },
+  { field: 'status',         label: 'Status',         width: 'w-[100px]' },
+  { field: 'assignee',       label: 'Assignee',       width: 'w-[120px]' },
+  { field: 'related_ticket', label: 'Related Ticket', width: 'w-[120px]' },
+  { field: 'target_date',    label: 'Due Date',       width: 'w-[95px]' },
+  { field: 'release',        label: 'Release',        width: 'w-[100px]' },
+  { field: 'fix_version',    label: 'Fix Version',    width: 'w-[100px]' },
+  { field: 'size',           label: 'Size',           width: 'w-[50px]' },
+  { field: 'lead_time',      label: 'Lead Time',      width: 'w-[80px]' },
+  { field: 'days_overdue',   label: 'Days',           width: 'w-[60px]' },
+]
+
+const RISK_PILLS = [
+  { value: 'All', label: 'All' },
+  { value: 'overdue', label: 'Overdue', icon: '●', color: '#c42f2f' },
+  { value: 'at_risk', label: 'At Risk', icon: '▲', color: '#8a6500' },
+  { value: 'on_track', label: 'On Track', icon: '✓', color: '#006300' },
+  { value: 'no_date', label: 'No Date', icon: '—', color: '#6a6e73' },
+]
+
+// --- State ---
+const riskFilter = ref('All')
+const releaseFilter = ref('All')
+const ticketSearch = ref('')
+const sortField = ref('days_overdue')
+const sortDir = ref('desc')
+const expandedRows = ref(new Set())
+
+// --- Computed ---
+const releaseOptions = computed(() => {
+  if (!packages.value.length) return []
+  const set = new Set()
+  for (const p of packages.value) set.add(p.release || 'None')
+  return [...set].sort()
+})
+
+const filteredPackages = computed(() => {
+  let list = packages.value
+  if (riskFilter.value !== 'All') {
+    list = list.filter(p => p.risk === riskFilter.value)
+  }
+  if (releaseFilter.value !== 'All') {
+    const target = releaseFilter.value === 'None' ? null : releaseFilter.value
+    list = list.filter(p => (p.release || null) === target)
+  }
+  if (ticketSearch.value) {
+    const q = ticketSearch.value.toUpperCase()
+    list = list.filter(p => p.related_ticket && p.related_ticket.toUpperCase().includes(q))
+  }
+  return [...list].sort((a, b) => {
+    const av = a[sortField.value]
+    const bv = b[sortField.value]
+    if (av == null) return 1
+    if (bv == null) return -1
+    const cmp = typeof av === 'number' ? av - bv : String(av).localeCompare(String(bv))
+    return sortDir.value === 'desc' ? -cmp : cmp
+  })
+})
+
+// --- Methods ---
+function toggleSort(field) {
+  if (sortField.value === field) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDir.value = field === 'days_overdue' ? 'desc' : 'asc'
+  }
+}
+
+function toggleRow(key) {
+  const next = new Set(expandedRows.value)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  expandedRows.value = next
+}
+
+function isJiraKey(str) {
+  return str && /^[A-Z]+-\d+$/.test(str)
+}
+
+function setRiskFilterFromCard(card) {
+  if (!card.riskFilter) {
+    riskFilter.value = 'All'
+  } else if (riskFilter.value === card.riskFilter) {
+    riskFilter.value = 'All'
+  } else {
+    riskFilter.value = card.riskFilter
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <!-- Error -->
+    <div v-if="error" class="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+      {{ error }}
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-center py-24">
+      <svg class="animate-spin h-10 w-10 text-gray-400 mx-auto" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      <div class="mt-4 text-gray-500 dark:text-gray-400">Loading package tracker...</div>
+    </div>
+
+    <template v-else-if="summary">
+      <!-- Summary cards -->
+      <div class="flex gap-4 mb-6 flex-wrap">
+        <button
+          v-for="card in SUMMARY_CARDS"
+          :key="card.key"
+          class="flex-1 min-w-[140px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-center py-5 px-4 transition-all hover:shadow-md cursor-pointer"
+          :class="card.riskFilter && riskFilter === card.riskFilter ? 'ring-2 ring-offset-1 ring-blue-400' : ''"
+          @click="setRiskFilterFromCard(card)"
+        >
+          <div class="text-[42px] font-bold leading-none" :style="{ color: card.color }">{{ summary[card.key] }}</div>
+          <div class="text-[13px] text-gray-500 dark:text-gray-400 mt-2">{{ card.label }}</div>
+        </button>
+      </div>
+
+      <!-- Filter bar -->
+      <div class="space-y-3 mb-4">
+        <!-- Row 1: Risk pills -->
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mr-1">Risk</span>
+          <button
+            v-for="pill in RISK_PILLS"
+            :key="pill.value"
+            class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors"
+            :class="riskFilter === pill.value
+              ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+            @click="riskFilter = riskFilter === pill.value ? 'All' : pill.value"
+          >
+            <span v-if="pill.icon" class="text-[10px]" :style="riskFilter !== pill.value ? { color: pill.color } : {}">{{ pill.icon }}</span>
+            {{ pill.label }}
+          </button>
+        </div>
+        <!-- Row 2: Release pills + ticket search + refresh -->
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mr-1">Release</span>
+          <button
+            class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium border transition-colors"
+            :class="releaseFilter === 'All'
+              ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+            @click="releaseFilter = 'All'"
+          >All</button>
+          <button
+            v-for="r in releaseOptions"
+            :key="r"
+            class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium border transition-colors"
+            :class="releaseFilter === r
+              ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+            @click="releaseFilter = releaseFilter === r ? 'All' : r"
+          >{{ r }}</button>
+
+          <div class="ml-auto flex items-center gap-3">
+            <!-- Related ticket search -->
+            <div class="relative">
+              <input
+                v-model="ticketSearch"
+                type="text"
+                placeholder="Search ticket..."
+                class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg pl-3 pr-7 py-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 w-40 placeholder:text-gray-400"
+              />
+              <button
+                v-if="ticketSearch"
+                class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm"
+                @click="ticketSearch = ''"
+              >×</button>
+            </div>
+            <span v-if="summary.generated_at" class="text-xs text-gray-400 dark:text-gray-500 hidden sm:inline">
+              Updated {{ summary.generated_at.slice(0, 16).replace('T', ' ') }} UTC
+            </span>
+            <button
+              v-if="isAdmin"
+              :disabled="refreshing"
+              class="px-3 py-1 text-sm font-medium text-white bg-gray-700 hover:bg-gray-800 dark:bg-gray-600 dark:hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+              @click="refresh"
+            >
+              {{ refreshing ? 'Refreshing...' : 'Refresh' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Count -->
+      <div class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+        Showing {{ filteredPackages.length }} of {{ packages.length }} packages
+      </div>
+
+      <!-- Table -->
+      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b-2 border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+              <th class="w-8 py-2.5 px-2"></th>
+              <th
+                v-for="col in SORTABLE_COLUMNS"
+                :key="col.field"
+                class="text-left py-2.5 px-2 font-medium text-gray-600 dark:text-gray-400 cursor-pointer hover:text-gray-900 dark:hover:text-gray-200 select-none whitespace-nowrap"
+                :class="col.width"
+                @click="toggleSort(col.field)"
+              >
+                {{ col.label }}
+                <span v-if="sortField === col.field" class="ml-0.5 text-blue-500">{{ sortDir === 'asc' ? '▲' : '▼' }}</span>
+              </th>
+              <th class="w-[75px] text-left py-2.5 px-2 font-medium text-gray-600 dark:text-gray-400">Risk</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
+            <template v-for="pkg in filteredPackages" :key="pkg.key">
+              <!-- Main row -->
+              <tr
+                class="transition-colors cursor-pointer"
+                :class="pkg.risk === 'overdue' ? 'bg-red-50/50 dark:bg-red-900/5 hover:bg-red-50 dark:hover:bg-red-900/10' : 'hover:bg-gray-50 dark:hover:bg-gray-750'"
+                @click="pkg.children.length > 0 && toggleRow(pkg.key)"
+              >
+                <!-- Expand -->
+                <td class="py-2 px-2 text-center text-gray-400">
+                  <span v-if="pkg.children.length > 0" class="text-xs">{{ expandedRows.has(pkg.key) ? '▾' : '▸' }}</span>
+                </td>
+                <!-- EPIC -->
+                <td class="py-2 px-2">
+                  <a :href="`${JIRA_BASE}/${pkg.key}`" target="_blank" rel="noopener noreferrer" class="font-semibold text-blue-600 hover:underline" @click.stop>{{ pkg.key }}</a>
+                </td>
+                <!-- Package -->
+                <td class="py-2 px-2 text-gray-900 dark:text-gray-200">{{ pkg.package }}</td>
+                <!-- Status -->
+                <td class="py-2 px-2">
+                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-white" :class="STATUS_CATEGORY_COLORS[pkg.status_category] || 'bg-gray-500'">{{ pkg.status }}</span>
+                </td>
+                <!-- Assignee -->
+                <td class="py-2 px-2 text-gray-700 dark:text-gray-300 truncate max-w-[120px]" :title="pkg.assignee">{{ pkg.assignee }}</td>
+                <!-- Related Ticket -->
+                <td class="py-2 px-2">
+                  <a v-if="isJiraKey(pkg.related_ticket)" :href="`${JIRA_BASE}/${pkg.related_ticket}`" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline" @click.stop>{{ pkg.related_ticket }}</a>
+                  <span v-else class="text-gray-400">{{ pkg.related_ticket || '—' }}</span>
+                </td>
+                <!-- Due Date -->
+                <td class="py-2 px-2 text-gray-700 dark:text-gray-300 tabular-nums">{{ pkg.target_date || '—' }}</td>
+                <!-- Release -->
+                <td class="py-2 px-2 text-gray-700 dark:text-gray-300">{{ pkg.release || '—' }}</td>
+                <!-- Fix Version -->
+                <td class="py-2 px-2 text-gray-700 dark:text-gray-300">{{ pkg.fix_version || '—' }}</td>
+                <!-- Size -->
+                <td class="py-2 px-2 text-gray-700 dark:text-gray-300">{{ pkg.size || '—' }}</td>
+                <!-- Lead Time -->
+                <td class="py-2 px-2 tabular-nums">
+                  <template v-if="pkg.lead_time != null">
+                    <span
+                      class="inline-flex items-center gap-1 text-gray-700 dark:text-gray-300"
+                      :title="pkg.lead_time_flag === 'critical' ? 'Critical: ≤3 days lead time' : pkg.lead_time_flag === 'tight' ? 'Tight: ≤7 days lead time' : 'Days between creation and due date'"
+                    >
+                      <span v-if="pkg.lead_time_flag === 'critical'" class="text-[8px]" style="color: #c42f2f">●</span>
+                      <span v-else-if="pkg.lead_time_flag === 'tight'" class="text-[8px]" style="color: #8a6500">●</span>
+                      {{ pkg.lead_time }}d<span v-if="pkg.lead_time_flag === 'critical'"> !!</span><span v-else-if="pkg.lead_time_flag === 'tight'"> !</span>
+                    </span>
+                  </template>
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <!-- Days -->
+                <td class="py-2 px-2 tabular-nums">
+                  <template v-if="pkg.days_overdue != null">
+                    <span class="inline-flex items-center gap-1 text-gray-700 dark:text-gray-300">
+                      <span v-if="pkg.days_overdue > 0" class="text-[8px]" style="color: #c42f2f">●</span>
+                      {{ pkg.days_overdue > 0 ? '+' : '' }}{{ pkg.days_overdue }}
+                    </span>
+                  </template>
+                  <span v-else class="text-gray-400">&mdash;</span>
+                </td>
+                <!-- Risk -->
+                <td class="py-2 px-2">
+                  <span
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border"
+                    :class="RISK_CONFIG[pkg.risk]?.border || ''"
+                    :style="{ color: RISK_CONFIG[pkg.risk]?.color, backgroundColor: RISK_CONFIG[pkg.risk]?.bg }"
+                  ><span class="text-[10px]">{{ RISK_CONFIG[pkg.risk]?.icon }}</span>{{ RISK_CONFIG[pkg.risk]?.label || pkg.risk }}</span>
+                </td>
+              </tr>
+              <!-- Child rows -->
+              <template v-if="expandedRows.has(pkg.key)">
+                <tr
+                  v-for="child in pkg.children"
+                  :key="child.key"
+                  class="bg-gray-50/70 dark:bg-gray-800/70"
+                >
+                  <td class="py-1.5 px-2"></td>
+                  <td class="py-1.5 px-2 pl-6">
+                    <a :href="`${JIRA_BASE}/${child.key}`" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline text-xs">{{ child.key }}</a>
+                  </td>
+                  <td class="py-1.5 px-2 text-gray-600 dark:text-gray-400 text-xs" colspan="8">{{ child.summary }}</td>
+                  <td class="py-1.5 px-2" colspan="2">
+                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium text-white" :class="STATUS_CATEGORY_COLORS[child.status_category] || 'bg-gray-500'">{{ child.status }}</span>
+                  </td>
+                  <td></td>
+                </tr>
+              </template>
+            </template>
+          </tbody>
+        </table>
+
+        <!-- Empty state -->
+        <div v-if="filteredPackages.length === 0 && packages.length > 0" class="text-center py-10 text-gray-500 dark:text-gray-400">
+          No packages match the current filters.
+        </div>
+        <div v-if="packages.length === 0 && !loading" class="text-center py-10 text-gray-500 dark:text-gray-400">
+          No open package EPICs found.
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/product-builds/client/views/VersionMapView.vue
+++ b/modules/product-builds/client/views/VersionMapView.vue
@@ -47,7 +47,7 @@ function displayVersion(pkg, release, acc) {
   return entry.version || (isPlanning(acc, release) ? 'TBD' : '')
 }
 
-function cellTooltip(pkg, release, acc, sv) {
+function cellTooltip(pkg, release, acc) {
   const entry = getVersion(pkg, release)
   let tip
   if (!entry) {
@@ -66,10 +66,12 @@ function cellTooltip(pkg, release, acc, sv) {
       else tip = `${pkg.name}: ${old.version} → ${ver}`
     }
   }
-  if (sv) {
-    const link = findJiraLink(acc.sheet, sv.name, pkg.name, release)
-    if (link) tip += ` — ${link.key}`
-  }
+  return tip
+}
+
+function cellTooltipWithLink(pkg, release, acc, link) {
+  let tip = cellTooltip(pkg, release, acc)
+  if (link) tip += ` — ${link.key}`
   return tip
 }
 
@@ -176,43 +178,42 @@ function normalizeRelease(r) {
   return r.replace(/^RHAI\s+/i, '').replace(/\.+\s/g, ' ').replace(/[-\s]*(EA|GA)[-\s]*/gi, ' $1').replace(/\s+/g, ' ').trim()
 }
 
+function getCellJiraLink(pkg, release, acc, sv) {
+  if (!jiraLinks.value) return null
+  const entry = getVersion(pkg, release)
+  if (!entry) return null
+  return findJiraLink(acc.sheet, sv.name, pkg.name, release)
+}
+
 function findJiraLink(sheetName, svName, pkgName, release) {
   if (!jiraLinks.value) return null
   const variant = extractVariantSlug(sheetName, svName)
   const pkg = pkgName.toLowerCase()
   const normR = normalizeRelease(release)
-  const releases = normR.includes('EA') ? [normR] : [`${normR} GA`, normR]
-  for (const rel of releases) {
+  const candidateReleases = normR.includes('EA') ? [normR] : [`${normR} GA`, normR]
+  for (const rel of candidateReleases) {
     const epicLink = jiraLinks.value.links[`${variant}:${rel}:${pkg}`]
     if (epicLink) return { key: epicLink.key, type: 'epic' }
   }
   for (const fk of Object.keys(jiraLinks.value.features)) {
     if (!fk.startsWith(variant)) continue
     const fRelease = fk.split(':')[1]
-    if (releases.includes(fRelease)) {
+    if (candidateReleases.includes(fRelease)) {
       const epicLink = jiraLinks.value.links[`${fk}:${pkg}`]
       if (epicLink) return { key: epicLink.key, type: 'epic' }
     }
   }
-  for (const rel of releases) {
+  for (const rel of candidateReleases) {
     const featureLink = jiraLinks.value.features[`${variant}:${rel}`]
     if (featureLink) return { key: featureLink.key, type: 'feature' }
   }
   for (const fk of Object.keys(jiraLinks.value.features)) {
     if (!fk.startsWith(variant)) continue
     const fRelease = fk.split(':')[1]
-    if (releases.includes(fRelease)) return { key: jiraLinks.value.features[fk].key, type: 'feature' }
+    if (candidateReleases.includes(fRelease)) return { key: jiraLinks.value.features[fk].key, type: 'feature' }
   }
   return null
 }
-
-function cellHasJiraLink(pkg, release, acc, sv) {
-  if (!jiraLinks.value) return false
-  const entry = getVersion(pkg, release)
-  if (!entry) return false
-  return !!findJiraLink(acc.sheet, sv.name, pkg.name, release)
-}
-
 onMounted(() => {
   load()
   loadJiraLinks()
@@ -416,27 +417,29 @@ onMounted(() => {
                             'text-blue-400 dark:text-blue-500 italic text-xs': isTbd(pkg, r, acc),
                             'text-gray-600 dark:text-gray-300': !isTbd(pkg, r, acc) && !getVersion(pkg, r)?.dropped,
                           }"
-                          :title="cellTooltip(pkg, r, acc, sv)"
                           @pointerenter="hoveredCell = cellKey(sv.name, pkg.name, r)"
                           @pointerleave="hoveredCell = null"
                         >
-                          <a
-                            v-if="cellHasJiraLink(pkg, r, acc, sv)"
-                            :href="`${JIRA_BASE}/${findJiraLink(acc.sheet, sv.name, pkg.name, r).key}`"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
-                            @click.stop
-                          >
-                            <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>
-                            <span>{{ displayVersion(pkg, r, acc) }}</span>
-                            <svg v-if="getVersion(pkg, r)?.tentative" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="tentative"><polygon points="5,0 10,5 5,10 0,5" fill="#d97706" /></svg>
-                          </a>
-                          <span v-else class="inline-flex items-center gap-1">
-                            <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>
-                            <span>{{ displayVersion(pkg, r, acc) }}</span>
-                            <svg v-if="getVersion(pkg, r)?.tentative" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="tentative"><polygon points="5,0 10,5 5,10 0,5" fill="#d97706" /></svg>
-                          </span>
+                          <template v-for="(jlink, _ji) in [getCellJiraLink(pkg, r, acc, sv)]" :key="_ji">
+                            <a
+                              v-if="jlink"
+                              :href="`${JIRA_BASE}/${jlink.key}`"
+                              :title="cellTooltipWithLink(pkg, r, acc, jlink)"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+                              @click.stop
+                            >
+                              <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>
+                              <span>{{ displayVersion(pkg, r, acc) }}</span>
+                              <svg v-if="getVersion(pkg, r)?.tentative" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="tentative"><polygon points="5,0 10,5 5,10 0,5" fill="#d97706" /></svg>
+                            </a>
+                            <span v-else class="inline-flex items-center gap-1" :title="cellTooltip(pkg, r, acc)">
+                              <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>
+                              <span>{{ displayVersion(pkg, r, acc) }}</span>
+                              <svg v-if="getVersion(pkg, r)?.tentative" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="tentative"><polygon points="5,0 10,5 5,10 0,5" fill="#d97706" /></svg>
+                            </span>
+                          </template>
                         </td>
                       </tr>
                     </tbody>

--- a/modules/product-builds/client/views/VersionMapView.vue
+++ b/modules/product-builds/client/views/VersionMapView.vue
@@ -5,7 +5,10 @@ import { useVersionMap } from '../composables/useVersionMap.js'
 const {
   data, loading, error, load, refresh, refreshing,
   releases, accelerators, source, allPackageNames, totalVariants,
+  jiraLinks, loadJiraLinks,
 } = useVersionMap()
+
+const JIRA_BASE = 'https://redhat.atlassian.net/browse'
 
 const packageFilter = ref('')
 const selectedAccelerators = ref([])
@@ -147,7 +150,65 @@ function clearReleaseFilter() {
 
 const totalPackages = computed(() => allPackageNames.value.length)
 
-onMounted(() => { load() })
+const SHEET_TO_JIRA_BASE = {
+  'CUDA': 'cuda', 'ROCm': 'rocm', 'Google TPU': 'tpu', 'CPU': 'cpu',
+  'Intel Gaudi': 'gaudi', 'AWS Neuron': 'neuron', 'Spyre': 'spyre',
+}
+
+function extractVariantSlug(sheetName, svName) {
+  const base = SHEET_TO_JIRA_BASE[sheetName] || sheetName.toLowerCase()
+  const stripped = svName.replace(new RegExp('^' + sheetName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*', 'i'), '').replace(/[^a-z0-9.]/gi, '')
+  return stripped ? `${base}${stripped}` : base
+}
+
+function normalizeRelease(r) {
+  return r.replace(/^RHAI\s+/i, '').replace(/\.+\s/g, ' ').replace(/[-\s]+(EA|GA)/gi, ' $1').replace(/\s+/g, ' ').trim()
+}
+
+function findJiraLink(sheetName, svName, pkgName, release) {
+  if (!jiraLinks.value) return null
+  const variant = extractVariantSlug(sheetName, svName)
+  const pkg = pkgName.toLowerCase()
+  const normR = normalizeRelease(release)
+  const releases = normR.includes('EA') ? [normR] : [`${normR} GA`, normR]
+  for (const rel of releases) {
+    const epicLink = jiraLinks.value.links[`${variant}:${rel}:${pkg}`]
+    if (epicLink) return { key: epicLink.key, type: 'epic' }
+  }
+  for (const fk of Object.keys(jiraLinks.value.features)) {
+    if (!fk.startsWith(variant)) continue
+    const fRelease = fk.split(':')[1]
+    if (releases.includes(fRelease)) {
+      const epicLink = jiraLinks.value.links[`${fk}:${pkg}`]
+      if (epicLink) return { key: epicLink.key, type: 'epic' }
+    }
+  }
+  for (const rel of releases) {
+    const featureLink = jiraLinks.value.features[`${variant}:${rel}`]
+    if (featureLink) return { key: featureLink.key, type: 'feature' }
+  }
+  for (const fk of Object.keys(jiraLinks.value.features)) {
+    if (!fk.startsWith(variant)) continue
+    const fRelease = fk.split(':')[1]
+    if (releases.includes(fRelease)) return { key: jiraLinks.value.features[fk].key, type: 'feature' }
+  }
+  return null
+}
+
+function cellHasJiraLink(pkg, release, acc, sv) {
+  if (!jiraLinks.value) return false
+  const entry = getVersion(pkg, release)
+  if (!entry) return false
+  if (entry.dropped || versionChanged(pkg, release)) {
+    return !!findJiraLink(acc.sheet, sv.name, pkg.name, release)
+  }
+  return false
+}
+
+onMounted(() => {
+  load()
+  loadJiraLinks()
+})
 </script>
 
 <template>
@@ -351,7 +412,19 @@ onMounted(() => { load() })
                           @pointerenter="hoveredCell = cellKey(sv.name, pkg.name, r)"
                           @pointerleave="hoveredCell = null"
                         >
-                          <span class="inline-flex items-center gap-1">
+                          <a
+                            v-if="cellHasJiraLink(pkg, r, acc, sv)"
+                            :href="`${JIRA_BASE}/${findJiraLink(acc.sheet, sv.name, pkg.name, r).key}`"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1 hover:underline"
+                            @click.stop
+                          >
+                            <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>
+                            <span>{{ displayVersion(pkg, r, acc) }}</span>
+                            <svg v-if="getVersion(pkg, r)?.tentative" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="tentative"><polygon points="5,0 10,5 5,10 0,5" fill="#d97706" /></svg>
+                          </a>
+                          <span v-else class="inline-flex items-center gap-1">
                             <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>
                             <span>{{ displayVersion(pkg, r, acc) }}</span>
                             <svg v-if="getVersion(pkg, r)?.tentative" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="tentative"><polygon points="5,0 10,5 5,10 0,5" fill="#d97706" /></svg>

--- a/modules/product-builds/client/views/VersionMapView.vue
+++ b/modules/product-builds/client/views/VersionMapView.vue
@@ -157,12 +157,13 @@ const SHEET_TO_JIRA_BASE = {
 
 function extractVariantSlug(sheetName, svName) {
   const base = SHEET_TO_JIRA_BASE[sheetName] || sheetName.toLowerCase()
-  const stripped = svName.replace(new RegExp('^' + sheetName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*', 'i'), '').replace(/[^a-z0-9.]/gi, '')
-  return stripped ? `${base}${stripped}` : base
+  const stripped = svName.replace(new RegExp('^' + sheetName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*', 'i'), '')
+  const versionMatch = stripped.match(/^(\d[\d.]*)/)
+  return versionMatch ? `${base}${versionMatch[1]}` : base
 }
 
 function normalizeRelease(r) {
-  return r.replace(/^RHAI\s+/i, '').replace(/\.+\s/g, ' ').replace(/[-\s]+(EA|GA)/gi, ' $1').replace(/\s+/g, ' ').trim()
+  return r.replace(/^RHAI\s+/i, '').replace(/\.+\s/g, ' ').replace(/[-\s]*(EA|GA)[-\s]*/gi, ' $1').replace(/\s+/g, ' ').trim()
 }
 
 function findJiraLink(sheetName, svName, pkgName, release) {

--- a/modules/product-builds/client/views/VersionMapView.vue
+++ b/modules/product-builds/client/views/VersionMapView.vue
@@ -47,20 +47,30 @@ function displayVersion(pkg, release, acc) {
   return entry.version || (isPlanning(acc, release) ? 'TBD' : '')
 }
 
-function cellTooltip(pkg, release, acc) {
+function cellTooltip(pkg, release, acc, sv) {
   const entry = getVersion(pkg, release)
+  let tip
   if (!entry) {
-    if (isPlanning(acc, release)) return `${pkg.name}: version not yet decided for ${release}`
-    return ''
+    if (isPlanning(acc, release)) tip = `${pkg.name}: version not yet decided for ${release}`
+    else return ''
+  } else if (entry.dropped) {
+    tip = `${pkg.name}: dropped in ${release}`
+  } else {
+    const ver = entry.version || 'TBD'
+    const prev = prevRelease(release)
+    if (!prev) tip = `${pkg.name} ${ver}`
+    else {
+      const old = getVersion(pkg, prev)
+      if (!old || old.dropped) tip = `${pkg.name} ${ver} (new in ${release})`
+      else if (old.version === ver) tip = `${pkg.name} ${ver} (unchanged)`
+      else tip = `${pkg.name}: ${old.version} → ${ver}`
+    }
   }
-  if (entry.dropped) return `${pkg.name}: dropped in ${release}`
-  const ver = entry.version || 'TBD'
-  const prev = prevRelease(release)
-  if (!prev) return `${pkg.name} ${ver}`
-  const old = getVersion(pkg, prev)
-  if (!old || old.dropped) return `${pkg.name} ${ver} (new in ${release})`
-  if (old.version === ver) return `${pkg.name} ${ver} (unchanged)`
-  return `${pkg.name}: ${old.version} → ${ver}`
+  if (sv) {
+    const link = findJiraLink(acc.sheet, sv.name, pkg.name, release)
+    if (link) tip += ` — ${link.key}`
+  }
+  return tip
 }
 
 function isTbd(pkg, release, acc) {
@@ -200,10 +210,7 @@ function cellHasJiraLink(pkg, release, acc, sv) {
   if (!jiraLinks.value) return false
   const entry = getVersion(pkg, release)
   if (!entry) return false
-  if (entry.dropped || versionChanged(pkg, release)) {
-    return !!findJiraLink(acc.sheet, sv.name, pkg.name, release)
-  }
-  return false
+  return !!findJiraLink(acc.sheet, sv.name, pkg.name, release)
 }
 
 onMounted(() => {
@@ -409,7 +416,7 @@ onMounted(() => {
                             'text-blue-400 dark:text-blue-500 italic text-xs': isTbd(pkg, r, acc),
                             'text-gray-600 dark:text-gray-300': !isTbd(pkg, r, acc) && !getVersion(pkg, r)?.dropped,
                           }"
-                          :title="cellTooltip(pkg, r, acc)"
+                          :title="cellTooltip(pkg, r, acc, sv)"
                           @pointerenter="hoveredCell = cellKey(sv.name, pkg.name, r)"
                           @pointerleave="hoveredCell = null"
                         >
@@ -418,7 +425,7 @@ onMounted(() => {
                             :href="`${JIRA_BASE}/${findJiraLink(acc.sheet, sv.name, pkg.name, r).key}`"
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="inline-flex items-center gap-1 hover:underline"
+                            class="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
                             @click.stop
                           >
                             <svg v-if="versionChanged(pkg, r) && displayVersion(pkg, r, acc) !== 'TBD'" class="w-2 h-2 shrink-0" viewBox="0 0 10 10" aria-label="bumped"><polygon points="5,1 9,9 1,9" fill="#0ca30c" /></svg>

--- a/modules/product-builds/lib/normalize-release.js
+++ b/modules/product-builds/lib/normalize-release.js
@@ -1,0 +1,10 @@
+function normalizeRelease(raw) {
+  return raw
+    .replace(/^RHAI\s+/i, '')
+    .replace(/\.+\s/g, ' ')
+    .replace(/[-\s]*(EA|GA)[-\s]*/gi, ' $1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+module.exports = { normalizeRelease };

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -58,6 +58,16 @@
         "key": "VERSION_MAP_SPREADSHEET_ID",
         "description": "Google Sheets spreadsheet ID for accelerator variant planning (defaults to the shared planning spreadsheet)",
         "required": false
+      },
+      {
+        "key": "TRACKER_TARGET_VERSION_FIELD",
+        "description": "JIRA custom field ID for target version (defaults to customfield_10855)",
+        "required": false
+      },
+      {
+        "key": "TRACKER_SIZE_FIELD",
+        "description": "JIRA custom field ID for size (defaults to customfield_10795)",
+        "required": false
       }
     ]
   },

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -922,6 +922,9 @@ module.exports = function registerRoutes(router, context) {
   // --- Version Map ---
   require('./version-map')(router, context);
 
+  // --- Package Tracker ---
+  require('./package-tracker')(router, context);
+
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
       const index = readFromStorage(PKG_INDEX_PATH);

--- a/modules/product-builds/server/package-tracker.js
+++ b/modules/product-builds/server/package-tracker.js
@@ -124,6 +124,7 @@ function extractTargetVersions(field) {
 
 const RISK_PRIORITY = { overdue: 0, at_risk: 1, on_track: 2, no_date: 3 };
 const CHILDREN_CONCURRENCY = 10;
+const JIRA_KEY_RE = /^[A-Z]+-\d+$/;
 
 async function buildReleaseTracker(jira) {
   const labels = _cfg.epicLabels.map(l => `"${l}"`).join(', ');
@@ -145,8 +146,9 @@ async function buildReleaseTracker(jira) {
     const batch = epics.slice(i, i + CHILDREN_CONCURRENCY);
     const childResults = await Promise.all(
       batch.map(epic =>
-        jira.fetchAllJqlResults(childrenJql(epic.key), childFields, { maxResults: 100 })
-          .catch(() => [])
+        JIRA_KEY_RE.test(epic.key)
+          ? jira.fetchAllJqlResults(childrenJql(epic.key), childFields, { maxResults: 100 }).catch(() => [])
+          : Promise.resolve([])
       )
     );
     for (let j = 0; j < batch.length; j++) {

--- a/modules/product-builds/server/package-tracker.js
+++ b/modules/product-builds/server/package-tracker.js
@@ -300,3 +300,8 @@ module.exports = function registerPackageTrackerRoutes(router, context) {
     }
   });
 };
+
+module.exports._testExports = {
+  extractAdfText, extractJiraLinks, parseDescriptionFields,
+  computeRisk, computeLeadTime, extractTargetVersions,
+};

--- a/modules/product-builds/server/package-tracker.js
+++ b/modules/product-builds/server/package-tracker.js
@@ -1,0 +1,300 @@
+const { createJiraClient } = require('../../../shared/server/jira');
+
+const DEFAULTS = {
+  targetVersionField: 'customfield_10855',
+  sizeField: 'customfield_10795',
+  cacheTtl: 3_600_000,
+  jiraProject: 'AIPCC',
+  epicLabels: ['dashboard-filed', 'package'],
+};
+
+let _cfg = { ...DEFAULTS };
+let _cache = null;
+let _cacheTime = 0;
+
+// --- ADF parsing ---
+
+function extractAdfText(node) {
+  if (!node) return '';
+  if (typeof node === 'string') return node;
+  if (node.type === 'text') return node.text || '';
+  if (!node.content || !Array.isArray(node.content)) return '';
+  return node.content.map(extractAdfText).join('');
+}
+
+function extractJiraLinks(node) {
+  const links = [];
+  if (!node) return links;
+  if (node.type === 'inlineCard' && node.attrs && node.attrs.url) {
+    const m = node.attrs.url.match(/atlassian\.net\/browse\/([A-Z]+-\d+)/);
+    if (m) links.push(m[1]);
+  }
+  if (node.type === 'text' && node.marks) {
+    for (const mark of node.marks) {
+      if (mark.type === 'link' && mark.attrs && mark.attrs.href) {
+        const m = mark.attrs.href.match(/atlassian\.net\/browse\/([A-Z]+-\d+)/);
+        if (m) links.push(m[1]);
+      }
+    }
+  }
+  if (node.content && Array.isArray(node.content)) {
+    for (const child of node.content) {
+      links.push(...extractJiraLinks(child));
+    }
+  }
+  return links;
+}
+
+function parseDescriptionFields(rawDesc) {
+  const result = { targetDate: null, release: null, relatedTicket: null, team: null, requester: null };
+  if (!rawDesc) return result;
+
+  const text = extractAdfText(rawDesc);
+
+  const dateMatch = text.match(/Target Date:?\s*(\d{4}-\d{2}-\d{2})/) ||
+                    text.match(/Target Date:?\s*(\S+)/);
+  if (dateMatch) result.targetDate = dateMatch[1];
+
+  const releaseMatch = text.match(/Release Commitment:?\s*(.+?)(?:Testing|Default|$)/);
+  if (releaseMatch) {
+    const versionMatch = releaseMatch[1].match(/(\d+\.\d+\s*(?:EA\s*\d+|GA))/i);
+    if (versionMatch) {
+      result.release = versionMatch[1].trim();
+    } else if (releaseMatch[1].trim() !== 'N/A') {
+      result.release = releaseMatch[1].trim();
+    }
+  }
+
+  const jiraLinks = extractJiraLinks(rawDesc);
+  if (jiraLinks.length > 0) {
+    result.relatedTicket = jiraLinks[0];
+  } else {
+    const ticketMatch = text.match(/Related Jira Ticket:?\s*([A-Z]+-\d+)/) ||
+                        text.match(/([A-Z]{2,}-\d+)/);
+    if (ticketMatch) result.relatedTicket = ticketMatch[1];
+  }
+
+  const teamMatch = text.match(/Team:?\s*(.+?)(?:Package|$)/);
+  if (teamMatch) result.team = teamMatch[1].trim();
+
+  const requesterMatch = text.match(/Requester:?\s*(\S+@\S+)/);
+  if (requesterMatch) result.requester = requesterMatch[1];
+
+  return result;
+}
+
+// --- Risk and lead time ---
+
+function computeRisk(targetDateStr) {
+  if (!targetDateStr) return { days_overdue: null, risk: 'no_date' };
+  const target = new Date(targetDateStr + 'T00:00:00Z');
+  if (isNaN(target.getTime())) return { days_overdue: null, risk: 'no_date' };
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const days = Math.round((today - target) / 86_400_000);
+
+  if (days > 0) return { days_overdue: days, risk: 'overdue' };
+  if (days >= -7) return { days_overdue: days, risk: 'at_risk' };
+  return { days_overdue: days, risk: 'on_track' };
+}
+
+function computeLeadTime(targetDateStr, createdStr) {
+  if (!targetDateStr || !createdStr) return { lead_time: null, lead_time_flag: null };
+  const target = new Date(targetDateStr);
+  const created = new Date(createdStr);
+  if (isNaN(target.getTime()) || isNaN(created.getTime())) return { lead_time: null, lead_time_flag: null };
+  const days = Math.round((target - created) / 86_400_000);
+  let flag = null;
+  if (days <= 3) flag = 'critical';
+  else if (days <= 7) flag = 'tight';
+  return { lead_time: days, lead_time_flag: flag };
+}
+
+// --- Target version extraction ---
+
+function extractTargetVersions(field) {
+  if (!field) return [];
+  if (Array.isArray(field)) return field.map(v => (v && v.name) || '').filter(Boolean);
+  if (field && typeof field === 'object' && field.name) return [field.name];
+  return [];
+}
+
+// --- Main data builder ---
+
+const RISK_PRIORITY = { overdue: 0, at_risk: 1, on_track: 2, no_date: 3 };
+const CHILDREN_CONCURRENCY = 10;
+
+async function buildReleaseTracker(jira) {
+  const labels = _cfg.epicLabels.map(l => `"${l}"`).join(', ');
+  const jql = `project = ${_cfg.jiraProject} AND issuetype = Epic AND labels in (${labels}) AND status not in (Closed, Done)`;
+  const fields = [
+    'key', 'summary', 'status', 'assignee', 'description',
+    'duedate', 'created', 'fixVersions',
+    _cfg.targetVersionField, _cfg.sizeField,
+  ].join(',');
+
+  const epics = await jira.fetchAllJqlResults(jql, fields);
+
+  const childrenJql = key => `"Epic Link" = ${key}`;
+  const childFields = 'key,summary,status';
+
+  // Fetch children in batches to avoid overwhelming JIRA
+  const packages = [];
+  for (let i = 0; i < epics.length; i += CHILDREN_CONCURRENCY) {
+    const batch = epics.slice(i, i + CHILDREN_CONCURRENCY);
+    const childResults = await Promise.all(
+      batch.map(epic =>
+        jira.fetchAllJqlResults(childrenJql(epic.key), childFields, { maxResults: 100 })
+          .catch(() => [])
+      )
+    );
+    for (let j = 0; j < batch.length; j++) {
+      const epic = batch[j];
+      const children = childResults[j];
+      const f = epic.fields || {};
+      const descFields = parseDescriptionFields(f.description);
+      const targetDate = f.duedate || descFields.targetDate;
+      const { days_overdue, risk } = computeRisk(targetDate);
+      const { lead_time, lead_time_flag } = computeLeadTime(targetDate, f.created);
+
+      const targetVersions = extractTargetVersions(f[_cfg.targetVersionField]);
+      const fixVersions = f.fixVersions || [];
+      const sizeRaw = f[_cfg.sizeField];
+
+      packages.push({
+        key: epic.key,
+        package: f.summary || '',
+        status: (f.status && f.status.name) || '',
+        status_category: (f.status && f.status.statusCategory && f.status.statusCategory.key) || 'undefined',
+        assignee: (f.assignee && f.assignee.displayName) || 'Unassigned',
+        target_date: targetDate || null,
+        created: f.created ? f.created.slice(0, 10) : null,
+        release: targetVersions[0] || null,
+        fix_version: (fixVersions[0] && fixVersions[0].name) || null,
+        related_ticket: descFields.relatedTicket || null,
+        team: descFields.team || null,
+        size: (sizeRaw && typeof sizeRaw === 'object') ? sizeRaw.value : (sizeRaw || null),
+        days_overdue,
+        risk,
+        lead_time,
+        lead_time_flag,
+        children: children.map(c => ({
+          key: c.key,
+          status: (c.fields && c.fields.status && c.fields.status.name) || '',
+          status_category: (c.fields && c.fields.status && c.fields.status.statusCategory && c.fields.status.statusCategory.key) || 'undefined',
+          summary: (c.fields && c.fields.summary) || '',
+        })),
+      });
+    }
+  }
+
+  packages.sort((a, b) => {
+    const pa = RISK_PRIORITY[a.risk] ?? 3;
+    const pb = RISK_PRIORITY[b.risk] ?? 3;
+    if (pa !== pb) return pa - pb;
+    const da = a.days_overdue ?? -Infinity;
+    const db = b.days_overdue ?? -Infinity;
+    return db - da;
+  });
+
+  const counts = { overdue: 0, at_risk: 0, on_track: 0, no_date: 0 };
+  for (const p of packages) counts[p.risk] = (counts[p.risk] || 0) + 1;
+
+  return {
+    generated_at: new Date().toISOString(),
+    total: packages.length,
+    ...counts,
+    packages,
+  };
+}
+
+// --- Route registration ---
+
+/**
+ * @param {import('express').Router} router
+ * @param {{ secrets?: Record<string, string>, resolveSecret?: Function, requireAdmin: Function }} context
+ */
+module.exports = function registerPackageTrackerRoutes(router, context) {
+  if (context.resolveSecret) {
+    const tvf = context.resolveSecret('TRACKER_TARGET_VERSION_FIELD');
+    if (tvf) _cfg.targetVersionField = tvf;
+    const sf = context.resolveSecret('TRACKER_SIZE_FIELD');
+    if (sf) _cfg.sizeField = sf;
+  }
+
+  let _jira;
+  function getJira() {
+    if (!_jira) {
+      _jira = createJiraClient({
+        email: (context.secrets && context.secrets.JIRA_EMAIL) || '',
+        token: (context.secrets && context.secrets.JIRA_TOKEN) || '',
+      });
+    }
+    return _jira;
+  }
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/package-tracker:
+   *   get:
+   *     tags: [Package Tracker]
+   *     summary: Get package release tracker data
+   *     description: Returns all open AIPCC package EPICs with risk assessment, due dates, release versions, and child issues. Cached for 1 hour.
+   *     parameters:
+   *       - name: refresh
+   *         in: query
+   *         schema:
+   *           type: string
+   *           enum: ['true']
+   *         description: Force cache refresh
+   *     responses:
+   *       200:
+   *         description: Package tracker data with risk summary and package list
+   *       500:
+   *         description: Failed to fetch tracker data
+   */
+  router.get('/package-tracker', async function(req, res) {
+    const forceRefresh = req.query.refresh === 'true';
+    const now = Date.now();
+
+    if (!forceRefresh && _cache && (now - _cacheTime) < _cfg.cacheTtl) {
+      return res.json(_cache);
+    }
+
+    try {
+      _cache = await buildReleaseTracker(getJira());
+      _cacheTime = Date.now();
+      res.json(_cache);
+    } catch (err) {
+      console.error('[package-tracker] Failed to build tracker:', err.message);
+      if (_cache) {
+        return res.json(_cache);
+      }
+      res.status(500).json({ error: 'Failed to fetch package tracker data' });
+    }
+  });
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/package-tracker/refresh:
+   *   post:
+   *     tags: [Package Tracker]
+   *     summary: Force refresh package tracker data (admin only)
+   *     responses:
+   *       200:
+   *         description: Refreshed package tracker data
+   *       500:
+   *         description: Refresh failed
+   */
+  router.post('/package-tracker/refresh', context.requireAdmin, async function(req, res) {
+    try {
+      _cache = await buildReleaseTracker(getJira());
+      _cacheTime = Date.now();
+      res.json(_cache);
+    } catch (err) {
+      console.error('[package-tracker] Refresh failed:', err.message);
+      res.status(500).json({ error: 'Refresh failed' });
+    }
+  });
+};

--- a/modules/product-builds/server/version-map.js
+++ b/modules/product-builds/server/version-map.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const { createGoogleSheetsClient } = require('../../../shared/server/google-sheets');
 const { createJiraClient } = require('../../../shared/server/jira');
+const { normalizeRelease } = require('../lib/normalize-release');
+
+const JIRA_KEY_RE = /^[A-Z]+-\d+$/;
 
 const DEFAULTS = {
   spreadsheetId: '1cFIL4klt4uRflIsTH2pigls1_3RdzyGx8sXZ6F2UtQ0',
@@ -229,15 +232,6 @@ function parseFeatureSummary(summary) {
   return { variant: m[1].toLowerCase().trim(), release: m[2].trim() };
 }
 
-function normalizeRelease(raw) {
-  return raw
-    .replace(/^RHAI\s+/i, '')
-    .replace(/\.+\s/g, ' ')
-    .replace(/[-\s]*(EA|GA)[-\s]*/gi, ' $1')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
 const VARIANT_TO_SHEET = {
   cuda: 'CUDA',
   rocm: 'ROCm',
@@ -277,8 +271,9 @@ async function buildJiraLinks(jira) {
     const batch = features.slice(i, i + BATCH);
     const childResults = await Promise.all(
       batch.map(f =>
-        jira.fetchAllJqlResults(`parent = ${f.key}`, 'key,summary,status', { maxResults: 50 })
-          .catch(() => [])
+        JIRA_KEY_RE.test(f.key)
+          ? jira.fetchAllJqlResults(`parent = ${f.key}`, 'key,summary,status', { maxResults: 50 }).catch(() => [])
+          : Promise.resolve([])
       )
     );
 

--- a/modules/product-builds/server/version-map.js
+++ b/modules/product-builds/server/version-map.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { createGoogleSheetsClient } = require('../../../shared/server/google-sheets');
+const { createJiraClient } = require('../../../shared/server/jira');
 
 const DEFAULTS = {
   spreadsheetId: '1cFIL4klt4uRflIsTH2pigls1_3RdzyGx8sXZ6F2UtQ0',
@@ -214,6 +215,114 @@ async function fetchFromSheets(googleKeyFile) {
   };
 }
 
+// --- JIRA variant feature links ---
+
+let _jiraLinksCache = null;
+let _jiraLinksCacheAt = 0;
+const JIRA_LINKS_CACHE_TTL = 60 * 60 * 1000;
+
+const VARIANT_FEATURE_RE = /^(.+?)-ubi9\s+for\s+(.+)$/i;
+
+function parseFeatureSummary(summary) {
+  const m = summary.match(VARIANT_FEATURE_RE);
+  if (!m) return null;
+  return { variant: m[1].toLowerCase().trim(), release: m[2].trim() };
+}
+
+function normalizeRelease(raw) {
+  return raw
+    .replace(/^RHAI\s+/i, '')
+    .replace(/[-\s]+(EA|GA)/gi, ' $1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const VARIANT_TO_SHEET = {
+  cuda: 'CUDA',
+  rocm: 'ROCm',
+  cpu: 'CPU',
+  gaudi: 'Intel Gaudi',
+  tpu: 'Google TPU',
+  neuron: 'AWS Neuron',
+  spyre: 'Spyre',
+};
+
+function extractVariantBase(variant) {
+  const m = variant.match(/^([a-z]+)/);
+  return m ? m[1] : variant;
+}
+
+function extractPackageFromEpic(summary) {
+  const lower = summary.toLowerCase();
+  let m = lower.match(/update\s+(.+?)\s+to\s+/);
+  if (m) return m[1].replace(/-ubi9.*/, '').trim();
+  m = lower.match(/upgrade\s+(.+?)\s+to\s+/);
+  if (m) return m[1].replace(/-ubi9.*/, '').trim();
+  m = lower.match(/wheels\s+for\s+(\S+)/);
+  if (m) return m[1].trim();
+  return null;
+}
+
+const VARIANT_LABELS = [
+  'aipcc-ae-cuda', 'aipcc-ae-rocm', 'aipcc-ae-gaudi',
+  'aipcc-ae-cpu', 'aipcc-ae-tpu', 'aipcc-ae-neuron', 'aipcc-ae-spyre',
+];
+
+async function buildJiraLinks(jira) {
+  const labels = VARIANT_LABELS.map(l => `"${l}"`).join(', ');
+  const jql = `project = AIPCC AND issuetype = Feature AND labels in (${labels}) ORDER BY created DESC`;
+  const features = await jira.fetchAllJqlResults(jql, 'key,summary,status');
+
+  const links = {};
+  const featureMap = {};
+  const BATCH = 10;
+
+  for (let i = 0; i < features.length; i += BATCH) {
+    const batch = features.slice(i, i + BATCH);
+    const childResults = await Promise.all(
+      batch.map(f =>
+        jira.fetchAllJqlResults(`parent = ${f.key}`, 'key,summary,status', { maxResults: 50 })
+          .catch(() => [])
+      )
+    );
+
+    for (let j = 0; j < batch.length; j++) {
+      const feature = batch[j];
+      const children = childResults[j];
+      const parsed = parseFeatureSummary(feature.fields.summary);
+      if (!parsed) continue;
+
+      const variantBase = extractVariantBase(parsed.variant);
+      const normRelease = normalizeRelease(parsed.release);
+
+      const featureKey = `${parsed.variant}:${normRelease}`;
+      featureMap[featureKey] = {
+        key: feature.key,
+        summary: feature.fields.summary,
+        variant: parsed.variant,
+        variantBase,
+        sheet: VARIANT_TO_SHEET[variantBase] || null,
+        release: normRelease,
+        status: (feature.fields.status && feature.fields.status.name) || '',
+      };
+
+      for (const child of children) {
+        const pkg = extractPackageFromEpic(child.fields.summary);
+        if (!pkg) continue;
+        const linkKey = `${parsed.variant}:${normRelease}:${pkg}`;
+        links[linkKey] = {
+          key: child.key,
+          summary: child.fields.summary,
+          status: (child.fields.status && child.fields.status.name) || '',
+          status_category: (child.fields.status && child.fields.status.statusCategory && child.fields.status.statusCategory.key) || 'undefined',
+        };
+      }
+    }
+  }
+
+  return { links, features: featureMap, generated_at: new Date().toISOString() };
+}
+
 /**
  * @param {import('express').Router} router
  * @param {import('@shared/server/module-context').ModuleContext} context
@@ -285,5 +394,47 @@ module.exports = function registerVersionMapRoutes(router, context) {
     const data = await fetchWithFallback('Refresh');
     if (data) return res.json(data);
     return res.status(503).json({ error: 'Version map data unavailable' });
+  });
+
+  // --- JIRA links for version map cells ---
+
+  let _jira;
+  function getJira() {
+    if (!_jira) {
+      _jira = createJiraClient({
+        email: (context.secrets && context.secrets.JIRA_EMAIL) || '',
+        token: (context.secrets && context.secrets.JIRA_TOKEN) || '',
+      });
+    }
+    return _jira;
+  }
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/version-map/jira-links:
+   *   get:
+   *     tags: [Package Analysis]
+   *     summary: Get JIRA links for version map cells
+   *     description: Returns a lookup map of variant feature epics and their child work items, matched by variant, release, and package name. Cached for 1 hour.
+   *     responses:
+   *       200:
+   *         description: JIRA links map with features and per-package epics
+   *       500:
+   *         description: Failed to fetch JIRA data
+   */
+  router.get('/version-map/jira-links', async function (req, res) {
+    const now = Date.now();
+    if (_jiraLinksCache && (now - _jiraLinksCacheAt) < JIRA_LINKS_CACHE_TTL) {
+      return res.json(_jiraLinksCache);
+    }
+    try {
+      _jiraLinksCache = await buildJiraLinks(getJira());
+      _jiraLinksCacheAt = Date.now();
+      res.json(_jiraLinksCache);
+    } catch (err) {
+      console.error('[version-map] JIRA links fetch failed:', err.message);
+      if (_jiraLinksCache) return res.json(_jiraLinksCache);
+      res.status(500).json({ error: 'Failed to fetch JIRA links' });
+    }
   });
 };

--- a/modules/product-builds/server/version-map.js
+++ b/modules/product-builds/server/version-map.js
@@ -232,7 +232,8 @@ function parseFeatureSummary(summary) {
 function normalizeRelease(raw) {
   return raw
     .replace(/^RHAI\s+/i, '')
-    .replace(/[-\s]+(EA|GA)/gi, ' $1')
+    .replace(/\.+\s/g, ' ')
+    .replace(/[-\s]*(EA|GA)[-\s]*/gi, ' $1')
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -263,15 +264,10 @@ function extractPackageFromEpic(summary) {
   return null;
 }
 
-const VARIANT_LABELS = [
-  'aipcc-ae-cuda', 'aipcc-ae-rocm', 'aipcc-ae-gaudi',
-  'aipcc-ae-cpu', 'aipcc-ae-tpu', 'aipcc-ae-neuron', 'aipcc-ae-spyre',
-];
-
 async function buildJiraLinks(jira) {
-  const labels = VARIANT_LABELS.map(l => `"${l}"`).join(', ');
-  const jql = `project = AIPCC AND issuetype = Feature AND labels in (${labels}) ORDER BY created DESC`;
-  const features = await jira.fetchAllJqlResults(jql, 'key,summary,status');
+  const jql = 'project = AIPCC AND issuetype = Feature AND "Target Version" is not EMPTY ORDER BY created DESC';
+  const allFeatures = await jira.fetchAllJqlResults(jql, 'key,summary,status');
+  const features = allFeatures.filter(f => VARIANT_FEATURE_RE.test(f.fields.summary));
 
   const links = {};
   const featureMap = {};

--- a/modules/product-builds/server/version-map.js
+++ b/modules/product-builds/server/version-map.js
@@ -429,3 +429,7 @@ module.exports = function registerVersionMapRoutes(router, context) {
     }
   });
 };
+
+module.exports._testExports = {
+  parseFeatureSummary, extractVariantBase, extractPackageFromEpic,
+};


### PR DESCRIPTION
## Summary

- Adds a **Tracker** tab to Package Analysis showing open AIPCC package EPICs with risk assessment, due dates, release versions, and expandable child issues — ported from the AIPCC dashboard (React/FastAPI → Vue/Express)
- Adds **JIRA links** to Version Map cells — bumped and changed versions link directly to the JIRA epic tracking the work; linked cells render in blue for visual distinction
- Both features use org-pulse's existing JIRA client with 1-hour server-side caching

## Package Tracker tab

- **Summary cards** — Total, Overdue, At Risk, On Track (clickable to filter)
- **Risk pill filters** with shape indicators (● ▲ ✓ —) for accessibility
- **Release pill filters** — dynamically generated from data
- **Ticket search** — free-text search on related ticket field
- **Sortable table** — 13 columns including risk badges, lead time flags, days overdue
- **Expandable rows** — child JIRA issues with locale-safe status badges
- **WCAG AA validated** — all status/risk colors pass 4.5:1 contrast

## Version Map JIRA links

- Cells with a JIRA link render in **blue text** (vs gray for unlinked)
- Tooltips show the JIRA key (e.g., `vllm: 0.21.0 → 0.24.0 — AIPCC-17397`)
- Matches variant features by Target Version field across all releases (3.4 EA1 → 3.5 GA)
- Falls back to parent feature when no package-specific epic exists

## Files

### Created
| File | Purpose |
|------|---------|
| `server/package-tracker.js` | JIRA query, ADF parsing, risk calculation, cache |
| `client/composables/usePackageTracker.js` | Vue composable |
| `client/views/PackageTrackerView.vue` | Tracker tab UI |

### Modified
| File | Change |
|------|--------|
| `server/version-map.js` | Added JIRA links endpoint + variant feature matching |
| `client/composables/useVersionMap.js` | Added `loadJiraLinks()` |
| `client/views/VersionMapView.vue` | Clickable cells, blue link color, JIRA key in tooltips |
| `client/views/PackageAnalysisView.vue` | Added Tracker tab |
| `server/index.js` | Registered package-tracker route |
| `module.json` | Added optional secrets for custom field IDs |

## Test plan

- [ ] Navigate to Package Analysis → Tracker tab, verify data loads
- [ ] Click summary cards to filter by risk
- [ ] Toggle risk and release pill filters
- [ ] Type in ticket search box, verify filtering
- [ ] Sort by clicking column headers
- [ ] Expand a row to see child issues
- [ ] Switch to Version Map tab
- [ ] Hover a version cell — tooltip shows JIRA key
- [ ] Click a blue version cell — opens JIRA epic in new tab
- [ ] Verify non-linked cells stay gray (not clickable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)