### PR TITLE
feat(releases): add AIPCC conforma data ingestion from ECP YAMLs

### DIFF
--- a/fixtures/releases/delivery/conforma-aipcc.json
+++ b/fixtures/releases/delivery/conforma-aipcc.json
@@ -1,0 +1,99 @@
+{
+  "fetchedAt": "2026-07-10T06:00:00.000Z",
+  "count": 2,
+  "releases": [
+    {
+      "version": "rhaii",
+      "gaDate": null,
+      "productLayer": true,
+      "displayName": "RHAII",
+      "exceptions": {
+        "policy": {
+          "configExcludes": [
+            "cve.cve_blockers",
+            "hermetic_task",
+            "rpm_packages.unique_version:ibm-aiu-toolbox-e2e",
+            "rpm_packages.unique_version:ibm-deeptools",
+            "rpm_packages.unique_version:ibm-flex",
+            "rpm_packages.unique_version:ibm-sendnn",
+            "rpm_packages.unique_version:ibm-senlib-core",
+            "rpm_packages.unique_version:ibm-senlib-dd2",
+            "rpm_packages.unique_version:ibm-spyre-model-cache",
+            "rpm_packages.unique_version:ibm-libaiupti"
+          ],
+          "volatileExcludes": []
+        }
+      },
+      "ruleData": {
+        "allowedRpmSignatureKeys": [
+          "910ea37ba2d18d0c",
+          "9cd0a493d42d0685",
+          "bac6f0c353d04109",
+          "9386b48a1a693c5c",
+          "fa296b056c5bb456",
+          "199e2f91fd431d51",
+          "94db5b8b35f2e93f",
+          "42548fd2af04c141",
+          "a8e2f24babaf900f",
+          "5749cad8646d9185"
+        ],
+        "allowedRegistryPrefixes": [
+          "registry.access.redhat.com/",
+          "registry.redhat.io/",
+          "quay.io/aipcc/base-images"
+        ],
+        "disallowedPlatformPatterns": []
+      },
+      "jiraReferences": [
+        "https://issues.redhat.com/browse/AIPCC-12203",
+        "https://issues.redhat.com/browse/AIPCC-17548",
+        "https://issues.redhat.com/browse/AIPCC-5124",
+        "https://issues.redhat.com/browse/AIPCC-6247",
+        "https://issues.redhat.com/browse/AIPCC-9821",
+        "https://issues.redhat.com/browse/AIPCC-1125"
+      ]
+    },
+    {
+      "version": "rhel-ai",
+      "gaDate": null,
+      "productLayer": true,
+      "displayName": "RHEL AI",
+      "exceptions": {
+        "policy": {
+          "configExcludes": [
+            "cve.cve_blockers",
+            "hermetic_task",
+            "labels.disallowed_inherited_labels",
+            "buildah_build_task.privileged_nested_param",
+            "buildah_build_task.add_capabilities_param",
+            "rpm_packages.unique_version:libatomic",
+            "rpm_packages.unique_version:libnvidia-container-tools",
+            "rpm_packages.unique_version:libnvidia-container1",
+            "rpm_packages.unique_version:nvidia-container-toolkit-base",
+            "rpm_packages.unique_version:nvidia-container-toolkit"
+          ],
+          "volatileExcludes": []
+        }
+      },
+      "ruleData": {
+        "allowedRpmSignatureKeys": [
+          "323dcf8585eb2859",
+          "9cd0a493d42d0685",
+          "bac6f0c353d04109",
+          "9386b48a1a693c5c",
+          "199e2f91fd431d51"
+        ],
+        "allowedRegistryPrefixes": [
+          "registry.access.redhat.com/",
+          "registry.redhat.io/"
+        ],
+        "disallowedPlatformPatterns": []
+      },
+      "jiraReferences": [
+        "https://issues.redhat.com/browse/RHELAI-2888",
+        "https://issues.redhat.com/browse/AIPCC-5892",
+        "https://issues.redhat.com/browse/RHELAI-6348"
+      ]
+    }
+  ]
+}

