### PR TITLE
feat: add upstream-pulse-admin role and strategy management UI

### DIFF
--- a/modules/upstream-pulse/__tests__/server/index.test.js
+++ b/modules/upstream-pulse/__tests__/server/index.test.js
@@ -13,8 +13,9 @@ describe('upstream-pulse server module', () => {
     const router = {
       get: vi.fn((...args) => registered.push({ method: 'get', path: args[0] })),
       post: vi.fn(),
+      patch: vi.fn(),
     }
-    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
+    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), registerRole: vi.fn(), requireAdmin: vi.fn(), requireRole: vi.fn(() => vi.fn()), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
 
     registerRoutes(router, context)
 
@@ -27,8 +28,10 @@ describe('upstream-pulse server module', () => {
     expect(paths).toContain('/orgs')
     expect(paths).toContain('/github-access')
     expect(paths).toContain('/project-jobs')
+    expect(paths).toContain('/strategy/permissions')
+    expect(paths).toContain('/org-info')
     expect(paths).toContain('/repo-info')
-    expect(paths).toHaveLength(9)
+    expect(paths).toHaveLength(11)
   })
 
   it('registers admin POST routes for projects and roster-push', () => {
@@ -36,11 +39,13 @@ describe('upstream-pulse server module', () => {
     const router = {
       get: vi.fn(),
       post: vi.fn((...args) => postCalls.push({ path: args[0] })),
+      patch: vi.fn(),
     }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), registerRole: vi.fn(), requireAdmin, requireRole: vi.fn(() => vi.fn()), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
 
-    expect(postCalls).toHaveLength(2)
+    expect(postCalls).toHaveLength(3)
+    expect(postCalls.map(c => c.path)).toContain('/orgs')
     expect(postCalls.map(c => c.path)).toContain('/projects')
     expect(postCalls.map(c => c.path)).toContain('/roster-push')
     expect(router.post).toHaveBeenCalledWith('/projects', requireAdmin, expect.any(Function), expect.any(Function))
@@ -48,25 +53,52 @@ describe('upstream-pulse server module', () => {
   })
 
   it('gates repo-info behind requireAdmin', () => {
-    const router = { get: vi.fn(), post: vi.fn() }
+    const router = { get: vi.fn(), post: vi.fn(), patch: vi.fn() }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), registerRole: vi.fn(), requireAdmin, requireRole: vi.fn(() => vi.fn()), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
 
     expect(router.get).toHaveBeenCalledWith('/repo-info', requireAdmin, expect.any(Function), expect.any(Function))
   })
 
   it('registers diagnostics hook when available', () => {
-    const router = { get: vi.fn(), post: vi.fn() }
-    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
+    const router = { get: vi.fn(), post: vi.fn(), patch: vi.fn() }
+    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), registerRole: vi.fn(), requireAdmin: vi.fn(), requireRole: vi.fn(() => vi.fn()), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
 
     registerRoutes(router, context)
     expect(context.registerDiagnostics).toHaveBeenCalledWith(expect.any(Function))
   })
 
   it('does not fail when registerDiagnostics is absent', () => {
-    const router = { get: vi.fn(), post: vi.fn() }
-    const context = { registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
+    const router = { get: vi.fn(), post: vi.fn(), patch: vi.fn() }
+    const context = { registerScopes: vi.fn(), registerRole: vi.fn(), requireAdmin: vi.fn(), requireRole: vi.fn(() => vi.fn()), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
 
     expect(() => registerRoutes(router, context)).not.toThrow()
+  })
+
+  it('registers PATCH route for org update', () => {
+    const patchCalls = []
+    const router = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn((...args) => patchCalls.push({ path: args[0] })),
+    }
+    const requireUpstreamAdmin = vi.fn()
+    const requireRole = vi.fn(() => requireUpstreamAdmin)
+    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), registerRole: vi.fn(), requireAdmin: vi.fn(), requireRole, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
+
+    expect(patchCalls).toHaveLength(1)
+    expect(patchCalls[0].path).toBe('/orgs/:githubOrg')
+    expect(router.patch).toHaveBeenCalledWith('/orgs/:githubOrg', requireUpstreamAdmin, expect.any(Function), expect.any(Function))
+  })
+
+  it('registers upstream-pulse-admin role', () => {
+    const router = { get: vi.fn(), post: vi.fn(), patch: vi.fn() }
+    const registerRole = vi.fn()
+    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), registerRole, requireAdmin: vi.fn(), requireRole: vi.fn(() => vi.fn()), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
+
+    expect(registerRole).toHaveBeenCalledWith('upstream-pulse-admin', expect.objectContaining({
+      label: 'Upstream Pulse Admin',
+      description: expect.any(String),
+    }))
   })
 })

