### PR TITLE
fix(product-builds): skip empty sub-variants in version map

### DIFF
--- a/modules/product-builds/server/version-map-snapshot.json
+++ b/modules/product-builds/server/version-map-snapshot.json
@@ -1321,15 +1321,6 @@
               }
             }
           ]
-        },
-        {
-          "name": "ROCm 7.2",
-          "architectures": "x86_64",
-          "first_release_index": 0,
-          "last_release_index": null,
-          "sdk_versions": {},
-          "packages": [],
-          "infra": []
         }
       ],
       "planning_from_index": 8

--- a/modules/product-builds/server/version-map.js
+++ b/modules/product-builds/server/version-map.js
@@ -159,6 +159,8 @@ function parseSheet(sheetName, rows) {
       }
     }
 
+    if (packages.length === 0 && infra.length === 0) continue;
+
     subVariants.push({
       name: variantName,
       architectures: arch,


### PR DESCRIPTION
## Summary
- Fixes variant count mismatch in the Version Map tab where ROCm showed "4 variants" but only 3 were rendered
- Root cause: the spreadsheet has a `ROCm 7.2` header row with no package data beneath it — the parser included it as a sub-variant, inflating the count badge, while the UI correctly hid it via `hasVisibleRows`
- Added a `continue` guard in `parseSheet` to skip sub-variants with empty packages and infra arrays
- Removed the empty `ROCm 7.2` entry from the static snapshot

Closes red-hat-data-services/org-pulse-core#27

## Test plan
- [ ] Verify ROCm section shows "3 variants" (not 4)
- [ ] Verify all 3 ROCm sub-variants (6.4, 7.1, 7.13) render correctly
- [ ] Verify other accelerator sections are unaffected
- [ ] Existing tests pass (16/16 in version-map-jira.test.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)