--- a/modules/releases/__tests__/server/delivery/conforma-fetcher.test.js
+++ b/modules/releases/__tests__/server/delivery/conforma-fetcher.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const SAMPLE_YAML = `---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: registry-ai-containers-prod
+  namespace: rhtap-releng-tenant
+spec:
+  description: 'Rules for shipping RHAIIS images to registry.redhat.io'
+  publicKey: 'k8s://openshift-pipelines/public-key'
+  sources:
+    - name: Release Policies
+      ruleData:
+        allowed_rpm_signature_keys:
+          # https://issues.redhat.com/browse/AIPCC-12203
+          - 910ea37ba2d18d0c
+          - 9cd0a493d42d0685
+        allowed_registry_prefixes:
+          - registry.access.redhat.com/
+          - registry.redhat.io/
+        disallowed_platform_patterns: []
+      config:
+        include:
+          - '@redhat'
+        exclude:
+          - cve.cve_blockers
+          - hermetic_task
+          # https://issues.redhat.com/browse/AIPCC-6247
+          - rpm_packages.unique_version:ibm-deeptools
+      volatileConfig:
+        exclude: []
+`
+
+describe('conforma fetcher', () => {
+  let mod
+
+  beforeEach(() => {
+    vi.resetModules()
+    mod = require('../../../server/delivery/conforma-fetcher')
+  })
+
+  describe('deriveVersion', () => {
+    it('maps known AIPCC ECP names to product versions', () => {
+      expect(mod.deriveVersion('registry-ai-containers-prod')).toBe('rhaii')
+      expect(mod.deriveVersion('registry-rhel-ai-containers-prod')).toBe('rhel-ai')
+      expect(mod.deriveVersion('registry-rhel-ai-disk-images-prod')).toBe('rhel-ai-disk-images')
+      expect(mod.deriveVersion('registry-rhel-ai-disk-image-containers-prod')).toBe('rhel-ai-container-disk-images')
+      expect(mod.deriveVersion('registry-aipcc-base-images-prod')).toBe('base-images')
+    })
+
+    it('handles names without prefix/suffix gracefully', () => {
+      expect(mod.deriveVersion('some-policy')).toBe('some-policy')
+    })
+  })
+
+  describe('extractJiraReferences', () => {
+    it('extracts Jira URLs from YAML comments', () => {
+      const refs = mod.extractJiraReferences(SAMPLE_YAML)
+      expect(refs).toContain('https://issues.redhat.com/browse/AIPCC-12203')
+      expect(refs).toContain('https://issues.redhat.com/browse/AIPCC-6247')
+      expect(refs).toHaveLength(2)
+    })
+
+    it('matches redhat.atlassian.net URLs too', () => {
+      const text = '# https://redhat.atlassian.net/browse/AIPCC-999\n'
+      const refs = mod.extractJiraReferences(text)
+      expect(refs).toContain('https://redhat.atlassian.net/browse/AIPCC-999')
+    })
+
+    it('deduplicates references', () => {
+      const text = '# https://issues.redhat.com/browse/AIPCC-1\n# https://issues.redhat.com/browse/AIPCC-1\n'
+      expect(mod.extractJiraReferences(text)).toHaveLength(1)
+    })
+
+    it('returns empty array for no references', () => {
+      expect(mod.extractJiraReferences('no refs here')).toEqual([])
+    })
+  })
+
+  describe('transformEcpToRelease', () => {
+    it('transforms parsed YAML to release object', () => {
+      const yaml = require('js-yaml')
+      const doc = yaml.load(SAMPLE_YAML)
+      const result = mod.transformEcpToRelease(doc, SAMPLE_YAML)
+
+      expect(result.version).toBe('rhaii')
+      expect(result.gaDate).toBeNull()
+      expect(result.productLayer).toBe(true)
+      expect(result.displayName).toBe('RHAII')
+      expect(result.exceptions.policy.configExcludes).toContain('cve.cve_blockers')
+      expect(result.exceptions.policy.configExcludes).toContain('hermetic_task')
+      expect(result.exceptions.policy.configExcludes).toContain('rpm_packages.unique_version:ibm-deeptools')
+      expect(result.exceptions.policy.volatileExcludes).toEqual([])
+      expect(result.ruleData.allowedRpmSignatureKeys).toContain('910ea37ba2d18d0c')
+      expect(result.ruleData.allowedRegistryPrefixes).toContain('registry.redhat.io/')
+      expect(result.jiraReferences).toContain('https://issues.redhat.com/browse/AIPCC-12203')
+    })
+  })
+
+  describe('fetchAipccConforma', () => {
+    const mockStorage = {
+      readFromStorage: () => ({ conformaEcpBaseUrl: 'https://example.com/ecp' })
+    }
+
+    it('fetches and transforms all YAML files', async () => {
+      mod._setFetch(async () => ({
+        ok: true,
+        text: async () => SAMPLE_YAML
+      }))
+
+      const result = await mod.fetchAipccConforma(mockStorage)
+      expect(result.releases).toHaveLength(5)
+      expect(result.errors).toHaveLength(0)
+      expect(result.releases[0].productLayer).toBe(true)
+    })
+
+    it('handles fetch errors gracefully', async () => {
+      let callCount = 0
+      mod._setFetch(async () => {
+        callCount++
+        if (callCount === 1) return { ok: false, status: 404 }
+        return { ok: true, text: async () => SAMPLE_YAML }
+      })
+
+      const result = await mod.fetchAipccConforma(mockStorage)
+      expect(result.releases).toHaveLength(4)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].error).toBe('HTTP 404')
+    })
+
+    it('handles network errors gracefully', async () => {
+      mod._setFetch(async () => { throw new Error('Network error') })
+
+      const result = await mod.fetchAipccConforma(mockStorage)
+      expect(result.releases).toHaveLength(0)
+      expect(result.errors).toHaveLength(5)
+    })
+
+    it('returns error when conformaEcpBaseUrl is not configured', async () => {
+      const emptyStorage = { readFromStorage: () => null }
+      const result = await mod.fetchAipccConforma(emptyStorage)
+      expect(result.releases).toHaveLength(0)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].error).toMatch(/not configured/)
+    })
+  })
+})

--- a/modules/releases/__tests__/server/delivery/conforma.test.js
+++ b/modules/releases/__tests__/server/delivery/conforma.test.js
@@ -57,6 +57,16 @@ const SAMPLE_RELEASE = {
   }
 }
 