--- a/modules/upstream-pulse/client/components/OrgEditModal.vue
+++ b/modules/upstream-pulse/client/components/OrgEditModal.vue
@@ -2,7 +2,6 @@
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import {
   X as XIcon,
-  Target as TargetIcon,
   Loader2 as Loader2Icon,
   CheckCircle2 as CheckCircle2Icon,
   AlertCircle as AlertCircleIcon,
@@ -10,6 +9,7 @@ import {
   Building2 as Building2Icon,
   Search as SearchIcon,
   Check as CheckIcon,
+  Plus as PlusIcon,
 } from 'lucide-vue-next'
 import { apiRequest } from '@shared/client/services/api'
 
@@ -19,13 +19,29 @@ const props = defineProps({
   open: { type: Boolean, default: false },
   org: { type: Object, default: null },
   allOrgs: { type: Array, default: () => [] },
+  mode: { type: String, default: 'auto' },
 })
 
 const emit = defineEmits(['close', 'saved'])
 
+const internalMode = ref('auto')
+
+const effectiveMode = computed(() => {
+  if (internalMode.value !== 'auto') return internalMode.value
+  if (props.mode !== 'auto') return props.mode
+  return props.org ? 'edit' : 'create'
+})
+
 const selectedGithubOrg = ref('')
+const orgName = ref('')
+const governanceModel = ref('none')
 const participation = ref('')
 const leadership = ref('')
+
+const orgLookupStatus = ref('idle')
+const orgInfo = ref(null)
+const nameManuallyEdited = ref(false)
+let orgLookupTimer = null
 
 const submitStatus = ref('idle')
 const submitError = ref('')
@@ -36,10 +52,18 @@ const orgHighlightIdx = ref(0)
 const orgSearchRef = ref(null)
 const orgContainerRef = ref(null)
 
+const governanceDropdownOpen = ref(false)
+const governanceContainerRef = ref(null)
 const participationDropdownOpen = ref(false)
 const leadershipDropdownOpen = ref(false)
 const participationContainerRef = ref(null)
 const leadershipContainerRef = ref(null)
+
+const governanceOptions = [
+  { value: 'owners', label: 'OWNERS', description: 'Uses OWNERS files for maintainer tracking' },
+  { value: 'codeowners', label: 'CODEOWNERS', description: 'Uses CODEOWNERS files for maintainer tracking' },
+  { value: 'none', label: 'None', description: 'No automated governance tracking' },
+]
 
 const participationOptions = [
   { value: '', label: 'None', description: 'No participation goal' },
@@ -55,7 +79,9 @@ const leadershipOptions = [
   { value: 'increasing_leadership', label: 'Increasing', description: 'Growing leadership investment' },
 ]
 
-const isAddMode = computed(() => !props.org)
+const isCreateMode = computed(() => effectiveMode.value === 'create')
+const isAddStrategyMode = computed(() => effectiveMode.value === 'addStrategy')
+const isEditMode = computed(() => effectiveMode.value === 'edit')
 
 const availableOrgs = computed(() =>
   props.allOrgs
@@ -75,13 +101,15 @@ const selectedOrgObj = computed(() =>
   props.allOrgs.find(o => o.githubOrg === selectedGithubOrg.value)
 )
 
-const targetGithubOrg = computed(() =>
-  isAddMode.value ? selectedGithubOrg.value : props.org?.githubOrg
-)
+const targetGithubOrg = computed(() => {
+  if (isEditMode.value) return props.org?.githubOrg
+  return selectedGithubOrg.value
+})
 
 const targetOrgName = computed(() => {
-  if (!isAddMode.value) return props.org?.name
-  return selectedOrgObj.value?.name || selectedGithubOrg.value
+  if (isEditMode.value) return props.org?.name
+  if (isAddStrategyMode.value) return selectedOrgObj.value?.name || selectedGithubOrg.value
+  return orgName.value || selectedGithubOrg.value
 })
 
 const participationLabel = computed(() => {
@@ -94,22 +122,45 @@ const leadershipLabel = computed(() => {
   return opt ? opt.label : 'None'
 })
 
-const canSubmit = computed(() =>
-  targetGithubOrg.value &&
-  (!isAddMode.value || participation.value || leadership.value) &&
-  submitStatus.value !== 'submitting'
+const governanceLabel = computed(() => {
+  const opt = governanceOptions.find(o => o.value === governanceModel.value)
+  return opt ? opt.label : 'None'
+})
+
+const canSubmit = computed(() => {
+  if (submitStatus.value === 'submitting') return false
+  if (isCreateMode.value) return selectedGithubOrg.value && orgName.value && orgLookupStatus.value === 'found' && !alreadyExists.value
+  if (isAddStrategyMode.value) return !!selectedGithubOrg.value
+  return !!targetGithubOrg.value
+})
+
+const alreadyExists = computed(() =>
+  isCreateMode.value &&
+  selectedGithubOrg.value &&
+  props.allOrgs.some(o => o.githubOrg === selectedGithubOrg.value.toLowerCase())
 )
 
-function resetForm() {
-  selectedGithubOrg.value = ''
-  participation.value = props.org?.strategicParticipation || ''
-  leadership.value = props.org?.strategicLeadership || ''
-  submitStatus.value = 'idle'
-  submitError.value = ''
-  orgDropdownOpen.value = false
-  participationDropdownOpen.value = false
-  leadershipDropdownOpen.value = false
-  orgSearch.value = ''
+function toTitleCase(str) {
+  return str.replace(/(^|[-_\s])(\w)/g, (_, sep, ch) => (sep === '-' || sep === '_' ? ' ' : sep) + ch.toUpperCase())
+}
+
+function parseGitHubOrgUrl(input) {
+  const trimmed = input.trim().replace(/\/+$/, '')
+  const urlMatch = trimmed.match(/(?:https?:\/\/)?(?:www\.)?github\.com\/([^/\s?#]+)/)
+  if (urlMatch) return urlMatch[1].toLowerCase()
+  if (/^[a-zA-Z0-9_.-]+$/.test(trimmed)) return trimmed.toLowerCase()
+  return null
+}
+
+function onGithubOrgInput(e) {
+  const raw = e.target ? e.target.value : selectedGithubOrg.value
+  const parsed = parseGitHubOrgUrl(raw)
+  if (parsed && parsed !== selectedGithubOrg.value) {
+    selectedGithubOrg.value = parsed
+  }
+  if (!nameManuallyEdited.value && selectedGithubOrg.value) {
+    orgName.value = toTitleCase(selectedGithubOrg.value)
+  }
 }
 
 function selectOrg(slug) {
@@ -154,14 +205,65 @@ function onOrgKeydown(e) {
 
 watch(orgSearch, () => { orgHighlightIdx.value = 0 })
 
-function onClickOutside(e) {
-  if (orgContainerRef.value && !orgContainerRef.value.contains(e.target)) orgDropdownOpen.value = false
-  if (participationContainerRef.value && !participationContainerRef.value.contains(e.target)) participationDropdownOpen.value = false
-  if (leadershipContainerRef.value && !leadershipContainerRef.value.contains(e.target)) leadershipDropdownOpen.value = false
+watch(selectedGithubOrg, (slug) => {
+  clearTimeout(orgLookupTimer)
+  if (!isCreateMode.value) return
+
+  if (!slug || slug.trim().length < 2) {
+    orgLookupStatus.value = 'idle'
+    orgInfo.value = null
+    return
+  }
+
+  orgLookupStatus.value = 'checking'
+  orgLookupTimer = setTimeout(async () => {
+    try {
+      const data = await apiRequest(`${MODULE_API}/org-info?org=${encodeURIComponent(slug.trim())}`)
+      orgLookupStatus.value = 'found'
+      orgInfo.value = data
+      if (!nameManuallyEdited.value) {
+        orgName.value = data.name || toTitleCase(slug)
+      }
+    } catch (err) {
+      orgLookupStatus.value = err.status === 404 ? 'not_found' : 'error'
+      orgInfo.value = null
+    }
+  }, 600)
+})
+
+function switchToCreateMode() {
+  internalMode.value = 'create'
+  selectedGithubOrg.value = ''
+  orgName.value = ''
+  governanceModel.value = 'none'
+  orgDropdownOpen.value = false
+}
+
+function resetForm() {
+  internalMode.value = 'auto'
+  selectedGithubOrg.value = ''
+  orgName.value = props.org?.name || ''
+  governanceModel.value = props.org?.governanceModel || 'none'
+  participation.value = props.org?.strategicParticipation || ''
+  leadership.value = props.org?.strategicLeadership || ''
+  submitStatus.value = 'idle'
+  submitError.value = ''
+  orgDropdownOpen.value = false
+  orgSearch.value = ''
+  governanceDropdownOpen.value = false
+  participationDropdownOpen.value = false
+  leadershipDropdownOpen.value = false
+  orgLookupStatus.value = 'idle'
+  orgInfo.value = null
+  nameManuallyEdited.value = false
+  clearTimeout(orgLookupTimer)
 }
 
 function selectOption(type, value) {
-  if (type === 'participation') {
+  if (type === 'governance') {
+    governanceModel.value = value
+    governanceDropdownOpen.value = false
+  } else if (type === 'participation') {
     participation.value = value
     participationDropdownOpen.value = false
   } else {
@@ -177,25 +279,56 @@ function getTierColor(value) {
   return { dot: 'bg-gray-300 dark:bg-gray-600', text: 'text-gray-500 dark:text-gray-400' }
 }
 
+function getGovernanceColor(value) {
+  if (value === 'owners') return { dot: 'bg-violet-500', text: 'text-violet-700 dark:text-violet-400' }
+  if (value === 'codeowners') return { dot: 'bg-cyan-500', text: 'text-cyan-700 dark:text-cyan-400' }
+  return { dot: 'bg-gray-300 dark:bg-gray-600', text: 'text-gray-500 dark:text-gray-400' }
+}
+
 async function handleSubmit() {
   if (!canSubmit.value) return
   submitStatus.value = 'submitting'
   submitError.value = ''
 
   try {
-    await apiRequest(`${MODULE_API}/orgs/${encodeURIComponent(targetGithubOrg.value)}/strategy`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        strategicParticipation: participation.value || null,
-        strategicLeadership: leadership.value || null,
-      }),
-    })
+    if (isCreateMode.value) {
+      await apiRequest(`${MODULE_API}/orgs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          githubOrg: selectedGithubOrg.value.toLowerCase(),
+          name: orgName.value,
+          governanceModel: governanceModel.value,
+          strategicParticipation: participation.value || null,
+          strategicLeadership: leadership.value || null,
+        }),
+      })
+    } else if (isAddStrategyMode.value) {
+      await apiRequest(`${MODULE_API}/orgs/${encodeURIComponent(selectedGithubOrg.value)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          strategicParticipation: participation.value || null,
+          strategicLeadership: leadership.value || null,
+        }),
+      })
+    } else {
+      await apiRequest(`${MODULE_API}/orgs/${encodeURIComponent(targetGithubOrg.value)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: orgName.value,
+          governanceModel: governanceModel.value,
+          strategicParticipation: participation.value || null,
+          strategicLeadership: leadership.value || null,
+        }),
+      })
+    }
     submitStatus.value = 'success'
     setTimeout(() => emit('saved'), 600)
   } catch (err) {
     submitStatus.value = 'error'
-    submitError.value = err.message || 'Failed to save strategy'
+    submitError.value = err.message || 'Failed to save organization'
   }
 }
 
@@ -206,10 +339,18 @@ function onBackdropClick() {
 function onEscape(e) {
   if (e.key === 'Escape' && submitStatus.value !== 'submitting') {
     if (orgDropdownOpen.value) { orgDropdownOpen.value = false; return }
+    if (governanceDropdownOpen.value) { governanceDropdownOpen.value = false; return }
     if (participationDropdownOpen.value) { participationDropdownOpen.value = false; return }
     if (leadershipDropdownOpen.value) { leadershipDropdownOpen.value = false; return }
     emit('close')
   }
+}
+
+function onClickOutside(e) {
+  if (orgContainerRef.value && !orgContainerRef.value.contains(e.target)) orgDropdownOpen.value = false
+  if (governanceContainerRef.value && !governanceContainerRef.value.contains(e.target)) governanceDropdownOpen.value = false
+  if (participationContainerRef.value && !participationContainerRef.value.contains(e.target)) participationDropdownOpen.value = false
+  if (leadershipContainerRef.value && !leadershipContainerRef.value.contains(e.target)) leadershipDropdownOpen.value = false
 }
 
 watch(() => props.open, (open) => {
@@ -226,6 +367,7 @@ watch(() => props.open, (open) => {
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onEscape)
   document.removeEventListener('mousedown', onClickOutside)
+  clearTimeout(orgLookupTimer)
 })
 </script>
 
@@ -248,14 +390,14 @@ onBeforeUnmount(() => {
         <div class="flex items-center justify-between px-6 pt-6 pb-4">
           <div class="flex items-center gap-3">
             <div class="w-10 h-10 rounded-xl bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center shrink-0">
-              <TargetIcon class="w-5 h-5 text-blue-600 dark:text-blue-400" :stroke-width="1.7" />
+              <Building2Icon class="w-5 h-5 text-blue-600 dark:text-blue-400" :stroke-width="1.7" />
             </div>
             <div>
               <h3 class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">
-                {{ isAddMode ? 'Add to Strategy' : 'Edit Strategy' }}
+                {{ isCreateMode ? 'Add Organization' : isAddStrategyMode ? 'Add to Strategy' : 'Edit Organization' }}
               </h3>
               <p class="text-[13px] text-gray-500 dark:text-gray-400 mt-0.5">
-                {{ isAddMode ? 'Set strategic goals for an organization' : `Update goals for ${org?.name}` }}
+                {{ isCreateMode ? 'Register a new upstream organization' : isAddStrategyMode ? 'Set strategic goals for an existing organization' : `Update settings for ${org?.name}` }}
               </p>
             </div>
           </div>
@@ -274,9 +416,14 @@ onBeforeUnmount(() => {
             <div class="flex items-start gap-3">
               <CheckCircle2Icon class="w-5 h-5 text-emerald-600 dark:text-emerald-400 mt-0.5 shrink-0" />
               <div>
-                <p class="text-sm font-medium text-emerald-900 dark:text-emerald-200">Strategy updated successfully</p>
+                <p class="text-sm font-medium text-emerald-900 dark:text-emerald-200">
+                  {{ isCreateMode ? 'Organization added successfully' : isAddStrategyMode ? 'Strategy updated successfully' : 'Organization updated successfully' }}
+                </p>
                 <p class="text-[13px] text-emerald-700 dark:text-emerald-300 mt-1">
-                  <span class="font-medium">{{ targetOrgName }}</span> strategic classification has been saved.
+                  <span class="font-medium">{{ targetOrgName }}</span> has been saved.
+                </p>
+                <p class="text-[12px] text-emerald-600 dark:text-emerald-400 mt-2">
+                  You can add projects for this organization from the Dashboard or Portfolio page.
                 </p>
               </div>
             </div>
@@ -286,8 +433,8 @@ onBeforeUnmount(() => {
         <!-- Form -->
         <form v-if="submitStatus !== 'success'" @submit.prevent="handleSubmit" class="px-6 pb-6">
           <div class="space-y-4">
-            <!-- Org picker (add mode) -->
-            <div v-if="isAddMode">
+            <!-- Org picker (addStrategy mode) -->
+            <div v-if="isAddStrategyMode">
               <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Organization <span class="text-red-400">*</span>
               </label>
@@ -325,8 +472,18 @@ onBeforeUnmount(() => {
                   </div>
 
                   <div class="max-h-[240px] overflow-y-auto py-1">
-                    <div v-if="filteredOrgs.length === 0" class="px-4 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
-                      {{ orgSearch ? `No organizations match "${orgSearch}"` : 'All organizations already have strategic classifications.' }}
+                    <div v-if="filteredOrgs.length === 0" class="px-4 py-5 text-center">
+                      <p class="text-sm text-gray-400 dark:text-gray-500">
+                        {{ orgSearch ? `No organizations match "${orgSearch}"` : 'All organizations already have strategic classifications.' }}
+                      </p>
+                      <button
+                        type="button"
+                        @click="switchToCreateMode(); orgDropdownOpen = false"
+                        class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+                      >
+                        <PlusIcon :size="14" />
+                        Create new organization
+                      </button>
                     </div>
                     <button
                       v-for="(o, idx) in filteredOrgs"
@@ -358,17 +515,133 @@ onBeforeUnmount(() => {
                   </div>
                 </div>
               </div>
+              <p class="mt-2 text-[12px] text-gray-400 dark:text-gray-500">
+                Organization not listed?
+                <button type="button" @click="switchToCreateMode" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium">
+                  Create new organization
+                </button>
+              </p>
             </div>
 
-            <!-- Org name (edit mode) -->
+            <!-- GitHub Org slug (create mode) -->
+            <div v-else-if="isCreateMode">
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                GitHub Organization <span class="text-red-400">*</span>
+              </label>
+              <div class="relative">
+                <input
+                  v-model="selectedGithubOrg"
+                  type="text"
+                  placeholder="Paste GitHub URL or type org slug..."
+                  :disabled="submitStatus === 'submitting'"
+                  class="w-full pl-3 pr-10 py-2.5 text-sm border rounded-xl outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 disabled:bg-gray-50 dark:disabled:bg-gray-800"
+                  :class="{
+                    'border-emerald-300 dark:border-emerald-600 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500': orgLookupStatus === 'found',
+                    'border-red-300 dark:border-red-600 focus:ring-2 focus:ring-red-500 focus:border-red-500': orgLookupStatus === 'not_found',
+                    'border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-blue-500': orgLookupStatus !== 'found' && orgLookupStatus !== 'not_found',
+                  }"
+                  @input="onGithubOrgInput"
+                />
+                <div class="absolute right-3 top-1/2 -translate-y-1/2">
+                  <Loader2Icon v-if="orgLookupStatus === 'checking'" class="w-4 h-4 text-gray-400 animate-spin" />
+                  <CheckCircle2Icon v-else-if="orgLookupStatus === 'found'" class="w-4 h-4 text-emerald-500" />
+                  <AlertCircleIcon v-else-if="orgLookupStatus === 'not_found'" class="w-4 h-4 text-red-400" />
+                </div>
+              </div>
+
+              <!-- Org info card -->
+              <div v-if="orgLookupStatus === 'found' && orgInfo" class="rounded-lg bg-gray-50 dark:bg-gray-700/60 border border-gray-200 dark:border-gray-600 px-3 py-2.5 mt-2">
+                <div class="flex items-start gap-3">
+                  <img v-if="orgInfo.avatarUrl" :src="orgInfo.avatarUrl" :alt="orgInfo.name" class="w-10 h-10 rounded-lg shrink-0" />
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <CheckCircle2Icon class="w-3.5 h-3.5 text-emerald-500 shrink-0" />
+                      <span class="text-[13px] font-medium text-gray-900 dark:text-gray-100 truncate">{{ orgInfo.name }}</span>
+                      <span v-if="orgInfo.type !== 'Organization'" class="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 font-medium shrink-0">User account</span>
+                    </div>
+                    <p v-if="orgInfo.description" class="text-[12px] text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2 ml-[22px]">{{ orgInfo.description }}</p>
+                    <span class="text-[11px] text-gray-400 dark:text-gray-500 ml-[22px]">{{ orgInfo.publicRepos }} public repos</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Not found message -->
+              <p v-if="orgLookupStatus === 'not_found'" class="mt-1.5 text-[12px] text-red-500 dark:text-red-400">
+                Organization "{{ selectedGithubOrg }}" was not found on GitHub.
+              </p>
+
+              <!-- Already exists warning -->
+              <p v-if="alreadyExists" class="mt-1.5 text-[12px] text-amber-600 dark:text-amber-400">
+                This organization is already being tracked.
+              </p>
+            </div>
+
+            <!-- GitHub Org slug (edit mode, read-only) -->
             <div v-else>
               <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
-                Organization
+                GitHub Organization
               </label>
-              <div class="w-full flex items-center gap-2 px-3 py-2.5 text-sm border border-gray-200 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300">
+              <div class="w-full flex items-center gap-2 px-3 py-2.5 text-sm border border-gray-200 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700/50 text-gray-500 dark:text-gray-400">
                 <Building2Icon class="w-4 h-4 text-gray-400 shrink-0" />
-                <span class="font-medium">{{ org?.name }}</span>
-                <span class="text-gray-400 dark:text-gray-500">{{ org?.githubOrg }}</span>
+                <span>{{ org?.githubOrg }}</span>
+              </div>
+            </div>
+
+            <!-- Display name (create + edit modes only) -->
+            <div v-if="!isAddStrategyMode">
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Display Name <span v-if="isCreateMode" class="text-red-400">*</span>
+                <span v-if="isCreateMode && !nameManuallyEdited && orgName" class="text-gray-400 font-normal ml-1">auto-filled</span>
+              </label>
+              <input
+                v-model="orgName"
+                type="text"
+                :placeholder="isCreateMode ? 'e.g. Kubernetes' : org?.name"
+                :disabled="submitStatus === 'submitting'"
+                class="w-full px-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500"
+                @input="nameManuallyEdited = true"
+              />
+            </div>
+
+            <!-- Governance model (create + edit modes only) -->
+            <div v-if="!isAddStrategyMode">
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Governance Model
+              </label>
+              <div ref="governanceContainerRef" class="relative">
+                <button
+                  type="button"
+                  @click="governanceDropdownOpen = !governanceDropdownOpen; participationDropdownOpen = false; leadershipDropdownOpen = false"
+                  :disabled="submitStatus === 'submitting'"
+                  class="w-full flex items-center justify-between pl-3 pr-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed"
+                  :class="governanceDropdownOpen
+                    ? 'border-blue-500 ring-2 ring-blue-500'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+                >
+                  <span class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full shrink-0" :class="getGovernanceColor(governanceModel).dot"></span>
+                    <span class="font-medium text-gray-900 dark:text-gray-100">{{ governanceLabel }}</span>
+                  </span>
+                  <ChevronDownIcon class="w-4 h-4 text-gray-400 shrink-0 ml-2 transition-transform" :class="{ 'rotate-180': governanceDropdownOpen }" />
+                </button>
+
+                <div v-if="governanceDropdownOpen" class="absolute z-50 mt-1.5 w-full bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 shadow-xl overflow-hidden py-1">
+                  <button
+                    v-for="opt in governanceOptions"
+                    :key="opt.value"
+                    type="button"
+                    @click="selectOption('governance', opt.value)"
+                    class="w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    :class="{ 'bg-blue-50 dark:bg-blue-900/30': governanceModel === opt.value }"
+                  >
+                    <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="getGovernanceColor(opt.value).dot"></span>
+                    <div class="flex-1 min-w-0">
+                      <span class="text-sm font-medium" :class="governanceModel === opt.value ? 'text-blue-700 dark:text-blue-300' : 'text-gray-900 dark:text-gray-100'">{{ opt.label }}</span>
+                      <p class="text-[11px] text-gray-400 dark:text-gray-500">{{ opt.description }}</p>
+                    </div>
+                    <CheckIcon v-if="governanceModel === opt.value" class="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -380,7 +653,7 @@ onBeforeUnmount(() => {
               <div ref="participationContainerRef" class="relative">
                 <button
                   type="button"
-                  @click="participationDropdownOpen = !participationDropdownOpen; leadershipDropdownOpen = false"
+                  @click="participationDropdownOpen = !participationDropdownOpen; leadershipDropdownOpen = false; governanceDropdownOpen = false"
                   :disabled="submitStatus === 'submitting'"
                   class="w-full flex items-center justify-between pl-3 pr-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed"
                   :class="participationDropdownOpen
@@ -422,7 +695,7 @@ onBeforeUnmount(() => {
               <div ref="leadershipContainerRef" class="relative">
                 <button
                   type="button"
-                  @click="leadershipDropdownOpen = !leadershipDropdownOpen; participationDropdownOpen = false"
+                  @click="leadershipDropdownOpen = !leadershipDropdownOpen; participationDropdownOpen = false; governanceDropdownOpen = false"
                   :disabled="submitStatus === 'submitting'"
                   class="w-full flex items-center justify-between pl-3 pr-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed"
                   :class="leadershipDropdownOpen
@@ -456,17 +729,13 @@ onBeforeUnmount(() => {
               </div>
             </div>
 
-            <!-- Validation hint -->
-            <p v-if="isAddMode && !participation && !leadership && selectedGithubOrg" class="text-[12px] text-amber-600 dark:text-amber-400">
-              Select at least one participation or leadership level.
-            </p>
 
             <!-- Submit error -->
             <div v-if="submitStatus === 'error'" class="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4">
               <div class="flex items-start gap-3">
                 <AlertCircleIcon class="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
                 <div>
-                  <p class="text-sm font-medium text-red-800 dark:text-red-200">Failed to save strategy</p>
+                  <p class="text-sm font-medium text-red-800 dark:text-red-200">Failed to save organization</p>
                   <p class="text-[13px] text-red-600 dark:text-red-400 mt-0.5">{{ submitError }}</p>
                 </div>
               </div>
@@ -487,7 +756,7 @@ onBeforeUnmount(() => {
               class="px-4 py-2 text-[13px] font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-xl transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Loader2Icon v-if="submitStatus === 'submitting'" class="w-4 h-4 animate-spin" />
-              {{ submitStatus === 'submitting' ? 'Saving...' : 'Save Strategy' }}
+              {{ submitStatus === 'submitting' ? 'Saving...' : isCreateMode ? 'Add Organization' : isAddStrategyMode ? 'Add to Strategy' : 'Save Changes' }}
             </button>
           </div>
         </form>

--- a/modules/upstream-pulse/client/components/StrategyEditModal.vue
+++ b/modules/upstream-pulse/client/components/StrategyEditModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import {
   X as XIcon,
   Target as TargetIcon,
@@ -7,6 +7,9 @@ import {
   CheckCircle2 as CheckCircle2Icon,
   AlertCircle as AlertCircleIcon,
   ChevronDown as ChevronDownIcon,
+  Building2 as Building2Icon,
+  Search as SearchIcon,
+  Check as CheckIcon,
 } from 'lucide-vue-next'
 import { apiRequest } from '@shared/client/services/api'
 
@@ -27,18 +30,29 @@ const leadership = ref('')
 const submitStatus = ref('idle')
 const submitError = ref('')
 
+const orgDropdownOpen = ref(false)
+const orgSearch = ref('')
+const orgHighlightIdx = ref(0)
+const orgSearchRef = ref(null)
+const orgContainerRef = ref(null)
+
+const participationDropdownOpen = ref(false)
+const leadershipDropdownOpen = ref(false)
+const participationContainerRef = ref(null)
+const leadershipContainerRef = ref(null)
+
 const participationOptions = [
-  { value: '', label: 'None' },
-  { value: 'evaluating_participation', label: 'Evaluating Participation' },
-  { value: 'sustaining_participation', label: 'Sustaining Participation' },
-  { value: 'increasing_participation', label: 'Increasing Participation' },
+  { value: '', label: 'None', description: 'No participation goal' },
+  { value: 'evaluating_participation', label: 'Evaluating', description: 'Exploring participation opportunities' },
+  { value: 'sustaining_participation', label: 'Sustaining', description: 'Maintaining current participation' },
+  { value: 'increasing_participation', label: 'Increasing', description: 'Growing participation investment' },
 ]
 
 const leadershipOptions = [
-  { value: '', label: 'None' },
-  { value: 'evaluating_leadership', label: 'Evaluating Leadership' },
-  { value: 'sustaining_leadership', label: 'Sustaining Leadership' },
-  { value: 'increasing_leadership', label: 'Increasing Leadership' },
+  { value: '', label: 'None', description: 'No leadership goal' },
+  { value: 'evaluating_leadership', label: 'Evaluating', description: 'Exploring leadership opportunities' },
+  { value: 'sustaining_leadership', label: 'Sustaining', description: 'Maintaining current leadership' },
+  { value: 'increasing_leadership', label: 'Increasing', description: 'Growing leadership investment' },
 ]
 
 const isAddMode = computed(() => !props.org)
@@ -49,14 +63,35 @@ const availableOrgs = computed(() =>
     .sort((a, b) => a.name.localeCompare(b.name))
 )
 
+const filteredOrgs = computed(() => {
+  if (!orgSearch.value.trim()) return availableOrgs.value
+  const q = orgSearch.value.toLowerCase()
+  return availableOrgs.value.filter(o =>
+    o.name.toLowerCase().includes(q) || o.githubOrg.toLowerCase().includes(q)
+  )
+})
+
+const selectedOrgObj = computed(() =>
+  props.allOrgs.find(o => o.githubOrg === selectedGithubOrg.value)
+)
+
 const targetGithubOrg = computed(() =>
   isAddMode.value ? selectedGithubOrg.value : props.org?.githubOrg
 )
 
 const targetOrgName = computed(() => {
   if (!isAddMode.value) return props.org?.name
-  const found = props.allOrgs.find(o => o.githubOrg === selectedGithubOrg.value)
-  return found?.name || selectedGithubOrg.value
+  return selectedOrgObj.value?.name || selectedGithubOrg.value
+})
+
+const participationLabel = computed(() => {
+  const opt = participationOptions.find(o => o.value === participation.value)
+  return opt ? opt.label : 'None'
+})
+
+const leadershipLabel = computed(() => {
+  const opt = leadershipOptions.find(o => o.value === leadership.value)
+  return opt ? opt.label : 'None'
 })
 
 const canSubmit = computed(() =>
@@ -71,6 +106,75 @@ function resetForm() {
   leadership.value = props.org?.strategicLeadership || ''
   submitStatus.value = 'idle'
   submitError.value = ''
+  orgDropdownOpen.value = false
+  participationDropdownOpen.value = false
+  leadershipDropdownOpen.value = false
+  orgSearch.value = ''
+}
+
+function selectOrg(slug) {
+  selectedGithubOrg.value = slug
+  orgDropdownOpen.value = false
+}
+
+function toggleOrgDropdown() {
+  orgDropdownOpen.value = !orgDropdownOpen.value
+  if (orgDropdownOpen.value) {
+    orgSearch.value = ''
+    orgHighlightIdx.value = 0
+    nextTick(() => orgSearchRef.value?.focus())
+  }
+}
+
+function onOrgKeydown(e) {
+  if (!orgDropdownOpen.value) {
+    if (['ArrowDown', 'Enter', ' '].includes(e.key)) {
+      e.preventDefault()
+      toggleOrgDropdown()
+    }
+    return
+  }
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    orgHighlightIdx.value = Math.min(orgHighlightIdx.value + 1, filteredOrgs.value.length - 1)
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    orgHighlightIdx.value = Math.max(orgHighlightIdx.value - 1, 0)
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    if (filteredOrgs.value[orgHighlightIdx.value]) {
+      selectOrg(filteredOrgs.value[orgHighlightIdx.value].githubOrg)
+    }
+  } else if (e.key === 'Escape') {
+    e.preventDefault()
+    e.stopPropagation()
+    orgDropdownOpen.value = false
+  }
+}
+
+watch(orgSearch, () => { orgHighlightIdx.value = 0 })
+
+function onClickOutside(e) {
+  if (orgContainerRef.value && !orgContainerRef.value.contains(e.target)) orgDropdownOpen.value = false
+  if (participationContainerRef.value && !participationContainerRef.value.contains(e.target)) participationDropdownOpen.value = false
+  if (leadershipContainerRef.value && !leadershipContainerRef.value.contains(e.target)) leadershipDropdownOpen.value = false
+}
+
+function selectOption(type, value) {
+  if (type === 'participation') {
+    participation.value = value
+    participationDropdownOpen.value = false
+  } else {
+    leadership.value = value
+    leadershipDropdownOpen.value = false
+  }
+}
+
+function getTierColor(value) {
+  if (value.includes('increasing')) return { dot: 'bg-green-500', text: 'text-green-700 dark:text-green-400' }
+  if (value.includes('sustaining')) return { dot: 'bg-blue-500', text: 'text-blue-700 dark:text-blue-400' }
+  if (value.includes('evaluating')) return { dot: 'bg-yellow-500', text: 'text-yellow-700 dark:text-yellow-400' }
+  return { dot: 'bg-gray-300 dark:bg-gray-600', text: 'text-gray-500 dark:text-gray-400' }
 }
 
 async function handleSubmit() {
@@ -101,6 +205,9 @@ function onBackdropClick() {
 
 function onEscape(e) {
   if (e.key === 'Escape' && submitStatus.value !== 'submitting') {
+    if (orgDropdownOpen.value) { orgDropdownOpen.value = false; return }
+    if (participationDropdownOpen.value) { participationDropdownOpen.value = false; return }
+    if (leadershipDropdownOpen.value) { leadershipDropdownOpen.value = false; return }
     emit('close')
   }
 }
@@ -109,13 +216,16 @@ watch(() => props.open, (open) => {
   if (open) {
     resetForm()
     document.addEventListener('keydown', onEscape)
+    document.addEventListener('mousedown', onClickOutside)
   } else {
     document.removeEventListener('keydown', onEscape)
+    document.removeEventListener('mousedown', onClickOutside)
   }
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onEscape)
+  document.removeEventListener('mousedown', onClickOutside)
 })
 </script>
 
@@ -132,7 +242,7 @@ onBeforeUnmount(() => {
       <div
         role="dialog"
         aria-modal="true"
-        class="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-[480px] max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto"
+        class="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-[480px] max-w-[calc(100vw-2rem)]"
       >
         <!-- Header -->
         <div class="flex items-center justify-between px-6 pt-6 pb-4">
@@ -176,27 +286,78 @@ onBeforeUnmount(() => {
         <!-- Form -->
         <form v-if="submitStatus !== 'success'" @submit.prevent="handleSubmit" class="px-6 pb-6">
           <div class="space-y-4">
-            <!-- Org picker (add mode only) -->
+            <!-- Org picker (add mode) -->
             <div v-if="isAddMode">
               <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Organization <span class="text-red-400">*</span>
               </label>
-              <div class="relative">
-                <select
-                  v-model="selectedGithubOrg"
+              <div ref="orgContainerRef" class="relative" @keydown="onOrgKeydown">
+                <button
+                  type="button"
+                  @click="toggleOrgDropdown"
                   :disabled="submitStatus === 'submitting'"
-                  class="w-full appearance-none pl-3 pr-10 py-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500"
+                  class="w-full flex items-center justify-between pl-3 pr-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed"
+                  :class="orgDropdownOpen
+                    ? 'border-blue-500 ring-2 ring-blue-500'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
                 >
-                  <option value="" disabled>Select an organization...</option>
-                  <option v-for="o in availableOrgs" :key="o.githubOrg" :value="o.githubOrg">
-                    {{ o.name }} ({{ o.githubOrg }})
-                  </option>
-                </select>
-                <ChevronDownIcon class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                  <span v-if="selectedOrgObj" class="flex items-center gap-2 min-w-0">
+                    <Building2Icon class="w-4 h-4 text-gray-400 shrink-0" />
+                    <span class="truncate font-medium text-gray-900 dark:text-gray-100">{{ selectedOrgObj.name }}</span>
+                    <span class="text-gray-400 dark:text-gray-500 shrink-0">{{ selectedOrgObj.githubOrg }}</span>
+                  </span>
+                  <span v-else class="text-gray-400 dark:text-gray-500">Select an organization...</span>
+                  <ChevronDownIcon class="w-4 h-4 text-gray-400 shrink-0 ml-2 transition-transform" :class="{ 'rotate-180': orgDropdownOpen }" />
+                </button>
+
+                <div v-if="orgDropdownOpen" class="absolute z-50 mt-1.5 w-full bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 shadow-xl overflow-hidden">
+                  <div class="p-2 border-b border-gray-100 dark:border-gray-700">
+                    <div class="relative">
+                      <SearchIcon class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
+                      <input
+                        ref="orgSearchRef"
+                        v-model="orgSearch"
+                        type="text"
+                        placeholder="Search organizations..."
+                        class="w-full pl-8 pr-3 py-2 text-sm bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg focus:ring-1 focus:ring-blue-500 focus:border-blue-500 outline-none placeholder:text-gray-400 dark:placeholder:text-gray-500 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="max-h-[240px] overflow-y-auto py-1">
+                    <div v-if="filteredOrgs.length === 0" class="px-4 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
+                      {{ orgSearch ? `No organizations match "${orgSearch}"` : 'All organizations already have strategic classifications.' }}
+                    </div>
+                    <button
+                      v-for="(o, idx) in filteredOrgs"
+                      :key="o.githubOrg"
+                      type="button"
+                      @click="selectOrg(o.githubOrg)"
+                      @mouseenter="orgHighlightIdx = idx"
+                      class="w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors"
+                      :class="{
+                        'bg-blue-50 dark:bg-blue-900/30': idx === orgHighlightIdx,
+                        'bg-gray-50 dark:bg-gray-700/50': o.githubOrg === selectedGithubOrg && idx !== orgHighlightIdx,
+                      }"
+                    >
+                      <div class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+                        :class="o.githubOrg === selectedGithubOrg ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-100 dark:bg-gray-700'">
+                        <Building2Icon class="w-4 h-4" :class="o.githubOrg === selectedGithubOrg ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400'" />
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2">
+                          <span class="text-sm font-medium truncate" :class="o.githubOrg === selectedGithubOrg ? 'text-blue-700 dark:text-blue-300' : 'text-gray-900 dark:text-gray-100'">{{ o.name }}</span>
+                          <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ o.githubOrg }}</span>
+                        </div>
+                        <span class="text-[11px] text-gray-400 dark:text-gray-500">
+                          {{ o.projectCount }} project{{ o.projectCount !== 1 ? 's' : '' }} tracked
+                        </span>
+                      </div>
+                      <CheckIcon v-if="o.githubOrg === selectedGithubOrg" class="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
+                    </button>
+                  </div>
+                </div>
               </div>
-              <p v-if="availableOrgs.length === 0" class="mt-1.5 text-[12px] text-gray-400 dark:text-gray-500">
-                All organizations already have strategic classifications.
-              </p>
             </div>
 
             <!-- Org name (edit mode) -->
@@ -204,8 +365,10 @@ onBeforeUnmount(() => {
               <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Organization
               </label>
-              <div class="w-full px-3 py-2.5 text-sm border border-gray-200 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300">
-                {{ org?.name }} <span class="text-gray-400 dark:text-gray-500">({{ org?.githubOrg }})</span>
+              <div class="w-full flex items-center gap-2 px-3 py-2.5 text-sm border border-gray-200 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300">
+                <Building2Icon class="w-4 h-4 text-gray-400 shrink-0" />
+                <span class="font-medium">{{ org?.name }}</span>
+                <span class="text-gray-400 dark:text-gray-500">{{ org?.githubOrg }}</span>
               </div>
             </div>
 
@@ -214,17 +377,40 @@ onBeforeUnmount(() => {
               <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Participation Level
               </label>
-              <div class="relative">
-                <select
-                  v-model="participation"
+              <div ref="participationContainerRef" class="relative">
+                <button
+                  type="button"
+                  @click="participationDropdownOpen = !participationDropdownOpen; leadershipDropdownOpen = false"
                   :disabled="submitStatus === 'submitting'"
-                  class="w-full appearance-none pl-3 pr-10 py-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500"
+                  class="w-full flex items-center justify-between pl-3 pr-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed"
+                  :class="participationDropdownOpen
+                    ? 'border-blue-500 ring-2 ring-blue-500'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
                 >
-                  <option v-for="opt in participationOptions" :key="opt.value" :value="opt.value">
-                    {{ opt.label }}
-                  </option>
-                </select>
-                <ChevronDownIcon class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                  <span class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full shrink-0" :class="getTierColor(participation).dot"></span>
+                    <span class="font-medium text-gray-900 dark:text-gray-100">{{ participationLabel }}</span>
+                  </span>
+                  <ChevronDownIcon class="w-4 h-4 text-gray-400 shrink-0 ml-2 transition-transform" :class="{ 'rotate-180': participationDropdownOpen }" />
+                </button>
+
+                <div v-if="participationDropdownOpen" class="absolute z-50 mt-1.5 w-full bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 shadow-xl overflow-hidden py-1">
+                  <button
+                    v-for="opt in participationOptions"
+                    :key="opt.value"
+                    type="button"
+                    @click="selectOption('participation', opt.value)"
+                    class="w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    :class="{ 'bg-blue-50 dark:bg-blue-900/30': participation === opt.value }"
+                  >
+                    <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="getTierColor(opt.value).dot"></span>
+                    <div class="flex-1 min-w-0">
+                      <span class="text-sm font-medium" :class="participation === opt.value ? 'text-blue-700 dark:text-blue-300' : 'text-gray-900 dark:text-gray-100'">{{ opt.label }}</span>
+                      <p class="text-[11px] text-gray-400 dark:text-gray-500">{{ opt.description }}</p>
+                    </div>
+                    <CheckIcon v-if="participation === opt.value" class="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -233,22 +419,45 @@ onBeforeUnmount(() => {
               <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                 Leadership Level
               </label>
-              <div class="relative">
-                <select
-                  v-model="leadership"
+              <div ref="leadershipContainerRef" class="relative">
+                <button
+                  type="button"
+                  @click="leadershipDropdownOpen = !leadershipDropdownOpen; participationDropdownOpen = false"
                   :disabled="submitStatus === 'submitting'"
-                  class="w-full appearance-none pl-3 pr-10 py-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500"
+                  class="w-full flex items-center justify-between pl-3 pr-3 py-2.5 text-sm border rounded-xl bg-white dark:bg-gray-700 outline-none transition-all disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500 disabled:cursor-not-allowed"
+                  :class="leadershipDropdownOpen
+                    ? 'border-blue-500 ring-2 ring-blue-500'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
                 >
-                  <option v-for="opt in leadershipOptions" :key="opt.value" :value="opt.value">
-                    {{ opt.label }}
-                  </option>
-                </select>
-                <ChevronDownIcon class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                  <span class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full shrink-0" :class="getTierColor(leadership).dot"></span>
+                    <span class="font-medium text-gray-900 dark:text-gray-100">{{ leadershipLabel }}</span>
+                  </span>
+                  <ChevronDownIcon class="w-4 h-4 text-gray-400 shrink-0 ml-2 transition-transform" :class="{ 'rotate-180': leadershipDropdownOpen }" />
+                </button>
+
+                <div v-if="leadershipDropdownOpen" class="absolute z-50 mt-1.5 w-full bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-600 shadow-xl overflow-hidden py-1">
+                  <button
+                    v-for="opt in leadershipOptions"
+                    :key="opt.value"
+                    type="button"
+                    @click="selectOption('leadership', opt.value)"
+                    class="w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    :class="{ 'bg-blue-50 dark:bg-blue-900/30': leadership === opt.value }"
+                  >
+                    <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="getTierColor(opt.value).dot"></span>
+                    <div class="flex-1 min-w-0">
+                      <span class="text-sm font-medium" :class="leadership === opt.value ? 'text-blue-700 dark:text-blue-300' : 'text-gray-900 dark:text-gray-100'">{{ opt.label }}</span>
+                      <p class="text-[11px] text-gray-400 dark:text-gray-500">{{ opt.description }}</p>
+                    </div>
+                    <CheckIcon v-if="leadership === opt.value" class="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
+                  </button>
+                </div>
               </div>
             </div>
 
             <!-- Validation hint -->
-            <p v-if="!participation && !leadership && (selectedGithubOrg || org)" class="text-[12px] text-amber-600 dark:text-amber-400">
+            <p v-if="isAddMode && !participation && !leadership && selectedGithubOrg" class="text-[12px] text-amber-600 dark:text-amber-400">
               Select at least one participation or leadership level.
             </p>
 

--- a/modules/upstream-pulse/client/components/StrategyEditModal.vue
+++ b/modules/upstream-pulse/client/components/StrategyEditModal.vue
@@ -1,0 +1,288 @@
+<script setup>
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import {
+  X as XIcon,
+  Target as TargetIcon,
+  Loader2 as Loader2Icon,
+  CheckCircle2 as CheckCircle2Icon,
+  AlertCircle as AlertCircleIcon,
+  ChevronDown as ChevronDownIcon,
+} from 'lucide-vue-next'
+import { apiRequest } from '@shared/client/services/api'
+
+const MODULE_API = '/modules/upstream-pulse'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  org: { type: Object, default: null },
+  allOrgs: { type: Array, default: () => [] },
+})
+
+const emit = defineEmits(['close', 'saved'])
+
+const selectedGithubOrg = ref('')
+const participation = ref('')
+const leadership = ref('')
+
+const submitStatus = ref('idle')
+const submitError = ref('')
+
+const participationOptions = [
+  { value: '', label: 'None' },
+  { value: 'evaluating_participation', label: 'Evaluating Participation' },
+  { value: 'sustaining_participation', label: 'Sustaining Participation' },
+  { value: 'increasing_participation', label: 'Increasing Participation' },
+]
+
+const leadershipOptions = [
+  { value: '', label: 'None' },
+  { value: 'evaluating_leadership', label: 'Evaluating Leadership' },
+  { value: 'sustaining_leadership', label: 'Sustaining Leadership' },
+  { value: 'increasing_leadership', label: 'Increasing Leadership' },
+]
+
+const isAddMode = computed(() => !props.org)
+
+const availableOrgs = computed(() =>
+  props.allOrgs
+    .filter(o => !o.strategicParticipation && !o.strategicLeadership)
+    .sort((a, b) => a.name.localeCompare(b.name))
+)
+
+const targetGithubOrg = computed(() =>
+  isAddMode.value ? selectedGithubOrg.value : props.org?.githubOrg
+)
+
+const targetOrgName = computed(() => {
+  if (!isAddMode.value) return props.org?.name
+  const found = props.allOrgs.find(o => o.githubOrg === selectedGithubOrg.value)
+  return found?.name || selectedGithubOrg.value
+})
+
+const canSubmit = computed(() =>
+  targetGithubOrg.value &&
+  (!isAddMode.value || participation.value || leadership.value) &&
+  submitStatus.value !== 'submitting'
+)
+
+function resetForm() {
+  selectedGithubOrg.value = ''
+  participation.value = props.org?.strategicParticipation || ''
+  leadership.value = props.org?.strategicLeadership || ''
+  submitStatus.value = 'idle'
+  submitError.value = ''
+}
+
+async function handleSubmit() {
+  if (!canSubmit.value) return
+  submitStatus.value = 'submitting'
+  submitError.value = ''
+
+  try {
+    await apiRequest(`${MODULE_API}/orgs/${encodeURIComponent(targetGithubOrg.value)}/strategy`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        strategicParticipation: participation.value || null,
+        strategicLeadership: leadership.value || null,
+      }),
+    })
+    submitStatus.value = 'success'
+    setTimeout(() => emit('saved'), 600)
+  } catch (err) {
+    submitStatus.value = 'error'
+    submitError.value = err.message || 'Failed to save strategy'
+  }
+}
+
+function onBackdropClick() {
+  if (submitStatus.value !== 'submitting') emit('close')
+}
+
+function onEscape(e) {
+  if (e.key === 'Escape' && submitStatus.value !== 'submitting') {
+    emit('close')
+  }
+}
+
+watch(() => props.open, (open) => {
+  if (open) {
+    resetForm()
+    document.addEventListener('keydown', onEscape)
+  } else {
+    document.removeEventListener('keydown', onEscape)
+  }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onEscape)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="fixed inset-0 z-[100] flex items-center justify-center">
+      <!-- Backdrop -->
+      <div
+        class="absolute inset-0 bg-black/30 dark:bg-black/50 backdrop-blur-[2px]"
+        @click="onBackdropClick"
+      />
+
+      <!-- Dialog -->
+      <div
+        role="dialog"
+        aria-modal="true"
+        class="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-[480px] max-w-[calc(100vw-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto"
+      >
+        <!-- Header -->
+        <div class="flex items-center justify-between px-6 pt-6 pb-4">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-xl bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center shrink-0">
+              <TargetIcon class="w-5 h-5 text-blue-600 dark:text-blue-400" :stroke-width="1.7" />
+            </div>
+            <div>
+              <h3 class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">
+                {{ isAddMode ? 'Add to Strategy' : 'Edit Strategy' }}
+              </h3>
+              <p class="text-[13px] text-gray-500 dark:text-gray-400 mt-0.5">
+                {{ isAddMode ? 'Set strategic goals for an organization' : `Update goals for ${org?.name}` }}
+              </p>
+            </div>
+          </div>
+          <button
+            @click="emit('close')"
+            :disabled="submitStatus === 'submitting'"
+            class="p-1.5 rounded-lg text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+          >
+            <XIcon class="w-4 h-4" />
+          </button>
+        </div>
+
+        <!-- Success state -->
+        <div v-if="submitStatus === 'success'" class="px-6 pb-6">
+          <div class="rounded-xl bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 p-4">
+            <div class="flex items-start gap-3">
+              <CheckCircle2Icon class="w-5 h-5 text-emerald-600 dark:text-emerald-400 mt-0.5 shrink-0" />
+              <div>
+                <p class="text-sm font-medium text-emerald-900 dark:text-emerald-200">Strategy updated successfully</p>
+                <p class="text-[13px] text-emerald-700 dark:text-emerald-300 mt-1">
+                  <span class="font-medium">{{ targetOrgName }}</span> strategic classification has been saved.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Form -->
+        <form v-if="submitStatus !== 'success'" @submit.prevent="handleSubmit" class="px-6 pb-6">
+          <div class="space-y-4">
+            <!-- Org picker (add mode only) -->
+            <div v-if="isAddMode">
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Organization <span class="text-red-400">*</span>
+              </label>
+              <div class="relative">
+                <select
+                  v-model="selectedGithubOrg"
+                  :disabled="submitStatus === 'submitting'"
+                  class="w-full appearance-none pl-3 pr-10 py-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500"
+                >
+                  <option value="" disabled>Select an organization...</option>
+                  <option v-for="o in availableOrgs" :key="o.githubOrg" :value="o.githubOrg">
+                    {{ o.name }} ({{ o.githubOrg }})
+                  </option>
+                </select>
+                <ChevronDownIcon class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              </div>
+              <p v-if="availableOrgs.length === 0" class="mt-1.5 text-[12px] text-gray-400 dark:text-gray-500">
+                All organizations already have strategic classifications.
+              </p>
+            </div>
+
+            <!-- Org name (edit mode) -->
+            <div v-else>
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Organization
+              </label>
+              <div class="w-full px-3 py-2.5 text-sm border border-gray-200 dark:border-gray-600 rounded-xl bg-gray-50 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300">
+                {{ org?.name }} <span class="text-gray-400 dark:text-gray-500">({{ org?.githubOrg }})</span>
+              </div>
+            </div>
+
+            <!-- Participation level -->
+            <div>
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Participation Level
+              </label>
+              <div class="relative">
+                <select
+                  v-model="participation"
+                  :disabled="submitStatus === 'submitting'"
+                  class="w-full appearance-none pl-3 pr-10 py-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500"
+                >
+                  <option v-for="opt in participationOptions" :key="opt.value" :value="opt.value">
+                    {{ opt.label }}
+                  </option>
+                </select>
+                <ChevronDownIcon class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              </div>
+            </div>
+
+            <!-- Leadership level -->
+            <div>
+              <label class="block text-[13px] font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                Leadership Level
+              </label>
+              <div class="relative">
+                <select
+                  v-model="leadership"
+                  :disabled="submitStatus === 'submitting'"
+                  class="w-full appearance-none pl-3 pr-10 py-2.5 text-sm border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:bg-gray-50 dark:disabled:bg-gray-800 disabled:text-gray-500"
+                >
+                  <option v-for="opt in leadershipOptions" :key="opt.value" :value="opt.value">
+                    {{ opt.label }}
+                  </option>
+                </select>
+                <ChevronDownIcon class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              </div>
+            </div>
+
+            <!-- Validation hint -->
+            <p v-if="!participation && !leadership && (selectedGithubOrg || org)" class="text-[12px] text-amber-600 dark:text-amber-400">
+              Select at least one participation or leadership level.
+            </p>
+
+            <!-- Submit error -->
+            <div v-if="submitStatus === 'error'" class="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4">
+              <div class="flex items-start gap-3">
+                <AlertCircleIcon class="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
+                <div>
+                  <p class="text-sm font-medium text-red-800 dark:text-red-200">Failed to save strategy</p>
+                  <p class="text-[13px] text-red-600 dark:text-red-400 mt-0.5">{{ submitError }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="flex justify-end mt-6 gap-2.5">
+            <button
+              type="button"
+              @click="emit('close')"
+              :disabled="submitStatus === 'submitting'"
+              class="px-4 py-2 text-[13px] font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-xl transition-colors disabled:opacity-50"
+            >Cancel</button>
+            <button
+              type="submit"
+              :disabled="!canSubmit"
+              class="px-4 py-2 text-[13px] font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-xl transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              <Loader2Icon v-if="submitStatus === 'submitting'" class="w-4 h-4 animate-spin" />
+              {{ submitStatus === 'submitting' ? 'Saving...' : 'Save Strategy' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/modules/upstream-pulse/client/composables/useStrategyPermissions.js
+++ b/modules/upstream-pulse/client/composables/useStrategyPermissions.js
@@ -1,0 +1,22 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const MODULE_API = '/modules/upstream-pulse'
+
+export function useStrategyPermissions() {
+  const canManageStrategy = ref(false)
+  const permissionsLoaded = ref(false)
+
+  async function loadPermissions() {
+    try {
+      const data = await apiRequest(MODULE_API + '/strategy/permissions')
+      canManageStrategy.value = data.canManageStrategy
+    } catch {
+      canManageStrategy.value = false
+    } finally {
+      permissionsLoaded.value = true
+    }
+  }
+
+  return { canManageStrategy, permissionsLoaded, loadPermissions }
+}

--- a/modules/upstream-pulse/client/views/Portfolio.vue
+++ b/modules/upstream-pulse/client/views/Portfolio.vue
@@ -103,10 +103,20 @@
       <!-- Organizations -->
       <section class="mb-10">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-            Organizations
-            <span class="text-sm font-normal text-gray-500 dark:text-gray-400 ml-1">({{ filteredOrgs.length }})</span>
-          </h3>
+          <div class="flex items-center gap-3">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Organizations
+              <span class="text-sm font-normal text-gray-500 dark:text-gray-400 ml-1">({{ filteredOrgs.length }})</span>
+            </h3>
+            <button
+              v-if="canManageStrategy && !loading"
+              @click="openAddOrg"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-800/40 border border-blue-200 dark:border-blue-800 rounded-lg transition-colors"
+            >
+              <PlusIcon :size="15" :stroke-width="2.5" />
+              Add Organization
+            </button>
+          </div>
           <div class="flex items-center gap-2">
             <div class="relative">
               <SearchIcon class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500" />
@@ -243,11 +253,20 @@
                 <tr
                   v-for="org in paginatedOrgs"
                   :key="org.githubOrg"
-                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer"
+                  class="group/org hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer"
                   @click="nav.navigateTo('org-detail', { org: org.githubOrg })"
                 >
                   <td class="px-6 py-4">
-                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ org.name }}</span>
+                    <div class="flex items-center gap-1.5">
+                      <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ org.name }}</span>
+                      <button
+                        v-if="canManageStrategy"
+                        @click.stop="openEditOrg(org)"
+                        class="inline-flex items-center p-1 rounded-md text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 opacity-0 group-hover/org:opacity-100 transition-all"
+                      >
+                        <PencilIcon :size="13" />
+                      </button>
+                    </div>
                   </td>
                   <td class="px-6 py-4">
                     <span
@@ -471,6 +490,14 @@
       @created="onProjectCreated"
       @navigate="({ view, params }) => nav.navigateTo(view, params)"
     />
+
+    <OrgEditModal
+      :open="showOrgModal"
+      :org="editingOrg"
+      :all-orgs="orgs"
+      @close="showOrgModal = false"
+      @saved="onOrgSaved"
+    />
   </div>
 </template>
 
@@ -495,18 +522,24 @@ import {
   ArrowUp as ArrowUpIcon,
   ArrowDown as ArrowDownIcon,
   Check as CheckIcon,
+  Pencil as PencilIcon,
 } from 'lucide-vue-next'
 import { apiRequest } from '@shared/client/services/api'
 import { useAuth } from '@shared/client/composables/useAuth'
 import OrgActivityCard from '../components/OrgActivityCard.vue'
+import OrgEditModal from '../components/OrgEditModal.vue'
 import AddProjectModal from '../components/AddProjectModal.vue'
 import { OrgCardSkeleton, StatCardSkeleton, TableRowSkeleton } from '../components/SkeletonLoaders.vue'
 import StickyPageHeader from '../components/StickyPageHeader.vue'
 import { getEngagementStatus } from '../composables/useStrategicClassification.js'
+import { useStrategyPermissions } from '../composables/useStrategyPermissions.js'
 
 const nav = inject('moduleNav')
 const { isAdmin } = useAuth()
+const { canManageStrategy, loadPermissions } = useStrategyPermissions()
 const showAddProject = ref(false)
+const showOrgModal = ref(false)
+const editingOrg = ref(null)
 
 const MODULE_API = '/modules/upstream-pulse'
 
@@ -754,6 +787,22 @@ function onProjectCreated() {
   loadData()
 }
 
+function openAddOrg() {
+  editingOrg.value = null
+  showOrgModal.value = true
+}
+
+function openEditOrg(org) {
+  editingOrg.value = org
+  showOrgModal.value = true
+}
+
+function onOrgSaved() {
+  showOrgModal.value = false
+  editingOrg.value = null
+  loadData()
+}
+
 function onClickOutside(e) {
   if (orgSortOpen.value && !e.target.closest('[data-sort-dropdown]')) {
     orgSortOpen.value = false
@@ -763,6 +812,7 @@ function onClickOutside(e) {
 watch(selectedDays, () => loadData())
 onMounted(() => {
   loadData()
+  loadPermissions()
   document.addEventListener('click', onClickOutside)
 })
 onBeforeUnmount(() => {

--- a/modules/upstream-pulse/client/views/Strategy.vue
+++ b/modules/upstream-pulse/client/views/Strategy.vue
@@ -12,7 +12,7 @@
         @click="openAddStrategy"
         class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-800/40 border border-blue-200 dark:border-blue-800 rounded-lg transition-colors"
       >
-        <PlusIcon :size="15" :stroke-width="2.5" />
+        <TargetIcon :size="14" :stroke-width="2.5" />
         Add to Strategy
       </button>
     </div>
@@ -47,7 +47,7 @@
       <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">No strategic classifications assigned</h3>
       <p v-if="canManageStrategy" class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto mb-4">No strategic classifications yet. Add organizations to start tracking progress.</p>
       <button v-if="canManageStrategy" @click="openAddStrategy" class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-xl transition-colors shadow-sm">
-        <PlusIcon :size="15" />
+        <TargetIcon :size="15" />
         Add to Strategy
       </button>
       <p v-else class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">Tag organizations in the org registry with strategic participation or leadership goals to track them here.</p>
@@ -245,10 +245,11 @@
       </div>
     </template>
 
-    <StrategyEditModal
+    <OrgEditModal
       :open="showEditModal"
       :org="editingOrg"
       :all-orgs="orgs"
+      :mode="modalMode"
       @close="showEditModal = false"
       @saved="onStrategySaved"
     />
@@ -261,13 +262,12 @@ import {
   Target as TargetIcon,
   Crown as CrownIcon,
   Shield as ShieldIcon,
-  Plus as PlusIcon,
   Pencil as PencilIcon,
 } from 'lucide-vue-next'
 import { apiRequest } from '@shared/client/services/api'
 import { StatCardSkeleton, TableRowSkeleton } from '../components/SkeletonLoaders.vue'
 import StickyPageHeader from '../components/StickyPageHeader.vue'
-import StrategyEditModal from '../components/StrategyEditModal.vue'
+import OrgEditModal from '../components/OrgEditModal.vue'
 import {
   getStrategicTier, TIER_CONFIG,
   getStrategicLabel, getStrategicBadgeClass,
@@ -282,6 +282,7 @@ const tierOrder = ['increasing', 'sustaining', 'evaluating']
 const { canManageStrategy, loadPermissions } = useStrategyPermissions()
 const showEditModal = ref(false)
 const editingOrg = ref(null)
+const modalMode = ref('auto')
 
 const selectedDays = ref('30')
 const selectedTier = ref(null)
@@ -355,11 +356,13 @@ async function loadData() {
 
 function openAddStrategy() {
   editingOrg.value = null
+  modalMode.value = 'addStrategy'
   showEditModal.value = true
 }
 
 function openEditStrategy(org) {
   editingOrg.value = org
+  modalMode.value = 'edit'
   showEditModal.value = true
 }
 

--- a/modules/upstream-pulse/client/views/Strategy.vue
+++ b/modules/upstream-pulse/client/views/Strategy.vue
@@ -151,7 +151,6 @@
                 <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Maintainers</th>
                 <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Projects</th>
                 <th v-if="selectedDays !== '0'" class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Trend</th>
-                <th v-if="canManageStrategy" class="px-3 py-2.5 w-10"></th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
@@ -165,7 +164,7 @@
                   <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ org.name }}</span>
                 </td>
                 <td class="px-4 py-3">
-                  <div class="flex flex-wrap gap-1">
+                  <div class="flex items-center gap-1.5 group/strategy">
                     <span
                       v-if="org.strategicParticipation"
                       class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium"
@@ -176,6 +175,14 @@
                       class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium"
                       :class="getStrategicBadgeClass(org.strategicLeadership)"
                     >{{ getStrategicLabel(org.strategicLeadership) }}</span>
+                    <button
+                      v-if="canManageStrategy"
+                      @click.stop="openEditStrategy(org)"
+                      class="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 opacity-0 group-hover/strategy:opacity-100 transition-all"
+                    >
+                      <PencilIcon :size="12" />
+                      Edit
+                    </button>
                   </div>
                 </td>
                 <td class="px-4 py-3 text-right">
@@ -205,15 +212,6 @@
                     {{ org.percentChange > 0 ? '↑' : org.percentChange < 0 ? '↓' : '→' }}{{ Math.abs(org.percentChange).toFixed(1) }}%
                   </span>
                 </td>
-                <td v-if="canManageStrategy" class="px-3 py-3 text-right">
-                  <button
-                    @click.stop="openEditStrategy(org)"
-                    class="p-1 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    title="Edit strategy"
-                  >
-                    <PencilIcon :size="14" />
-                  </button>
-                </td>
               </tr>
             </tbody>
             <!-- Subtotal row -->
@@ -240,7 +238,6 @@
                     {{ tierSummaries[tier].avgChange > 0 ? '↑' : tierSummaries[tier].avgChange < 0 ? '↓' : '→' }}{{ Math.abs(tierSummaries[tier].avgChange).toFixed(1) }}% avg
                   </span>
                 </td>
-                <td v-if="canManageStrategy" class="px-3 py-2.5"></td>
               </tr>
             </tfoot>
           </table>

--- a/modules/upstream-pulse/client/views/Strategy.vue
+++ b/modules/upstream-pulse/client/views/Strategy.vue
@@ -7,6 +7,16 @@
       :loading="loading"
     />
 
+    <div v-if="canManageStrategy && !loading && !error" class="flex justify-end mb-4">
+      <button
+        @click="openAddStrategy"
+        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-800/40 border border-blue-200 dark:border-blue-800 rounded-lg transition-colors"
+      >
+        <PlusIcon :size="15" :stroke-width="2.5" />
+        Add to Strategy
+      </button>
+    </div>
+
     <!-- Loading -->
     <div v-if="loading">
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-3">
@@ -35,7 +45,12 @@
         <TargetIcon :size="28" class="text-gray-400 dark:text-gray-500" />
       </div>
       <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">No strategic classifications assigned</h3>
-      <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">Tag organizations in the org registry with strategic participation or leadership goals to track them here.</p>
+      <p v-if="canManageStrategy" class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto mb-4">No strategic classifications yet. Add organizations to start tracking progress.</p>
+      <button v-if="canManageStrategy" @click="openAddStrategy" class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-xl transition-colors shadow-sm">
+        <PlusIcon :size="15" />
+        Add to Strategy
+      </button>
+      <p v-else class="text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">Tag organizations in the org registry with strategic participation or leadership goals to track them here.</p>
     </div>
 
     <!-- Content -->
@@ -136,6 +151,7 @@
                 <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Maintainers</th>
                 <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Projects</th>
                 <th v-if="selectedDays !== '0'" class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Trend</th>
+                <th v-if="canManageStrategy" class="px-3 py-2.5 w-10"></th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
@@ -189,6 +205,15 @@
                     {{ org.percentChange > 0 ? '↑' : org.percentChange < 0 ? '↓' : '→' }}{{ Math.abs(org.percentChange).toFixed(1) }}%
                   </span>
                 </td>
+                <td v-if="canManageStrategy" class="px-3 py-3 text-right">
+                  <button
+                    @click.stop="openEditStrategy(org)"
+                    class="p-1 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                    title="Edit strategy"
+                  >
+                    <PencilIcon :size="14" />
+                  </button>
+                </td>
               </tr>
             </tbody>
             <!-- Subtotal row -->
@@ -215,12 +240,21 @@
                     {{ tierSummaries[tier].avgChange > 0 ? '↑' : tierSummaries[tier].avgChange < 0 ? '↓' : '→' }}{{ Math.abs(tierSummaries[tier].avgChange).toFixed(1) }}% avg
                   </span>
                 </td>
+                <td v-if="canManageStrategy" class="px-3 py-2.5"></td>
               </tr>
             </tfoot>
           </table>
         </div>
       </div>
     </template>
+
+    <StrategyEditModal
+      :open="showEditModal"
+      :org="editingOrg"
+      :all-orgs="orgs"
+      @close="showEditModal = false"
+      @saved="onStrategySaved"
+    />
   </div>
 </template>
 
@@ -230,19 +264,27 @@ import {
   Target as TargetIcon,
   Crown as CrownIcon,
   Shield as ShieldIcon,
+  Plus as PlusIcon,
+  Pencil as PencilIcon,
 } from 'lucide-vue-next'
 import { apiRequest } from '@shared/client/services/api'
 import { StatCardSkeleton, TableRowSkeleton } from '../components/SkeletonLoaders.vue'
 import StickyPageHeader from '../components/StickyPageHeader.vue'
+import StrategyEditModal from '../components/StrategyEditModal.vue'
 import {
   getStrategicTier, TIER_CONFIG,
   getStrategicLabel, getStrategicBadgeClass,
 } from '../composables/useStrategicClassification.js'
+import { useStrategyPermissions } from '../composables/useStrategyPermissions.js'
 
 const nav = inject('moduleNav')
 const MODULE_API = '/modules/upstream-pulse'
 
 const tierOrder = ['increasing', 'sustaining', 'evaluating']
+
+const { canManageStrategy, loadPermissions } = useStrategyPermissions()
+const showEditModal = ref(false)
+const editingOrg = ref(null)
 
 const selectedDays = ref('30')
 const selectedTier = ref(null)
@@ -314,6 +356,25 @@ async function loadData() {
   }
 }
 
+function openAddStrategy() {
+  editingOrg.value = null
+  showEditModal.value = true
+}
+
+function openEditStrategy(org) {
+  editingOrg.value = org
+  showEditModal.value = true
+}
+
+function onStrategySaved() {
+  showEditModal.value = false
+  editingOrg.value = null
+  loadData()
+}
+
 watch(selectedDays, () => loadData())
-onMounted(() => loadData())
+onMounted(() => {
+  loadData()
+  loadPermissions()
+})
 </script>

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -602,10 +602,10 @@ module.exports = function registerRoutes(router, context) {
 
   /**
    * @openapi
-   * /api/modules/upstream-pulse/orgs/{githubOrg}/strategy:
+   * /api/modules/upstream-pulse/orgs/{githubOrg}:
    *   patch:
    *     tags: [Upstream Pulse]
-   *     summary: Update strategic classification for a GitHub organization
+   *     summary: Update an organization's settings
    *     parameters:
    *       - in: path
    *         name: githubOrg
@@ -614,15 +614,15 @@ module.exports = function registerRoutes(router, context) {
    *           type: string
    *     responses:
    *       200:
-   *         description: Updated strategy classification
+   *         description: Updated organization
    *       403:
    *         description: Not available in demo mode or insufficient permissions
    */
-  router.patch('/orgs/:githubOrg/strategy', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
+  router.patch('/orgs/:githubOrg', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       if (DEMO_MODE) return res.status(403).json({ error: 'Not available in demo mode' });
       var data = await proxyMutatingRequest(
-        '/api/orgs/' + encodeURIComponent(req.params.githubOrg) + '/strategy',
+        '/api/orgs/' + encodeURIComponent(req.params.githubOrg),
         req.body, req, 'PATCH'
       );
       // Invalidate orgs and dashboard cache
@@ -631,6 +631,32 @@ module.exports = function registerRoutes(router, context) {
           responseCache.delete(key);
         }
       }
+      res.json(data);
+    } catch (err) {
+      handleProxyError(res, err);
+    }
+  });
+
+  router.post('/orgs', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
+    try {
+      if (DEMO_MODE) return res.status(403).json({ error: 'Not available in demo mode' });
+      var data = await proxyMutatingRequest('/api/orgs', req.body, req);
+      // Invalidate orgs and dashboard cache
+      for (var key of responseCache.keys()) {
+        if (key.startsWith('/api/orgs') || key.startsWith('/api/metrics/dashboard') || key.startsWith('/api/projects')) {
+          responseCache.delete(key);
+        }
+      }
+      res.json(data);
+    } catch (err) {
+      handleProxyError(res, err);
+    }
+  });
+
+  router.get('/org-info', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
+    try {
+      if (DEMO_MODE) return res.json({ login: req.query.org, name: req.query.org, type: 'Organization', publicRepos: 0 });
+      var data = await proxyAdminGet('/api/github/org-info', { org: req.query.org }, req);
       res.json(data);
     } catch (err) {
       handleProxyError(res, err);

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -67,13 +67,13 @@ function buildIdentityHeaders(req) {
   return headers;
 }
 
-async function proxyMutatingRequest(path, body, req) {
+async function proxyMutatingRequest(path, body, req, method = 'POST') {
   const base = getBaseUrl();
   const url = new URL(path, base);
   const headers = buildIdentityHeaders(req);
 
   const response = await fetch(url.toString(), {
-    method: 'POST',
+    method: method,
     signal: AbortSignal.timeout(PROXY_TIMEOUT),
     headers,
     body: JSON.stringify(body),
@@ -259,7 +259,7 @@ function startPeriodicRosterPush(storage) {
 }
 
 module.exports = function registerRoutes(router, context) {
-  const { requireScope, secrets } = context;
+  const { requireScope, requireRole, secrets } = context;
   _moduleSecrets = secrets;
   const DEMO_MODE = process.env.DEMO_MODE === 'true';
 
@@ -268,6 +268,13 @@ module.exports = function registerRoutes(router, context) {
     { key: 'upstream-pulse:read', label: 'Upstream Pulse (Read)', description: 'Read upstream pulse data', category: 'Upstream Pulse' },
     { key: 'upstream-pulse:write', label: 'Upstream Pulse (Write)', description: 'Mutate upstream pulse data', category: 'Upstream Pulse' }
   ]);
+
+  // Register upstream-pulse-admin role
+  context.registerRole('upstream-pulse-admin', {
+    label: 'Upstream Pulse Admin',
+    description: 'Manage strategic classifications and upstream pulse configuration'
+  });
+  const requireUpstreamAdmin = requireRole('upstream-pulse-admin');
 
   function handleProxyError(res, err) {
     const status = err.upstreamStatus || 502;
@@ -570,6 +577,33 @@ module.exports = function registerRoutes(router, context) {
       const data = await response.json();
       const jobs = (data.recentJobs || []).filter(j => j.projectId === projectId);
       res.json({ jobs });
+    } catch (err) {
+      handleProxyError(res, err);
+    }
+  });
+
+  // ── Strategy management ──────────────────────────────────────
+
+  router.get('/strategy/permissions', requireScope('upstream-pulse:read'), function(req, res) {
+    if (DEMO_MODE) return res.json({ canManageStrategy: false });
+    var canManageStrategy = req.isAdmin || (req.userRoles || []).includes('upstream-pulse-admin');
+    res.json({ canManageStrategy: canManageStrategy });
+  });
+
+  router.patch('/orgs/:githubOrg/strategy', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
+    try {
+      if (DEMO_MODE) return res.status(403).json({ error: 'Not available in demo mode' });
+      var data = await proxyMutatingRequest(
+        '/api/orgs/' + encodeURIComponent(req.params.githubOrg) + '/strategy',
+        req.body, req, 'PATCH'
+      );
+      // Invalidate orgs and dashboard cache
+      for (var key of responseCache.keys()) {
+        if (key.startsWith('/api/orgs') || key.startsWith('/api/metrics/dashboard')) {
+          responseCache.delete(key);
+        }
+      }
+      res.json(data);
     } catch (err) {
       handleProxyError(res, err);
     }

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -584,12 +584,40 @@ module.exports = function registerRoutes(router, context) {
 
   // ── Strategy management ──────────────────────────────────────
 
+  /**
+   * @openapi
+   * /api/modules/upstream-pulse/strategy/permissions:
+   *   get:
+   *     tags: [Upstream Pulse]
+   *     summary: Check strategy management permissions for current user
+   *     responses:
+   *       200:
+   *         description: Permission flags for strategy management
+   */
   router.get('/strategy/permissions', requireScope('upstream-pulse:read'), function(req, res) {
     if (DEMO_MODE) return res.json({ canManageStrategy: false });
     var canManageStrategy = req.isAdmin || (req.userRoles || []).includes('upstream-pulse-admin');
     res.json({ canManageStrategy: canManageStrategy });
   });
 
+  /**
+   * @openapi
+   * /api/modules/upstream-pulse/orgs/{githubOrg}/strategy:
+   *   patch:
+   *     tags: [Upstream Pulse]
+   *     summary: Update strategic classification for a GitHub organization
+   *     parameters:
+   *       - in: path
+   *         name: githubOrg
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Updated strategy classification
+   *       403:
+   *         description: Not available in demo mode or insufficient permissions
+   */
   router.patch('/orgs/:githubOrg/strategy', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       if (DEMO_MODE) return res.status(403).json({ error: 'Not available in demo mode' });

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -596,8 +596,8 @@ module.exports = function registerRoutes(router, context) {
    */
   router.get('/strategy/permissions', requireScope('upstream-pulse:read'), function(req, res) {
     if (DEMO_MODE) return res.json({ canManageStrategy: false });
-    var canManageStrategy = req.isAdmin || (req.userRoles || []).includes('upstream-pulse-admin');
-    res.json({ canManageStrategy: canManageStrategy });
+    const canManageStrategy = req.isAdmin || (req.userRoles || []).includes('upstream-pulse-admin');
+    res.json({ canManageStrategy });
   });
 
   /**
@@ -621,12 +621,12 @@ module.exports = function registerRoutes(router, context) {
   router.patch('/orgs/:githubOrg', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       if (DEMO_MODE) return res.status(403).json({ error: 'Not available in demo mode' });
-      var data = await proxyMutatingRequest(
+      const data = await proxyMutatingRequest(
         '/api/orgs/' + encodeURIComponent(req.params.githubOrg),
         req.body, req, 'PATCH'
       );
       // Invalidate orgs and dashboard cache
-      for (var key of responseCache.keys()) {
+      for (const key of responseCache.keys()) {
         if (key.startsWith('/api/orgs') || key.startsWith('/api/metrics/dashboard')) {
           responseCache.delete(key);
         }
@@ -637,12 +637,24 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
+  /**
+   * @openapi
+   * /api/modules/upstream-pulse/orgs:
+   *   post:
+   *     tags: [Upstream Pulse]
+   *     summary: Add a new organization to track
+   *     responses:
+   *       200:
+   *         description: Created organization
+   *       403:
+   *         description: Not available in demo mode or insufficient permissions
+   */
   router.post('/orgs', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       if (DEMO_MODE) return res.status(403).json({ error: 'Not available in demo mode' });
-      var data = await proxyMutatingRequest('/api/orgs', req.body, req);
+      const data = await proxyMutatingRequest('/api/orgs', req.body, req);
       // Invalidate orgs and dashboard cache
-      for (var key of responseCache.keys()) {
+      for (const key of responseCache.keys()) {
         if (key.startsWith('/api/orgs') || key.startsWith('/api/metrics/dashboard') || key.startsWith('/api/projects')) {
           responseCache.delete(key);
         }
@@ -653,10 +665,26 @@ module.exports = function registerRoutes(router, context) {
     }
   });
 
+  /**
+   * @openapi
+   * /api/modules/upstream-pulse/org-info:
+   *   get:
+   *     tags: [Upstream Pulse]
+   *     summary: Look up a GitHub organization's info
+   *     parameters:
+   *       - in: query
+   *         name: org
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: GitHub organization info
+   */
   router.get('/org-info', requireUpstreamAdmin, requireScope('upstream-pulse:write'), async function(req, res) {
     try {
       if (DEMO_MODE) return res.json({ login: req.query.org, name: req.query.org, type: 'Organization', publicRepos: 0 });
-      var data = await proxyAdminGet('/api/github/org-info', { org: req.query.org }, req);
+      const data = await proxyAdminGet('/api/github/org-info', { org: req.query.org }, req);
       res.json(data);
     } catch (err) {
       handleProxyError(res, err);


### PR DESCRIPTION
## Summary

- Registers `upstream-pulse-admin` role for gating strategy edits (appears in Settings > Users)
- Adds `GET /strategy/permissions` endpoint returning `canManageStrategy` flag
- Adds `PATCH /orgs/:githubOrg/strategy` proxy route with cache invalidation
- Extends `proxyMutatingRequest` to accept HTTP method parameter (default POST, backward compatible)
- Creates `StrategyEditModal` with org picker (add mode) and participation/leadership dropdowns (edit mode)
- Adds "Add to Strategy" button and per-row edit pencil on Strategy page, gated by permissions
- Updates empty state with CTA for users with manage permission
- Tests updated: route count, PATCH route, role registration (8/8 passing)

**Companion PR:** dpanshug/upstream-pulse — adds the backend DB table and PATCH endpoint

## Breaking changes

None. Strategy page remains read-only for users without the role. All new routes are additive.

## Test plan

- [ ] Verify Strategy page shows edit controls only when user has `upstream-pulse-admin` role or is admin
- [ ] Verify "Add to Strategy" opens modal with org picker filtered to unclassified orgs
- [ ] Verify edit pencil opens modal pre-filled with current classification
- [ ] Verify save calls PATCH and refreshes the page data
- [ ] Verify setting both to "None" in edit mode clears the classification
- [ ] Verify non-admin users see the read-only Strategy page (no edit controls)
- [ ] Verify demo mode returns `canManageStrategy: false`