### PR TITLE
refactor: convert module storage I/O from sync to async

### DIFF
--- a/modules/ai-catalyst/__tests__/server/index.test.js
+++ b/modules/ai-catalyst/__tests__/server/index.test.js
@@ -15,9 +15,8 @@ describe('ai-catalyst server module', () => {
     }
     const context = {
       storage: {
-        readFromStorage: vi.fn(),
-        writeToStorage: vi.fn(),
-        writeToStorageAtomic: vi.fn()
+        readFromStorage: vi.fn(async () => null),
+        writeToStorage: vi.fn(async () => {})
       },
       requireAuth: vi.fn((req, res, next) => next()),
       requireAdmin: vi.fn((req, res, next) => next()),
@@ -52,9 +51,8 @@ describe('ai-catalyst server module', () => {
     }
     const context = {
       storage: {
-        readFromStorage: vi.fn(),
-        writeToStorage: vi.fn(),
-        writeToStorageAtomic: vi.fn()
+        readFromStorage: vi.fn(async () => null),
+        writeToStorage: vi.fn(async () => {})
       },
       requireAuth: vi.fn((req, res, next) => next()),
       requireAdmin: vi.fn((req, res, next) => next()),
@@ -79,7 +77,7 @@ describe('ai-catalyst server module', () => {
   it('registers scopes', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const context = {
-      storage: { readFromStorage: vi.fn(), writeToStorage: vi.fn(), writeToStorageAtomic: vi.fn() },
+      storage: { readFromStorage: vi.fn(async () => null), writeToStorage: vi.fn(async () => {}) },
       requireAuth: vi.fn((req, res, next) => next()),
       requireAdmin: vi.fn((req, res, next) => next()),
       requireScope: vi.fn(() => vi.fn((req, res, next) => next())),
@@ -104,7 +102,7 @@ describe('ai-catalyst server module', () => {
   it('registers refresh handlers', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const context = {
-      storage: { readFromStorage: vi.fn(), writeToStorage: vi.fn(), writeToStorageAtomic: vi.fn() },
+      storage: { readFromStorage: vi.fn(async () => null), writeToStorage: vi.fn(async () => {}) },
       requireAuth: vi.fn((req, res, next) => next()),
       requireAdmin: vi.fn((req, res, next) => next()),
       requireScope: vi.fn(() => vi.fn((req, res, next) => next())),
@@ -131,7 +129,7 @@ describe('ai-catalyst server module', () => {
   it('registers diagnostics hook', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const context = {
-      storage: { readFromStorage: vi.fn(), writeToStorage: vi.fn(), writeToStorageAtomic: vi.fn() },
+      storage: { readFromStorage: vi.fn(async () => null), writeToStorage: vi.fn(async () => {}) },
       requireAuth: vi.fn((req, res, next) => next()),
       requireAdmin: vi.fn((req, res, next) => next()),
       requireScope: vi.fn(() => vi.fn((req, res, next) => next())),
@@ -151,7 +149,7 @@ describe('ai-catalyst server module', () => {
   it('registers export hook', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const context = {
-      storage: { readFromStorage: vi.fn(), writeToStorage: vi.fn(), writeToStorageAtomic: vi.fn() },
+      storage: { readFromStorage: vi.fn(async () => null), writeToStorage: vi.fn(async () => {}) },
       requireAuth: vi.fn((req, res, next) => next()),
       requireAdmin: vi.fn((req, res, next) => next()),
       requireScope: vi.fn(() => vi.fn((req, res, next) => next())),

--- a/modules/ai-catalyst/server/board-config.js
+++ b/modules/ai-catalyst/server/board-config.js
@@ -4,12 +4,12 @@ const DEFAULT_CONFIG = {
   sheetId: ''
 };
 
-function getConfig(readFromStorage) {
-  const saved = readFromStorage(CONFIG_KEY);
+async function getConfig(readFromStorage) {
+  const saved = await readFromStorage(CONFIG_KEY);
   return { ...DEFAULT_CONFIG, ...saved };
 }
 
-function saveConfig(writeToStorage, config) {
+async function saveConfig(writeToStorage, config) {
   const merged = { ...DEFAULT_CONFIG };
 
   if (config.sheetId !== undefined) {
@@ -19,7 +19,7 @@ function saveConfig(writeToStorage, config) {
     merged.sheetId = config.sheetId.trim();
   }
 
-  writeToStorage(CONFIG_KEY, merged);
+  await writeToStorage(CONFIG_KEY, merged);
 }
 
 module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, CONFIG_KEY };

--- a/modules/ai-catalyst/server/index.js
+++ b/modules/ai-catalyst/server/index.js
@@ -135,7 +135,7 @@ function computeStats(candidates) {
  */
 module.exports = function registerRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireScope, secrets } = context;
-  const { readFromStorage, writeToStorage, writeToStorageAtomic } = storage;
+  const { readFromStorage, writeToStorage } = storage;
 
   context.registerScopes([
     { key: 'ai-catalyst:read', label: 'AI Catalyst (Read)', description: 'Read AI Catalyst board data', category: 'AI Catalyst' },
@@ -145,20 +145,20 @@ module.exports = function registerRoutes(router, context) {
   let lastSyncTime = null;
   let syncRunning = false;
 
-  function getSheetId() {
-    return getBoardConfig(readFromStorage).sheetId || (secrets && secrets.POC_EXPLORER_SHEET_ID) || '';
+  async function getSheetId() {
+    return (await getBoardConfig(readFromStorage)).sheetId || (secrets && secrets.POC_EXPLORER_SHEET_ID) || '';
   }
 
-  function isConfigured() {
-    return !!getSheetId();
+  async function isConfigured() {
+    return !!(await getSheetId());
   }
 
-  function readIndex() {
-    return readFromStorage(INDEX_PATH) || { boards: [] };
+  async function readIndex() {
+    return (await readFromStorage(INDEX_PATH)) || { boards: [] };
   }
 
-  function readBoard(month) {
-    return readFromStorage(`${STORAGE_PREFIX}/boards/${month}.json`);
+  async function readBoard(month) {
+    return await readFromStorage(`${STORAGE_PREFIX}/boards/${month}.json`);
   }
 
   // --- Demo data ---
@@ -182,12 +182,12 @@ module.exports = function registerRoutes(router, context) {
   // --- Sync logic ---
 
   async function syncBoards() {
-    if (syncRunning || !isConfigured()) return { skipped: true };
+    if (syncRunning || !(await isConfigured())) return { skipped: true };
     syncRunning = true;
     try {
       const keyFile = (secrets && secrets.GOOGLE_SERVICE_ACCOUNT_KEY_FILE) || '/etc/secrets/google-sa-key.json';
       const sheetsClient = createGoogleSheetsClient({ keyFile });
-      const sheetId = getSheetId();
+      const sheetId = await getSheetId();
 
       const sheetNames = await sheetsClient.discoverSheetNames(sheetId);
       const boardSheets = sheetNames.filter(n => BOARD_SHEET_RE.test(n));
@@ -196,7 +196,7 @@ module.exports = function registerRoutes(router, context) {
         return { synced: 0, message: 'No board sheets found' };
       }
 
-      const existingIndex = readIndex();
+      const existingIndex = await readIndex();
       const existingMonths = new Set((existingIndex.boards || []).map(b => b.month));
       let syncCount = 0;
 
@@ -207,7 +207,7 @@ module.exports = function registerRoutes(router, context) {
         if (!headers.length) continue;
 
         const candidates = parseBoardSheet(headers, rows);
-        writeToStorage(`${STORAGE_PREFIX}/boards/${month}.json`, candidates);
+        await writeToStorage(`${STORAGE_PREFIX}/boards/${month}.json`, candidates);
         syncCount++;
 
         if (!existingMonths.has(month)) {
@@ -215,16 +215,17 @@ module.exports = function registerRoutes(router, context) {
         }
       }
 
-      const boards = [...existingMonths].sort().reverse().map(month => {
-        const data = readBoard(month);
-        return {
+      const boards = [];
+      for (const month of [...existingMonths].sort().reverse()) {
+        const data = await readBoard(month);
+        boards.push({
           month,
           candidateCount: Array.isArray(data) ? data.length : 0,
           lastSynced: new Date().toISOString()
-        };
-      });
+        });
+      }
 
-      writeToStorageAtomic(INDEX_PATH, { boards, lastSynced: new Date().toISOString() });
+      await writeToStorage(INDEX_PATH, { boards, lastSynced: new Date().toISOString() });
       lastSyncTime = new Date().toISOString();
       return { synced: syncCount, total: boardSheets.length };
     } finally {
@@ -244,8 +245,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Current board configuration
    */
-  router.get('/board-config', requireAdmin, function(req, res) {
-    res.json(getBoardConfig(readFromStorage));
+  router.get('/board-config', requireAdmin, async function(req, res) {
+    res.json(await getBoardConfig(readFromStorage));
   });
 
   /**
@@ -260,9 +261,9 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Validation error
    */
-  router.post('/board-config', requireAdmin, function(req, res) {
+  router.post('/board-config', requireAdmin, async function(req, res) {
     try {
-      saveBoardConfig(writeToStorage, req.body);
+      await saveBoardConfig(writeToStorage, req.body);
       res.json({ status: 'saved' });
     } catch (err) {
       res.status(400).json({ error: err.message });
@@ -279,10 +280,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Configuration status
    */
-  router.get('/config', requireAuth, requireScope('ai-catalyst:read'), function(req, res) {
-    const index = DEMO_MODE ? getDemoIndex() : readIndex();
+  router.get('/config', requireAuth, requireScope('ai-catalyst:read'), async function(req, res) {
+    const index = DEMO_MODE ? getDemoIndex() : await readIndex();
     res.json({
-      configured: isConfigured(),
+      configured: await isConfigured(),
       demoMode: DEMO_MODE,
       lastSyncTime: lastSyncTime || (index && index.lastSynced) || null,
       boardCount: (index && index.boards) ? index.boards.length : 0
@@ -299,8 +300,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of available board months with candidate counts
    */
-  router.get('/boards', requireAuth, requireScope('ai-catalyst:read'), function(req, res) {
-    const index = DEMO_MODE ? getDemoIndex() : readIndex();
+  router.get('/boards', requireAuth, requireScope('ai-catalyst:read'), async function(req, res) {
+    const index = DEMO_MODE ? getDemoIndex() : await readIndex();
     res.json({ boards: (index && index.boards) || [] });
   });
 
@@ -348,13 +349,13 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Board not found
    */
-  router.get('/boards/:month', requireAuth, requireScope('ai-catalyst:read'), function(req, res) {
+  router.get('/boards/:month', requireAuth, requireScope('ai-catalyst:read'), async function(req, res) {
     const { month } = req.params;
     if (!/^\d{4}-\d{2}$/.test(month)) {
       return res.status(400).json({ error: 'Month must be in YYYY-MM format' });
     }
 
-    const candidates = DEMO_MODE ? getDemoBoard(month) : readBoard(month);
+    const candidates = DEMO_MODE ? getDemoBoard(month) : await readBoard(month);
     if (!candidates) {
       return res.status(404).json({ error: `Board not found for ${month}` });
     }
@@ -387,13 +388,13 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Candidate not found
    */
-  router.get('/candidates/:id', requireAuth, requireScope('ai-catalyst:read'), function(req, res) {
+  router.get('/candidates/:id', requireAuth, requireScope('ai-catalyst:read'), async function(req, res) {
     const { id } = req.params;
-    const index = DEMO_MODE ? getDemoIndex() : readIndex();
+    const index = DEMO_MODE ? getDemoIndex() : await readIndex();
     const months = (index && index.boards) ? index.boards.map(b => b.month) : [];
 
     for (const month of months) {
-      const candidates = DEMO_MODE ? getDemoBoard(month) : readBoard(month);
+      const candidates = DEMO_MODE ? getDemoBoard(month) : await readBoard(month);
       if (!Array.isArray(candidates)) continue;
       const found = candidates.find(c => c.uniqueId === id);
       if (found) {
@@ -419,19 +420,19 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Aggregate statistics
    */
-  router.get('/stats', requireAuth, requireScope('ai-catalyst:read'), function(req, res) {
+  router.get('/stats', requireAuth, requireScope('ai-catalyst:read'), async function(req, res) {
     const { month } = req.query;
-    const index = DEMO_MODE ? getDemoIndex() : readIndex();
+    const index = DEMO_MODE ? getDemoIndex() : await readIndex();
 
     if (month) {
-      const candidates = DEMO_MODE ? getDemoBoard(month) : readBoard(month);
+      const candidates = DEMO_MODE ? getDemoBoard(month) : await readBoard(month);
       return res.json(computeStats(candidates || []));
     }
 
     const allCandidates = [];
     const months = (index && index.boards) ? index.boards.map(b => b.month) : [];
     for (const m of months) {
-      const candidates = DEMO_MODE ? getDemoBoard(m) : readBoard(m);
+      const candidates = DEMO_MODE ? getDemoBoard(m) : await readBoard(m);
       if (Array.isArray(candidates)) {
         allCandidates.push(...candidates);
       }
@@ -467,8 +468,8 @@ module.exports = function registerRoutes(router, context) {
 
   const showcaseKeyFile = context.resolveSecret('GOOGLE_SERVICE_ACCOUNT_KEY_FILE') || '/etc/secrets/google-sa-key.json';
 
-  function loadShowcaseDemoData() {
-    return readFromStorage(SHOWCASE_STORAGE_KEY) || { entries: [], pillars: [], fetchedAt: null };
+  async function loadShowcaseDemoData() {
+    return (await readFromStorage(SHOWCASE_STORAGE_KEY)) || { entries: [], pillars: [], fetchedAt: null };
   }
 
   /**
@@ -481,8 +482,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Current showcase configuration
    */
-  router.get('/showcase/config', requireAdmin, function(req, res) {
-    res.json(getShowcaseConfig(readFromStorage));
+  router.get('/showcase/config', requireAdmin, async function(req, res) {
+    res.json(await getShowcaseConfig(readFromStorage));
   });
 
   /**
@@ -497,9 +498,9 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Validation error
    */
-  router.post('/showcase/config', requireAdmin, function(req, res) {
+  router.post('/showcase/config', requireAdmin, async function(req, res) {
     try {
-      saveShowcaseConfig(writeToStorage, req.body);
+      await saveShowcaseConfig(writeToStorage, req.body);
       res.json({ status: 'saved' });
     } catch (err) {
       res.status(400).json({ error: err.message });
@@ -519,9 +520,9 @@ module.exports = function registerRoutes(router, context) {
   router.get('/showcase/entries', requireAuth, requireScope('ai-catalyst:showcase'), async function(req, res) {
     try {
       let data;
-      const sheetId = getShowcaseConfig(readFromStorage).sheetId;
+      const sheetId = (await getShowcaseConfig(readFromStorage)).sheetId;
       if (DEMO_MODE || !sheetId) {
-        data = loadShowcaseDemoData();
+        data = await loadShowcaseDemoData();
       } else {
         data = await getShowcaseData(sheetId, showcaseKeyFile, storage);
       }
@@ -563,9 +564,9 @@ module.exports = function registerRoutes(router, context) {
   router.get('/showcase/entries/:slug', requireAuth, requireScope('ai-catalyst:showcase'), async function(req, res) {
     try {
       let data;
-      const sheetId = getShowcaseConfig(readFromStorage).sheetId;
+      const sheetId = (await getShowcaseConfig(readFromStorage)).sheetId;
       if (DEMO_MODE || !sheetId) {
-        data = loadShowcaseDemoData();
+        data = await loadShowcaseDemoData();
       } else {
         data = await getShowcaseData(sheetId, showcaseKeyFile, storage);
       }
@@ -600,7 +601,7 @@ module.exports = function registerRoutes(router, context) {
    *         description: Refresh result
    */
   router.post('/showcase/refresh', requireAdmin, async function(req, res) {
-    const sheetId = getShowcaseConfig(readFromStorage).sheetId;
+    const sheetId = (await getShowcaseConfig(readFromStorage)).sheetId;
     if (DEMO_MODE || !sheetId) {
       return res.json({ status: 'skipped', reason: 'Demo mode or no sheet configured' });
     }
@@ -629,7 +630,7 @@ module.exports = function registerRoutes(router, context) {
       description: 'Sync monthly board data from POC Explorer Google Sheet',
       handler: async function() {
         if (DEMO_MODE) return { status: 'skipped', reason: 'demo mode' };
-        if (!isConfigured()) return { status: 'skipped', reason: 'not configured' };
+        if (!(await isConfigured())) return { status: 'skipped', reason: 'not configured' };
         const result = await syncBoards();
         return { status: 'success', ...result };
       }
@@ -640,7 +641,7 @@ module.exports = function registerRoutes(router, context) {
       cadence: '1h',
       description: 'Sync AI Catalyst Showcase data from Google Sheets',
       handler: async function() {
-        const sheetId = getShowcaseConfig(readFromStorage).sheetId;
+        const sheetId = (await getShowcaseConfig(readFromStorage)).sheetId;
         if (DEMO_MODE || !sheetId) return;
         clearShowcaseCache();
         await fetchShowcaseData(sheetId, showcaseKeyFile, storage);
@@ -652,17 +653,17 @@ module.exports = function registerRoutes(router, context) {
 
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const index = readIndex();
-      const showcaseData = readFromStorage(SHOWCASE_STORAGE_KEY);
+      const index = await readIndex();
+      const showcaseData = await readFromStorage(SHOWCASE_STORAGE_KEY);
       return {
-        configured: isConfigured(),
+        configured: await isConfigured(),
         demoMode: DEMO_MODE,
         lastSyncTime,
         syncRunning,
         boardCount: (index && index.boards) ? index.boards.length : 0,
         boards: (index && index.boards) || [],
         showcase: {
-          sheetConfigured: !!getShowcaseConfig(readFromStorage).sheetId,
+          sheetConfigured: !!(await getShowcaseConfig(readFromStorage)).sheetId,
           dataExists: !!showcaseData,
           entryCount: showcaseData?.entries?.length || 0,
           pillarCount: showcaseData?.pillars?.length || 0,
@@ -676,19 +677,19 @@ module.exports = function registerRoutes(router, context) {
 
   if (context.registerExport) {
     context.registerExport(async function(addFile, exportStorage) {
-      const index = exportStorage.readFromStorage(INDEX_PATH);
+      const index = await exportStorage.readFromStorage(INDEX_PATH);
       if (!index) return;
       addFile(INDEX_PATH, index);
 
       const boards = (index && index.boards) || [];
       for (const b of boards) {
-        const data = exportStorage.readFromStorage(`${STORAGE_PREFIX}/boards/${b.month}.json`);
+        const data = await exportStorage.readFromStorage(`${STORAGE_PREFIX}/boards/${b.month}.json`);
         if (data) {
           addFile(`${STORAGE_PREFIX}/boards/${b.month}.json`, data);
         }
       }
 
-      const showcaseData = exportStorage.readFromStorage(SHOWCASE_STORAGE_KEY);
+      const showcaseData = await exportStorage.readFromStorage(SHOWCASE_STORAGE_KEY);
       if (showcaseData) {
         addFile(SHOWCASE_STORAGE_KEY, showcaseData);
       }

--- a/modules/ai-catalyst/server/showcase/config.js
+++ b/modules/ai-catalyst/server/showcase/config.js
@@ -4,12 +4,12 @@ const DEFAULT_CONFIG = {
   sheetId: ''
 };
 
-function getConfig(readFromStorage) {
-  const saved = readFromStorage(CONFIG_KEY);
+async function getConfig(readFromStorage) {
+  const saved = await readFromStorage(CONFIG_KEY);
   return { ...DEFAULT_CONFIG, ...saved };
 }
 
-function saveConfig(writeToStorage, config) {
+async function saveConfig(writeToStorage, config) {
   const merged = { ...DEFAULT_CONFIG };
 
   if (config.sheetId !== undefined) {
@@ -19,7 +19,7 @@ function saveConfig(writeToStorage, config) {
     merged.sheetId = config.sheetId.trim();
   }
 
-  writeToStorage(CONFIG_KEY, merged);
+  await writeToStorage(CONFIG_KEY, merged);
 }
 
 module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, CONFIG_KEY };

--- a/modules/ai-catalyst/server/showcase/sheets-sync.js
+++ b/modules/ai-catalyst/server/showcase/sheets-sync.js
@@ -100,7 +100,7 @@ async function fetchShowcaseData(sheetId, keyFilePath, storage) {
   _cache = { data: result, ts: Date.now() };
 
   if (storage) {
-    storage.writeToStorage(STORAGE_KEY, result);
+    await storage.writeToStorage(STORAGE_KEY, result);
   }
 
   return result;
@@ -120,7 +120,7 @@ async function getShowcaseData(sheetId, keyFilePath, storage) {
     }
 
     if (storage) {
-      const stored = storage.readFromStorage(STORAGE_KEY);
+      const stored = await storage.readFromStorage(STORAGE_KEY);
       if (stored) {
         console.error('[ai-catalyst:showcase] Sheet fetch failed, using stored fallback:', err.message);
         _cache = { data: stored, ts: 0 };

--- a/modules/ai-impact/__tests__/server/assessment-routes.test.js
+++ b/modules/ai-impact/__tests__/server/assessment-routes.test.js
@@ -26,8 +26,8 @@ function makeValidBody() {
 function makeContext(storageData = null) {
   return {
     storage: {
-      readFromStorage: vi.fn().mockReturnValue(storageData),
-      writeToStorageAtomic: vi.fn()
+      readFromStorage: vi.fn().mockResolvedValue(storageData),
+      writeToStorage: vi.fn().mockResolvedValue(undefined)
     },
     requireAdmin: (req, res, next) => next(),
     requireScope: () => (req, res, next) => next()

--- a/modules/ai-impact/__tests__/server/assessment-storage.test.js
+++ b/modules/ai-impact/__tests__/server/assessment-storage.test.js
@@ -27,31 +27,31 @@ function makeEmptyData() {
 }
 
 describe('readAssessments', () => {
-  it('returns empty state when storage returns null', () => {
-    const read = vi.fn().mockReturnValue(null);
-    const result = readAssessments(read);
+  it('returns empty state when storage returns null', async () => {
+    const read = vi.fn().mockResolvedValue(null);
+    const result = await readAssessments(read);
     expect(result).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
   });
 
-  it('returns empty state when storage returns undefined', () => {
-    const read = vi.fn().mockReturnValue(undefined);
-    expect(readAssessments(read)).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
+  it('returns empty state when storage returns undefined', async () => {
+    const read = vi.fn().mockResolvedValue(undefined);
+    expect(await readAssessments(read)).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
   });
 
-  it('returns empty state when data is malformed (missing assessments key)', () => {
-    const read = vi.fn().mockReturnValue({ lastSyncedAt: 'x' });
-    expect(readAssessments(read)).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
+  it('returns empty state when data is malformed (missing assessments key)', async () => {
+    const read = vi.fn().mockResolvedValue({ lastSyncedAt: 'x' });
+    expect(await readAssessments(read)).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
   });
 
-  it('returns empty state when data is a non-object', () => {
-    const read = vi.fn().mockReturnValue('null');
-    expect(readAssessments(read)).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
+  it('returns empty state when data is a non-object', async () => {
+    const read = vi.fn().mockResolvedValue('null');
+    expect(await readAssessments(read)).toEqual({ lastSyncedAt: null, totalAssessed: 0, assessments: {} });
   });
 
-  it('returns valid data unchanged', () => {
+  it('returns valid data unchanged', async () => {
     const data = { lastSyncedAt: '2026-04-19T12:00:00Z', totalAssessed: 5, assessments: { A: {} } };
-    const read = vi.fn().mockReturnValue(data);
-    expect(readAssessments(read)).toBe(data);
+    const read = vi.fn().mockResolvedValue(data);
+    expect(await readAssessments(read)).toBe(data);
   });
 });
 

--- a/modules/ai-impact/__tests__/server/config.test.js
+++ b/modules/ai-impact/__tests__/server/config.test.js
@@ -2,67 +2,67 @@ import { describe, it, expect, vi } from 'vitest';
 import { getConfig, saveConfig, DEFAULT_CONFIG, validateJqlSafeString } from '../../server/config.js';
 
 describe('getConfig', () => {
-  it('returns defaults when no file exists', () => {
-    const readFromStorage = vi.fn().mockReturnValue(null);
-    expect(getConfig(readFromStorage)).toEqual(DEFAULT_CONFIG);
+  it('returns defaults when no file exists', async () => {
+    const readFromStorage = vi.fn().mockResolvedValue(null);
+    expect(await getConfig(readFromStorage)).toEqual(DEFAULT_CONFIG);
   });
 
-  it('merges saved config with defaults', () => {
-    const readFromStorage = vi.fn().mockReturnValue({ jiraProject: 'CUSTOM' });
-    const config = getConfig(readFromStorage);
+  it('merges saved config with defaults', async () => {
+    const readFromStorage = vi.fn().mockResolvedValue({ jiraProject: 'CUSTOM' });
+    const config = await getConfig(readFromStorage);
     expect(config.jiraProject).toBe('CUSTOM');
     expect(config.linkedProject).toBe('RHAISTRAT'); // default
   });
 });
 
 describe('saveConfig', () => {
-  it('saves valid config', () => {
-    const writeToStorage = vi.fn();
-    saveConfig(writeToStorage, { jiraProject: 'MYPROJECT' });
+  it('saves valid config', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await saveConfig(writeToStorage, { jiraProject: 'MYPROJECT' });
     expect(writeToStorage).toHaveBeenCalledWith('ai-impact/config.json', expect.objectContaining({
       jiraProject: 'MYPROJECT',
       linkedProject: 'RHAISTRAT'
     }));
   });
 
-  it('rejects JQL-unsafe characters in string fields', () => {
-    const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { jiraProject: 'BAD"PROJECT' })).toThrow('unsafe characters');
-    expect(() => saveConfig(writeToStorage, { jiraProject: "BAD'PROJECT" })).toThrow('unsafe characters');
-    expect(() => saveConfig(writeToStorage, { jiraProject: 'BAD(PROJECT)' })).toThrow('unsafe characters');
-    expect(() => saveConfig(writeToStorage, { jiraProject: 'BAD;PROJECT' })).toThrow('unsafe characters');
-    expect(() => saveConfig(writeToStorage, { jiraProject: 'BAD\\PROJECT' })).toThrow('unsafe characters');
+  it('rejects JQL-unsafe characters in string fields', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await expect(saveConfig(writeToStorage, { jiraProject: 'BAD"PROJECT' })).rejects.toThrow('unsafe characters');
+    await expect(saveConfig(writeToStorage, { jiraProject: "BAD'PROJECT" })).rejects.toThrow('unsafe characters');
+    await expect(saveConfig(writeToStorage, { jiraProject: 'BAD(PROJECT)' })).rejects.toThrow('unsafe characters');
+    await expect(saveConfig(writeToStorage, { jiraProject: 'BAD;PROJECT' })).rejects.toThrow('unsafe characters');
+    await expect(saveConfig(writeToStorage, { jiraProject: 'BAD\\PROJECT' })).rejects.toThrow('unsafe characters');
   });
 
-  it('rejects non-string values for string fields', () => {
-    const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { jiraProject: '' })).toThrow('non-empty string');
+  it('rejects non-string values for string fields', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await expect(saveConfig(writeToStorage, { jiraProject: '' })).rejects.toThrow('non-empty string');
   });
 
-  it('rejects non-integer lookbackMonths', () => {
-    const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { lookbackMonths: 1.5 })).toThrow('integer between 0 and 120');
-    expect(() => saveConfig(writeToStorage, { lookbackMonths: -1 })).toThrow('integer between 0 and 120');
-    expect(() => saveConfig(writeToStorage, { lookbackMonths: 121 })).toThrow('integer between 0 and 120');
+  it('rejects non-integer lookbackMonths', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await expect(saveConfig(writeToStorage, { lookbackMonths: 1.5 })).rejects.toThrow('integer between 0 and 120');
+    await expect(saveConfig(writeToStorage, { lookbackMonths: -1 })).rejects.toThrow('integer between 0 and 120');
+    await expect(saveConfig(writeToStorage, { lookbackMonths: 121 })).rejects.toThrow('integer between 0 and 120');
   });
 
-  it('rejects non-array excludedStatuses', () => {
-    const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { excludedStatuses: 'Closed' })).toThrow('must be an array');
+  it('rejects non-array excludedStatuses', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await expect(saveConfig(writeToStorage, { excludedStatuses: 'Closed' })).rejects.toThrow('must be an array');
   });
 
-  it('rejects unsafe excludedStatuses entries', () => {
-    const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { excludedStatuses: ['Good', 'Bad"Status'] })).toThrow('unsafe characters');
+  it('rejects unsafe excludedStatuses entries', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await expect(saveConfig(writeToStorage, { excludedStatuses: ['Good', 'Bad"Status'] })).rejects.toThrow('unsafe characters');
   });
 
-  it('validates trendThresholdPp range', () => {
-    const writeToStorage = vi.fn();
-    expect(() => saveConfig(writeToStorage, { trendThresholdPp: -1 })).toThrow('number between 0 and 50');
-    expect(() => saveConfig(writeToStorage, { trendThresholdPp: 51 })).toThrow('number between 0 and 50');
+  it('validates trendThresholdPp range', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await expect(saveConfig(writeToStorage, { trendThresholdPp: -1 })).rejects.toThrow('number between 0 and 50');
+    await expect(saveConfig(writeToStorage, { trendThresholdPp: 51 })).rejects.toThrow('number between 0 and 50');
     // Valid edge cases
-    saveConfig(writeToStorage, { trendThresholdPp: 0 });
-    saveConfig(writeToStorage, { trendThresholdPp: 50 });
+    await saveConfig(writeToStorage, { trendThresholdPp: 0 });
+    await saveConfig(writeToStorage, { trendThresholdPp: 50 });
   });
 });
 

--- a/modules/ai-impact/__tests__/server/feature-routes.test.js
+++ b/modules/ai-impact/__tests__/server/feature-routes.test.js
@@ -30,7 +30,7 @@ function makeValidBody() {
 function makeContext(storageData = null) {
   return {
     storage: {
-      readFromStorage: vi.fn().mockReturnValue(storageData)
+      readFromStorage: vi.fn().mockResolvedValue(storageData)
     },
     requireAdmin: (req, res, next) => next(),
     requireScope: () => (req, res, next) => next()

--- a/modules/ai-impact/__tests__/server/feature-storage.test.js
+++ b/modules/ai-impact/__tests__/server/feature-storage.test.js
@@ -40,7 +40,7 @@ function makeFeatureFile(overrides = {}) {
 }
 
 describe('readFeatures', () => {
-  it('returns features from releases index when aiReview data exists', () => {
+  it('returns features from releases index when aiReview data exists', async () => {
     const indexEntry = {
       key: 'RHAISTRAT-1168',
       summary: 'GPU-as-a-Service Observability',
@@ -56,76 +56,76 @@ describe('readFeatures', () => {
       }
     };
     const featureFile = makeFeatureFile();
-    const read = vi.fn(function(key) {
+    const read = vi.fn(async function(key) {
       if (key === 'releases/execution/index.json') return makeReleasesIndex([indexEntry]);
       if (key === 'releases/execution/features/RHAISTRAT-1168.json') return featureFile;
       return null;
     });
 
-    const result = readFeatures(read);
+    const result = await readFeatures(read);
     expect(result.totalFeatures).toBe(1);
     expect(result.features['RHAISTRAT-1168']).toBeDefined();
     expect(result.features['RHAISTRAT-1168'].latest.recommendation).toBe('approve');
     expect(result.features['RHAISTRAT-1168'].history).toHaveLength(1);
   });
 
-  it('falls back to legacy store when no releases index', () => {
+  it('falls back to legacy store when no releases index', async () => {
     const legacyData = {
       lastSyncedAt: '2026-04-19T12:00:00Z',
       totalFeatures: 1,
       features: { A: { latest: { key: 'A' }, history: [] } }
     };
-    const read = vi.fn(function(key) {
+    const read = vi.fn(async function(key) {
       if (key === 'releases/execution/index.json') return null;
       if (key === 'ai-impact/features.json') return legacyData;
       return null;
     });
 
-    const result = readFeatures(read);
+    const result = await readFeatures(read);
     expect(result).toBe(legacyData);
   });
 
-  it('falls back to legacy store when releases index has no aiReview features', () => {
+  it('falls back to legacy store when releases index has no aiReview features', async () => {
     const legacyData = {
       lastSyncedAt: '2026-04-19T12:00:00Z',
       totalFeatures: 1,
       features: { A: { latest: { key: 'A' }, history: [] } }
     };
-    const read = vi.fn(function(key) {
+    const read = vi.fn(async function(key) {
       if (key === 'releases/execution/index.json') return makeReleasesIndex([{ key: 'X', summary: 'No AI' }]);
       if (key === 'ai-impact/features.json') return legacyData;
       return null;
     });
 
-    const result = readFeatures(read);
+    const result = await readFeatures(read);
     expect(result).toBe(legacyData);
   });
 
-  it('returns empty state when both stores are empty', () => {
-    const read = vi.fn().mockReturnValue(null);
-    expect(readFeatures(read)).toEqual({ lastSyncedAt: null, totalFeatures: 0, features: {} });
+  it('returns empty state when both stores are empty', async () => {
+    const read = vi.fn().mockResolvedValue(null);
+    expect(await readFeatures(read)).toEqual({ lastSyncedAt: null, totalFeatures: 0, features: {} });
   });
 
-  it('returns empty state when releases index exists but no features', () => {
-    const read = vi.fn(function(key) {
+  it('returns empty state when releases index exists but no features', async () => {
+    const read = vi.fn(async function(key) {
       if (key === 'releases/execution/index.json') return makeReleasesIndex([]);
       return null;
     });
-    expect(readFeatures(read)).toEqual({ lastSyncedAt: null, totalFeatures: 0, features: {} });
+    expect(await readFeatures(read)).toEqual({ lastSyncedAt: null, totalFeatures: 0, features: {} });
   });
 
-  it('skips features without aiReview in releases index', () => {
+  it('skips features without aiReview in releases index', async () => {
     const indexEntries = [
       { key: 'A', summary: 'With AI', aiReview: { recommendation: 'approve', scores: {}, humanReviewStatus: 'approved', needsAttention: false, reviewedAt: '2026-04-19T12:00:00Z' } },
       { key: 'B', summary: 'Without AI' }
     ];
-    const read = vi.fn(function(key) {
+    const read = vi.fn(async function(key) {
       if (key === 'releases/execution/index.json') return makeReleasesIndex(indexEntries);
       if (key === 'releases/execution/features/A.json') return { key: 'A', aiReview: { recommendation: 'approve', reviewedAt: '2026-04-19T12:00:00Z', history: [] } };
       return null;
     });
 
-    const result = readFeatures(read);
+    const result = await readFeatures(read);
     expect(result.totalFeatures).toBe(1);
     expect(result.features['A']).toBeDefined();
     expect(result.features['B']).toBeUndefined();

--- a/modules/ai-impact/__tests__/server/test-plan-routes.test.js
+++ b/modules/ai-impact/__tests__/server/test-plan-routes.test.js
@@ -29,8 +29,8 @@ function makeValidBody() {
 function makeContext(storageData = null) {
   return {
     storage: {
-      readFromStorage: vi.fn().mockReturnValue(storageData),
-      writeToStorageAtomic: vi.fn()
+      readFromStorage: vi.fn().mockResolvedValue(storageData),
+      writeToStorage: vi.fn().mockResolvedValue(undefined)
     },
     requireAdmin: (req, res, next) => next(),
     requireScope: () => (req, res, next) => next()

--- a/modules/ai-impact/__tests__/server/test-plan-storage.test.js
+++ b/modules/ai-impact/__tests__/server/test-plan-storage.test.js
@@ -34,25 +34,25 @@ function makeEmptyData() {
 }
 
 describe('readTestPlans', () => {
-  it('returns empty state when storage returns null', () => {
-    const read = vi.fn().mockReturnValue(null);
-    expect(readTestPlans(read)).toEqual({ lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} });
+  it('returns empty state when storage returns null', async () => {
+    const read = vi.fn().mockResolvedValue(null);
+    expect(await readTestPlans(read)).toEqual({ lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} });
   });
 
-  it('returns empty state when storage returns undefined', () => {
-    const read = vi.fn().mockReturnValue(undefined);
-    expect(readTestPlans(read)).toEqual({ lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} });
+  it('returns empty state when storage returns undefined', async () => {
+    const read = vi.fn().mockResolvedValue(undefined);
+    expect(await readTestPlans(read)).toEqual({ lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} });
   });
 
-  it('returns empty state when data is malformed', () => {
-    const read = vi.fn().mockReturnValue({ lastSyncedAt: 'x' });
-    expect(readTestPlans(read)).toEqual({ lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} });
+  it('returns empty state when data is malformed', async () => {
+    const read = vi.fn().mockResolvedValue({ lastSyncedAt: 'x' });
+    expect(await readTestPlans(read)).toEqual({ lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} });
   });
 
-  it('returns valid data unchanged', () => {
+  it('returns valid data unchanged', async () => {
     const data = { lastSyncedAt: '2026-05-10T12:00:00Z', totalTestPlans: 1, testPlans: { A: {} } };
-    const read = vi.fn().mockReturnValue(data);
-    expect(readTestPlans(read)).toBe(data);
+    const read = vi.fn().mockResolvedValue(data);
+    expect(await readTestPlans(read)).toBe(data);
   });
 });
 

--- a/modules/ai-impact/server/assessments/routes.js
+++ b/modules/ai-impact/server/assessments/routes.js
@@ -28,13 +28,13 @@ const BULK_CAP = 5000;
  */
 module.exports = function registerAssessmentRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage, writeToStorageAtomic } = storage;
+  const { readFromStorage, writeToStorage } = storage;
 
   // ─── 1. Static routes FIRST ───
 
   // GET /assessments/status (Admin) — assessment data status for settings page
-  router.get('/assessments/status', requireAdmin, requireScope('ai-impact:read'), function(req, res) {
-    const data = readAssessments(readFromStorage);
+  router.get('/assessments/status', requireAdmin, requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readAssessments(readFromStorage);
     res.json({
       lastSyncedAt: data.lastSyncedAt,
       totalAssessed: data.totalAssessed,
@@ -43,7 +43,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // POST /assessments/bulk (Admin) — bulk upsert assessments
-  router.post('/assessments/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
+  router.post('/assessments/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }
@@ -56,7 +56,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
       return res.status(400).json({ error: `Bulk payload exceeds maximum of ${BULK_CAP} entries` });
     }
 
-    const data = readAssessments(readFromStorage);
+    const data = await readAssessments(readFromStorage);
     const counts = { created: 0, updated: 0, unchanged: 0 };
     const errors = [];
 
@@ -79,7 +79,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
     data.lastSyncedAt = new Date().toISOString();
     data.totalAssessed = Object.keys(data.assessments).length;
 
-    writeAssessmentsAtomic(writeToStorageAtomic, data);
+    await writeAssessmentsAtomic(writeToStorage, data);
 
     res.json({
       created: counts.created,
@@ -90,26 +90,26 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // DELETE /assessments (Admin) — clear all assessment data
-  router.delete('/assessments', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
+  router.delete('/assessments', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }
 
-    writeAssessmentsAtomic(writeToStorageAtomic, { lastSyncedAt: null, totalAssessed: 0, assessments: {} });
+    await writeAssessmentsAtomic(writeToStorage, { lastSyncedAt: null, totalAssessed: 0, assessments: {} });
     res.json({ status: 'cleared' });
   });
 
   // GET /assessments — list all latest assessments (slim projection)
-  router.get('/assessments', requireScope('ai-impact:read'), function(req, res) {
-    const data = readAssessments(readFromStorage);
+  router.get('/assessments', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readAssessments(readFromStorage);
     res.json(getLatestProjection(data));
   });
 
   // ─── 2. Parameterized routes AFTER ───
 
   // GET /assessments/:key — single RFE assessment + history
-  router.get('/assessments/:key', requireScope('ai-impact:read'), function(req, res) {
-    const data = readAssessments(readFromStorage);
+  router.get('/assessments/:key', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readAssessments(readFromStorage);
     const entry = data.assessments[req.params.key];
     if (!entry) {
       return res.status(404).json({ error: 'Not found' });
@@ -121,7 +121,7 @@ module.exports = function registerAssessmentRoutes(router, context) {
   });
 
   // PUT /assessments/:key (Admin) — upsert single assessment
-  router.put('/assessments/:key', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
+  router.put('/assessments/:key', requireAdmin, requireScope('ai-impact:write'), jsonLimit, async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Assessment ingest disabled in demo mode' });
     }
@@ -131,13 +131,13 @@ module.exports = function registerAssessmentRoutes(router, context) {
       return res.status(400).json({ errors: result.errors });
     }
 
-    const data = readAssessments(readFromStorage);
+    const data = await readAssessments(readFromStorage);
     const status = upsertAssessment(data, req.params.key, result.data);
 
     data.lastSyncedAt = new Date().toISOString();
     data.totalAssessed = Object.keys(data.assessments).length;
 
-    writeAssessmentsAtomic(writeToStorageAtomic, data);
+    await writeAssessmentsAtomic(writeToStorage, data);
     res.json({ status });
   });
 };

--- a/modules/ai-impact/server/assessments/storage.js
+++ b/modules/ai-impact/server/assessments/storage.js
@@ -6,8 +6,8 @@ const MAX_HISTORY = 20;
  * @param {Function} readFromStorage - The storage read function
  * @returns {object} Assessments data object (never null)
  */
-function readAssessments(readFromStorage) {
-  const data = readFromStorage(STORAGE_KEY);
+async function readAssessments(readFromStorage) {
+  const data = await readFromStorage(STORAGE_KEY);
   if (!data || typeof data !== 'object' || !data.assessments) {
     return { lastSyncedAt: null, totalAssessed: 0, assessments: {} };
   }
@@ -16,11 +16,11 @@ function readAssessments(readFromStorage) {
 
 /**
  * Atomic write via the shared storage abstraction.
- * @param {Function} writeToStorageAtomic - The storage atomic write function
+ * @param {Function} writeToStorage - The storage write function
  * @param {object} data - The assessments data object to write
  */
-function writeAssessmentsAtomic(writeToStorageAtomic, data) {
-  writeToStorageAtomic(STORAGE_KEY, data);
+async function writeAssessmentsAtomic(writeToStorage, data) {
+  await writeToStorage(STORAGE_KEY, data);
 }
 
 /**

--- a/modules/ai-impact/server/component-onboarding/routes.js
+++ b/modules/ai-impact/server/component-onboarding/routes.js
@@ -18,7 +18,7 @@ const BULK_CAP = 5000;
  */
 module.exports = function registerComponentOnboardingRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage, writeToStorageAtomic } = storage;
+  const { readFromStorage, writeToStorage } = storage;
 
   // ─── Static routes first ───
 
@@ -33,8 +33,8 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
    *       200:
    *         description: Component onboarding data status
    */
-  router.get('/component-onboarding/status', requireAdmin, requireScope('ai-impact:read'), function(req, res) {
-    const data = readComponentOnboarding(readFromStorage);
+  router.get('/component-onboarding/status', requireAdmin, requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readComponentOnboarding(readFromStorage);
     res.json({
       fetchedAt: data.fetchedAt,
       totalComponents: data.totalComponents,
@@ -53,7 +53,7 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
    *       200:
    *         description: Bulk upsert result
    */
-  router.post('/component-onboarding/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
+  router.post('/component-onboarding/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Component onboarding ingest disabled in demo mode' });
     }
@@ -66,7 +66,7 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
       return res.status(400).json({ error: `Bulk payload exceeds maximum of ${BULK_CAP} entries` });
     }
 
-    const data = readComponentOnboarding(readFromStorage);
+    const data = await readComponentOnboarding(readFromStorage);
     const counts = { created: 0, updated: 0, unchanged: 0 };
     const errors = [];
 
@@ -89,7 +89,7 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
     data.fetchedAt = new Date().toISOString();
     data.totalComponents = Object.keys(data.components).length;
 
-    writeComponentOnboardingAtomic(writeToStorageAtomic, data);
+    await writeComponentOnboardingAtomic(writeToStorage, data);
 
     res.json({
       created: counts.created,
@@ -110,11 +110,11 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
    *       200:
    *         description: Data cleared
    */
-  router.delete('/component-onboarding', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
+  router.delete('/component-onboarding', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Component onboarding ingest disabled in demo mode' });
     }
-    writeComponentOnboardingAtomic(writeToStorageAtomic, { fetchedAt: null, totalComponents: 0, components: {} });
+    await writeComponentOnboardingAtomic(writeToStorage, { fetchedAt: null, totalComponents: 0, components: {} });
     res.json({ status: 'cleared' });
   });
 
@@ -128,8 +128,8 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
    *       200:
    *         description: All component onboarding data with latest projections
    */
-  router.get('/component-onboarding', requireScope('ai-impact:read'), function(req, res) {
-    const data = readComponentOnboarding(readFromStorage);
+  router.get('/component-onboarding', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readComponentOnboarding(readFromStorage);
     res.json(getLatestProjection(data));
   });
 
@@ -153,8 +153,8 @@ module.exports = function registerComponentOnboardingRoutes(router, context) {
    *       404:
    *         description: Component not found
    */
-  router.get('/component-onboarding/:key', requireScope('ai-impact:read'), function(req, res) {
-    const data = readComponentOnboarding(readFromStorage);
+  router.get('/component-onboarding/:key', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readComponentOnboarding(readFromStorage);
     const entry = data.components[req.params.key];
     if (!entry) {
       return res.status(404).json({ error: 'Not found' });

--- a/modules/ai-impact/server/component-onboarding/storage.js
+++ b/modules/ai-impact/server/component-onboarding/storage.js
@@ -1,16 +1,16 @@
 const STORAGE_KEY = 'ai-impact/component-onboarding-data.json';
 const MAX_HISTORY = 20;
 
-function readComponentOnboarding(readFromStorage) {
-  const data = readFromStorage(STORAGE_KEY);
+async function readComponentOnboarding(readFromStorage) {
+  const data = await readFromStorage(STORAGE_KEY);
   if (!data || typeof data !== 'object' || !data.components) {
     return { fetchedAt: null, totalComponents: 0, components: {} };
   }
   return data;
 }
 
-function writeComponentOnboardingAtomic(writeToStorageAtomic, data) {
-  writeToStorageAtomic(STORAGE_KEY, data);
+async function writeComponentOnboardingAtomic(writeToStorage, data) {
+  await writeToStorage(STORAGE_KEY, data);
 }
 
 function trimForHistory(component) {

--- a/modules/ai-impact/server/config.js
+++ b/modules/ai-impact/server/config.js
@@ -31,8 +31,8 @@ function validateJqlSafeString(value, fieldName) {
   }
 }
 
-function getConfig(readFromStorage) {
-  const saved = readFromStorage('ai-impact/config.json');
+async function getConfig(readFromStorage) {
+  const saved = await readFromStorage('ai-impact/config.json');
   return { ...DEFAULT_CONFIG, ...saved };
 }
 
@@ -41,7 +41,7 @@ function getConfig(readFromStorage) {
  * All string fields are checked for JQL-unsafe characters since they are
  * interpolated into JQL queries in rfe-fetcher.js.
  */
-function saveConfig(writeToStorage, config) {
+async function saveConfig(writeToStorage, config) {
   const merged = { ...DEFAULT_CONFIG };
 
   // Warn about unknown fields (helps catch frontend/backend key mismatches)
@@ -128,7 +128,7 @@ function saveConfig(writeToStorage, config) {
     merged.autofixProjects = config.autofixProjects;
   }
 
-  writeToStorage('ai-impact/config.json', merged);
+  await writeToStorage('ai-impact/config.json', merged);
 }
 
 module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, validateJqlSafeString };

--- a/modules/ai-impact/server/export.js
+++ b/modules/ai-impact/server/export.js
@@ -63,7 +63,7 @@ function anonymizeIssue(issue, mapping) {
 }
 
 async function exportRfeData(addFile, readFromStorage, mapping) {
-  const data = readFromStorage(`${PREFIX}/rfe-data.json`);
+  const data = await readFromStorage(`${PREFIX}/rfe-data.json`);
   if (!data) return;
 
   const anonymized = { ...data };
@@ -74,7 +74,7 @@ async function exportRfeData(addFile, readFromStorage, mapping) {
 }
 
 async function exportAutofixData(addFile, readFromStorage, mapping) {
-  const data = readFromStorage(`${PREFIX}/autofix-data.json`);
+  const data = await readFromStorage(`${PREFIX}/autofix-data.json`);
   if (!data) return;
 
   const anonymized = { ...data };
@@ -85,7 +85,7 @@ async function exportAutofixData(addFile, readFromStorage, mapping) {
 }
 
 async function exportDocData(addFile, readFromStorage, mapping) {
-  const data = readFromStorage(`${PREFIX}/doc-data.json`);
+  const data = await readFromStorage(`${PREFIX}/doc-data.json`);
   if (!data) return;
 
   const anonymized = { ...data };
@@ -111,7 +111,7 @@ async function exportDocData(addFile, readFromStorage, mapping) {
 }
 
 async function exportDocMrKpiData(addFile, readFromStorage, mapping) {
-  const data = readFromStorage(`${PREFIX}/doc-mr-kpi-data.json`);
+  const data = await readFromStorage(`${PREFIX}/doc-mr-kpi-data.json`);
   if (!data) return;
 
   const anonymized = { ...data };
@@ -130,7 +130,7 @@ async function exportDocMrKpiData(addFile, readFromStorage, mapping) {
 
 async function exportConfig(addFile, readFromStorage) {
   const { getConfig } = require('./config');
-  const config = getConfig(readFromStorage);
+  const config = await getConfig(readFromStorage);
   if (!config) return;
 
   addFile(`${PREFIX}/config.json`, config);
@@ -138,7 +138,7 @@ async function exportConfig(addFile, readFromStorage) {
 
 async function exportAssessments(addFile, readFromStorage, mapping) {
   const { readAssessments } = require('./assessments/storage');
-  const data = readAssessments(readFromStorage);
+  const data = await readAssessments(readFromStorage);
   if (!data.assessments || Object.keys(data.assessments).length === 0) return;
 
   const anonymized = { ...data, assessments: {} };
@@ -161,7 +161,7 @@ function anonymizeAssessment(assessment, mapping) {
 
 async function exportTestPlans(addFile, readFromStorage, mapping) {
   const { readTestPlans } = require('./test-plans/storage');
-  const data = readTestPlans(readFromStorage);
+  const data = await readTestPlans(readFromStorage);
   if (!data.testPlans || Object.keys(data.testPlans).length === 0) return;
 
   const anonymized = { ...data, testPlans: {} };
@@ -188,7 +188,7 @@ function anonymizeTestPlan(plan, mapping) {
 }
 
 async function exportFeatures(addFile, readFromStorage, mapping) {
-  const data = readFromStorage(`${PREFIX}/features.json`);
+  const data = await readFromStorage(`${PREFIX}/features.json`);
   if (!data || !data.features) return;
 
   const anonymized = { ...data, features: {} };
@@ -214,7 +214,7 @@ function anonymizeFeatureReview(review, mapping) {
 
 async function exportComponentOnboarding(addFile, readFromStorage, mapping) {
   const { readComponentOnboarding } = require('./component-onboarding/storage');
-  const data = readComponentOnboarding(readFromStorage);
+  const data = await readComponentOnboarding(readFromStorage);
   if (!data.components || Object.keys(data.components).length === 0) return;
 
   const anonymized = { ...data, components: {} };

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -116,8 +116,8 @@ module.exports = function registerFeatureRoutes(router, context) {
   // ─── 1. Static routes FIRST ───
 
   // GET /features/status (Admin) — feature data status for settings page
-  router.get('/features/status', requireAdmin, requireScope('ai-impact:read'), function(req, res) {
-    const data = readFeatures(readFromStorage);
+  router.get('/features/status', requireAdmin, requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readFeatures(readFromStorage);
     res.json({
       lastSyncedAt: data.lastSyncedAt,
       lastJiraSyncAt: data.lastJiraSyncAt || null,
@@ -223,16 +223,16 @@ module.exports = function registerFeatureRoutes(router, context) {
   });
 
   // GET /features — list all features (slim projection)
-  router.get('/features', requireScope('ai-impact:read'), function(req, res) {
-    const data = readFeatures(readFromStorage);
+  router.get('/features', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readFeatures(readFromStorage);
     res.json(getLatestProjection(data));
   });
 
   // ─── 2. Parameterized routes AFTER ───
 
   // GET /features/:key — single feature + history
-  router.get('/features/:key', requireScope('ai-impact:read'), function(req, res) {
-    const data = readFeatures(readFromStorage);
+  router.get('/features/:key', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readFeatures(readFromStorage);
     const entry = data.features[req.params.key];
     if (!entry) {
       return res.status(404).json({ error: 'Not found' });

--- a/modules/ai-impact/server/features/storage.js
+++ b/modules/ai-impact/server/features/storage.js
@@ -22,11 +22,11 @@ const LEGACY_STORAGE_KEY = 'ai-impact/features.json';
  * @param {Function} readFromStorage - The storage read function
  * @returns {object} Features data object (never null)
  */
-function readFeatures(readFromStorage) {
-  const index = readFromStorage(RELEASES_INDEX_KEY);
+async function readFeatures(readFromStorage) {
+  const index = await readFromStorage(RELEASES_INDEX_KEY);
   if (!index || !Array.isArray(index.features)) {
     // Fallback to legacy store
-    const legacy = readFromStorage(LEGACY_STORAGE_KEY);
+    const legacy = await readFromStorage(LEGACY_STORAGE_KEY);
     if (legacy && typeof legacy === 'object' && legacy.features) {
       return legacy;
     }
@@ -37,7 +37,7 @@ function readFeatures(readFromStorage) {
   const aiFeatures = index.features.filter(function(f) { return f.aiReview; });
   if (aiFeatures.length === 0) {
     // Check legacy store as fallback
-    const legacy = readFromStorage(LEGACY_STORAGE_KEY);
+    const legacy = await readFromStorage(LEGACY_STORAGE_KEY);
     if (legacy && typeof legacy === 'object' && legacy.features && Object.keys(legacy.features).length > 0) {
       return legacy;
     }
@@ -48,7 +48,7 @@ function readFeatures(readFromStorage) {
   for (var i = 0; i < aiFeatures.length; i++) {
     var entry = aiFeatures[i];
     // Read the full feature file for history
-    var featureFile = readFromStorage(RELEASES_FEATURE_PREFIX + entry.key + '.json');
+    var featureFile = await readFromStorage(RELEASES_FEATURE_PREFIX + entry.key + '.json');
     var aiReview = featureFile && featureFile.aiReview ? featureFile.aiReview : {};
 
     features[entry.key] = {

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -78,12 +78,12 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: RFE dataset with metrics, trend data, breakdown, and pipeline friction
    */
-  router.get('/rfe-data', requireScope('ai-impact:read'), function(req, res) {
+  router.get('/rfe-data', requireScope('ai-impact:read'), async function(req, res) {
     const timeWindow = VALID_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow
       : 'month';
 
-    const data = readFromStorage('ai-impact/rfe-data.json');
+    const data = await readFromStorage('ai-impact/rfe-data.json');
     if (!data || !data.issues) {
       return res.json({
         fetchedAt: null,
@@ -97,7 +97,7 @@ module.exports = function registerRoutes(router, context) {
     }
 
     // Compute metrics server-side from cached issues
-    const config = getConfig(readFromStorage);
+    const config = await getConfig(readFromStorage);
     const { metrics, trendData, breakdown, pipelineFriction } = computeAllMetrics(data.issues, timeWindow, config);
 
     res.json({
@@ -139,9 +139,9 @@ module.exports = function registerRoutes(router, context) {
     };
   }
 
-  function getAutofixData() {
+  async function getAutofixData() {
     if (!autofixDataCache) {
-      const raw = readFromStorage('ai-impact/autofix-data.json');
+      const raw = await readFromStorage('ai-impact/autofix-data.json');
       autofixDataCache = DEMO_MODE ? shiftAutofixDates(raw) : raw;
     }
     return autofixDataCache;
@@ -192,12 +192,12 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Autofix dataset with metrics, trend data, and issues
    */
-  router.get('/autofix-data', requireScope('ai-impact:read'), function(req, res) {
+  router.get('/autofix-data', requireScope('ai-impact:read'), async function(req, res) {
     const timeWindow = VALID_AUTOFIX_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow
       : 'month';
 
-    const data = getAutofixData();
+    const data = await getAutofixData();
     if (!data || !data.issues) {
       return res.json({
         fetchedAt: null,
@@ -265,8 +265,8 @@ module.exports = function registerRoutes(router, context) {
     };
   }
 
-  router.get('/doc-data', requireScope('ai-impact:read'), function(req, res) {
-    const rawData = readFromStorage('ai-impact/doc-data.json');
+  router.get('/doc-data', requireScope('ai-impact:read'), async function(req, res) {
+    const rawData = await readFromStorage('ai-impact/doc-data.json');
     if (!rawData || !rawData.issues) {
       return res.json({
         fetchedAt: null,
@@ -303,33 +303,33 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: MR KPI data with merge request metrics
    */
-  router.get('/doc-mr-kpi-data', requireScope('ai-impact:read'), function(req, res) {
-    const data = readFromStorage('ai-impact/doc-mr-kpi-data.json');
+  router.get('/doc-mr-kpi-data', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readFromStorage('ai-impact/doc-mr-kpi-data.json');
     if (!data || !data.mergeRequests) {
       return res.json({ fetchedAt: null, mergeRequests: [] });
     }
     res.json(data);
   });
 
-  router.get('/config', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
-    res.json(getConfig(readFromStorage));
+  router.get('/config', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
+    res.json(await getConfig(readFromStorage));
   });
 
-  router.post('/config', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
+  router.post('/config', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
     try {
-      saveConfig(writeToStorage, req.body);
+      await saveConfig(writeToStorage, req.body);
       res.json({ status: 'saved' });
     } catch (err) {
       res.status(400).json({ error: err.message });
     }
   });
 
-  router.delete('/cache', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
-    writeToStorage('ai-impact/rfe-data.json', null);
-    writeToStorage('ai-impact/autofix-data.json', null);
+  router.delete('/cache', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
+    await writeToStorage('ai-impact/rfe-data.json', null);
+    await writeToStorage('ai-impact/autofix-data.json', null);
     invalidateAutofixCache();
-    writeToStorage('ai-impact/doc-data.json', null);
-    writeToStorage('ai-impact/doc-mr-kpi-data.json', null);
+    await writeToStorage('ai-impact/doc-data.json', null);
+    await writeToStorage('ai-impact/doc-mr-kpi-data.json', null);
     res.json({ status: 'cleared' });
   });
 
@@ -340,11 +340,11 @@ module.exports = function registerRoutes(router, context) {
   async function runAiImpactRefresh() {
     if (DEMO_MODE) return;
 
-    const config = getConfig(readFromStorage);
+    const config = await getConfig(readFromStorage);
 
     const issues = await fetchRFEData(jiraRequest, config);
     const withLinks = await resolveLinkedFeatures(jiraRequest, issues, config);
-    writeToStorage('ai-impact/rfe-data.json', {
+    await writeToStorage('ai-impact/rfe-data.json', {
       fetchedAt: new Date().toISOString(),
       issues: withLinks
     });
@@ -352,7 +352,7 @@ module.exports = function registerRoutes(router, context) {
     let autofixCount = 0;
     try {
       const autofixIssues = await fetchAutofixData(jiraRequest, config);
-      writeToStorage('ai-impact/autofix-data.json', {
+      await writeToStorage('ai-impact/autofix-data.json', {
         fetchedAt: new Date().toISOString(),
         issues: autofixIssues
       });
@@ -370,7 +370,7 @@ module.exports = function registerRoutes(router, context) {
         fetchedAt: new Date().toISOString(),
         mergeRequests: mrKpiResult.mergeRequests
       };
-      writeToStorage('ai-impact/doc-mr-kpi-data.json', mrKpiData);
+      await writeToStorage('ai-impact/doc-mr-kpi-data.json', mrKpiData);
       mrKpiCount = mrKpiResult.mergeRequests.length;
     } catch (mrKpiErr) {
       console.error('[ai-impact] MR KPI data refresh failed:', mrKpiErr.message);
@@ -406,7 +406,7 @@ module.exports = function registerRoutes(router, context) {
       } catch (mrErr) {
         console.error('[ai-impact] MR status enrichment failed:', mrErr.message);
       }
-      writeToStorage('ai-impact/doc-data.json', {
+      await writeToStorage('ai-impact/doc-data.json', {
         fetchedAt: new Date().toISOString(),
         issues: docResult.issues,
         labelEvents: docResult.labelEvents,
@@ -470,10 +470,10 @@ module.exports = function registerRoutes(router, context) {
 
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const rfeData = readFromStorage('ai-impact/rfe-data.json');
-      const autofixData = readFromStorage('ai-impact/autofix-data.json');
-      const docData = readFromStorage('ai-impact/doc-data.json');
-      const coData = readFromStorage('ai-impact/component-onboarding-data.json');
+      const rfeData = await readFromStorage('ai-impact/rfe-data.json');
+      const autofixData = await readFromStorage('ai-impact/autofix-data.json');
+      const docData = await readFromStorage('ai-impact/doc-data.json');
+      const coData = await readFromStorage('ai-impact/component-onboarding-data.json');
       return {
         refreshState,
         rfe: {

--- a/modules/ai-impact/server/test-plans/jira-sync.js
+++ b/modules/ai-impact/server/test-plans/jira-sync.js
@@ -31,11 +31,11 @@ function releaseLock() {
  * @param {Function} readFromStorage
  * @returns {Promise<{synced: number, updated: number, statusChanged: number, notFound: number, errors: string[]}>}
  */
-async function syncTestPlansFromJira(readFromStorage, writeToStorageAtomic) {
-  const data = readTestPlans(readFromStorage);
+async function syncTestPlansFromJira(readFromStorage, writeToStorage) {
+  const data = await readTestPlans(readFromStorage);
   const result = await syncTestPlanData(data);
   data.lastJiraSyncAt = new Date().toISOString();
-  writeTestPlansAtomic(writeToStorageAtomic, data);
+  await writeTestPlansAtomic(writeToStorage, data);
   return result;
 }
 

--- a/modules/ai-impact/server/test-plans/routes.js
+++ b/modules/ai-impact/server/test-plans/routes.js
@@ -26,7 +26,7 @@ const syncState = {
  * Run the Jira sync in the background. Updates syncState.
  * @param {Function} readFromStorage
  */
-async function runSync(readFromStorage, writeToStorageAtomic) {
+async function runSync(readFromStorage, writeToStorage) {
   if (syncState.running) return;
   if (!acquireLock()) {
     console.warn('[ai-impact] Test plan sync skipped: write lock held');
@@ -37,7 +37,7 @@ async function runSync(readFromStorage, writeToStorageAtomic) {
   syncState.startedAt = new Date().toISOString();
 
   try {
-    const result = await syncTestPlansFromJira(readFromStorage, writeToStorageAtomic);
+    const result = await syncTestPlansFromJira(readFromStorage, writeToStorage);
     syncState.lastResult = {
       status: result.errors.length > 0 ? 'partial' : 'success',
       message: `Synced ${result.synced} test plans: ${result.updated} updated (${result.statusChanged} review status changes), ${result.notFound} not found in Jira`,
@@ -59,7 +59,7 @@ async function runSync(readFromStorage, writeToStorageAtomic) {
 
 module.exports = function registerTestPlanRoutes(router, context) {
   const { storage, requireAdmin, requireScope } = context;
-  const { readFromStorage, writeToStorageAtomic } = storage;
+  const { readFromStorage, writeToStorage } = storage;
 
   // ─── 1. Static routes FIRST ───
 
@@ -74,8 +74,8 @@ module.exports = function registerTestPlanRoutes(router, context) {
    *       200:
    *         description: Test plan data status
    */
-  router.get('/test-plans/status', requireAdmin, requireScope('ai-impact:read'), function(req, res) {
-    const data = readTestPlans(readFromStorage);
+  router.get('/test-plans/status', requireAdmin, requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readTestPlans(readFromStorage);
     res.json({
       lastSyncedAt: data.lastSyncedAt,
       lastJiraSyncAt: data.lastJiraSyncAt || null,
@@ -118,7 +118,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     }
 
     res.json({ status: 'started' });
-    runSync(readFromStorage, writeToStorageAtomic);
+    runSync(readFromStorage, writeToStorage);
   });
 
   /**
@@ -141,7 +141,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
    *       200:
    *         description: Bulk upsert results
    */
-  router.post('/test-plans/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
+  router.post('/test-plans/bulk', requireAdmin, requireScope('ai-impact:write'), jsonLimit, async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Test plan ingest disabled in demo mode' });
     }
@@ -154,7 +154,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
       return res.status(400).json({ error: `Bulk payload exceeds maximum of ${BULK_CAP} entries` });
     }
 
-    const data = readTestPlans(readFromStorage);
+    const data = await readTestPlans(readFromStorage);
     const counts = { created: 0, updated: 0, unchanged: 0 };
     const errors = [];
 
@@ -178,7 +178,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     if (counts.created > 0 || counts.updated > 0) {
       data.lastSyncedAt = new Date().toISOString();
       data.totalTestPlans = Object.keys(data.testPlans).length;
-      writeTestPlansAtomic(writeToStorageAtomic, data);
+      await writeTestPlansAtomic(writeToStorage, data);
     }
 
     res.json({
@@ -193,7 +193,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
     if (counts.created > 0 || counts.updated > 0) {
       setTimeout(() => {
         console.log('[ai-impact] Triggering post-ingest test plan Jira sync');
-        runSync(readFromStorage, writeToStorageAtomic);
+        runSync(readFromStorage, writeToStorage);
       }, 10000);
     }
   });
@@ -209,12 +209,12 @@ module.exports = function registerTestPlanRoutes(router, context) {
    *       200:
    *         description: Test plan data cleared
    */
-  router.delete('/test-plans', requireAdmin, requireScope('ai-impact:write'), function(req, res) {
+  router.delete('/test-plans', requireAdmin, requireScope('ai-impact:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Test plan ingest disabled in demo mode' });
     }
 
-    writeTestPlansAtomic(writeToStorageAtomic, { lastSyncedAt: null, totalTestPlans: 0, testPlans: {} });
+    await writeTestPlansAtomic(writeToStorage, { lastSyncedAt: null, totalTestPlans: 0, testPlans: {} });
     res.json({ status: 'cleared' });
   });
 
@@ -228,8 +228,8 @@ module.exports = function registerTestPlanRoutes(router, context) {
    *       200:
    *         description: All test plans with latest scores
    */
-  router.get('/test-plans', requireScope('ai-impact:read'), function(req, res) {
-    const data = readTestPlans(readFromStorage);
+  router.get('/test-plans', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readTestPlans(readFromStorage);
     res.json(getLatestProjection(data));
   });
 
@@ -253,8 +253,8 @@ module.exports = function registerTestPlanRoutes(router, context) {
    *       404:
    *         description: Not found
    */
-  router.get('/test-plans/:key', requireScope('ai-impact:read'), function(req, res) {
-    const data = readTestPlans(readFromStorage);
+  router.get('/test-plans/:key', requireScope('ai-impact:read'), async function(req, res) {
+    const data = await readTestPlans(readFromStorage);
     const entry = data.testPlans[req.params.key];
     if (!entry) {
       return res.status(404).json({ error: 'Not found' });
@@ -290,7 +290,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
    *       400:
    *         description: Validation errors
    */
-  router.put('/test-plans/:key', requireAdmin, requireScope('ai-impact:write'), jsonLimit, function(req, res) {
+  router.put('/test-plans/:key', requireAdmin, requireScope('ai-impact:write'), jsonLimit, async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Test plan ingest disabled in demo mode' });
     }
@@ -300,13 +300,13 @@ module.exports = function registerTestPlanRoutes(router, context) {
       return res.status(400).json({ errors: result.errors });
     }
 
-    const data = readTestPlans(readFromStorage);
+    const data = await readTestPlans(readFromStorage);
     const status = upsertTestPlan(data, req.params.key, result.data);
 
     data.lastSyncedAt = new Date().toISOString();
     data.totalTestPlans = Object.keys(data.testPlans).length;
 
-    writeTestPlansAtomic(writeToStorageAtomic, data);
+    await writeTestPlansAtomic(writeToStorage, data);
     res.json({ status });
   });
 
@@ -317,7 +317,7 @@ module.exports = function registerTestPlanRoutes(router, context) {
       description: 'Syncs test plan data from Jira, updating local test plan records.',
       handler: async function() {
         if (DEMO_MODE) return;
-        await runSync(readFromStorage, writeToStorageAtomic);
+        await runSync(readFromStorage, writeToStorage);
       }
     });
   }

--- a/modules/ai-impact/server/test-plans/storage.js
+++ b/modules/ai-impact/server/test-plans/storage.js
@@ -1,16 +1,16 @@
 const STORAGE_KEY = 'ai-impact/test-plans.json';
 const MAX_HISTORY = 20;
 
-function readTestPlans(readFromStorage) {
-  const data = readFromStorage(STORAGE_KEY);
+async function readTestPlans(readFromStorage) {
+  const data = await readFromStorage(STORAGE_KEY);
   if (!data || typeof data !== 'object' || !data.testPlans) {
     return { lastSyncedAt: null, lastJiraSyncAt: null, totalTestPlans: 0, testPlans: {} };
   }
   return data;
 }
 
-function writeTestPlansAtomic(writeToStorageAtomic, data) {
-  writeToStorageAtomic(STORAGE_KEY, data);
+async function writeTestPlansAtomic(writeToStorage, data) {
+  await writeToStorage(STORAGE_KEY, data);
 }
 
 function trimForHistory(testPlan) {

--- a/modules/customer-insights/server/index.js
+++ b/modules/customer-insights/server/index.js
@@ -27,8 +27,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Current spreadsheet configuration
    */
-  router.get('/sheet-config', requireAdmin, function(req, res) {
-    res.json(getSheetConfig(readFromStorage))
+  router.get('/sheet-config', requireAdmin, async function(req, res) {
+    res.json(await getSheetConfig(readFromStorage))
   })
 
   /**
@@ -43,9 +43,9 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Validation error
    */
-  router.post('/sheet-config', requireAdmin, function(req, res) {
+  router.post('/sheet-config', requireAdmin, async function(req, res) {
     try {
-      saveSheetConfig(writeToStorage, req.body)
+      await saveSheetConfig(writeToStorage, req.body)
       res.json({ status: 'saved' })
     } catch (err) {
       res.status(400).json({ error: err.message })

--- a/modules/customer-insights/server/routes/analytics.js
+++ b/modules/customer-insights/server/routes/analytics.js
@@ -12,11 +12,11 @@ module.exports = function registerAnalyticsRoutes(router, context) {
 
   // Lazy initialization of service account storage
   let sheetsStorage = null
-  function getStorage() {
+  async function getStorage() {
     if (isDemoMode) return null
     if (!sheetsStorage) {
       try {
-        sheetsStorage = createStorage(context)
+        sheetsStorage = await createStorage(context)
       } catch {
         return null
       }
@@ -44,7 +44,7 @@ module.exports = function registerAnalyticsRoutes(router, context) {
     try {
       if (isDemoMode) {
         // Return demo fixtures
-        const analytics = readFromStorage('customer-insights/analytics.json')
+        const analytics = await readFromStorage('customer-insights/analytics.json')
         if (!analytics) {
           return res.status(404).json({ error: 'Analytics fixtures not found' })
         }
@@ -52,7 +52,7 @@ module.exports = function registerAnalyticsRoutes(router, context) {
       }
 
       // Get interactions using service account storage
-      const store = getStorage()
+      const store = await getStorage()
       if (!store) {
         return res.json({})
       }

--- a/modules/customer-insights/server/routes/insights.js
+++ b/modules/customer-insights/server/routes/insights.js
@@ -13,11 +13,11 @@ module.exports = function registerInsightsRoutes(router, context) {
 
   // Lazy initialization of service account storage
   let sheetsStorage = null
-  function getStorage() {
+  async function getStorage() {
     if (isDemoMode) return null
     if (!sheetsStorage) {
       try {
-        sheetsStorage = createStorage(context)
+        sheetsStorage = await createStorage(context)
       } catch {
         return null
       }
@@ -45,7 +45,7 @@ module.exports = function registerInsightsRoutes(router, context) {
     try {
       if (isDemoMode) {
         // Return demo fixtures
-        const insights = readFromStorage('customer-insights/insights.json')
+        const insights = await readFromStorage('customer-insights/insights.json')
         if (!insights) {
           return res.status(404).json({ error: 'Insights fixtures not found' })
         }
@@ -53,7 +53,7 @@ module.exports = function registerInsightsRoutes(router, context) {
       }
 
       // Check if insights have been generated
-      const insights = readFromStorage('customer-insights/insights.json')
+      const insights = await readFromStorage('customer-insights/insights.json')
       if (!insights) {
         return res.json({
           message: 'No insights generated yet. Click "Generate Insights" to analyze customer interactions.',
@@ -92,7 +92,7 @@ module.exports = function registerInsightsRoutes(router, context) {
     try {
       if (isDemoMode) {
         // In demo mode, return a simple history array
-        const latest = readFromStorage('customer-insights/insights.json')
+        const latest = await readFromStorage('customer-insights/insights.json')
         if (!latest) {
           return res.json([])
         }
@@ -106,7 +106,7 @@ module.exports = function registerInsightsRoutes(router, context) {
       }
 
       // For now, just return the latest insights as a single history item
-      const latest = readFromStorage('customer-insights/insights.json')
+      const latest = await readFromStorage('customer-insights/insights.json')
       if (!latest) {
         return res.json([])
       }
@@ -153,10 +153,10 @@ module.exports = function registerInsightsRoutes(router, context) {
 
       if (isDemoMode) {
         // Load from fixtures in demo mode
-        interactions = readFromStorage('customer-insights/interactions.json') || []
+        interactions = await readFromStorage('customer-insights/interactions.json') || []
       } else {
         // Fetch from service account storage
-        const store = getStorage()
+        const store = await getStorage()
         if (store) {
           interactions = await store.getAll(component ? { component } : {})
         }
@@ -222,7 +222,7 @@ JSON:`
       }
 
       // Save insights
-      writeToStorage('customer-insights/insights.json', insights)
+      await writeToStorage('customer-insights/insights.json', insights)
 
       res.json(insights)
     } catch (error) {

--- a/modules/customer-insights/server/routes/interactions.js
+++ b/modules/customer-insights/server/routes/interactions.js
@@ -13,11 +13,11 @@ module.exports = function registerInteractionsRoutes(router, context) {
 
   // Lazy initialization of service account storage
   let sheetsStorage = null
-  function getStorage() {
+  async function getStorage() {
     if (isDemoMode) return null
     if (!sheetsStorage) {
       try {
-        sheetsStorage = createStorage(context)
+        sheetsStorage = await createStorage(context)
       } catch {
         return null
       }
@@ -58,7 +58,7 @@ module.exports = function registerInteractionsRoutes(router, context) {
     try {
       if (isDemoMode) {
         // Return demo fixtures (readFromStorage already returns parsed JSON)
-        let data = readFromStorage('customer-insights/interactions.json') || []
+        let data = await readFromStorage('customer-insights/interactions.json') || []
 
         // Apply filters
         const { component, status, geo, industryVertical } = req.query
@@ -79,7 +79,7 @@ module.exports = function registerInteractionsRoutes(router, context) {
       }
 
       // Use service account storage
-      const store = getStorage()
+      const store = await getStorage()
       if (!store) {
         return res.json([])
       }
@@ -113,7 +113,7 @@ module.exports = function registerInteractionsRoutes(router, context) {
         return res.status(400).json({ error: 'Cannot create interactions in demo mode' })
       }
 
-      const store = getStorage()
+      const store = await getStorage()
       if (!store) {
         return res.status(503).json({ error: 'Google Spreadsheet not configured' })
       }
@@ -153,7 +153,7 @@ module.exports = function registerInteractionsRoutes(router, context) {
         return res.status(400).json({ error: 'Cannot update interactions in demo mode' })
       }
 
-      const store = getStorage()
+      const store = await getStorage()
       if (!store) {
         return res.status(503).json({ error: 'Google Spreadsheet not configured' })
       }
@@ -192,7 +192,7 @@ module.exports = function registerInteractionsRoutes(router, context) {
         return res.status(400).json({ error: 'Cannot delete interactions in demo mode' })
       }
 
-      const store = getStorage()
+      const store = await getStorage()
       if (!store) {
         return res.status(503).json({ error: 'Google Spreadsheet not configured' })
       }
@@ -244,7 +244,7 @@ module.exports = function registerInteractionsRoutes(router, context) {
         return res.status(400).json({ error: 'interactions must be an array' })
       }
 
-      const store = getStorage()
+      const store = await getStorage()
       if (!store) {
         return res.status(503).json({ error: 'Google Spreadsheet not configured' })
       }

--- a/modules/customer-insights/server/routes/roadmap.js
+++ b/modules/customer-insights/server/routes/roadmap.js
@@ -14,11 +14,11 @@ module.exports = function registerRoadmapRoutes(router, context) {
 
   // Lazy initialization of service account storage
   let sheetsStorage = null
-  function getStorage() {
+  async function getStorage() {
     if (isDemoMode) return null
     if (!sheetsStorage) {
       try {
-        sheetsStorage = createStorage(context)
+        sheetsStorage = await createStorage(context)
       } catch {
         return null
       }
@@ -70,7 +70,7 @@ module.exports = function registerRoadmapRoutes(router, context) {
 
       if (isDemoMode) {
         // Return demo fixtures
-        let roadmap = readFromStorage('customer-insights/roadmap.json')
+        let roadmap = await readFromStorage('customer-insights/roadmap.json')
         if (!roadmap) {
           return res.status(404).json({ error: 'Roadmap fixtures not found' })
         }
@@ -92,7 +92,7 @@ module.exports = function registerRoadmapRoutes(router, context) {
       }
 
       // Check if roadmap has been generated
-      const roadmap = readFromStorage('customer-insights/roadmap.json')
+      const roadmap = await readFromStorage('customer-insights/roadmap.json')
       if (!roadmap) {
         // Return empty structure
         return res.json({
@@ -153,7 +153,7 @@ module.exports = function registerRoadmapRoutes(router, context) {
       let interactions = []
 
       if (!isDemoMode) {
-        const store = getStorage()
+        const store = await getStorage()
         if (store) {
           interactions = await store.getAll(component ? { component } : {})
         }
@@ -239,7 +239,7 @@ JSON:`
         component: component || 'all'
       }
 
-      writeToStorage('customer-insights/roadmap.json', roadmap)
+      await writeToStorage('customer-insights/roadmap.json', roadmap)
 
       res.json(roadmap)
     } catch (error) {
@@ -280,7 +280,7 @@ JSON:`
       const { actionId } = req.body
 
       // Load current roadmap
-      const roadmap = readFromStorage('customer-insights/roadmap.json')
+      const roadmap = await readFromStorage('customer-insights/roadmap.json')
       if (!roadmap?.aiRecommendations?.quickActions) {
         return res.status(404).json({ error: 'No recommendations found' })
       }
@@ -324,7 +324,7 @@ JSON:`
 
         // Remove this action from recommendations
         roadmap.aiRecommendations.quickActions = roadmap.aiRecommendations.quickActions.filter(a => a.id !== actionId)
-        writeToStorage('customer-insights/roadmap.json', roadmap)
+        await writeToStorage('customer-insights/roadmap.json', roadmap)
 
         res.json({ success: true, message: `Updated ${action.rfeKey}` })
       } else {
@@ -360,7 +360,7 @@ JSON:`
       const { suggestionId } = req.body
 
       // Load current roadmap
-      const roadmap = readFromStorage('customer-insights/roadmap.json')
+      const roadmap = await readFromStorage('customer-insights/roadmap.json')
       if (!roadmap?.aiRecommendations?.suggestedRFEs) {
         return res.status(404).json({ error: 'No suggestions found' })
       }

--- a/modules/customer-insights/server/services/googleSheetsStorage.js
+++ b/modules/customer-insights/server/services/googleSheetsStorage.js
@@ -93,8 +93,8 @@ async function getAllFromSheet(sheets, spreadsheetId) {
  * @param {object} context - Module context from route handler
  * @returns {object} Storage instance with CRUD methods
  */
-function createStorage(context) {
-  const configSheetId = getConfig(context.storage.readFromStorage).sheetId
+async function createStorage(context) {
+  const configSheetId = (await getConfig(context.storage.readFromStorage)).sheetId
   const spreadsheetId = configSheetId || context.secrets.GOOGLE_SPREADSHEET_ID
   if (!spreadsheetId) {
     throw new Error('Google Spreadsheet ID not configured — set it in Settings or via GOOGLE_SPREADSHEET_ID secret')

--- a/modules/customer-insights/server/services/userTokenStore.js
+++ b/modules/customer-insights/server/services/userTokenStore.js
@@ -23,7 +23,7 @@ function createUserTokenStore(storageBackend) {
    * @returns {Promise<object|null>}
    */
   async function getTokens(userEmail) {
-    const allTokens = readFromStorage(TOKEN_KEY) || {}
+    const allTokens = await readFromStorage(TOKEN_KEY) || {}
     return allTokens[userEmail] || null
   }
 
@@ -33,14 +33,14 @@ function createUserTokenStore(storageBackend) {
    * @param {object} tokens
    */
   async function saveTokens(userEmail, tokens) {
-    const allTokens = readFromStorage(TOKEN_KEY) || {}
+    const allTokens = await readFromStorage(TOKEN_KEY) || {}
 
     allTokens[userEmail] = {
       ...tokens,
       updatedAt: new Date().toISOString()
     }
 
-    writeToStorage(TOKEN_KEY, allTokens)
+    await writeToStorage(TOKEN_KEY, allTokens)
   }
 
   /**
@@ -48,9 +48,9 @@ function createUserTokenStore(storageBackend) {
    * @param {string} userEmail
    */
   async function deleteTokens(userEmail) {
-    const allTokens = readFromStorage(TOKEN_KEY) || {}
+    const allTokens = await readFromStorage(TOKEN_KEY) || {}
     delete allTokens[userEmail]
-    writeToStorage(TOKEN_KEY, allTokens)
+    await writeToStorage(TOKEN_KEY, allTokens)
   }
 
   return {

--- a/modules/customer-insights/server/sheet-config.js
+++ b/modules/customer-insights/server/sheet-config.js
@@ -4,12 +4,12 @@ const DEFAULT_CONFIG = {
   sheetId: ''
 };
 
-function getConfig(readFromStorage) {
-  const saved = readFromStorage(CONFIG_KEY);
+async function getConfig(readFromStorage) {
+  const saved = await readFromStorage(CONFIG_KEY);
   return { ...DEFAULT_CONFIG, ...saved };
 }
 
-function saveConfig(writeToStorage, config) {
+async function saveConfig(writeToStorage, config) {
   const merged = { ...DEFAULT_CONFIG };
 
   if (config.sheetId !== undefined) {
@@ -19,7 +19,7 @@ function saveConfig(writeToStorage, config) {
     merged.sheetId = config.sheetId.trim();
   }
 
-  writeToStorage(CONFIG_KEY, merged);
+  await writeToStorage(CONFIG_KEY, merged);
 }
 
 module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, CONFIG_KEY };

--- a/modules/okr-hub/server/export.js
+++ b/modules/okr-hub/server/export.js
@@ -1,5 +1,5 @@
 module.exports = async function okrHubExport(addFile, storage) {
-  var cveSla = storage.readFromStorage('okr-hub/cve-sla-data.json')
+  var cveSla = await storage.readFromStorage('okr-hub/cve-sla-data.json')
   if (cveSla) {
     addFile('okr-hub/cve-sla-data.json', {
       year: cveSla.year || 2026,
@@ -8,7 +8,7 @@ module.exports = async function okrHubExport(addFile, storage) {
     })
   }
 
-  var supportCases = storage.readFromStorage('okr-hub/support-case-data.json')
+  var supportCases = await storage.readFromStorage('okr-hub/support-case-data.json')
   if (supportCases) {
     addFile('okr-hub/support-case-data.json', {
       year: supportCases.year || 2026,
@@ -17,7 +17,7 @@ module.exports = async function okrHubExport(addFile, storage) {
     })
   }
 
-  var overrides = storage.readFromStorage('okr-hub/on-time-overrides.json')
+  var overrides = await storage.readFromStorage('okr-hub/on-time-overrides.json')
   if (overrides) {
     addFile('okr-hub/on-time-overrides.json', {
       releases: (overrides.releases || []).map(function(r) {
@@ -26,7 +26,7 @@ module.exports = async function okrHubExport(addFile, storage) {
     })
   }
 
-  var trackingConfig = storage.readFromStorage('okr-hub/90day-tracking-config.json')
+  var trackingConfig = await storage.readFromStorage('okr-hub/90day-tracking-config.json')
   if (trackingConfig) {
     addFile('okr-hub/90day-tracking-config.json', {
       releases: (trackingConfig.releases || []).map(function(r) {
@@ -40,7 +40,7 @@ module.exports = async function okrHubExport(addFile, storage) {
     })
   }
 
-  var featureConfig = storage.readFromStorage('okr-hub/feature-delivery-config.json')
+  var featureConfig = await storage.readFromStorage('okr-hub/feature-delivery-config.json')
   if (featureConfig) {
     addFile('okr-hub/feature-delivery-config.json', {
       releases: (featureConfig.releases || []).map(function(r) {

--- a/modules/okr-hub/server/index.js
+++ b/modules/okr-hub/server/index.js
@@ -69,7 +69,7 @@ module.exports = function registerRoutes(router, context) {
     try {
       var since = req.query.since || '2026-04-01'
 
-      var overrides = storage.readFromStorage('okr-hub/on-time-overrides.json')
+      var overrides = await storage.readFromStorage('okr-hub/on-time-overrides.json')
       var overrideMap = {}
       var removedIds = {}
       var customReleases = []
@@ -82,7 +82,7 @@ module.exports = function registerRoutes(router, context) {
         }
       }
 
-      var registry = storage.readFromStorage('releases/registry.json')
+      var registry = await storage.readFromStorage('releases/registry.json')
       var registryReleases = (registry && Array.isArray(registry.releases)) ? registry.releases : []
 
       var candidates = []
@@ -222,8 +222,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Override entries
    */
-  router.get('/reports/on-time-releases/overrides', requireScope('okr-hub:read'), function(req, res) {
-    var saved = storage.readFromStorage('okr-hub/on-time-overrides.json')
+  router.get('/reports/on-time-releases/overrides', requireScope('okr-hub:read'), async function(req, res) {
+    var saved = await storage.readFromStorage('okr-hub/on-time-overrides.json')
     res.json(saved || { releases: [] })
   })
 
@@ -242,13 +242,13 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Saved
    */
-  router.put('/reports/on-time-releases/overrides', requireScope('okr-hub:write'), function(req, res) {
+  router.put('/reports/on-time-releases/overrides', requireScope('okr-hub:write'), async function(req, res) {
     try {
       var body = req.body
       if (!body || !Array.isArray(body.releases)) {
         return res.status(400).json({ error: 'Invalid payload: requires releases array' })
       }
-      storage.writeToStorage('okr-hub/on-time-overrides.json', body)
+      await storage.writeToStorage('okr-hub/on-time-overrides.json', body)
       res.json({ ok: true })
     } catch (err) {
       console.error('[okr-hub] on-time-overrides save error:', err)
@@ -295,8 +295,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: CVE SLA dataset
    */
-  router.get('/reports/cve-sla', requireScope('okr-hub:read'), function(req, res) {
-    var saved = storage.readFromStorage('okr-hub/cve-sla-data.json')
+  router.get('/reports/cve-sla', requireScope('okr-hub:read'), async function(req, res) {
+    var saved = await storage.readFromStorage('okr-hub/cve-sla-data.json')
     if (saved && saved.products && saved.months) {
       return res.json(saved)
     }
@@ -318,13 +318,13 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Saved successfully
    */
-  router.put('/reports/cve-sla', requireScope('okr-hub:write'), function(req, res) {
+  router.put('/reports/cve-sla', requireScope('okr-hub:write'), async function(req, res) {
     try {
       var body = req.body
       if (!body || !Array.isArray(body.products) || !body.months) {
         return res.status(400).json({ error: 'Invalid payload: requires products array and months object' })
       }
-      storage.writeToStorage('okr-hub/cve-sla-data.json', body)
+      await storage.writeToStorage('okr-hub/cve-sla-data.json', body)
       res.json({ ok: true })
     } catch (err) {
       console.error('[okr-hub] cve-sla save error:', err)
@@ -609,8 +609,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Support case data by quarter and product
    */
-  router.get('/reports/support-cases', requireScope('okr-hub:read'), function(req, res) {
-    var saved = storage.readFromStorage('okr-hub/support-case-data.json')
+  router.get('/reports/support-cases', requireScope('okr-hub:read'), async function(req, res) {
+    var saved = await storage.readFromStorage('okr-hub/support-case-data.json')
     if (saved && saved.products && saved.quarters) {
       return res.json(saved)
     }
@@ -632,13 +632,13 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Saved
    */
-  router.put('/reports/support-cases', requireScope('okr-hub:write'), function(req, res) {
+  router.put('/reports/support-cases', requireScope('okr-hub:write'), async function(req, res) {
     try {
       var body = req.body
       if (!body || !Array.isArray(body.products) || !body.quarters) {
         return res.status(400).json({ error: 'Invalid payload: requires products array and quarters object' })
       }
-      storage.writeToStorage('okr-hub/support-case-data.json', body)
+      await storage.writeToStorage('okr-hub/support-case-data.json', body)
       res.json({ ok: true })
     } catch (err) {
       console.error('[okr-hub] support-cases save error:', err)
@@ -656,8 +656,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Version configuration per release family
    */
-  router.get('/reports/90day-tracking-config', requireScope('okr-hub:read'), function(req, res) {
-    var saved = storage.readFromStorage('okr-hub/90day-tracking-config.json')
+  router.get('/reports/90day-tracking-config', requireScope('okr-hub:read'), async function(req, res) {
+    var saved = await storage.readFromStorage('okr-hub/90day-tracking-config.json')
     if (saved && Array.isArray(saved.releases)) {
       return res.json(saved)
     }
@@ -679,13 +679,13 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Saved
    */
-  router.put('/reports/90day-tracking-config', requireScope('okr-hub:write'), function(req, res) {
+  router.put('/reports/90day-tracking-config', requireScope('okr-hub:write'), async function(req, res) {
     try {
       var body = req.body
       if (!body || !Array.isArray(body.releases)) {
         return res.status(400).json({ error: 'Invalid payload: requires releases array' })
       }
-      storage.writeToStorage('okr-hub/90day-tracking-config.json', body)
+      await storage.writeToStorage('okr-hub/90day-tracking-config.json', body)
       res.json({ ok: true })
     } catch (err) {
       console.error('[okr-hub] 90day-tracking-config save error:', err)
@@ -703,8 +703,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Release configuration with product versions and dates
    */
-  router.get('/reports/feature-delivery-config', requireScope('okr-hub:read'), function(req, res) {
-    var saved = storage.readFromStorage('okr-hub/feature-delivery-config.json')
+  router.get('/reports/feature-delivery-config', requireScope('okr-hub:read'), async function(req, res) {
+    var saved = await storage.readFromStorage('okr-hub/feature-delivery-config.json')
     if (saved && Array.isArray(saved.releases)) {
       return res.json(saved)
     }
@@ -726,13 +726,13 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Saved
    */
-  router.put('/reports/feature-delivery-config', requireScope('okr-hub:write'), function(req, res) {
+  router.put('/reports/feature-delivery-config', requireScope('okr-hub:write'), async function(req, res) {
     try {
       var body = req.body
       if (!body || !Array.isArray(body.releases)) {
         return res.status(400).json({ error: 'Invalid payload: requires releases array' })
       }
-      storage.writeToStorage('okr-hub/feature-delivery-config.json', body)
+      await storage.writeToStorage('okr-hub/feature-delivery-config.json', body)
       featureDeliveryCache = {}
       res.json({ ok: true })
     } catch (err) {
@@ -753,7 +753,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.get('/reports/feature-delivery', requireScope('okr-hub:read'), async function(req, res) {
     try {
-      var config = storage.readFromStorage('okr-hub/feature-delivery-config.json')
+      var config = await storage.readFromStorage('okr-hub/feature-delivery-config.json')
       if (!config || !Array.isArray(config.releases) || config.releases.length === 0) {
         return res.json({ releases: [], summary: { committed: 0, delivered: 0, accuracy: 0 } })
       }

--- a/modules/product-builds/__tests__/server/routes.test.js
+++ b/modules/product-builds/__tests__/server/routes.test.js
@@ -5,13 +5,13 @@ const registerRoutes = require('../../server/index')
 function makeStorage(data = {}) {
   const store = { ...data }
   return {
-    readFromStorage(key) {
+    async readFromStorage(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage(key, value) {
+    async writeToStorage(key, value) {
       store[key] = value
     },
-    listStorageFiles(prefix) {
+    async listStorageFiles(prefix) {
       return Object.keys(store)
         .filter(k => k.startsWith(prefix))
         .map(k => k.slice(prefix.length))
@@ -98,114 +98,114 @@ describe('product-builds routes', () => {
   })
 
   describe('GET /config', () => {
-    it('returns default config when nothing saved', () => {
+    it('returns default config when nothing saved', async () => {
       const handler = router._routes.get['/config'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._json).toEqual({ baseUrl: '' })
     })
 
-    it('returns saved config', () => {
-      storage.writeToStorage('product-builds/config.json', { baseUrl: 'https://api.example.com' })
+    it('returns saved config', async () => {
+      await storage.writeToStorage('product-builds/config.json', { baseUrl: 'https://api.example.com' })
       const handler = router._routes.get['/config'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._json.baseUrl).toBe('https://api.example.com')
     })
 
-    it('falls back to env var', () => {
+    it('falls back to env var', async () => {
       process.env.PRODUCT_BUILDS_API_URL = 'https://env.example.com'
       const handler = router._routes.get['/config'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._json.baseUrl).toBe('https://env.example.com')
     })
   })
 
   describe('POST /config', () => {
-    it('saves valid URL', () => {
+    it('saves valid URL', async () => {
       const handler = router._routes.post['/config'].at(-1)
       const res = makeRes()
-      handler({ body: { baseUrl: 'https://api.example.com' } }, res)
+      await handler({ body: { baseUrl: 'https://api.example.com' } }, res)
       expect(res._json.status).toBe('ok')
       expect(res._json.baseUrl).toBe('https://api.example.com')
     })
 
-    it('rejects non-HTTP URL', () => {
+    it('rejects non-HTTP URL', async () => {
       const handler = router._routes.post['/config'].at(-1)
       const res = makeRes()
-      handler({ body: { baseUrl: 'ftp://bad.example.com' } }, res)
+      await handler({ body: { baseUrl: 'ftp://bad.example.com' } }, res)
       expect(res._status).toBe(400)
     })
 
-    it('accepts empty URL to clear config', () => {
+    it('accepts empty URL to clear config', async () => {
       const handler = router._routes.post['/config'].at(-1)
       const res = makeRes()
-      handler({ body: { baseUrl: '' } }, res)
+      await handler({ body: { baseUrl: '' } }, res)
       expect(res._json.status).toBe('ok')
       expect(res._json.baseUrl).toBe('')
     })
 
-    it('rejects non-string baseUrl', () => {
+    it('rejects non-string baseUrl', async () => {
       const handler = router._routes.post['/config'].at(-1)
       const res = makeRes()
-      handler({ body: { baseUrl: 123 } }, res)
+      await handler({ body: { baseUrl: 123 } }, res)
       expect(res._status).toBe(400)
     })
   })
 
   describe('GET /package-reports', () => {
-    it('returns empty array when no index exists', () => {
+    it('returns empty array when no index exists', async () => {
       const handler = router._routes.get['/package-reports'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._json).toEqual([])
     })
 
-    it('returns index from storage', () => {
+    it('returns index from storage', async () => {
       const index = [{ report_date: '2026-06-07', summary: { open_epics: 10 } }]
-      storage.writeToStorage('product-builds/package-reports/index.json', index)
+      await storage.writeToStorage('product-builds/package-reports/index.json', index)
       const handler = router._routes.get['/package-reports'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._json).toEqual(index)
     })
   })
 
   describe('GET /package-reports/latest', () => {
-    it('returns 404 when no reports exist', () => {
+    it('returns 404 when no reports exist', async () => {
       const handler = router._routes.get['/package-reports/latest'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._status).toBe(404)
     })
 
-    it('returns latest report from storage', () => {
+    it('returns latest report from storage', async () => {
       const index = [{ report_date: '2026-06-07' }]
       const report = { report_date: '2026-06-07', summary: {}, categories: {} }
-      storage.writeToStorage('product-builds/package-reports/index.json', index)
-      storage.writeToStorage('product-builds/package-reports/2026-06-07.json', report)
+      await storage.writeToStorage('product-builds/package-reports/index.json', index)
+      await storage.writeToStorage('product-builds/package-reports/2026-06-07.json', report)
       const handler = router._routes.get['/package-reports/latest'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
       expect(res._json.report_date).toBe('2026-06-07')
     })
   })
 
   describe('GET /package-reports/:date', () => {
-    it('returns 404 for missing report', () => {
+    it('returns 404 for missing report', async () => {
       const handler = router._routes.get['/package-reports/:date'].at(-1)
       const res = makeRes()
-      handler({ params: { date: '2026-01-01' } }, res)
+      await handler({ params: { date: '2026-01-01' } }, res)
       expect(res._status).toBe(404)
     })
 
-    it('returns report for valid date', () => {
+    it('returns report for valid date', async () => {
       const report = { report_date: '2026-06-07', summary: {}, categories: {} }
-      storage.writeToStorage('product-builds/package-reports/2026-06-07.json', report)
+      await storage.writeToStorage('product-builds/package-reports/2026-06-07.json', report)
       const handler = router._routes.get['/package-reports/:date'].at(-1)
       const res = makeRes()
-      handler({ params: { date: '2026-06-07' } }, res)
+      await handler({ params: { date: '2026-06-07' } }, res)
       expect(res._json.report_date).toBe('2026-06-07')
     })
   })

--- a/modules/product-builds/server/export.js
+++ b/modules/product-builds/server/export.js
@@ -1,7 +1,7 @@
 const { getConfig } = require('./index');
 
 module.exports = async function productBuildsExport(addFile, storage) {
-  const config = getConfig(storage.readFromStorage);
+  const config = await getConfig(storage.readFromStorage);
   if (!config || !config.baseUrl) return;
 
   addFile('product-builds/config.json', { baseUrl: 'https://api.example.com' });

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -29,8 +29,8 @@ const DEFAULT_CONFIG = {
   baseUrl: ''
 };
 
-function getConfig(readFromStorage) {
-  const saved = readFromStorage(CONFIG_PATH);
+async function getConfig(readFromStorage) {
+  const saved = await readFromStorage(CONFIG_PATH);
   if (saved && typeof saved === 'object' && !saved._deleted && saved.baseUrl) {
     return { ...DEFAULT_CONFIG, ...saved };
   }
@@ -57,8 +57,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Current configuration including AIPCC Dashboard API base URL
    */
-  router.get('/config', requireAdmin, function(req, res) {
-    res.json(getConfig(readFromStorage));
+  router.get('/config', requireAdmin, async function(req, res) {
+    res.json(await getConfig(readFromStorage));
   });
 
   /**
@@ -83,7 +83,7 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Invalid baseUrl (must be HTTP/HTTPS or empty string)
    */
-  router.post('/config', requireAdmin, function(req, res) {
+  router.post('/config', requireAdmin, async function(req, res) {
     const { baseUrl } = req.body;
     if (typeof baseUrl !== 'string') {
       return res.status(400).json({ error: 'baseUrl must be a string' });
@@ -92,7 +92,7 @@ module.exports = function registerRoutes(router, context) {
     if (trimmed && !/^https?:\/\//i.test(trimmed)) {
       return res.status(400).json({ error: 'baseUrl must be an HTTP or HTTPS URL' });
     }
-    writeToStorage(CONFIG_PATH, { baseUrl: trimmed });
+    await writeToStorage(CONFIG_PATH, { baseUrl: trimmed });
     res.json({ status: 'ok', baseUrl: trimmed });
   });
 
@@ -107,7 +107,7 @@ module.exports = function registerRoutes(router, context) {
    *         description: Health status with latency
    */
   router.get('/health', async function(req, res) {
-    const { baseUrl } = getConfig(readFromStorage);
+    const { baseUrl } = await getConfig(readFromStorage);
     if (!baseUrl) {
       return res.json({ status: 'not_configured' });
     }
@@ -131,8 +131,8 @@ module.exports = function registerRoutes(router, context) {
 
   // --- Helper to get baseUrl for proxy ---
 
-  function upstream(upstreamPath, req, res) {
-    const { baseUrl } = getConfig(readFromStorage);
+  async function upstream(upstreamPath, req, res) {
+    const { baseUrl } = await getConfig(readFromStorage);
     return proxyGet(baseUrl, upstreamPath, req.query, res);
   }
 
@@ -160,8 +160,8 @@ module.exports = function registerRoutes(router, context) {
    *       503:
    *         description: AIPCC Dashboard API not configured
    */
-  router.get('/products/:key', function(req, res) {
-    upstream(`/products/${encodeURIComponent(req.params.key)}`, req, res);
+  router.get('/products/:key', async function(req, res) {
+    await upstream(`/products/${encodeURIComponent(req.params.key)}`, req, res);
   });
 
   /**
@@ -211,8 +211,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of Drop objects (key, name, product_key, product_version, git_branch, environments, release_timings, created_at)
    */
-  router.get('/drops', function(req, res) {
-    upstream('/drops', req, res);
+  router.get('/drops', async function(req, res) {
+    await upstream('/drops', req, res);
   });
 
   /**
@@ -235,8 +235,8 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Drop not found
    */
-  router.get('/drops/:key', function(req, res) {
-    upstream(`/drops/${encodeURIComponent(req.params.key)}`, req, res);
+  router.get('/drops/:key', async function(req, res) {
+    await upstream(`/drops/${encodeURIComponent(req.params.key)}`, req, res);
   });
 
   /**
@@ -259,8 +259,8 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Drop not found
    */
-  router.get('/drops/:key/changelog', function(req, res) {
-    upstream(`/drops/${encodeURIComponent(req.params.key)}/changelog`, req, res);
+  router.get('/drops/:key/changelog', async function(req, res) {
+    await upstream(`/drops/${encodeURIComponent(req.params.key)}/changelog`, req, res);
   });
 
   /**
@@ -283,8 +283,8 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Drop not found
    */
-  router.get('/drops/:key/metrics', function(req, res) {
-    upstream(`/drops/${encodeURIComponent(req.params.key)}/metrics`, req, res);
+  router.get('/drops/:key/metrics', async function(req, res) {
+    await upstream(`/drops/${encodeURIComponent(req.params.key)}/metrics`, req, res);
   });
 
   /**
@@ -305,8 +305,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of series name strings
    */
-  router.get('/series', function(req, res) {
-    upstream('/series', req, res);
+  router.get('/series', async function(req, res) {
+    await upstream('/series', req, res);
   });
 
   /**
@@ -329,8 +329,8 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Too many keys (over 50)
    */
-  router.get('/artifacts/build-sequences', function(req, res) {
-    upstream('/artifacts/build-sequences', req, res);
+  router.get('/artifacts/build-sequences', async function(req, res) {
+    await upstream('/artifacts/build-sequences', req, res);
   });
 
   /**
@@ -344,8 +344,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Object with product_keys (string[]) and variants (string[])
    */
-  router.get('/artifacts/wheels-collections/filters', function(req, res) {
-    upstream('/artifacts/wheels-collections/filters', req, res);
+  router.get('/artifacts/wheels-collections/filters', async function(req, res) {
+    await upstream('/artifacts/wheels-collections/filters', req, res);
   });
 
   /**
@@ -391,8 +391,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of objects with artifact_key, variant, package_version, created_at
    */
-  router.get('/artifacts/wheels/build-history/:packageName', function(req, res) {
-    upstream(`/artifacts/wheels/build-history/${encodeURIComponent(req.params.packageName)}`, req, res);
+  router.get('/artifacts/wheels/build-history/:packageName', async function(req, res) {
+    await upstream(`/artifacts/wheels/build-history/${encodeURIComponent(req.params.packageName)}`, req, res);
   });
 
   /**
@@ -436,8 +436,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of Artifact objects (key, type, variant, archs, environments, commit, created_at, sha_digest, labels, konflux_data, constraints_file, build_sequence_summary)
    */
-  router.get('/artifacts', function(req, res) {
-    upstream('/artifacts', req, res);
+  router.get('/artifacts', async function(req, res) {
+    await upstream('/artifacts', req, res);
   });
 
   /**
@@ -460,8 +460,8 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Artifact not found
    */
-  router.get('/artifacts/:key', function(req, res) {
-    upstream(`/artifacts/${encodeURIComponent(req.params.key)}`, req, res);
+  router.get('/artifacts/:key', async function(req, res) {
+    await upstream(`/artifacts/${encodeURIComponent(req.params.key)}`, req, res);
   });
 
   /**
@@ -484,8 +484,8 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Artifact not found
    */
-  router.get('/artifacts/:key/wheels', function(req, res) {
-    upstream(`/artifacts/${encodeURIComponent(req.params.key)}/wheels`, req, res);
+  router.get('/artifacts/:key/wheels', async function(req, res) {
+    await upstream(`/artifacts/${encodeURIComponent(req.params.key)}/wheels`, req, res);
   });
 
   /**
@@ -510,8 +510,8 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: Artifact not found
    */
-  router.get('/artifacts/:key/containers', function(req, res) {
-    upstream(`/artifacts/${encodeURIComponent(req.params.key)}/containers`, req, res);
+  router.get('/artifacts/:key/containers', async function(req, res) {
+    await upstream(`/artifacts/${encodeURIComponent(req.params.key)}/containers`, req, res);
   });
 
   // --- Package Analysis ---
@@ -527,12 +527,12 @@ module.exports = function registerRoutes(router, context) {
     return _jira;
   }
 
-  function rebuildPackageIndex() {
-    const files = storage.listStorageFiles(PKG_STORAGE_PREFIX + '/');
+  async function rebuildPackageIndex() {
+    const files = await storage.listStorageFiles(PKG_STORAGE_PREFIX + '/');
     const index = [];
     for (const file of files) {
       if (file === 'index.json' || !file.endsWith('.json')) continue;
-      const report = readFromStorage(`${PKG_STORAGE_PREFIX}/${file}`);
+      const report = await readFromStorage(`${PKG_STORAGE_PREFIX}/${file}`);
       if (report && report.summary) {
         index.push({
           report_date: report.report_date,
@@ -547,9 +547,9 @@ module.exports = function registerRoutes(router, context) {
 
   async function generatePackageReport(reportDate) {
     const report = await buildReport(getJira(), { reportDate });
-    writeToStorage(`${PKG_STORAGE_PREFIX}/${report.report_date}.json`, report);
-    const index = rebuildPackageIndex();
-    writeToStorage(PKG_INDEX_PATH, index);
+    await writeToStorage(`${PKG_STORAGE_PREFIX}/${report.report_date}.json`, report);
+    const index = await rebuildPackageIndex();
+    await writeToStorage(PKG_INDEX_PATH, index);
     return report;
   }
 
@@ -563,8 +563,8 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Array of report summaries sorted by date descending
    */
-  router.get('/package-reports', function(req, res) {
-    const index = readFromStorage(PKG_INDEX_PATH);
+  router.get('/package-reports', async function(req, res) {
+    const index = await readFromStorage(PKG_INDEX_PATH);
     res.json(index || []);
   });
 
@@ -580,12 +580,12 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: No reports available
    */
-  router.get('/package-reports/latest', function(req, res) {
-    const index = readFromStorage(PKG_INDEX_PATH);
+  router.get('/package-reports/latest', async function(req, res) {
+    const index = await readFromStorage(PKG_INDEX_PATH);
     if (!index || index.length === 0) {
       return res.status(404).json({ error: 'No reports available' });
     }
-    const latest = readFromStorage(`${PKG_STORAGE_PREFIX}/${index[0].report_date}.json`);
+    const latest = await readFromStorage(`${PKG_STORAGE_PREFIX}/${index[0].report_date}.json`);
     if (!latest) {
       return res.status(404).json({ error: 'Report file not found' });
     }
@@ -642,12 +642,12 @@ module.exports = function registerRoutes(router, context) {
    *       404:
    *         description: No report for the specified date
    */
-  router.get('/package-reports/:date', function(req, res) {
+  router.get('/package-reports/:date', async function(req, res) {
     const date = req.params.date;
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
       return res.status(400).json({ error: 'Invalid date format, expected YYYY-MM-DD' });
     }
-    const report = readFromStorage(`${PKG_STORAGE_PREFIX}/${date}.json`);
+    const report = await readFromStorage(`${PKG_STORAGE_PREFIX}/${date}.json`);
     if (!report) {
       return res.status(404).json({ error: `No report for ${date}` });
     }
@@ -689,7 +689,7 @@ module.exports = function registerRoutes(router, context) {
           return new RefreshSkip('Before 6am UTC');
         }
         const today = now.toISOString().slice(0, 10);
-        const existing = readFromStorage(`${PKG_STORAGE_PREFIX}/${today}.json`);
+        const existing = await readFromStorage(`${PKG_STORAGE_PREFIX}/${today}.json`);
         if (existing) {
           return new RefreshSkip('Report already exists for ' + today);
         }
@@ -927,7 +927,7 @@ module.exports = function registerRoutes(router, context) {
 
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const index = readFromStorage(PKG_INDEX_PATH);
+      const index = await readFromStorage(PKG_INDEX_PATH);
       const hasReports = index && index.length > 0;
       return {
         status: hasReports ? 'ok' : 'no_data',

--- a/modules/releases/__tests__/server/audit-unified.test.js
+++ b/modules/releases/__tests__/server/audit-unified.test.js
@@ -5,8 +5,8 @@ const { logAudit, getAuditLog } = require('../../server/planning/audit-log')
 function createMockStorage(initial = {}) {
   const store = { ...initial }
   return {
-    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null },
-    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)) },
+    async readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null },
+    async writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)) },
     _store: store
   }
 }
@@ -23,10 +23,10 @@ function makeEntry(overrides = {}) {
 }
 
 describe('logAudit', () => {
-  it('creates entries with correct structure', () => {
+  it('creates entries with correct structure', async () => {
     const { readFromStorage, writeToStorage, _store } = createMockStorage()
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'planning',
       version: '2.0',
       action: 'create',
@@ -49,21 +49,21 @@ describe('logAudit', () => {
     expect(entry.details).toEqual({ key: 'BR-1' })
   })
 
-  it('defaults domain to planning when not specified', () => {
+  it('defaults domain to planning when not specified', async () => {
     const { readFromStorage, writeToStorage, _store } = createMockStorage()
 
-    logAudit(readFromStorage, writeToStorage, makeEntry())
+    await logAudit(readFromStorage, writeToStorage, makeEntry())
 
     const entry = _store[STORAGE_KEY].entries[0]
     expect(entry.domain).toBe('planning')
   })
 
-  it('supports cross-domain logging', () => {
+  it('supports cross-domain logging', async () => {
     const { readFromStorage, writeToStorage, _store } = createMockStorage()
 
     const domains = ['execution', 'delivery', 'registry']
     for (const domain of domains) {
-      logAudit(readFromStorage, writeToStorage, makeEntry({ domain }))
+      await logAudit(readFromStorage, writeToStorage, makeEntry({ domain }))
     }
 
     const entries = _store[STORAGE_KEY].entries
@@ -73,23 +73,23 @@ describe('logAudit', () => {
     expect(entries[2].domain).toBe('registry')
   })
 
-  it('sets version to null when not specified', () => {
+  it('sets version to null when not specified', async () => {
     const { readFromStorage, writeToStorage, _store } = createMockStorage()
 
-    logAudit(readFromStorage, writeToStorage, makeEntry())
+    await logAudit(readFromStorage, writeToStorage, makeEntry())
 
     expect(_store[STORAGE_KEY].entries[0].version).toBeNull()
   })
 
-  it('sets details to null when not provided', () => {
+  it('sets details to null when not provided', async () => {
     const { readFromStorage, writeToStorage, _store } = createMockStorage()
 
-    logAudit(readFromStorage, writeToStorage, makeEntry())
+    await logAudit(readFromStorage, writeToStorage, makeEntry())
 
     expect(_store[STORAGE_KEY].entries[0].details).toBeNull()
   })
 
-  it('truncates entries to MAX_ENTRIES when exceeded', () => {
+  it('truncates entries to MAX_ENTRIES when exceeded', async () => {
     const existing = Array.from({ length: 5000 }, (_, i) => ({
       id: `audit-old-${i}`,
       timestamp: '2026-01-01T00:00:00.000Z',
@@ -105,7 +105,7 @@ describe('logAudit', () => {
       [STORAGE_KEY]: { entries: existing }
     })
 
-    logAudit(readFromStorage, writeToStorage, makeEntry({ summary: 'New entry' }))
+    await logAudit(readFromStorage, writeToStorage, makeEntry({ summary: 'New entry' }))
 
     const log = _store[STORAGE_KEY]
     expect(log.entries).toHaveLength(5000)
@@ -114,10 +114,10 @@ describe('logAudit', () => {
     expect(log.entries[0].id).toBe('audit-old-1')
   })
 
-  it('handles empty/missing storage gracefully', () => {
+  it('handles empty/missing storage gracefully', async () => {
     const { readFromStorage, writeToStorage, _store } = createMockStorage()
 
-    logAudit(readFromStorage, writeToStorage, makeEntry())
+    await logAudit(readFromStorage, writeToStorage, makeEntry())
 
     expect(_store[STORAGE_KEY].entries).toHaveLength(1)
   })
@@ -142,41 +142,41 @@ describe('getAuditLog', () => {
     }
   }
 
-  it('returns all entries when no filters specified', () => {
+  it('returns all entries when no filters specified', async () => {
     const { readFromStorage } = createMockStorage(buildLog([{}, {}, {}]))
 
-    const result = getAuditLog(readFromStorage)
+    const result = await getAuditLog(readFromStorage)
     expect(result.entries).toHaveLength(3)
     expect(result.total).toBe(3)
   })
 
-  it('filters by version', () => {
+  it('filters by version', async () => {
     const { readFromStorage } = createMockStorage(buildLog([
       { version: '2.0' },
       { version: '3.0' },
       { version: '2.0' }
     ]))
 
-    const result = getAuditLog(readFromStorage, { version: '2.0' })
+    const result = await getAuditLog(readFromStorage, { version: '2.0' })
     expect(result.entries).toHaveLength(2)
     expect(result.total).toBe(2)
     expect(result.entries.every(e => e.version === '2.0')).toBe(true)
   })
 
-  it('filters by action', () => {
+  it('filters by action', async () => {
     const { readFromStorage } = createMockStorage(buildLog([
       { action: 'create' },
       { action: 'delete' },
       { action: 'create' }
     ]))
 
-    const result = getAuditLog(readFromStorage, { action: 'delete' })
+    const result = await getAuditLog(readFromStorage, { action: 'delete' })
     expect(result.entries).toHaveLength(1)
     expect(result.total).toBe(1)
     expect(result.entries[0].action).toBe('delete')
   })
 
-  it('filters by domain', () => {
+  it('filters by domain', async () => {
     const { readFromStorage } = createMockStorage(buildLog([
       { domain: 'planning' },
       { domain: 'execution' },
@@ -184,49 +184,49 @@ describe('getAuditLog', () => {
       { domain: 'execution' }
     ]))
 
-    const result = getAuditLog(readFromStorage, { domain: 'execution' })
+    const result = await getAuditLog(readFromStorage, { domain: 'execution' })
     expect(result.entries).toHaveLength(2)
     expect(result.total).toBe(2)
     expect(result.entries.every(e => e.domain === 'execution')).toBe(true)
   })
 
-  it('supports pagination with limit and offset', () => {
+  it('supports pagination with limit and offset', async () => {
     const items = Array.from({ length: 10 }, (_, i) => ({ summary: `Entry ${i}` }))
     const { readFromStorage } = createMockStorage(buildLog(items))
 
-    const result = getAuditLog(readFromStorage, { limit: 3, offset: 2 })
+    const result = await getAuditLog(readFromStorage, { limit: 3, offset: 2 })
     expect(result.entries).toHaveLength(3)
     expect(result.total).toBe(10)
   })
 
-  it('returns entries in reverse chronological order (newest first)', () => {
+  it('returns entries in reverse chronological order (newest first)', async () => {
     const { readFromStorage } = createMockStorage(buildLog([
       { summary: 'First' },
       { summary: 'Second' },
       { summary: 'Third' }
     ]))
 
-    const result = getAuditLog(readFromStorage)
+    const result = await getAuditLog(readFromStorage)
     expect(result.entries[0].summary).toBe('Third')
     expect(result.entries[1].summary).toBe('Second')
     expect(result.entries[2].summary).toBe('First')
   })
 
-  it('returns total count reflecting filters', () => {
+  it('returns total count reflecting filters', async () => {
     const { readFromStorage } = createMockStorage(buildLog([
       { domain: 'planning' },
       { domain: 'execution' },
       { domain: 'planning' }
     ]))
 
-    const result = getAuditLog(readFromStorage, { domain: 'planning' })
+    const result = await getAuditLog(readFromStorage, { domain: 'planning' })
     expect(result.total).toBe(2)
   })
 
-  it('returns empty result for no data', () => {
+  it('returns empty result for no data', async () => {
     const { readFromStorage } = createMockStorage()
 
-    const result = getAuditLog(readFromStorage)
+    const result = await getAuditLog(readFromStorage)
     expect(result.entries).toEqual([])
     expect(result.total).toBe(0)
   })

--- a/modules/releases/__tests__/server/delivery/conforma.test.js
+++ b/modules/releases/__tests__/server/delivery/conforma.test.js
@@ -6,9 +6,9 @@ function makeStorage() {
   const store = {}
   return {
     data: store,
-    readFromStorage: (key) => store[key] || null,
-    writeToStorage: (key, val) => { store[key] = val },
-    deleteFromStorage: (key) => { delete store[key] }
+    readFromStorage: async (key) => store[key] || null,
+    writeToStorage: async (key, val) => { store[key] = val },
+    deleteFromStorage: async (key) => { delete store[key] }
   }
 }
 
@@ -33,11 +33,11 @@ function makeRouter() {
       }
       // Run middleware then handler (skip requireAuth/requireAdmin by calling next)
       let i = 0
-      const next = () => {
+      const next = async () => {
         const fn = fns[i++]
-        if (fn) fn(req, res, next)
+        if (fn) await fn(req, res, next)
       }
-      next()
+      await next()
       return res
     }
   }
@@ -152,7 +152,7 @@ describe('conforma backend routes', () => {
       expect(res._body.count).toBe(1)
       expect(res._body.savedAt).toBeDefined()
 
-      const stored = storage.readFromStorage('releases/delivery/conforma.json')
+      const stored = await storage.readFromStorage('releases/delivery/conforma.json')
       expect(stored.releases).toHaveLength(1)
       expect(stored.releases[0].version).toBe('rhoai-3.4')
     })
@@ -189,7 +189,7 @@ describe('conforma backend routes', () => {
       storage.writeToStorage('releases/delivery/conforma.json', { releases: [SAMPLE_RELEASE] })
       const res = await router._dispatch('DELETE', '/conforma')
       expect(res._status).toBe(204)
-      expect(storage.readFromStorage('releases/delivery/conforma.json')).toBeNull()
+      expect(await storage.readFromStorage('releases/delivery/conforma.json')).toBeNull()
     })
 
     it('returns 204 even when no data exists', async () => {
@@ -223,7 +223,7 @@ describe('conforma backend routes — demo mode', () => {
     const res = await router._dispatch('POST', '/conforma/bulk', req)
     expect(res._status).toBe(200)
     expect(res._body.status).toBe('skipped')
-    expect(storage.readFromStorage('releases/delivery/conforma.json')).toBeNull()
+    expect(await storage.readFromStorage('releases/delivery/conforma.json')).toBeNull()
   })
 
   it('DELETE /conforma returns 400 in demo mode', async () => {

--- a/modules/releases/__tests__/server/draft-plans/fetch.test.js
+++ b/modules/releases/__tests__/server/draft-plans/fetch.test.js
@@ -7,8 +7,8 @@ const mockFetch = vi.fn()
 function makeStorage() {
   const written = {}
   return {
-    writeToStorage(key, data) { written[key] = data },
-    readFromStorage(key) { return written[key] || null },
+    async writeToStorage(key, data) { written[key] = data },
+    async readFromStorage(key) { return written[key] || null },
     _written: written
   }
 }

--- a/modules/releases/__tests__/server/draft-plans/routes.test.js
+++ b/modules/releases/__tests__/server/draft-plans/routes.test.js
@@ -28,8 +28,8 @@ const HEALTH_DATA = {
 function makeStorage(data = {}) {
   const store = { ...data }
   return {
-    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null },
-    writeToStorage(key, value) { store[key] = value },
+    async readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null },
+    async writeToStorage(key, value) { store[key] = value },
     _store: store
   }
 }
@@ -55,14 +55,14 @@ function makeRes() {
 
 function passthrough(req, res, next) { if (next) next(); }
 
-function setupRouter(storageData = {}, secretsOverride = null) {
+async function setupRouter(storageData = {}, secretsOverride = null) {
   const storage = makeStorage(storageData)
   const router = makeRouter()
   const refreshHandlers = {}
   const diagnosticsFn = vi.fn()
 
   const registerDraftPlanRoutes = require('../../../server/draft-plans/routes')
-  registerDraftPlanRoutes(router, {
+  await registerDraftPlanRoutes(router, {
     storage,
     requireAuth: passthrough,
     requireScope: () => passthrough,
@@ -96,7 +96,7 @@ describe('draft-plans routes', () => {
 
   describe('GET /releases', () => {
     it('returns empty products when no data stored', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/releases')
 
       expect(res._json.products).toEqual([])
@@ -104,7 +104,7 @@ describe('draft-plans routes', () => {
     })
 
     it('returns release list with health summary when data is stored', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA,
         [`${DATA_PREFIX}/RHOAI/release-health.json`]: HEALTH_DATA,
         [`${DATA_PREFIX}/last-fetch.json`]: { timestamp: '2026-07-08T12:00:00Z' }
@@ -125,7 +125,7 @@ describe('draft-plans routes', () => {
     })
 
     it('filters by product query param', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA
       })
 
@@ -136,7 +136,7 @@ describe('draft-plans routes', () => {
 
   describe('GET /:version', () => {
     it('returns full version plan data', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA
       })
 
@@ -152,7 +152,7 @@ describe('draft-plans routes', () => {
     })
 
     it('returns 404 for unknown version', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/RHOAI/release-plan.json`]: PLAN_DATA
       })
 
@@ -161,19 +161,19 @@ describe('draft-plans routes', () => {
     })
 
     it('returns 400 for invalid version format', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/:version', { params: { version: '../etc/passwd' } })
       expect(res._status).toBe(400)
     })
 
     it('accepts version names with spaces', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/:version', { params: { version: 'RHOAI 3.5' } })
       expect(res._status).not.toBe(400)
     })
 
     it('returns 404 when no data stored', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/:version', { params: { version: '3.5' } })
       expect(res._status).toBe(404)
     })
@@ -181,7 +181,7 @@ describe('draft-plans routes', () => {
 
   describe('GET /:version/health', () => {
     it('returns health data for a version', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/RHOAI/release-health.json`]: HEALTH_DATA
       })
 
@@ -196,7 +196,7 @@ describe('draft-plans routes', () => {
     })
 
     it('returns 404 for unknown version', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/RHOAI/release-health.json`]: HEALTH_DATA
       })
 
@@ -205,13 +205,13 @@ describe('draft-plans routes', () => {
     })
 
     it('returns 400 for invalid version format', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/:version/health', { params: { version: 'a'.repeat(51) } })
       expect(res._status).toBe(400)
     })
 
     it('accepts version names with spaces', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/:version/health', { params: { version: 'RHOAI 3.5' } })
       expect(res._status).not.toBe(400)
     })
@@ -219,7 +219,7 @@ describe('draft-plans routes', () => {
 
   describe('GET /config', () => {
     it('returns default config with token status', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/config')
 
       expect(res._json.enabled).toBe(false)
@@ -229,7 +229,7 @@ describe('draft-plans routes', () => {
     })
 
     it('reports DRAFT_PLANS_GITLAB_TOKEN as preferred source', async () => {
-      const { router } = setupRouter({}, { DRAFT_PLANS_GITLAB_TOKEN: 'dp-token', GITLAB_TOKEN: 'gl-token' })
+      const { router } = await setupRouter({}, { DRAFT_PLANS_GITLAB_TOKEN: 'dp-token', GITLAB_TOKEN: 'gl-token' })
       const res = await callRoute(router, 'get', '/config')
 
       expect(res._json.tokenConfigured).toBe(true)
@@ -237,7 +237,7 @@ describe('draft-plans routes', () => {
     })
 
     it('reports no token when secrets are empty', async () => {
-      const { router } = setupRouter({}, {})
+      const { router } = await setupRouter({}, {})
       const res = await callRoute(router, 'get', '/config')
 
       expect(res._json.tokenConfigured).toBe(false)
@@ -247,7 +247,7 @@ describe('draft-plans routes', () => {
 
   describe('POST /config', () => {
     it('saves valid config without enabling', async () => {
-      const { router, storage } = setupRouter()
+      const { router, storage } = await setupRouter()
       const res = await callRoute(router, 'post', '/config', {
         body: { projectId: '12345', refreshIntervalHours: 12 }
       })
@@ -265,7 +265,7 @@ describe('draft-plans routes', () => {
         text: () => Promise.resolve(JSON.stringify(PLAN_DATA))
       })
 
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'post', '/config', {
         body: { enabled: true, projectId: '12345' }
       })
@@ -275,7 +275,7 @@ describe('draft-plans routes', () => {
     })
 
     it('rejects invalid projectId', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'post', '/config', {
         body: { projectId: 'not-a-number' }
       })
@@ -285,7 +285,7 @@ describe('draft-plans routes', () => {
     })
 
     it('rejects non-https gitlabBaseUrl', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'post', '/config', {
         body: { gitlabBaseUrl: 'http://gitlab.internal' }
       })
@@ -295,7 +295,7 @@ describe('draft-plans routes', () => {
     })
 
     it('rejects refreshIntervalHours out of range', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'post', '/config', {
         body: { refreshIntervalHours: 0 }
       })
@@ -306,7 +306,7 @@ describe('draft-plans routes', () => {
 
   describe('POST /refresh', () => {
     it('returns 500 when no token configured', async () => {
-      const { router } = setupRouter(
+      const { router } = await setupRouter(
         { [`${DATA_PREFIX}/config.json`]: { ...PLAN_DATA, enabled: true } },
         {}
       )
@@ -317,7 +317,7 @@ describe('draft-plans routes', () => {
     })
 
     it('returns 400 when fetch is disabled', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'post', '/refresh')
 
       expect(res._status).toBe(400)
@@ -331,7 +331,7 @@ describe('draft-plans routes', () => {
         text: () => Promise.resolve(JSON.stringify(PLAN_DATA))
       })
 
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/config.json`]: { enabled: true, projectId: '81798612', branch: 'main', gitlabBaseUrl: 'https://gitlab.com' }
       })
 
@@ -343,7 +343,7 @@ describe('draft-plans routes', () => {
 
   describe('GET /refresh/status', () => {
     it('returns status with no prior fetch', async () => {
-      const { router } = setupRouter()
+      const { router } = await setupRouter()
       const res = await callRoute(router, 'get', '/refresh/status')
 
       expect(res._json.running).toBe(false)
@@ -351,7 +351,7 @@ describe('draft-plans routes', () => {
     })
 
     it('returns last fetch info when available', async () => {
-      const { router } = setupRouter({
+      const { router } = await setupRouter({
         [`${DATA_PREFIX}/last-fetch.json`]: { status: 'success', timestamp: '2026-07-08T12:00:00Z', fileCount: 2 }
       })
 
@@ -362,8 +362,8 @@ describe('draft-plans routes', () => {
   })
 
   describe('registerRefresh', () => {
-    it('registers a draft-plans refresh handler', () => {
-      const { refreshHandlers } = setupRouter()
+    it('registers a draft-plans refresh handler', async () => {
+      const { refreshHandlers } = await setupRouter()
 
       expect(refreshHandlers['draft-plans']).toBeDefined()
       expect(refreshHandlers['draft-plans'].order).toBe(80)
@@ -372,14 +372,14 @@ describe('draft-plans routes', () => {
     })
 
     it('refresh handler skips when disabled', async () => {
-      const { refreshHandlers } = setupRouter()
+      const { refreshHandlers } = await setupRouter()
       const result = await refreshHandlers['draft-plans'].handler()
 
       expect(result.status).toBe('skipped')
     })
 
     it('refresh handler skips when no token', async () => {
-      const { refreshHandlers } = setupRouter(
+      const { refreshHandlers } = await setupRouter(
         { [`${DATA_PREFIX}/config.json`]: { enabled: true, projectId: '81798612' } },
         {}
       )
@@ -391,14 +391,14 @@ describe('draft-plans routes', () => {
   })
 
   describe('registerDiagnostics', () => {
-    it('registers a diagnostics function', () => {
-      const { diagnosticsFn } = setupRouter()
+    it('registers a diagnostics function', async () => {
+      const { diagnosticsFn } = await setupRouter()
       expect(diagnosticsFn).toHaveBeenCalledOnce()
       expect(diagnosticsFn.mock.calls[0][0]).toBeTypeOf('function')
     })
 
     it('diagnostics returns status info', async () => {
-      const { diagnosticsFn } = setupRouter({
+      const { diagnosticsFn } = await setupRouter({
         [`${DATA_PREFIX}/last-fetch.json`]: { status: 'success', timestamp: '2026-07-08T12:00:00Z', fileCount: 2 }
       })
 

--- a/modules/releases/__tests__/server/execution/export.test.js
+++ b/modules/releases/__tests__/server/execution/export.test.js
@@ -18,11 +18,11 @@ const FIXTURE_ROSTER = {
 
 function makeStorage(data = {}) {
   return {
-    readFromStorage(key) {
+    async readFromStorage(key) {
       return data[key] ? JSON.parse(JSON.stringify(data[key])) : null
     },
-    writeToStorage() {},
-    listStorageFiles(dir) {
+    async writeToStorage() {},
+    async listStorageFiles(dir) {
       return Object.keys(data)
         .filter(k => k.startsWith(dir + '/') || k.startsWith(dir))
         .map(k => k.split('/').pop())

--- a/modules/releases/__tests__/server/execution/feature-store.test.js
+++ b/modules/releases/__tests__/server/execution/feature-store.test.js
@@ -9,9 +9,9 @@ const {
 function makeStorage(initialFiles = {}) {
   const files = { ...initialFiles }
   return {
-    readFromStorage(key) { return files[key] || null },
-    writeToStorage(key, data) { files[key] = data },
-    listStorageFiles(dir) {
+    async readFromStorage(key) { return files[key] || null },
+    async writeToStorage(key, data) { files[key] = data },
+    async listStorageFiles(dir) {
       const prefix = dir + '/'
       return Object.keys(files)
         .filter(k => k.startsWith(prefix))

--- a/modules/releases/__tests__/server/execution/feature-tracking.test.js
+++ b/modules/releases/__tests__/server/execution/feature-tracking.test.js
@@ -440,7 +440,7 @@ describe('normalizeVersionName', function () {
 
 // ─── fetchDroppedFeatures — freeze date filtering ─────────────────
 
-describe('fetchDroppedFeatures — freeze date filtering', function () {
+describe('fetchDroppedFeatures — freeze date filtering', function() {
   function makeDroppedRawIssue(key, removedAt) {
     return {
       key: key,

--- a/modules/releases/__tests__/server/execution/gitlab-fetch.test.js
+++ b/modules/releases/__tests__/server/execution/gitlab-fetch.test.js
@@ -16,9 +16,9 @@ function createZipBuffer(files) {
 function makeStorage() {
   const written = {}
   return {
-    writeToStorage(key, data) { written[key] = data },
-    readFromStorage(key) { return written[key] || null },
-    listStorageFiles(dir) {
+    async writeToStorage(key, data) { written[key] = data },
+    async readFromStorage(key) { return written[key] || null },
+    async listStorageFiles(dir) {
       const prefix = dir + '/'
       return Object.keys(written)
         .filter(k => k.startsWith(prefix))

--- a/modules/releases/__tests__/server/execution/jira-sync.test.js
+++ b/modules/releases/__tests__/server/execution/jira-sync.test.js
@@ -9,9 +9,9 @@ const {
 function makeStorage(initialFiles = {}) {
   const files = { ...initialFiles }
   return {
-    readFromStorage(key) { return files[key] || null },
-    writeToStorage(key, data) { files[key] = data },
-    listStorageFiles(dir) {
+    async readFromStorage(key) { return files[key] || null },
+    async writeToStorage(key, data) { files[key] = data },
+    async listStorageFiles(dir) {
       const prefix = dir + '/'
       return Object.keys(files)
         .filter(k => k.startsWith(prefix))

--- a/modules/releases/__tests__/server/execution/routes.test.js
+++ b/modules/releases/__tests__/server/execution/routes.test.js
@@ -8,13 +8,13 @@ const mockFetchArtifacts = vi.fn()
 function makeStorage(data = {}) {
   const store = { ...data }
   return {
-    readFromStorage(key) {
+    async readFromStorage(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage(key, value) {
+    async writeToStorage(key, value) {
       store[key] = value
     },
-    listStorageFiles(prefix) {
+    async listStorageFiles(prefix) {
       return Object.keys(store)
         .filter(k => k.startsWith(prefix + '/'))
         .map(k => k.slice(prefix.length + 1))
@@ -51,7 +51,7 @@ function makeRes() {
 describe('execution routes', () => {
   let router, requireAdmin, context, storage
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     _setFetchFn(mockFetchArtifacts)
 
@@ -66,7 +66,7 @@ describe('execution routes', () => {
       registerDiagnostics: vi.fn(),
       secrets: {}
     }
-    registerExecutionRoutes(router, context)
+    await registerExecutionRoutes(router, context)
   })
 
   describe('route registration', () => {
@@ -101,10 +101,10 @@ describe('execution routes', () => {
   })
 
   describe('GET /status', () => {
-    it('returns expected shape when no data', () => {
+    it('returns expected shape when no data', async () => {
       const handler = router._routes.get['/status'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
 
       expect(res._json).toMatchObject({
         dataAvailable: false,
@@ -117,16 +117,16 @@ describe('execution routes', () => {
       expect(res._json.dataSource).toMatch(/gitlab-ci/)
     })
 
-    it('includes lastFetch when present', () => {
+    it('includes lastFetch when present', async () => {
       const storageWithData = makeStorage({
         'releases/execution/last-fetch.json': { status: 'success', timestamp: '2026-04-08T06:00:00Z' }
       })
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: storageWithData, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
+      await registerExecutionRoutes(r, { storage: storageWithData, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.get['/status'].at(-1)
       const res = makeRes()
-      handler({}, res)
+      await handler({}, res)
 
       expect(res._json.lastFetch).toBeDefined()
       expect(res._json.lastFetch.status).toBe('success')
@@ -143,7 +143,7 @@ describe('execution routes', () => {
         'releases/execution/config.json': { enabled: true }
       })
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: storageWithConfig, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn(), secrets: { GITLAB_TOKEN: 'token' } })
+      await registerExecutionRoutes(r, { storage: storageWithConfig, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn(), secrets: { GITLAB_TOKEN: 'token' } })
 
       const handler = r._routes.post['/refresh'].at(-1)
 
@@ -169,7 +169,7 @@ describe('execution routes', () => {
 
       const storageForConfig = makeStorage()
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: storageForConfig, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
+      await registerExecutionRoutes(r, { storage: storageForConfig, requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const postHandler = r._routes.post['/config'].at(-1)
       const res1 = makeRes()
@@ -189,7 +189,7 @@ describe('execution routes', () => {
       // Load it back
       const getHandler = r._routes.get['/config'].at(-1)
       const res2 = makeRes()
-      getHandler({}, res2)
+      await getHandler({}, res2)
       expect(res2._json.gitlabBaseUrl).toBe('https://custom.gitlab.com')
       expect(res2._json.projectPath).toBe('my/project')
       expect(res2._json.branch).toBe('develop')
@@ -200,7 +200,7 @@ describe('execution routes', () => {
 
     it('rejects http:// in gitlabBaseUrl', async () => {
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
+      await registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
       const res = makeRes()
@@ -216,7 +216,7 @@ describe('execution routes', () => {
 
     it('rejects invalid refreshIntervalHours', async () => {
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
+      await registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
 
@@ -237,7 +237,7 @@ describe('execution routes', () => {
 
     it('rejects non-string fields', async () => {
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
+      await registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
       const res = makeRes()
@@ -250,7 +250,7 @@ describe('execution routes', () => {
 
     it('rejects non-boolean enabled', async () => {
       const r = makeRouter()
-      registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
+      await registerExecutionRoutes(r, { storage: makeStorage(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), registerDiagnostics: vi.fn() })
 
       const handler = r._routes.post['/config'].at(-1)
       const res = makeRes()

--- a/modules/releases/__tests__/server/execution/scheduler.test.js
+++ b/modules/releases/__tests__/server/execution/scheduler.test.js
@@ -19,10 +19,10 @@ const mockFetchArtifacts = vi.fn()
 function makeStorage(data = {}) {
   const store = { ...data }
   return {
-    readFromStorage(key) {
+    async readFromStorage(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage(key, value) {
+    async writeToStorage(key, value) {
       store[key] = value
     },
     _store: store
@@ -62,17 +62,17 @@ describe('scheduler', () => {
   })
 
   describe('loadConfig', () => {
-    it('returns DEFAULT_CONFIG when no stored config', () => {
+    it('returns DEFAULT_CONFIG when no stored config', async () => {
       const storage = makeStorage()
-      const config = loadConfig(storage)
+      const config = await loadConfig(storage)
       expect(config).toEqual(DEFAULT_CONFIG)
     })
 
-    it('merges stored config with defaults', () => {
+    it('merges stored config with defaults', async () => {
       const storage = makeStorage({
         'releases/execution/config.json': { projectPath: 'custom/path', enabled: true }
       })
-      const config = loadConfig(storage)
+      const config = await loadConfig(storage)
       expect(config.projectPath).toBe('custom/path')
       expect(config.enabled).toBe(true)
       expect(config.gitlabBaseUrl).toBe('https://gitlab.com')

--- a/modules/releases/__tests__/server/hygiene/config.test.js
+++ b/modules/releases/__tests__/server/hygiene/config.test.js
@@ -5,8 +5,8 @@ const { loadConfig, saveConfig, getDefaults } = require('../../../server/hygiene
 function createMockStorage() {
   var store = {}
   return {
-    readFromStorage: function (key) { return store[key] || null },
-    writeToStorage: function (key, data) { store[key] = data },
+    readFromStorage: async function (key) { return store[key] || null },
+    writeToStorage: async function (key, data) { store[key] = data },
     _store: store
   }
 }
@@ -49,36 +49,36 @@ describe('getDefaults', function () {
 
 // ─── loadConfig ──────────────────────────────────────────────────────
 
-describe('loadConfig', function () {
-  it('returns defaults when nothing is stored', function () {
+describe('loadConfig', function() {
+  it('returns defaults when nothing is stored', async function() {
     var storage = createMockStorage()
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     var defaults = getDefaults()
     expect(config).toEqual(defaults)
   })
 
-  it('returns defaults when stored value is null', function () {
+  it('returns defaults when stored value is null', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = null
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     expect(config).toEqual(getDefaults())
   })
 
-  it('returns defaults when stored value is not an object', function () {
+  it('returns defaults when stored value is not an object', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = 'not-an-object'
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     expect(config).toEqual(getDefaults())
   })
 
-  it('merges stored rules with defaults', function () {
+  it('merges stored rules with defaults', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = {
       rules: {
         'missing-team': { enabled: false, threshold: 30 }
       }
     }
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
 
     // Stored override applied
     expect(config.rules['missing-team'].enabled).toBe(false)
@@ -88,50 +88,50 @@ describe('loadConfig', function () {
     expect(config.rules['missing-assignee'].enabled).toBe(true)
   })
 
-  it('preserves stored projects array', function () {
+  it('preserves stored projects array', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = {
       projects: ['MYPROJECT']
     }
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     expect(config.projects).toEqual(['MYPROJECT'])
   })
 
-  it('preserves stored issueTypes array', function () {
+  it('preserves stored issueTypes array', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = {
       issueTypes: ['Bug']
     }
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     expect(config.issueTypes).toEqual(['Bug'])
   })
 
-  it('falls back to default projects if stored projects is not an array', function () {
+  it('falls back to default projects if stored projects is not an array', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = {
       projects: 'not-an-array'
     }
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     expect(config.projects).toEqual(['RHAISTRAT', 'RHOAIENG'])
   })
 
-  it('falls back to default issueTypes if stored issueTypes is not an array', function () {
+  it('falls back to default issueTypes if stored issueTypes is not an array', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = {
       issueTypes: null
     }
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     expect(config.issueTypes).toEqual(['Feature', 'Initiative'])
   })
 
-  it('includes new rules not present in stored config', function () {
+  it('includes new rules not present in stored config', async function() {
     var storage = createMockStorage()
     storage._store['releases/hygiene-config.json'] = {
       rules: {
         'missing-assignee': { enabled: false }
       }
     }
-    var config = loadConfig(storage)
+    var config = await loadConfig(storage)
     // New rules from defaults should be present
     expect(config.rules).toHaveProperty('missing-team')
     expect(config.rules['missing-team'].enabled).toBe(true)
@@ -142,15 +142,15 @@ describe('loadConfig', function () {
 
 // ─── saveConfig ──────────────────────────────────────────────────────
 
-describe('saveConfig', function () {
-  it('writes config to the correct storage key', function () {
+describe('saveConfig', function() {
+  it('writes config to the correct storage key', async function() {
     var storage = createMockStorage()
     var config = {
       rules: { 'missing-team': { enabled: false } },
       projects: ['TESTPROJ'],
       issueTypes: ['Feature']
     }
-    saveConfig(storage, config)
+    await saveConfig(storage, config)
     var stored = storage._store['releases/hygiene-config.json']
     expect(stored).toBeTruthy()
     expect(stored.rules['missing-team'].enabled).toBe(false)
@@ -158,36 +158,36 @@ describe('saveConfig', function () {
     expect(stored.issueTypes).toEqual(['Feature'])
   })
 
-  it('defaults projects if not provided as array', function () {
+  it('defaults projects if not provided as array', async function() {
     var storage = createMockStorage()
-    saveConfig(storage, { rules: {} })
+    await saveConfig(storage, { rules: {} })
     var stored = storage._store['releases/hygiene-config.json']
     expect(stored.projects).toEqual(['RHAISTRAT', 'RHOAIENG'])
     expect(stored.issueTypes).toEqual(['Feature', 'Initiative'])
   })
 
-  it('defaults rules to empty object if not provided', function () {
+  it('defaults rules to empty object if not provided', async function() {
     var storage = createMockStorage()
-    saveConfig(storage, {})
+    await saveConfig(storage, {})
     var stored = storage._store['releases/hygiene-config.json']
     expect(stored.rules).toEqual({})
   })
 
-  it('throws when config is not an object', function () {
+  it('throws when config is not an object', async function() {
     var storage = createMockStorage()
-    expect(function () { saveConfig(storage, null) }).toThrow('Config must be an object')
-    expect(function () { saveConfig(storage, 'bad') }).toThrow('Config must be an object')
+    await expect(saveConfig(storage, null)).rejects.toThrow('Config must be an object')
+    await expect(saveConfig(storage, 'bad')).rejects.toThrow('Config must be an object')
   })
 
-  it('roundtrips with loadConfig', function () {
+  it('roundtrips with loadConfig', async function() {
     var storage = createMockStorage()
     var config = {
       rules: { 'missing-team': { enabled: false } },
       projects: ['MYPROJ'],
       issueTypes: ['Bug', 'Feature']
     }
-    saveConfig(storage, config)
-    var loaded = loadConfig(storage)
+    await saveConfig(storage, config)
+    var loaded = await loadConfig(storage)
     expect(loaded.projects).toEqual(['MYPROJ'])
     expect(loaded.issueTypes).toEqual(['Bug', 'Feature'])
     expect(loaded.rules['missing-team'].enabled).toBe(false)

--- a/modules/releases/__tests__/server/hygiene/jira-fetch.test.js
+++ b/modules/releases/__tests__/server/hygiene/jira-fetch.test.js
@@ -607,7 +607,7 @@ describe('transformIssue', function () {
 
 const { fetchHygieneFeatures } = require('../../../server/hygiene/jira-fetch')
 
-describe('fetchHygieneFeatures jqlVersions option', function () {
+describe('fetchHygieneFeatures jqlVersions option', function() {
   // Capture JQL queries without hitting Jira
   function createMockJira() {
     var capturedJqls = []

--- a/modules/releases/__tests__/server/planning/cache-reader.test.js
+++ b/modules/releases/__tests__/server/planning/cache-reader.test.js
@@ -183,7 +183,7 @@ describe('findRfeFromLinks', () => {
 })
 
 describe('findTier1Features', () => {
-  it('finds features whose parentKey matches outcome keys', () => {
+  it('finds features whose parentKey matches outcome keys', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'In Progress' }),
@@ -198,12 +198,12 @@ describe('findTier1Features', () => {
     ]
     const readFromStorage = createMockStorage(details)
 
-    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = await findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-100')
   })
 
-  it('excludes closed statuses', () => {
+  it('excludes closed statuses', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'Closed' })
@@ -212,11 +212,11 @@ describe('findTier1Features', () => {
     }
     const readFromStorage = createMockStorage([])
 
-    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = await findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(0)
   })
 
-  it('excludes features without target versions', () => {
+  it('excludes features without target versions', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: null, status: 'In Progress' })
@@ -225,11 +225,11 @@ describe('findTier1Features', () => {
     }
     const readFromStorage = createMockStorage([])
 
-    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = await findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(0)
   })
 
-  it('populates stats object when provided', () => {
+  it('populates stats object when provided', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'In Progress' }),
@@ -245,7 +245,7 @@ describe('findTier1Features', () => {
     const readFromStorage = createMockStorage(details)
     const stats = {}
 
-    const results = findTier1Features(readFromStorage, index, ['KEY-1'], stats)
+    const results = await findTier1Features(readFromStorage, index, ['KEY-1'], stats)
 
     expect(results).toHaveLength(1)
     expect(stats.totalMatches).toBe(3)
@@ -253,7 +253,7 @@ describe('findTier1Features', () => {
     expect(stats.closedFiltered).toBe(1)
   })
 
-  it('works unchanged when stats parameter is not provided', () => {
+  it('works unchanged when stats parameter is not provided', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { parentKey: 'KEY-1', targetVersions: ['rhoai-3.5'], status: 'In Progress' })
@@ -266,14 +266,14 @@ describe('findTier1Features', () => {
     const readFromStorage = createMockStorage(details)
 
     // Call without stats parameter -- should work exactly as before
-    const results = findTier1Features(readFromStorage, index, ['KEY-1'])
+    const results = await findTier1Features(readFromStorage, index, ['KEY-1'])
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-100')
   })
 })
 
 describe('findTier1Rfes', () => {
-  it('finds RFEs linked to outcome keys with candidate label', () => {
+  it('finds RFEs linked to outcome keys with candidate label', async () => {
     const index = {
       features: [],
       rfes: [
@@ -293,12 +293,12 @@ describe('findTier1Rfes', () => {
     ]
     const readFromStorage = createMockStorage([], rfeDetails)
 
-    const results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
+    const results = await findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAIRFE-100')
   })
 
-  it('excludes Approved RFEs', () => {
+  it('excludes Approved RFEs', async () => {
     const index = {
       features: [],
       rfes: [
@@ -307,11 +307,11 @@ describe('findTier1Rfes', () => {
     }
     const readFromStorage = createMockStorage([], [])
 
-    const results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
+    const results = await findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
     expect(results).toHaveLength(0)
   })
 
-  it('excludes closed RFEs', () => {
+  it('excludes closed RFEs', async () => {
     const index = {
       features: [],
       rfes: [
@@ -320,13 +320,13 @@ describe('findTier1Rfes', () => {
     }
     const readFromStorage = createMockStorage([], [])
 
-    const results = findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
+    const results = await findTier1Rfes(readFromStorage, index, ['KEY-1'], '3.5')
     expect(results).toHaveLength(0)
   })
 })
 
 describe('findOutcomeSummaries', () => {
-  it('returns summaries for outcome keys found in features', () => {
+  it('returns summaries for outcome keys found in features', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome A' }),
@@ -336,27 +336,27 @@ describe('findOutcomeSummaries', () => {
       rfes: []
     }
 
-    const result = findOutcomeSummaries(index, ['KEY-1', 'KEY-2'])
+    const result = await findOutcomeSummaries(index, ['KEY-1', 'KEY-2'])
     expect(result).toEqual({
       'KEY-1': 'Outcome A',
       'KEY-2': 'Outcome B'
     })
   })
 
-  it('returns empty for missing keys', () => {
+  it('returns empty for missing keys', async () => {
     const index = { features: [], rfes: [] }
-    const result = findOutcomeSummaries(index, ['KEY-999'])
+    const result = await findOutcomeSummaries(index, ['KEY-999'])
     expect(result).toEqual({})
   })
 
-  it('returns empty for empty input', () => {
-    const result = findOutcomeSummaries({ features: [] }, [])
+  it('returns empty for empty input', async () => {
+    const result = await findOutcomeSummaries({ features: [] }, [])
     expect(result).toEqual({})
   })
 })
 
 describe('findTier2Features', () => {
-  it('finds features with matching target version, excluding Tier 1', () => {
+  it('finds features with matching target version, excluding Tier 1', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { targetVersions: ['rhoai-3.5'] }),
@@ -371,12 +371,12 @@ describe('findTier2Features', () => {
     const readFromStorage = createMockStorage(details)
     const excludeKeys = new Set(['RHAISTRAT-100'])
 
-    const results = findTier2Features(readFromStorage, index, '3.5', excludeKeys)
+    const results = await findTier2Features(readFromStorage, index, '3.5', excludeKeys)
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-101')
   })
 
-  it('excludes closed statuses', () => {
+  it('excludes closed statuses', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { targetVersions: ['rhoai-3.5'], status: 'Done' })
@@ -385,13 +385,13 @@ describe('findTier2Features', () => {
     }
     const readFromStorage = createMockStorage([])
 
-    const results = findTier2Features(readFromStorage, index, '3.5', new Set())
+    const results = await findTier2Features(readFromStorage, index, '3.5', new Set())
     expect(results).toHaveLength(0)
   })
 })
 
 describe('findTier2Rfes', () => {
-  it('finds RFEs with candidate label, excluding Tier 1', () => {
+  it('finds RFEs with candidate label, excluding Tier 1', async () => {
     const index = {
       features: [],
       rfes: [
@@ -406,14 +406,14 @@ describe('findTier2Rfes', () => {
     const readFromStorage = createMockStorage([], rfeDetails)
     const excludeKeys = new Set(['RHAIRFE-100'])
 
-    const results = findTier2Rfes(readFromStorage, index, '3.5', excludeKeys)
+    const results = await findTier2Rfes(readFromStorage, index, '3.5', excludeKeys)
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAIRFE-101')
   })
 })
 
 describe('findTier3Features', () => {
-  it('finds In Progress features without target version or fix version', () => {
+  it('finds In Progress features without target version or fix version', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { status: 'In Progress', targetVersions: null, fixVersions: [] }),
@@ -428,12 +428,12 @@ describe('findTier3Features', () => {
     ]
     const readFromStorage = createMockStorage(details)
 
-    const results = findTier3Features(readFromStorage, index, new Set())
+    const results = await findTier3Features(readFromStorage, index, new Set())
     expect(results).toHaveLength(1)
     expect(results[0].key).toBe('RHAISTRAT-100')
   })
 
-  it('excludes already-discovered keys', () => {
+  it('excludes already-discovered keys', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-100', { status: 'In Progress', targetVersions: null, fixVersions: [] })
@@ -442,7 +442,7 @@ describe('findTier3Features', () => {
     }
     const readFromStorage = createMockStorage([])
 
-    const results = findTier3Features(readFromStorage, index, new Set(['RHAISTRAT-100']))
+    const results = await findTier3Features(readFromStorage, index, new Set(['RHAISTRAT-100']))
     expect(results).toHaveLength(0)
   })
 })

--- a/modules/releases/__tests__/server/planning/config-backup.test.js
+++ b/modules/releases/__tests__/server/planning/config-backup.test.js
@@ -12,23 +12,23 @@ function createMocks(configData, releaseFiles, existingBackupFiles) {
     }
   }
   return {
-    readFromStorage: vi.fn(function(key) {
+    readFromStorage: vi.fn(async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     }),
-    writeToStorage: vi.fn(),
-    listStorageFiles: vi.fn().mockReturnValue(existingBackupFiles || []),
-    deleteFromStorage: vi.fn()
+    writeToStorage: vi.fn().mockResolvedValue(undefined),
+    listStorageFiles: vi.fn().mockResolvedValue(existingBackupFiles || []),
+    deleteFromStorage: vi.fn().mockResolvedValue(undefined)
   }
 }
 
 describe('backupConfig', () => {
-  it('creates a timestamped backup bundling config and per-release files', () => {
+  it('creates a timestamped backup bundling config and per-release files', async () => {
     const config = { releases: { '3.5': { release: '3.5' } } }
     const releaseData = { release: '3.5', bigRocks: [{ name: 'A', priority: 1 }] }
     const { readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage } =
       createMocks(config, { '3.5': releaseData }, [])
 
-    backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
     expect(readFromStorage).toHaveBeenCalledWith('releases/planning/config.json')
     expect(readFromStorage).toHaveBeenCalledWith('releases/planning/releases/3.5.json')
@@ -41,25 +41,25 @@ describe('backupConfig', () => {
     expect(data.releases['3.5']).toEqual(releaseData)
   })
 
-  it('does nothing when config.json is null', () => {
+  it('does nothing when config.json is null', async () => {
     const { readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage } =
       createMocks(null, null, [])
 
-    backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('handles missing listStorageFiles gracefully', () => {
+  it('handles missing listStorageFiles gracefully', async () => {
     const config = { releases: {} }
     const { readFromStorage, writeToStorage } = createMocks(config)
 
-    backupConfig(readFromStorage, writeToStorage, null, vi.fn())
+    await backupConfig(readFromStorage, writeToStorage, null, vi.fn())
 
     expect(writeToStorage).toHaveBeenCalledTimes(1)
   })
 
-  it('bundles multiple per-release files', () => {
+  it('bundles multiple per-release files', async () => {
     const config = { releases: { '3.5': { release: '3.5' }, '3.6': { release: '3.6' } } }
     const { readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage } =
       createMocks(config, {
@@ -67,14 +67,14 @@ describe('backupConfig', () => {
         '3.6': { release: '3.6', bigRocks: [{ name: 'B' }] }
       }, [])
 
-    backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
     const data = writeToStorage.mock.calls[0][1]
     expect(data.releases['3.5'].bigRocks[0].name).toBe('A')
     expect(data.releases['3.6'].bigRocks[0].name).toBe('B')
   })
 
-  it('prunes old backups when more than 10 exist', () => {
+  it('prunes old backups when more than 10 exist', async () => {
     const config = { releases: {} }
     const existingFiles = Array.from({ length: 12 }, (_, i) => {
       const num = String(i).padStart(2, '0')
@@ -84,14 +84,14 @@ describe('backupConfig', () => {
     const { readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage } =
       createMocks(config, null, existingFiles)
 
-    backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
     expect(deleteFromStorage).toHaveBeenCalledTimes(2)
     expect(deleteFromStorage.mock.calls[0][0]).toContain('config-backup-2026-04-00')
     expect(deleteFromStorage.mock.calls[1][0]).toContain('config-backup-2026-04-01')
   })
 
-  it('does not prune when 10 or fewer backups exist', () => {
+  it('does not prune when 10 or fewer backups exist', async () => {
     const config = { releases: {} }
     const existingFiles = Array.from({ length: 9 }, (_, i) =>
       `config-backup-2026-04-0${i + 1}T12-00-00-000Z.json`
@@ -100,12 +100,12 @@ describe('backupConfig', () => {
     const { readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage } =
       createMocks(config, null, existingFiles)
 
-    backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
     expect(deleteFromStorage).not.toHaveBeenCalled()
   })
 
-  it('ignores non-backup files when pruning', () => {
+  it('ignores non-backup files when pruning', async () => {
     const config = { releases: {} }
     const existingFiles = [
       'config.json',
@@ -118,17 +118,17 @@ describe('backupConfig', () => {
     const { readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage } =
       createMocks(config, null, existingFiles)
 
-    backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
     expect(deleteFromStorage).not.toHaveBeenCalled()
   })
 
-  it('handles listStorageFiles error gracefully', () => {
+  it('handles listStorageFiles error gracefully', async () => {
     const config = { releases: {} }
     const { readFromStorage, writeToStorage } = createMocks(config)
-    const listStorageFiles = vi.fn().mockImplementation(() => { throw new Error('disk error') })
+    const listStorageFiles = vi.fn().mockRejectedValue(new Error('disk error'))
 
-    expect(() => backupConfig(readFromStorage, writeToStorage, listStorageFiles, vi.fn())).not.toThrow()
+    await backupConfig(readFromStorage, writeToStorage, listStorageFiles, vi.fn())
     expect(writeToStorage).toHaveBeenCalledTimes(1)
   })
 })

--- a/modules/releases/__tests__/server/planning/config-crud.test.js
+++ b/modules/releases/__tests__/server/planning/config-crud.test.js
@@ -11,10 +11,10 @@ function createStorage(configReleases, releaseFiles) {
     }
   }
   return {
-    readFromStorage: vi.fn(function(key) {
+    readFromStorage: vi.fn(async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     }),
-    writeToStorage: vi.fn(function(key, data) {
+    writeToStorage: vi.fn(async function(key, data) {
       store[key] = JSON.parse(JSON.stringify(data))
     }),
     _store: store
@@ -28,7 +28,7 @@ function makeReleaseFile(bigRocks, version) {
 
 describe('saveBigRock', () => {
   describe('creating a new Big Rock', () => {
-    it('adds a new Big Rock to the end of the list', () => {
+    it('adds a new Big Rock to the end of the list', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -36,7 +36,7 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
         name: 'New Rock',
         pillar: 'Platform'
       })
@@ -48,13 +48,13 @@ describe('saveBigRock', () => {
       expect(writeToStorage).toHaveBeenCalledWith('releases/planning/releases/3.5.json', expect.any(Object))
     })
 
-    it('assigns priority 1 to the first Big Rock', () => {
+    it('assigns priority 1 to the first Big Rock', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
         name: 'First Rock'
       })
 
@@ -62,13 +62,13 @@ describe('saveBigRock', () => {
       expect(result.bigRocks).toHaveLength(1)
     })
 
-    it('defaults optional fields to empty strings/arrays', () => {
+    it('defaults optional fields to empty strings/arrays', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
         name: 'Minimal Rock'
       })
 
@@ -81,13 +81,13 @@ describe('saveBigRock', () => {
       expect(result.bigRock.description).toBe('')
     })
 
-    it('trims the name', () => {
+    it('trims the name', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', null, {
         name: '  Spaced Name  '
       })
 
@@ -96,7 +96,7 @@ describe('saveBigRock', () => {
   })
 
   describe('updating an existing Big Rock', () => {
-    it('updates fields of an existing Big Rock by name', () => {
+    it('updates fields of an existing Big Rock by name', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -105,7 +105,7 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', 'MaaS', {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', 'MaaS', {
         name: 'MaaS',
         fullName: 'Updated Name',
         pillar: 'New Pillar',
@@ -118,7 +118,7 @@ describe('saveBigRock', () => {
       expect(result.bigRocks).toHaveLength(2)
     })
 
-    it('allows renaming a Big Rock', () => {
+    it('allows renaming a Big Rock', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -126,7 +126,7 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', 'OldName', {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', 'OldName', {
         name: 'NewName'
       })
 
@@ -134,7 +134,7 @@ describe('saveBigRock', () => {
       expect(result.bigRocks[0].name).toBe('NewName')
     })
 
-    it('renames a rock while other rocks are unaffected', () => {
+    it('renames a rock while other rocks are unaffected', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -144,7 +144,7 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', 'A', {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', 'A', {
         name: 'RenamedA'
       })
 
@@ -157,7 +157,7 @@ describe('saveBigRock', () => {
       expect(result.bigRocks.some(function(r) { return r.name === 'A' })).toBe(false)
     })
 
-    it('throws when the original name is not found', () => {
+    it('throws when the original name is not found', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -165,12 +165,10 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      expect(() => {
-        saveBigRock(readFromStorage, writeToStorage, '3.5', 'NonExistent', { name: 'X' })
-      }).toThrow("'NonExistent' not found")
+      await expect(saveBigRock(readFromStorage, writeToStorage, '3.5', 'NonExistent', { name: 'X' })).rejects.toThrow("'NonExistent' not found")
     })
 
-    it('preserves priority during update', () => {
+    it('preserves priority during update', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -180,7 +178,7 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', 'B', {
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', 'B', {
         name: 'B',
         pillar: 'Updated'
       })
@@ -191,7 +189,7 @@ describe('saveBigRock', () => {
   })
 
   describe('priority renumbering', () => {
-    it('renumbers priorities sequentially after save', () => {
+    it('renumbers priorities sequentially after save', async () => {
       const { readFromStorage, writeToStorage } = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -200,7 +198,7 @@ describe('saveBigRock', () => {
         ]) }
       )
 
-      const result = saveBigRock(readFromStorage, writeToStorage, '3.5', null, { name: 'C' })
+      const result = await saveBigRock(readFromStorage, writeToStorage, '3.5', null, { name: 'C' })
 
       expect(result.bigRocks[0].priority).toBe(1)
       expect(result.bigRocks[1].priority).toBe(2)
@@ -210,7 +208,7 @@ describe('saveBigRock', () => {
 })
 
 describe('deleteBigRock', () => {
-  it('deletes a Big Rock by name', () => {
+  it('deletes a Big Rock by name', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -220,14 +218,14 @@ describe('deleteBigRock', () => {
       ]) }
     )
 
-    const result = deleteBigRock(readFromStorage, writeToStorage, '3.5', 'B')
+    const result = await deleteBigRock(readFromStorage, writeToStorage, '3.5', 'B')
 
     expect(result.deleted).toBe('B')
     expect(result.bigRocks).toHaveLength(2)
     expect(result.bigRocks.map(r => r.name)).toEqual(['A', 'C'])
   })
 
-  it('renumbers priorities after deletion', () => {
+  it('renumbers priorities after deletion', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -237,7 +235,7 @@ describe('deleteBigRock', () => {
       ]) }
     )
 
-    const result = deleteBigRock(readFromStorage, writeToStorage, '3.5', 'A')
+    const result = await deleteBigRock(readFromStorage, writeToStorage, '3.5', 'A')
 
     expect(result.bigRocks[0].priority).toBe(1)
     expect(result.bigRocks[0].name).toBe('B')
@@ -245,7 +243,7 @@ describe('deleteBigRock', () => {
     expect(result.bigRocks[1].name).toBe('C')
   })
 
-  it('allows deleting the last Big Rock', () => {
+  it('allows deleting the last Big Rock', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -253,13 +251,13 @@ describe('deleteBigRock', () => {
       ]) }
     )
 
-    const result = deleteBigRock(readFromStorage, writeToStorage, '3.5', 'Only')
+    const result = await deleteBigRock(readFromStorage, writeToStorage, '3.5', 'Only')
 
     expect(result.deleted).toBe('Only')
     expect(result.bigRocks).toHaveLength(0)
   })
 
-  it('throws when the Big Rock name is not found', () => {
+  it('throws when the Big Rock name is not found', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -267,12 +265,10 @@ describe('deleteBigRock', () => {
       ]) }
     )
 
-    expect(() => {
-      deleteBigRock(readFromStorage, writeToStorage, '3.5', 'NonExistent')
-    }).toThrow("'NonExistent' not found")
+    await expect(deleteBigRock(readFromStorage, writeToStorage, '3.5', 'NonExistent')).rejects.toThrow("'NonExistent' not found")
   })
 
-  it('writes the updated release file to storage', () => {
+  it('writes the updated release file to storage', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -281,7 +277,7 @@ describe('deleteBigRock', () => {
       ]) }
     )
 
-    deleteBigRock(readFromStorage, writeToStorage, '3.5', 'A')
+    await deleteBigRock(readFromStorage, writeToStorage, '3.5', 'A')
 
     expect(writeToStorage).toHaveBeenCalledWith('releases/planning/releases/3.5.json', expect.objectContaining({
       bigRocks: expect.arrayContaining([

--- a/modules/releases/__tests__/server/planning/config-release.test.js
+++ b/modules/releases/__tests__/server/planning/config-release.test.js
@@ -11,10 +11,10 @@ function createStorage(configReleases, releaseFiles) {
     }
   }
   return {
-    readFromStorage: vi.fn(function(key) {
+    readFromStorage: vi.fn(async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     }),
-    writeToStorage: vi.fn(function(key, data) {
+    writeToStorage: vi.fn(async function(key, data) {
       store[key] = JSON.parse(JSON.stringify(data))
     }),
     _store: store
@@ -36,13 +36,13 @@ function makeRock(name, priority) {
 }
 
 describe('createRelease', () => {
-  it('creates a blank release successfully', () => {
+  it('creates a blank release successfully', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [] } }
     )
 
-    const result = createRelease(readFromStorage, writeToStorage, '3.6')
+    const result = await createRelease(readFromStorage, writeToStorage, '3.6')
 
     expect(result.version).toBe('3.6')
     expect(result.bigRockCount).toBe(0)
@@ -57,13 +57,13 @@ describe('createRelease', () => {
     })
   })
 
-  it('fails if version already exists (409)', () => {
+  it('fails if version already exists (409)', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } }
     )
 
     try {
-      createRelease(readFromStorage, writeToStorage, '3.5')
+      await createRelease(readFromStorage, writeToStorage, '3.5')
       expect.unreachable('should have thrown')
     } catch (err) {
       expect(err.message).toContain('already exists')
@@ -72,19 +72,17 @@ describe('createRelease', () => {
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('fails if version is empty', () => {
+  it('fails if version is empty', async () => {
     const { readFromStorage, writeToStorage } = createStorage({})
 
-    expect(() => {
-      createRelease(readFromStorage, writeToStorage, '')
-    }).toThrow('Version is required')
+    await expect(createRelease(readFromStorage, writeToStorage, '')).rejects.toThrow('Version is required')
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('creates the first release when config has no releases', () => {
+  it('creates the first release when config has no releases', async () => {
     const { readFromStorage, writeToStorage } = createStorage({})
 
-    const result = createRelease(readFromStorage, writeToStorage, '3.5')
+    const result = await createRelease(readFromStorage, writeToStorage, '3.5')
 
     expect(result.version).toBe('3.5')
     expect(result.bigRockCount).toBe(0)
@@ -97,13 +95,13 @@ describe('createRelease', () => {
 })
 
 describe('cloneRelease', () => {
-  it('clones Big Rocks from an existing release', () => {
+  it('clones Big Rocks from an existing release', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2)] } }
     )
 
-    const result = cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
+    const result = await cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
 
     expect(result.version).toBe('3.6')
     expect(result.bigRockCount).toBe(2)
@@ -116,13 +114,13 @@ describe('cloneRelease', () => {
     }))
   })
 
-  it('deep-copies Big Rocks so modifying clone does not affect source', () => {
+  it('deep-copies Big Rocks so modifying clone does not affect source', async () => {
     const { readFromStorage, writeToStorage, _store } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2)] } }
     )
 
-    cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
+    await cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
 
     const clonedData = _store['releases/planning/releases/3.6.json']
     const sourceData = _store['releases/planning/releases/3.5.json']
@@ -131,14 +129,14 @@ describe('cloneRelease', () => {
     expect(sourceData.bigRocks[0].name).toBe('A')
   })
 
-  it('fails if source release does not exist', () => {
+  it('fails if source release does not exist', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [] } }
     )
 
     try {
-      cloneRelease(readFromStorage, writeToStorage, '3.6', '9.9')
+      await cloneRelease(readFromStorage, writeToStorage, '3.6', '9.9')
       expect.unreachable('should have thrown')
     } catch (err) {
       expect(err.message).toContain('9.9')
@@ -148,7 +146,7 @@ describe('cloneRelease', () => {
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('fails if target version already exists', () => {
+  it('fails if target version already exists', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       {
         '3.5': { release: '3.5' },
@@ -161,7 +159,7 @@ describe('cloneRelease', () => {
     )
 
     try {
-      cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
+      await cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
       expect.unreachable('should have thrown')
     } catch (err) {
       expect(err.statusCode).toBe(409)
@@ -169,19 +167,19 @@ describe('cloneRelease', () => {
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('clones from a release with empty Big Rocks', () => {
+  it('clones from a release with empty Big Rocks', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [] } }
     )
 
-    const result = cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
+    const result = await cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
 
     expect(result.version).toBe('3.6')
     expect(result.bigRockCount).toBe(0)
   })
 
-  it('preserves outcomeKeys as arrays in the clone', () => {
+  it('preserves outcomeKeys as arrays in the clone', async () => {
     const { readFromStorage, writeToStorage, _store } = createStorage(
       { '3.5': { release: '3.5' } },
       {
@@ -192,7 +190,7 @@ describe('cloneRelease', () => {
       }
     )
 
-    cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
+    await cloneRelease(readFromStorage, writeToStorage, '3.6', '3.5')
 
     const clonedData = _store['releases/planning/releases/3.6.json']
     expect(clonedData.bigRocks[0].outcomeKeys).toEqual(['KEY-1', 'KEY-2'])
@@ -202,7 +200,7 @@ describe('cloneRelease', () => {
 })
 
 describe('deleteRelease', () => {
-  it('deletes an existing release from config registry', () => {
+  it('deletes an existing release from config registry', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       {
         '3.5': { release: '3.5' },
@@ -210,7 +208,7 @@ describe('deleteRelease', () => {
       }
     )
 
-    const result = deleteRelease(readFromStorage, writeToStorage, '3.5')
+    const result = await deleteRelease(readFromStorage, writeToStorage, '3.5')
 
     expect(result.deleted).toBe('3.5')
     expect(writeToStorage).toHaveBeenCalledWith('releases/planning/config.json', expect.any(Object))
@@ -219,13 +217,13 @@ describe('deleteRelease', () => {
     expect(writtenConfig.releases['3.6']).toBeDefined()
   })
 
-  it('fails if release does not exist', () => {
+  it('fails if release does not exist', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } }
     )
 
     try {
-      deleteRelease(readFromStorage, writeToStorage, '9.9')
+      await deleteRelease(readFromStorage, writeToStorage, '9.9')
       expect.unreachable('should have thrown')
     } catch (err) {
       expect(err.message).toContain('9.9')
@@ -235,12 +233,12 @@ describe('deleteRelease', () => {
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('returns the version name of the deleted release', () => {
+  it('returns the version name of the deleted release', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } }
     )
 
-    const result = deleteRelease(readFromStorage, writeToStorage, '3.5')
+    const result = await deleteRelease(readFromStorage, writeToStorage, '3.5')
     expect(result.deleted).toBe('3.5')
   })
 })

--- a/modules/releases/__tests__/server/planning/config-reorder.test.js
+++ b/modules/releases/__tests__/server/planning/config-reorder.test.js
@@ -11,10 +11,10 @@ function createStorage(configReleases, releaseFiles) {
     }
   }
   return {
-    readFromStorage: vi.fn(function(key) {
+    readFromStorage: vi.fn(async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     }),
-    writeToStorage: vi.fn(function(key, data) {
+    writeToStorage: vi.fn(async function(key, data) {
       store[key] = JSON.parse(JSON.stringify(data))
     })
   }
@@ -35,25 +35,25 @@ function makeRock(name, priority) {
 }
 
 describe('reorderBigRocks', () => {
-  it('reorders Big Rocks to match the provided name list', () => {
+  it('reorders Big Rocks to match the provided name list', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2), makeRock('C', 3)] } }
     )
 
-    const result = reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['C', 'A', 'B'])
+    const result = await reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['C', 'A', 'B'])
 
     expect(result.bigRocks.map(r => r.name)).toEqual(['C', 'A', 'B'])
     expect(writeToStorage).toHaveBeenCalledWith('releases/planning/releases/3.5.json', expect.any(Object))
   })
 
-  it('renumbers priorities sequentially after reorder', () => {
+  it('renumbers priorities sequentially after reorder', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('X', 1), makeRock('Y', 2), makeRock('Z', 3)] } }
     )
 
-    const result = reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['Z', 'X', 'Y'])
+    const result = await reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['Z', 'X', 'Y'])
 
     expect(result.bigRocks[0].priority).toBe(1)
     expect(result.bigRocks[0].name).toBe('Z')
@@ -63,88 +63,80 @@ describe('reorderBigRocks', () => {
     expect(result.bigRocks[2].name).toBe('Y')
   })
 
-  it('fails with a missing name', () => {
+  it('fails with a missing name', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2), makeRock('C', 3)] } }
     )
 
-    expect(() => {
-      reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'B'])
-    }).toThrow('Order list does not match')
+    await expect(reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'B'])).rejects.toThrow('Order list does not match')
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('fails with an extra name', () => {
+  it('fails with an extra name', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2)] } }
     )
 
-    expect(() => {
-      reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'B', 'C'])
-    }).toThrow('Order list does not match')
+    await expect(reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'B', 'C'])).rejects.toThrow('Order list does not match')
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('fails with duplicate names in the order list', () => {
+  it('fails with duplicate names in the order list', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2)] } }
     )
 
-    expect(() => {
-      reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'A'])
-    }).toThrow('duplicate name')
+    await expect(reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'A'])).rejects.toThrow('duplicate name')
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('fails for a non-existent release', () => {
+  it('fails for a non-existent release', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [] } }
     )
 
-    expect(() => {
-      reorderBigRocks(readFromStorage, writeToStorage, '9.9', ['A'])
-    }).toThrow('Release 9.9 not found')
+    await expect(reorderBigRocks(readFromStorage, writeToStorage, '9.9', ['A'])).rejects.toThrow('Release 9.9 not found')
     expect(writeToStorage).not.toHaveBeenCalled()
   })
 
-  it('succeeds with an empty Big Rocks list and empty order', () => {
+  it('succeeds with an empty Big Rocks list and empty order', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [] } }
     )
 
-    const result = reorderBigRocks(readFromStorage, writeToStorage, '3.5', [])
+    const result = await reorderBigRocks(readFromStorage, writeToStorage, '3.5', [])
 
     expect(result.bigRocks).toEqual([])
     expect(writeToStorage).toHaveBeenCalled()
   })
 
-  it('sets statusCode 409 on mismatch errors', () => {
+  it('sets statusCode 409 on mismatch errors', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('A', 1), makeRock('B', 2)] } }
     )
 
     try {
-      reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'C'])
+      await reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['A', 'C'])
       expect.unreachable('should have thrown')
     } catch (err) {
       expect(err.statusCode).toBe(409)
     }
   })
 
-  it('includes expected names in mismatch error message', () => {
+  it('includes expected names in mismatch error message', async () => {
     const { readFromStorage, writeToStorage } = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': { release: '3.5', bigRocks: [makeRock('Alpha', 1), makeRock('Beta', 2)] } }
     )
 
     try {
-      reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['Alpha', 'Gamma'])
+      await reorderBigRocks(readFromStorage, writeToStorage, '3.5', ['Alpha', 'Gamma'])
       expect.unreachable('should have thrown')
     } catch (err) {
       expect(err.message).toContain('Alpha')

--- a/modules/releases/__tests__/server/planning/config.test.js
+++ b/modules/releases/__tests__/server/planning/config.test.js
@@ -12,14 +12,14 @@ function makeStorage(data) {
 }
 
 describe('getConfig', () => {
-  it('returns default config when storage is empty', () => {
-    const config = getConfig(makeStorage())
+  it('returns default config when storage is empty', async () => {
+    const config = await getConfig(makeStorage())
     expect(config.fieldMapping).toEqual(DEFAULT_CONFIG.fieldMapping)
     expect(config.customFieldIds).toEqual(DEFAULT_CONFIG.customFieldIds)
     expect(config.releases).toEqual({})
   })
 
-  it('merges stored config with defaults', () => {
+  it('merges stored config with defaults', async () => {
     const readFromStorage = makeStorage({
       'releases/planning/config.json': {
         releases: { '3.5': { release: '3.5' } },
@@ -27,30 +27,30 @@ describe('getConfig', () => {
       }
     })
 
-    const config = getConfig(readFromStorage)
+    const config = await getConfig(readFromStorage)
     expect(config.releases['3.5']).toBeDefined()
     expect(config.fieldMapping.team).toBe('customfield_12345')
     expect(config.fieldMapping.rfeLinkType).toBe('is required by')
     expect(config.customFieldIds.targetVersion).toBe('customfield_10855')
   })
 
-  it('handles non-object storage values', () => {
+  it('handles non-object storage values', async () => {
     const readFromStorage = makeStorage({ 'releases/planning/config.json': 'invalid' })
-    const config = getConfig(readFromStorage)
+    const config = await getConfig(readFromStorage)
     expect(config).toEqual(DEFAULT_CONFIG)
   })
 })
 
 describe('loadBigRocks', () => {
-  it('returns empty array when release not found', () => {
+  it('returns empty array when release not found', async () => {
     const readFromStorage = makeStorage({
       'releases/planning/config.json': { releases: {} }
     })
-    const rocks = loadBigRocks(readFromStorage, '3.5')
+    const rocks = await loadBigRocks(readFromStorage, '3.5')
     expect(rocks).toEqual([])
   })
 
-  it('returns big rocks from per-release file', () => {
+  it('returns big rocks from per-release file', async () => {
     const readFromStorage = makeStorage({
       'releases/planning/config.json': { releases: { '3.5': { release: '3.5' } } },
       'releases/planning/releases/3.5.json': {
@@ -62,7 +62,7 @@ describe('loadBigRocks', () => {
       }
     })
 
-    const rocks = loadBigRocks(readFromStorage, '3.5')
+    const rocks = await loadBigRocks(readFromStorage, '3.5')
     expect(rocks).toHaveLength(2)
     expect(rocks[0].name).toBe('MaaS')
     expect(rocks[1].name).toBe('Gen AI Studio')
@@ -70,30 +70,30 @@ describe('loadBigRocks', () => {
 })
 
 describe('loadFieldMapping', () => {
-  it('returns default mapping when storage is empty', () => {
-    const mapping = loadFieldMapping(makeStorage())
+  it('returns default mapping when storage is empty', async () => {
+    const mapping = await loadFieldMapping(makeStorage())
     expect(mapping.rfeLinkType).toBe('is required by')
   })
 
-  it('returns stored mapping', () => {
+  it('returns stored mapping', async () => {
     const readFromStorage = makeStorage({
       'releases/planning/config.json': {
         fieldMapping: { team: 'customfield_99999', rfeLinkType: 'blocks' }
       }
     })
-    const mapping = loadFieldMapping(readFromStorage)
+    const mapping = await loadFieldMapping(readFromStorage)
     expect(mapping.team).toBe('customfield_99999')
     expect(mapping.rfeLinkType).toBe('blocks')
   })
 })
 
 describe('getConfiguredReleases', () => {
-  it('returns empty array when no releases configured', () => {
-    const releases = getConfiguredReleases(makeStorage())
+  it('returns empty array when no releases configured', async () => {
+    const releases = await getConfiguredReleases(makeStorage())
     expect(releases).toEqual([])
   })
 
-  it('returns release list with rock counts from per-release files', () => {
+  it('returns release list with rock counts from per-release files', async () => {
     const readFromStorage = makeStorage({
       'releases/planning/config.json': {
         releases: { '3.5': { release: '3.5' }, '3.4': { release: '3.4' } }
@@ -107,7 +107,7 @@ describe('getConfiguredReleases', () => {
         bigRocks: [{ name: 'C' }]
       }
     })
-    const releases = getConfiguredReleases(readFromStorage)
+    const releases = await getConfiguredReleases(readFromStorage)
     expect(releases).toHaveLength(2)
 
     const r35 = releases.find(r => r.version === '3.5')

--- a/modules/releases/__tests__/server/planning/doc-import.test.js
+++ b/modules/releases/__tests__/server/planning/doc-import.test.js
@@ -11,10 +11,10 @@ function createStorage(configReleases, releaseFiles) {
     }
   }
   return {
-    readFromStorage: vi.fn(function(key) {
+    readFromStorage: vi.fn(async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     }),
-    writeToStorage: vi.fn(function(key, data) {
+    writeToStorage: vi.fn(async function(key, data) {
       store[key] = JSON.parse(JSON.stringify(data))
     }),
     _store: store
@@ -81,7 +81,7 @@ describe('parseDocId', () => {
 
 describe('executeDocImport', () => {
   describe('replace mode', () => {
-    it('replaces all existing Big Rocks', () => {
+    it('replaces all existing Big Rocks', async () => {
       const storage = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -94,7 +94,7 @@ describe('executeDocImport', () => {
         makeRock('New Rock 2', ['RHAISTRAT-400'])
       ])
 
-      const result = executeDocImport(
+      const result = await executeDocImport(
         storage.readFromStorage, storage.writeToStorage,
         '3.5', 'test-doc-id', 'replace', parsedDoc
       )
@@ -109,7 +109,7 @@ describe('executeDocImport', () => {
   })
 
   describe('append mode', () => {
-    it('adds new rocks after existing ones', () => {
+    it('adds new rocks after existing ones', async () => {
       const storage = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -120,7 +120,7 @@ describe('executeDocImport', () => {
         makeRock('New Rock', ['RHAISTRAT-200'])
       ])
 
-      const result = executeDocImport(
+      const result = await executeDocImport(
         storage.readFromStorage, storage.writeToStorage,
         '3.5', 'test-doc-id', 'append', parsedDoc
       )
@@ -131,7 +131,7 @@ describe('executeDocImport', () => {
       expect(result.bigRocks).toHaveLength(2)
     })
 
-    it('skips duplicate names', () => {
+    it('skips duplicate names', async () => {
       const storage = createStorage(
         { '3.5': { release: '3.5' } },
         { '3.5': makeReleaseFile([
@@ -143,7 +143,7 @@ describe('executeDocImport', () => {
         makeRock('New Rock', ['RHAISTRAT-300'])
       ])
 
-      const result = executeDocImport(
+      const result = await executeDocImport(
         storage.readFromStorage, storage.writeToStorage,
         '3.5', 'test-doc-id', 'append', parsedDoc
       )
@@ -155,37 +155,33 @@ describe('executeDocImport', () => {
     })
   })
 
-  it('throws when no Big Rocks are parsed', () => {
+  it('throws when no Big Rocks are parsed', async () => {
     const storage = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([]) }
     )
     const parsedDoc = makeParsedDoc([])
 
-    expect(function() {
-      executeDocImport(
-        storage.readFromStorage, storage.writeToStorage,
-        '3.5', 'test-doc-id', 'replace', parsedDoc
-      )
-    }).toThrow('No Big Rocks could be extracted')
+    await expect(executeDocImport(
+      storage.readFromStorage, storage.writeToStorage,
+      '3.5', 'test-doc-id', 'replace', parsedDoc
+    )).rejects.toThrow('No Big Rocks could be extracted')
   })
 
-  it('throws when release version not found', () => {
+  it('throws when release version not found', async () => {
     const storage = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([]) }
     )
     const parsedDoc = makeParsedDoc([makeRock('Test')])
 
-    expect(function() {
-      executeDocImport(
-        storage.readFromStorage, storage.writeToStorage,
-        '9.9', 'test-doc-id', 'replace', parsedDoc
-      )
-    }).toThrow('Release 9.9 not found')
+    await expect(executeDocImport(
+      storage.readFromStorage, storage.writeToStorage,
+      '9.9', 'test-doc-id', 'replace', parsedDoc
+    )).rejects.toThrow('Release 9.9 not found')
   })
 
-  it('skips rocks that fail validation', () => {
+  it('skips rocks that fail validation', async () => {
     const storage = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([]) }
@@ -196,7 +192,7 @@ describe('executeDocImport', () => {
       makeRock('Valid Rock', ['RHAISTRAT-100'])
     ])
 
-    const result = executeDocImport(
+    const result = await executeDocImport(
       storage.readFromStorage, storage.writeToStorage,
       '3.5', 'test-doc-id', 'replace', parsedDoc
     )
@@ -207,7 +203,7 @@ describe('executeDocImport', () => {
     expect(result.validationErrors[0].name).toBe(longName)
   })
 
-  it('writes per-release file exactly once in replace mode', () => {
+  it('writes per-release file exactly once in replace mode', async () => {
     const storage = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -221,7 +217,7 @@ describe('executeDocImport', () => {
       makeRock('New 2', ['RHAISTRAT-500'])
     ])
 
-    executeDocImport(
+    await executeDocImport(
       storage.readFromStorage, storage.writeToStorage,
       '3.5', 'test-doc-id', 'replace', parsedDoc
     )
@@ -233,7 +229,7 @@ describe('executeDocImport', () => {
     )
   })
 
-  it('writes per-release file exactly once in append mode', () => {
+  it('writes per-release file exactly once in append mode', async () => {
     const storage = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([
@@ -245,7 +241,7 @@ describe('executeDocImport', () => {
       makeRock('New B', ['RHAISTRAT-300'])
     ])
 
-    executeDocImport(
+    await executeDocImport(
       storage.readFromStorage, storage.writeToStorage,
       '3.5', 'test-doc-id', 'append', parsedDoc
     )
@@ -257,7 +253,7 @@ describe('executeDocImport', () => {
     )
   })
 
-  it('renumbers priorities sequentially', () => {
+  it('renumbers priorities sequentially', async () => {
     const storage = createStorage(
       { '3.5': { release: '3.5' } },
       { '3.5': makeReleaseFile([]) }
@@ -268,7 +264,7 @@ describe('executeDocImport', () => {
       makeRock('Rock C')
     ])
 
-    const result = executeDocImport(
+    const result = await executeDocImport(
       storage.readFromStorage, storage.writeToStorage,
       '3.5', 'test-doc-id', 'replace', parsedDoc
     )

--- a/modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js
+++ b/modules/releases/__tests__/server/planning/health-pipeline-fpdor.test.js
@@ -11,10 +11,10 @@ function makeStorage(data) {
     for (var k in data) store[k] = data[k]
   }
   return {
-    readFromStorage: function(key) {
+    readFromStorage: async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage: function(key, value) {
+    writeToStorage: async function(key, value) {
       store[key] = value
     },
     _store: store

--- a/modules/releases/__tests__/server/planning/health-pipeline.test.js
+++ b/modules/releases/__tests__/server/planning/health-pipeline.test.js
@@ -21,10 +21,10 @@ function makeStorage(data) {
     for (var k in data) store[k] = data[k]
   }
   return {
-    readFromStorage: function(key) {
+    readFromStorage: async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage: function(key, value) {
+    writeToStorage: async function(key, value) {
       store[key] = value
     },
     _store: store
@@ -217,14 +217,14 @@ describe('computePlanningDeadline', function() {
 })
 
 describe('loadFeaturesFromCandidates', function() {
-  it('returns warning when candidates cache is empty', function() {
+  it('returns warning when candidates cache is empty', async function() {
     var storage = makeStorage({})
-    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
+    var result = await loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
     expect(result.features).toEqual([])
     expect(result.warnings[0]).toContain('No candidates found')
   })
 
-  it('maps candidate fields to health feature shape', function() {
+  it('maps candidate fields to health feature shape', async function() {
     var storage = makeStorage({
       'releases/planning/candidates-cache-3.5.json': {
         cachedAt: '2026-04-26T00:00:00Z',
@@ -248,7 +248,7 @@ describe('loadFeaturesFromCandidates', function() {
         }
       }
     })
-    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
+    var result = await loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
     expect(result.features).toHaveLength(1)
     var f = result.features[0]
     expect(f.key).toBe('RHOAIENG-1001')
@@ -262,7 +262,7 @@ describe('loadFeaturesFromCandidates', function() {
     expect(f.labels).toEqual(['test', 'feature'])
   })
 
-  it('excludes closed features', function() {
+  it('excludes closed features', async function() {
     var storage = makeStorage({
       'releases/planning/candidates-cache-3.5.json': {
         cachedAt: '2026-04-26T00:00:00Z',
@@ -274,12 +274,12 @@ describe('loadFeaturesFromCandidates', function() {
         }
       }
     })
-    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
+    var result = await loadFeaturesFromCandidates(storage.readFromStorage, '3.5', null)
     expect(result.features).toHaveLength(1)
     expect(result.features[0].key).toBe('T-2')
   })
 
-  it('applies phase filter', function() {
+  it('applies phase filter', async function() {
     var storage = makeStorage({
       'releases/planning/candidates-cache-3.5.json': {
         cachedAt: '2026-04-26T00:00:00Z',
@@ -292,7 +292,7 @@ describe('loadFeaturesFromCandidates', function() {
         }
       }
     })
-    var result = loadFeaturesFromCandidates(storage.readFromStorage, '3.5', 'EA2')
+    var result = await loadFeaturesFromCandidates(storage.readFromStorage, '3.5', 'EA2')
     expect(result.features).toHaveLength(2)
     var keys = result.features.map(function(f) { return f.key })
     expect(keys).toContain('T-2')
@@ -302,14 +302,14 @@ describe('loadFeaturesFromCandidates', function() {
 })
 
 describe('loadFeaturesForRelease', function() {
-  it('returns warning when index is empty', function() {
+  it('returns warning when index is empty', async function() {
     var storage = makeStorage({})
-    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    var result = await loadFeaturesForRelease(storage.readFromStorage, '3.5')
     expect(result.features).toEqual([])
     expect(result.warnings).toContain('Feature index is empty -- run an execution data refresh first')
   })
 
-  it('filters features by targetVersions match', function() {
+  it('filters features by targetVersions match', async function() {
     var storage = makeStorage({
       'releases/execution/index.json': {
         features: [
@@ -318,12 +318,12 @@ describe('loadFeaturesForRelease', function() {
         ]
       }
     })
-    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    var result = await loadFeaturesForRelease(storage.readFromStorage, '3.5')
     expect(result.features).toHaveLength(1)
     expect(result.features[0].key).toBe('T-1')
   })
 
-  it('filters features by fixVersions match', function() {
+  it('filters features by fixVersions match', async function() {
     var storage = makeStorage({
       'releases/execution/index.json': {
         features: [
@@ -331,11 +331,11 @@ describe('loadFeaturesForRelease', function() {
         ]
       }
     })
-    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    var result = await loadFeaturesForRelease(storage.readFromStorage, '3.5')
     expect(result.features).toHaveLength(1)
   })
 
-  it('excludes closed features', function() {
+  it('excludes closed features', async function() {
     var storage = makeStorage({
       'releases/execution/index.json': {
         features: [
@@ -343,11 +343,11 @@ describe('loadFeaturesForRelease', function() {
         ]
       }
     })
-    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    var result = await loadFeaturesForRelease(storage.readFromStorage, '3.5')
     expect(result.features).toHaveLength(0)
   })
 
-  it('merges detail data onto features', function() {
+  it('merges detail data onto features', async function() {
     var storage = makeStorage({
       'releases/execution/index.json': {
         features: [
@@ -360,7 +360,7 @@ describe('loadFeaturesForRelease', function() {
         releaseType: 'General Availability'
       }
     })
-    var result = loadFeaturesForRelease(storage.readFromStorage, '3.5')
+    var result = await loadFeaturesForRelease(storage.readFromStorage, '3.5')
     expect(result.features[0].pm).toEqual({ displayName: 'Jane PM' })
     expect(result.features[0].components).toEqual(['Model Serving'])
     expect(result.features[0].releaseType).toBe('General Availability')
@@ -378,13 +378,13 @@ describe('loadMilestones', function() {
     }
   }
 
-  it('returns milestones from Product Pages cache', function() {
+  it('returns milestones from Product Pages cache', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: '2026-05-01' },
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA2', dueDate: '2026-07-01', codeFreezeDate: '2026-06-15' },
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result).not.toBeNull()
     expect(result.ea1Freeze).toBe('2026-05-01')
     expect(result.ea1Target).toBe('2026-05-15')
@@ -394,24 +394,24 @@ describe('loadMilestones', function() {
     expect(result.gaTarget).toBe('2026-08-15')
   })
 
-  it('returns null when cache is missing', function() {
+  it('returns null when cache is missing', async function() {
     var storage = makeStorage({})
-    expect(loadMilestones(storage.readFromStorage, '3.5')).toBeNull()
+    expect(await loadMilestones(storage.readFromStorage, '3.5')).toBeNull()
   })
 
-  it('returns null when no matching version', function() {
+  it('returns null when no matching version', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'rhoai', releaseNumber: 'rhoai-3.4', dueDate: '2026-03-01', codeFreezeDate: '2026-02-15' }
     ]))
-    expect(loadMilestones(storage.readFromStorage, '3.5')).toBeNull()
+    expect(await loadMilestones(storage.readFromStorage, '3.5')).toBeNull()
   })
 
-  it('handles missing codeFreezeDate', function() {
+  it('handles missing codeFreezeDate', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: null },
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: null }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result).not.toBeNull()
     expect(result.ea1Freeze).toBeNull()
     expect(result.ea1Target).toBe('2026-05-15')
@@ -419,11 +419,11 @@ describe('loadMilestones', function() {
     expect(result.gaTarget).toBe('2026-08-15')
   })
 
-  it('returns partial milestones when only some phases exist', function() {
+  it('returns partial milestones when only some phases exist', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result).not.toBeNull()
     expect(result.ea1Freeze).toBeNull()
     expect(result.ea1Target).toBeNull()
@@ -433,13 +433,13 @@ describe('loadMilestones', function() {
     expect(result.gaTarget).toBe('2026-08-15')
   })
 
-  it('matches space-separated EA release numbers (expanded milestone format)', function() {
+  it('matches space-separated EA release numbers (expanded milestone format)', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'rhelai', releaseNumber: 'rhelai-3.5 EA1 release', dueDate: '2026-06-18', codeFreezeDate: null },
       { productName: 'rhelai', releaseNumber: 'rhelai-3.5 EA2 release', dueDate: '2026-07-16', codeFreezeDate: null },
       { productName: 'rhelai', releaseNumber: 'rhelai-3.5 GA', dueDate: '2026-08-20', codeFreezeDate: null }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result).not.toBeNull()
     expect(result.ea1Target).toBe('2026-06-18')
     expect(result.ea2Target).toBe('2026-07-16')
@@ -449,13 +449,13 @@ describe('loadMilestones', function() {
     expect(result._matched.ga).toBe('rhelai-3.5 GA')
   })
 
-  it('does not match EA releases as GA', function() {
+  it('does not match EA releases as GA', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'RHAII', releaseNumber: 'RHAII-3.5 EA1', dueDate: '2026-06-02', codeFreezeDate: null },
       { productName: 'RHAII', releaseNumber: 'RHAII-3.5 EA2', dueDate: '2026-07-01', codeFreezeDate: null },
       { productName: 'RHAII', releaseNumber: 'RHAII-3.5 GA', dueDate: '2026-08-04', codeFreezeDate: null }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result).not.toBeNull()
     expect(result.ea1Target).toBe('2026-06-02')
     expect(result.ea2Target).toBe('2026-07-01')
@@ -463,26 +463,26 @@ describe('loadMilestones', function() {
     expect(result._matched.ga).toBe('RHAII-3.5 GA')
   })
 
-  it('prefers rhoai/rhelai product when multiple products match', function() {
+  it('prefers rhoai/rhelai product when multiple products match', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'RHAII', releaseNumber: 'RHAII-3.5 EA1', dueDate: '2026-06-02', codeFreezeDate: null },
       { productName: 'rhelai', releaseNumber: 'rhelai-3.5 EA1 release', dueDate: '2026-06-18', codeFreezeDate: null },
       { productName: 'RHAII', releaseNumber: 'RHAII-3.5 GA', dueDate: '2026-08-04', codeFreezeDate: null },
       { productName: 'rhelai', releaseNumber: 'rhelai-3.5 GA', dueDate: '2026-08-20', codeFreezeDate: null }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result.ea1Target).toBe('2026-06-18')
     expect(result.gaTarget).toBe('2026-08-20')
     expect(result._matched.ea1).toBe('rhelai-3.5 EA1 release')
     expect(result._matched.ga).toBe('rhelai-3.5 GA')
   })
 
-  it('returns _matched with release numbers for debugging', function() {
+  it('returns _matched with release numbers for debugging', async function() {
     var storage = makeStorage(ppCache([
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5.EA1', dueDate: '2026-05-15', codeFreezeDate: '2026-05-01' },
       { productName: 'rhoai', releaseNumber: 'rhoai-3.5', dueDate: '2026-08-15', codeFreezeDate: '2026-08-01' }
     ]))
-    var result = loadMilestones(storage.readFromStorage, '3.5')
+    var result = await loadMilestones(storage.readFromStorage, '3.5')
     expect(result._matched).toEqual({
       ea1: 'rhoai-3.5.EA1',
       ea2: null,

--- a/modules/releases/__tests__/server/planning/health-routes.test.js
+++ b/modules/releases/__tests__/server/planning/health-routes.test.js
@@ -58,10 +58,10 @@ function makeStorage(data) {
     for (var k in data) store[k] = data[k]
   }
   return {
-    readFromStorage: function(key) {
+    readFromStorage: async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage: function(key, value) {
+    writeToStorage: async function(key, value) {
       store[key] = value
     },
     _store: store
@@ -197,49 +197,49 @@ describe('health routes', function() {
   // ─── GET /releases/:version/health ───
 
   describe('GET /releases/:version/health', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '../evil' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('Invalid version')
     })
 
-    it('returns 400 for __proto__ version', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+    it('returns 400 for __proto__ version', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '__proto__' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 202 with _noCache when no cache exists', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+    it('returns 202 with _noCache when no cache exists', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(202)
       expect(res._json._noCache).toBe(true)
       expect(res._json.features).toEqual([])
     })
 
-    it('returns cached data when available', function() {
+    it('returns cached data when available', async function() {
       var cached = freshCache('3.5')
       storage._store['releases/planning/health-cache-3.5-all.json'] = cached
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(200)
       expect(res._json.version).toBe('3.5')
       expect(res._json.features).toHaveLength(2)
     })
 
-    it('sets _cacheStale true for old cache', function() {
+    it('sets _cacheStale true for old cache', async function() {
       var cached = freshCache('3.5', { cachedAt: new Date(Date.now() - 20 * 60 * 1000).toISOString() })
       storage._store['releases/planning/health-cache-3.5-all.json'] = cached
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' } }))
       expect(res._json._cacheStale).toBe(true)
     })
 
-    it('sets _cacheStale false for fresh cache', function() {
+    it('sets _cacheStale false for fresh cache', async function() {
       var cached = freshCache('3.5')
       storage._store['releases/planning/health-cache-3.5-all.json'] = cached
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' } }))
       expect(res._json._cacheStale).toBe(false)
     })
@@ -248,71 +248,71 @@ describe('health routes', function() {
   // ─── Phase validation ───
 
   describe('phase query param validation', function() {
-    it('returns 400 for invalid phase on GET health', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+    it('returns 400 for invalid phase on GET health', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' }, query: { phase: 'INVALID' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('phase')
     })
 
-    it('accepts valid EA1 phase on GET health', function() {
+    it('accepts valid EA1 phase on GET health', async function() {
       storage._store['releases/planning/health-cache-3.5-EA1.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' }, query: { phase: 'EA1' } }))
       expect(res._status).toBe(200)
     })
 
-    it('accepts valid EA2 phase on GET health', function() {
+    it('accepts valid EA2 phase on GET health', async function() {
       storage._store['releases/planning/health-cache-3.5-EA2.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' }, query: { phase: 'EA2' } }))
       expect(res._status).toBe(200)
     })
 
-    it('accepts valid GA phase on GET health', function() {
+    it('accepts valid GA phase on GET health', async function() {
       storage._store['releases/planning/health-cache-3.5-GA.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' }, query: { phase: 'GA' } }))
       expect(res._status).toBe(200)
     })
 
-    it('uses phase-specific cache key', function() {
+    it('uses phase-specific cache key', async function() {
       storage._store['releases/planning/health-cache-3.5-EA2.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' }, query: { phase: 'EA2' } }))
       expect(res._status).toBe(200)
       expect(res._json.features).toHaveLength(2)
     })
 
-    it('returns 202 when phase-specific cache does not exist', function() {
+    it('returns 202 when phase-specific cache does not exist', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' }, query: { phase: 'EA1' } }))
       expect(res._status).toBe(202)
       expect(res._json._noCache).toBe(true)
     })
 
-    it('returns 400 for invalid phase on GET summary', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+    it('returns 400 for invalid phase on GET summary', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/summary',
         makeReq({ params: { version: '3.5' }, query: { phase: 'WRONG' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 400 for invalid phase on POST refresh', function() {
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+    it('returns 400 for invalid phase on POST refresh', async function() {
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
         makeReq({ params: { version: '3.5' }, query: { phase: 'BAD' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 400 for invalid phase on GET refresh status', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+    it('returns 400 for invalid phase on GET refresh status', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
         makeReq({ params: { version: '3.5' }, query: { phase: 'XYZ' } }))
       expect(res._status).toBe(400)
     })
 
-    it('uses phase-specific refresh state key', function() {
+    it('uses phase-specific refresh state key', async function() {
       refreshStates.set('health:3.5:EA1', { running: true, startedAt: '2026-04-26T12:00:00Z', lastResult: null })
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
         makeReq({ params: { version: '3.5' }, query: { phase: 'EA1' } }))
       expect(res._json.running).toBe(true)
     })
@@ -321,21 +321,21 @@ describe('health routes', function() {
   // ─── GET /releases/:version/health/summary ───
 
   describe('GET /releases/:version/health/summary', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/summary',
         makeReq({ params: { version: '!bad!' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 404 when no cache exists', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+    it('returns 404 when no cache exists', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/summary',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(404)
     })
 
-    it('returns summary from cached data', function() {
+    it('returns summary from cached data', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/summary',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/summary',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(200)
       expect(res._json.version).toBe('3.5')
@@ -348,36 +348,36 @@ describe('health routes', function() {
   // ─── GET /releases/:version/health/feature/:key ───
 
   describe('GET /releases/:version/health/feature/:key', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
         makeReq({ params: { version: '!bad', key: 'T-1' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 400 for invalid feature key', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+    it('returns 400 for invalid feature key', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
         makeReq({ params: { version: '3.5', key: 'not-valid' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('Invalid feature key')
     })
 
-    it('returns 404 when no cache exists', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+    it('returns 404 when no cache exists', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
         makeReq({ params: { version: '3.5', key: 'T-1' } }))
       expect(res._status).toBe(404)
     })
 
-    it('returns 404 when feature not found in cache', function() {
+    it('returns 404 when feature not found in cache', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
         makeReq({ params: { version: '3.5', key: 'T-999' } }))
       expect(res._status).toBe(404)
       expect(res._json.error).toContain('T-999')
     })
 
-    it('returns feature data when found', function() {
+    it('returns feature data when found', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/feature/:key',
         makeReq({ params: { version: '3.5', key: 'T-1' } }))
       expect(res._status).toBe(200)
       expect(res._json.key).toBe('T-1')
@@ -388,35 +388,35 @@ describe('health routes', function() {
   // ─── PUT /releases/:version/health/override/:featureKey ───
 
   describe('PUT /releases/:version/health/override/:featureKey', function() {
-    it('returns 400 for invalid risk level', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('returns 400 for invalid risk level', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'purple', reason: 'test' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('riskOverride')
     })
 
-    it('returns 400 when reason is missing', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('returns 400 when reason is missing', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('reason')
     })
 
-    it('returns 400 when reason is empty string', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('returns 400 when reason is empty string', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green', reason: '   ' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 400 when reason exceeds max length', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('returns 400 when reason exceeds max length', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green', reason: 'x'.repeat(501) } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('500')
     })
 
-    it('writes override and returns confirmation on success', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('writes override and returns confirmation on success', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'green', reason: 'PM verified' } }))
       expect(res._status).toBe(200)
       expect(res._json.featureKey).toBe('T-1')
@@ -428,8 +428,8 @@ describe('health routes', function() {
       expect(overrides.overrides['T-1'].reason).toBe('PM verified')
     })
 
-    it('writes audit log entry', function() {
-      callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('writes audit log entry', async function() {
+      await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' }, body: { riskOverride: 'yellow', reason: 'Under review' } }))
       var auditLog = storage._store['releases/audit-log.json']
       expect(auditLog).toBeDefined()
@@ -442,24 +442,24 @@ describe('health routes', function() {
   // ─── DELETE /releases/:version/health/override/:featureKey ───
 
   describe('DELETE /releases/:version/health/override/:featureKey', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '!bad', featureKey: 'T-1' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 404 when no override exists', function() {
-      var res = callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+    it('returns 404 when no override exists', async function() {
+      var res = await callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' } }))
       expect(res._status).toBe(404)
     })
 
-    it('removes override and returns confirmation', function() {
+    it('removes override and returns confirmation', async function() {
       storage._store['releases/planning/health-overrides-3.5.json'] = {
         version: '3.5',
         overrides: { 'T-1': { riskOverride: 'green', reason: 'old reason' } }
       }
-      var res = callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+      var res = await callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' } }))
       expect(res._status).toBe(200)
       expect(res._json.removed).toBe(true)
@@ -468,12 +468,12 @@ describe('health routes', function() {
       expect(overrides.overrides['T-1']).toBeUndefined()
     })
 
-    it('writes audit log entry', function() {
+    it('writes audit log entry', async function() {
       storage._store['releases/planning/health-overrides-3.5.json'] = {
         version: '3.5',
         overrides: { 'T-1': { riskOverride: 'green', reason: 'test' } }
       }
-      callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
+      await callRoute(router._routes, 'DELETE', '/releases/:version/health/override/:featureKey',
         makeReq({ params: { version: '3.5', featureKey: 'T-1' } }))
       var auditLog = storage._store['releases/audit-log.json']
       expect(auditLog).toBeDefined()
@@ -485,29 +485,29 @@ describe('health routes', function() {
   // ─── POST /releases/:version/health/refresh ───
 
   describe('POST /releases/:version/health/refresh', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
         makeReq({ params: { version: '../bad' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns already_running when refresh in progress', function() {
+    it('returns already_running when refresh in progress', async function() {
       refreshStates.set('health:3.5:all', { running: true, startedAt: new Date().toISOString() })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
         makeReq({ params: { version: '3.5' } }))
       expect(res._json.status).toBe('already_running')
     })
 
-    it('returns 429 when max concurrent refreshes reached', function() {
+    it('returns 429 when max concurrent refreshes reached', async function() {
       refreshStates.set('health:3.4:all', { running: true })
       refreshStates.set('health:3.3:all', { running: true })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(429)
     })
 
-    it('returns started on success', function() {
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
+    it('returns started on success', async function() {
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/refresh',
         makeReq({ params: { version: '3.5' } }))
       expect(res._json.status).toBe('started')
     })
@@ -516,23 +516,23 @@ describe('health routes', function() {
   // ─── GET /releases/:version/health/refresh/status ───
 
   describe('GET /releases/:version/health/refresh/status', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
         makeReq({ params: { version: '!bad' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns initial state when no refresh has run', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+    it('returns initial state when no refresh has run', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(200)
       expect(res._json.running).toBe(false)
       expect(res._json.lastResult).toBeNull()
     })
 
-    it('returns running state during refresh', function() {
+    it('returns running state during refresh', async function() {
       refreshStates.set('health:3.5:all', { running: true, startedAt: '2026-04-26T12:00:00Z', lastResult: null })
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/refresh/status',
         makeReq({ params: { version: '3.5' } }))
       expect(res._json.running).toBe(true)
       expect(res._json.startedAt).toBe('2026-04-26T12:00:00Z')
@@ -542,7 +542,7 @@ describe('health routes', function() {
   // ─── GET /releases/:version/health with committedSnapshots ───
 
   describe('GET /releases/:version/health with committed snapshots', function() {
-    it('includes committedSnapshots when snapshot files exist', function() {
+    it('includes committedSnapshots when snapshot files exist', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5')
       storage._store['releases/planning/committed-snapshot-3.5-EA1.json'] = {
         version: '3.5',
@@ -552,7 +552,7 @@ describe('health routes', function() {
         featureKeys: ['T-1', 'T-2'],
         features: [{ key: 'T-1', summary: 'F1' }, { key: 'T-2', summary: 'F2' }]
       }
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(200)
       expect(res._json.committedSnapshots).toBeDefined()
@@ -562,9 +562,9 @@ describe('health routes', function() {
       expect(res._json.committedSnapshots.EA2).toBeUndefined()
     })
 
-    it('returns empty committedSnapshots when no snapshots exist', function() {
+    it('returns empty committedSnapshots when no snapshots exist', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5')
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health',
         makeReq({ params: { version: '3.5' } }))
       expect(res._status).toBe(200)
       expect(res._json.committedSnapshots).toBeDefined()
@@ -575,26 +575,26 @@ describe('health routes', function() {
   // ─── GET /releases/:version/health/snapshot/:phase ───
 
   describe('GET /releases/:version/health/snapshot/:phase', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '../bad', phase: 'EA1' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 400 for invalid phase', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
+    it('returns 400 for invalid phase', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '3.5', phase: 'INVALID' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('Invalid phase')
     })
 
-    it('returns 404 when no snapshot exists', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
+    it('returns 404 when no snapshot exists', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '3.5', phase: 'EA1' } }))
       expect(res._status).toBe(404)
     })
 
-    it('returns snapshot data when it exists', function() {
+    it('returns snapshot data when it exists', async function() {
       storage._store['releases/planning/committed-snapshot-3.5-EA1.json'] = {
         version: '3.5',
         phase: 'EA1',
@@ -603,7 +603,7 @@ describe('health routes', function() {
         featureKeys: ['T-1'],
         features: [{ key: 'T-1', summary: 'Feature 1' }]
       }
-      var res = callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
+      var res = await callRoute(router._routes, 'GET', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '3.5', phase: 'ea1' } }))
       expect(res._status).toBe(200)
       expect(res._json.phase).toBe('EA1')
@@ -614,26 +614,26 @@ describe('health routes', function() {
   // ─── POST /releases/:version/health/snapshot/:phase ───
 
   describe('POST /releases/:version/health/snapshot/:phase', function() {
-    it('returns 400 for invalid version', function() {
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
+    it('returns 400 for invalid version', async function() {
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '!bad', phase: 'EA1' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 400 for invalid phase', function() {
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
+    it('returns 400 for invalid phase', async function() {
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '3.5', phase: 'WRONG' } }))
       expect(res._status).toBe(400)
     })
 
-    it('returns 404 when no health cache exists', function() {
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
+    it('returns 404 when no health cache exists', async function() {
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '3.5', phase: 'EA1' } }))
       expect(res._status).toBe(404)
       expect(res._json.error).toContain('No health cache')
     })
 
-    it('creates snapshot with matching features and writes audit log', function() {
+    it('creates snapshot with matching features and writes audit log', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5', {
         features: [
           { key: 'T-1', summary: 'F1', status: 'In Progress', fixVersions: 'rhoai-3.5.EA1', components: 'Comp1', deliveryOwner: 'owner1' },
@@ -641,7 +641,7 @@ describe('health routes', function() {
           { key: 'T-3', summary: 'F3', status: 'Done', fixVersions: 'rhoai-3.5.EA1, rhoai-3.5.EA2', components: 'Comp3', deliveryOwner: 'owner3' }
         ]
       })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
         makeReq({ params: { version: '3.5', phase: 'EA1' } }))
       expect(res._status).toBe(200)
       expect(res._json.phase).toBe('EA1')
@@ -759,20 +759,20 @@ describe('health routes', function() {
   // ─── GET /releases/health-admin/config ───
 
   describe('GET /releases/health-admin/config', function() {
-    it('returns config with defaults when no config saved', function() {
-      var res = callRoute(router._routes, 'GET', '/releases/health-admin/config', makeReq())
+    it('returns config with defaults when no config saved', async function() {
+      var res = await callRoute(router._routes, 'GET', '/releases/health-admin/config', makeReq())
       expect(res._status).toBe(200)
       expect(res._json.customFieldIds).toBeDefined()
       expect(res._json.enableRice).toBe(false)
       expect(res._json.enableStratCreator).toBe(false)
     })
 
-    it('returns saved config', function() {
+    it('returns saved config', async function() {
       storage._store['releases/planning/config.json'] = {
         customFieldIds: { riceScoreField: 'customfield_10864' },
         healthConfig: { enableRice: true, enableStratCreator: true }
       }
-      var res = callRoute(router._routes, 'GET', '/releases/health-admin/config', makeReq())
+      var res = await callRoute(router._routes, 'GET', '/releases/health-admin/config', makeReq())
       expect(res._status).toBe(200)
       expect(res._json.enableRice).toBe(true)
       expect(res._json.enableStratCreator).toBe(true)
@@ -782,8 +782,8 @@ describe('health routes', function() {
   // ─── PUT /releases/health-admin/config ───
 
   describe('PUT /releases/health-admin/config', function() {
-    it('saves riceScoreField', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('saves riceScoreField', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { riceScoreField: 'customfield_10864' } }))
       expect(res._status).toBe(200)
       expect(res._json.saved).toBe(true)
@@ -793,15 +793,15 @@ describe('health routes', function() {
       expect(config.customFieldIds.riceScoreField).toBe('customfield_10864')
     })
 
-    it('returns 400 for riceScoreField with invalid characters', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('returns 400 for riceScoreField with invalid characters', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { riceScoreField: 'bad field!' } }))
       expect(res._status).toBe(400)
       expect(res._json.error).toContain('Invalid riceScoreField')
     })
 
-    it('saves enableRice flag', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('saves enableRice flag', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { enableRice: true } }))
       expect(res._status).toBe(200)
       expect(res._json.enableRice).toBe(true)
@@ -810,20 +810,20 @@ describe('health routes', function() {
       expect(config.healthConfig.enableRice).toBe(true)
     })
 
-    it('preserves existing field IDs when updating enableRice only', function() {
+    it('preserves existing field IDs when updating enableRice only', async function() {
       storage._store['releases/planning/config.json'] = {
         customFieldIds: { riceScoreField: 'customfield_10864' },
         healthConfig: {}
       }
-      callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+      await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { enableRice: true } }))
       var config = storage._store['releases/planning/config.json']
       expect(config.customFieldIds.riceScoreField).toBe('customfield_10864')
       expect(config.healthConfig.enableRice).toBe(true)
     })
 
-    it('saves enableStratCreator flag', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('saves enableStratCreator flag', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { enableStratCreator: true } }))
       expect(res._status).toBe(200)
       expect(res._json.enableStratCreator).toBe(true)
@@ -832,8 +832,8 @@ describe('health routes', function() {
       expect(config.healthConfig.enableStratCreator).toBe(true)
     })
 
-    it('returns enableStratCreator in response', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('returns enableStratCreator in response', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { enableRice: true, enableStratCreator: true } }))
       expect(res._json.enableRice).toBe(true)
       expect(res._json.enableStratCreator).toBe(true)
@@ -909,8 +909,8 @@ describe('health routes', function() {
   // ─── Open Access ───
 
   describe('open access for authenticated users', function() {
-    it('allows non-admin, non-planning-manager to set risk override', function() {
-      var res = callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('allows non-admin, non-planning-manager to set risk override', async function() {
+      var res = await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({
           isAdmin: false,
           isReleaseManager: false,
@@ -922,13 +922,13 @@ describe('health routes', function() {
       expect(res._json.featureKey).toBe('T-1')
     })
 
-    it('allows non-admin, non-planning-manager to create snapshot', function() {
+    it('allows non-admin, non-planning-manager to create snapshot', async function() {
       storage._store['releases/planning/health-cache-3.5-all.json'] = freshCache('3.5', {
         features: [
           { key: 'T-1', summary: 'F1', fixVersions: 'rhoai-3.5.EA1', status: 'In Progress', components: 'Comp1', deliveryOwner: 'owner1' }
         ]
       })
-      var res = callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
+      var res = await callRoute(router._routes, 'POST', '/releases/:version/health/snapshot/:phase',
         makeReq({
           isAdmin: false,
           isReleaseManager: false,
@@ -958,8 +958,8 @@ describe('health routes', function() {
   // ─── Audit Actor ───
 
   describe('audit actor tracking', function() {
-    it('uses auditActor in audit log for risk override', function() {
-      callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('uses auditActor in audit log for risk override', async function() {
+      await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({
           params: { version: '3.5', featureKey: 'T-1' },
           body: { riskOverride: 'yellow', reason: 'Under review' },
@@ -970,8 +970,8 @@ describe('health routes', function() {
       expect(entry.user).toBe('target@test.com (impersonated by admin@test.com)')
     })
 
-    it('falls back to userEmail when auditActor is not set', function() {
-      callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
+    it('falls back to userEmail when auditActor is not set', async function() {
+      await callRoute(router._routes, 'PUT', '/releases/:version/health/override/:featureKey',
         makeReq({
           params: { version: '3.5', featureKey: 'T-1' },
           body: { riskOverride: 'red', reason: 'Critical issue' },
@@ -986,8 +986,8 @@ describe('health routes', function() {
   // ─── Health Admin Config Audit ───
 
   describe('PUT /releases/health-admin/config audit logging', function() {
-    it('writes audit log entry on config save', function() {
-      callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('writes audit log entry on config save', async function() {
+      await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({ body: { enableRice: true, riceScoreField: 'customfield_123' } }))
       var auditLog = storage._store['releases/audit-log.json']
       expect(auditLog).toBeDefined()
@@ -997,8 +997,8 @@ describe('health routes', function() {
       expect(entry.details.riceScoreField).toBe('customfield_123')
     })
 
-    it('uses auditActor in health config audit log', function() {
-      callRoute(router._routes, 'PUT', '/releases/health-admin/config',
+    it('uses auditActor in health config audit log', async function() {
+      await callRoute(router._routes, 'PUT', '/releases/health-admin/config',
         makeReq({
           body: { enableStratCreator: true },
           auditActor: 'user@test.com (impersonated by admin@test.com)'

--- a/modules/releases/__tests__/server/planning/invalidate-cache.test.js
+++ b/modules/releases/__tests__/server/planning/invalidate-cache.test.js
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // but the real pipeline.js is used (vi.mock does not intercept CJS require
 // for the pipeline module inside index.js in this test environment).
 vi.mock('../../../server/planning/config-lock', () => ({
-  withConfigLock: vi.fn(function(fn) { return fn() })
+  withConfigLock: vi.fn(async function(fn) { return await fn() })
 }))
 
 vi.mock('../../../server/planning/config-backup', () => ({
@@ -29,14 +29,14 @@ function makeStorage(data) {
     for (const k in data) store[k] = data[k]
   }
   return {
-    readFromStorage: function(key) {
+    readFromStorage: async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage: function(key, value) {
+    writeToStorage: async function(key, value) {
       store[key] = value
     },
-    listStorageFiles: vi.fn().mockReturnValue([]),
-    deleteFromStorage: vi.fn(function(key) {
+    listStorageFiles: vi.fn().mockResolvedValue([]),
+    deleteFromStorage: vi.fn(async function(key) {
       delete store[key]
     }),
     _store: store
@@ -115,7 +115,7 @@ const VALID_ROCK = {
 describe('invalidateCache behavior', function() {
   let router, storage, context
 
-  beforeEach(function() {
+  beforeEach(async function() {
     vi.clearAllMocks()
     storage = makeStorage({
       'releases/planning/config.json': { releases: { '3.5': { release: '3.5' } } },
@@ -132,7 +132,7 @@ describe('invalidateCache behavior', function() {
       requireScope: function() { return function(req, res, next) { next() } },
       registerDiagnostics: vi.fn()
     }
-    registerRoutes(router, context)
+    await registerRoutes(router, context)
   })
 
   it('after Big Rock edit, GET returns data (not empty 202)', async function() {
@@ -160,7 +160,7 @@ describe('invalidateCache behavior', function() {
 
     // GET candidates -- should return data (not 202 with empty arrays)
     const getReq = makeReq({ params: { version: '3.5' }, query: {} })
-    const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', getReq)
+    const res = await callRoute(router._routes, 'GET', '/releases/:version/candidates', getReq)
 
     expect(res._status).toBe(200)
     expect(res._json.features).toBeDefined()
@@ -183,7 +183,7 @@ describe('invalidateCache behavior', function() {
 
     // Trigger a refresh
     const refreshReq = makeReq({ params: { version: '3.5' } })
-    callRoute(router._routes, 'POST', '/releases/:version/refresh', refreshReq)
+    await callRoute(router._routes, 'POST', '/releases/:version/refresh', refreshReq)
 
     // Wait for the background refresh promise to settle
     await new Promise(function(resolve) { setTimeout(resolve, 50) })
@@ -258,15 +258,15 @@ describe('invalidateCache behavior', function() {
       }
     })
     var origWrite = spyStorage.writeToStorage
-    spyStorage.writeToStorage = function(key, value) {
+    spyStorage.writeToStorage = async function(key, value) {
       if (key === 'releases/planning/candidates-cache-3.5.json' && value && value._invalidatedAt) {
         markerWritten = true
       }
-      origWrite(key, value)
+      await origWrite(key, value)
     }
 
     var spyRouter = makeRouter()
-    registerRoutes(spyRouter, {
+    await registerRoutes(spyRouter, {
       storage: spyStorage,
       requireAuth: function(req, res, next) { next() },
       requireAdmin: function(req, res, next) { next() },

--- a/modules/releases/__tests__/server/planning/pipeline.test.js
+++ b/modules/releases/__tests__/server/planning/pipeline.test.js
@@ -120,7 +120,7 @@ function makeConfig() {
 }
 
 describe('runPipeline', () => {
-  it('discovers Tier 1 features from outcome children', () => {
+  it('discovers Tier 1 features from outcome children', async () => {
     const index = {
       features: [
         makeFeatureIndex('RHAISTRAT-1513', { summary: 'MaaS Outcome', status: 'New' }),
@@ -140,7 +140,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'MaaS', outcomeKeys: ['RHAISTRAT-1513'], pillar: 'Inference' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(2)
     expect(result.tier1Features).toBe(2)
@@ -148,7 +148,7 @@ describe('runPipeline', () => {
     expect(result.features[0].tier).toBe(1)
   })
 
-  it('filters features without matching target release', () => {
+  it('filters features without matching target release', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
@@ -168,14 +168,14 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].issueKey).toBe('RHAISTRAT-101')
     expect(result.skippedCount).toBe(1)
   })
 
-  it('filters terminal status features', () => {
+  it('filters terminal status features', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
@@ -195,14 +195,14 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     // Terminal feature is discovered and filtered in both Tier 1 and Tier 2 scans
     expect(result.terminalFilteredCount).toBe(2)
   })
 
-  it('deduplicates features across multiple rocks sharing an outcome', () => {
+  it('deduplicates features across multiple rocks sharing an outcome', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome 1', status: 'New' }),
@@ -221,13 +221,13 @@ describe('runPipeline', () => {
       { priority: 2, name: 'Rock B', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].bigRock).toBe('Rock A, Rock B')
   })
 
-  it('applies rockFilter', () => {
+  it('applies rockFilter', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
@@ -246,25 +246,23 @@ describe('runPipeline', () => {
       { priority: 2, name: 'Other', outcomeKeys: ['KEY-2'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage, { rockFilter: 'MaaS' })
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage, { rockFilter: 'MaaS' })
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].bigRock).toBe('MaaS')
   })
 
-  it('throws for invalid rockFilter', () => {
+  it('throws for invalid rockFilter', async () => {
     const readFromStorage = createMockStorage({ features: [], rfes: [] })
     const config = makeConfig()
     const bigRocks = [
       { priority: 1, name: 'MaaS', outcomeKeys: ['KEY-1'], pillar: 'Inference' }
     ]
 
-    expect(function() {
-      runPipeline(config, bigRocks, '3.5', readFromStorage, { rockFilter: 'NonExistent' })
-    }).toThrow('No matching rock found')
+    await expect(runPipeline(config, bigRocks, '3.5', readFromStorage, { rockFilter: 'NonExistent' })).rejects.toThrow('No matching rock found')
   })
 
-  it('skips rocks without outcome keys', () => {
+  it('skips rocks without outcome keys', async () => {
     const index = { features: [], rfes: [] }
     const readFromStorage = createMockStorage(index)
 
@@ -273,7 +271,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'NoOutcome', outcomeKeys: [], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(0)
     expect(result.rocksWithoutOutcomes).toContain('NoOutcome')
@@ -283,7 +281,7 @@ describe('runPipeline', () => {
     )
   })
 
-  it('filters invalid outcome keys before processing', () => {
+  it('filters invalid outcome keys before processing', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Valid Outcome', status: 'New' }),
@@ -301,7 +299,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1', 'not valid', '', 123, 'KEY-2'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.features).toHaveLength(1)
     expect(result.features[0].issueKey).toBe('RHAISTRAT-100')
@@ -310,7 +308,7 @@ describe('runPipeline', () => {
     )
   })
 
-  it('provides diagnostic detail when rock has outcomes but no qualifying features', () => {
+  it('provides diagnostic detail when rock has outcomes but no qualifying features', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
@@ -331,7 +329,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'TestRock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     // Should have a diagnostic warning with filter breakdown
     expect(result.warnings).toEqual(
@@ -343,7 +341,7 @@ describe('runPipeline', () => {
     expect(diagWarning).toContain('excluded')
   })
 
-  it('warns about missing parentKey when no features match at all', () => {
+  it('warns about missing parentKey when no features match at all', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' })
@@ -357,14 +355,14 @@ describe('runPipeline', () => {
       { priority: 1, name: 'EmptyRock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.warnings).toEqual(
       expect.arrayContaining([expect.stringContaining('no features with matching parentKey found in the index')])
     )
   })
 
-  it('accumulates warnings for empty index', () => {
+  it('accumulates warnings for empty index', async () => {
     const index = { features: [], rfes: [] }
     const readFromStorage = createMockStorage(index)
 
@@ -373,7 +371,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-999'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.warnings).toEqual(
       expect.arrayContaining([
@@ -382,7 +380,7 @@ describe('runPipeline', () => {
     )
   })
 
-  it('returns missingOutcomes array listing keys not found in index', () => {
+  it('returns missingOutcomes array listing keys not found in index', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome Found' })
@@ -396,7 +394,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1', 'KEY-999', 'KEY-888'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.missingOutcomes).toBeDefined()
     expect(result.missingOutcomes).toContain('KEY-999')
@@ -408,7 +406,7 @@ describe('runPipeline', () => {
     )
   })
 
-  it('discovers RFEs linked to outcomes', () => {
+  it('discovers RFEs linked to outcomes', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' })
@@ -430,14 +428,14 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Data' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.rfes).toHaveLength(1)
     expect(result.rfes[0].issueKey).toBe('RHAIRFE-100')
     expect(result.tier1Rfes).toBe(1)
   })
 
-  it('excludes Approved RFEs', () => {
+  it('excludes Approved RFEs', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' })
@@ -453,11 +451,11 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Data' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
     expect(result.rfes).toHaveLength(0)
   })
 
-  it('discovers Tier 2 and Tier 3 features', () => {
+  it('discovers Tier 2 and Tier 3 features', async () => {
     const index = {
       features: [
         makeFeatureIndex('KEY-1', { summary: 'Outcome', status: 'New' }),
@@ -479,7 +477,7 @@ describe('runPipeline', () => {
       { priority: 1, name: 'Rock', outcomeKeys: ['KEY-1'], pillar: 'Platform' }
     ]
 
-    const result = runPipeline(config, bigRocks, '3.5', readFromStorage)
+    const result = await runPipeline(config, bigRocks, '3.5', readFromStorage)
 
     expect(result.tier1Features).toBe(1)
     expect(result.tier2Features).toBe(1)
@@ -492,7 +490,7 @@ describe('runPipeline', () => {
 })
 
 describe('buildCandidateResponse', () => {
-  it('builds a complete response object', () => {
+  it('builds a complete response object', async () => {
     const pipelineResult = {
       features: [
         { issueKey: 'RHAISTRAT-100', status: 'In Progress', priority: 'Major', components: 'Serving', bigRock: 'MaaS', tier: 1, labels: '' },
@@ -526,7 +524,7 @@ describe('buildCandidateResponse', () => {
       }
     ]
 
-    const response = buildCandidateResponse(pipelineResult, '3.5', bigRocks, false)
+    const response = await buildCandidateResponse(pipelineResult, '3.5', bigRocks, false)
 
     expect(response.version).toBe('3.5')
     expect(response.demoMode).toBe(false)
@@ -544,7 +542,7 @@ describe('buildCandidateResponse', () => {
     expect(response.pipelineWarnings).toEqual(['test warning'])
   })
 
-  it('omits pipelineWarnings when empty', () => {
+  it('omits pipelineWarnings when empty', async () => {
     const pipelineResult = {
       features: [],
       rfes: [],
@@ -559,7 +557,7 @@ describe('buildCandidateResponse', () => {
       warnings: []
     }
 
-    const response = buildCandidateResponse(pipelineResult, '3.5', [], false)
+    const response = await buildCandidateResponse(pipelineResult, '3.5', [], false)
 
     expect(response.pipelineWarnings).toBeUndefined()
   })

--- a/modules/releases/__tests__/server/planning/routes.test.js
+++ b/modules/releases/__tests__/server/planning/routes.test.js
@@ -47,14 +47,14 @@ function makeStorage(data) {
     for (const k in data) store[k] = data[k]
   }
   return {
-    readFromStorage: function(key) {
+    readFromStorage: async function(key) {
       return store[key] ? JSON.parse(JSON.stringify(store[key])) : null
     },
-    writeToStorage: function(key, value) {
+    writeToStorage: async function(key, value) {
       store[key] = value
     },
-    listStorageFiles: vi.fn().mockReturnValue([]),
-    deleteFromStorage: vi.fn(),
+    listStorageFiles: vi.fn().mockResolvedValue([]),
+    deleteFromStorage: vi.fn().mockResolvedValue(undefined),
     _store: store
   }
 }
@@ -214,14 +214,14 @@ describe('release-planning routes', function() {
   // ─── GET /releases ───
 
   describe('GET /releases', function() {
-    it('returns configured releases', function() {
-      const res = callRoute(router._routes, 'GET', '/releases')
+    it('returns configured releases', async function() {
+      const res = await callRoute(router._routes, 'GET', '/releases')
       expect(res._json).toEqual([{ version: '3.5', bigRockCount: 0 }])
     })
 
-    it('returns empty array when no releases configured', function() {
+    it('returns empty array when no releases configured', async function() {
       storage._store['releases/planning/config.json'] = { releases: {} }
-      const res = callRoute(router._routes, 'GET', '/releases')
+      const res = await callRoute(router._routes, 'GET', '/releases')
       expect(res._json).toEqual([])
     })
   })
@@ -229,63 +229,63 @@ describe('release-planning routes', function() {
   // ─── GET /releases/:version/candidates ───
 
   describe('GET /releases/:version/candidates', function() {
-    it('rejects invalid version format', function() {
+    it('rejects invalid version format', async function() {
       const req = makeReq({ params: { version: '../etc/passwd' } })
-      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const res = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._status).toBe(400)
       expect(res._json.error).toMatch(/Invalid version/)
     })
 
-    it('returns cached data when available', function() {
+    it('returns cached data when available', async function() {
       storage._store['releases/planning/candidates-cache-3.5.json'] = {
         cachedAt: new Date().toISOString(),
         data: { features: [{ issueKey: 'TEST-1' }], rfes: [], bigRocks: [], summary: null }
       }
       const req = makeReq({ params: { version: '3.5' }, query: {} })
-      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const res = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._json.features).toHaveLength(1)
     })
 
-    it('returns 202 when no cache exists', function() {
+    it('returns 202 when no cache exists', async function() {
       const req = makeReq({ params: { version: '3.5' }, query: {} })
-      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const res = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._status).toBe(202)
       expect(res._json._noCache).toBe(true)
     })
 
-    it('returns ETag header with cached response', function() {
+    it('returns ETag header with cached response', async function() {
       storage._store['releases/planning/candidates-cache-3.5.json'] = {
         cachedAt: new Date().toISOString(),
         data: { features: [], rfes: [], bigRocks: [], summary: null }
       }
       const req = makeReq({ params: { version: '3.5' }, query: {} })
-      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const res = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._headers['ETag']).toBeDefined()
       expect(res._headers['ETag']).toMatch(/^"[a-f0-9]+"$/)
     })
 
-    it('returns 304 when If-None-Match matches ETag', function() {
+    it('returns 304 when If-None-Match matches ETag', async function() {
       storage._store['releases/planning/candidates-cache-3.5.json'] = {
         cachedAt: new Date().toISOString(),
         data: { features: [], rfes: [], bigRocks: [], summary: null }
       }
       const req1 = makeReq({ params: { version: '3.5' }, query: {} })
-      const res1 = callRoute(router._routes, 'GET', '/releases/:version/candidates', req1)
+      const res1 = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req1)
       const etag = res1._headers['ETag']
 
       const req2 = makeReq({ params: { version: '3.5' }, query: {}, headers: { 'if-none-match': etag } })
-      const res2 = callRoute(router._routes, 'GET', '/releases/:version/candidates', req2)
+      const res2 = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req2)
       expect(res2._status).toBe(304)
       expect(res2._ended).toBe(true)
     })
 
-    it('returns 200 when If-None-Match does not match', function() {
+    it('returns 200 when If-None-Match does not match', async function() {
       storage._store['releases/planning/candidates-cache-3.5.json'] = {
         cachedAt: new Date().toISOString(),
         data: { features: [{ issueKey: 'TEST-1' }], rfes: [], bigRocks: [], summary: null }
       }
       const req = makeReq({ params: { version: '3.5' }, query: {}, headers: { 'if-none-match': '"stale-etag"' } })
-      const res = callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
+      const res = await callRoute(router._routes, 'GET', '/releases/:version/candidates', req)
       expect(res._status).toBe(200)
       expect(res._json.features).toHaveLength(1)
     })
@@ -296,19 +296,19 @@ describe('release-planning routes', function() {
   describe('version validation', function() {
     it('rejects reserved version names', async function() {
       const req = makeReq({ params: { version: '__proto__' } })
-      const res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
       expect(res._status).toBe(400)
     })
 
     it('rejects versions with special characters', async function() {
       const req = makeReq({ params: { version: 'v1;rm -rf' } })
-      const res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
       expect(res._status).toBe(400)
     })
 
     it('accepts valid version formats', async function() {
       const req = makeReq({ params: { version: '3.5' } })
-      const res = callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
+      const res = await callRoute(router._routes, 'POST', '/releases/:version/refresh', req)
       expect(res._status).toBe(200)
     })
   })
@@ -477,27 +477,27 @@ describe('release-planning routes', function() {
   // ─── GET /permissions ───
 
   describe('GET /permissions', function() {
-    it('returns canEdit true for admin', function() {
+    it('returns canEdit true for admin', async function() {
       const req = makeReq({ isAdmin: true, userEmail: 'admin@test.com' })
-      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      const res = await callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
     })
 
-    it('returns canEdit true for planning manager', function() {
+    it('returns canEdit true for planning manager', async function() {
       const req = makeReq({ isAdmin: false, isPlanningManager: true, userEmail: 'pm@test.com' })
-      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      const res = await callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
     })
 
-    it('returns canEdit true for regular user', function() {
+    it('returns canEdit true for regular user', async function() {
       const req = makeReq({ isAdmin: false, isPlanningManager: false, userEmail: 'user@test.com' })
-      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      const res = await callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json.canEdit).toBe(true)
     })
 
-    it('returns granular flags for admin', function() {
+    it('returns granular flags for admin', async function() {
       const req = makeReq({ isAdmin: true, isPlanningManager: false, userEmail: 'admin@test.com' })
-      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      const res = await callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json).toEqual({
         canEdit: true,
         canAdd: true,
@@ -506,9 +506,9 @@ describe('release-planning routes', function() {
       })
     })
 
-    it('returns granular flags for planning-manager', function() {
+    it('returns granular flags for planning-manager', async function() {
       const req = makeReq({ isAdmin: false, isPlanningManager: true, userEmail: 'pm@test.com' })
-      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      const res = await callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json).toEqual({
         canEdit: true,
         canAdd: true,
@@ -517,9 +517,9 @@ describe('release-planning routes', function() {
       })
     })
 
-    it('returns restricted flags for regular user', function() {
+    it('returns restricted flags for regular user', async function() {
       const req = makeReq({ isAdmin: false, isPlanningManager: false, userEmail: 'user@test.com' })
-      const res = callRoute(router._routes, 'GET', '/permissions', req)
+      const res = await callRoute(router._routes, 'GET', '/permissions', req)
       expect(res._json).toEqual({
         canEdit: true,
         canAdd: false,
@@ -532,14 +532,14 @@ describe('release-planning routes', function() {
   // ─── Audit Log ───
 
   describe('GET /audit-log', function() {
-    it('returns empty entries when no log exists', function() {
+    it('returns empty entries when no log exists', async function() {
       const req = makeReq({ query: {} })
-      const res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const res = await callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toEqual([])
       expect(res._json.total).toBe(0)
     })
 
-    it('returns entries filtered by version', function() {
+    it('returns entries filtered by version', async function() {
       storage._store['releases/audit-log.json'] = {
         entries: [
           { id: '1', timestamp: '2026-01-01T00:00:00Z', version: '3.5', action: 'create_rock', user: 'a@b.com', summary: 'test' },
@@ -547,12 +547,12 @@ describe('release-planning routes', function() {
         ]
       }
       const req = makeReq({ query: { version: '3.5' } })
-      const res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const res = await callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toHaveLength(1)
       expect(res._json.total).toBe(1)
     })
 
-    it('returns entries filtered by action', function() {
+    it('returns entries filtered by action', async function() {
       storage._store['releases/audit-log.json'] = {
         entries: [
           { id: '1', timestamp: '2026-01-01T00:00:00Z', version: '3.5', action: 'create_rock', user: 'a@b.com', summary: 'test' },
@@ -560,26 +560,26 @@ describe('release-planning routes', function() {
         ]
       }
       const req = makeReq({ query: { action: 'delete_rock' } })
-      const res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const res = await callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toHaveLength(1)
       expect(res._json.entries[0].action).toBe('delete_rock')
     })
 
-    it('respects limit and offset', function() {
+    it('respects limit and offset', async function() {
       const entries = []
       for (let i = 0; i < 10; i++) {
         entries.push({ id: String(i), timestamp: '2026-01-0' + (i + 1) + 'T00:00:00Z', version: '3.5', action: 'create_rock', user: 'a@b.com', summary: 'entry ' + i })
       }
       storage._store['releases/audit-log.json'] = { entries: entries }
       const req = makeReq({ query: { limit: '3', offset: '2' } })
-      const res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const res = await callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json.entries).toHaveLength(3)
       expect(res._json.total).toBe(10)
     })
 
-    it('clamps limit to max 500', function() {
+    it('clamps limit to max 500', async function() {
       const req = makeReq({ query: { limit: '1000' } })
-      const res = callRoute(router._routes, 'GET', '/audit-log', req)
+      const res = await callRoute(router._routes, 'GET', '/audit-log', req)
       expect(res._json).toBeDefined()
     })
   })
@@ -617,21 +617,21 @@ describe('release-planning routes', function() {
   // ─── Refresh Status ───
 
   describe('GET /refresh/status', function() {
-    it('returns initial refresh state', function() {
-      const res = callRoute(router._routes, 'GET', '/refresh/status')
+    it('returns initial refresh state', async function() {
+      const res = await callRoute(router._routes, 'GET', '/refresh/status')
       expect(res._json.running).toBe(false)
     })
 
-    it('returns aggregate state when no version specified', function() {
+    it('returns aggregate state when no version specified', async function() {
       const req = makeReq({ query: {} })
-      const res = callRoute(router._routes, 'GET', '/refresh/status', req)
+      const res = await callRoute(router._routes, 'GET', '/refresh/status', req)
       expect(res._json.running).toBe(false)
       expect(res._json.lastResult).toBe(null)
     })
 
-    it('returns per-version state when version specified', function() {
+    it('returns per-version state when version specified', async function() {
       const req = makeReq({ query: { version: '3.5' } })
-      const res = callRoute(router._routes, 'GET', '/refresh/status', req)
+      const res = await callRoute(router._routes, 'GET', '/refresh/status', req)
       expect(res._json.running).toBe(false)
       expect(res._json.lastResult).toBe(null)
     })
@@ -750,7 +750,7 @@ describe('release-planning routes', function() {
   // ─── GET /pillar-options ───
 
   describe('GET /pillar-options', function() {
-    it('returns pillar names from PM Hub config', function() {
+    it('returns pillar names from PM Hub config', async function() {
       storage._store['releases/pm-hub/pillar-config.json'] = {
         pillars: [
           { name: 'Inference', components: [] },
@@ -758,17 +758,17 @@ describe('release-planning routes', function() {
         ]
       }
       const req = makeReq()
-      const res = callRoute(router._routes, 'GET', '/pillar-options', req)
+      const res = await callRoute(router._routes, 'GET', '/pillar-options', req)
       expect(res._json.options).toEqual(['Inference', 'Platform'])
     })
 
-    it('returns empty array when no PM Hub config exists', function() {
+    it('returns empty array when no PM Hub config exists', async function() {
       const req = makeReq()
-      const res = callRoute(router._routes, 'GET', '/pillar-options', req)
+      const res = await callRoute(router._routes, 'GET', '/pillar-options', req)
       expect(res._json.options).toEqual([])
     })
 
-    it('filters out empty pillar names', function() {
+    it('filters out empty pillar names', async function() {
       storage._store['releases/pm-hub/pillar-config.json'] = {
         pillars: [
           { name: 'Inference', components: [] },
@@ -777,7 +777,7 @@ describe('release-planning routes', function() {
         ]
       }
       const req = makeReq()
-      const res = callRoute(router._routes, 'GET', '/pillar-options', req)
+      const res = await callRoute(router._routes, 'GET', '/pillar-options', req)
       expect(res._json.options).toEqual(['Inference', 'Platform'])
     })
   })

--- a/modules/releases/__tests__/server/registry-sync.test.js
+++ b/modules/releases/__tests__/server/registry-sync.test.js
@@ -9,8 +9,8 @@ const configMod = require('../../server/delivery/config');
 function createMockStorage(initial = {}) {
   const store = { ...initial };
   return {
-    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
-    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    async readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    async writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
     _store: store
   };
 }

--- a/modules/releases/__tests__/server/registry-version-resolution.test.js
+++ b/modules/releases/__tests__/server/registry-version-resolution.test.js
@@ -6,8 +6,8 @@ const { loadRegistryConfig, saveRegistryConfig, STORAGE_KEY } = require('../../s
 function createMockStorage(initial = {}) {
   const store = { ...initial };
   return {
-    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
-    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    async readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    async writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
     _store: store
   };
 }
@@ -234,41 +234,41 @@ describe('matchVersionsToReleases', () => {
 });
 
 describe('registry-config', () => {
-  it('returns defaults when no config exists', () => {
+  it('returns defaults when no config exists', async () => {
     const storage = createMockStorage();
-    const config = loadRegistryConfig(storage);
+    const config = await loadRegistryConfig(storage);
     expect(config.jiraProjects).toEqual(['RHAISTRAT', 'RHOAIENG']);
   });
 
-  it('loads stored config', () => {
+  it('loads stored config', async () => {
     const storage = createMockStorage({
       [STORAGE_KEY]: { jiraProjects: ['PROJ1', 'PROJ2'] }
     });
-    const config = loadRegistryConfig(storage);
+    const config = await loadRegistryConfig(storage);
     expect(config.jiraProjects).toEqual(['PROJ1', 'PROJ2']);
   });
 
-  it('falls back to defaults for malformed data', () => {
+  it('falls back to defaults for malformed data', async () => {
     const storage = createMockStorage({ [STORAGE_KEY]: 'not-object' });
-    const config = loadRegistryConfig(storage);
+    const config = await loadRegistryConfig(storage);
     expect(config.jiraProjects).toEqual(['RHAISTRAT', 'RHOAIENG']);
   });
 
-  it('saves config to storage', () => {
+  it('saves config to storage', async () => {
     const storage = createMockStorage();
-    saveRegistryConfig(storage, { jiraProjects: ['A', 'B'] });
+    await saveRegistryConfig(storage, { jiraProjects: ['A', 'B'] });
     expect(storage._store[STORAGE_KEY].jiraProjects).toEqual(['A', 'B']);
   });
 
-  it('filters out non-string and empty project values', () => {
+  it('filters out non-string and empty project values', async () => {
     const storage = createMockStorage();
-    saveRegistryConfig(storage, { jiraProjects: ['A', '', null, 42, 'B'] });
+    await saveRegistryConfig(storage, { jiraProjects: ['A', '', null, 42, 'B'] });
     expect(storage._store[STORAGE_KEY].jiraProjects).toEqual(['A', 'B']);
   });
 
-  it('throws on non-object config', () => {
+  it('throws on non-object config', async () => {
     const storage = createMockStorage();
-    expect(() => saveRegistryConfig(storage, null)).toThrow('Config must be an object');
+    await expect(saveRegistryConfig(storage, null)).rejects.toThrow('Config must be an object');
   });
 });
 
@@ -458,9 +458,9 @@ describe('migration + auto-resolve pipeline (integration)', () => {
     });
 
     // Step 1: Migration merges .z entries into clean entries, carrying fixVersions
-    const registry = storage.readFromStorage(REGISTRY_FILE);
+    const registry = await storage.readFromStorage(REGISTRY_FILE);
     const migrated = migrateNormalizedIds(registry);
-    storage.writeToStorage(REGISTRY_FILE, registry);
+    await storage.writeToStorage(REGISTRY_FILE, registry);
 
     expect(migrated).toBe(3); // 3 groups merged
     expect(registry.releases).toHaveLength(4); // 7 → 4
@@ -500,9 +500,9 @@ describe('migration + auto-resolve pipeline (integration)', () => {
     });
 
     // Step 1: Migration is a no-op (IDs already clean)
-    const registry = storage.readFromStorage(REGISTRY_FILE);
+    const registry = await storage.readFromStorage(REGISTRY_FILE);
     const migrated = migrateNormalizedIds(registry);
-    storage.writeToStorage(REGISTRY_FILE, registry);
+    await storage.writeToStorage(REGISTRY_FILE, registry);
     expect(migrated).toBe(0);
 
     // Step 2: Auto-resolve populates fixVersions from Jira
@@ -510,7 +510,7 @@ describe('migration + auto-resolve pipeline (integration)', () => {
     expect(result.status).toBe('ok');
     expect(result.resolved).toBe(2);
 
-    const final = storage.readFromStorage(REGISTRY_FILE);
+    const final = await storage.readFromStorage(REGISTRY_FILE);
     expect(final.releases.find(r => r.id === 'rhoai-3.5').fixVersions).toContain('rhoai-3.5');
     expect(final.releases.find(r => r.id === 'rhoai-3.5.ea1').fixVersions).toContain('rhoai-3.5.EA1');
   });
@@ -533,9 +533,9 @@ describe('migration + auto-resolve pipeline (integration)', () => {
     });
 
     // Migration should carry the manual fixVersion
-    const registry = storage.readFromStorage(REGISTRY_FILE);
+    const registry = await storage.readFromStorage(REGISTRY_FILE);
     migrateNormalizedIds(registry);
-    storage.writeToStorage(REGISTRY_FILE, registry);
+    await storage.writeToStorage(REGISTRY_FILE, registry);
 
     const merged = registry.releases.find(r => r.id === 'rhoai-3.5');
     expect(merged.fixVersions).toContain('manual-custom-fv');

--- a/modules/releases/__tests__/server/registry.test.js
+++ b/modules/releases/__tests__/server/registry.test.js
@@ -5,42 +5,42 @@ const { readRegistry, writeRegistry, validateRelease, normalizeRelease, migrateN
 function createMockStorage(initial = {}) {
   const store = { ...initial };
   return {
-    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
-    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    async readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    async writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
     _store: store
   };
 }
 
 describe('readRegistry', () => {
-  it('returns empty registry when no data exists', () => {
+  it('returns empty registry when no data exists', async () => {
     const storage = createMockStorage();
-    const result = readRegistry(storage.readFromStorage);
+    const result = await readRegistry(storage.readFromStorage);
     expect(result).toEqual({ schemaVersion: 1, releases: [] });
   });
 
-  it('returns stored registry data', () => {
+  it('returns stored registry data', async () => {
     const data = {
       schemaVersion: 1,
       releases: [{ id: 'test-1.0', displayName: 'Test 1.0' }]
     };
     const storage = createMockStorage({ [REGISTRY_FILE]: data });
-    const result = readRegistry(storage.readFromStorage);
+    const result = await readRegistry(storage.readFromStorage);
     expect(result.releases).toHaveLength(1);
     expect(result.releases[0].id).toBe('test-1.0');
   });
 
-  it('returns empty registry for malformed data', () => {
+  it('returns empty registry for malformed data', async () => {
     const storage = createMockStorage({ [REGISTRY_FILE]: { foo: 'bar' } });
-    const result = readRegistry(storage.readFromStorage);
+    const result = await readRegistry(storage.readFromStorage);
     expect(result).toEqual({ schemaVersion: 1, releases: [] });
   });
 });
 
 describe('writeRegistry', () => {
-  it('writes registry to storage', () => {
+  it('writes registry to storage', async () => {
     const storage = createMockStorage();
     const registry = { schemaVersion: 1, releases: [{ id: 'v1' }] };
-    writeRegistry(storage.writeToStorage, registry);
+    await writeRegistry(storage.writeToStorage, registry);
     expect(storage._store[REGISTRY_FILE]).toEqual(registry);
   });
 });

--- a/modules/releases/__tests__/server/storage-migration.test.js
+++ b/modules/releases/__tests__/server/storage-migration.test.js
@@ -12,7 +12,7 @@ vi.mock('express', () => ({
   Router: () => createMockRouter()
 }));
 vi.mock('../../server/planning/audit-log', () => ({
-  getAuditLog: vi.fn(() => ({ entries: [] }))
+  getAuditLog: vi.fn(async () => ({ entries: [] }))
 }));
 
 function createMockRouter() {
@@ -30,9 +30,9 @@ function createMockRouter() {
 function createMockStorage(initial = {}) {
   const store = { ...initial };
   return {
-    readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
-    writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
-    listStorageFiles(prefix) {
+    async readFromStorage(key) { return store[key] ? JSON.parse(JSON.stringify(store[key])) : null; },
+    async writeToStorage(key, data) { store[key] = JSON.parse(JSON.stringify(data)); },
+    async listStorageFiles(prefix) {
       const matches = [];
       const dirPrefix = prefix.endsWith('/') ? prefix : prefix + '/';
       for (const key of Object.keys(store)) {
@@ -46,7 +46,7 @@ function createMockStorage(initial = {}) {
       }
       return matches;
     },
-    deleteFromStorage(key) {
+    async deleteFromStorage(key) {
       if (!(key in store)) throw new Error(`File not found: ${key}`);
       delete store[key];
     },
@@ -70,26 +70,26 @@ function createMockContext(storage) {
 const registerRoutes = require('../../server/index');
 
 describe('Storage migration on startup', () => {
-  it('copies data from old prefixes to new prefixes', () => {
+  it('copies data from old prefixes to new prefixes', async () => {
     const storage = createMockStorage({
       'release-planning/config.json': { planning: true },
       'feature-traffic/index.json': { features: [1, 2] },
       'release-analysis/conforma.json': { releases: [] }
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     expect(storage._store['releases/planning/config.json']).toEqual({ planning: true });
     expect(storage._store['releases/execution/index.json']).toEqual({ features: [1, 2] });
     expect(storage._store['releases/delivery/conforma.json']).toEqual({ releases: [] });
   });
 
-  it('does NOT delete old files after copying', () => {
+  it('does NOT delete old files after copying', async () => {
     const storage = createMockStorage({
       'release-planning/config.json': { planning: true }
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     // Old data should still exist
     expect(storage._store['release-planning/config.json']).toEqual({ planning: true });
@@ -97,41 +97,41 @@ describe('Storage migration on startup', () => {
     expect(storage._store['releases/planning/config.json']).toEqual({ planning: true });
   });
 
-  it('does NOT overwrite existing data at new paths', () => {
+  it('does NOT overwrite existing data at new paths', async () => {
     const storage = createMockStorage({
       'release-planning/config.json': { old: true },
       'releases/planning/config.json': { new: true, preserved: true }
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     // New data should be unchanged
     expect(storage._store['releases/planning/config.json']).toEqual({ new: true, preserved: true });
   });
 
-  it('migrates audit-log.json to releases/audit-log.json', () => {
+  it('migrates audit-log.json to releases/audit-log.json', async () => {
     const auditData = { entries: [{ action: 'created', ts: '2026-01-01' }] };
     const storage = createMockStorage({
       'release-planning/audit-log.json': auditData
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     expect(storage._store['releases/audit-log.json']).toEqual(auditData);
   });
 
-  it('does NOT overwrite existing audit-log.json at new path', () => {
+  it('does NOT overwrite existing audit-log.json at new path', async () => {
     const storage = createMockStorage({
       'release-planning/audit-log.json': { entries: [{ action: 'old' }] },
       'releases/audit-log.json': { entries: [{ action: 'new' }] }
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     expect(storage._store['releases/audit-log.json']).toEqual({ entries: [{ action: 'new' }] });
   });
 
-  it('migrates subdirectory files (releases, features, rfes)', () => {
+  it('migrates subdirectory files (releases, features, rfes)', async () => {
     // A top-level JSON file must exist at the old prefix for the subdirectory
     // loop to run (the code skips the entire prefix if no top-level files exist).
     const storage = createMockStorage({
@@ -141,38 +141,38 @@ describe('Storage migration on startup', () => {
       'feature-traffic/features/feat-1.json': { key: 'FEAT-1' }
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     expect(storage._store['releases/planning/releases/rhoai-2.14.json']).toEqual({ version: '2.14' });
     expect(storage._store['releases/execution/features/feat-1.json']).toEqual({ key: 'FEAT-1' });
   });
 
-  it('skips non-JSON files', () => {
+  it('skips non-JSON files', async () => {
     const storage = createMockStorage({
       'release-planning/readme.txt': 'not json'
     });
     const router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     expect(storage._store['releases/planning/readme.txt']).toBeUndefined();
   });
 
-  it('handles missing old directories gracefully', () => {
+  it('handles missing old directories gracefully', async () => {
     const storage = createMockStorage({});
     const router = createMockRouter();
 
     // Should not throw
-    expect(() => registerRoutes(router, createMockContext(storage))).not.toThrow();
+    await registerRoutes(router, createMockContext(storage));
   });
 
-  it('handles migration errors without crashing', () => {
+  it('handles migration errors without crashing', async () => {
     const storage = createMockStorage({});
     // Force listStorageFiles to throw for all calls
     storage.listStorageFiles = () => { throw new Error('disk error'); };
     const router = createMockRouter();
 
     // The try/catch in registerRoutes should prevent this from crashing
-    expect(() => registerRoutes(router, createMockContext(storage))).not.toThrow();
+    await registerRoutes(router, createMockContext(storage));
   });
 });
 
@@ -180,10 +180,10 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
   let router;
   let handler;
 
-  function setupRoute(storageData) {
+  async function setupRoute(storageData) {
     const storage = createMockStorage(storageData);
     router = createMockRouter();
-    registerRoutes(router, createMockContext(storage));
+    await registerRoutes(router, createMockContext(storage));
 
     // The cleanup route is registered as POST /admin/migrate-storage
     const handlers = router._routes.post['/admin/migrate-storage'];
@@ -192,14 +192,14 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     return storage;
   }
 
-  it('deletes old files when new paths exist', () => {
-    const storage = setupRoute({
+  it('deletes old files when new paths exist', async () => {
+    const storage = await setupRoute({
       'release-planning/config.json': { old: true },
       'releases/planning/config.json': { new: true }
     });
 
     const res = { json: vi.fn() };
-    handler({ query: {} }, res);
+    await handler({ query: {} }, res);
 
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
       status: 'completed',
@@ -211,14 +211,14 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     expect(storage._store['releases/planning/config.json']).toEqual({ new: true });
   });
 
-  it('skips deletion when new path does not exist', () => {
-    setupRoute({
+  it('skips deletion when new path does not exist', async () => {
+    await setupRoute({
       'release-planning/config.json': { old: true }
       // No corresponding new path — migration copies it, so both exist now
     });
 
     const res = { json: vi.fn() };
-    handler({ query: {} }, res);
+    await handler({ query: {} }, res);
 
     const result = res.json.mock.calls[0][0];
     // The startup migration would have copied old → new, so cleanup deletes the old.
@@ -228,10 +228,10 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     expect(result.status).toBe('completed');
   });
 
-  it('deletes old subdirectory files when new paths exist', () => {
+  it('deletes old subdirectory files when new paths exist', async () => {
     // A top-level JSON file must exist at the old prefix for the subdirectory
     // cleanup loop to run.
-    const storage = setupRoute({
+    const storage = await setupRoute({
       'feature-traffic/index.json': { features: [] },
       'feature-traffic/features/feat-1.json': { key: 'FEAT-1' },
       'releases/execution/index.json': { features: [] },
@@ -239,7 +239,7 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     });
 
     const res = { json: vi.fn() };
-    handler({ query: {} }, res);
+    await handler({ query: {} }, res);
 
     const result = res.json.mock.calls[0][0];
     expect(result.deleted).toBeGreaterThanOrEqual(1);
@@ -247,15 +247,15 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     expect(storage._store['releases/execution/features/feat-1.json']).toEqual({ key: 'FEAT-1' });
   });
 
-  it('reports errors when deletion fails', () => {
-    const storage = setupRoute({
+  it('reports errors when deletion fails', async () => {
+    const storage = await setupRoute({
       'release-analysis/conforma.json': { data: true },
       'releases/delivery/conforma.json': { data: true }
     });
 
     // Make deleteFromStorage throw for a specific path
     const origDelete = storage.deleteFromStorage.bind(storage);
-    storage.deleteFromStorage = (key) => {
+    storage.deleteFromStorage = async (key) => {
       if (key === 'release-analysis/conforma.json') {
         throw new Error('permission denied');
       }
@@ -263,7 +263,7 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     };
 
     const res = { json: vi.fn() };
-    handler({ query: {} }, res);
+    await handler({ query: {} }, res);
 
     const result = res.json.mock.calls[0][0];
     expect(result.errors).toEqual(
@@ -273,11 +273,11 @@ describe('POST /admin/migrate-storage (cleanup endpoint)', () => {
     );
   });
 
-  it('returns zero counts when no old data exists', () => {
-    setupRoute({});
+  it('returns zero counts when no old data exists', async () => {
+    await setupRoute({});
 
     const res = { json: vi.fn() };
-    handler({ query: {} }, res);
+    await handler({ query: {} }, res);
 
     const result = res.json.mock.calls[0][0];
     expect(result.status).toBe('completed');

--- a/modules/releases/server/delivery/config.js
+++ b/modules/releases/server/delivery/config.js
@@ -71,8 +71,8 @@ function applyEnvOverrides(config) {
   return config;
 }
 
-function getConfig(readFromStorage) {
-  const saved = readFromStorage('releases/delivery/config.json');
+async function getConfig(readFromStorage) {
+  const saved = await readFromStorage('releases/delivery/config.json');
   let config;
 
   // saved is null when file doesn't exist or was cleared by deleteConfig
@@ -90,7 +90,7 @@ function getConfig(readFromStorage) {
   return config;
 }
 
-function saveConfig(writeToStorage, config) {
+async function saveConfig(writeToStorage, config) {
   const merged = { ...DEFAULT_CONFIG };
 
   const knownKeys = new Set(Object.keys(DEFAULT_CONFIG));
@@ -264,13 +264,13 @@ function saveConfig(writeToStorage, config) {
     merged.commitmentTrackingJql = fragment;
   }
 
-  writeToStorage('releases/delivery/config.json', merged);
+  await writeToStorage('releases/delivery/config.json', merged);
 }
 
-function deleteConfig(writeToStorage) {
+async function deleteConfig(writeToStorage) {
   // Storage API has no delete-file function. Write a tombstone marker that
   // getConfig recognises as "no stored config" so it falls back to env vars.
-  writeToStorage('releases/delivery/config.json', { _deleted: true });
+  await writeToStorage('releases/delivery/config.json', { _deleted: true });
 }
 
 module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, deleteConfig };

--- a/modules/releases/server/delivery/conforma.js
+++ b/modules/releases/server/delivery/conforma.js
@@ -13,7 +13,7 @@ function validateRelease(r) {
   return null
 }
 
-module.exports = function registerConformaRoutes(router, context) {
+module.exports = async function registerConformaRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage, deleteFromStorage } = storage
 
@@ -27,8 +27,8 @@ module.exports = function registerConformaRoutes(router, context) {
    *       200:
    *         description: Conforma data status
    */
-  router.get('/conforma/status', requireAuth, requireScope('releases:read'), function (req, res) {
-    const data = readFromStorage(STORAGE_KEY)
+  router.get('/conforma/status', requireAuth, requireScope('releases:read'), async function (req, res) {
+    const data = await readFromStorage(STORAGE_KEY)
     if (!data) return res.json({ status: 'no_data' })
     res.json({
       fetchedAt: data.fetchedAt || null,
@@ -47,8 +47,8 @@ module.exports = function registerConformaRoutes(router, context) {
    *       200:
    *         description: Conforma releases list
    */
-  router.get('/conforma/releases', requireAuth, requireScope('releases:read'), function (req, res) {
-    const data = readFromStorage(STORAGE_KEY)
+  router.get('/conforma/releases', requireAuth, requireScope('releases:read'), async function (req, res) {
+    const data = await readFromStorage(STORAGE_KEY)
     if (!data) {
       return res.status(404).json({ error: 'No conforma data available. Run the ingestion pipeline.' })
     }
@@ -70,8 +70,8 @@ module.exports = function registerConformaRoutes(router, context) {
    *       200:
    *         description: Single conforma release
    */
-  router.get('/conforma/releases/:version', requireAuth, requireScope('releases:read'), function (req, res) {
-    const data = readFromStorage(STORAGE_KEY)
+  router.get('/conforma/releases/:version', requireAuth, requireScope('releases:read'), async function (req, res) {
+    const data = await readFromStorage(STORAGE_KEY)
     if (!data) {
       return res.status(404).json({ error: 'No conforma data available.' })
     }
@@ -92,7 +92,7 @@ module.exports = function registerConformaRoutes(router, context) {
    *       200:
    *         description: Bulk import results
    */
-  router.post('/conforma/bulk', requireAdmin, requireScope('releases:write'), function (req, res) {
+  router.post('/conforma/bulk', requireAdmin, requireScope('releases:write'), async function (req, res) {
     if (process.env.DEMO_MODE === 'true') {
       return res.json({ status: 'skipped', message: 'Conforma ingest disabled in demo mode.' })
     }
@@ -122,14 +122,14 @@ module.exports = function registerConformaRoutes(router, context) {
     }
 
     const savedAt = new Date().toISOString()
-    writeToStorage(STORAGE_KEY, {
+    await writeToStorage(STORAGE_KEY, {
       fetchedAt: savedAt,
       minDate: minDate || DEFAULT_MIN_DATE,
       count: valid.length,
       releases: valid
     })
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'delivery',
       action: 'conforma_bulk_import',
       user: req.userEmail || 'unknown',
@@ -150,12 +150,12 @@ module.exports = function registerConformaRoutes(router, context) {
    *       204:
    *         description: Conforma data cleared
    */
-  router.delete('/conforma', requireAdmin, requireScope('releases:write'), function (req, res) {
+  router.delete('/conforma', requireAdmin, requireScope('releases:write'), async function (req, res) {
     if (process.env.DEMO_MODE === 'true') {
       return res.status(400).json({ error: 'Cannot delete in demo mode.' })
     }
     try {
-      deleteFromStorage(STORAGE_KEY)
+      await deleteFromStorage(STORAGE_KEY)
     } catch {
       // File may not exist — treat as already cleared
     }

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -238,7 +238,7 @@ async function discoverReleasesFromJira(storage, config) {
   }
 
   // Load metadata from storage
-  const metadata = storage.readFromStorage('releases/delivery/releases-metadata.json') || {}
+  const metadata = await storage.readFromStorage('releases/delivery/releases-metadata.json') || {}
 
   // Build releases array with metadata
   const releases = []
@@ -277,7 +277,7 @@ async function fetchOpenReleases(storage, config) {
     try {
       const releases = await fetchProductsByShortname(config.productPagesProductShortnames, config)
       if (releases.length > 0) {
-        storage.writeToStorage('releases/delivery/product-pages-releases-cache.json', {
+        await storage.writeToStorage('releases/delivery/product-pages-releases-cache.json', {
           source: 'api',
           fetchedAt: new Date().toISOString(),
           releases
@@ -314,7 +314,7 @@ async function fetchOpenReleases(storage, config) {
         planningFreezeDate: toIsoDate(r.planningFreezeDate || r.planning_freeze_date || r.planningFreeze || r.planning_freeze) || null
       }))
       .filter(r => r.productName && r.releaseNumber && r.dueDate)
-    storage.writeToStorage('releases/delivery/product-pages-releases-cache.json', {
+    await storage.writeToStorage('releases/delivery/product-pages-releases-cache.json', {
       source: 'api',
       fetchedAt: new Date().toISOString(),
       releases
@@ -323,7 +323,7 @@ async function fetchOpenReleases(storage, config) {
   }
 
   // Fallback cache. This lets teams load MCP-fetched release snapshots into storage.
-  const cached = storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
+  const cached = await storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
   if (cached?.releases && Array.isArray(cached.releases)) {
     return cached.releases
   }
@@ -1038,7 +1038,7 @@ async function runFullAnalysis(storage, config) {
 
 const CACHE_MAX_AGE_MS = 60 * 60 * 1000 // 1 hour
 
-module.exports = function registerRoutes(router, context) {
+module.exports = async function registerRoutes(router, context) {
   // Initialize product-pages with secrets
   if (context.secrets) productPages.init(context.secrets)
 
@@ -1059,9 +1059,9 @@ module.exports = function registerRoutes(router, context) {
     if (refreshState.running) return { status: 'already_running' }
     refreshState = { running: true, startedAt: new Date().toISOString(), lastResult: refreshState.lastResult }
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const result = await runFullAnalysis(storage, config)
-      writeToStorage('releases/delivery/analysis-cache.json', {
+      await writeToStorage('releases/delivery/analysis-cache.json', {
         cachedAt: new Date().toISOString(),
         data: result
       })
@@ -1101,10 +1101,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Configuration with source info
    */
-  router.get('/config', requireAdmin, requireScope('releases:write'), function(req, res) {
-    const saved = readFromStorage('releases/delivery/config.json')
+  router.get('/config', requireAdmin, requireScope('releases:write'), async function(req, res) {
+    const saved = await readFromStorage('releases/delivery/config.json')
     const hasStoredConfig = saved && typeof saved === 'object' && !saved._deleted
-    const config = getConfig(readFromStorage)
+    const config = await getConfig(readFromStorage)
     // Never expose featureWeightField fallback in stored form — show raw stored value
     if (hasStoredConfig && saved.featureWeightField === undefined) {
       config.featureWeightField = ''
@@ -1122,10 +1122,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Configuration saved
    */
-  router.post('/config', requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.post('/config', requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
-      saveConfig(writeToStorage, req.body)
-      logAudit(readFromStorage, writeToStorage, {
+      await saveConfig(writeToStorage, req.body)
+      await logAudit(readFromStorage, writeToStorage, {
         domain: 'delivery',
         action: 'config_save',
         user: req.userEmail || 'unknown',
@@ -1148,9 +1148,9 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Configuration reset to defaults
    */
-  router.delete('/config', requireAdmin, requireScope('releases:write'), function(req, res) {
-    deleteConfig(writeToStorage)
-    const config = getConfig(readFromStorage)
+  router.delete('/config', requireAdmin, requireScope('releases:write'), async function(req, res) {
+    await deleteConfig(writeToStorage)
+    const config = await getConfig(readFromStorage)
     res.json({ config, source: 'env' })
   })
 
@@ -1168,7 +1168,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.get('/product-pages/products', requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const authStatus = getAuthStatus()
       const products = await fetchAllProducts(config)
       res.json({ products, authStatus })
@@ -1204,14 +1204,14 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Refresh started or already running
    */
-  router.post('/refresh', requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.post('/refresh', requireAdmin, requireScope('releases:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' })
     }
     if (refreshState.running || (context.isRefreshRunning && context.isRefreshRunning())) {
       return res.json({ status: 'already_running' })
     }
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'delivery',
       action: 'manual_refresh',
       user: req.userEmail || 'unknown',
@@ -1233,10 +1233,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Analysis data (possibly stale, with refresh indicators)
    */
-  router.get('/analysis', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/analysis', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
       const forceRefresh = req.query.refresh === 'true'
-      const cached = readFromStorage('releases/delivery/analysis-cache.json')
+      const cached = await readFromStorage('releases/delivery/analysis-cache.json')
       const hasCachedData = cached?.data && cached.cachedAt
 
       if (hasCachedData) {
@@ -1313,14 +1313,14 @@ module.exports = function registerRoutes(router, context) {
 
       // Load committed snapshot
       const snapshotPath = `releases/planning/committed-snapshot-${version}-${phase}.json`
-      const snapshot = readFromStorage(snapshotPath)
+      const snapshot = await readFromStorage(snapshotPath)
 
       if (!snapshot) {
         return res.status(404).json({ error: `No snapshot found for ${version} ${phase}. Use the "Create Snapshot" button above.` })
       }
 
       // Query Jira directly for current state (independent of delivery analysis cache)
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const commitmentJql = config.commitmentTrackingJql || 'cf[10855] is not EMPTY'
 
       const projectsFilter = config.jiraAllProjects
@@ -1479,7 +1479,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.get('/commitment/versions', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const commitmentJql = config.commitmentTrackingJql || 'cf[10855] is not EMPTY'
 
       // Build project filter
@@ -1589,7 +1589,7 @@ module.exports = function registerRoutes(router, context) {
       }
 
       // Load config for commitment tracking JQL (separate from delivery analysis)
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const commitmentJql = config.commitmentTrackingJql || 'cf[10855] is not EMPTY'
 
       // Build project filter
@@ -1665,7 +1665,7 @@ module.exports = function registerRoutes(router, context) {
 
       // Write to storage
       const snapshotPath = `releases/planning/committed-snapshot-${version}-${phase}.json`
-      writeToStorage(snapshotPath, snapshotData)
+      await writeToStorage(snapshotPath, snapshotData)
 
       console.log(`[releases/delivery] Created snapshot for ${version} ${phase}: ${seenKeys.size} features`)
 
@@ -1683,7 +1683,7 @@ module.exports = function registerRoutes(router, context) {
   // --- Startup cache seeding ---
   // Warm the cache in the background so the first user request is instant
   if (!DEMO_MODE) {
-    const existing = readFromStorage('releases/delivery/analysis-cache.json')
+    const existing = await readFromStorage('releases/delivery/analysis-cache.json')
     const hasFreshCache = existing?.data && existing.cachedAt &&
       (Date.now() - new Date(existing.cachedAt).getTime()) < CACHE_MAX_AGE_MS
     if (!hasFreshCache) {
@@ -1702,7 +1702,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Releases uploaded and analysis triggered
    */
-  router.post('/admin/releases', requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.post('/admin/releases', requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
       const releases = Array.isArray(req.body?.releases) ? req.body.releases : null
       if (!releases || releases.length === 0) {
@@ -1720,7 +1720,7 @@ module.exports = function registerRoutes(router, context) {
         return res.status(400).json({ error: 'No valid releases after normalization' })
       }
 
-      writeToStorage('releases/delivery/product-pages-releases-cache.json', {
+      await writeToStorage('releases/delivery/product-pages-releases-cache.json', {
         source: 'manual',
         fetchedAt: new Date().toISOString(),
         releases: normalized
@@ -1741,7 +1741,7 @@ module.exports = function registerRoutes(router, context) {
   let bugsCache = { data: null, timestamp: 0, projectsKey: '' }
   const BUGS_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
-  function loadAllBugs(projects) {
+  async function loadAllBugs(projects) {
     const projectsKey = projects.join(',')
     const now = Date.now()
 
@@ -1757,7 +1757,7 @@ module.exports = function registerRoutes(router, context) {
     // Cache miss or stale - read from storage
     const allBugs = []
     for (const project of projects) {
-      const bugs = readFromStorage(`releases/delivery/quality/bugs-${project}.json`) || []
+      const bugs = await readFromStorage(`releases/delivery/quality/bugs-${project}.json`) || []
       allBugs.push(...bugs)
     }
 
@@ -1776,9 +1776,9 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Versions sorted by bug count
    */
-  router.get('/quality/versions', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/quality/versions', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const versions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const versions = await readFromStorage('releases/delivery/quality/versions.json') || []
 
       const sorted = [...versions].sort((a, b) => (b.bugCount || 0) - (a.bugCount || 0))
 
@@ -1809,9 +1809,9 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Chart data with labels and datasets
    */
-  router.get('/quality/bugs', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/quality/bugs', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const versions = (req.query.versions || '').split(',').filter(Boolean)
       const component = req.query.component || null
 
@@ -1832,7 +1832,7 @@ module.exports = function registerRoutes(router, context) {
         )
       }
 
-      const allVersions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const allVersions = await readFromStorage('releases/delivery/quality/versions.json') || []
       const versionReleaseMap = new Map(allVersions.map(v => [v.name, v.releaseDate]))
 
       const chartData = computeCumulativeBugData(filteredBugs, versions, versionReleaseMap)
@@ -1853,9 +1853,9 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Components sorted by bug count
    */
-  router.get('/quality/components', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/quality/components', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const allBugs = loadAllBugs(config.projectKeys)
 
       const componentCounts = {}
@@ -1893,7 +1893,7 @@ module.exports = function registerRoutes(router, context) {
       return res.json({ status: 'skipped', message: 'Refresh disabled in demo mode' })
     }
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const versions = await fetchQualityVersions(config.projectKeys)
 
       const bugCounts = await fetchBugCounts(config.projectKeys, versions)
@@ -1901,11 +1901,11 @@ module.exports = function registerRoutes(router, context) {
         ...v,
         bugCount: bugCounts.get(v.name) || 0
       }))
-      writeToStorage('releases/delivery/quality/versions.json', versionsWithCounts)
+      await writeToStorage('releases/delivery/quality/versions.json', versionsWithCounts)
 
       for (const project of config.projectKeys) {
         const bugs = await fetchBugs(project, versions)
-        writeToStorage(`releases/delivery/quality/bugs-${project}.json`, bugs)
+        await writeToStorage(`releases/delivery/quality/bugs-${project}.json`, bugs)
       }
 
       bugsCache = { data: null, timestamp: 0, projectsKey: '' }
@@ -1926,10 +1926,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Diagnostic information about bug data and version matching
    */
-  router.get('/quality/debug', requireAdmin, requireScope('releases:read'), function(req, res) {
+  router.get('/quality/debug', requireAdmin, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
-      const versions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const config = await getConfig(readFromStorage)
+      const versions = await readFromStorage('releases/delivery/quality/versions.json') || []
 
       const cacheSnapshot = {
         projectsKey: bugsCache.projectsKey,
@@ -1942,7 +1942,7 @@ module.exports = function registerRoutes(router, context) {
 
       const bugsByProject = {}
       for (const project of config.projectKeys) {
-        const bugs = readFromStorage(`releases/delivery/quality/bugs-${project}.json`) || []
+        const bugs = await readFromStorage(`releases/delivery/quality/bugs-${project}.json`) || []
         bugsByProject[project] = bugs.length
       }
 
@@ -2126,10 +2126,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Bug counts per product within 90 days of GA for each major release
    */
-  router.get('/quality/90day-summary', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/quality/90day-summary', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
-      const versions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const config = await getConfig(readFromStorage)
+      const versions = await readFromStorage('releases/delivery/quality/versions.json') || []
       const allBugs = loadAllBugs(config.projectKeys)
       const releases = compute90DaySummary(null, allBugs, versions)
       res.json({ releases: releases })
@@ -2154,10 +2154,10 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Bug counts per product within 90 days of GA using provided config
    */
-  router.post('/quality/90day-summary', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.post('/quality/90day-summary', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
-      const versions = readFromStorage('releases/delivery/quality/versions.json') || []
+      const config = await getConfig(readFromStorage)
+      const versions = await readFromStorage('releases/delivery/quality/versions.json') || []
       const allBugs = loadAllBugs(config.projectKeys)
       const configReleases = req.body && req.body.releases ? req.body.releases : null
       const releases = compute90DaySummary(configReleases, allBugs, versions)
@@ -2181,7 +2181,7 @@ module.exports = function registerRoutes(router, context) {
    */
   router.post('/discover-releases', requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
-      const config = getConfig(readFromStorage)
+      const config = await getConfig(readFromStorage)
       const releases = await discoverReleasesFromJira(storage, config)
       res.json({ releases })
     } catch (error) {
@@ -2201,9 +2201,9 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Releases metadata object
    */
-  router.get('/releases-metadata', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases-metadata', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const metadata = readFromStorage('releases/delivery/releases-metadata.json') || {}
+      const metadata = await readFromStorage('releases/delivery/releases-metadata.json') || {}
       res.json(metadata)
     } catch (error) {
       console.error('[releases/delivery] Get metadata error:', error)
@@ -2239,13 +2239,13 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Metadata saved successfully
    */
-  router.post('/releases-metadata', requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.post('/releases-metadata', requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
       const metadata = req.body
       if (typeof metadata !== 'object' || Array.isArray(metadata)) {
         return res.status(400).json({ error: 'Metadata must be an object' })
       }
-      writeToStorage('releases/delivery/releases-metadata.json', metadata)
+      await writeToStorage('releases/delivery/releases-metadata.json', metadata)
       res.json({ success: true })
     } catch (error) {
       console.error('[releases/delivery] Save metadata error:', error)
@@ -2264,9 +2264,9 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Risk dashboard config object
    */
-  router.get('/risk-dashboard-config', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/risk-dashboard-config', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
-      const config = readFromStorage('releases/delivery/risk-dashboard-config.json') || { portfolioReleases: [] }
+      const config = await readFromStorage('releases/delivery/risk-dashboard-config.json') || { portfolioReleases: [] }
       res.json(config)
     } catch (error) {
       console.error('[releases/delivery] Get risk-dashboard-config error:', error)
@@ -2319,7 +2319,7 @@ module.exports = function registerRoutes(router, context) {
    *       400:
    *         description: Invalid config
    */
-  router.post('/risk-dashboard-config', requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.post('/risk-dashboard-config', requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
       const config = req.body
       if (typeof config !== 'object' || Array.isArray(config)) {
@@ -2348,7 +2348,7 @@ module.exports = function registerRoutes(router, context) {
           return res.status(400).json({ error: 'Portfolio "' + p.name + '" dueDate must be a YYYY-MM-DD string or null' })
         }
       }
-      writeToStorage('releases/delivery/risk-dashboard-config.json', config)
+      await writeToStorage('releases/delivery/risk-dashboard-config.json', config)
       res.json({ success: true })
     } catch (error) {
       console.error('[releases/delivery] Save risk-dashboard-config error:', error)

--- a/modules/releases/server/draft-plans/fetch.js
+++ b/modules/releases/server/draft-plans/fetch.js
@@ -80,7 +80,7 @@ async function fetchDraftPlans(storage, config, token) {
           continue;
         }
 
-        storage.writeToStorage(`${DATA_PREFIX}/${product}/${fileName}`, parsed);
+        await storage.writeToStorage(`${DATA_PREFIX}/${product}/${fileName}`, parsed);
         productResults[product].files++;
         fileCount++;
       } catch (err) {
@@ -109,7 +109,7 @@ async function fetchDraftPlans(storage, config, token) {
     warnings: warnings.length > 0 ? warnings : undefined
   };
 
-  storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
+  await storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
 
   return result;
 }

--- a/modules/releases/server/draft-plans/routes.js
+++ b/modules/releases/server/draft-plans/routes.js
@@ -3,7 +3,7 @@ const { logAudit } = require('../planning/audit-log');
 
 const COOLDOWN_MS = 5 * 60 * 1000;
 
-module.exports = function registerDraftPlanRoutes(router, context) {
+module.exports = async function registerDraftPlanRoutes(router, context) {
   const { storage, requireAuth, requireScope, secrets, registerRefresh, isRefreshRunning } = context;
 
   let fetchInProgress = false;
@@ -22,13 +22,13 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     return null;
   }
 
-  function loadConfig() {
-    var stored = storage.readFromStorage(DATA_PREFIX + '/config.json');
+  async function loadConfig() {
+    var stored = await storage.readFromStorage(DATA_PREFIX + '/config.json');
     return Object.assign({}, DEFAULT_CONFIG, stored || {});
   }
 
-  function saveConfig(config) {
-    storage.writeToStorage(DATA_PREFIX + '/config.json', config);
+  async function saveConfig(config) {
+    await storage.writeToStorage(DATA_PREFIX + '/config.json', config);
   }
 
   function validateConfig(input) {
@@ -60,7 +60,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
     if (!token) {
       return { status: 'error', message: 'No GitLab token configured. Set DRAFT_PLANS_GITLAB_TOKEN or GITLAB_TOKEN.' };
     }
-    var config = loadConfig();
+    var config = await loadConfig();
     if (!config.enabled) {
       return { status: 'skipped', message: 'Draft plans fetch is disabled' };
     }
@@ -75,7 +75,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       return result;
     } catch (err) {
       var errorResult = { status: 'error', message: err.message, timestamp: new Date().toISOString() };
-      storage.writeToStorage(DATA_PREFIX + '/last-fetch.json', errorResult);
+      await storage.writeToStorage(DATA_PREFIX + '/last-fetch.json', errorResult);
       refreshState = { running: false, lastResult: errorResult };
       throw err;
     } finally {
@@ -100,7 +100,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    *       200:
    *         description: Draft plan releases with health data
    */
-  router.get('/releases', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases', requireAuth, requireScope('releases:read'), async function(req, res) {
     var productFilter = req.query.product || null;
     var results = [];
 
@@ -108,8 +108,8 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       var product = KNOWN_PRODUCTS[i];
       if (productFilter && product !== productFilter) continue;
 
-      var plan = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-plan.json');
-      var health = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-health.json');
+      var plan = await storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-plan.json');
+      var health = await storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-health.json');
 
       if (!plan && !health) continue;
 
@@ -146,7 +146,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       });
     }
 
-    var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
+    var lastFetch = await storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
     res.json({
       fetchedAt: lastFetch ? lastFetch.timestamp : null,
       products: results
@@ -192,14 +192,14 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       return res.status(500).json({ status: 'error', message: 'No GitLab token configured. Set DRAFT_PLANS_GITLAB_TOKEN or GITLAB_TOKEN.' });
     }
 
-    var config = loadConfig();
+    var config = await loadConfig();
     if (!config.enabled) {
       return res.status(400).json({ status: 'error', message: 'Draft plans fetch is disabled. Enable it in config.' });
     }
 
     try {
       var result = await doFetch();
-      logAudit(storage.readFromStorage, storage.writeToStorage, {
+      await logAudit(storage.readFromStorage, storage.writeToStorage, {
         domain: 'draft-plans',
         action: 'manual_refresh',
         user: req.userEmail || 'unknown',
@@ -222,8 +222,8 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    *       200:
    *         description: Refresh status
    */
-  router.get('/refresh/status', requireAuth, requireScope('releases:read'), function(req, res) {
-    var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
+  router.get('/refresh/status', requireAuth, requireScope('releases:read'), async function(req, res) {
+    var lastFetch = await storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
     res.json({
       running: refreshState.running,
       startedAt: refreshState.startedAt || null,
@@ -242,8 +242,8 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    *       200:
    *         description: Current configuration with token status
    */
-  router.get('/config', requireAuth, requireScope('releases:write'), function(req, res) {
-    var config = loadConfig();
+  router.get('/config', requireAuth, requireScope('releases:write'), async function(req, res) {
+    var config = await loadConfig();
     res.json(Object.assign({}, config, {
       tokenConfigured: !!getToken(),
       tokenSource: getTokenSource()
@@ -265,11 +265,11 @@ module.exports = function registerDraftPlanRoutes(router, context) {
   router.post('/config', requireAuth, requireScope('releases:write'), async function(req, res) {
     try {
       validateConfig(req.body);
-      var oldConfig = loadConfig();
+      var oldConfig = await loadConfig();
       var config = Object.assign({}, oldConfig, req.body);
-      saveConfig(config);
+      await saveConfig(config);
 
-      logAudit(storage.readFromStorage, storage.writeToStorage, {
+      await logAudit(storage.readFromStorage, storage.writeToStorage, {
         domain: 'draft-plans',
         action: 'config_save',
         user: req.userEmail || 'unknown',
@@ -319,7 +319,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    *       404:
    *         description: No data found for version
    */
-  router.get('/:version', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/:version', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = req.params.version;
     if (!/^[a-zA-Z0-9 ._-]{1,50}$/.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
@@ -332,7 +332,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       var product = KNOWN_PRODUCTS[i];
       if (productFilter && product !== productFilter) continue;
 
-      var plan = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-plan.json');
+      var plan = await storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-plan.json');
       if (!plan || !Array.isArray(plan.releases)) continue;
 
       var match = null;
@@ -384,7 +384,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
    *       404:
    *         description: No health data found for version
    */
-  router.get('/:version/health', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/:version/health', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = req.params.version;
     if (!/^[a-zA-Z0-9 ._-]{1,50}$/.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
@@ -397,7 +397,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       var product = KNOWN_PRODUCTS[i];
       if (productFilter && product !== productFilter) continue;
 
-      var health = storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-health.json');
+      var health = await storage.readFromStorage(DATA_PREFIX + '/' + product + '/release-health.json');
       if (!health || !Array.isArray(health.releases)) continue;
 
       var match = null;
@@ -428,7 +428,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
   // ─── registerRefresh ──────────────────────────────────────────────
 
   if (registerRefresh) {
-    var initialConfig = loadConfig();
+    var initialConfig = await loadConfig();
 
     registerRefresh('draft-plans', {
       order: 80,
@@ -436,7 +436,7 @@ module.exports = function registerDraftPlanRoutes(router, context) {
       description: 'Fetches draft release plan data from the release-planning-data GitLab repository.',
       cadence: initialConfig.refreshIntervalHours + 'h',
       handler: async function() {
-        var config = loadConfig();
+        var config = await loadConfig();
         if (!config.enabled) {
           return { status: 'skipped', message: 'Draft plans fetch is disabled' };
         }
@@ -461,8 +461,8 @@ module.exports = function registerDraftPlanRoutes(router, context) {
 
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      var lastFetch = storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
-      var config = loadConfig();
+      var lastFetch = await storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
+      var config = await loadConfig();
       return {
         lastFetchStatus: lastFetch ? lastFetch.status : null,
         lastFetchTimestamp: lastFetch ? lastFetch.timestamp : null,

--- a/modules/releases/server/execution/__tests__/feature-store.test.js
+++ b/modules/releases/server/execution/__tests__/feature-store.test.js
@@ -67,11 +67,11 @@ describe('mergeFeatureData — aiReview handling', function() {
 })
 
 describe('rebuildIndex — aiReview summary', function() {
-  it('includes slim aiReview in index entries for features with aiReview', function() {
+  it('includes slim aiReview in index entries for features with aiReview', async function() {
     const stored = {}
     const storage = {
-      listStorageFiles: function() { return ['TEST-1.json'] },
-      readFromStorage: function(path) {
+      listStorageFiles: async function() { return ['TEST-1.json'] },
+      readFromStorage: async function(path) {
         if (path.endsWith('TEST-1.json')) {
           return {
             key: 'TEST-1',
@@ -89,12 +89,12 @@ describe('rebuildIndex — aiReview summary', function() {
         }
         return null
       },
-      writeToStorage: function(path, data) {
+      writeToStorage: async function(path, data) {
         stored[path] = data
       }
     }
 
-    rebuildIndex(storage)
+    await rebuildIndex(storage)
 
     const index = stored['releases/execution/index.json']
     expect(index.features[0].aiReview).toEqual({
@@ -109,22 +109,22 @@ describe('rebuildIndex — aiReview summary', function() {
     expect(index.features[0].aiReview.history).toBeUndefined()
   })
 
-  it('sets aiReview to null in index for features without aiReview', function() {
+  it('sets aiReview to null in index for features without aiReview', async function() {
     const stored = {}
     const storage = {
-      listStorageFiles: function() { return ['TEST-2.json'] },
-      readFromStorage: function(path) {
+      listStorageFiles: async function() { return ['TEST-2.json'] },
+      readFromStorage: async function(path) {
         if (path.endsWith('TEST-2.json')) {
           return { key: 'TEST-2', summary: 'No AI review' }
         }
         return null
       },
-      writeToStorage: function(path, data) {
+      writeToStorage: async function(path, data) {
         stored[path] = data
       }
     }
 
-    rebuildIndex(storage)
+    await rebuildIndex(storage)
 
     const index = stored['releases/execution/index.json']
     expect(index.features[0].aiReview).toBeNull()

--- a/modules/releases/server/execution/feature-store.js
+++ b/modules/releases/server/execution/feature-store.js
@@ -141,7 +141,7 @@ async function writeFeatures(storage, features) {
     for (let i = 0; i < features.length; i++) {
       const feature = features[i];
       if (!feature.key) continue;
-      storage.writeToStorage(
+      await storage.writeToStorage(
         DATA_PREFIX + '/features/' + feature.key + '.json',
         feature
       );
@@ -160,9 +160,9 @@ async function writeFeatures(storage, features) {
  * @param {object} storage - Storage abstraction
  */
 async function rebuildIndex(storage) {
-  const fileNames = storage.listStorageFiles(DATA_PREFIX + '/features');
+  const fileNames = await storage.listStorageFiles(DATA_PREFIX + '/features');
   if (!fileNames || fileNames.length === 0) {
-    storage.writeToStorage(DATA_PREFIX + '/index.json', {
+    await storage.writeToStorage(DATA_PREFIX + '/index.json', {
       fetchedAt: new Date().toISOString(),
       schemaVersion: 'v2',
       featureCount: 0,
@@ -177,7 +177,7 @@ async function rebuildIndex(storage) {
     const fileName = fileNames[i];
     if (!fileName.endsWith('.json')) continue;
 
-    const feature = storage.readFromStorage(DATA_PREFIX + '/features/' + fileName);
+    const feature = await storage.readFromStorage(DATA_PREFIX + '/features/' + fileName);
     if (!feature || !feature.key) continue;
 
     // Map detail fields to index summary fields
@@ -226,7 +226,7 @@ async function rebuildIndex(storage) {
     features.push(indexEntry);
   }
 
-  storage.writeToStorage(DATA_PREFIX + '/index.json', {
+  await storage.writeToStorage(DATA_PREFIX + '/index.json', {
     fetchedAt: new Date().toISOString(),
     schemaVersion: 'v2',
     featureCount: features.length,

--- a/modules/releases/server/execution/feature-tracking-routes.js
+++ b/modules/releases/server/execution/feature-tracking-routes.js
@@ -417,8 +417,8 @@ function findFixVersionRemovedDate(changelog, fixVersionNames) {
  * Returns a map: { "rhoai-3.5.EA1": "2026-05-15", "rhelai-3.5.EA1": "2026-04-17", ... }
  * Also returns the earliest date across products as a portfolio-level fallback.
  */
-function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
-  const ppCache = readFromStorage(PP_CACHE_FILE)
+async function getFeatureFreezeDatesFromCache(portfolioVersion, readFromStorage) {
+  const ppCache = await readFromStorage(PP_CACHE_FILE)
   const ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
 
   const normalizedPortfolio = normalizeVersionName(portfolioVersion)
@@ -536,18 +536,18 @@ function validateTrackingConfig(body) {
   return null
 }
 
-function loadTrackingConfig(readFromStorage) {
-  var config = readFromStorage(TRACKING_CONFIG_FILE)
+async function loadTrackingConfig(readFromStorage) {
+  var config = await readFromStorage(TRACKING_CONFIG_FILE)
   return config || { releases: {} }
 }
 
-module.exports = function registerFeatureTrackingRoutes(router, context) {
+module.exports = async function registerFeatureTrackingRoutes(router, context) {
   const storage = context.storage
   const requireAuth = context.requireAuth
   const requireScope = context.requireScope
 
   // GET /tracking/versions
-  router.get('/tracking/versions', requireAuth, requireScope('releases:read'), function (req, res) {
+  router.get('/tracking/versions', requireAuth, requireScope('releases:read'), async function (req, res) {
     const versionMap = {}
 
     function addVersion(releaseNumber) {
@@ -565,7 +565,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       }
     }
 
-    const registry = readRegistry(storage.readFromStorage)
+    const registry = await readRegistry(storage.readFromStorage)
     const registryReleases = registry.releases || []
     for (let ri = 0; ri < registryReleases.length; ri++) {
       const rel = registryReleases[ri]
@@ -573,13 +573,13 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       addVersion(rel.displayName || rel.id || '')
     }
 
-    const ppCache = storage.readFromStorage(PP_CACHE_FILE)
+    const ppCache = await storage.readFromStorage(PP_CACHE_FILE)
     const ppReleases = Array.isArray(ppCache) ? ppCache : (ppCache && ppCache.releases) || []
     for (let pi = 0; pi < ppReleases.length; pi++) {
       if (ppReleases[pi].releaseNumber) addVersion(ppReleases[pi].releaseNumber)
     }
 
-    const planningConfig = storage.readFromStorage(PLANNING_CONFIG_FILE)
+    const planningConfig = await storage.readFromStorage(PLANNING_CONFIG_FILE)
     if (planningConfig && planningConfig.releases) {
       const configVersions = Object.keys(planningConfig.releases)
       for (let ci = 0; ci < configVersions.length; ci++) {
@@ -591,7 +591,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
     }
 
     // Source 4: feature tracking config (user-defined releases)
-    const trackingConfig = loadTrackingConfig(storage.readFromStorage)
+    const trackingConfig = await loadTrackingConfig(storage.readFromStorage)
     if (trackingConfig.releases) {
       const trackingVersions = Object.keys(trackingConfig.releases)
       for (let ti = 0; ti < trackingVersions.length; ti++) {
@@ -623,7 +623,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       if (userDate) {
         versions[vi].planningFreezeDate = userDate
       } else {
-        const fd = getFeatureFreezeDatesFromCache(vKey, storage.readFromStorage)
+        const fd = await getFeatureFreezeDatesFromCache(vKey, storage.readFromStorage)
         versions[vi].planningFreezeDate = fd.earliest || null
       }
     }
@@ -649,7 +649,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
 
     try {
       if (!forceRefresh) {
-        const cached = storage.readFromStorage(cacheKey(version))
+        const cached = await storage.readFromStorage(cacheKey(version))
         if (cached && cached.fetchedAt) {
           const age = Date.now() - new Date(cached.fetchedAt).getTime()
           if (age < CACHE_TTL_MS) {
@@ -665,9 +665,9 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
       const jiraRequest = jira.jiraRequest
       const fetchAllJqlResults = jira.fetchAllJqlResults
 
-      const tConfig = loadTrackingConfig(storage.readFromStorage)
+      const tConfig = await loadTrackingConfig(storage.readFromStorage)
       const productVersions = await resolveProductVersionsFromJira(version, jiraRequest, tConfig)
-      const freezeDates = getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
+      const freezeDates = await getFeatureFreezeDatesFromCache(version, storage.readFromStorage)
       const cacheDates = Object.assign({}, freezeDates.byProduct)
 
       // Always try the schedule API — it returns EA-specific freeze dates
@@ -791,7 +791,7 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
         _freezeDatesFinal: Object.assign({}, freezeDates.byProduct)
       }
 
-      storage.writeToStorage(cacheKey(version), responseData)
+      await storage.writeToStorage(cacheKey(version), responseData)
 
       res.json(responseData)
     } catch (err) {
@@ -801,16 +801,16 @@ module.exports = function registerFeatureTrackingRoutes(router, context) {
   })
 
   // GET /tracking/config
-  router.get('/tracking/config', requireAuth, requireScope('releases:read'), function (req, res) {
-    res.json(loadTrackingConfig(storage.readFromStorage))
+  router.get('/tracking/config', requireAuth, requireScope('releases:read'), async function (req, res) {
+    res.json(await loadTrackingConfig(storage.readFromStorage))
   })
 
   // PUT /tracking/config
-  router.put('/tracking/config', requireAuth, requireScope('releases:write'), function (req, res) {
+  router.put('/tracking/config', requireAuth, requireScope('releases:write'), async function (req, res) {
     var err = validateTrackingConfig(req.body)
     if (err) return res.status(400).json({ error: err })
     var config = { releases: req.body.releases }
-    storage.writeToStorage(TRACKING_CONFIG_FILE, config)
+    await storage.writeToStorage(TRACKING_CONFIG_FILE, config)
     res.json(config)
   })
 

--- a/modules/releases/server/execution/gitlab-fetch.js
+++ b/modules/releases/server/execution/gitlab-fetch.js
@@ -162,7 +162,7 @@ async function fetchArtifacts(storage, config, token, jira) {
   // Write non-feature files directly (e.g., config files in the artifact)
   let fileCount = 0;
   for (const [filePath, data] of nonFeatureFiles) {
-    storage.writeToStorage(`${DATA_PREFIX}/${filePath}`, data);
+    await storage.writeToStorage(`${DATA_PREFIX}/${filePath}`, data);
     fileCount++;
   }
 
@@ -189,7 +189,7 @@ async function fetchArtifacts(storage, config, token, jira) {
   const mergedFeatures = [];
 
   for (const [key, pipelineData] of pipelineFeatures) {
-    const existing = storage.readFromStorage(`${DATA_PREFIX}/features/${key}.json`);
+    const existing = await storage.readFromStorage(`${DATA_PREFIX}/features/${key}.json`);
     const jiraData = enrichmentMap.get(key) || null;
     const merged = mergeFeatureData(existing, pipelineData, jiraData);
     mergedFeatures.push(merged);
@@ -216,7 +216,7 @@ async function fetchArtifacts(storage, config, token, jira) {
   };
 
   // Write last-fetch metadata
-  storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
+  await storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
 
   return result;
 }

--- a/modules/releases/server/execution/jira-enrich.js
+++ b/modules/releases/server/execution/jira-enrich.js
@@ -303,7 +303,7 @@ async function fetchSignOffDetails(keys, storage, jiraRequestFn, fetchAllJqlResu
   // Filter to only keys that need sign-off backfill
   const needsSignOff = [];
   for (let i = 0; i < keys.length; i++) {
-    const feature = storage.readFromStorage(DATA_PREFIX + '/features/' + keys[i] + '.json');
+    const feature = await storage.readFromStorage(DATA_PREFIX + '/features/' + keys[i] + '.json');
     if (!feature || !feature.aiReview) continue;
     if (feature.aiReview.humanReviewStatus === 'approved' &&
         !feature.aiReview.approvedBy && !feature.aiReview.approvedAt) {

--- a/modules/releases/server/execution/jira-sync.js
+++ b/modules/releases/server/execution/jira-sync.js
@@ -22,7 +22,7 @@ async function syncAllFeatures(storage, jiraRequestFn, fetchAllJqlResultsFn) {
   const startTime = Date.now();
 
   // List all feature files
-  const fileNames = storage.listStorageFiles(DATA_PREFIX + '/features');
+  const fileNames = await storage.listStorageFiles(DATA_PREFIX + '/features');
   if (!fileNames || fileNames.length === 0) {
     return {
       status: 'skipped',
@@ -48,7 +48,7 @@ async function syncAllFeatures(storage, jiraRequestFn, fetchAllJqlResultsFn) {
   const mergedFeatures = [];
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    const existing = storage.readFromStorage(DATA_PREFIX + '/features/' + key + '.json');
+    const existing = await storage.readFromStorage(DATA_PREFIX + '/features/' + key + '.json');
     const jiraData = enrichmentMap.get(key) || null;
     const merged = mergeFeatureData(existing, null, jiraData);
     mergedFeatures.push(merged);
@@ -64,7 +64,7 @@ async function syncAllFeatures(storage, jiraRequestFn, fetchAllJqlResultsFn) {
     if (signOffMap.size > 0) {
       const signOffUpdates = [];
       for (const [key, signOff] of signOffMap) {
-        const feature = storage.readFromStorage(DATA_PREFIX + '/features/' + key + '.json');
+        const feature = await storage.readFromStorage(DATA_PREFIX + '/features/' + key + '.json');
         if (feature && feature.aiReview) {
           feature.aiReview.approvedBy = signOff.approvedBy;
           feature.aiReview.approvedAt = signOff.approvedAt;
@@ -91,7 +91,7 @@ async function syncAllFeatures(storage, jiraRequestFn, fetchAllJqlResultsFn) {
   };
 
   // Write enrichment metadata
-  storage.writeToStorage(DATA_PREFIX + '/last-enrichment.json', result);
+  await storage.writeToStorage(DATA_PREFIX + '/last-enrichment.json', result);
 
   console.log('[jira-sync] Sync complete: ' + enrichmentMap.size + '/' + keys.length + ' enriched in ' + duration + 'ms');
 
@@ -119,7 +119,7 @@ async function discoverFromJira(storage, jiraRequestFn, fetchAllJqlResultsFn, co
   const newFeatures = [];
   for (let i = 0; i < discovered.length; i++) {
     const feature = discovered[i];
-    const existing = storage.readFromStorage(DATA_PREFIX + '/features/' + feature.key + '.json');
+    const existing = await storage.readFromStorage(DATA_PREFIX + '/features/' + feature.key + '.json');
     if (!existing) {
       // Create new entry from Jira data
       const merged = mergeFeatureData(null, null, feature);
@@ -147,7 +147,7 @@ async function discoverFromJira(storage, jiraRequestFn, fetchAllJqlResultsFn, co
  */
 async function reconcileTrackingData(storage) {
   // Find all tracking-data-*.json files
-  const files = storage.listStorageFiles(DATA_PREFIX);
+  const files = await storage.listStorageFiles(DATA_PREFIX);
   const trackingFiles = [];
   for (let i = 0; i < files.length; i++) {
     if (files[i].startsWith('tracking-data-') && files[i].endsWith('.json')) {
@@ -157,7 +157,7 @@ async function reconcileTrackingData(storage) {
 
   const discoveredKeys = new Set();
   for (let i = 0; i < trackingFiles.length; i++) {
-    const data = storage.readFromStorage(DATA_PREFIX + '/' + trackingFiles[i]);
+    const data = await storage.readFromStorage(DATA_PREFIX + '/' + trackingFiles[i]);
     if (!data || !data.features) continue;
 
     // data.features is either an array or an object keyed by issue key
@@ -175,7 +175,7 @@ async function reconcileTrackingData(storage) {
   // Check which keys don't have feature files yet
   const newFeatures = [];
   for (const key of discoveredKeys) {
-    const existing = storage.readFromStorage(DATA_PREFIX + '/features/' + key + '.json');
+    const existing = await storage.readFromStorage(DATA_PREFIX + '/features/' + key + '.json');
     if (!existing) {
       newFeatures.push({
         key,

--- a/modules/releases/server/execution/routes.js
+++ b/modules/releases/server/execution/routes.js
@@ -148,20 +148,20 @@ function stripZStream(value) {
  *         description: Per-key cooldown active
  */
 
-module.exports = function registerExecutionRoutes(router, context) {
+module.exports = async function registerExecutionRoutes(router, context) {
   // Initialize scheduler with secrets and jira client
   const jira = context.jira || null;
   if (context.secrets) scheduler.init(context.secrets, jira);
 
   const { storage, requireAuth, requireScope } = context;
 
-  function readDataFile(relativePath) {
-    return storage.readFromStorage(`${DATA_PREFIX}/${relativePath}`);
+  async function readDataFile(relativePath) {
+    return await storage.readFromStorage(`${DATA_PREFIX}/${relativePath}`);
   }
 
   // GET /features — list all features with summary metrics
-  router.get('/features', requireAuth, requireScope('releases:read'), function(req, res) {
-    const index = readDataFile('index.json');
+  router.get('/features', requireAuth, requireScope('releases:read'), async function(req, res) {
+    const index = await readDataFile('index.json');
     if (!index || !index.features) {
       return res.json({
         fetchedAt: null,
@@ -215,7 +215,7 @@ module.exports = function registerExecutionRoutes(router, context) {
   });
 
   // GET /features/:key — full feature detail
-  router.get('/features/:key', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/features/:key', requireAuth, requireScope('releases:read'), async function(req, res) {
     const key = req.params.key.toUpperCase();
 
     // Validate key format (RHAISTRAT in production, TEST* in demo mode)
@@ -223,7 +223,7 @@ module.exports = function registerExecutionRoutes(router, context) {
       return res.status(400).json({ error: 'Invalid feature key format' });
     }
 
-    const feature = readDataFile(`features/${key}.json`);
+    const feature = await readDataFile(`features/${key}.json`);
     if (!feature) {
       return res.status(404).json({ error: `Feature ${key} not found` });
     }
@@ -242,7 +242,7 @@ module.exports = function registerExecutionRoutes(router, context) {
       return res.status(400).json({ error: 'Invalid feature key format' });
     }
 
-    const existing = readDataFile(`features/${key}.json`);
+    const existing = await readDataFile(`features/${key}.json`);
     if (!existing) {
       return res.status(404).json({ error: `Feature ${key} not found` });
     }
@@ -277,10 +277,10 @@ module.exports = function registerExecutionRoutes(router, context) {
   });
 
   // GET /status — data freshness and sync info
-  router.get('/status', requireAuth, requireScope('releases:read'), function(req, res) {
-    const index = readDataFile('index.json');
-    const lastFetch = readDataFile('last-fetch.json');
-    const config = loadConfig(storage);
+  router.get('/status', requireAuth, requireScope('releases:read'), async function(req, res) {
+    const index = await readDataFile('index.json');
+    const lastFetch = await readDataFile('last-fetch.json');
+    const config = await loadConfig(storage);
     const token = getToken();
 
     const result = {
@@ -319,7 +319,7 @@ module.exports = function registerExecutionRoutes(router, context) {
 
     // Jira enrichment status
     const jiraEnrichConfig = config.jiraEnrichment || {};
-    const lastEnrichment = readDataFile('last-enrichment.json');
+    const lastEnrichment = await readDataFile('last-enrichment.json');
     result.jiraEnrichment = {
       enabled: jiraEnrichConfig.enabled !== false,
       jiraConfigured: !!jira,
@@ -347,8 +347,8 @@ module.exports = function registerExecutionRoutes(router, context) {
   });
 
   // GET /versions — list unique fix versions across all features
-  router.get('/versions', requireAuth, requireScope('releases:read'), function(req, res) {
-    const index = readDataFile('index.json');
+  router.get('/versions', requireAuth, requireScope('releases:read'), async function(req, res) {
+    const index = await readDataFile('index.json');
     if (!index || !index.features) {
       return res.json({ versions: [] });
     }
@@ -373,7 +373,7 @@ module.exports = function registerExecutionRoutes(router, context) {
       if (result.httpStatus === 429) {
         return res.status(429).json({ status: result.status, retryAfter: result.retryAfter });
       }
-      logAudit(storage.readFromStorage, storage.writeToStorage, {
+      await logAudit(storage.readFromStorage, storage.writeToStorage, {
         domain: 'execution',
         action: 'manual_refresh',
         user: req.userEmail || 'unknown',
@@ -387,8 +387,8 @@ module.exports = function registerExecutionRoutes(router, context) {
   });
 
   // GET /config — get current fetch configuration (admin only)
-  router.get('/config', context.requireAdmin, requireScope('releases:write'), function(req, res) {
-    const config = loadConfig(storage);
+  router.get('/config', context.requireAdmin, requireScope('releases:write'), async function(req, res) {
+    const config = await loadConfig(storage);
     res.json({
       ...config,
       tokenConfigured: !!getToken(),
@@ -400,7 +400,7 @@ module.exports = function registerExecutionRoutes(router, context) {
   router.post('/config', context.requireAdmin, requireScope('releases:write'), async function(req, res) {
     try {
       const result = await onConfigSave(storage, req.body);
-      logAudit(storage.readFromStorage, storage.writeToStorage, {
+      await logAudit(storage.readFromStorage, storage.writeToStorage, {
         domain: 'execution',
         action: 'config_save',
         user: req.userEmail || 'unknown',
@@ -468,7 +468,7 @@ module.exports = function registerExecutionRoutes(router, context) {
           continue;
         }
 
-        const existing = readDataFile('features/' + entry.key + '.json');
+        const existing = await readDataFile('features/' + entry.key + '.json');
         const { aiReview, status } = mergeAiReview(
           existing ? existing.aiReview : null,
           entry.aiReview
@@ -505,19 +505,19 @@ module.exports = function registerExecutionRoutes(router, context) {
    *       200:
    *         description: Deletion started
    */
-  router.delete('/ai-review', context.requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.delete('/ai-review', context.requireAdmin, requireScope('releases:write'), async function(req, res) {
     res.json({ status: 'started', message: 'AI review data removal started' });
 
     // Process in background
     (async function() {
       try {
-        const fileNames = storage.listStorageFiles(DATA_PREFIX + '/features');
+        const fileNames = await storage.listStorageFiles(DATA_PREFIX + '/features');
         if (!fileNames || fileNames.length === 0) return;
 
         const toWrite = [];
         for (let i = 0; i < fileNames.length; i++) {
           if (!fileNames[i].endsWith('.json')) continue;
-          const feature = storage.readFromStorage(DATA_PREFIX + '/features/' + fileNames[i]);
+          const feature = await storage.readFromStorage(DATA_PREFIX + '/features/' + fileNames[i]);
           if (feature && feature.aiReview) {
             delete feature.aiReview;
             if (feature._sources) {
@@ -540,10 +540,10 @@ module.exports = function registerExecutionRoutes(router, context) {
   // Diagnostics
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const index = readDataFile('index.json');
-      const lastFetch = readDataFile('last-fetch.json');
-      const lastEnrichment = readDataFile('last-enrichment.json');
-      const config = loadConfig(storage);
+      const index = await readDataFile('index.json');
+      const lastFetch = await readDataFile('last-fetch.json');
+      const lastEnrichment = await readDataFile('last-enrichment.json');
+      const config = await loadConfig(storage);
       const jiraEnrichConfig = config.jiraEnrichment || {};
       return {
         dataAvailable: !!index,
@@ -579,7 +579,7 @@ module.exports = function registerExecutionRoutes(router, context) {
   };
 
   if (context.registerRefresh) {
-    const initialConfig = loadConfig(storage);
+    const initialConfig = await loadConfig(storage);
     context.registerRefresh('execution', {
       ...handlerConfig,
       cadence: initialConfig.refreshIntervalHours + 'h'
@@ -601,7 +601,7 @@ module.exports = function registerExecutionRoutes(router, context) {
       const syncIntervalHours = enrichmentConfig.syncIntervalHours || 6;
 
       const enrichmentHandler = async function() {
-        const config = loadConfig(storage);
+        const config = await loadConfig(storage);
         const jiraEnrichConfig = config.jiraEnrichment || {};
         // Default to enabled — Jira enrichment should run unless explicitly disabled
         if (jiraEnrichConfig.enabled === false) {

--- a/modules/releases/server/execution/scheduler.js
+++ b/modules/releases/server/execution/scheduler.js
@@ -48,13 +48,13 @@ function getTokenSource() {
 
 const DATA_PREFIX = gitlabFetch.DATA_PREFIX;
 
-function loadConfig(storage) {
-  const stored = storage.readFromStorage(`${DATA_PREFIX}/config.json`);
+async function loadConfig(storage) {
+  const stored = await storage.readFromStorage(`${DATA_PREFIX}/config.json`);
   return { ...DEFAULT_CONFIG, ...stored };
 }
 
-function saveConfig(storage, config) {
-  storage.writeToStorage(`${DATA_PREFIX}/config.json`, config);
+async function saveConfig(storage, config) {
+  await storage.writeToStorage(`${DATA_PREFIX}/config.json`, config);
 }
 
 /**
@@ -70,7 +70,7 @@ async function runFetch(storage, config) {
     return { status: 'error', message: 'No GitLab token configured. Set FEATURE_TRAFFIC_GITLAB_TOKEN or GITLAB_TOKEN.' };
   }
 
-  config = config || loadConfig(storage);
+  config = config || await loadConfig(storage);
   if (!config.enabled) {
     return { status: 'skipped', message: 'Feature traffic fetch is disabled' };
   }
@@ -83,7 +83,7 @@ async function runFetch(storage, config) {
     }
     // Write last-fetch metadata (also written inside fetchArtifacts for success, but handle artifact_expired here)
     if (result.status === 'artifact_expired') {
-      storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
+      await storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, result);
     }
     return result;
   } catch (err) {
@@ -93,7 +93,7 @@ async function runFetch(storage, config) {
       message: err.message,
       timestamp: new Date().toISOString()
     };
-    storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, errorResult);
+    await storage.writeToStorage(`${DATA_PREFIX}/last-fetch.json`, errorResult);
     return errorResult;
   } finally {
     fetchInProgress = false;
@@ -161,11 +161,11 @@ function setOnCadenceChange(callback) {
 async function onConfigSave(storage, newConfig) {
   validateConfig(newConfig);
 
-  const oldConfig = loadConfig(storage);
+  const oldConfig = await loadConfig(storage);
   const wasEnabled = oldConfig.enabled;
   const config = { ...DEFAULT_CONFIG, ...newConfig };
 
-  saveConfig(storage, config);
+  await saveConfig(storage, config);
 
   // Notify cadence change
   if (_onCadenceChange) {

--- a/modules/releases/server/export.js
+++ b/modules/releases/server/export.js
@@ -17,13 +17,13 @@ module.exports = async function releasesExport(addFile, storage, mapping) {
   const { readFromStorage, listStorageFiles } = storage;
 
   // Registry (no sensitive data — export as-is)
-  const registry = readFromStorage(`${DATA_PREFIX}/registry.json`);
+  const registry = await readFromStorage(`${DATA_PREFIX}/registry.json`);
   if (registry) {
     addFile(`${DATA_PREFIX}/registry.json`, registry);
   }
 
   // Execution data (feature-traffic storage -> releases/execution export)
-  const index = readFromStorage(`${EXECUTION_STORAGE_PREFIX}/index.json`);
+  const index = await readFromStorage(`${EXECUTION_STORAGE_PREFIX}/index.json`);
   if (index) {
     const anonymizedIndex = { ...index };
     if (Array.isArray(anonymizedIndex.features)) {
@@ -33,9 +33,9 @@ module.exports = async function releasesExport(addFile, storage, mapping) {
 
     // features/*.json
     let featureFiles;
-    try { featureFiles = listStorageFiles(`${EXECUTION_STORAGE_PREFIX}/features`) || []; } catch { featureFiles = []; }
+    try { featureFiles = await listStorageFiles(`${EXECUTION_STORAGE_PREFIX}/features`) || []; } catch { featureFiles = []; }
     for (const fileName of featureFiles) {
-      const feature = readFromStorage(`${EXECUTION_STORAGE_PREFIX}/features/${fileName}`);
+      const feature = await readFromStorage(`${EXECUTION_STORAGE_PREFIX}/features/${fileName}`);
       if (!feature) continue;
       const anonymized = anonymizeFeatureDetail(feature, mapping);
       const anonymizedFileName = anonymized.key ? `${anonymized.key}.json` : fileName;

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -720,7 +720,7 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
   sanitizeInfinity(result)
 
   // Cache
-  storage.writeToStorage(CACHE_KEY, result)
+  await storage.writeToStorage(CACHE_KEY, result)
   console.log('[releases/feature-pressure] Cached analysis (' + features.length + ' features, ' + rfes.length + ' RFEs, ' + componentPressure.length + ' components)')
 
   return result
@@ -730,14 +730,14 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
 // Route registration
 // ---------------------------------------------------------------------------
 
-function registerRoutes(router, context) {
+async function registerRoutes(router, context) {
   var storage = context.storage
   var requireAuth = context.requireAuth
   var requireScope = context.requireScope
 
   var refreshState = { running: false, lastResult: null, startedAt: null, completedAt: null }
 
-  function triggerBackgroundRefresh(lookbackMonths, force) {
+  async function triggerBackgroundRefresh(lookbackMonths, force) {
     if (refreshState.running) return
     if (!force && refreshState.completedAt) {
       var elapsed = Date.now() - new Date(refreshState.completedAt).getTime()
@@ -748,8 +748,8 @@ function registerRoutes(router, context) {
     refreshState.startedAt = new Date().toISOString()
 
     console.log('[releases/feature-pressure] Background refresh started (lookback: ' + lookbackMonths + 'mo)')
-    setImmediate(function () {
-      fetchAndAnalyze(lookbackMonths, storage)
+    setImmediate(async function () {
+      await fetchAndAnalyze(lookbackMonths, storage)
         .then(function (result) {
           refreshState.running = false
           refreshState.completedAt = new Date().toISOString()
@@ -786,8 +786,8 @@ function registerRoutes(router, context) {
    *       202:
    *         description: Data pipeline is running for the first time
    */
-  router.get('/', requireAuth, requireScope('releases:read'), function (req, res) {
-    var data = storage.readFromStorage(CACHE_KEY)
+  router.get('/', requireAuth, requireScope('releases:read'), async function (req, res) {
+    var data = await storage.readFromStorage(CACHE_KEY)
 
     if (data) {
       var cachedAt = data.metadata && data.metadata.generated_at
@@ -869,7 +869,7 @@ function registerRoutes(router, context) {
   // Diagnostics hook
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function () {
-      var fp = storage.readFromStorage(CACHE_KEY)
+      var fp = await storage.readFromStorage(CACHE_KEY)
       return {
         featurePressure: fp ? {
           generatedAt: fp.metadata && fp.metadata.generated_at,

--- a/modules/releases/server/hygiene/config.js
+++ b/modules/releases/server/hygiene/config.js
@@ -29,9 +29,9 @@ function getDefaults() {
  * @param {{ readFromStorage: function }} storage - Storage abstraction
  * @returns {{ rules: Record<string, object>, projects: string[], issueTypes: string[] }}
  */
-function loadConfig(storage) {
+async function loadConfig(storage) {
   const defaults = getDefaults()
-  const stored = storage.readFromStorage(STORAGE_KEY)
+  const stored = await storage.readFromStorage(STORAGE_KEY)
 
   if (!stored || typeof stored !== 'object') {
     return defaults
@@ -58,7 +58,7 @@ function loadConfig(storage) {
  * @param {{ writeToStorage: function }} storage - Storage abstraction
  * @param {{ rules?: Record<string, object>, projects?: string[], issueTypes?: string[] }} config - Config to save
  */
-function saveConfig(storage, config) {
+async function saveConfig(storage, config) {
   if (!config || typeof config !== 'object') {
     throw new Error('Config must be an object')
   }
@@ -69,7 +69,7 @@ function saveConfig(storage, config) {
     issueTypes: Array.isArray(config.issueTypes) ? config.issueTypes : DEFAULT_ISSUE_TYPES.slice()
   }
 
-  storage.writeToStorage(STORAGE_KEY, toSave)
+  await storage.writeToStorage(STORAGE_KEY, toSave)
 }
 
 module.exports = {

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -121,18 +121,18 @@ const refreshState = {
  *         description: Cross-version hygiene summary for program reporting
  */
 
-module.exports = function registerHygieneRoutes(router, context) {
+module.exports = async function registerHygieneRoutes(router, context) {
   const { storage, requireAuth, requirePlanningManager, requireScope, registerDiagnostics } = context;
 
   function storageKey(version) {
     return DATA_PREFIX + '/features-' + version + '.json';
   }
 
-  function resolveHygieneVersion(version) {
-    var data = storage.readFromStorage(storageKey(version));
+  async function resolveHygieneVersion(version) {
+    var data = await storage.readFromStorage(storageKey(version));
     if (data) return { data: data, resolvedVersion: version };
 
-    var registry = readRegistry(storage.readFromStorage);
+    var registry = await readRegistry(storage.readFromStorage);
     var registryReleases = registry.releases || [];
     for (var ri = 0; ri < registryReleases.length; ri++) {
       var rel = registryReleases[ri];
@@ -149,7 +149,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       if (isMatch) {
         for (var ai3 = 0; ai3 < aliases.length; ai3++) {
           if (aliases[ai3] !== version) {
-            var aliasData = storage.readFromStorage(storageKey(aliases[ai3]));
+            var aliasData = await storage.readFromStorage(storageKey(aliases[ai3]));
             if (aliasData) return { data: aliasData, resolvedVersion: aliases[ai3] };
           }
         }
@@ -167,7 +167,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       return { status: 'cooldown' };
     }
 
-    var registry = readRegistry(storage.readFromStorage);
+    var registry = await readRegistry(storage.readFromStorage);
     var registryReleases = registry.releases || [];
     var seen = {};
     var activeVersions = [];
@@ -190,7 +190,7 @@ module.exports = function registerHygieneRoutes(router, context) {
     refreshState.lastResult = null;
     refreshState.progress = { stage: 'starting', message: 'Refreshing all versions (' + activeVersions.length + ')' };
 
-    var config = loadConfig(storage);
+    var config = await loadConfig(storage);
     var jira = require('../../../../shared/server/jira');
     var jiraRequest = jira.jiraRequest;
     var fetchAllJqlResults = jira.fetchAllJqlResults;
@@ -246,7 +246,7 @@ module.exports = function registerHygieneRoutes(router, context) {
             feature.violations = evaluateHygiene(feature, rulesConfig);
           }
 
-          storage.writeToStorage(storageKey(version), result);
+          await storage.writeToStorage(storageKey(version), result);
           results.push({ version: version, status: 'success', featureCount: featureKeys.length });
         } catch (err) {
           console.error('[hygiene] Refresh-all failed for ' + version + ':', err.message);
@@ -264,7 +264,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       };
       refreshState.progress = null;
 
-      logAudit(storage.readFromStorage, storage.writeToStorage, {
+      await logAudit(storage.readFromStorage, storage.writeToStorage, {
         domain: 'hygiene',
         action: 'hygiene_refresh_all',
         user: (options && options.user) || 'system',
@@ -283,13 +283,13 @@ module.exports = function registerHygieneRoutes(router, context) {
   }
 
   // GET /features — hygiene features for a release version
-  router.get('/features', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/features', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = Array.isArray(req.query.version) ? req.query.version[0] : req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
 
-    var resolved = resolveHygieneVersion(version);
+    var resolved = await resolveHygieneVersion(version);
     var data = resolved.data;
     if (!data) {
       return res.json({ features: {}, fetchedAt: null, version: version });
@@ -308,13 +308,13 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // GET /summary — aggregate violation summary
-  router.get('/summary', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/summary', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = Array.isArray(req.query.version) ? req.query.version[0] : req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
 
-    var resolved = resolveHygieneVersion(version);
+    var resolved = await resolveHygieneVersion(version);
     var data = resolved.data;
     if (!data || !data.features) {
       return res.json({
@@ -327,7 +327,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       });
     }
 
-    var config = loadConfig(storage);
+    var config = await loadConfig(storage);
     var rulesConfig = config.rules || {};
 
     var totalFeatures = 0;
@@ -363,7 +363,7 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // POST /refresh — trigger Jira data refresh (fire-and-forget)
-  router.post('/refresh', requirePlanningManager, requireScope('releases:write'), function(req, res) {
+  router.post('/refresh', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     var version = Array.isArray(req.query.version) ? req.query.version[0] : req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
@@ -391,15 +391,15 @@ module.exports = function registerHygieneRoutes(router, context) {
 
     var userEmail = req.userEmail || 'unknown';
 
-    setImmediate(function() {
-      var config = loadConfig(storage);
+    setImmediate(async function() {
+      var config = await loadConfig(storage);
 
       var jira = require('../../../../shared/server/jira');
       var jiraRequest = jira.jiraRequest;
       var fetchAllJqlResults = jira.fetchAllJqlResults;
 
       // Look up fixVersions from registry for JQL queries
-      var registry = readRegistry(storage.readFromStorage);
+      var registry = await readRegistry(storage.readFromStorage);
       var registryReleases = registry.releases || [];
       var jqlVersions = null;
       for (var rli = 0; rli < registryReleases.length; rli++) {
@@ -417,7 +417,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       }
 
       fetchHygieneFeatures(jiraRequest, fetchAllJqlResults, version, config, onProgress, { jqlVersions: jqlVersions })
-        .then(function(result) {
+        .then(async function(result) {
           // Enrich with version-released status from registry
           var registryReleases = registry.releases || [];
           var versionReleased = false;
@@ -448,7 +448,7 @@ module.exports = function registerHygieneRoutes(router, context) {
             feature.violations = evaluateHygiene(feature, rulesConfig);
           }
 
-          storage.writeToStorage(storageKey(version), result);
+          await storage.writeToStorage(storageKey(version), result);
 
           refreshState.running = false;
           refreshState.completedAt = new Date().toISOString();
@@ -460,7 +460,7 @@ module.exports = function registerHygieneRoutes(router, context) {
           };
           refreshState.progress = null;
 
-          logAudit(storage.readFromStorage, storage.writeToStorage, {
+          await logAudit(storage.readFromStorage, storage.writeToStorage, {
             domain: 'hygiene',
             action: 'hygiene_refresh',
             user: userEmail,
@@ -493,12 +493,12 @@ module.exports = function registerHygieneRoutes(router, context) {
    *       200:
    *         description: Refresh started, already running, or no versions
    */
-  router.post('/refresh-all', requirePlanningManager, requireScope('releases:write'), function(req, res) {
+  router.post('/refresh-all', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     if (refreshState.running || (context.isRefreshRunning && context.isRefreshRunning())) {
       return res.json({ status: 'already_running' });
     }
 
-    var registry = readRegistry(storage.readFromStorage);
+    var registry = await readRegistry(storage.readFromStorage);
     var registryReleases = registry.releases || [];
     var seen = {};
     var activeVersions = [];
@@ -518,7 +518,7 @@ module.exports = function registerHygieneRoutes(router, context) {
     res.json({ status: 'started', versions: activeVersions });
 
     var userEmail = req.userEmail || 'unknown';
-    runHygieneRefreshAll({ skipCooldown: true, user: userEmail }).catch(function() {});
+    await runHygieneRefreshAll({ skipCooldown: true, user: userEmail }).catch(function() {});
   });
 
   // GET /refresh/status — current refresh state
@@ -534,8 +534,8 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // GET /config — hygiene rule configuration with rule definitions
-  router.get('/config', requirePlanningManager, requireScope('releases:read'), function(req, res) {
-    var config = loadConfig(storage);
+  router.get('/config', requirePlanningManager, requireScope('releases:read'), async function(req, res) {
+    var config = await loadConfig(storage);
 
     var ruleDefinitions = [];
     for (var i = 0; i < hygieneRules.length; i++) {
@@ -559,11 +559,11 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // POST /config — save hygiene rule configuration
-  router.post('/config', requirePlanningManager, requireScope('releases:write'), function(req, res) {
+  router.post('/config', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     try {
-      saveConfig(storage, req.body);
+      await saveConfig(storage, req.body);
 
-      logAudit(storage.readFromStorage, storage.writeToStorage, {
+      await logAudit(storage.readFromStorage, storage.writeToStorage, {
         domain: 'hygiene',
         action: 'hygiene_config_update',
         user: req.userEmail || 'unknown',
@@ -583,15 +583,15 @@ module.exports = function registerHygieneRoutes(router, context) {
   });
 
   // GET /program-report — aggregate hygiene across all versions
-  router.get('/program-report', requireAuth, requireScope('releases:read'), function(req, res) {
-    var registry = readRegistry(storage.readFromStorage);
+  router.get('/program-report', requireAuth, requireScope('releases:read'), async function(req, res) {
+    var registry = await readRegistry(storage.readFromStorage);
     var registryReleases = registry.releases || [];
-    var config = loadConfig(storage);
+    var config = await loadConfig(storage);
     var rulesConfig = config.rules || {};
 
     // Scan stored hygiene data files instead of iterating registry
     // (hygiene version strings may differ from registry IDs)
-    var hygieneFiles = storage.listStorageFiles ? storage.listStorageFiles('releases/hygiene') : [];
+    var hygieneFiles = storage.listStorageFiles ? await storage.listStorageFiles('releases/hygiene') : [];
     var versions = [];
 
     for (var ri = 0; ri < hygieneFiles.length; ri++) {
@@ -599,7 +599,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       if (!match) continue;
 
       var versionId = match[1];
-      var data = storage.readFromStorage(storageKey(versionId));
+      var data = await storage.readFromStorage(storageKey(versionId));
       if (!data || !data.features || Object.keys(data.features).length === 0) continue;
 
       // Look up registry release for GA date / released status
@@ -739,7 +739,7 @@ module.exports = function registerHygieneRoutes(router, context) {
       timeout: 600000,
       description: 'Fetches feature data from Jira and evaluates hygiene rules across active releases.',
       handler: async function() {
-        return runHygieneRefreshAll({ skipCooldown: true, user: 'system' });
+        return await runHygieneRefreshAll({ skipCooldown: true, user: 'system' });
       }
     });
   }

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -30,7 +30,7 @@ const { getAuditLog } = require('./planning/audit-log');
  *   feature-traffic/  → releases/execution/
  *   release-analysis/ → releases/delivery/
  */
-function migrateStoragePaths(storage) {
+async function migrateStoragePaths(storage) {
   const { readFromStorage, writeToStorage, listStorageFiles } = storage;
 
   const migrations = [
@@ -42,17 +42,17 @@ function migrateStoragePaths(storage) {
   // Also migrate the unified audit log from old planning path
   const auditOld = 'release-planning/audit-log.json';
   const auditNew = 'releases/audit-log.json';
-  const oldAudit = readFromStorage(auditOld);
-  const newAudit = readFromStorage(auditNew);
+  const oldAudit = await readFromStorage(auditOld);
+  const newAudit = await readFromStorage(auditNew);
   if (oldAudit && !newAudit) {
-    writeToStorage(auditNew, oldAudit);
+    await writeToStorage(auditNew, oldAudit);
     console.log('[releases] Migrated audit-log.json to releases/audit-log.json');
   }
 
   for (const { oldPrefix, newPrefix } of migrations) {
     let files;
     try {
-      files = listStorageFiles(oldPrefix);
+      files = await listStorageFiles(oldPrefix);
     } catch {
       // Directory doesn't exist — nothing to migrate
       continue;
@@ -68,13 +68,13 @@ function migrateStoragePaths(storage) {
       const oldPath = `${oldPrefix}/${fileName}`;
       const newPath = `${newPrefix}/${fileName}`;
 
-      const oldData = readFromStorage(oldPath);
+      const oldData = await readFromStorage(oldPath);
       if (!oldData) continue;
 
-      const existing = readFromStorage(newPath);
+      const existing = await readFromStorage(newPath);
       if (existing) continue;
 
-      writeToStorage(newPath, oldData);
+      await writeToStorage(newPath, oldData);
       migrated++;
     }
     }
@@ -84,7 +84,7 @@ function migrateStoragePaths(storage) {
     for (const subdir of subdirs) {
       let subFiles;
       try {
-        subFiles = listStorageFiles(`${oldPrefix}/${subdir}`);
+        subFiles = await listStorageFiles(`${oldPrefix}/${subdir}`);
       } catch {
         continue;
       }
@@ -96,13 +96,13 @@ function migrateStoragePaths(storage) {
         const oldPath = `${oldPrefix}/${subdir}/${fileName}`;
         const newPath = `${newPrefix}/${subdir}/${fileName}`;
 
-        const oldData = readFromStorage(oldPath);
+        const oldData = await readFromStorage(oldPath);
         if (!oldData) continue;
 
-        const existing = readFromStorage(newPath);
+        const existing = await readFromStorage(newPath);
         if (existing) continue;
 
-        writeToStorage(newPath, oldData);
+        await writeToStorage(newPath, oldData);
         migrated++;
       }
     }
@@ -113,7 +113,7 @@ function migrateStoragePaths(storage) {
   }
 }
 
-module.exports = function registerRoutes(router, context) {
+module.exports = async function registerRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireRole, requireScope, roleStore, secrets } = context;
   const requirePlanningManager = requireRole('planning-manager');
 
@@ -147,7 +147,7 @@ module.exports = function registerRoutes(router, context) {
   // Uses raw storage manipulation (not roleStore API) because the old role
   // is no longer registered and roleStore.revokeRole() would reject it.
   try {
-    const rolesData = storage.readFromStorage('roles.json');
+    const rolesData = await storage.readFromStorage('roles.json');
     if (rolesData && rolesData.assignments) {
       let migrated = 0;
       for (const [, entry] of Object.entries(rolesData.assignments)) {
@@ -158,7 +158,7 @@ module.exports = function registerRoutes(router, context) {
       if (migrated > 0) {
         // Backup before overwriting, following migrateEmailDomains() pattern
         const backupKey = 'roles-backup-premigration.json';
-        storage.writeToStorage(backupKey, JSON.parse(JSON.stringify(rolesData)));
+        await storage.writeToStorage(backupKey, JSON.parse(JSON.stringify(rolesData)));
         console.log(`[releases] Backup saved to ${backupKey}`);
 
         for (const [, entry] of Object.entries(rolesData.assignments)) {
@@ -169,7 +169,7 @@ module.exports = function registerRoutes(router, context) {
             }
           }
         }
-        storage.writeToStorage('roles.json', rolesData);
+        await storage.writeToStorage('roles.json', rolesData);
         console.log(`[releases] Migrated ${migrated} user(s) from release-manager to planning-manager`);
       }
     }
@@ -178,11 +178,11 @@ module.exports = function registerRoutes(router, context) {
   }
 
   // Run storage path migration on module startup (skip if already done)
-  const migrationMarker = storage.readFromStorage('releases/.migration-complete');
+  const migrationMarker = await storage.readFromStorage('releases/.migration-complete');
   if (!migrationMarker) {
     try {
-      migrateStoragePaths(storage);
-      storage.writeToStorage('releases/.migration-complete', { completedAt: new Date().toISOString() });
+      await migrateStoragePaths(storage);
+      await storage.writeToStorage('releases/.migration-complete', { completedAt: new Date().toISOString() });
     } catch (err) {
       console.error('[releases] Storage migration failed:', err.message);
     }
@@ -339,7 +339,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Audit log entries
    */
-  router.get('/audit-log', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/audit-log', requireAuth, requireScope('releases:read'), async function(req, res) {
     const options = {};
     if (req.query.version) options.version = req.query.version;
     if (req.query.action) options.action = req.query.action;
@@ -347,7 +347,7 @@ module.exports = function registerRoutes(router, context) {
     if (req.query.limit) options.limit = parseInt(req.query.limit, 10) || 100;
     if (req.query.offset) options.offset = parseInt(req.query.offset, 10) || 0;
 
-    const result = getAuditLog(storage.readFromStorage, options);
+    const result = await getAuditLog(storage.readFromStorage, options);
     res.json(result);
   });
 
@@ -364,7 +364,7 @@ module.exports = function registerRoutes(router, context) {
    *       200:
    *         description: Migration cleanup results
    */
-  router.post('/admin/migrate-storage', requireAdmin, requireScope('releases:write'), function(req, res) {
+  router.post('/admin/migrate-storage', requireAdmin, requireScope('releases:write'), async function(req, res) {
     const { readFromStorage, listStorageFiles, deleteFromStorage } = storage;
 
     const migrations = [
@@ -378,7 +378,7 @@ module.exports = function registerRoutes(router, context) {
     for (const { oldPrefix, newPrefix } of migrations) {
       let files;
       try {
-        files = listStorageFiles(oldPrefix);
+        files = await listStorageFiles(oldPrefix);
       } catch {
         continue;
       }
@@ -388,14 +388,14 @@ module.exports = function registerRoutes(router, context) {
         const oldPath = `${oldPrefix}/${fileName}`;
         const newPath = `${newPrefix}/${fileName}`;
 
-        const newData = readFromStorage(newPath);
+        const newData = await readFromStorage(newPath);
         if (!newData) {
           results.skipped++;
           continue;
         }
 
         try {
-          deleteFromStorage(oldPath);
+          await deleteFromStorage(oldPath);
           results.deleted++;
         } catch (err) {
           results.errors.push({ path: oldPath, error: err.message });
@@ -408,7 +408,7 @@ module.exports = function registerRoutes(router, context) {
       for (const subdir of subdirs) {
         let subFiles;
         try {
-          subFiles = listStorageFiles(`${oldPrefix}/${subdir}`);
+          subFiles = await listStorageFiles(`${oldPrefix}/${subdir}`);
         } catch {
           continue;
         }
@@ -419,14 +419,14 @@ module.exports = function registerRoutes(router, context) {
           const oldPath = `${oldPrefix}/${subdir}/${fileName}`;
           const newPath = `${newPrefix}/${subdir}/${fileName}`;
 
-          const newData = readFromStorage(newPath);
+          const newData = await readFromStorage(newPath);
           if (!newData) {
             results.skipped++;
             continue;
           }
 
           try {
-            deleteFromStorage(oldPath);
+            await deleteFromStorage(oldPath);
             results.deleted++;
           } catch (err) {
             results.errors.push({ path: oldPath, error: err.message });

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -375,27 +375,27 @@ describe('computeBlockers', function() {
 
 describe('buildFeatureReadiness', function() {
   describe('empty / null store', function() {
-    it('returns empty buckets when ai-impact key returns null', function() {
+    it('returns empty buckets when ai-impact key returns null', async function() {
       var readFromStorage = makeReadFromStorage({})
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toEqual([])
       expect(result.ready).toEqual([])
       expect(result.filterMeta).toEqual({ components: [], priorities: [], bigRocks: [], targetVersions: [], fixVersions: [], teams: [] })
       expect(result.meta).toEqual({ total: 0, pendingReviewCount: 0, readyCount: 0, versions: [], lastSyncedAt: null, jiraAvailable: false })
     })
 
-    it('returns empty buckets when no features with aiReview exist', function() {
+    it('returns empty buckets when no features with aiReview exist', async function() {
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat({ lastSyncedAt: '2026-01-01T00:00:00.000Z' })
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toEqual([])
       expect(result.ready).toEqual([])
     })
   })
 
   describe('gate logic — bucket assignment', function() {
-    it('humanReviewStatus approved with all gates → goes to ready bucket', function() {
+    it('humanReviewStatus approved with all gates → goes to ready bucket', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -405,49 +405,49 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(1)
       expect(result.ready[0].key).toBe('RHAISTRAT-1')
       expect(result.pendingReview).toHaveLength(0)
     })
 
-    it('humanReviewStatus awaiting-review → goes to pendingReview bucket', function() {
+    it('humanReviewStatus awaiting-review → goes to pendingReview bucket', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'awaiting-review' }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.ready).toHaveLength(0)
     })
 
-    it('humanReviewStatus needs-review → goes to pendingReview bucket', function() {
+    it('humanReviewStatus needs-review → goes to pendingReview bucket', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'needs-review' }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.ready).toHaveLength(0)
     })
 
-    it('null humanReviewStatus → goes to pendingReview bucket', function() {
+    it('null humanReviewStatus → goes to pendingReview bucket', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: null }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.ready).toHaveLength(0)
     })
 
-    it('skips entries with no latest', function() {
+    it('skips entries with no latest', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) },
         'RHAISTRAT-2': {}
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var allFeatures = result.pendingReview.concat(result.ready)
       expect(allFeatures).toHaveLength(1)
       expect(allFeatures[0].key).toBe('RHAISTRAT-1')
@@ -455,7 +455,7 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('confidence field', function() {
-    it('approved feature with fixVersion gets confidence=committed', function() {
+    it('approved feature with fixVersion gets confidence=committed', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -469,11 +469,11 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/candidates-cache-3.6.json': candidateCache,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready[0].confidence).toBe('committed')
     })
 
-    it('approved feature without fixVersion gets confidence=ready', function() {
+    it('approved feature without fixVersion gets confidence=ready', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -483,27 +483,27 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready[0].confidence).toBe('ready')
     })
 
-    it('non-approved feature gets confidence=not-ready', function() {
+    it('non-approved feature gets confidence=not-ready', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: null }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview[0].confidence).toBe('not-ready')
     })
   })
 
   describe('readinessGates on all features', function() {
-    it('strat-creator features have readinessGates with FPDoR fields', function() {
+    it('strat-creator features have readinessGates with FPDoR fields', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.readinessGates).toBeDefined()
       expect(typeof feat.readinessGates.fpDorPassed).toBe('number')
@@ -512,7 +512,7 @@ describe('buildFeatureReadiness', function() {
       expect(feat.readinessGates.noBlockingViolations).toBe(true)
     })
 
-    it('health-pipeline features have readinessGates with FPDoR and noBlockingViolations', function() {
+    it('health-pipeline features have readinessGates with FPDoR and noBlockingViolations', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -525,7 +525,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview[0]
       expect(typeof feat.readinessGates.fpDorPassed).toBe('number')
       expect(typeof feat.readinessGates.fpDorTotal).toBe('number')
@@ -535,7 +535,7 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('hygiene violations integration', function() {
-    it('attaches violations from hygiene cache to features', function() {
+    it('attaches violations from hygiene cache to features', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -550,11 +550,11 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache,
         'releases/hygiene/features-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready[0].violations).toEqual(violations)
     })
 
-    it('blocking hygiene violation moves approved feature to pendingReview', function() {
+    it('blocking hygiene violation moves approved feature to pendingReview', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -569,13 +569,13 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache,
         'releases/hygiene/features-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.pendingReview[0].confidence).toBe('not-ready')
       expect(result.pendingReview[0].readinessGates.noBlockingViolations).toBe(true)
     })
 
-    it('non-blocking violations do not affect readiness', function() {
+    it('non-blocking violations do not affect readiness', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -590,12 +590,12 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache,
         'releases/hygiene/features-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(1)
       expect(result.ready[0].readinessGates.noBlockingViolations).toBe(true)
     })
 
-    it('health-pipeline feature with hygiene violations still has noBlockingViolations=true (hygiene decoupled)', function() {
+    it('health-pipeline feature with hygiene violations still has noBlockingViolations=true (hygiene decoupled)', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -613,33 +613,33 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache,
         'releases/hygiene/features-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.pendingReview[0].readinessGates.noBlockingViolations).toBe(true)
     })
   })
 
   describe('sort order — approved', function() {
-    it('sorts by effectivePriorityScore descending', function() {
+    it('sorts by effectivePriorityScore descending', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-LOW': { latest: makeLatest({ humanReviewStatus: 'approved', priority: 'Minor', scores: { feasibility: 1, testability: 1, scope: 1, architecture: 1 } }) },
         'RHAISTRAT-HIGH': { latest: makeLatest({ humanReviewStatus: 'approved', priority: 'Blocker', scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2 } }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var highIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-HIGH' })
       var lowIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-LOW' })
       expect(highIdx).toBeLessThan(lowIdx)
     })
 
-    it('higher rubric score → higher effectivePriorityScore → appears first', function() {
+    it('higher rubric score → higher effectivePriorityScore → appears first', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-LOWTOTAL': { latest: makeLatest({ key: 'RHAISTRAT-LOWTOTAL', humanReviewStatus: 'approved', priority: 'Normal', scores: { feasibility: 1, testability: 1, scope: 1, architecture: 1 } }) },
         'RHAISTRAT-HIGHTOTAL': { latest: makeLatest({ key: 'RHAISTRAT-HIGHTOTAL', humanReviewStatus: 'approved', priority: 'Normal', scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2 } }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var highIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-HIGHTOTAL' })
       var lowIdx = all.findIndex(function(f) { return f.key === 'RHAISTRAT-LOWTOTAL' })
@@ -648,28 +648,28 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('sort order — pendingReview', function() {
-    it('higher priority → higher effectivePriorityScore → appears first', function() {
+    it('higher priority → higher effectivePriorityScore → appears first', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-LOW': { latest: makeLatest({ key: 'RHAISTRAT-LOW', humanReviewStatus: null, priority: 'Minor', scores: { feasibility: 0, testability: 0, scope: 0, architecture: 0 } }) },
         'RHAISTRAT-HIGH': { latest: makeLatest({ key: 'RHAISTRAT-HIGH', humanReviewStatus: null, priority: 'Blocker', scores: { feasibility: 0, testability: 0, scope: 0, architecture: 0 } }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview[0].key).toBe('RHAISTRAT-HIGH')
       expect(result.pendingReview[1].key).toBe('RHAISTRAT-LOW')
     })
 
-    it('equal priority: higher rubric score → higher effectivePriorityScore → appears first', function() {
+    it('equal priority: higher rubric score → higher effectivePriorityScore → appears first', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-A': { latest: makeLatest({ key: 'RHAISTRAT-A', humanReviewStatus: null, priority: 'Normal', size: null, scores: { feasibility: 2, testability: 1, scope: 0, architecture: 0 } }) },
         'RHAISTRAT-B': { latest: makeLatest({ key: 'RHAISTRAT-B', humanReviewStatus: null, priority: 'Normal', size: null, scores: { feasibility: 1, testability: 0, scope: 0, architecture: 0 } }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview[0].key).toBe('RHAISTRAT-A')
     })
 
-    it('tiebreaker: equal effectivePriorityScore → higher rubricTotal first', function() {
+    it('tiebreaker: equal effectivePriorityScore → higher rubricTotal first', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-TIE-A': { latest: makeLatest({ key: 'RHAISTRAT-TIE-A', humanReviewStatus: null, priority: 'Normal', scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2 } }) },
         'RHAISTRAT-TIE-B': { latest: makeLatest({ key: 'RHAISTRAT-TIE-B', humanReviewStatus: null, priority: 'Normal', scores: { feasibility: 1, testability: 1, scope: 1, architecture: 1 } }) }
@@ -685,7 +685,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var idxA = result.pendingReview.findIndex(function(f) { return f.key === 'RHAISTRAT-TIE-A' })
       var idxB = result.pendingReview.findIndex(function(f) { return f.key === 'RHAISTRAT-TIE-B' })
       expect(idxA).toBeLessThan(idxB)
@@ -695,7 +695,7 @@ describe('buildFeatureReadiness', function() {
   describe('candidates cache cross-reference', function() {
     var candidatesKey = 'releases/planning/candidates-cache-3.6.json'
 
-    it('populates tier, bigRock, targetVersions, fixVersion from matching candidate', function() {
+    it('populates tier, bigRock, targetVersions, fixVersion from matching candidate', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -713,7 +713,7 @@ describe('buildFeatureReadiness', function() {
         [candidatesKey]: candidateCache,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var f = result.ready[0]
       expect(f.tier).toBe(1)
       expect(f.bigRock).toBe('AI Efficiency')
@@ -721,7 +721,7 @@ describe('buildFeatureReadiness', function() {
       expect(f.fixVersion).toBe('3.6.0')
     })
 
-    it('leaves tier/bigRock/targetVersions empty when no candidate matches but feature is in health cache', function() {
+    it('leaves tier/bigRock/targetVersions empty when no candidate matches but feature is in health cache', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -737,7 +737,7 @@ describe('buildFeatureReadiness', function() {
         [candidatesKey]: candidateCache,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var f = result.pendingReview.concat(result.ready).find(function(feat) { return feat.key === 'RHAISTRAT-1' })
       expect(f.tier).toBeNull()
       expect(f.bigRock).toBeNull()
@@ -745,7 +745,7 @@ describe('buildFeatureReadiness', function() {
       expect(f.fixVersion).toBeNull()
     })
 
-    it('tier is normalized to T-string (numeric 2 → T2)', function() {
+    it('tier is normalized to T-string (numeric 2 → T2)', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -757,14 +757,14 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         [candidatesKey]: candidateCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.tier).toBe(2)
     })
   })
 
   describe('missing candidates cache', function() {
-    it('includes all features when configured releases exist but all caches are empty', function() {
+    it('includes all features when configured releases exist but all caches are empty', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -772,22 +772,22 @@ describe('buildFeatureReadiness', function() {
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview.concat(result.ready)).toHaveLength(1)
     })
 
-    it('includes all features when no releases are configured', function() {
+    it('includes all features when no releases are configured', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var readFromStorage = makeReadFromStorage({
         ...convertToUnifiedFormat(store)
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview.concat(result.ready)).toHaveLength(1)
     })
 
-    it('falls back to health cache for tier, bigRock, targetVersions, fixVersion when candidates cache is absent', function() {
+    it('falls back to health cache for tier, bigRock, targetVersions, fixVersion when candidates cache is absent', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -813,7 +813,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var f = result.ready[0]
       expect(f.tier).toBe(2)
       expect(f.bigRock).toBe('Platform Efficiency')
@@ -822,7 +822,7 @@ describe('buildFeatureReadiness', function() {
       expect(f.deliveryOwner).toBe('Jane Smith')
     })
 
-    it('candidates cache takes priority over health cache for tier/bigRock/targetVersions/fixVersion', function() {
+    it('candidates cache takes priority over health cache for tier/bigRock/targetVersions/fixVersion', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -838,7 +838,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/candidates-cache-3.6.json': candidateCache,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var f = result.ready[0]
       expect(f.tier).toBe(1)
       expect(f.bigRock).toBe('AI Speed')
@@ -846,7 +846,7 @@ describe('buildFeatureReadiness', function() {
       expect(f.fixVersion).toBe('3.6.0-cand')
     })
 
-    it('health cache components (string) are split into array when ai-impact components are empty', function() {
+    it('health cache components (string) are split into array when ai-impact components are empty', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved', components: [] }) }
       })
@@ -858,7 +858,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.components).toEqual(['Serving', 'Training'])
     })
@@ -867,7 +867,7 @@ describe('buildFeatureReadiness', function() {
   describe('health cache cross-reference', function() {
     var healthKey = 'releases/planning/health-cache-3.6-all.json'
 
-    it('feature gets batch-computed priorityScore', function() {
+    it('feature gets batch-computed priorityScore', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -879,13 +879,13 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         [healthKey]: healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var f = result.ready[0]
       expect(typeof f.effectivePriorityScore).toBe('number')
       expect(f.effectivePriorityScore).toBeGreaterThan(0)
     })
 
-    it('priorityScoreBreakdown has rice, bigRock, targetVersion, priority fields', function() {
+    it('priorityScoreBreakdown has rice, bigRock, targetVersion, priority fields', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -897,7 +897,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         [healthKey]: healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var bd = result.ready[0].priorityScoreBreakdown
       expect(typeof bd.rice).toBe('number')
       expect(typeof bd.bigRock).toBe('number')
@@ -907,7 +907,7 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('batch scoring', function() {
-    it('all features get batch-computed scores from computePriorityScores', function() {
+    it('all features get batch-computed scores from computePriorityScores', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved', priority: 'Blocker', riceScore: 200 }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: 'approved', priority: 'Minor', riceScore: 10 }) }
@@ -923,7 +923,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var f1 = all.find(function(f) { return f.key === 'RHAISTRAT-1' })
       var f2 = all.find(function(f) { return f.key === 'RHAISTRAT-2' })
@@ -932,7 +932,7 @@ describe('buildFeatureReadiness', function() {
       expect(f2.priorityScoreBreakdown).toBeDefined()
     })
 
-    it('RICE scores are min-max normalized across the batch', function() {
+    it('RICE scores are min-max normalized across the batch', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-HIGH': { latest: makeLatest({ humanReviewStatus: 'approved', riceScore: 1000 }) },
         'RHAISTRAT-LOW': { latest: makeLatest({ key: 'RHAISTRAT-LOW', humanReviewStatus: 'approved', riceScore: 10 }) }
@@ -941,7 +941,7 @@ describe('buildFeatureReadiness', function() {
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': CONFIG_3_6
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var high = all.find(function(f) { return f.key === 'RHAISTRAT-HIGH' })
       var low = all.find(function(f) { return f.key === 'RHAISTRAT-LOW' })
@@ -951,14 +951,14 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('stable rank', function() {
-    it('assigns rank numbers based on global sort position', function() {
+    it('assigns rank numbers based on global sort position', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-A': { latest: makeLatest({ key: 'RHAISTRAT-A', humanReviewStatus: 'approved', priority: 'Blocker' }) },
         'RHAISTRAT-B': { latest: makeLatest({ key: 'RHAISTRAT-B', humanReviewStatus: null, priority: 'Minor' }) },
         'RHAISTRAT-C': { latest: makeLatest({ key: 'RHAISTRAT-C', humanReviewStatus: null, priority: 'Normal' }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       for (var i = 0; i < all.length; i++) {
         expect(typeof all[i].rank).toBe('number')
@@ -966,14 +966,14 @@ describe('buildFeatureReadiness', function() {
       }
     })
 
-    it('rank values are unique and contiguous starting from 1', function() {
+    it('rank values are unique and contiguous starting from 1', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved', priority: 'Blocker' }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: null, priority: 'Normal' }) },
         'RHAISTRAT-3': { latest: makeLatest({ key: 'RHAISTRAT-3', humanReviewStatus: null, priority: 'Minor' }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var ranks = all.map(function(f) { return f.rank }).sort(function(a, b) { return a - b })
       for (var i = 0; i < ranks.length; i++) {
@@ -981,13 +981,13 @@ describe('buildFeatureReadiness', function() {
       }
     })
 
-    it('highest-scored feature gets rank 1', function() {
+    it('highest-scored feature gets rank 1', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-LOW': { latest: makeLatest({ key: 'RHAISTRAT-LOW', humanReviewStatus: null, priority: 'Minor', riceScore: 10 }) },
         'RHAISTRAT-HIGH': { latest: makeLatest({ key: 'RHAISTRAT-HIGH', humanReviewStatus: null, priority: 'Blocker', riceScore: 1000 }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var high = all.find(function(f) { return f.key === 'RHAISTRAT-HIGH' })
       var low = all.find(function(f) { return f.key === 'RHAISTRAT-LOW' })
@@ -997,7 +997,7 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('cross-version bigRockPriorityMap', function() {
-    it('uses best (lowest) priority number when a rock appears in multiple releases', function() {
+    it('uses best (lowest) priority number when a rock appears in multiple releases', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: null }) }
       })
@@ -1016,7 +1016,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/releases/3.5.json': { release: '3.5', bigRocks: [{ name: 'AI Efficiency', priority: 1 }] },
         'releases/planning/releases/3.6.json': { release: '3.6', bigRocks: [{ name: 'AI Efficiency', priority: 3 }] }
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var all = result.pendingReview.concat(result.ready)
       var feat = all.find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat).toBeDefined()
@@ -1025,7 +1025,7 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('filterMeta', function() {
-    it('contains unique sorted arrays of priorities, components, bigRocks, targetVersions, fixVersions', function() {
+    it('contains unique sorted arrays of priorities, components, bigRocks, targetVersions, fixVersions', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved', priority: 'Critical', components: ['Serving', 'Platform'] }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: 'approved', priority: 'Normal', components: ['Platform'] }) }
@@ -1043,7 +1043,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/candidates-cache-3.6.json': candidateCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var fm = result.filterMeta
       expect(fm.priorities).toEqual(['Critical', 'Normal'])
       expect(fm.components).toEqual(['Platform', 'Serving'])
@@ -1052,7 +1052,7 @@ describe('buildFeatureReadiness', function() {
       expect(fm.fixVersions).toEqual(['3.6.0'])
     })
 
-    it('filterMeta.teams is populated from hygiene cache team values', function() {
+    it('filterMeta.teams is populated from hygiene cache team values', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: 'approved' }) }
@@ -1075,11 +1075,11 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache,
         'releases/hygiene/features-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.filterMeta.teams).toEqual(['Alice', 'Bob'])
     })
 
-    it('feature.team comes from hygiene cache, not deliveryOwner', function() {
+    it('feature.team comes from hygiene cache, not deliveryOwner', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1091,7 +1091,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.6-all.json': healthCache,
         'releases/hygiene/features-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.team).toBe('Real Team')
       expect(result.filterMeta.teams).toEqual(['Real Team'])
@@ -1099,7 +1099,7 @@ describe('buildFeatureReadiness', function() {
   })
 
   describe('meta', function() {
-    it('contains correct counts and versions array', function() {
+    it('contains correct counts and versions array', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: null }) },
@@ -1117,25 +1117,25 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.meta.total).toBe(3)
       expect(result.meta.readyCount).toBe(1)
       expect(result.meta.pendingReviewCount).toBe(2)
       expect(result.meta.versions).toEqual(['3.6'])
     })
 
-    it('meta.versions is empty when no releases are configured', function() {
+    it('meta.versions is empty when no releases are configured', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.meta.versions).toEqual([])
     })
   })
 
   describe('rubricTotal calculation', function() {
-    it('sums all four dimension scores', function() {
+    it('sums all four dimension scores', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({
           humanReviewStatus: 'approved',
@@ -1144,12 +1144,12 @@ describe('buildFeatureReadiness', function() {
         }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.rubricTotal).toBe(8)
     })
 
-    it('treats missing score dimensions as 0', function() {
+    it('treats missing score dimensions as 0', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({
           humanReviewStatus: 'approved',
@@ -1157,14 +1157,14 @@ describe('buildFeatureReadiness', function() {
         }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.rubricTotal).toBe(2)
     })
   })
 
   describe('health cache scores fallback', function() {
-    it('uses health cache scores when aiReview is not available', function() {
+    it('uses health cache scores when aiReview is not available', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -1179,14 +1179,14 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'AIPCC-500' })
       expect(feat).toBeDefined()
       expect(feat.rubricTotal).toBe(8)
       expect(feat.scores).toEqual({ feasibility: 2, testability: 2, scope: 2, architecture: 2 })
     })
 
-    it('prefers aiReview scores over health cache scores', function() {
+    it('prefers aiReview scores over health cache scores', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({
           humanReviewStatus: 'approved',
@@ -1204,14 +1204,14 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.rubricTotal).toBe(12)
     })
   })
 
   describe('version-scoping guard', function() {
-    it('excludes features not in any cache when caches have data', function() {
+    it('excludes features not in any cache when caches have data', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-IN': { latest: makeLatest({ humanReviewStatus: 'approved' }) },
         'RHAISTRAT-OUT': { latest: makeLatest({ key: 'RHAISTRAT-OUT', humanReviewStatus: 'approved' }) }
@@ -1231,25 +1231,25 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var allFeatures = result.pendingReview.concat(result.ready)
       expect(allFeatures).toHaveLength(1)
       expect(allFeatures[0].key).toBe('RHAISTRAT-IN')
     })
 
-    it('includes all features when no configured releases exist', function() {
+    it('includes all features when no configured releases exist', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: null }) }
       })
       var readFromStorage = makeReadFromStorage({ ...convertToUnifiedFormat(store) })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview.concat(result.ready)).toHaveLength(2)
     })
   })
 
   describe('multi-version loading', function() {
-    it('merges features from multiple configured versions', function() {
+    it('merges features from multiple configured versions', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) },
         'RHAISTRAT-2': { latest: makeLatest({ key: 'RHAISTRAT-2', humanReviewStatus: 'approved' }) }
@@ -1261,12 +1261,12 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/health-cache-3.5-all.json': { features: [{ key: 'RHAISTRAT-1', deliveryOwner: 'Alice', pmOwner: 'Jane', targetRelease: 'rhoai-3.5', priorityScore: 80, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving', 'UXD'], docsRequired: 'Required' }] },
         'releases/planning/health-cache-3.6-all.json': { features: [{ key: 'RHAISTRAT-2', deliveryOwner: 'Bob', pmOwner: 'Jane', targetRelease: 'rhoai-3.6', priorityScore: 60, storyPoints: 5, epicCount: 3, releaseType: 'GA', components: ['Platform', 'Serving', 'UXD'], docsRequired: 'Required' }] }
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready).toHaveLength(2)
       expect(result.meta.versions).toEqual(['3.5', '3.6'])
     })
 
-    it('duplicate features across versions use first-seen data', function() {
+    it('duplicate features across versions use first-seen data', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1277,14 +1277,14 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/candidates-cache-3.5.json': { data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, bigRock: 'First' }] } },
         'releases/planning/candidates-cache-3.6.json': { data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 2, bigRock: 'Second' }] } }
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var allFeatures = result.pendingReview.concat(result.ready)
       expect(allFeatures).toHaveLength(1)
       expect(allFeatures[0].tier).toBe(1)
       expect(allFeatures[0].bigRock).toBe('First')
     })
 
-    it('meta.versions reflects all configured release versions', function() {
+    it('meta.versions reflects all configured release versions', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1293,7 +1293,7 @@ describe('buildFeatureReadiness', function() {
         ...convertToUnifiedFormat(store),
         'releases/planning/config.json': config
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.meta.versions).toEqual(['3.4', '3.5', '3.6'])
     })
   })
@@ -1586,7 +1586,7 @@ describe('buildFeatureReadiness', function() {
   // -------------------------------------------------------------------------
 
   describe('cache-based feature discovery', function() {
-    it('discovers features in health cache but not in ai-impact', function() {
+    it('discovers features in health cache but not in ai-impact', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{ key: 'AIPCC-100', summary: 'AIPCC Feature', status: 'In Progress', priority: 'Major', deliveryOwner: 'Alice', blockerCount: 0, targetRelease: 'rhoai-3.6' }]
@@ -1596,7 +1596,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready.length + result.pendingReview.length).toBe(1)
       var feat = result.ready[0] || result.pendingReview[0]
       expect(feat.key).toBe('AIPCC-100')
@@ -1605,7 +1605,7 @@ describe('buildFeatureReadiness', function() {
       expect(feat.rubricTotal).toBe(0)
     })
 
-    it('health-pipeline feature always goes to pendingReview (no approval/rubric)', function() {
+    it('health-pipeline feature always goes to pendingReview (no approval/rubric)', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -1618,12 +1618,12 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.pendingReview[0].key).toBe('AIPCC-200')
     })
 
-    it('health-pipeline feature missing owner goes to pendingReview', function() {
+    it('health-pipeline feature missing owner goes to pendingReview', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -1636,12 +1636,12 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.pendingReview[0].key).toBe('AIPCC-300')
     })
 
-    it('strat-creator features get dataSource strat-creator', function() {
+    it('strat-creator features get dataSource strat-creator', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1653,11 +1653,11 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.ready[0].dataSource).toBe('strat-creator')
     })
 
-    it('feature in both ai-impact and health cache is NOT duplicated', function() {
+    it('feature in both ai-impact and health cache is NOT duplicated', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1672,7 +1672,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var allFeatures = result.ready.concat(result.pendingReview)
       var keys = allFeatures.map(function(f) { return f.key })
       expect(keys).toHaveLength(2)
@@ -1680,7 +1680,7 @@ describe('buildFeatureReadiness', function() {
       expect(keys).toContain('AIPCC-100')
     })
 
-    it('health-pipeline features get batch-computed priority score', function() {
+    it('health-pipeline features get batch-computed priority score', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -1694,13 +1694,13 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview[0]
       expect(typeof feat.effectivePriorityScore).toBe('number')
       expect(feat.effectivePriorityScore).toBeGreaterThan(0)
     })
 
-    it('readinessGates are populated on health-pipeline features', function() {
+    it('readinessGates are populated on health-pipeline features', async function() {
       var store = makeFeaturesStore({})
       var healthCache = {
         features: [{
@@ -1713,7 +1713,7 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview[0]
       expect(typeof feat.readinessGates.fpDorPassed).toBe('number')
       expect(typeof feat.readinessGates.fpDorTotal).toBe('number')
@@ -1722,7 +1722,7 @@ describe('buildFeatureReadiness', function() {
       expect(feat.readinessGates.noBlockingViolations).toBe(true)
     })
 
-    it('works when no AI review data exists', function() {
+    it('works when no AI review data exists', async function() {
       var healthCache = {
         features: [{
           key: 'AIPCC-900', summary: 'No ai-impact', status: 'In Progress',
@@ -1733,12 +1733,12 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview).toHaveLength(1)
       expect(result.pendingReview[0].key).toBe('AIPCC-900')
     })
 
-    it('meta counts include health-pipeline features', function() {
+    it('meta counts include health-pipeline features', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1753,14 +1753,14 @@ describe('buildFeatureReadiness', function() {
         'releases/planning/config.json': CONFIG_3_6,
         'releases/planning/health-cache-3.6-all.json': healthCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.meta.total).toBe(2)
       expect(result.meta.readyCount).toBe(1)
     })
   })
 
   describe('hygiene alias lookup', function() {
-    it('finds hygiene cache via registry displayName when config key differs', function() {
+    it('finds hygiene cache via registry displayName when config key differs', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1781,12 +1781,12 @@ describe('buildFeatureReadiness', function() {
         'releases/registry.json': registryData,
         'releases/hygiene/features-RHOAI 3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.violations).toEqual(violations)
     })
 
-    it('finds hygiene cache via registry id alias', function() {
+    it('finds hygiene cache via registry id alias', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1807,12 +1807,12 @@ describe('buildFeatureReadiness', function() {
         'releases/registry.json': registryData,
         'releases/hygiene/features-rhoai-3.6.json': hygieneCache
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       expect(result.pendingReview[0].violations).toEqual(violations)
       expect(result.pendingReview[0].readinessGates.noBlockingViolations).toBe(true)
     })
 
-    it('prefers direct config key match over alias', function() {
+    it('prefers direct config key match over alias', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1832,14 +1832,14 @@ describe('buildFeatureReadiness', function() {
         'releases/hygiene/features-3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'A', violations: directViolations } } },
         'releases/hygiene/features-RHOAI 3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'A', violations: aliasViolations } } }
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.violations).toEqual(directViolations)
     })
   })
 
   describe('hygieneIndex independent of teamIndex', function() {
-    it('indexes violations separately from team across versions', function() {
+    it('indexes violations separately from team across versions', async function() {
       var store = makeFeaturesStore({
         'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
       })
@@ -1854,7 +1854,7 @@ describe('buildFeatureReadiness', function() {
         'releases/hygiene/features-3.5.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Alpha' } } },
         'releases/hygiene/features-3.6.json': { features: { 'RHAISTRAT-1': { key: 'RHAISTRAT-1', violations: violations } } }
       })
-      var result = buildFeatureReadiness(readFromStorage)
+      var result = await buildFeatureReadiness(readFromStorage)
       var feat = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
       expect(feat.team).toBe('Alpha')
       expect(feat.violations).toEqual(violations)
@@ -1966,7 +1966,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     }, overrides)
   }
 
-  it('includes execution index features not in caches or ai-impact', function() {
+  it('includes execution index features not in caches or ai-impact', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -1975,7 +1975,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-999')
     expect(result.pendingReview[0].dataSource).toBe('execution')
@@ -1984,7 +1984,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     expect(result.pendingReview[0].team).toBe('Platform')
   })
 
-  it('execution feature with sign-off but no rubric goes to pendingReview', function() {
+  it('execution feature with sign-off but no rubric goes to pendingReview', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -1998,7 +1998,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].confidence).toBe('not-ready')
     expect(result.pendingReview[0].humanReviewStatus).toBe('approved')
@@ -2006,7 +2006,7 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
     expect(typeof result.pendingReview[0].readinessGates.fpDorEvaluated).toBe('number')
   })
 
-  it('execution feature in Refinement status is not ready', function() {
+  it('execution feature in Refinement status is not ready', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2018,12 +2018,12 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].readinessGates.pastRefinement).toBe(false)
   })
 
-  it('skips closed features from execution index', function() {
+  it('skips closed features from execution index', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2034,12 +2034,12 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-668')
   })
 
-  it('does not duplicate features already in strat-creator pass', function() {
+  it('does not duplicate features already in strat-creator pass', async function() {
     var store = makeFeaturesStore({
       'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
     })
@@ -2051,12 +2051,12 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
     expect(new Set(keys).size).toBe(keys.length)
   })
 
-  it('does not duplicate features already in health-pipeline pass', function() {
+  it('does not duplicate features already in health-pipeline pass', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2068,14 +2068,14 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
     expect(new Set(keys).size).toBe(keys.length)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-50' })
     expect(feature.dataSource).toBe('health-pipeline')
   })
 
-  it('populates filter metadata from execution features', function() {
+  it('populates filter metadata from execution features', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2089,14 +2089,14 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.filterMeta.components).toContain('NewComp')
     expect(result.filterMeta.teams).toContain('NewTeam')
     expect(result.filterMeta.priorities).toContain('Blocker')
     expect(result.filterMeta.targetVersions).toContain('rhoai-4.0')
   })
 
-  it('execution feature with fix version still goes to pendingReview (no rubric)', function() {
+  it('execution feature with fix version still goes to pendingReview (no rubric)', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2111,12 +2111,12 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.pendingReview[0].confidence).toBe('not-ready')
     expect(result.pendingReview[0].fixVersion).toBe('rhoai-3.6')
   })
 
-  it('handles string components from execution index', function() {
+  it('handles string components from execution index', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2125,11 +2125,11 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.pendingReview[0].components).toEqual(['UI', 'API', 'Docs'])
   })
 
-  it('handles multiple execution features sorted by priority score', function() {
+  it('handles multiple execution features sorted by priority score', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2140,30 +2140,30 @@ describe('buildFeatureReadiness — pass 3 (execution index)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.pendingReview.length).toBe(3)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-B')
     expect(result.pendingReview[result.pendingReview.length - 1].key).toBe('RHAISTRAT-A')
   })
 
-  it('handles empty execution index gracefully', function() {
+  it('handles empty execution index gracefully', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.meta.total).toBe(0)
   })
 
-  it('handles missing execution index gracefully', function() {
+  it('handles missing execution index gracefully', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6
     })
 
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     expect(result.meta.total).toBe(0)
   })
 })
@@ -2217,7 +2217,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     }, overrides)
   }
 
-  it('uses jiraFeatures as pass 3 source when provided', function() {
+  it('uses jiraFeatures as pass 3 source when provided', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-900')
     ])
@@ -2227,14 +2227,14 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-900')
     expect(result.pendingReview[0].dataSource).toBe('jira')
     expect(result.pendingReview[0].title).toBe('Jira Feature RHAISTRAT-900')
   })
 
-  it('falls back to execution index when jiraFeatures is null', function() {
+  it('falls back to execution index when jiraFeatures is null', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2243,13 +2243,13 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, null)
+    var result = await buildFeatureReadiness(readFromStorage, null)
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-800')
     expect(result.pendingReview[0].dataSource).toBe('execution')
   })
 
-  it('falls back to execution index when jiraFeatures is empty Map', function() {
+  it('falls back to execution index when jiraFeatures is empty Map', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),
       'releases/planning/config.json': CONFIG_3_6,
@@ -2258,13 +2258,13 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, new Map())
+    var result = await buildFeatureReadiness(readFromStorage, new Map())
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-700')
     expect(result.pendingReview[0].dataSource).toBe('execution')
   })
 
-  it('does not duplicate features already in strat-creator pass', function() {
+  it('does not duplicate features already in strat-creator pass', async function() {
     var store = makeFeaturesStore({
       'RHAISTRAT-1': { latest: makeLatest({ humanReviewStatus: 'approved' }) }
     })
@@ -2277,12 +2277,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
     expect(new Set(keys).size).toBe(keys.length)
   })
 
-  it('does not duplicate features already in health-pipeline pass', function() {
+  it('does not duplicate features already in health-pipeline pass', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-50')
     ])
@@ -2295,14 +2295,14 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var keys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
     expect(new Set(keys).size).toBe(keys.length)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-50' })
     expect(feature.dataSource).toBe('health-pipeline')
   })
 
-  it('enriches Jira features with execution index data when available', function() {
+  it('enriches Jira features with execution index data when available', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-600', { riceScore: null })
     ])
@@ -2314,7 +2314,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.meta.total).toBe(1)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-600' })
     expect(feature.dataSource).toBe('jira')
@@ -2322,7 +2322,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     expect(typeof feature.readinessGates.fpDorPassed).toBe('number')
   })
 
-  it('Jira feature with sign-off but no rubric goes to pendingReview', function() {
+  it('Jira feature with sign-off but no rubric goes to pendingReview', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-500', {
         labels: ['strat-creator-human-sign-off'],
@@ -2343,7 +2343,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].confidence).toBe('not-ready')
     expect(result.pendingReview[0].humanReviewStatus).toBe('approved')
@@ -2351,7 +2351,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     expect(typeof result.pendingReview[0].readinessGates.fpDorEvaluated).toBe('number')
   })
 
-  it('Jira feature with fix version still goes to pendingReview (no rubric)', function() {
+  it('Jira feature with fix version still goes to pendingReview (no rubric)', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-400', {
         labels: ['strat-creator-human-sign-off'],
@@ -2367,12 +2367,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview[0].confidence).toBe('not-ready')
     expect(result.pendingReview[0].fixVersion).toBe('rhoai-3.6')
   })
 
-  it('skips closed Jira features', function() {
+  it('skips closed Jira features', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-C1', { status: 'Closed' }),
       makeJiraFeature('RHAISTRAT-C2', { status: 'Resolved' }),
@@ -2384,12 +2384,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-C3')
   })
 
-  it('Jira feature in Refinement status is not ready', function() {
+  it('Jira feature in Refinement status is not ready', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-REF', {
         labels: ['strat-creator-human-sign-off'],
@@ -2402,12 +2402,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].readinessGates.pastRefinement).toBe(false)
   })
 
-  it('populates filter metadata from Jira features', function() {
+  it('populates filter metadata from Jira features', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-META', {
         components: ['NewJiraComp'],
@@ -2422,14 +2422,14 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.filterMeta.components).toContain('NewJiraComp')
     expect(result.filterMeta.teams).toContain('JiraTeam')
     expect(result.filterMeta.priorities).toContain('Critical')
     expect(result.filterMeta.targetVersions).toContain('rhoai-4.0')
   })
 
-  it('prefers Jira riceScore over execution index riceScore', function() {
+  it('prefers Jira riceScore over execution index riceScore', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-RICE', { riceScore: 100 })
     ])
@@ -2441,12 +2441,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-RICE' })
     expect(feature.riceScore).toBe(100)
   })
 
-  it('uses execution index riceScore when Jira riceScore is null', function() {
+  it('uses execution index riceScore when Jira riceScore is null', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-RICE2', { riceScore: null })
     ])
@@ -2458,12 +2458,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-RICE2' })
     expect(feature.riceScore).toBe(75)
   })
 
-  it('includes Jira features not present in execution index', function() {
+  it('includes Jira features not present in execution index', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-JONLY', { summary: 'Jira only feature' })
     ])
@@ -2473,12 +2473,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.meta.total).toBe(1)
     expect(result.pendingReview[0].title).toBe('Jira only feature')
   })
 
-  it('handles multiple Jira features sorted by priority score', function() {
+  it('handles multiple Jira features sorted by priority score', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-J1', { priority: 'Minor' }),
       makeJiraFeature('RHAISTRAT-J2', { priority: 'Blocker' }),
@@ -2490,13 +2490,13 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(3)
     expect(result.pendingReview[0].key).toBe('RHAISTRAT-J2')
     expect(result.pendingReview[result.pendingReview.length - 1].key).toBe('RHAISTRAT-J1')
   })
 
-  it('Jira feature without assignee fails FPDoR owners check', function() {
+  it('Jira feature without assignee fails FPDoR owners check', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-NOOWN', {
         assignee: null,
@@ -2509,12 +2509,12 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].readinessGates.fpDorPassed).toBeLessThan(result.pendingReview[0].readinessGates.fpDorEvaluated)
   })
 
-  it('Jira feature without target version fails FPDoR target version check', function() {
+  it('Jira feature without target version fails FPDoR target version check', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-NOTV', {
         targetVersions: [],
@@ -2527,7 +2527,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     expect(result.pendingReview.length).toBe(1)
     expect(result.pendingReview[0].readinessGates.fpDorPassed).toBeLessThan(result.pendingReview[0].readinessGates.fpDorEvaluated)
   })
@@ -2582,7 +2582,7 @@ describe('buildFeatureReadiness - all-hygiene-files loading', function() {
     }, overrides)
   }
 
-  it('loads team and violations from non-configured hygiene files via listStorageFiles', function() {
+  it('loads team and violations from non-configured hygiene files via listStorageFiles', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-500', { team: null })
     ])
@@ -2606,14 +2606,14 @@ describe('buildFeatureReadiness - all-hygiene-files loading', function() {
       return []
     }
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-500' })
     expect(feature).toBeDefined()
     expect(feature.team).toBe('Llama Stack Core')
     expect(feature.violations).toEqual([{ id: 'missing-fix-version', name: 'Missing Fix Version' }])
   })
 
-  it('does not overwrite team from configured version with non-configured version data', function() {
+  it('does not overwrite team from configured version with non-configured version data', async function() {
     var readFromStorage = makeReadFromStorage({
       'ai-impact/features.json': makeFeaturesStore({}),
       'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
@@ -2637,13 +2637,13 @@ describe('buildFeatureReadiness - all-hygiene-files loading', function() {
       return []
     }
 
-    var result = buildFeatureReadiness(readFromStorage, null, listStorageFiles)
+    var result = await buildFeatureReadiness(readFromStorage, null, listStorageFiles)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-600' })
     expect(feature).toBeDefined()
     expect(feature.team).toBe('RHOAI Dashboard')
   })
 
-  it('works without listStorageFiles (backward compatible)', function() {
+  it('works without await listStorageFiles (backward compatible)', async function() {
     var readFromStorage = makeReadFromStorage({
       'ai-impact/features.json': makeFeaturesStore({}),
       'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
@@ -2652,11 +2652,11 @@ describe('buildFeatureReadiness - all-hygiene-files loading', function() {
       ])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, null)
+    var result = await buildFeatureReadiness(readFromStorage, null)
     expect(result.pendingReview.concat(result.ready).length).toBeGreaterThan(0)
   })
 
-  it('handles listStorageFiles throwing an error gracefully', function() {
+  it('handles listStorageFiles throwing an error gracefully', async function() {
     var readFromStorage = makeReadFromStorage({
       'ai-impact/features.json': makeFeaturesStore({}),
       'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
@@ -2669,7 +2669,7 @@ describe('buildFeatureReadiness - all-hygiene-files loading', function() {
       throw new Error('directory not found')
     }
 
-    var result = buildFeatureReadiness(readFromStorage, null, listStorageFiles)
+    var result = await buildFeatureReadiness(readFromStorage, null, listStorageFiles)
     expect(result.pendingReview.concat(result.ready).length).toBeGreaterThan(0)
   })
 })
@@ -2704,7 +2704,7 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
     }, overrides)
   }
 
-  it('pass 1: uses Jira team when teamIndex has no entry', function() {
+  it('pass 1: uses Jira team when teamIndex has no entry', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-1', { team: 'JiraTeamFallback' })
     ])
@@ -2722,13 +2722,13 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
       'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
     expect(feature).toBeDefined()
     expect(feature.team).toBe('JiraTeamFallback')
   })
 
-  it('pass 1: uses Jira components when strat-creator and health-cache are empty', function() {
+  it('pass 1: uses Jira components when strat-creator and health-cache are empty', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-1', { components: ['CompFromJira'] })
     ])
@@ -2746,13 +2746,13 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
       'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
     expect(feature).toBeDefined()
     expect(feature.components).toEqual(['CompFromJira'])
   })
 
-  it('pass 1: uses Jira assignee as deliveryOwner when healthData has none', function() {
+  it('pass 1: uses Jira assignee as deliveryOwner when healthData has none', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-1', { assignee: 'JiraOwner' })
     ])
@@ -2770,13 +2770,13 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
       'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
     expect(feature).toBeDefined()
     expect(feature.deliveryOwner).toBe('JiraOwner')
   })
 
-  it('pass 2: uses Jira team when teamIndex has no entry', function() {
+  it('pass 2: uses Jira team when teamIndex has no entry', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-HP1', { team: 'JiraTeamHP' })
     ])
@@ -2797,13 +2797,13 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
       'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-HP1' })
     expect(feature).toBeDefined()
     expect(feature.team).toBe('JiraTeamHP')
   })
 
-  it('pass 2: uses Jira components when health-cache components are empty', function() {
+  it('pass 2: uses Jira components when health-cache components are empty', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-HP2', { components: ['JiraCompHP'] })
     ])
@@ -2824,7 +2824,7 @@ describe('buildFeatureReadiness - Jira data fallback enrichment', function() {
       'releases/execution/index.json': { features: [], fetchedAt: '2026-06-09T00:00:00Z', schemaVersion: 'v2', featureCount: 0 }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-HP2' })
     expect(feature).toBeDefined()
     expect(feature.components).toEqual(['JiraCompHP'])
@@ -2870,7 +2870,7 @@ describe('buildFeatureReadiness - hygiene violations from cache', function() {
     }, overrides)
   }
 
-  it('attaches cached violations from hygieneIndex', function() {
+  it('attaches cached violations from hygieneIndex', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-DYN2', {
         status: 'In Progress',
@@ -2892,13 +2892,13 @@ describe('buildFeatureReadiness - hygiene violations from cache', function() {
       }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN2' })
     expect(feature).toBeDefined()
     expect(feature.violations).toEqual([{ id: 'cached-violation', name: 'Cached Violation' }])
   })
 
-  it('returns null violations for features not in hygieneIndex', function() {
+  it('returns null violations for features not in hygieneIndex', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-DYN1', {
         status: 'In Progress',
@@ -2913,13 +2913,13 @@ describe('buildFeatureReadiness - hygiene violations from cache', function() {
       'releases/execution/index.json': makeExecIndex([])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN1' })
     expect(feature).toBeDefined()
     expect(feature.violations).toBeNull()
   })
 
-  it('returns null violations for execution index features', function() {
+  it('returns null violations for execution index features', async function() {
     var readFromStorage = makeReadFromStorage({
       'ai-impact/features.json': makeFeaturesStore({}),
       'releases/planning/config.json': { releases: { '3.6': { release: '3.6' } } },
@@ -2937,7 +2937,7 @@ describe('buildFeatureReadiness - hygiene violations from cache', function() {
       }])
     })
 
-    var result = buildFeatureReadiness(readFromStorage, null)
+    var result = await buildFeatureReadiness(readFromStorage, null)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-DYN3' })
     expect(feature).toBeDefined()
     expect(feature.violations).toBeNull()
@@ -3124,7 +3124,7 @@ describe('buildFeatureReadiness — single-pass merging', function() {
 
 
 
-  it('feature with aiReview + Jira gets rubric scores AND Jira status', function() {
+  it('feature with aiReview + Jira gets rubric scores AND Jira status', async function() {
     var store = makeFeaturesStore({
       'RHAISTRAT-1': { latest: makeLatest({ status: 'OldStatus', humanReviewStatus: 'approved' }) }
     })
@@ -3144,7 +3144,7 @@ describe('buildFeatureReadiness — single-pass merging', function() {
       ...convertToUnifiedFormat(store),
       'releases/planning/config.json': CONFIG_3_6
     })
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
 
     var all = result.pendingReview.concat(result.ready)
     var feature = all.find(function(f) { return f.key === 'RHAISTRAT-1' })
@@ -3155,7 +3155,7 @@ describe('buildFeatureReadiness — single-pass merging', function() {
     expect(feature.dataSource).toBe('strat-creator')
   })
 
-  it('feature with only Jira data appears on list', function() {
+  it('feature with only Jira data appears on list', async function() {
     var store = makeFeaturesStore({})
     var jiraFeatures = new Map([['RHAISTRAT-JIRA', {
       summary: 'Jira Only Feature',
@@ -3172,7 +3172,7 @@ describe('buildFeatureReadiness — single-pass merging', function() {
       ...convertToUnifiedFormat(store),
       'releases/planning/config.json': CONFIG_3_6
     })
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-JIRA' })
     expect(feature).toBeDefined()
     expect(feature.dataSource).toBe('jira')
@@ -3180,7 +3180,7 @@ describe('buildFeatureReadiness — single-pass merging', function() {
     expect(feature.components).toEqual(['Backend'])
   })
 
-  it('feature with null hygiene shows hygieneStatus unknown', function() {
+  it('feature with null hygiene shows hygieneStatus unknown', async function() {
     var store = makeFeaturesStore({
       'RHAISTRAT-1': { latest: makeLatest() }
     })
@@ -3191,24 +3191,24 @@ describe('buildFeatureReadiness — single-pass merging', function() {
         data: { features: [{ issueKey: 'RHAISTRAT-1', tier: 1, targetRelease: '3.6' }] }
       }
     })
-    var result = buildFeatureReadiness(readFromStorage)
+    var result = await buildFeatureReadiness(readFromStorage)
     var feature = result.pendingReview.concat(result.ready).find(function(f) { return f.key === 'RHAISTRAT-1' })
     expect(feature.hygieneStatus).toBe('unknown')
     expect(feature.violations).toBeNull()
   })
 
-  it('meta includes jiraAvailable flag', function() {
+  it('meta includes jiraAvailable flag', async function() {
     var store = makeFeaturesStore({})
     var readFromStorage = makeReadFromStorage(convertToUnifiedFormat(store))
 
-    var r1 = buildFeatureReadiness(readFromStorage, null)
+    var r1 = await buildFeatureReadiness(readFromStorage, null)
     expect(r1.meta.jiraAvailable).toBe(false)
 
-    var r2 = buildFeatureReadiness(readFromStorage, new Map())
+    var r2 = await buildFeatureReadiness(readFromStorage, new Map())
     expect(r2.meta.jiraAvailable).toBe(true)
   })
 
-  it('no feature is excluded — all sources contribute to canonical set', function() {
+  it('no feature is excluded — all sources contribute to canonical set', async function() {
     var store = makeFeaturesStore({
       'RHAISTRAT-AI': { latest: makeLatest() }
     })
@@ -3231,7 +3231,7 @@ describe('buildFeatureReadiness — single-pass merging', function() {
       }
     })
 
-    var result = buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
     var allKeys = result.pendingReview.concat(result.ready).map(function(f) { return f.key })
     expect(allKeys).toContain('RHAISTRAT-AI')
     expect(allKeys).toContain('RHAISTRAT-JIRA')

--- a/modules/releases/server/planning/__tests__/team-lookup.test.js
+++ b/modules/releases/server/planning/__tests__/team-lookup.test.js
@@ -12,30 +12,30 @@ function makeReadFromStorage(overrides) {
 }
 
 describe('buildTeamIndex', function() {
-  it('returns empty Map when version is null', function() {
-    var index = buildTeamIndex(makeReadFromStorage({}), null)
+  it('returns empty Map when version is null', async function() {
+    var index = await buildTeamIndex(makeReadFromStorage({}), null)
     expect(index.size).toBe(0)
   })
 
-  it('returns empty Map when version is undefined', function() {
-    var index = buildTeamIndex(makeReadFromStorage({}), undefined)
+  it('returns empty Map when version is undefined', async function() {
+    var index = await buildTeamIndex(makeReadFromStorage({}), undefined)
     expect(index.size).toBe(0)
   })
 
-  it('returns empty Map when hygiene cache is absent', function() {
-    var index = buildTeamIndex(makeReadFromStorage({}), '3.5')
+  it('returns empty Map when hygiene cache is absent', async function() {
+    var index = await buildTeamIndex(makeReadFromStorage({}), '3.5')
     expect(index.size).toBe(0)
   })
 
-  it('returns empty Map when hygiene cache has no features', function() {
+  it('returns empty Map when hygiene cache has no features', async function() {
     var readFromStorage = makeReadFromStorage({
       'releases/hygiene/features-3.5.json': { fetchedAt: '2026-01-01T00:00:00.000Z' }
     })
-    var index = buildTeamIndex(readFromStorage, '3.5')
+    var index = await buildTeamIndex(readFromStorage, '3.5')
     expect(index.size).toBe(0)
   })
 
-  it('builds index from hygiene cache features object', function() {
+  it('builds index from hygiene cache features object', async function() {
     var hygieneCache = {
       features: {
         'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Model Serving' },
@@ -45,13 +45,13 @@ describe('buildTeamIndex', function() {
     var readFromStorage = makeReadFromStorage({
       'releases/hygiene/features-3.5.json': hygieneCache
     })
-    var index = buildTeamIndex(readFromStorage, '3.5')
+    var index = await buildTeamIndex(readFromStorage, '3.5')
     expect(index.size).toBe(2)
     expect(index.get('RHAISTRAT-1')).toBe('Model Serving')
     expect(index.get('RHAISTRAT-2')).toBe('Training')
   })
 
-  it('skips features without a team field', function() {
+  it('skips features without a team field', async function() {
     var hygieneCache = {
       features: {
         'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: 'Platform' },
@@ -61,23 +61,23 @@ describe('buildTeamIndex', function() {
     var readFromStorage = makeReadFromStorage({
       'releases/hygiene/features-3.5.json': hygieneCache
     })
-    var index = buildTeamIndex(readFromStorage, '3.5')
+    var index = await buildTeamIndex(readFromStorage, '3.5')
     expect(index.size).toBe(1)
     expect(index.get('RHAISTRAT-1')).toBe('Platform')
     expect(index.has('RHAISTRAT-2')).toBe(false)
   })
 
-  it('uses the version string in the storage key', function() {
+  it('uses the version string in the storage key', async function() {
     var called = []
-    function readFromStorage(key) {
+    async function readFromStorage(key) {
       called.push(key)
       return null
     }
-    buildTeamIndex(readFromStorage, 'RHOAI 2.14')
+    await buildTeamIndex(readFromStorage, 'RHOAI 2.14')
     expect(called).toContain('releases/hygiene/features-RHOAI 2.14.json')
   })
 
-  it('returns empty Map when features have null team values', function() {
+  it('returns empty Map when features have null team values', async function() {
     var hygieneCache = {
       features: {
         'RHAISTRAT-1': { key: 'RHAISTRAT-1', team: null }
@@ -86,7 +86,7 @@ describe('buildTeamIndex', function() {
     var readFromStorage = makeReadFromStorage({
       'releases/hygiene/features-3.5.json': hygieneCache
     })
-    var index = buildTeamIndex(readFromStorage, '3.5')
+    var index = await buildTeamIndex(readFromStorage, '3.5')
     expect(index.size).toBe(0)
   })
 })

--- a/modules/releases/server/planning/audit-log.js
+++ b/modules/releases/server/planning/audit-log.js
@@ -7,9 +7,9 @@ function generateId() {
   return 'audit-' + Date.now().toString(36) + '-' + crypto.randomBytes(4).toString('hex')
 }
 
-function logAudit(readFromStorage, writeToStorage, entry) {
+async function logAudit(readFromStorage, writeToStorage, entry) {
   try {
-    const log = readFromStorage(STORAGE_KEY) || { entries: [] }
+    const log = await readFromStorage(STORAGE_KEY) || { entries: [] }
 
     log.entries.push({
       id: generateId(),
@@ -26,14 +26,14 @@ function logAudit(readFromStorage, writeToStorage, entry) {
       log.entries = log.entries.slice(log.entries.length - MAX_ENTRIES)
     }
 
-    writeToStorage(STORAGE_KEY, log)
+    await writeToStorage(STORAGE_KEY, log)
   } catch (err) {
     console.error('[audit-log] Failed to write audit entry:', err.message)
   }
 }
 
-function getAuditLog(readFromStorage, options) {
-  const log = readFromStorage(STORAGE_KEY) || { entries: [] }
+async function getAuditLog(readFromStorage, options) {
+  const log = await readFromStorage(STORAGE_KEY) || { entries: [] }
   let entries = log.entries
 
   if (options && options.version) {

--- a/modules/releases/server/planning/cache-reader.js
+++ b/modules/releases/server/planning/cache-reader.js
@@ -11,16 +11,16 @@ const FT_PREFIX = 'releases/execution'
 
 // ─── Data Loading ───
 
-function loadIndex(readFromStorage) {
-  return readFromStorage(FT_PREFIX + '/index.json') || { features: [], rfes: [] }
+async function loadIndex(readFromStorage) {
+  return await readFromStorage(FT_PREFIX + '/index.json') || { features: [], rfes: [] }
 }
 
-function loadFeatureDetail(readFromStorage, key) {
-  return readFromStorage(FT_PREFIX + '/features/' + key + '.json')
+async function loadFeatureDetail(readFromStorage, key) {
+  return await readFromStorage(FT_PREFIX + '/features/' + key + '.json')
 }
 
-function loadRfeDetail(readFromStorage, key) {
-  return readFromStorage(FT_PREFIX + '/rfes/' + key + '.json')
+async function loadRfeDetail(readFromStorage, key) {
+  return await readFromStorage(FT_PREFIX + '/rfes/' + key + '.json')
 }
 
 // ─── Field Extraction Helpers ───
@@ -159,7 +159,7 @@ function rfeLinksToOutcome(issueLinks, outcomeSet) {
  * Find Tier 1 features: children of outcome keys with matching target version.
  * Uses parentKey from the index to identify outcome children.
  */
-function findTier1Features(readFromStorage, index, outcomeKeys, stats) {
+async function findTier1Features(readFromStorage, index, outcomeKeys, stats) {
   const outcomeSet = new Set(outcomeKeys)
   const results = []
 
@@ -189,7 +189,7 @@ function findTier1Features(readFromStorage, index, outcomeKeys, stats) {
     }
 
     // Load detail for components and issueLinks
-    const detail = loadFeatureDetail(readFromStorage, f.key)
+    const detail = await loadFeatureDetail(readFromStorage, f.key)
     if (detail) {
       detail._indexEntry = f
     }
@@ -206,7 +206,7 @@ function findTier1Features(readFromStorage, index, outcomeKeys, stats) {
  * Note: RFEs don't have parentKey in the pipeline data, so we use
  * issueLinks to find connections to outcome keys.
  */
-function findTier1Rfes(readFromStorage, index, outcomeKeys, release) {
+async function findTier1Rfes(readFromStorage, index, outcomeKeys, release) {
   const outcomeSet = new Set(outcomeKeys)
   const results = []
   const candidateLabel = release + '-candidate'
@@ -222,7 +222,7 @@ function findTier1Rfes(readFromStorage, index, outcomeKeys, release) {
     if (labels.indexOf(candidateLabel) === -1) continue
 
     // Need detail file to check issueLinks
-    const detail = loadRfeDetail(readFromStorage, r.key)
+    const detail = await loadRfeDetail(readFromStorage, r.key)
     if (!detail) continue
 
     if (!rfeLinksToOutcome(detail.issueLinks, outcomeSet)) continue
@@ -256,7 +256,7 @@ function findOutcomeSummaries(index, outcomeKeys) {
  * Find Tier 2 features: features with target version matching the release,
  * excluding already-discovered Tier 1 keys.
  */
-function findTier2Features(readFromStorage, index, release, excludeKeys) {
+async function findTier2Features(readFromStorage, index, release, excludeKeys) {
   const results = []
   const features = index.features || []
 
@@ -277,7 +277,7 @@ function findTier2Features(readFromStorage, index, release, excludeKeys) {
     const status = f.status || ''
     if (CLOSED_STATUSES.indexOf(status) !== -1) continue
 
-    const detail = loadFeatureDetail(readFromStorage, f.key)
+    const detail = await loadFeatureDetail(readFromStorage, f.key)
     results.push(detail || f)
   }
 
@@ -288,7 +288,7 @@ function findTier2Features(readFromStorage, index, release, excludeKeys) {
  * Find Tier 2 RFEs: RFEs with {release}-candidate label,
  * not closed, not Approved, excluding Tier 1 keys.
  */
-function findTier2Rfes(readFromStorage, index, release, excludeKeys) {
+async function findTier2Rfes(readFromStorage, index, release, excludeKeys) {
   const results = []
   const candidateLabel = release + '-candidate'
   const rfes = index.rfes || []
@@ -304,7 +304,7 @@ function findTier2Rfes(readFromStorage, index, release, excludeKeys) {
     const labels = getLabels(r)
     if (labels.indexOf(candidateLabel) === -1) continue
 
-    const detail = loadRfeDetail(readFromStorage, r.key)
+    const detail = await loadRfeDetail(readFromStorage, r.key)
     results.push(detail || r)
   }
 
@@ -314,7 +314,7 @@ function findTier2Rfes(readFromStorage, index, release, excludeKeys) {
 /**
  * Find Tier 3 features: In Progress, no target version, no fix version.
  */
-function findTier3Features(readFromStorage, index, excludeKeys) {
+async function findTier3Features(readFromStorage, index, excludeKeys) {
   const results = []
   const features = index.features || []
 
@@ -330,7 +330,7 @@ function findTier3Features(readFromStorage, index, excludeKeys) {
     const fixVersions = getFixVersions(f)
     if (fixVersions.length > 0) continue
 
-    const detail = loadFeatureDetail(readFromStorage, f.key)
+    const detail = await loadFeatureDetail(readFromStorage, f.key)
     results.push(detail || f)
   }
 

--- a/modules/releases/server/planning/config-backup.js
+++ b/modules/releases/server/planning/config-backup.js
@@ -9,28 +9,28 @@
 const BACKUP_PREFIX = 'releases/planning/config-backup-'
 const MAX_BACKUPS = 10
 
-function backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage) {
-  const config = readFromStorage('releases/planning/config.json')
+async function backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage) {
+  const config = await readFromStorage('releases/planning/config.json')
   if (!config) return
 
   const bundle = { config: config, releases: {} }
   const versions = Object.keys(config.releases || {})
   for (let i = 0; i < versions.length; i++) {
-    const data = readFromStorage('releases/planning/releases/' + versions[i] + '.json')
+    const data = await readFromStorage('releases/planning/releases/' + versions[i] + '.json')
     if (data) bundle.releases[versions[i]] = data
   }
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-')
-  writeToStorage(`${BACKUP_PREFIX}${ts}.json`, bundle)
+  await writeToStorage(`${BACKUP_PREFIX}${ts}.json`, bundle)
 
-  pruneOldBackups(listStorageFiles, deleteFromStorage)
+  await pruneOldBackups(listStorageFiles, deleteFromStorage)
 }
 
-function pruneOldBackups(listStorageFiles, deleteFromStorage) {
+async function pruneOldBackups(listStorageFiles, deleteFromStorage) {
   if (!listStorageFiles || !deleteFromStorage) return
 
   try {
-    const files = listStorageFiles('releases/planning')
+    const files = await listStorageFiles('releases/planning')
     const backupFiles = files
       .filter(function(f) { return f.startsWith('config-backup-') && f.endsWith('.json') })
       .sort()
@@ -38,7 +38,7 @@ function pruneOldBackups(listStorageFiles, deleteFromStorage) {
     if (backupFiles.length > MAX_BACKUPS) {
       const toDelete = backupFiles.slice(0, backupFiles.length - MAX_BACKUPS)
       for (const file of toDelete) {
-        deleteFromStorage(`releases/planning/${file}`)
+        await deleteFromStorage(`releases/planning/${file}`)
       }
     }
   } catch (err) {

--- a/modules/releases/server/planning/config.js
+++ b/modules/releases/server/planning/config.js
@@ -54,8 +54,8 @@ function releaseFilePath(version) {
   return 'releases/planning/releases/' + version + '.json'
 }
 
-function getConfig(readFromStorage) {
-  const stored = readFromStorage('releases/planning/config.json')
+async function getConfig(readFromStorage) {
+  const stored = await readFromStorage('releases/planning/config.json')
   if (stored && typeof stored === 'object') {
     const storedHealth = stored.healthConfig || {}
     var config = {
@@ -78,37 +78,41 @@ function getConfig(readFromStorage) {
   return { ...DEFAULT_CONFIG }
 }
 
-function loadReleaseData(readFromStorage, version) {
-  return readFromStorage(releaseFilePath(version)) || { release: version, bigRocks: [] }
+async function loadReleaseData(readFromStorage, version) {
+  return await readFromStorage(releaseFilePath(version)) || { release: version, bigRocks: [] }
 }
 
-function loadBigRocks(readFromStorage, version) {
-  const data = loadReleaseData(readFromStorage, version)
+async function loadBigRocks(readFromStorage, version) {
+  const data = await loadReleaseData(readFromStorage, version)
   return data.bigRocks || []
 }
 
-function loadFieldMapping(readFromStorage) {
-  const config = getConfig(readFromStorage)
+async function loadFieldMapping(readFromStorage) {
+  const config = await getConfig(readFromStorage)
   return config.fieldMapping || DEFAULT_CONFIG.fieldMapping
 }
 
-function getConfiguredReleases(readFromStorage) {
-  const config = getConfig(readFromStorage)
-  return Object.keys(config.releases || {}).map(function(version) {
-    const releaseData = loadReleaseData(readFromStorage, version)
-    return {
+async function getConfiguredReleases(readFromStorage) {
+  const config = await getConfig(readFromStorage)
+  const versions = Object.keys(config.releases || {})
+  const results = []
+  for (let i = 0; i < versions.length; i++) {
+    const version = versions[i]
+    const releaseData = await loadReleaseData(readFromStorage, version)
+    results.push({
       version: version,
       bigRockCount: (releaseData.bigRocks || []).length
-    }
-  })
+    })
+  }
+  return results
 }
 
 /**
  * Save a Big Rock (create or update) within a release.
  * Reads/writes only the per-release file, not the global config.
  */
-function saveBigRock(readFromStorage, writeToStorage, version, originalName, data) {
-  const releaseData = loadReleaseData(readFromStorage, version)
+async function saveBigRock(readFromStorage, writeToStorage, version, originalName, data) {
+  const releaseData = await loadReleaseData(readFromStorage, version)
   const bigRocks = releaseData.bigRocks || []
 
   if (originalName) {
@@ -150,7 +154,7 @@ function saveBigRock(readFromStorage, writeToStorage, version, originalName, dat
   renumberPriorities(bigRocks)
 
   releaseData.bigRocks = bigRocks
-  writeToStorage(releaseFilePath(version), releaseData)
+  await writeToStorage(releaseFilePath(version), releaseData)
 
   const savedRock = bigRocks.find(function(r) { return r.name === (data.name || '').trim() })
   return { bigRock: savedRock, bigRocks: bigRocks }
@@ -160,8 +164,8 @@ function saveBigRock(readFromStorage, writeToStorage, version, originalName, dat
  * Delete a Big Rock by name from a release.
  * Reads/writes only the per-release file.
  */
-function deleteBigRock(readFromStorage, writeToStorage, version, name) {
-  const releaseData = loadReleaseData(readFromStorage, version)
+async function deleteBigRock(readFromStorage, writeToStorage, version, name) {
+  const releaseData = await loadReleaseData(readFromStorage, version)
   const bigRocks = releaseData.bigRocks || []
   const idx = bigRocks.findIndex(function(r) { return r.name === name })
 
@@ -173,7 +177,7 @@ function deleteBigRock(readFromStorage, writeToStorage, version, name) {
   renumberPriorities(bigRocks)
 
   releaseData.bigRocks = bigRocks
-  writeToStorage(releaseFilePath(version), releaseData)
+  await writeToStorage(releaseFilePath(version), releaseData)
 
   return { deleted: name, bigRocks: bigRocks }
 }
@@ -182,8 +186,8 @@ function deleteBigRock(readFromStorage, writeToStorage, version, name) {
  * Reorder Big Rocks within a release.
  * Reads/writes only the per-release file.
  */
-function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames) {
-  const config = getConfig(readFromStorage)
+async function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames) {
+  const config = await getConfig(readFromStorage)
   if (!config.releases[version]) {
     throw Object.assign(
       new Error('Release ' + version + ' not found'),
@@ -191,7 +195,7 @@ function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames)
     )
   }
 
-  const releaseData = loadReleaseData(readFromStorage, version)
+  const releaseData = await loadReleaseData(readFromStorage, version)
   const bigRocks = releaseData.bigRocks || []
   const currentNames = bigRocks.map(function(r) { return r.name })
 
@@ -236,7 +240,7 @@ function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames)
   renumberPriorities(reordered)
 
   releaseData.bigRocks = reordered
-  writeToStorage(releaseFilePath(version), releaseData)
+  await writeToStorage(releaseFilePath(version), releaseData)
 
   return { bigRocks: reordered }
 }
@@ -245,12 +249,12 @@ function reorderBigRocks(readFromStorage, writeToStorage, version, orderedNames)
  * Create a new blank release.
  * Registers in config.json and creates per-release file.
  */
-function createRelease(readFromStorage, writeToStorage, version) {
+async function createRelease(readFromStorage, writeToStorage, version) {
   if (!version || typeof version !== 'string' || version.trim().length === 0) {
     throw new Error('Version is required')
   }
 
-  const config = getConfig(readFromStorage)
+  const config = await getConfig(readFromStorage)
 
   if (config.releases[version]) {
     throw Object.assign(
@@ -260,8 +264,8 @@ function createRelease(readFromStorage, writeToStorage, version) {
   }
 
   config.releases[version] = { release: version }
-  writeToStorage('releases/planning/config.json', config)
-  writeToStorage(releaseFilePath(version), { release: version, bigRocks: [] })
+  await writeToStorage('releases/planning/config.json', config)
+  await writeToStorage(releaseFilePath(version), { release: version, bigRocks: [] })
 
   return { version: version, bigRockCount: 0 }
 }
@@ -270,12 +274,12 @@ function createRelease(readFromStorage, writeToStorage, version) {
  * Create a new release by cloning Big Rocks from an existing release.
  * Registers in config.json and creates per-release file with cloned data.
  */
-function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
+async function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
   if (!version || typeof version !== 'string' || version.trim().length === 0) {
     throw new Error('Version is required')
   }
 
-  const config = getConfig(readFromStorage)
+  const config = await getConfig(readFromStorage)
 
   if (config.releases[version]) {
     throw Object.assign(
@@ -291,12 +295,12 @@ function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
     )
   }
 
-  const sourceData = loadReleaseData(readFromStorage, cloneFrom)
+  const sourceData = await loadReleaseData(readFromStorage, cloneFrom)
   const clonedBigRocks = JSON.parse(JSON.stringify(sourceData.bigRocks || []))
 
   config.releases[version] = { release: version }
-  writeToStorage('releases/planning/config.json', config)
-  writeToStorage(releaseFilePath(version), { release: version, bigRocks: clonedBigRocks })
+  await writeToStorage('releases/planning/config.json', config)
+  await writeToStorage(releaseFilePath(version), { release: version, bigRocks: clonedBigRocks })
 
   return { version: version, bigRockCount: clonedBigRocks.length }
 }
@@ -305,8 +309,8 @@ function cloneRelease(readFromStorage, writeToStorage, version, cloneFrom) {
  * Delete a release from the registry.
  * The caller is responsible for deleting the per-release file and cache.
  */
-function deleteRelease(readFromStorage, writeToStorage, version) {
-  const config = getConfig(readFromStorage)
+async function deleteRelease(readFromStorage, writeToStorage, version) {
+  const config = await getConfig(readFromStorage)
 
   if (!config.releases[version]) {
     throw Object.assign(
@@ -316,7 +320,7 @@ function deleteRelease(readFromStorage, writeToStorage, version) {
   }
 
   delete config.releases[version]
-  writeToStorage('releases/planning/config.json', config)
+  await writeToStorage('releases/planning/config.json', config)
 
   return { deleted: version }
 }
@@ -325,8 +329,8 @@ function deleteRelease(readFromStorage, writeToStorage, version) {
  * Migrate legacy config: move bigRocks from config.json release entries
  * into per-release files. Idempotent — skips releases already migrated.
  */
-function migrateConfig(readFromStorage, writeToStorage) {
-  const config = getConfig(readFromStorage)
+async function migrateConfig(readFromStorage, writeToStorage) {
+  const config = await getConfig(readFromStorage)
   const versions = Object.keys(config.releases || {})
   let migrated = 0
 
@@ -335,10 +339,10 @@ function migrateConfig(readFromStorage, writeToStorage) {
     const entry = config.releases[version]
     if (!entry || !Array.isArray(entry.bigRocks)) continue
 
-    const existing = readFromStorage(releaseFilePath(version))
+    const existing = await readFromStorage(releaseFilePath(version))
     if (existing) continue
 
-    writeToStorage(releaseFilePath(version), {
+    await writeToStorage(releaseFilePath(version), {
       release: version,
       bigRocks: entry.bigRocks
     })
@@ -348,7 +352,7 @@ function migrateConfig(readFromStorage, writeToStorage) {
   }
 
   if (migrated > 0) {
-    writeToStorage('releases/planning/config.json', config)
+    await writeToStorage('releases/planning/config.json', config)
     console.log('[releases/planning] Migrated ' + migrated + ' release(s) to per-release files')
   }
 }

--- a/modules/releases/server/planning/doc-import.js
+++ b/modules/releases/server/planning/doc-import.js
@@ -86,7 +86,7 @@ function normalizeRock(data, priority) {
  * @param {object} parsedDoc - Pre-fetched parse result from previewDocImport
  * @returns {object} { imported, skipped, skippedNames, validationErrors, mode, bigRocks }
  */
-function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, mode, parsedDoc) {
+async function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, mode, parsedDoc) {
   const parsedRocks = parsedDoc.bigRocks
 
   if (parsedRocks.length === 0) {
@@ -96,18 +96,18 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
     )
   }
 
-  const config = getConfig(readFromStorage)
+  const config = await getConfig(readFromStorage)
   if (!config.releases[version]) {
     throw Object.assign(new Error('Release ' + version + ' not found'), { statusCode: 404 })
   }
 
   // Load pillar options from PM Hub config for validation
-  var pillarConfig = readFromStorage('releases/pm-hub/pillar-config.json')
+  var pillarConfig = await readFromStorage('releases/pm-hub/pillar-config.json')
   var pillarOptions = (pillarConfig && Array.isArray(pillarConfig.pillars))
     ? pillarConfig.pillars.map(function(p) { return p.name }).filter(Boolean)
     : []
 
-  const releaseData = loadReleaseData(readFromStorage, version)
+  const releaseData = await loadReleaseData(readFromStorage, version)
   const bigRocks = mode === 'replace' ? [] : (releaseData.bigRocks || []).slice()
   const existingNames = new Set(bigRocks.map(function(r) { return r.name }))
 
@@ -146,7 +146,7 @@ function executeDocImport(readFromStorage, writeToStorage, version, docIdOrUrl, 
   }
 
   releaseData.bigRocks = bigRocks
-  writeToStorage(releaseFilePath(version), releaseData)
+  await writeToStorage(releaseFilePath(version), releaseData)
 
   return {
     imported: imported,

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -104,14 +104,14 @@ function deriveHumanReviewStatusFromLabels(labels) {
 }
 
 
-function loadExecutionData(readFromStorage) {
-  var execIndexData = loadIndex(readFromStorage)
+async function loadExecutionData(readFromStorage) {
+  var execIndexData = await loadIndex(readFromStorage)
   var aiReviewMap = {}
   var execFeatures = execIndexData.features || []
   for (var ari = 0; ari < execFeatures.length; ari++) {
     var arEntry = execFeatures[ari]
     if (arEntry.key && arEntry.aiReview) {
-      var fullFeature = readFromStorage('releases/execution/features/' + arEntry.key + '.json')
+      var fullFeature = await readFromStorage('releases/execution/features/' + arEntry.key + '.json')
       if (fullFeature && fullFeature.aiReview) {
         aiReviewMap[arEntry.key] = {
           latest: {
@@ -145,13 +145,13 @@ function loadExecutionData(readFromStorage) {
   }
 }
 
-function loadCacheIndexes(readFromStorage, listStorageFiles) {
+async function loadCacheIndexes(readFromStorage, listStorageFiles) {
   var candidateIndex = new Map()
   var healthIndex = new Map()
   var teamIndex = new Map()
   var hygieneIndex = new Map()
 
-  var registry = readFromStorage('releases/registry.json')
+  var registry = await readFromStorage('releases/registry.json')
   var registryReleases = (registry && registry.releases) || []
 
   var versionAliasMap = {}
@@ -163,7 +163,7 @@ function loadCacheIndexes(readFromStorage, listStorageFiles) {
     }
   }
 
-  var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
+  var configuredVersions = (await getConfiguredReleases(readFromStorage)).map(function(r) { return r.version })
 
   for (var cvi = 0; cvi < configuredVersions.length; cvi++) {
     var cv = configuredVersions[cvi]
@@ -184,7 +184,7 @@ function loadCacheIndexes(readFromStorage, listStorageFiles) {
 
   for (var vi = 0; vi < configuredVersions.length; vi++) {
     var ver = configuredVersions[vi]
-    var candidateCache = readFromStorage('releases/planning/candidates-cache-' + ver + '.json')
+    var candidateCache = await readFromStorage('releases/planning/candidates-cache-' + ver + '.json')
     if (candidateCache && candidateCache.data && Array.isArray(candidateCache.data.features)) {
       var candidates = candidateCache.data.features
       for (var ci = 0; ci < candidates.length; ci++) {
@@ -193,7 +193,7 @@ function loadCacheIndexes(readFromStorage, listStorageFiles) {
       }
     }
 
-    var healthCache = readFromStorage('releases/planning/health-cache-' + ver + '-all.json')
+    var healthCache = await readFromStorage('releases/planning/health-cache-' + ver + '-all.json')
     if (healthCache && Array.isArray(healthCache.features)) {
       var hf = healthCache.features
       for (var hi = 0; hi < hf.length; hi++) {
@@ -202,12 +202,12 @@ function loadCacheIndexes(readFromStorage, listStorageFiles) {
       }
     }
 
-    var hygieneData = readFromStorage('releases/hygiene/features-' + ver + '.json')
+    var hygieneData = await readFromStorage('releases/hygiene/features-' + ver + '.json')
     if (!hygieneData && versionAliasMap[ver]) {
       var hygieneAliases = versionAliasMap[ver]
       for (var ali = 0; ali < hygieneAliases.length && !hygieneData; ali++) {
         if (hygieneAliases[ali] !== ver) {
-          hygieneData = readFromStorage('releases/hygiene/features-' + hygieneAliases[ali] + '.json')
+          hygieneData = await readFromStorage('releases/hygiene/features-' + hygieneAliases[ali] + '.json')
         }
       }
     }
@@ -225,12 +225,12 @@ function loadCacheIndexes(readFromStorage, listStorageFiles) {
 
   if (listStorageFiles) {
     var hygieneFiles = []
-    try { hygieneFiles = listStorageFiles('releases/hygiene') } catch { /* directory may not exist */ }
+    try { hygieneFiles = await listStorageFiles('releases/hygiene') } catch { /* directory may not exist */ }
     for (var hfi = 0; hfi < hygieneFiles.length; hfi++) {
       var hfMatch = hygieneFiles[hfi].match(/^features-(.+)\.json$/)
       if (!hfMatch) continue
       try {
-        var hfData = readFromStorage('releases/hygiene/' + hygieneFiles[hfi])
+        var hfData = await readFromStorage('releases/hygiene/' + hygieneFiles[hfi])
         if (!hfData || !hfData.features) continue
         var hfKeys = Object.keys(hfData.features)
         for (var hfki = 0; hfki < hfKeys.length; hfki++) {
@@ -465,9 +465,9 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
   }
 }
 
-function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) {
-  var execData = loadExecutionData(readFromStorage)
-  var cacheData = loadCacheIndexes(readFromStorage, listStorageFiles)
+async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) {
+  var execData = await loadExecutionData(readFromStorage)
+  var cacheData = await loadCacheIndexes(readFromStorage, listStorageFiles)
 
   var execMap = new Map()
   for (var emi = 0; emi < execData.execFeatures.length; emi++) {
@@ -487,7 +487,7 @@ function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles) 
 
   var bigRockPriorityMap = new Map()
   for (var bvi = 0; bvi < cacheData.configuredVersions.length; bvi++) {
-    var bigRocks = loadBigRocks(readFromStorage, cacheData.configuredVersions[bvi])
+    var bigRocks = await loadBigRocks(readFromStorage, cacheData.configuredVersions[bvi])
     for (var bri = 0; bri < bigRocks.length; bri++) {
       var rockName = bigRocks[bri].name
       if (!rockName) continue

--- a/modules/releases/server/planning/health/health-pipeline.js
+++ b/modules/releases/server/planning/health/health-pipeline.js
@@ -153,10 +153,10 @@ function mapCandidateToHealthFeature(candidate) {
  * @param {string|null} phase - Phase filter (EA1/EA2/GA) or null for all
  * @returns {{ features: Array<object>, warnings: Array<string> }}
  */
-function loadFeaturesFromCandidates(readFromStorage, version, phase) {
+async function loadFeaturesFromCandidates(readFromStorage, version, phase) {
   var warnings = []
   var cacheKey = DATA_PREFIX + '/candidates-cache-' + version + '.json'
-  var cached = readFromStorage(cacheKey)
+  var cached = await readFromStorage(cacheKey)
 
   if (!cached || !cached.data || !cached.data.features) {
     warnings.push('No candidates found -- run a Big Rocks refresh first')
@@ -264,8 +264,8 @@ function getFeaturePhase(feature) {
  * @param {string} version - Release version (e.g., '3.5')
  * @returns {object|null} Milestone dates or null
  */
-function loadMilestones(readFromStorage, version) {
-  var cached = readFromStorage('releases/delivery/product-pages-releases-cache.json')
+async function loadMilestones(readFromStorage, version) {
+  var cached = await readFromStorage('releases/delivery/product-pages-releases-cache.json')
   if (!cached || !cached.releases || !Array.isArray(cached.releases)) {
     return null
   }
@@ -327,7 +327,7 @@ async function loadPreviousGaFreeze(readFromStorage, version) {
   var prevVersion = parts[0] + '.' + prevMinor
 
   // Try Product Pages cache first
-  var cached = readFromStorage('releases/delivery/product-pages-releases-cache.json')
+  var cached = await readFromStorage('releases/delivery/product-pages-releases-cache.json')
   if (cached && cached.releases && Array.isArray(cached.releases)) {
     for (var i = 0; i < cached.releases.length; i++) {
       var r = cached.releases[i]
@@ -496,8 +496,8 @@ function deriveFreezeDates(milestones) {
  * @param {string} version - Release version (e.g., '3.5')
  * @returns {{ features: Array<object>, warnings: Array<string> }}
  */
-function loadFeaturesForRelease(readFromStorage, version) {
-  var index = loadIndex(readFromStorage)
+async function loadFeaturesForRelease(readFromStorage, version) {
+  var index = await loadIndex(readFromStorage)
   var warnings = []
 
   if (!index.features || index.features.length === 0) {
@@ -536,7 +536,7 @@ function loadFeaturesForRelease(readFromStorage, version) {
     if (CLOSED_STATUSES.indexOf(status) !== -1) continue
 
     // Load detail file for additional fields
-    var detail = loadFeatureDetail(readFromStorage, f.key)
+    var detail = await loadFeatureDetail(readFromStorage, f.key)
 
     // Merge index + detail data, preferring detail where available
     var merged = Object.assign({}, f)
@@ -639,7 +639,7 @@ function deriveReleasePhaseMode(currentPhase) {
  * @returns {Promise<object>} Health cache data
  */
 async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraRequest, fetchAllJqlResults, phase) {
-  var config = getConfig(readFromStorage)
+  var config = await getConfig(readFromStorage)
   var healthConfig = config.healthConfig || {}
   var warnings = []
   var today = new Date()
@@ -648,14 +648,14 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   console.log('[health] Starting health pipeline for version ' + version + ' phase ' + phaseKey)
 
   // Step 1: Load features from Big Rocks candidates cache
-  var featureResult = loadFeaturesFromCandidates(readFromStorage, version, phase)
+  var featureResult = await loadFeaturesFromCandidates(readFromStorage, version, phase)
   var features = featureResult.features
   warnings = warnings.concat(featureResult.warnings)
 
   if (features.length === 0) {
     console.warn('[health] No features found for version ' + version + ' phase ' + phaseKey)
     var emptyCache = buildEmptyCache(version, warnings)
-    writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', emptyCache)
+    await writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', emptyCache)
     return emptyCache
   }
 
@@ -664,7 +664,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   // Step 1b: Enrich epicCount + scores from execution index
   // mapCandidateToHealthFeature() does not map epicCount; source it from execution index.
   // Also bridge aiReview.scores from feature detail files so FPDoR rubric items can be evaluated.
-  var execIndex = loadIndex(readFromStorage)
+  var execIndex = await loadIndex(readFromStorage)
   if (execIndex && execIndex.features) {
     var execByKey = {}
     for (var ei = 0; ei < execIndex.features.length; ei++) {
@@ -679,7 +679,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
         features[fi].completionPct = execFeature.completionPct
       }
       if (execFeature && !features[fi].scores) {
-        var execDetail = loadFeatureDetail(readFromStorage, features[fi].key)
+        var execDetail = await loadFeatureDetail(readFromStorage, features[fi].key)
         if (execDetail && execDetail.aiReview && execDetail.aiReview.scores) {
           features[fi].scores = execDetail.aiReview.scores
         }
@@ -688,7 +688,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   }
 
   // Step 2: Load milestone dates (Product Pages → Smartsheet fallback → derived from targets)
-  var milestones = loadMilestones(readFromStorage, version)
+  var milestones = await loadMilestones(readFromStorage, version)
   var fallbackResult = await backfillFreezeDatesFromSmartsheet(milestones, version)
   milestones = fallbackResult.milestones
   warnings = warnings.concat(fallbackResult.warnings)
@@ -708,7 +708,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   }
 
   // Step 4: Load overrides
-  var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || { overrides: {} }
+  var overrides = await readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || { overrides: {} }
 
   // Step 5: Build per-feature health assessments
   var planningDeadline = computePlanningDeadline(milestones, phase, prevGaFreeze)
@@ -859,12 +859,12 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   }
 
   // Step 6b: Build Big Rock priority map and compute composite priority scores
-  var bigRocks = loadBigRocks(readFromStorage, version)
+  var bigRocks = await loadBigRocks(readFromStorage, version)
   var bigRockPriorityMap = new Map()
   for (var bri = 0; bri < bigRocks.length; bri++) {
     if (bigRocks[bri].name) bigRockPriorityMap.set(bigRocks[bri].name, bigRocks[bri].priority || (bri + 1))
   }
-  var configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
+  var configuredVersions = (await getConfiguredReleases(readFromStorage)).map(function(r) { return r.version })
   var priorityScores = computePriorityScores(healthFeatures, { bigRockPriorityMap: bigRockPriorityMap, configuredVersions: configuredVersions })
   for (var pi = 0; pi < healthFeatures.length; pi++) {
     var pKey = healthFeatures[pi].key
@@ -969,7 +969,7 @@ async function runHealthPipeline(version, readFromStorage, writeToStorage, jiraR
   }
 
   // Step 7: Write health cache
-  writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', cache)
+  await writeToStorage(DATA_PREFIX + '/health-cache-' + version + '-' + phaseKey + '.json', cache)
   console.log('[health] Health pipeline completed for version ' + version + ' phase ' + phaseKey + ': ' + features.length + ' features assessed')
 
   return cache

--- a/modules/releases/server/planning/health/health-routes.js
+++ b/modules/releases/server/planning/health/health-routes.js
@@ -63,7 +63,7 @@ function getCommittedPhases(planningFreezes) {
  * @param {object} router - Express router (already mounted at /api/modules/releases/planning/)
  * @param {object} context - Module context with storage, auth, refreshStates, etc.
  */
-function healthRoutes(router, context) {
+async function healthRoutes(router, context) {
   var storage = context.storage
   var readFromStorage = storage.readFromStorage
   var writeToStorage = storage.writeToStorage
@@ -133,7 +133,7 @@ function healthRoutes(router, context) {
    *       400:
    *         description: Invalid version or phase
    */
-  router.get('/releases/:version/health', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases/:version/health', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = req.params.version
     var phase = parsePhase(req)
     if (!isValidVersion(version)) {
@@ -152,7 +152,7 @@ function healthRoutes(router, context) {
     }
 
     var pk = phaseKey(phase)
-    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    var cached = await readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
     var hasCachedData = cached && cached.cachedAt
 
     if (hasCachedData) {
@@ -165,7 +165,7 @@ function healthRoutes(router, context) {
 
       var snapshots = {}
       for (var si = 0; si < PHASE_LABELS.length; si++) {
-        var snap = readFromStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + PHASE_LABELS[si] + '.json')
+        var snap = await readFromStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + PHASE_LABELS[si] + '.json')
         if (snap) {
           snapshots[PHASE_LABELS[si]] = {
             snapshotAt: snap.snapshotAt,
@@ -222,7 +222,7 @@ function healthRoutes(router, context) {
    *       404:
    *         description: No health data available
    */
-  router.get('/releases/:version/health/summary', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases/:version/health/summary', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = req.params.version
     var phase = parsePhase(req)
     if (!isValidVersion(version)) {
@@ -248,7 +248,7 @@ function healthRoutes(router, context) {
     }
 
     var pk = phaseKey(phase)
-    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    var cached = await readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
     if (!cached || !cached.cachedAt) {
       return res.status(404).json({ error: 'No health data available for version ' + version + '. Trigger a health refresh first.' })
     }
@@ -294,7 +294,7 @@ function healthRoutes(router, context) {
    *       404:
    *         description: Feature not found
    */
-  router.get('/releases/:version/health/feature/:key', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases/:version/health/feature/:key', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = req.params.version
     var key = req.params.key
     var phase = parsePhase(req)
@@ -327,7 +327,7 @@ function healthRoutes(router, context) {
     }
 
     var pk = phaseKey(phase)
-    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    var cached = await readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
     if (!cached || !cached.features) {
       return res.status(404).json({ error: 'No health data available for version ' + version })
     }
@@ -370,7 +370,7 @@ function healthRoutes(router, context) {
    *       400:
    *         description: Invalid input
    */
-  router.put('/releases/:version/health/override/:featureKey', requirePM, blockDuringImpersonation, requireScope('releases:write'), function(req, res) {
+  router.put('/releases/:version/health/override/:featureKey', requirePM, blockDuringImpersonation, requireScope('releases:write'), async function(req, res) {
     var version = req.params.version
     var featureKey = req.params.featureKey
     if (!isValidVersion(version)) {
@@ -400,7 +400,7 @@ function healthRoutes(router, context) {
     var userEmail = req.userEmail || 'unknown'
 
     // Read existing overrides
-    var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || {
+    var overrides = await readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || {
       version: version,
       overrides: {}
     }
@@ -414,10 +414,10 @@ function healthRoutes(router, context) {
       updatedAt: now
     }
 
-    writeToStorage(DATA_PREFIX + '/health-overrides-' + version + '.json', overrides)
+    await writeToStorage(DATA_PREFIX + '/health-overrides-' + version + '.json', overrides)
 
     // Audit log
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       version: version,
       action: 'set_risk_override',
       user: req.auditActor || userEmail,
@@ -457,7 +457,7 @@ function healthRoutes(router, context) {
    *       404:
    *         description: No override found
    */
-  router.delete('/releases/:version/health/override/:featureKey', requirePM, blockDuringImpersonation, requireScope('releases:write'), function(req, res) {
+  router.delete('/releases/:version/health/override/:featureKey', requirePM, blockDuringImpersonation, requireScope('releases:write'), async function(req, res) {
     var version = req.params.version
     var featureKey = req.params.featureKey
     if (!isValidVersion(version)) {
@@ -469,7 +469,7 @@ function healthRoutes(router, context) {
 
     var userEmail = req.userEmail || 'unknown'
 
-    var overrides = readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || {
+    var overrides = await readFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json') || {
       version: version,
       overrides: {}
     }
@@ -479,9 +479,9 @@ function healthRoutes(router, context) {
     }
 
     delete overrides.overrides[featureKey]
-    writeToStorage(DATA_PREFIX + '/health-overrides-' + version + '.json', overrides)
+    await writeToStorage(DATA_PREFIX + '/health-overrides-' + version + '.json', overrides)
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       version: version,
       action: 'remove_risk_override',
       user: req.auditActor || userEmail,
@@ -517,7 +517,7 @@ function healthRoutes(router, context) {
    *       404:
    *         description: No snapshot found
    */
-  router.get('/releases/:version/health/snapshot/:phase', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases/:version/health/snapshot/:phase', requireAuth, requireScope('releases:read'), async function(req, res) {
     var version = req.params.version
     var phase = (req.params.phase || '').toUpperCase()
     if (!isValidVersion(version)) {
@@ -527,7 +527,7 @@ function healthRoutes(router, context) {
       return res.status(400).json({ error: 'Invalid phase. Must be one of: ' + PHASE_LABELS.join(', ') })
     }
 
-    var snap = readFromStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json')
+    var snap = await readFromStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json')
     if (!snap) {
       return res.status(404).json({ error: 'No committed snapshot found for ' + version + ' ' + phase })
     }
@@ -560,7 +560,7 @@ function healthRoutes(router, context) {
    *       404:
    *         description: No health cache available
    */
-  router.post('/releases/:version/health/snapshot/:phase', requirePM, blockDuringImpersonation, requireScope('releases:write'), function(req, res) {
+  router.post('/releases/:version/health/snapshot/:phase', requirePM, blockDuringImpersonation, requireScope('releases:write'), async function(req, res) {
     var version = req.params.version
     var phase = (req.params.phase || '').toUpperCase()
     if (!isValidVersion(version)) {
@@ -571,7 +571,7 @@ function healthRoutes(router, context) {
     }
 
     var pk = phaseKey(null)
-    var cached = readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
+    var cached = await readFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json')
     if (!cached || !cached.features) {
       return res.status(404).json({ error: 'No health cache available. Run a health refresh first.' })
     }
@@ -599,10 +599,10 @@ function healthRoutes(router, context) {
       features: snapshotFeatures
     }
 
-    writeToStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json', snapshotData)
+    await writeToStorage(DATA_PREFIX + '/committed-snapshot-' + version + '-' + phase + '.json', snapshotData)
 
     var user = req.auditActor || req.userEmail || 'unknown'
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       version: version,
       action: 'committed_snapshot',
       user: user,
@@ -702,7 +702,7 @@ function healthRoutes(router, context) {
 
   // ─── Health refresh helper ───
 
-  function triggerHealthRefresh(version, phase) {
+  async function triggerHealthRefresh(version, phase) {
     var pk = phaseKey(phase)
     var stateKey = 'health:' + version + ':' + pk
     var state = getHealthRefreshState(version, phase)
@@ -712,13 +712,13 @@ function healthRoutes(router, context) {
     refreshStates.forEach(function(s) { if (s.running) runningCount++ })
     if (runningCount >= MAX_CONCURRENT_REFRESHES) return
 
-    var config = getConfig(readFromStorage)
+    var config = await getConfig(readFromStorage)
     var healthConfig = config.healthConfig || {}
     var timeoutMs = healthConfig.healthRefreshTimeoutMs || 480000
 
     // Snapshot old cache for committed-list audit
     var cacheFile = DATA_PREFIX + '/health-cache-' + version + '-' + pk + '.json'
-    var oldCache = readFromStorage(cacheFile)
+    var oldCache = await readFromStorage(cacheFile)
 
     refreshStates.set(stateKey, {
       running: true,
@@ -736,7 +736,7 @@ function healthRoutes(router, context) {
     })
 
     Promise.race([pipeline, timeout])
-      .then(function(result) {
+      .then(async function(result) {
         refreshStates.set(stateKey, {
           running: false,
           lastResult: {
@@ -769,7 +769,7 @@ function healthRoutes(router, context) {
             var removed = oldKeys.filter(function(k) { return !newSet[k] })
 
             if (added.length > 0 || removed.length > 0) {
-              logAudit(readFromStorage, writeToStorage, {
+              await logAudit(readFromStorage, writeToStorage, {
                 version: version,
                 action: 'committed_list_change',
                 user: 'system',
@@ -794,7 +794,7 @@ function healthRoutes(router, context) {
               if (todayStr < freezeDate) continue
 
               var snapshotKey = DATA_PREFIX + '/committed-snapshot-' + version + '-' + sp + '.json'
-              var existingSnapshot = readFromStorage(snapshotKey)
+              var existingSnapshot = await readFromStorage(snapshotKey)
               if (existingSnapshot) continue
 
               var snapshotKeys = getStrictPhaseKeys(newFeatures, version, sp)
@@ -811,7 +811,7 @@ function healthRoutes(router, context) {
                 }
               }
 
-              writeToStorage(snapshotKey, {
+              await writeToStorage(snapshotKey, {
                 version: version,
                 phase: sp,
                 snapshotAt: new Date().toISOString(),
@@ -820,7 +820,7 @@ function healthRoutes(router, context) {
                 features: snapshotFeatures
               })
 
-              logAudit(readFromStorage, writeToStorage, {
+              await logAudit(readFromStorage, writeToStorage, {
                 version: version,
                 action: 'committed_snapshot',
                 user: 'system',
@@ -854,13 +854,13 @@ function healthRoutes(router, context) {
   var FIELD_CACHE_TTL_MS = 60 * 60 * 1000
 
   async function getCachedFieldList() {
-    var cached = readFromStorage(FIELD_CACHE_KEY)
+    var cached = await readFromStorage(FIELD_CACHE_KEY)
     if (cached && cached.fetchedAt) {
       var age = Date.now() - new Date(cached.fetchedAt).getTime()
       if (age < FIELD_CACHE_TTL_MS) return cached.fields
     }
     var fields = await jiraRequest('/rest/api/3/field')
-    writeToStorage(FIELD_CACHE_KEY, { fetchedAt: new Date().toISOString(), fields: fields })
+    await writeToStorage(FIELD_CACHE_KEY, { fetchedAt: new Date().toISOString(), fields: fields })
     return fields
   }
 
@@ -923,8 +923,8 @@ function healthRoutes(router, context) {
    *       200:
    *         description: Config saved
    */
-  router.put('/releases/health-admin/config', requirePM, requireScope('releases:write'), function(req, res) {
-    var config = getConfig(readFromStorage)
+  router.put('/releases/health-admin/config', requirePM, requireScope('releases:write'), async function(req, res) {
+    var config = await getConfig(readFromStorage)
 
     if (req.body.riceScoreField !== undefined) {
       var fieldVal = req.body.riceScoreField || ''
@@ -952,9 +952,9 @@ function healthRoutes(router, context) {
       }
     }
 
-    writeToStorage('releases/planning/config.json', config)
+    await writeToStorage('releases/planning/config.json', config)
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       version: null,
       action: 'update_health_config',
       user: req.auditActor || req.userEmail,
@@ -989,7 +989,7 @@ function healthRoutes(router, context) {
    *         description: No RICE field IDs configured
    */
   router.post('/releases/health-admin/rice-test', requirePM, requireScope('releases:write'), async function(req, res) {
-    var config = getConfig(readFromStorage)
+    var config = await getConfig(readFromStorage)
     var ids = config.customFieldIds || {}
     var riceScoreField = ids.riceScoreField || ''
 
@@ -1032,8 +1032,8 @@ function healthRoutes(router, context) {
    *       200:
    *         description: Current health admin config
    */
-  router.get('/releases/health-admin/config', requirePM, requireScope('releases:write'), function(req, res) {
-    var config = getConfig(readFromStorage)
+  router.get('/releases/health-admin/config', requirePM, requireScope('releases:write'), async function(req, res) {
+    var config = await getConfig(readFromStorage)
     res.json({
       customFieldIds: config.customFieldIds || {},
       enableRice: config.healthConfig ? !!config.healthConfig.enableRice : false,
@@ -1067,7 +1067,7 @@ function healthRoutes(router, context) {
     }
 
     try {
-      var ppCache = readFromStorage('releases/delivery/product-pages-releases-cache.json')
+      var ppCache = await readFromStorage('releases/delivery/product-pages-releases-cache.json')
       var ppEntries = []
       if (ppCache && ppCache.releases) {
         ppEntries = ppCache.releases.filter(function(r) {

--- a/modules/releases/server/planning/outcome-fetch.js
+++ b/modules/releases/server/planning/outcome-fetch.js
@@ -57,7 +57,7 @@ async function getOutcomeSummaries(jiraRequest, keys, version, readFromStorage, 
   if (!keys || keys.length === 0) return {}
 
   var cachePath = DATA_PREFIX + '/outcome-summaries-cache-' + version + '.json'
-  var cached = readFromStorage(cachePath)
+  var cached = await readFromStorage(cachePath)
 
   // Check if all keys are already cached
   if (cached) {
@@ -86,7 +86,7 @@ async function getOutcomeSummaries(jiraRequest, keys, version, readFromStorage, 
     for (var key in fetched) {
       merged[key] = fetched[key]
     }
-    writeToStorage(cachePath, merged)
+    await writeToStorage(cachePath, merged)
     console.log('[release-planning] Fetched ' + Object.keys(fetched).length + ' outcome summaries from Jira')
   }
 

--- a/modules/releases/server/planning/pipeline.js
+++ b/modules/releases/server/planning/pipeline.js
@@ -19,7 +19,7 @@ function sortByPriority(a, b) {
   return a.issueKey.localeCompare(b.issueKey)
 }
 
-function runPipeline(config, bigRocks, release, readFromStorage, opts) {
+async function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   const rockFilter = opts && opts.rockFilter
 
   const rocksToProcess = rockFilter
@@ -53,7 +53,7 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   }
 
   // Load the execution feature index once
-  const index = loadIndex(readFromStorage)
+  const index = await loadIndex(readFromStorage)
 
   if (!index.features || index.features.length === 0) {
     warnings.push('Feature index is empty — pipeline data may be incomplete. Run an execution data refresh first.')
@@ -87,7 +87,7 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
 
     // Find Tier 1 features for this rock's outcomes (with stats tracking)
     var rockStats = { totalMatches: 0, closedFiltered: 0, noTargetVersion: 0 }
-    const rawFeatures = findTier1Features(readFromStorage, index, rock.outcomeKeys, rockStats)
+    const rawFeatures = await findTier1Features(readFromStorage, index, rock.outcomeKeys, rockStats)
     var rockTerminalFiltered = 0
     var rockReleaseMismatch = 0
     for (let fi = 0; fi < rawFeatures.length; fi++) {
@@ -126,7 +126,7 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
     }
 
     // Find Tier 1 RFEs for this rock's outcomes
-    const rawRfes = findTier1Rfes(readFromStorage, index, rock.outcomeKeys, release)
+    const rawRfes = await findTier1Rfes(readFromStorage, index, rock.outcomeKeys, release)
     for (let rfi = 0; rfi < rawRfes.length; rfi++) {
       const rfe = rawRfes[rfi]
       const rfeCandidate = mapToCandidate(rfe, rock.name, 'outcome')
@@ -204,8 +204,8 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   const tier1FeatureKeys = new Set(tier1Features.map(function(c) { return c.issueKey }))
   const tier1RfeKeys = new Set(tier1Rfes.map(function(c) { return c.issueKey }))
 
-  const rawTier2Features = findTier2Features(readFromStorage, index, release, tier1FeatureKeys)
-  const rawTier2Rfes = findTier2Rfes(readFromStorage, index, release, tier1RfeKeys)
+  const rawTier2Features = await findTier2Features(readFromStorage, index, release, tier1FeatureKeys)
+  const rawTier2Rfes = await findTier2Rfes(readFromStorage, index, release, tier1RfeKeys)
 
   // Post-filter terminal statuses on Tier 2 features
   const tier2Features = []
@@ -241,7 +241,7 @@ function runPipeline(config, bigRocks, release, readFromStorage, opts) {
   tier1FeatureKeys.forEach(function(k) { tier3Exclude.add(k) })
   tier2FeatureKeys.forEach(function(k) { tier3Exclude.add(k) })
 
-  const rawTier3Features = findTier3Features(readFromStorage, index, tier3Exclude)
+  const rawTier3Features = await findTier3Features(readFromStorage, index, tier3Exclude)
 
   const tier3Features = []
   for (let t3i = 0; t3i < rawTier3Features.length; t3i++) {

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -44,7 +44,7 @@ function isValidVersion(version) {
  * @param {object} router - Express router mounted at /api/modules/releases/planning/
  * @param {object} context - { storage, requireAuth, requireAdmin, requireScope, roleStore, registerDiagnostics }
  */
-module.exports = function registerPlanningRoutes(router, context) {
+module.exports = async function registerPlanningRoutes(router, context) {
   var smartsheetClient = context.smartsheet || require('../../../../shared/server/smartsheet')
   var jiraClient = context.jira || null
 
@@ -53,14 +53,14 @@ module.exports = function registerPlanningRoutes(router, context) {
   const listStorageFiles = storage.listStorageFiles || null
   const deleteFromStorage = storage.deleteFromStorage || null
 
-  migrateConfig(readFromStorage, writeToStorage)
+  await migrateConfig(readFromStorage, writeToStorage)
 
   // ─── PM User Auto-Migration ───
   // Migrate pm-users.json entries to the central planning-manager role.
   // This runs once on module startup; after migration the file is deleted.
   if (context.roleStore) {
     try {
-      var pmData = readFromStorage('releases/planning/pm-users.json')
+      var pmData = await readFromStorage('releases/planning/pm-users.json')
       if (pmData && pmData.emails && pmData.emails.length > 0) {
         var migrated = 0
         for (var mi = 0; mi < pmData.emails.length; mi++) {
@@ -72,7 +72,7 @@ module.exports = function registerPlanningRoutes(router, context) {
         }
         console.log('[releases/planning] Migrated ' + migrated + ' PM user(s) to planning-manager role')
         if (deleteFromStorage) {
-          deleteFromStorage('releases/planning/pm-users.json')
+          await deleteFromStorage('releases/planning/pm-users.json')
           console.log('[releases/planning] Deleted pm-users.json after migration')
         }
       }
@@ -122,7 +122,7 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
   }
 
-  function triggerBackgroundRefresh(version) {
+  async function triggerBackgroundRefresh(version) {
     const state = getRefreshState(version)
     if (state.running) return
 
@@ -137,8 +137,8 @@ module.exports = function registerPlanningRoutes(router, context) {
       lastResult: state.lastResult
     })
 
-    const config = getConfig(readFromStorage)
-    const bigRocks = loadBigRocks(readFromStorage, version)
+    const config = await getConfig(readFromStorage)
+    const bigRocks = await loadBigRocks(readFromStorage, version)
 
     if (!bigRocks.length) {
       refreshStates.set(version, {
@@ -156,18 +156,18 @@ module.exports = function registerPlanningRoutes(router, context) {
     console.log('[releases/planning] Background refresh started for ' + version)
     var refreshStartTime = Date.now()
 
-    function doRefresh(attempt) {
-      const pipeline = new Promise(function(resolve) { resolve(runPipeline(config, bigRocks, version, readFromStorage)) })
+    async function doRefresh(attempt) {
+      const pipeline = runPipeline(config, bigRocks, version, readFromStorage)
       const timeout = new Promise(function(_, reject) {
         setTimeout(function() { reject(new Error('Refresh timed out after 5 minutes')) }, REFRESH_TIMEOUT_MS)
       })
 
       Promise.race([pipeline, timeout])
-        .then(function(result) {
+        .then(async function(result) {
           // Jira fallback: fetch missing outcome summaries asynchronously
           var fallback
           if (result.missingOutcomes && result.missingOutcomes.length > 0) {
-            fallback = getOutcomeSummaries(jiraClient ? jiraClient.jiraRequest : null, result.missingOutcomes, version, readFromStorage, writeToStorage)
+            fallback = await getOutcomeSummaries(jiraClient ? jiraClient.jiraRequest : null, result.missingOutcomes, version, readFromStorage, writeToStorage)
               .then(function(fetched) {
                 // Merge fetched summaries into the pipeline result
                 for (var key in fetched) {
@@ -181,9 +181,9 @@ module.exports = function registerPlanningRoutes(router, context) {
             fallback = Promise.resolve()
           }
 
-          return fallback.then(function() {
+          return fallback.then(async function() {
             const response = buildCandidateResponse(result, version, bigRocks, false)
-            writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', {
+            await writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', {
               cachedAt: new Date().toISOString(),
               data: response
             })
@@ -200,7 +200,7 @@ module.exports = function registerPlanningRoutes(router, context) {
             })
           })
         })
-        .catch(function(err) {
+        .catch(async function(err) {
           if (attempt < 3) {
             console.warn('[releases/planning] Refresh attempt ' + attempt + ' failed for ' + version + ', retrying: ' + err.message)
             setTimeout(function() { doRefresh(attempt + 1) }, attempt * 5000)
@@ -210,10 +210,10 @@ module.exports = function registerPlanningRoutes(router, context) {
 
           // Remove _invalidatedAt marker so cache reverts to normal
           // stale-while-revalidate behavior (15-min cycle)
-          var staleCache = readFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
+          var staleCache = await readFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
           if (staleCache && staleCache._invalidatedAt) {
             delete staleCache._invalidatedAt
-            writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', staleCache)
+            await writeToStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json', staleCache)
           }
 
           refreshStates.set(version, {
@@ -255,7 +255,7 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Array of releases with version and bigRockCount
    */
-  router.get('/releases', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases', requireAuth, requireScope('releases:read'), async function(req, res) {
     if (DEMO_MODE) {
       const demoConfig = loadFixture('config.json')
       if (demoConfig && demoConfig.releases) {
@@ -270,7 +270,7 @@ module.exports = function registerPlanningRoutes(router, context) {
       return res.json([])
     }
 
-    const releases = getConfiguredReleases(readFromStorage)
+    const releases = await getConfiguredReleases(readFromStorage)
     res.json(releases)
   })
 
@@ -293,7 +293,7 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Candidate features, RFEs, and Big Rocks
    */
-  router.get('/releases/:version/candidates', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/releases/:version/candidates', requireAuth, requireScope('releases:read'), async function(req, res) {
     const version = req.params.version
     if (!isValidVersion(version)) {
       return res.status(400).json({ error: 'Invalid version format' })
@@ -320,7 +320,7 @@ module.exports = function registerPlanningRoutes(router, context) {
       return res.status(404).json({ error: 'Demo data not available' })
     }
 
-    const cached = readFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
+    const cached = await readFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
     const hasCachedData = cached && cached.data && cached.cachedAt
 
     if (hasCachedData) {
@@ -448,8 +448,8 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Planning config
    */
-  router.get('/config', requireAdmin, requireScope('releases:write'), function(req, res) {
-    const config = getConfig(readFromStorage)
+  router.get('/config', requireAdmin, requireScope('releases:write'), async function(req, res) {
+    const config = await getConfig(readFromStorage)
     res.json(config)
   })
 
@@ -478,7 +478,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           console.warn('[releases/planning] Jira feature query failed, falling back to execution index:', jiraErr.message)
         }
       }
-      var result = buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles)
+      var result = await buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageFiles)
       res.json(result)
     } catch (err) {
       console.error('[releases/planning] Feature readiness build failed:', err.message)
@@ -551,19 +551,19 @@ module.exports = function registerPlanningRoutes(router, context) {
 
   // ─── Cache Invalidation Helper ───
 
-  function invalidateCache(version) {
+  async function invalidateCache(version) {
     if (deleteFromStorage) {
       var healthPhases = ['all', 'EA1', 'EA2', 'GA']
       for (var hp = 0; hp < healthPhases.length; hp++) {
-        deleteFromStorage(`${DATA_PREFIX}/health-cache-${version}-${healthPhases[hp]}.json`)
+        await deleteFromStorage(`${DATA_PREFIX}/health-cache-${version}-${healthPhases[hp]}.json`)
       }
-      deleteFromStorage(`${DATA_PREFIX}/outcome-summaries-cache-${version}.json`)
+      await deleteFromStorage(`${DATA_PREFIX}/outcome-summaries-cache-${version}.json`)
     }
 
-    var cached = readFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
+    var cached = await readFromStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`)
     if (cached) {
       cached._invalidatedAt = new Date().toISOString()
-      writeToStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`, cached)
+      await writeToStorage(`${DATA_PREFIX}/candidates-cache-${version}.json`, cached)
     }
 
     triggerBackgroundRefresh(version)
@@ -592,8 +592,8 @@ module.exports = function registerPlanningRoutes(router, context) {
 
   // ─── Pillar Options Helper ───
 
-  function loadPillarOptions() {
-    var pillarConfig = readFromStorage('releases/pm-hub/pillar-config.json')
+  async function loadPillarOptions() {
+    var pillarConfig = await readFromStorage('releases/pm-hub/pillar-config.json')
     if (pillarConfig && Array.isArray(pillarConfig.pillars)) {
       return pillarConfig.pillars.map(function(p) { return p.name }).filter(Boolean)
     }
@@ -614,8 +614,8 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Array of pillar name strings
    */
-  router.get('/pillar-options', requireAuth, requireScope('releases:read'), function(req, res) {
-    res.json({ options: loadPillarOptions() })
+  router.get('/pillar-options', requireAuth, requireScope('releases:read'), async function(req, res) {
+    res.json({ options: await loadPillarOptions() })
   })
 
   /**
@@ -655,18 +655,18 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
 
     try {
-      var previousOrder = loadBigRocks(readFromStorage, version).map(function(r) { return r.name })
-      const result = await withConfigLock(function() {
-        return reorderBigRocks(readFromStorage, writeToStorage, version, order)
+      var previousOrder = (await loadBigRocks(readFromStorage, version)).map(function(r) { return r.name })
+      const result = await withConfigLock(async function() {
+        return await reorderBigRocks(readFromStorage, writeToStorage, version, order)
       })
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'reorder_rocks',
         user: req.auditActor || req.userEmail,
         summary: 'Reordered Big Rocks',
         details: { previousOrder: previousOrder, newOrder: order }
       })
-      invalidateCache(version)
+      await invalidateCache(version)
       res.json(result)
     } catch (err) {
       const status = err.statusCode || 500
@@ -708,12 +708,12 @@ module.exports = function registerPlanningRoutes(router, context) {
 
     try {
       var existingRockSnapshot = null
-      const result = await withConfigLock(function() {
-        const currentConfig = getConfig(readFromStorage)
+      const result = await withConfigLock(async function() {
+        const currentConfig = await getConfig(readFromStorage)
         if (!currentConfig.releases[version]) {
           throw Object.assign(new Error('Release ' + version + ' not found'), { statusCode: 404 })
         }
-        const existingRocks = loadBigRocks(readFromStorage, version)
+        const existingRocks = await loadBigRocks(readFromStorage, version)
         const existingNames = existingRocks.map(function(r) { return r.name })
 
         existingRockSnapshot = existingRocks.find(function(r) { return r.name === name })
@@ -721,7 +721,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           existingRockSnapshot = JSON.parse(JSON.stringify(existingRockSnapshot))
         }
 
-        var pillarOpts = loadPillarOptions()
+        var pillarOpts = await loadPillarOptions()
         const validation = validateBigRock(req.body, {
           existingNames: existingNames,
           originalName: name,
@@ -731,11 +731,11 @@ module.exports = function registerPlanningRoutes(router, context) {
           throw Object.assign(new Error('Validation failed'), { statusCode: 400, fields: validation.errors })
         }
 
-        return saveBigRock(readFromStorage, writeToStorage, version, name, req.body)
+        return await saveBigRock(readFromStorage, writeToStorage, version, name, req.body)
       })
 
       var isRename = req.body.name && req.body.name.trim() !== name
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'update_rock',
         user: req.auditActor || req.userEmail,
@@ -744,7 +744,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           : 'Updated Big Rock "' + name + '"',
         details: { rockName: name, newName: isRename ? req.body.name.trim() : undefined, changes: computeFieldDiff(existingRockSnapshot, req.body) }
       })
-      invalidateCache(version)
+      await invalidateCache(version)
       res.json(result)
     } catch (err) {
       const status = err.statusCode || 500
@@ -777,15 +777,15 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
 
     try {
-      const result = await withConfigLock(function() {
-        const currentConfig = getConfig(readFromStorage)
+      const result = await withConfigLock(async function() {
+        const currentConfig = await getConfig(readFromStorage)
         if (!currentConfig.releases[version]) {
           throw Object.assign(new Error('Release ' + version + ' not found'), { statusCode: 404 })
         }
-        const existingRocks = loadBigRocks(readFromStorage, version)
+        const existingRocks = await loadBigRocks(readFromStorage, version)
         const existingNames = existingRocks.map(function(r) { return r.name })
 
-        var pillarOpts = loadPillarOptions()
+        var pillarOpts = await loadPillarOptions()
         const validation = validateBigRock(req.body, {
           existingNames: existingNames,
           pillarOptions: pillarOpts
@@ -794,11 +794,11 @@ module.exports = function registerPlanningRoutes(router, context) {
           throw Object.assign(new Error('Validation failed'), { statusCode: 400, fields: validation.errors })
         }
 
-        return saveBigRock(readFromStorage, writeToStorage, version, null, req.body)
+        return await saveBigRock(readFromStorage, writeToStorage, version, null, req.body)
       })
 
       const newName = req.body && req.body.name
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'create_rock',
         user: req.auditActor || req.userEmail,
@@ -817,7 +817,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           }
         }
       })
-      invalidateCache(version)
+      await invalidateCache(version)
       res.status(201).json(result)
     } catch (err) {
       const status = err.statusCode || 500
@@ -861,12 +861,12 @@ module.exports = function registerPlanningRoutes(router, context) {
 
     try {
       var deletedRockSnapshot = null
-      const result = await withConfigLock(function() {
-        const currentConfig = getConfig(readFromStorage)
+      const result = await withConfigLock(async function() {
+        const currentConfig = await getConfig(readFromStorage)
         if (!currentConfig.releases[version]) {
           throw Object.assign(new Error('Release ' + version + ' not found'), { statusCode: 404 })
         }
-        const existingRocks = loadBigRocks(readFromStorage, version)
+        const existingRocks = await loadBigRocks(readFromStorage, version)
         const found = existingRocks.find(function(r) { return r.name === name })
         if (!found) {
           throw Object.assign(new Error("Big Rock '" + name + "' not found for release " + version), { statusCode: 404 })
@@ -881,19 +881,19 @@ module.exports = function registerPlanningRoutes(router, context) {
           architect: found.architect
         }
 
-        backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+        await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
-        return deleteBigRock(readFromStorage, writeToStorage, version, name)
+        return await deleteBigRock(readFromStorage, writeToStorage, version, name)
       })
 
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'delete_rock',
         user: req.auditActor || req.userEmail,
         summary: 'Deleted Big Rock "' + name + '"',
         details: { rockName: name, deletedDefinition: deletedRockSnapshot }
       })
-      invalidateCache(version)
+      await invalidateCache(version)
       res.json(result)
     } catch (err) {
       const status = err.statusCode || 500
@@ -936,14 +936,14 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
 
     try {
-      const result = await withConfigLock(function() {
+      const result = await withConfigLock(async function() {
         if (cloneFrom) {
-          backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
-          return cloneRelease(readFromStorage, writeToStorage, version, cloneFrom)
+          await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+          return await cloneRelease(readFromStorage, writeToStorage, version, cloneFrom)
         }
-        return createRelease(readFromStorage, writeToStorage, version)
+        return await createRelease(readFromStorage, writeToStorage, version)
       })
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: cloneFrom ? 'clone_release' : 'create_release',
         user: req.auditActor || req.userEmail,
@@ -981,12 +981,12 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
 
     try {
-      const result = await withConfigLock(function() {
-        backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
-        return deleteRelease(readFromStorage, writeToStorage, version)
+      const result = await withConfigLock(async function() {
+        await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+        return await deleteRelease(readFromStorage, writeToStorage, version)
       })
 
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'delete_release',
         user: req.auditActor || req.userEmail,
@@ -994,14 +994,14 @@ module.exports = function registerPlanningRoutes(router, context) {
       })
 
       if (deleteFromStorage) {
-        deleteFromStorage(releaseFilePath(version))
-        deleteFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
+        await deleteFromStorage(releaseFilePath(version))
+        await deleteFromStorage(DATA_PREFIX + '/candidates-cache-' + version + '.json')
         var delPhases = ['all', 'EA1', 'EA2', 'GA']
         for (var dp = 0; dp < delPhases.length; dp++) {
-          deleteFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + delPhases[dp] + '.json')
+          await deleteFromStorage(DATA_PREFIX + '/health-cache-' + version + '-' + delPhases[dp] + '.json')
         }
-        deleteFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json')
-        deleteFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json')
+        await deleteFromStorage(DATA_PREFIX + '/dor-state-' + version + '.json')
+        await deleteFromStorage(DATA_PREFIX + '/health-overrides-' + version + '.json')
       }
 
       res.json(result)
@@ -1032,7 +1032,7 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Validation results
    */
-  router.post('/jira/validate-keys', requireAuth, requireScope('releases:write'), function(req, res) {
+  router.post('/jira/validate-keys', requireAuth, requireScope('releases:write'), async function(req, res) {
     const keys = req.body && req.body.keys
     if (!Array.isArray(keys) || keys.length === 0) {
       return res.status(400).json({ error: 'keys must be a non-empty array' })
@@ -1053,7 +1053,7 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
 
     if (keysToValidate.length > 0) {
-      const index = loadIndex(readFromStorage)
+      const index = await loadIndex(readFromStorage)
       const cacheResults = validateKeysFromCache(index, keysToValidate)
       Object.assign(results, cacheResults)
     }
@@ -1090,7 +1090,7 @@ module.exports = function registerPlanningRoutes(router, context) {
     try {
       const result = await previewDocImport(docId)
 
-      const existingRocks = loadBigRocks(readFromStorage, version)
+      const existingRocks = await loadBigRocks(readFromStorage, version)
       const existingNames = new Set(existingRocks.map(function(r) { return r.name }))
 
       for (let i = 0; i < result.bigRocks.length; i++) {
@@ -1151,17 +1151,17 @@ module.exports = function registerPlanningRoutes(router, context) {
       const parsedDoc = await previewDocImport(docId)
 
       var existingRocksBeforeImport = mode === 'replace'
-        ? loadBigRocks(readFromStorage, version).map(function(r) { return { name: r.name, pillar: r.pillar, jiraKeys: r.jiraKeys } })
+        ? (await loadBigRocks(readFromStorage, version)).map(function(r) { return { name: r.name, pillar: r.pillar, jiraKeys: r.jiraKeys } })
         : undefined
 
-      const result = await withConfigLock(function() {
+      const result = await withConfigLock(async function() {
         if (mode === 'replace') {
-          backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+          await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
         }
-        return executeDocImport(readFromStorage, writeToStorage, version, docId, mode, parsedDoc)
+        return await executeDocImport(readFromStorage, writeToStorage, version, docId, mode, parsedDoc)
       })
 
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         version: version,
         action: 'import_doc',
         user: req.auditActor || req.userEmail,
@@ -1173,7 +1173,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           replacedRocks: existingRocksBeforeImport
         }
       })
-      invalidateCache(version)
+      await invalidateCache(version)
       res.json(result)
     } catch (err) {
       const status = err.statusCode || 500
@@ -1201,7 +1201,7 @@ module.exports = function registerPlanningRoutes(router, context) {
       }
 
       const releases = await smartsheetClient.discoverReleases()
-      const configuredVersions = getConfiguredReleases(readFromStorage).map(function(r) { return r.version })
+      const configuredVersions = (await getConfiguredReleases(readFromStorage)).map(function(r) { return r.version })
       const configuredSet = new Set(configuredVersions)
 
       const available = releases.map(function(rel) {
@@ -1270,17 +1270,17 @@ module.exports = function registerPlanningRoutes(router, context) {
     }
 
     try {
-      const result = await withConfigLock(function() {
-        backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
+      const result = await withConfigLock(async function() {
+        await backupConfig(readFromStorage, writeToStorage, listStorageFiles, deleteFromStorage)
 
-        const existing = getConfig(readFromStorage)
+        const existing = await getConfig(readFromStorage)
 
         const mergedReleases = { ...existing.releases }
         for (let vi = 0; vi < versions.length; vi++) {
           const ver = versions[vi]
           const rocks = config.releases[ver].bigRocks || []
           mergedReleases[ver] = { release: ver }
-          writeToStorage(releaseFilePath(ver), { release: ver, bigRocks: rocks })
+          await writeToStorage(releaseFilePath(ver), { release: ver, bigRocks: rocks })
         }
 
         const merged = {
@@ -1290,7 +1290,7 @@ module.exports = function registerPlanningRoutes(router, context) {
           customFieldIds: { ...existing.customFieldIds, ...(config.customFieldIds || {}) }
         }
 
-        writeToStorage('releases/planning/config.json', merged)
+        await writeToStorage('releases/planning/config.json', merged)
 
         const seededVersions = versions.map(function(v) {
           return { version: v, bigRockCount: (config.releases[v].bigRocks || []).length }
@@ -1299,7 +1299,7 @@ module.exports = function registerPlanningRoutes(router, context) {
         return { seeded: seededVersions, totalReleases: Object.keys(merged.releases).length }
       })
 
-      logAudit(readFromStorage, writeToStorage, {
+      await logAudit(readFromStorage, writeToStorage, {
         action: 'seed',
         user: req.auditActor || req.userEmail,
         summary: 'Seeded release data for ' + versions.join(', ')
@@ -1354,13 +1354,13 @@ module.exports = function registerPlanningRoutes(router, context) {
    *       200:
    *         description: Audit log entries
    */
-  router.get('/audit-log', requireAuth, requireScope('releases:read'), function(req, res) {
+  router.get('/audit-log', requireAuth, requireScope('releases:read'), async function(req, res) {
     const version = req.query.version || null
     const action = req.query.action || null
     const limit = Math.min(Math.max(parseInt(req.query.limit) || 50, 1), 500)
     const offset = Math.max(parseInt(req.query.offset) || 0, 0)
 
-    const result = getAuditLog(readFromStorage, {
+    const result = await getAuditLog(readFromStorage, {
       version: version,
       action: action,
       limit: limit,
@@ -1373,10 +1373,10 @@ module.exports = function registerPlanningRoutes(router, context) {
   // Diagnostics
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const releases = getConfiguredReleases(readFromStorage)
+      const releases = await getConfiguredReleases(readFromStorage)
       const cacheFiles = []
       for (const rel of releases) {
-        const cached = readFromStorage(`${DATA_PREFIX}/candidates-cache-${rel.version}.json`)
+        const cached = await readFromStorage(`${DATA_PREFIX}/candidates-cache-${rel.version}.json`)
         cacheFiles.push({
           version: rel.version,
           hasCachedData: !!(cached && cached.data),

--- a/modules/releases/server/planning/team-lookup.js
+++ b/modules/releases/server/planning/team-lookup.js
@@ -1,6 +1,6 @@
-function buildTeamIndex(readFromStorage, version) {
+async function buildTeamIndex(readFromStorage, version) {
   if (!version) return new Map()
-  var hygieneData = readFromStorage('releases/hygiene/features-' + version + '.json')
+  var hygieneData = await readFromStorage('releases/hygiene/features-' + version + '.json')
   if (!hygieneData || !hygieneData.features) return new Map()
   var index = new Map()
   var keys = Object.keys(hygieneData.features)

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -428,7 +428,7 @@ function extractTargetVersions(rawIssue) {
  * @param {import('express').Router} router
  * @param {{ requireAuth: Function, requireScope: Function, jira: object, storage: object }} context
  */
-module.exports = function registerPmHubRoutes(router, context) {
+module.exports = async function registerPmHubRoutes(router, context) {
   var jiraClient = context.jira || null
 
   /**
@@ -554,16 +554,16 @@ module.exports = function registerPmHubRoutes(router, context) {
    *       200:
    *         description: Pillar config object with pillars array
    */
-  router.get('/pillar-config', context.requireAuth, context.requireScope('releases:read'), function(req, res) {
+  router.get('/pillar-config', context.requireAuth, context.requireScope('releases:read'), async function(req, res) {
     var storage = context.storage
-    var config = storage.readFromStorage(PILLAR_CONFIG_FILE)
+    var config = await storage.readFromStorage(PILLAR_CONFIG_FILE)
     if (!config) {
       config = DEFAULT_PILLAR_CONFIG
-      storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+      await storage.writeToStorage(PILLAR_CONFIG_FILE, config)
     } else {
       var migrated = backfillLeads(config)
       if (migrated) {
-        storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+        await storage.writeToStorage(PILLAR_CONFIG_FILE, config)
       }
     }
     res.json(config)
@@ -605,13 +605,13 @@ module.exports = function registerPmHubRoutes(router, context) {
    *       400:
    *         description: Invalid config shape
    */
-  router.put('/pillar-config', context.requireAuth, blockDuringImpersonation, context.requireScope('releases:write'), function(req, res) {
+  router.put('/pillar-config', context.requireAuth, blockDuringImpersonation, context.requireScope('releases:write'), async function(req, res) {
     var err = validatePillarConfig(req.body)
     if (err) {
       return res.status(400).json({ error: err })
     }
     var config = { pillars: req.body.pillars }
-    context.storage.writeToStorage(PILLAR_CONFIG_FILE, config)
+    await context.storage.writeToStorage(PILLAR_CONFIG_FILE, config)
     res.json(config)
   })
 

--- a/modules/releases/server/registry-config.js
+++ b/modules/releases/server/registry-config.js
@@ -22,9 +22,9 @@ function getDefaults() {
  * @param {{ readFromStorage: function }} storage
  * @returns {{ jiraProjects: string[] }}
  */
-function loadRegistryConfig(storage) {
+async function loadRegistryConfig(storage) {
   var defaults = getDefaults()
-  var stored = storage.readFromStorage(STORAGE_KEY)
+  var stored = await storage.readFromStorage(STORAGE_KEY)
 
   if (!stored || typeof stored !== 'object') {
     return defaults
@@ -40,7 +40,7 @@ function loadRegistryConfig(storage) {
  * @param {{ writeToStorage: function }} storage
  * @param {{ jiraProjects?: string[] }} config
  */
-function saveRegistryConfig(storage, config) {
+async function saveRegistryConfig(storage, config) {
   if (!config || typeof config !== 'object') {
     throw new Error('Config must be an object')
   }
@@ -51,7 +51,7 @@ function saveRegistryConfig(storage, config) {
       : DEFAULT_JIRA_PROJECTS.slice()
   }
 
-  storage.writeToStorage(STORAGE_KEY, toSave)
+  await storage.writeToStorage(STORAGE_KEY, toSave)
 }
 
 module.exports = {

--- a/modules/releases/server/registry.js
+++ b/modules/releases/server/registry.js
@@ -22,8 +22,8 @@ const PP_MANAGED_FIELDS = ['displayName', 'productPagesShortname', 'productPages
 /**
  * Read the registry from storage, returning a normalized object.
  */
-function readRegistry(readFromStorage) {
-  const data = readFromStorage(REGISTRY_FILE);
+async function readRegistry(readFromStorage) {
+  const data = await readFromStorage(REGISTRY_FILE);
   if (data && Array.isArray(data.releases)) return data;
   return { schemaVersion: SCHEMA_VERSION, releases: [] };
 }
@@ -31,8 +31,8 @@ function readRegistry(readFromStorage) {
 /**
  * Write the registry to storage.
  */
-function writeRegistry(writeToStorage, registry) {
-  writeToStorage(REGISTRY_FILE, registry);
+async function writeRegistry(writeToStorage, registry) {
+  await writeToStorage(REGISTRY_FILE, registry);
 }
 
 /**
@@ -251,7 +251,7 @@ function migrateNormalizedIds(registry) {
  */
 async function autoResolveFixVersions(storage, deps) {
   const { readFromStorage, writeToStorage } = storage;
-  const registry = readRegistry(readFromStorage);
+  const registry = await readRegistry(readFromStorage);
 
   const activeReleases = registry.releases.filter(function (r) {
     return r.state === 'active';
@@ -261,7 +261,7 @@ async function autoResolveFixVersions(storage, deps) {
     return { status: 'skipped', message: 'No active releases in registry' };
   }
 
-  const config = loadRegistryConfig(storage);
+  const config = await loadRegistryConfig(storage);
   const projects = config.jiraProjects || [];
   if (projects.length === 0) {
     return { status: 'skipped', message: 'No Jira projects configured for version resolution' };
@@ -300,8 +300,8 @@ async function autoResolveFixVersions(storage, deps) {
   }
 
   if (applied.length > 0) {
-    writeRegistry(writeToStorage, registry);
-    logAudit(readFromStorage, writeToStorage, {
+    await writeRegistry(writeToStorage, registry);
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'registry',
       action: 'registry_auto_resolve_versions',
       user: 'system',
@@ -339,7 +339,7 @@ async function runRegistrySync(storage, options) {
     return { status: 'skipped', message: 'Product Pages auth not configured' };
   }
 
-  const deliveryConfig = getConfig(readFromStorage);
+  const deliveryConfig = await getConfig(readFromStorage);
   const shortnames = deliveryConfig.productPagesProductShortnames || [];
   if (shortnames.length === 0) {
     return { status: 'skipped', message: 'No product shortnames configured' };
@@ -350,7 +350,7 @@ async function runRegistrySync(storage, options) {
     return { status: 'empty', discovered: 0, created: 0, message: 'No releases found from Product Pages' };
   }
 
-  const registry = readRegistry(readFromStorage);
+  const registry = await readRegistry(readFromStorage);
 
   // Merge stale .z-suffixed entries into their clean counterparts before lookup.
   // This fixes the split caused by stripZStream normalising IDs while the old
@@ -446,8 +446,8 @@ async function runRegistrySync(storage, options) {
   }
 
   if (created > 0 || updated > 0 || archived > 0) {
-    writeRegistry(writeToStorage, registry);
-    logAudit(readFromStorage, writeToStorage, {
+    await writeRegistry(writeToStorage, registry);
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'registry',
       action: 'registry_discover',
       user: options.user || 'system',
@@ -462,7 +462,7 @@ async function runRegistrySync(storage, options) {
 /**
  * Register release registry routes on the provided router.
  */
-function registerRegistryRoutes(router, context) {
+async function registerRegistryRoutes(router, context) {
   const { storage, requireAuth, requirePlanningManager, requireScope } = context;
   const { readFromStorage, writeToStorage } = storage;
 
@@ -487,8 +487,8 @@ function registerRegistryRoutes(router, context) {
    *                   items:
    *                     type: object
    */
-  router.get('/registry', requireAuth, requireScope('releases:read'), function(req, res) {
-    const registry = readRegistry(readFromStorage);
+  router.get('/registry', requireAuth, requireScope('releases:read'), async function(req, res) {
+    const registry = await readRegistry(readFromStorage);
     res.json(registry);
   });
 
@@ -502,8 +502,8 @@ function registerRegistryRoutes(router, context) {
    *       200:
    *         description: Registry config
    */
-  router.get('/registry/config', requirePlanningManager, requireScope('releases:read'), function(req, res) {
-    var config = loadRegistryConfig(storage);
+  router.get('/registry/config', requirePlanningManager, requireScope('releases:read'), async function(req, res) {
+    var config = await loadRegistryConfig(storage);
     res.json(config);
   });
 
@@ -530,9 +530,9 @@ function registerRegistryRoutes(router, context) {
    *       400:
    *         description: Validation error
    */
-  router.post('/registry/config', requirePlanningManager, requireScope('releases:write'), function(req, res) {
+  router.post('/registry/config', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     try {
-      saveRegistryConfig(storage, req.body);
+      await saveRegistryConfig(storage, req.body);
       res.json({ status: 'saved' });
     } catch (err) {
       res.status(400).json({ error: err.message });
@@ -557,8 +557,8 @@ function registerRegistryRoutes(router, context) {
    *       404:
    *         description: Release not found
    */
-  router.get('/registry/:id', requireAuth, requireScope('releases:read'), function(req, res) {
-    const registry = readRegistry(readFromStorage);
+  router.get('/registry/:id', requireAuth, requireScope('releases:read'), async function(req, res) {
+    const registry = await readRegistry(readFromStorage);
     const release = registry.releases.find(r => r.id === req.params.id);
     if (!release) {
       return res.status(404).json({ error: 'Release not found' });
@@ -603,13 +603,13 @@ function registerRegistryRoutes(router, context) {
    *       400:
    *         description: Validation error or duplicate ID
    */
-  router.post('/registry', requirePlanningManager, requireScope('releases:write'), function(req, res) {
+  router.post('/registry', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     const error = validateRelease(req.body);
     if (error) {
       return res.status(400).json({ error });
     }
 
-    const registry = readRegistry(readFromStorage);
+    const registry = await readRegistry(readFromStorage);
     const normalizedId = stripZStream(req.body.id.trim()).toLowerCase();
 
     if (registry.releases.some(r => r.id === normalizedId)) {
@@ -618,9 +618,9 @@ function registerRegistryRoutes(router, context) {
 
     const release = normalizeRelease(req.body);
     registry.releases.push(release);
-    writeRegistry(writeToStorage, registry);
+    await writeRegistry(writeToStorage, registry);
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'registry',
       action: 'registry_create',
       user: req.userEmail || 'unknown',
@@ -657,8 +657,8 @@ function registerRegistryRoutes(router, context) {
    *       404:
    *         description: Release not found
    */
-  router.put('/registry/:id', requirePlanningManager, requireScope('releases:write'), function(req, res) {
-    const registry = readRegistry(readFromStorage);
+  router.put('/registry/:id', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
+    const registry = await readRegistry(readFromStorage);
     const idx = registry.releases.findIndex(r => r.id === req.params.id);
     if (idx === -1) {
       return res.status(404).json({ error: 'Release not found' });
@@ -693,9 +693,9 @@ function registerRegistryRoutes(router, context) {
     const updated = normalizeRelease(merged);
     updated.createdAt = existing.createdAt; // preserve original
     registry.releases[idx] = updated;
-    writeRegistry(writeToStorage, registry);
+    await writeRegistry(writeToStorage, registry);
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'registry',
       action: 'registry_update',
       user: req.userEmail || 'unknown',
@@ -724,8 +724,8 @@ function registerRegistryRoutes(router, context) {
    *       404:
    *         description: Release not found
    */
-  router.delete('/registry/:id', requirePlanningManager, requireScope('releases:write'), function(req, res) {
-    const registry = readRegistry(readFromStorage);
+  router.delete('/registry/:id', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
+    const registry = await readRegistry(readFromStorage);
     const idx = registry.releases.findIndex(r => r.id === req.params.id);
     if (idx === -1) {
       return res.status(404).json({ error: 'Release not found' });
@@ -734,9 +734,9 @@ function registerRegistryRoutes(router, context) {
     // Archive rather than hard delete
     registry.releases[idx].state = 'archived';
     registry.releases[idx].updatedAt = new Date().toISOString();
-    writeRegistry(writeToStorage, registry);
+    await writeRegistry(writeToStorage, registry);
 
-    logAudit(readFromStorage, writeToStorage, {
+    await logAudit(readFromStorage, writeToStorage, {
       domain: 'registry',
       action: 'registry_archive',
       user: req.userEmail || 'unknown',
@@ -793,7 +793,7 @@ function registerRegistryRoutes(router, context) {
    */
   router.post('/registry/resolve-jira-versions', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     try {
-      var config = loadRegistryConfig(storage);
+      var config = await loadRegistryConfig(storage);
       var projects = config.jiraProjects || [];
 
       if (projects.length === 0) {
@@ -805,7 +805,7 @@ function registerRegistryRoutes(router, context) {
       var { fetchProjectVersions, jiraRequest: jiraRequestFn } = require('../../../shared/server/jira');
 
       var jiraVersions = await fetchProjectVersions(jiraRequestFn, projects);
-      var registry = readRegistry(readFromStorage);
+      var registry = await readRegistry(readFromStorage);
       var result = matchVersionsToReleases(jiraVersions, registry.releases);
 
       res.json({
@@ -856,13 +856,13 @@ function registerRegistryRoutes(router, context) {
    *       400:
    *         description: Invalid request
    */
-  router.post('/registry/resolve-jira-versions/apply', requirePlanningManager, requireScope('releases:write'), function(req, res) {
+  router.post('/registry/resolve-jira-versions/apply', requirePlanningManager, requireScope('releases:write'), async function(req, res) {
     var mappings = req.body && req.body.mappings;
     if (!Array.isArray(mappings) || mappings.length === 0) {
       return res.status(400).json({ error: 'mappings array is required and must not be empty' });
     }
 
-    var registry = readRegistry(readFromStorage);
+    var registry = await readRegistry(readFromStorage);
     var updated = [];
 
     for (var i = 0; i < mappings.length; i++) {
@@ -888,8 +888,8 @@ function registerRegistryRoutes(router, context) {
     }
 
     if (updated.length > 0) {
-      writeRegistry(writeToStorage, registry);
-      logAudit(readFromStorage, writeToStorage, {
+      await writeRegistry(writeToStorage, registry);
+      await logAudit(readFromStorage, writeToStorage, {
         domain: 'registry',
         action: 'registry_resolve_jira_versions',
         user: req.userEmail || 'unknown',
@@ -907,7 +907,7 @@ function registerRegistryRoutes(router, context) {
       timeout: 300000,
       description: 'Syncs the release registry from Product Pages, updating release metadata and versions.',
       handler: async function() {
-        return runRegistrySync(storage);
+        return await runRegistrySync(storage);
       }
     });
 
@@ -916,7 +916,7 @@ function registerRegistryRoutes(router, context) {
       timeout: 120000,
       description: 'Auto-resolves Jira fixVersions for active registry releases (additive only).',
       handler: async function() {
-        return autoResolveFixVersions(storage);
+        return await autoResolveFixVersions(storage);
       }
     });
   }

--- a/modules/releases/server/release-readiness/routes.js
+++ b/modules/releases/server/release-readiness/routes.js
@@ -61,14 +61,14 @@ const STORAGE_PREFIX = 'releases/release-readiness';
 
 function registerReleaseReadinessRoutes(router, { storage, requireAuth, requireScope }) {
 
-  router.get('/', requireAuth, requireScope('releases:read'), (req, res) => {
+  router.get('/', requireAuth, requireScope('releases:read'), async (req, res) => {
     const version = req.query.version;
     if (!version) {
       return res.status(400).json({ error: 'version query parameter is required' });
     }
 
     const filename = sanitizeFilename(version);
-    const data = storage.readFromStorage(`${STORAGE_PREFIX}/${filename}.json`);
+    const data = await storage.readFromStorage(`${STORAGE_PREFIX}/${filename}.json`);
 
     if (!data) {
       return res.status(404).json({ error: `No release readiness metrics found for version "${version}"` });
@@ -77,10 +77,10 @@ function registerReleaseReadinessRoutes(router, { storage, requireAuth, requireS
     res.json(data);
   });
 
-  router.get('/versions', requireAuth, requireScope('releases:read'), (req, res) => {
+  router.get('/versions', requireAuth, requireScope('releases:read'), async (req, res) => {
     let files;
     try {
-      files = storage.listStorageFiles(STORAGE_PREFIX);
+      files = await storage.listStorageFiles(STORAGE_PREFIX);
     } catch {
       return res.json({ versions: [] });
     }
@@ -92,7 +92,7 @@ function registerReleaseReadinessRoutes(router, { storage, requireAuth, requireS
     res.json({ versions });
   });
 
-  router.post('/upload', requireAuth, requireScope('releases:write'), (req, res) => {
+  router.post('/upload', requireAuth, requireScope('releases:write'), async (req, res) => {
     const payload = req.body;
 
     if (!payload || !payload.version || !payload.summary) {
@@ -100,7 +100,7 @@ function registerReleaseReadinessRoutes(router, { storage, requireAuth, requireS
     }
 
     const filename = sanitizeFilename(payload.version);
-    storage.writeToStorage(`${STORAGE_PREFIX}/${filename}.json`, payload);
+    await storage.writeToStorage(`${STORAGE_PREFIX}/${filename}.json`, payload);
 
     res.json({ status: 'stored', version: payload.version, filename: `${filename}.json` });
   });

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -25,10 +25,10 @@ const jqlSafePattern = /^[a-zA-Z0-9._ -]+$/
  * Fetch configured releases from planning module and expand to EA1, EA2, GA variants.
  * Returns array of release strings in timeline order: [...EA1s, ...EA2s, ...GAs]
  */
-function fetchReleasesFromPlanning(storage) {
+async function fetchReleasesFromPlanning(storage) {
   try {
     // Try to read from planning module's config
-    const planningData = storage.readFromStorage('releases/planning/config.json')
+    const planningData = await storage.readFromStorage('releases/planning/config.json')
     if (!planningData || !planningData.releases) {
       console.warn('[releases/tv-fv-delta] No planning config found — falling back to DEFAULT_RELEASES. Update the constant if the current release has changed.')
       return { releases: DEFAULT_RELEASES, source: 'default' }
@@ -425,7 +425,7 @@ async function fetchAndClassify(releases, storage, jiraProject) {
 
   // Look up release dates from Product Pages delivery cache
   const releaseDates = {}
-  const ppCache = storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
+  const ppCache = await storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
   if (ppCache && Array.isArray(ppCache.releases)) {
     for (let pi = 0; pi < ppCache.releases.length; pi++) {
       const ppRel = ppCache.releases[pi]
@@ -443,7 +443,7 @@ async function fetchAndClassify(releases, storage, jiraProject) {
   const result = buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject, releaseDates)
 
   // Cache
-  storage.writeToStorage(CACHE_KEY, result)
+  await storage.writeToStorage(CACHE_KEY, result)
   console.log('[releases/tv-fv-delta] Cached TV/FV delta (' + classifications.length + ' classifications, ' + (allComponents ? allComponents.length : 0) + ' components)')
 
   return result
@@ -466,7 +466,7 @@ module.exports.DEFAULT_RELEASES = DEFAULT_RELEASES
 module.exports.DEFAULT_JIRA_PROJECT = DEFAULT_JIRA_PROJECT
 module.exports.jqlSafePattern = jqlSafePattern
 
-function registerRoutes(router, context) {
+async function registerRoutes(router, context) {
   const storage = context.storage
   const requireAuth = context.requireAuth
   const requireScope = context.requireScope
@@ -477,7 +477,7 @@ function registerRoutes(router, context) {
   const REFRESH_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
   const refreshState = { running: false, lastResult: null, startedAt: null, completedAt: null }
 
-  function triggerBackgroundRefresh(releases, force) {
+  async function triggerBackgroundRefresh(releases, force) {
     if (refreshState.running) return
     if (!force && refreshState.completedAt) {
       const elapsed = Date.now() - new Date(refreshState.completedAt).getTime()
@@ -493,8 +493,8 @@ function registerRoutes(router, context) {
     refreshState.startedAt = new Date().toISOString()
 
     console.log('[releases/tv-fv-delta] Background refresh started')
-    setImmediate(function() {
-      fetchAndClassify(releases, storage, JIRA_PROJECT)
+    setImmediate(async function() {
+      await fetchAndClassify(releases, storage, JIRA_PROJECT)
       .then(function(result) {
         refreshState.running = false
         refreshState.completedAt = new Date().toISOString()
@@ -531,8 +531,8 @@ function registerRoutes(router, context) {
    *       404:
    *         description: No data available — trigger a refresh
    */
-  router.get('/', requireAuth, requireScope('releases:read'), function (req, res) {
-    const data = storage.readFromStorage(CACHE_KEY)
+  router.get('/', requireAuth, requireScope('releases:read'), async function (req, res) {
+    const data = await storage.readFromStorage(CACHE_KEY)
 
     if (data) {
       // Check staleness
@@ -552,7 +552,7 @@ function registerRoutes(router, context) {
     }
 
     // No cache — trigger first fetch using planning config if available
-    triggerBackgroundRefresh(fetchReleasesFromPlanning(storage).releases)
+    triggerBackgroundRefresh(await fetchReleasesFromPlanning(storage).releases)
     res.status(202).json({
       _refreshing: true,
       _noCache: true,
@@ -581,7 +581,7 @@ function registerRoutes(router, context) {
    *       200:
    *         description: Refresh started or already running
    */
-  router.post('/refresh', requireAuth, requireScope('releases:write'), function (req, res) {
+  router.post('/refresh', requireAuth, requireScope('releases:write'), async function (req, res) {
     if (refreshState.running) {
       return res.json({ status: 'already_running', startedAt: refreshState.startedAt })
     }
@@ -592,7 +592,7 @@ function registerRoutes(router, context) {
       releases = req.body.releases
     } else {
       // Auto-discover from planning module (Smartsheet SSOT)
-      releases = fetchReleasesFromPlanning(storage).releases
+      releases = await fetchReleasesFromPlanning(storage).releases
     }
 
     // Cap releases array to prevent excessive API load
@@ -639,9 +639,9 @@ function registerRoutes(router, context) {
    *       200:
    *         description: Release list expanded to EA1, EA2, GA variants
    */
-  router.get('/releases', requireAuth, requireScope('releases:read'), function (req, res) {
+  router.get('/releases', requireAuth, requireScope('releases:read'), async function (req, res) {
     try {
-      const result = fetchReleasesFromPlanning(storage)
+      const result = await fetchReleasesFromPlanning(storage)
       res.json({
         releases: result.releases,
         source: result.source,
@@ -665,7 +665,7 @@ function registerRoutes(router, context) {
    */
   router.get('/versions', requireAuth, requireScope('releases:read'), async function (req, res) {
     // Check cache first
-    const cached = storage.readFromStorage(VERSIONS_CACHE_KEY)
+    const cached = await storage.readFromStorage(VERSIONS_CACHE_KEY)
     if (cached && cached.fetchedAt) {
       const age = Date.now() - new Date(cached.fetchedAt).getTime()
       if (age < VERSIONS_CACHE_MAX_AGE_MS) {
@@ -677,7 +677,7 @@ function registerRoutes(router, context) {
       const allVersions = await fetchProjectVersions(jiraRequest, [JIRA_PROJECT])
       if (!Array.isArray(allVersions)) {
         const result = { versions: [], fetchedAt: new Date().toISOString() }
-        storage.writeToStorage(VERSIONS_CACHE_KEY, result)
+        await storage.writeToStorage(VERSIONS_CACHE_KEY, result)
         return res.json(result)
       }
       const versions = allVersions
@@ -685,7 +685,7 @@ function registerRoutes(router, context) {
         .sort(function(a, b) { return (a.name || '').localeCompare(b.name || '') })
 
       const result = { versions: versions, fetchedAt: new Date().toISOString() }
-      storage.writeToStorage(VERSIONS_CACHE_KEY, result)
+      await storage.writeToStorage(VERSIONS_CACHE_KEY, result)
       res.json(result)
     } catch (err) {
       console.error('[releases/tv-fv-delta] Failed to fetch versions:', err.message)
@@ -698,7 +698,7 @@ function registerRoutes(router, context) {
   // Diagnostics hook
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function () {
-      const tvfv = storage.readFromStorage(CACHE_KEY)
+      const tvfv = await storage.readFromStorage(CACHE_KEY)
       return {
         tvFvDelta: tvfv ? { generatedAt: tvfv.metadata?.generated_at, releases: tvfv.metadata?.releases } : null,
         refresh: refreshState

--- a/modules/system-health/server/disconnected/github-fetch.js
+++ b/modules/system-health/server/disconnected/github-fetch.js
@@ -1,7 +1,7 @@
 const AdmZip = require('adm-zip');
 const path = require('path');
 const { Octokit } = require('@octokit/rest');
-const { upsertReport, readReports, writeReportsAtomic } = require('./storage');
+const { upsertReport, readReports, writeReports } = require('./storage');
 
 const SCORER_OWNER = 'opendatahub-io';
 const SCORER_REPO = 'disconnected-readiness-scorer';
@@ -128,7 +128,7 @@ async function fetchAllReports(storage, token) {
     return { status: result.status, message: result.message, timestamp: new Date().toISOString() };
   }
 
-  const data = readReports(storage.readFromStorage);
+  const data = await readReports(storage.readFromStorage);
   const counts = { created: 0, updated: 0, unchanged: 0 };
 
   for (const report of result.reports) {
@@ -141,7 +141,7 @@ async function fetchAllReports(storage, token) {
 
   data.lastSyncedAt = new Date().toISOString();
   data.repoCount = Object.keys(data.repos).length;
-  writeReportsAtomic(storage.writeToStorageAtomic, data);
+  await writeReports(storage.writeToStorage, data);
 
   const duration = Date.now() - startTime;
   console.log(`[system-health/disconnected] Fetch complete: ${result.reports.length} repos in ${duration}ms (${counts.created} created, ${counts.updated} updated, ${counts.unchanged} unchanged)`);

--- a/modules/system-health/server/disconnected/routes.js
+++ b/modules/system-health/server/disconnected/routes.js
@@ -1,6 +1,6 @@
 const {
   readReports,
-  writeReportsAtomic,
+  writeReports,
   getSummaryProjection
 } = require('./storage');
 
@@ -85,10 +85,10 @@ const DEMO_MODE = process.env.DEMO_MODE === 'true';
 
 module.exports = function registerDisconnectedRoutes(router, context) {
   const { storage, requireAuth, requireAdmin, requireScope } = context;
-  const { readFromStorage, writeToStorageAtomic } = storage;
+  const { readFromStorage, writeToStorage } = storage;
 
-  router.get('/summary', requireAuth, requireScope('system-health:read'), function(req, res) {
-    const data = readReports(readFromStorage);
+  router.get('/summary', requireAuth, requireScope('system-health:read'), async function(req, res) {
+    const data = await readReports(readFromStorage);
     const summary = getSummaryProjection(data);
 
     let repos = summary.repos;
@@ -114,7 +114,7 @@ module.exports = function registerDisconnectedRoutes(router, context) {
     res.json({ ...summary, repos });
   });
 
-  router.get('/repos/:repoKey', requireAuth, requireScope('system-health:read'), function(req, res) {
+  router.get('/repos/:repoKey', requireAuth, requireScope('system-health:read'), async function(req, res) {
     const repoKey = req.params.repoKey;
 
     if (!/^[a-zA-Z0-9._-]+--[a-zA-Z0-9._-]+$/.test(repoKey)) {
@@ -123,7 +123,7 @@ module.exports = function registerDisconnectedRoutes(router, context) {
 
     const sepIdx = repoKey.indexOf('--');
     const repoSlug = repoKey.slice(0, sepIdx) + '/' + repoKey.slice(sepIdx + 2);
-    const data = readReports(readFromStorage);
+    const data = await readReports(readFromStorage);
     const entry = data.repos[repoSlug];
 
     if (!entry) {
@@ -136,8 +136,8 @@ module.exports = function registerDisconnectedRoutes(router, context) {
     });
   });
 
-  router.get('/status', requireAuth, requireScope('system-health:read'), function(req, res) {
-    const data = readReports(readFromStorage);
+  router.get('/status', requireAuth, requireScope('system-health:read'), async function(req, res) {
+    const data = await readReports(readFromStorage);
     res.json({
       dataAvailable: Object.keys(data.repos).length > 0,
       lastSyncedAt: data.lastSyncedAt,
@@ -145,11 +145,11 @@ module.exports = function registerDisconnectedRoutes(router, context) {
     });
   });
 
-  router.delete('/', requireAdmin, requireScope('system-health:write'), function(req, res) {
+  router.delete('/', requireAdmin, requireScope('system-health:write'), async function(req, res) {
     if (DEMO_MODE) {
       return res.json({ status: 'skipped', message: 'Disabled in demo mode' });
     }
-    writeReportsAtomic(writeToStorageAtomic, { lastSyncedAt: null, repoCount: 0, repos: {} });
+    await writeReports(writeToStorage, { lastSyncedAt: null, repoCount: 0, repos: {} });
     res.json({ status: 'cleared' });
   });
 

--- a/modules/system-health/server/disconnected/scheduler.js
+++ b/modules/system-health/server/disconnected/scheduler.js
@@ -46,12 +46,12 @@ async function runFetch(storage) {
     if (fetchResult.status === 'success') {
       lastSuccessfulFetch = Date.now();
     }
-    storage.writeToStorage('system-health/disconnected/last-fetch.json', fetchResult);
+    await storage.writeToStorage('system-health/disconnected/last-fetch.json', fetchResult);
     return fetchResult;
   } catch (err) {
     console.error('[system-health/disconnected] Fetch error:', err.message);
     const errorResult = { status: 'error', message: err.message, timestamp: new Date().toISOString() };
-    storage.writeToStorage('system-health/disconnected/last-fetch.json', errorResult);
+    await storage.writeToStorage('system-health/disconnected/last-fetch.json', errorResult);
     return errorResult;
   } finally {
     fetchInProgress = false;

--- a/modules/system-health/server/disconnected/storage.js
+++ b/modules/system-health/server/disconnected/storage.js
@@ -1,16 +1,16 @@
 const STORAGE_KEY = 'system-health/disconnected/reports.json';
 const MAX_HISTORY = 90;
 
-function readReports(readFromStorage) {
-  const data = readFromStorage(STORAGE_KEY);
+async function readReports(readFromStorage) {
+  const data = await readFromStorage(STORAGE_KEY);
   if (!data || typeof data !== 'object' || !data.repos) {
     return { lastSyncedAt: null, repoCount: 0, repos: {} };
   }
   return data;
 }
 
-function writeReportsAtomic(writeToStorageAtomic, data) {
-  writeToStorageAtomic(STORAGE_KEY, data);
+async function writeReports(writeToStorage, data) {
+  await writeToStorage(STORAGE_KEY, data);
 }
 
 function trimForHistory(report) {
@@ -159,7 +159,7 @@ module.exports = {
   STORAGE_KEY,
   MAX_HISTORY,
   readReports,
-  writeReportsAtomic,
+  writeReports,
   trimForHistory,
   buildLatest,
   toDay,

--- a/modules/system-health/server/index.js
+++ b/modules/system-health/server/index.js
@@ -36,8 +36,8 @@ module.exports = function registerRoutes(router, context) {
 
   if (context.registerDiagnostics) {
     context.registerDiagnostics(async function() {
-      const data = storage.readFromStorage('system-health/disconnected/reports.json');
-      const lastFetch = storage.readFromStorage('system-health/disconnected/last-fetch.json');
+      const data = await storage.readFromStorage('system-health/disconnected/reports.json');
+      const lastFetch = await storage.readFromStorage('system-health/disconnected/last-fetch.json');
       return {
         dataAvailable: !!(data && data.repos && Object.keys(data.repos).length > 0),
         repoCount: data ? Object.keys(data.repos || {}).length : 0,

--- a/modules/upstream-pulse/__tests__/server/index.test.js
+++ b/modules/upstream-pulse/__tests__/server/index.test.js
@@ -14,7 +14,7 @@ describe('upstream-pulse server module', () => {
       get: vi.fn((...args) => registered.push({ method: 'get', path: args[0] })),
       post: vi.fn(),
     }
-    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } }
+    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
 
     registerRoutes(router, context)
 
@@ -38,7 +38,7 @@ describe('upstream-pulse server module', () => {
       post: vi.fn((...args) => postCalls.push({ path: args[0] })),
     }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
 
     expect(postCalls).toHaveLength(2)
     expect(postCalls.map(c => c.path)).toContain('/projects')
@@ -50,14 +50,14 @@ describe('upstream-pulse server module', () => {
   it('gates repo-info behind requireAdmin', () => {
     const router = { get: vi.fn(), post: vi.fn() }
     const requireAdmin = vi.fn()
-    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } })
+    registerRoutes(router, { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin, requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } })
 
     expect(router.get).toHaveBeenCalledWith('/repo-info', requireAdmin, expect.any(Function), expect.any(Function))
   })
 
   it('registers diagnostics hook when available', () => {
     const router = { get: vi.fn(), post: vi.fn() }
-    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } }
+    const context = { registerDiagnostics: vi.fn(), registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
 
     registerRoutes(router, context)
     expect(context.registerDiagnostics).toHaveBeenCalledWith(expect.any(Function))
@@ -65,7 +65,7 @@ describe('upstream-pulse server module', () => {
 
   it('does not fail when registerDiagnostics is absent', () => {
     const router = { get: vi.fn(), post: vi.fn() }
-    const context = { registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn() } }
+    const context = { registerScopes: vi.fn(), requireAdmin: vi.fn(), requireScope: () => (req, res, next) => next(), storage: { readFromStorage: vi.fn().mockResolvedValue(null) } }
 
     expect(() => registerRoutes(router, context)).not.toThrow()
   })

--- a/modules/upstream-pulse/server/index.js
+++ b/modules/upstream-pulse/server/index.js
@@ -232,9 +232,9 @@ async function pushRosterToUpstream(storage) {
 function startPeriodicRosterPush(storage) {
   if (process.env.DEMO_MODE === 'true') return;
 
-  function checkAndPush() {
+  async function checkAndPush() {
     try {
-      const registry = storage.readFromStorage('team-data/registry.json');
+      const registry = await storage.readFromStorage('team-data/registry.json');
       if (!registry || !registry.meta || !registry.meta.generatedAt) return;
 
       const generatedAt = registry.meta.generatedAt;
@@ -624,7 +624,7 @@ module.exports = function registerRoutes(router, context) {
     try {
       const result = await pushRosterToUpstream(context.storage);
       if (!result.skipped) {
-        const registry = context.storage.readFromStorage('team-data/registry.json');
+        const registry = await context.storage.readFromStorage('team-data/registry.json');
         if (registry && registry.meta) _lastPushGeneratedAt = registry.meta.generatedAt;
       }
       res.json(result);


### PR DESCRIPTION
## Summary

- Converts all storage function calls across 8 consumer modules from synchronous to async (`await`), preparing for [org-pulse-core v3 async storage API](https://github.com/red-hat-data-services/org-pulse-core/pull/29)
- Makes route handlers and helper functions `async` where they call storage
- Replaces all `writeToStorageAtomic` usage with `writeToStorage` (removed in core v3)
- Updates all test mocks to return Promises and converts `expect().toThrow()` to `await expect().rejects.toThrow()` where needed

### Modules updated

| Module | Files | Tests |
|--------|-------|-------|
| releases | ~64 | 1830 pass |
| ai-impact | 17 | 593 pass |
| customer-insights | 8 | — |
| ai-catalyst | 5 | pass |
| system-health | 5 | — |
| product-builds | 3 | 171 pass |
| okr-hub | 2 | — |
| upstream-pulse | 2 | 52 pass |

## Test plan

- [x] `npm test` — 4327 tests pass (8 pre-existing client-side Vue test failures unrelated to this change)
- [x] `npm run lint` — clean
- [ ] `npm run dev:full` — app starts and serves data correctly
- [ ] Smoke test container images

🤖 Generated with [Claude Code](https://claude.com/claude-code)