+const SAMPLE_PRODUCT_LAYER = {
+  version: 'rhaii',
+  gaDate: null,
+  productLayer: true,
+  displayName: 'RHAII',
+  exceptions: {
+    policy: { configExcludes: ['cve.cve_blockers', 'hermetic_task'], volatileExcludes: [] }
+  }
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('conforma backend routes', () => {
@@ -181,6 +191,81 @@ describe('conforma backend routes', () => {
       const req = { body: { releases: [{ version: '', gaDate: '' }] } }
       const res = await router._dispatch('POST', '/conforma/bulk', req)
       expect(res._status).toBe(400)
+    })
+  })
+
+  describe('POST /conforma/bulk with product layers', () => {
+    it('accepts releases with productLayer and no gaDate', async () => {
+      const req = { body: { releases: [SAMPLE_PRODUCT_LAYER] } }
+      const res = await router._dispatch('POST', '/conforma/bulk', req)
+      expect(res._status).toBe(200)
+      expect(res._body.count).toBe(1)
+    })
+
+    it('rejects releases without gaDate and without productLayer', async () => {
+      const req = { body: { releases: [{ version: 'bad', exceptions: {} }] } }
+      const res = await router._dispatch('POST', '/conforma/bulk', req)
+      expect(res._status).toBe(400)
+    })
+  })
+
+  describe('merged RHOAI + AIPCC data', () => {
+    it('GET /conforma/releases returns releases from both storage keys', async () => {
+      storage.writeToStorage('releases/delivery/conforma.json', {
+        fetchedAt: '2026-05-10T00:00:00.000Z',
+        minDate: '2025-05-22',
+        count: 1,
+        releases: [SAMPLE_RELEASE]
+      })
+      storage.writeToStorage('releases/delivery/conforma-aipcc.json', {
+        fetchedAt: '2026-07-10T00:00:00.000Z',
+        count: 1,
+        releases: [SAMPLE_PRODUCT_LAYER]
+      })
+      const res = await router._dispatch('GET', '/conforma/releases')
+      expect(res._status).toBe(200)
+      expect(res._body.releases).toHaveLength(2)
+      expect(res._body.count).toBe(2)
+      expect(res._body.releases.map(r => r.version)).toEqual(['rhoai-3.4', 'rhaii'])
+    })
+
+    it('GET /conforma/releases/:version finds AIPCC product layer', async () => {
+      storage.writeToStorage('releases/delivery/conforma-aipcc.json', {
+        fetchedAt: '2026-07-10T00:00:00.000Z',
+        count: 1,
+        releases: [SAMPLE_PRODUCT_LAYER]
+      })
+      const res = await router._dispatch('GET', '/conforma/releases/:version', { params: { version: 'rhaii' } })
+      expect(res._status).toBe(200)
+      expect(res._body.productLayer).toBe(true)
+      expect(res._body.displayName).toBe('RHAII')
+    })
+
+    it('GET /conforma/status reports combined count', async () => {
+      storage.writeToStorage('releases/delivery/conforma.json', {
+        fetchedAt: '2026-05-10T00:00:00.000Z',
+        count: 1,
+        releases: [SAMPLE_RELEASE]
+      })
+      storage.writeToStorage('releases/delivery/conforma-aipcc.json', {
+        fetchedAt: '2026-07-10T00:00:00.000Z',
+        count: 1,
+        releases: [SAMPLE_PRODUCT_LAYER]
+      })
+      const res = await router._dispatch('GET', '/conforma/status')
+      expect(res._body.count).toBe(2)
+      expect(res._body.fetchedAt).toBe('2026-07-10T00:00:00.000Z')
+    })
+
+    it('GET /conforma/releases works with only AIPCC data', async () => {
+      storage.writeToStorage('releases/delivery/conforma-aipcc.json', {
+        fetchedAt: '2026-07-10T00:00:00.000Z',
+        count: 1,
+        releases: [SAMPLE_PRODUCT_LAYER]
+      })
+      const res = await router._dispatch('GET', '/conforma/releases')
+      expect(res._status).toBe(200)
+      expect(res._body.releases).toHaveLength(1)
     })
   })
 

--- a/modules/releases/client/deliver/components/DeliverySettings.vue
+++ b/modules/releases/client/deliver/components/DeliverySettings.vue
@@ -453,6 +453,21 @@ onMounted(() => {
         </div>
       </div>
 
+      <!-- Section 4: Conforma / ECP -->
+      <div>
+        <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Conforma / ECP</h4>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">ECP Base URL</label>
+          <input
+            v-model="config.conformaEcpBaseUrl"
+            type="text"
+            placeholder="https://..."
+            class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-800 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500"
+          />
+          <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">Base URL for the konflux-release-data ECP YAML files (e.g. raw GitLab URL). Required for AIPCC conforma data ingestion.</p>
+        </div>
+      </div>
+
       <!-- Save / Reset buttons -->
       <div class="flex items-center gap-3">
         <button

--- a/modules/releases/client/deliver/composables/release-utils.js
+++ b/modules/releases/client/deliver/composables/release-utils.js
@@ -1,8 +1,9 @@
-export const KNOWN_PRODUCTS = ['base-images', 'rhel-ai', 'rhoai', 'rhaii']
+export const KNOWN_PRODUCTS = ['base-images', 'rhel-ai-container-disk-images', 'rhel-ai-disk-images', 'rhel-ai', 'rhoai', 'rhaii']
 
 export function extractProduct(releaseNumber) {
   const s = (releaseNumber || '').toLowerCase()
   for (const p of KNOWN_PRODUCTS) {
+    if (s === p) return p
     if (s.startsWith(p + '-') && /\d/.test(s[p.length + 1])) return p
   }
   const m = s.match(/^(.+?)-(\d.*)$/)

--- a/modules/releases/client/deliver/constants/conforma.js
+++ b/modules/releases/client/deliver/constants/conforma.js
@@ -3,7 +3,8 @@ import { extractProduct, extractVersion } from '../composables/release-utils'
 // FIPS is first because it is matched by keyword, not by value prefix.
 export const KNOWN_CATEGORIES = [
   'fips', 'hermetic_task', 'test', 'tasks', 'schedule',
-  'sbom_spdx', 'rpm_signature', 'cve', 'other'
+  'sbom_spdx', 'rpm_signature', 'rpm_packages', 'cve',
+  'labels', 'base_image_registries', 'buildah_build_task', 'other'
 ]
 
 export const CATEGORY_BADGE = {
@@ -17,6 +18,10 @@ export const CATEGORY_BADGE = {
   cve:                   'bg-pink-100 dark:bg-pink-900/40 text-pink-700 dark:text-pink-300',
   source_image:          'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300',
   step_image_registries: 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300',
+  rpm_packages:          'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300',
+  labels:                'bg-lime-100 dark:bg-lime-900/40 text-lime-700 dark:text-lime-300',
+  base_image_registries: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300',
+  buildah_build_task:    'bg-fuchsia-100 dark:bg-fuchsia-900/40 text-fuchsia-700 dark:text-fuchsia-300',
   other:                 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
 }
 
@@ -31,9 +36,23 @@ export const CATEGORY_DOCS = {
   cve:                   'https://conforma.dev/docs/policy/packages/release_cve.html',
   source_image:          'https://conforma.dev/docs/policy/packages/release_source_image.html',
   step_image_registries: 'https://conforma.dev/docs/policy/packages/task_step_image_registries.html',
+  rpm_packages:          'https://conforma.dev/docs/policy/packages/release_rpm_packages.html',
+  labels:                'https://conforma.dev/docs/policy/packages/release_labels.html',
+  base_image_registries: 'https://conforma.dev/docs/policy/packages/release_base_image_registries.html',
+  buildah_build_task:    'https://conforma.dev/docs/policy/packages/release_buildah_build_task.html',
 }
 
-export const EXTENSION_JIRA_TEMPLATE_URL = 'https://redhat.atlassian.net/browse/RHOAIENG-62569'
+const EXTENSION_JIRA_URLS = {
+  rhoai: 'https://redhat.atlassian.net/browse/RHOAIENG-62569'
+}
+
+export const EXTENSION_JIRA_TEMPLATE_URL = EXTENSION_JIRA_URLS.rhoai
+
+export function extensionJiraTemplateUrl(release) {
+  if (release?.productLayer) return null
+  const product = extractProduct(release?.version || '')
+  return EXTENSION_JIRA_URLS[product] || EXTENSION_JIRA_URLS.rhoai
+}
 
 export const ACTIONABLE_DAYS_THRESHOLD = 7
 
@@ -151,7 +170,7 @@ export function normalizeTargetRelease(raw) {
 export function extractCategory(value) {
   if (!value) return 'other'
   if (value.toLowerCase().includes('fips')) return 'fips'
-  const prefixKnown = ['hermetic_task', 'test', 'tasks', 'schedule', 'sbom_spdx', 'rpm_signature', 'cve', 'source_image', 'step_image_registries']
+  const prefixKnown = ['hermetic_task', 'test', 'tasks', 'schedule', 'sbom_spdx', 'rpm_signature', 'rpm_packages', 'cve', 'source_image', 'step_image_registries', 'labels', 'base_image_registries', 'buildah_build_task']
   const prefix = value.split('.')[0].split(':')[0]
   return prefixKnown.includes(prefix) ? prefix : 'other'
 }

--- a/modules/releases/client/deliver/views/ConformaExceptionsView.vue
+++ b/modules/releases/client/deliver/views/ConformaExceptionsView.vue
@@ -59,13 +59,16 @@
       <div class="rounded-2xl bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 dark:from-blue-700 dark:via-indigo-700 dark:to-violet-700 px-6 py-5 shadow-lg text-white">
         <div class="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <p class="text-xs font-bold uppercase tracking-widest text-blue-200 mb-1">Viewing Release</p>
+            <p class="text-xs font-bold uppercase tracking-widest text-blue-200 mb-1">
+              {{ isProductLayer ? 'Product Layer' : 'Viewing Release' }}
+            </p>
             <h3 class="text-3xl font-extrabold tracking-tight leading-none">
-              {{ selectedRelease.version }}
+              {{ selectedRelease.displayName || selectedRelease.version }}
               <span v-if="tableFilterTeam" class="text-lg font-semibold text-blue-200 ml-2">· {{ tableFilterTeam }}</span>
             </h3>
+            <p v-if="isProductLayer && selectedRelease.displayName" class="text-sm text-blue-200 mt-1">{{ selectedRelease.version }}</p>
           </div>
-          <div class="flex flex-wrap gap-3">
+          <div v-if="!isProductLayer" class="flex flex-wrap gap-3">
             <div class="flex flex-col items-center bg-white/15 backdrop-blur-sm rounded-xl px-5 py-2.5 min-w-[90px]">
               <span class="text-[10px] font-semibold uppercase tracking-wider text-blue-200 mb-0.5">GA Date</span>
               <span class="text-sm font-bold">{{ selectedRelease.gaDate }}</span>
@@ -152,8 +155,8 @@
         </div>
       </div>
 
-      <!-- Charts row 2 -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Charts row 2 (hidden for product layers — no gaDate or volatile data) -->
+      <div v-if="!isProductLayer" class="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <!-- Trend across releases -->
         <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 p-5">
           <div class="flex items-center justify-between mb-4">
@@ -308,7 +311,7 @@
           <div class="flex flex-wrap items-center gap-2">
             <!-- Actionable toggle -->
             <button
-              v-if="isLatestUnshipped && actionableCount > 0"
+              v-if="!isProductLayer && isLatestUnshipped && actionableCount > 0"
               @click="actionableOnly = !actionableOnly"
               :class="actionableOnly
                 ? 'bg-red-600 text-white border-red-600 shadow-md'
@@ -419,7 +422,7 @@
             <thead>
               <tr class="bg-gray-50 dark:bg-gray-800/60 text-gray-500 dark:text-gray-400 uppercase tracking-wide">
                 <th
-                  v-for="col in TABLE_COLUMNS"
+                  v-for="col in visibleColumns"
                   :key="col.key"
                   class="px-4 py-3 text-left font-semibold select-none"
                   :class="[col.sortable ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200' : '', col.width || '']"
@@ -513,11 +516,11 @@
                   {{ ex.team || '—' }}
                 </td>
                 <!-- Effective Until -->
-                <td class="px-4 py-3 whitespace-nowrap text-gray-600 dark:text-gray-400">
+                <td v-if="!isProductLayer" class="px-4 py-3 whitespace-nowrap text-gray-600 dark:text-gray-400">
                   {{ ex.effectiveUntil ? ex.effectiveUntil.slice(0, 10) : '—' }}
                 </td>
                 <!-- Days After GA -->
-                <td class="px-4 py-3 whitespace-nowrap text-center font-semibold" :class="daysAfterGaCls(ex.daysAfterGa)">
+                <td v-if="!isProductLayer" class="px-4 py-3 whitespace-nowrap text-center font-semibold" :class="daysAfterGaCls(ex.daysAfterGa)">
                   {{ ex.daysAfterGa !== null ? ex.daysAfterGa : '—' }}
                 </td>
                 <!-- References -->
@@ -532,7 +535,7 @@
                   <span v-else class="text-gray-400">—</span>
                 </td>
                 <!-- Action -->
-                <td class="px-4 py-3 whitespace-nowrap">
+                <td v-if="!isProductLayer" class="px-4 py-3 whitespace-nowrap">
                   <template v-if="ex.isActionable">
                     <a
                       v-if="ex.extensionJiraKey"
@@ -599,7 +602,7 @@
 
   <!-- Security Policy Compliance Warning Dialog -->
   <div
-    v-if="showJiraWarning"
+    v-if="showJiraWarning && !isProductLayer"
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
     @click.self="showJiraWarning = false"
   >
@@ -674,7 +677,7 @@ import {
   KNOWN_CATEGORIES, CATEGORY_BADGE, CATEGORY_DOCS,
   AI_CATEGORIES, PERMANENT_TARGET, targetReleaseBadgeCls, targetReleaseLabel,
   normalizeTargetRelease, EXTENSION_JIRA_TEMPLATE_URL, ACTIONABLE_DAYS_THRESHOLD,
-  extractCategory, policyLabel, policyColor, sortPolicyFiles
+  extractCategory, policyLabel, policyColor, sortPolicyFiles, extensionJiraTemplateUrl
 } from '../constants/conforma'
 
 ChartJS.register(
@@ -712,20 +715,25 @@ const chartKey = ref(0)
 const todayStr = new Date().toLocaleDateString('sv-SE') // YYYY-MM-DD in local time
 
 const allReleasesRaw = computed(() => {
-  const releases = (state.releases || []).filter(r => r.gaDate)
-  const shipped = releases
+  const all = state.releases || []
+  const dated = all.filter(r => r.gaDate)
+  const productLayers = all.filter(r => !r.gaDate)
+  const shipped = dated
     .filter(r => r.gaDate <= todayStr)
     .sort((a, b) => b.gaDate.localeCompare(a.gaDate))
-  const upcoming = releases
+  const upcoming = dated
     .filter(r => r.gaDate > todayStr)
     .sort((a, b) => a.gaDate.localeCompare(b.gaDate))
-  return [...upcoming, ...shipped]
+  return [...productLayers, ...upcoming, ...shipped]
 })
 
 const allReleases = computed(() => {
-  const nextUpcoming = allReleasesRaw.value.find(r => r.gaDate > todayStr)
-  const shipped = allReleasesRaw.value.filter(r => r.gaDate <= todayStr)
-  return nextUpcoming ? [nextUpcoming, ...shipped] : shipped
+  const dated = allReleasesRaw.value.filter(r => r.gaDate)
+  const productLayers = allReleasesRaw.value.filter(r => !r.gaDate)
+  const nextUpcoming = dated.find(r => r.gaDate > todayStr)
+  const shipped = dated.filter(r => r.gaDate <= todayStr)
+  const releases = nextUpcoming ? [nextUpcoming, ...shipped] : shipped
+  return [...productLayers, ...releases]
 })
 
 const filteredConformaReleases = computed(() => {
@@ -755,6 +763,16 @@ const selectedRelease = computed(() =>
 
 const selectedVersion = computed(() => selectedRelease.value?.version || null)
 
+const isProductLayer = computed(() => !!selectedRelease.value?.productLayer)
+
+// ─── Table columns (hide release-specific columns for product layers) ───────
+
+const visibleColumns = computed(() => {
+  if (!isProductLayer.value) return TABLE_COLUMNS
+  const hide = new Set(['effectiveUntil', 'daysAfterGa', 'action'])
+  return TABLE_COLUMNS.filter(c => !hide.has(c.key))
+})
+
 // ─── Actionable exceptions ─────────────────────────────────────────────────
 
 const isLatestUnshipped = computed(() => {
@@ -772,7 +790,8 @@ function handleCreateJira() {
 
 function confirmCreateJira() {
   showJiraWarning.value = false
-  window.open(EXTENSION_JIRA_TEMPLATE_URL, '_blank', 'noopener')
+  const url = extensionJiraTemplateUrl(selectedRelease.value) || EXTENSION_JIRA_TEMPLATE_URL
+  window.open(url, '_blank', 'noopener')
 }
 
 function dismissHoveredTooltip() {
@@ -1217,7 +1236,7 @@ const typeDonutData = computed(() => {
 const trendChartData = computed(() => {
   const prods = filter.selectedProducts
   const sorted = [...allReleasesRaw.value]
-    .filter(r => !prods.size || prods.has(extractProduct(r.version)))
+    .filter(r => r.gaDate && (!prods.size || prods.has(extractProduct(r.version))))
     .sort((a, b) => a.gaDate.localeCompare(b.gaDate))
   if (sorted.length < 2) return null
 

--- a/modules/releases/server/delivery/config.js
+++ b/modules/releases/server/delivery/config.js
@@ -12,7 +12,8 @@ const DEFAULT_CONFIG = {
   productPagesTokenUrl: 'https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token',
   jiraAllProjects: false,
   targetVersionJqlFragment: '',
-  commitmentTrackingJql: 'cf[10855] is not EMPTY'
+  commitmentTrackingJql: 'cf[10855] is not EMPTY',
+  conformaEcpBaseUrl: ''
 };
 
 const PROJECT_KEY_PATTERN = /^[A-Z][A-Z0-9_]+$/;
@@ -58,6 +59,9 @@ function applyEnvOverrides(config) {
   }
   if (env.PRODUCT_PAGES_TOKEN_URL) {
     config.productPagesTokenUrl = env.PRODUCT_PAGES_TOKEN_URL;
+  }
+  if (env.CONFORMA_ECP_BASE_URL) {
+    config.conformaEcpBaseUrl = env.CONFORMA_ECP_BASE_URL;
   }
   if (env.RELEASE_ANALYSIS_JIRA_ALL_PROJECTS) {
     config.jiraAllProjects = ['1', 'true', 'yes'].includes(
@@ -262,6 +266,18 @@ async function saveConfig(writeToStorage, config) {
       throw new Error('commitmentTrackingJql contains invalid characters');
     }
     merged.commitmentTrackingJql = fragment;
+  }
+
+  // conformaEcpBaseUrl — empty or valid HTTP(S) URL
+  if (config.conformaEcpBaseUrl !== undefined) {
+    if (typeof config.conformaEcpBaseUrl !== 'string') {
+      throw new Error('conformaEcpBaseUrl must be a string');
+    }
+    const url = config.conformaEcpBaseUrl.trim();
+    if (url && !/^https?:\/\//i.test(url)) {
+      throw new Error('conformaEcpBaseUrl must be an HTTP or HTTPS URL');
+    }
+    merged.conformaEcpBaseUrl = url;
   }
 
   await writeToStorage('releases/delivery/config.json', merged);

--- a/modules/releases/server/delivery/conforma-fetcher.js
+++ b/modules/releases/server/delivery/conforma-fetcher.js
@@ -1,0 +1,180 @@
+'use strict'
+
+const yaml = require('js-yaml')
+
+let _fetch = globalThis.fetch
+
+const { getConfig } = require('./config')
+
+const AIPCC_FILES = [
+  'registry-ai-containers-prod.yaml',
+  'registry-rhel-ai-containers-prod.yaml',
+  'registry-rhel-ai-disk-images-prod.yaml',
+  'registry-rhel-ai-disk-image-containers-prod.yaml',
+  'registry-aipcc-base-images-prod.yaml'
+]
+
+const STORAGE_KEY = 'releases/delivery/conforma-aipcc.json'
+
+const VERSION_MAP = {
+  'registry-ai-containers-prod': 'rhaii',
+  'registry-rhel-ai-containers-prod': 'rhel-ai',
+  'registry-rhel-ai-disk-images-prod': 'rhel-ai-disk-images',
+  'registry-rhel-ai-disk-image-containers-prod': 'rhel-ai-container-disk-images',
+  'registry-aipcc-base-images-prod': 'base-images'
+}
+
+function deriveVersion(metadataName) {
+  return VERSION_MAP[metadataName] || metadataName
+    .replace(/^registry-/, '')
+    .replace(/-prod$/, '')
+}
+
+const DISPLAY_NAME_MAP = {
+  'rhaii': 'RHAII',
+  'rhel-ai': 'RHEL AI',
+  'rhel-ai-disk-images': 'RHEL AI Disk Images',
+  'rhel-ai-container-disk-images': 'RHEL AI Container Disk Images',
+  'base-images': 'Base Images'
+}
+
+function deriveDisplayName(version) {
+  return DISPLAY_NAME_MAP[version] || version.toUpperCase()
+}
+
+function extractJiraReferences(yamlText) {
+  const refs = new Set()
+  const pattern = /https:\/\/(?:issues\.redhat\.com|redhat\.atlassian\.net)\/browse\/[A-Z]+-\d+/g
+  let match
+  while ((match = pattern.exec(yamlText)) !== null) {
+    refs.add(match[0])
+  }
+  return [...refs]
+}
+
+function transformEcpToRelease(doc, yamlText) {
+  const meta = doc.metadata || {}
+  const spec = doc.spec || {}
+  const source = (spec.sources || [])[0] || {}
+  const config = source.config || {}
+  const volatileConfig = source.volatileConfig || {}
+  const ruleData = source.ruleData || {}
+
+  const version = deriveVersion(meta.name || '')
+  const configExcludes = config.exclude || []
+  const volatileExcludes = (volatileConfig.exclude || []).map(v =>
+    typeof v === 'string' ? { value: v } : v
+  )
+
+  const jiraRefs = extractJiraReferences(yamlText)
+
+  return {
+    version,
+    gaDate: null,
+    productLayer: true,
+    displayName: deriveDisplayName(version),
+    exceptions: {
+      policy: {
+        configExcludes,
+        volatileExcludes
+      }
+    },
+    ruleData: {
+      allowedRpmSignatureKeys: ruleData.allowed_rpm_signature_keys || [],
+      allowedRegistryPrefixes: ruleData.allowed_registry_prefixes || [],
+      disallowedPlatformPatterns: ruleData.disallowed_platform_patterns || []
+    },
+    jiraReferences: jiraRefs
+  }
+}
+
+async function fetchAipccConforma(storage) {
+  const config = await getConfig(storage.readFromStorage)
+  const ecpBase = (config.conformaEcpBaseUrl || '').replace(/\/+$/, '')
+  if (!ecpBase) {
+    return { releases: [], errors: [{ file: '*', error: 'conformaEcpBaseUrl not configured — set it in Releases > Deliver settings' }] }
+  }
+  const releases = []
+  const errors = []
+
+  const results = await Promise.allSettled(AIPCC_FILES.map(async (filename) => {
+    const url = `${ecpBase}/${filename}`
+    const res = await _fetch(url, { signal: AbortSignal.timeout(30000) })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const text = await res.text()
+    const doc = yaml.load(text)
+    if (!doc || !doc.metadata) throw new Error('Invalid YAML structure')
+    return { filename, release: transformEcpToRelease(doc, text) }
+  }))
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i]
+    if (r.status === 'fulfilled') {
+      releases.push(r.value.release)
+    } else {
+      errors.push({ file: AIPCC_FILES[i], error: r.reason?.message || String(r.reason) })
+    }
+  }
+
+  return { releases, errors }
+}
+
+function registerConformaFetcher(router, context) {
+  const { storage, requireAdmin, requireScope } = context
+  const { writeToStorage } = storage
+
+  async function runFetch() {
+    const { releases, errors } = await fetchAipccConforma(storage)
+    if (releases.length === 0 && errors.length > 0) {
+      return { status: 'error', message: 'All fetches failed', errors }
+    }
+
+    const savedAt = new Date().toISOString()
+    await writeToStorage(STORAGE_KEY, {
+      fetchedAt: savedAt,
+      count: releases.length,
+      releases
+    })
+
+    return { status: 'ok', count: releases.length, savedAt, errors: errors.length ? errors : undefined }
+  }
+
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/conforma/fetch-aipcc:
+   *   post:
+   *     summary: Trigger AIPCC conforma data fetch from ECP YAMLs (admin only)
+   *     tags: [Releases - Delivery]
+   *     responses:
+   *       200:
+   *         description: Fetch results
+   */
+  router.post('/conforma/fetch-aipcc', requireAdmin, requireScope('releases:write'), async function (req, res) {
+    if (process.env.DEMO_MODE === 'true') {
+      return res.json({ status: 'skipped', message: 'Fetch disabled in demo mode.' })
+    }
+    try {
+      const result = await runFetch()
+      res.json(result)
+    } catch (err) {
+      res.status(500).json({ error: err.message })
+    }
+  })
+
+  if (context.registerRefresh) {
+    context.registerRefresh('conforma-aipcc', {
+      order: 80,
+      cadence: '12h',
+      timeout: 120000,
+      description: 'Fetches AIPCC Enterprise Contract Policy YAMLs from konflux-release-data and updates conforma data.',
+      handler: async function () {
+        if (process.env.DEMO_MODE === 'true') {
+          return { status: 'skipped', message: 'Fetch disabled in demo mode' }
+        }
+        return runFetch()
+      }
+    })
+  }
+}
+
+module.exports = { registerConformaFetcher, fetchAipccConforma, transformEcpToRelease, deriveVersion, extractJiraReferences, STORAGE_KEY, AIPCC_FILES, _setFetch: fn => { _fetch = fn } }

--- a/modules/releases/server/delivery/conforma.js
+++ b/modules/releases/server/delivery/conforma.js
@@ -2,13 +2,16 @@
 
 const { logAudit } = require('../planning/audit-log')
 
+const { STORAGE_KEY: AIPCC_STORAGE_KEY } = require('./conforma-fetcher')
+
 const STORAGE_KEY = 'releases/delivery/conforma.json'
 const DEFAULT_MIN_DATE = '2024-01-01'
 
 function validateRelease(r) {
   if (!r || typeof r !== 'object') return 'must be an object'
   if (!r.version || typeof r.version !== 'string') return 'missing version'
-  if (!r.gaDate || typeof r.gaDate !== 'string') return 'missing gaDate'
+  if (r.gaDate != null && typeof r.gaDate !== 'string') return 'gaDate must be a string'
+  if (!r.gaDate && !r.productLayer) return 'missing gaDate (required unless productLayer is set)'
   if (!r.exceptions || typeof r.exceptions !== 'object') return 'missing exceptions'
   return null
 }
@@ -16,6 +19,22 @@ function validateRelease(r) {
 module.exports = async function registerConformaRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage, deleteFromStorage } = storage
+
+  async function getMergedReleases() {
+    const rhoai = await readFromStorage(STORAGE_KEY)
+    const aipcc = await readFromStorage(AIPCC_STORAGE_KEY)
+    const rhoaiReleases = rhoai ? (rhoai.releases || []) : []
+    const aipccReleases = aipcc ? (aipcc.releases || []) : []
+    const releases = [...rhoaiReleases, ...aipccReleases]
+    if (!rhoai && !aipcc) return null
+    const latest = [rhoai?.fetchedAt, aipcc?.fetchedAt].filter(Boolean).sort().pop() || null
+    return {
+      fetchedAt: latest,
+      minDate: rhoai?.minDate || DEFAULT_MIN_DATE,
+      count: releases.length,
+      releases
+    }
+  }
 
   /**
    * @openapi
@@ -28,11 +47,11 @@ module.exports = async function registerConformaRoutes(router, context) {
    *         description: Conforma data status
    */
   router.get('/conforma/status', requireAuth, requireScope('releases:read'), async function (req, res) {
-    const data = await readFromStorage(STORAGE_KEY)
+    const data = await getMergedReleases()
     if (!data) return res.json({ status: 'no_data' })
     res.json({
       fetchedAt: data.fetchedAt || null,
-      count: data.count || (data.releases || []).length,
+      count: data.count,
       minDate: data.minDate || DEFAULT_MIN_DATE
     })
   })
@@ -48,15 +67,15 @@ module.exports = async function registerConformaRoutes(router, context) {
    *         description: Conforma releases list
    */
   router.get('/conforma/releases', requireAuth, requireScope('releases:read'), async function (req, res) {
-    const data = await readFromStorage(STORAGE_KEY)
+    const data = await getMergedReleases()
     if (!data) {
       return res.status(404).json({ error: 'No conforma data available. Run the ingestion pipeline.' })
     }
     res.json({
       fetchedAt: data.fetchedAt,
       minDate: data.minDate || DEFAULT_MIN_DATE,
-      count: data.count || (data.releases || []).length,
-      releases: data.releases || []
+      count: data.count,
+      releases: data.releases
     })
   })
 
@@ -71,11 +90,11 @@ module.exports = async function registerConformaRoutes(router, context) {
    *         description: Single conforma release
    */
   router.get('/conforma/releases/:version', requireAuth, requireScope('releases:read'), async function (req, res) {
-    const data = await readFromStorage(STORAGE_KEY)
+    const data = await getMergedReleases()
     if (!data) {
       return res.status(404).json({ error: 'No conforma data available.' })
     }
-    const release = (data.releases || []).find(r => r.version === req.params.version)
+    const release = data.releases.find(r => r.version === req.params.version)
     if (!release) {
       return res.status(404).json({ error: `Release '${req.params.version}' not found.` })
     }
@@ -144,7 +163,7 @@ module.exports = async function registerConformaRoutes(router, context) {
    * @openapi
    * /api/modules/releases/delivery/conforma:
    *   delete:
-   *     summary: Clear all conforma data (admin only)
+   *     summary: Clear RHOAI conforma data (admin only)
    *     tags: [Releases - Delivery]
    *     responses:
    *       204:

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -4,6 +4,7 @@ const { getConfig, saveConfig, deleteConfig } = require('./config')
 const productPages = require('./product-pages')
 const { fetchProductsByShortname, fetchAllProducts, getProductPagesToken, getAuthStatus } = productPages
 const registerConformaRoutes = require('./conforma')
+const { registerConformaFetcher } = require('./conforma-fetcher')
 const { logAudit } = require('../planning/audit-log')
 const { stripZStream: sharedStripZStream, normalizeVersionName, extractProduct: sharedExtractProduct } = require('../version-utils')
 
@@ -1049,6 +1050,7 @@ module.exports = async function registerRoutes(router, context) {
   }
 
   registerConformaRoutes(router, context)
+  registerConformaFetcher(router, context)
 
   const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage } = storage


### PR DESCRIPTION
Fetches Enterprise Contract Policy YAML files from konflux-release-data for AIPCC product layers (RHAII, RHEL AI, disk images, base images) and displays them alongside RHOAI release-scoped conforma data. Product layer entries show a simplified UI without release-specific elements (GA date, scatter timeline, trend chart, actionable alerts).

AIPCC-19024