### PR TITLE
refactor: move enablement links from core to ai-impact module

### DIFF
--- a/modules/ai-impact/client/components/AssessmentGuideModal.vue
+++ b/modules/ai-impact/client/components/AssessmentGuideModal.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, watch } from 'vue'
 import { Video, Presentation, StickyNote, Play, ExternalLink } from 'lucide-vue-next'
-import { getAIImpactEnablementCategories } from '@shared/client/enablement-links.js'
+import { getAIImpactEnablementCategories } from '../enablement-links.js'
 
 const iconMap = { Video, Presentation, StickyNote, Play }
 function resolveIcon(name) { return iconMap[name] || Video }

--- a/modules/ai-impact/client/enablement-links.js
+++ b/modules/ai-impact/client/enablement-links.js
@@ -1,0 +1,157 @@
+export const enablementCategories = [
+  {
+    id: 'release-planning-overview',
+    title: 'Release Planning Overview',
+    section: 'release-planning',
+    slackChannel: { name: 'Submit Suggestion', url: 'https://forms.gle/fioq7nF6Qh5vVkTF8' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1GpZv_hyY3-TOve9EzZ3jQ0p4iW2mgA3B/view' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1LUudV27xT9SRx8xGcC00MDp1IK_xU8b8nT2-vXDgljs/edit?tab=t.pw30ggryjpo7' },
+      { label: 'Enablement Chat', icon: 'MessageSquare', url: 'https://drive.google.com/file/d/1O8WwDcifjv1rlNmKLe7_0CoDAqFENY-I/view' },
+    ],
+  },
+  {
+    id: 'rfe-builder',
+    title: 'RFE Builder',
+    section: 'ai-sdlc',
+    slackChannel: { name: '#wg-rhai-rfe-builder', url: 'https://app.slack.com/client/E030G10V24F/C0AMPLH0Y9G' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1qZomlB-TK2FODtmvjzpMeH_g5qpuAOh-/view?usp=sharing' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1O-F8naJxAfYtcXjTJHySYjeLtrKfb1OHhtyhoItya0s/edit?usp=sharing' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1pTpIvKkYns2aG5g0ueOxy6P8j1m_yNnD13XBB35NgWQ/edit?usp=sharing' },
+      { label: 'Demo', icon: 'Play', url: 'https://drive.google.com/file/d/1ANaZOeUorSMqlFm3WzfK1xRPvld2TGM-/view' },
+    ],
+  },
+  {
+    id: 'strat-builder',
+    title: 'STRAT Builder',
+    section: 'ai-sdlc',
+    slackChannel: { name: '#wg-rhai-strat-refine-review', url: 'https://app.slack.com/client/E030G10V24F/C0APA0E2J3Z' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1dXtifXiAsbnZtfiU9-vKUCEvfLX5ANvg/view' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1oBIyJo30MSuig9Q1Qokq-6yclm_OL9htbWV91_YWMFs/edit?slide=id.g3dc5b8ade0b_0_14#slide=id.g3dc5b8ade0b_0_14' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1n-UEt0RloVmEDmjO4E3EoEQPLJTNVwPvao4Uvf3XD4U/edit?tab=t.uwq8408i1mre' },
+    ],
+  },
+  {
+    id: 'ai-first-build-release',
+    title: 'AI First Build & Release',
+    section: 'ai-sdlc',
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1sY1waCkq516tAy5RqmYUSsZyUaXNwPCY/view' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1SMYTQ-nE2NSh7tRdKhKdUkJnIlblbh1_NB3en97dwdA/edit?slide=id.g3d48d3b5671_0_5160#slide=id.g3d48d3b5671_0_5160' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1U2n3HMBvTm79qSyxLmG_M2dZ_DaGltaIPUSSJcpibEc/edit?tab=t.g4ru03c6tqzb' },
+    ],
+  },
+  {
+    id: 'ai-quality',
+    title: 'AI Quality',
+    section: 'ai-sdlc',
+    slackChannel: { name: '#wg-rhai-quality-eng-builder', url: 'https://app.slack.com/client/E030G10V24F/C0ANMTUF5FW' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1jlsw8rVpRRo1Y1kkKhJ7LHDy3N6C_Uxp/view' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1XuLna0_2DHX7EzepJHk03PpQF1urFoF39xaq9N-G6rY/edit?slide=id.g3d48d3b5671_0_5160#slide=id.g3d48d3b5671_0_5160' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1B006LrfEAUf_wb6Hr7PZJnpg2oW2bAQdxNmYcbLJo30/edit?tab=t.iqa6kux2ki3f' },
+    ],
+  },
+  {
+    id: 'ai-first-documentation',
+    title: 'AI First Documentation',
+    section: 'ai-sdlc',
+    slackChannel: { name: '#wg-rhai-document-builder', url: 'https://redhat.enterprise.slack.com/archives/C0APCEUR196' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1A0JARScdMm1mnoHBj7P9mOULtNumWmDM/view' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1Nv8Pp7fNRSzgED8B7p7KaBg1OaPnI011iA41EY-tCzo/edit?slide=id.g3e334837aa4_0_0#slide=id.g3e334837aa4_0_0' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1D6-LmPIYRqLAWL5adDN8iVCmuV1Dz_JYkN3w7P7TYXw/edit?tab=t.p8v68m1kpy1y' },
+    ],
+  },
+  {
+    id: 'component-onboarding',
+    title: 'Component Onboarding',
+    section: 'ai-sdlc',
+    slackChannel: { name: '#forum-rhai-ai-first', url: 'https://app.slack.com/client/E030G10V24F/C0APP9DDB2R' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'javascript:void(0)' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'javascript:void(0)' },
+    ],
+  },
+  {
+    id: 'jira-autofix',
+    title: 'Jira Autofix',
+    section: 'ai-workflows',
+    slackChannel: { name: '#wg-rhai-ai-first-code-autofix', url: 'https://app.slack.com/client/E030G10V24F/C0ASJ32PJ0N' },
+    linkGroups: [
+      {
+        date: '2026JUN11',
+        links: [
+          { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1B3TYRfH2J8AtMXE4SsNuOl39hu4Z5boY/view' },
+          { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1m0TEwUxyuouEt8MK5F42mXS0PMuYt6IBcM3BKZUcvdU/edit?slide=id.g3dc5b8ade0b_0_14#slide=id.g3dc5b8ade0b_0_14' },
+          { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1Md24Vb77hbz4aP0Cu-RRdArJcfupAxPkcdoPjHfHims/edit?tab=t.xjqu48g1l03j' },
+          { label: 'Enablement Chat', icon: 'MessageSquare', url: 'https://drive.google.com/file/d/1h-CGNO2tSteblI0mls49yXtjiJdShh4g/view' },
+        ],
+      },
+      {
+        date: '2026APR22',
+        links: [
+          { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1b-PZD3OiPAA8LOZ8lWmfcNZBByUa0Nel/view?ts=69e8ff07' },
+          { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1_UaHAI65K1P5Y2pAhZ4ie2KY-tHiSrqbnWN0UUqvsYs/edit?slide=id.g3d84ce2c2ca_1_0#slide=id.g3d84ce2c2ca_1_0' },
+          { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1O3i5Ijoo3fi-gPHG0e9ON70Nfij2EUdfU18KOrVQADY/edit?tab=t.4ih80ylpl5y1' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'agent-eval-harness',
+    title: 'Agent Eval Harness',
+    section: 'other',
+    slackChannel: { name: '#wg-agent-eval-harness', url: 'https://app.slack.com/client/E030G10V24F/C0B01HA68KC' },
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1SVPwRZzo2U1ohnlTtgjlyOvXHrJB1Jxu/view' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/15vhrPqtu-uzxQC4v3whN8YQL1NK46kqNULhZff3uC8E/edit?slide=id.g3d8e714406d_0_0#slide=id.g3d8e714406d_0_0' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1HJJBt2Psnqy7JWx26UUP0fENJqDPAZBDhFcHpHt6sjM/edit?tab=t.tcc7ue9usok7' },
+    ],
+  },
+  {
+    id: 'skills-registry',
+    title: 'Skills Registry',
+    section: 'other',
+    links: [
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1izke023uzA3YnUB9kxf3huM5ZIJODKhA82abymerrqU/edit?slide=id.g3f362a4cb5a_0_0#slide=id.g3f362a4cb5a_0_0' },
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1CvEcigQBe4qYtldzSIAhPm4X9uiz6hBd/view' },
+    ],
+  },
+  {
+    id: 'rfe-builder-lessons-learned',
+    title: 'RFE Builder Lessons Learned',
+    section: 'other',
+    links: [
+      { label: 'Lessons Learned Recording', icon: 'Video', url: 'https://drive.google.com/file/d/15UWUdbITmkccmxeW8U1oIxlS3Wei2j3g/view' },
+      { label: 'Lessons Learned Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1XhMa0hn6no4ALO2W7y8HthqF0iQh3b9z9vXja7BMKao/edit?slide=id.slide_01#slide=id.slide_01' },
+      { label: 'Lessons Learned Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1glUr8WhghdDmri1KKSCJutMjfzxnueoZuYGFjg2OwxI/edit?tab=t.q557l4ag5zjk' },
+    ],
+  },
+  {
+    id: 'adlc-putting-pieces-together',
+    title: 'ADLC - Putting the Pieces Together',
+    section: 'other',
+    links: [
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1jL4H4HNIxZoJ0EQUycvk80tQ3F_-NTw0/view' },
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1C8bVcKE2818wwGKogDBa-yrRJ4C3t8vx_j65uSNu8qg/edit?slide=id.g3e77d255e42_0_9#slide=id.g3e77d255e42_0_9' },
+      { label: 'Enablement Chat', icon: 'MessageSquare', url: 'https://drive.google.com/file/d/1dp0hHyP6uM9ClxWSXmyq8Tikvu7gItuv/view' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/11yTvpFIl4IRct_ds2HJiBjzIlOxPqS_OLMtSso4pQ_U/edit?tab=t.542hs4xvrwe3' },
+    ],
+  },
+]
+
+export const enablementSections = [
+  { id: 'release-planning', label: 'Release Planning Materials' },
+  { id: 'ai-sdlc', label: 'AI SDLC Materials' },
+  { id: 'ai-workflows', label: 'AI Workflows Enablement' },
+  { id: 'other', label: 'Other Enablement' },
+]
+
+export function getAIImpactEnablementCategories() {
+  return enablementCategories.filter(c =>
+    ['rfe-builder', 'strat-builder', 'ai-quality', 'ai-first-documentation', 'component-onboarding'].includes(c.id)
+  )
+}

--- a/platform/about-tabs/DocsTab.vue
+++ b/platform/about-tabs/DocsTab.vue
@@ -65,7 +65,7 @@
 
 <script setup>
 import { ExternalLink, Video, Presentation, StickyNote, Play, MessageSquare } from 'lucide-vue-next'
-import { enablementCategories, enablementSections } from '@shared/client/enablement-links.js'
+import { enablementCategories, enablementSections } from '@modules/ai-impact/client/enablement-links.js'
 
 const iconMap = { Video, Presentation, StickyNote, Play, MessageSquare }
 


### PR DESCRIPTION
## Summary
- Moves AI Engineering-specific enablement link data from `@org-pulse/core` into `modules/ai-impact/client/enablement-links.js`
- Updates `DocsTab.vue` and `AssessmentGuideModal.vue` imports to use the local file
- Adds the Skills Registry entry (from org-pulse-core#20)

This data doesn't belong in core — it's only consumed by AI Eng's platform extension and ai-impact module. Companion PR to remove from core: red-hat-data-services/org-pulse-core#30

## Test plan
- [ ] About → Docs tab renders all enablement sections and links correctly
- [ ] Skills Registry appears in the "Other Enablement" section
- [ ] AI Impact Assessment Guide modal still shows the filtered enablement categories
- [ ] `npm run lint` passes
- [ ] `npm test` passes (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)