### PR TITLE
feat(product-builds): add Pre-Built Packages tab to Wheel Collections

### DIFF
--- a/modules/product-builds/client/composables/useWheelCollections.js
+++ b/modules/product-builds/client/composables/useWheelCollections.js
@@ -167,6 +167,39 @@ export function useWheelPackageSearch() {
   }
 }
 
+export function useWheelOverrides() {
+  const overrides = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+  const variantFilter = ref('')
+
+  async function load() {
+    loading.value = true
+    error.value = null
+    try {
+      const params = new URLSearchParams()
+      if (variantFilter.value) {
+        params.set('variant', variantFilter.value)
+      }
+      const queryString = params.toString()
+      const url = `${BASE}/wheel-overrides${queryString ? '?' + queryString : ''}`
+      const data = await apiRequest(url)
+      overrides.value = Array.isArray(data) ? data : []
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function setVariantFilter(variant) {
+    variantFilter.value = variant
+    load()
+  }
+
+  return { overrides, loading, error, variantFilter, load, setVariantFilter }
+}
+
 export function useWheelFilters() {
   const products = ref([])
   const variants = ref([])

--- a/modules/product-builds/client/views/WheelCollectionsView.vue
+++ b/modules/product-builds/client/views/WheelCollectionsView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onUnmounted, inject } from 'vue'
-import { useWheelBrowse, useWheelPackageSearch, useWheelFilters } from '../composables/useWheelCollections'
+import { useWheelBrowse, useWheelPackageSearch, useWheelFilters, useWheelOverrides } from '../composables/useWheelCollections'
 import { formatDate, envBadgeClass, archBadgeClass, getCommitUrl } from '../utils/formatting'
 import { apiRequest, getApiBase } from '@shared/client/services/api'
 import { impersonatingUid } from '@shared/client/state/impersonation'
@@ -311,10 +311,27 @@ function navigateToArtifact(artifactKey, productKey) {
   nav.navigateTo('artifact-detail', { key: artifactKey, product: productKey || 'rhai' })
 }
 
+// --- Pre-Built Packages tab ---
+const wheelOverrides = useWheelOverrides()
+const BUILDER_REPO_URL = 'https://gitlab.com/redhat/rhel-ai/wheels/builder'
+const OVERRIDE_VARIANTS = ['cpu-ubi9', 'cuda-ubi9', 'gaudi-ubi9', 'neuron-ubi9', 'rocm-ubi9', 'spyre-ubi9', 'tpu-ubi9']
+let overridesInitialized = false
+
+function getOverrideFileUrl(override) {
+  if (!override.source_file) return null
+  const ref = override.commit_sha || 'main'
+  return `${BUILDER_REPO_URL}/-/blob/${ref}/${override.source_file}`
+}
+
+
 watch(activeTab, (tab) => {
   if (tab === 'artifacts' && !artifactsInitialized) {
     artifactsInitialized = true
     loadArtifactsData()
+  }
+  if (tab === 'pre-built' && !overridesInitialized) {
+    overridesInitialized = true
+    wheelOverrides.load()
   }
 })
 
@@ -343,6 +360,7 @@ onUnmounted(() => { clearTimeout(searchTimeout); clearTimeout(containerHoverTime
             { key: 'browse-all', label: 'Browse All' },
             { key: 'search-package', label: 'Search by Package' },
             { key: 'artifacts', label: 'Artifacts' },
+            { key: 'pre-built', label: 'Pre-Built Packages' },
           ]"
           :key="tab.key"
           @click="activeTab = tab.key"
@@ -912,6 +930,80 @@ onUnmounted(() => { clearTimeout(searchTimeout); clearTimeout(containerHoverTime
                 : 'border-gray-200 dark:border-gray-700 text-gray-300 dark:text-gray-600 cursor-not-allowed'"
             >Next</button>
           </div>
+        </div>
+      </template>
+    </div>
+
+    <!-- ==================== Pre-Built Packages Tab ==================== -->
+    <div v-if="activeTab === 'pre-built'" class="space-y-4">
+      <!-- Variant filter -->
+      <div class="flex items-center gap-3">
+        <select
+          :value="wheelOverrides.variantFilter.value"
+          @change="wheelOverrides.setVariantFilter($event.target.value)"
+          class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        >
+          <option value="">All variants</option>
+          <option v-for="v in OVERRIDE_VARIANTS" :key="v" :value="v">{{ v }}</option>
+        </select>
+        <span v-if="!wheelOverrides.loading.value && wheelOverrides.overrides.value.length > 0" class="text-sm text-gray-500 dark:text-gray-400">
+          {{ wheelOverrides.overrides.value.length }} package{{ wheelOverrides.overrides.value.length !== 1 ? 's' : '' }}
+        </span>
+        <span v-if="wheelOverrides.loading.value" class="text-sm text-gray-500 dark:text-gray-400">Loading...</span>
+      </div>
+
+      <!-- Error -->
+      <div v-if="wheelOverrides.error.value" class="text-sm text-red-600 dark:text-red-400">{{ wheelOverrides.error.value }}</div>
+
+      <!-- Empty state -->
+      <div v-else-if="!wheelOverrides.loading.value && wheelOverrides.overrides.value.length === 0" class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+        No pre-built packages found.
+      </div>
+
+      <!-- Table -->
+      <template v-if="wheelOverrides.overrides.value.length > 0">
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 22%">Package</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 25%">Variants</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 33%">Reason</th>
+                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style="width: 20%">Jira</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tr
+                v-for="pkg in wheelOverrides.overrides.value"
+                :key="pkg.package_name"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+              >
+                <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 font-mono">
+                  {{ pkg.package_name }}
+                  <a v-if="getOverrideFileUrl(pkg)" :href="getOverrideFileUrl(pkg)" target="_blank" rel="noopener noreferrer" class="ml-1.5 inline-flex text-gray-400 dark:text-gray-500 hover:text-primary-600 dark:hover:text-blue-400" title="View source file">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                  </a>
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex gap-1 flex-wrap">
+                    <span
+                      v-for="v in pkg.pre_built_variants"
+                      :key="v"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+                    >{{ v }}</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ pkg.reason || '—' }}</td>
+                <td class="px-4 py-3 text-sm">
+                  <template v-if="pkg.jira_key">
+                    <a :href="`https://redhat.atlassian.net/browse/${pkg.jira_key}`" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline">{{ pkg.jira_key }}</a>
+                    <span v-if="pkg.jira_status" class="ml-1.5 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300">{{ pkg.jira_status }}</span>
+                  </template>
+                  <span v-else class="text-gray-400 dark:text-gray-500">—</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </template>
     </div>

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -350,6 +350,27 @@ module.exports = function registerRoutes(router, context) {
 
   /**
    * @openapi
+   * /api/modules/product-builds/wheel-overrides:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: List pre-built wheel packages
+   *     description: Returns packages that are pre-built (binary-only) in at least one variant, sourced from builder repo override files.
+   *     parameters:
+   *       - name: variant
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by variant (e.g. cpu-ubi9, cuda-ubi9, rocm-ubi9)
+   *     responses:
+   *       200:
+   *         description: Array of wheel override objects with package_name, pre_built_variants, reason, source_file, commit_sha
+   */
+  router.get('/wheel-overrides', function(req, res) {
+    upstream('/wheel-overrides', req, res);
+  });
+
+  /**
+   * @openapi
    * /api/modules/product-builds/artifacts/wheels/build-history/{packageName}:
    *   get:
    *     tags: [Product Builds]


### PR DESCRIPTION
Add a new tab showing packages that are pre-built (binary-only) per variant, sourced from the dashboard API wheel-overrides endpoint. Includes variant filter, source file links, and badge styling.

1. new tab added to Wheel collections -> Pre-Built Packages
2. there is a filter for variant
3. table contains package name, link to source-of-truth config file, list of variants, reason why we don't build it from source and link and status of Jira story for items that could be built from source

<img width="2068" height="2283" alt="Screenshot_20260714_170818" src="https://github.com/user-attachments/assets/263b3fef-e9af-48cd-aa12-b7d9dc1cc42c" />
