### PR TITLE
fix(customer-insights): fetch Picker API key from backend at runtime

### DIFF
--- a/modules/customer-insights/client/composables/useGoogleDrive.js
+++ b/modules/customer-insights/client/composables/useGoogleDrive.js
@@ -12,10 +12,12 @@ export function useGoogleDrive() {
 
   let popupWindow = null
   let messageListener = null
+  let pickerApiKey = null
 
   // Check connection status on mount
   onMounted(async () => {
     await checkConnectionStatus()
+    await fetchPickerConfig()
     loadPickerApi()
   })
 
@@ -59,6 +61,21 @@ export function useGoogleDrive() {
       }
     } catch (err) {
       console.error('Error fetching OAuth token:', err)
+    }
+  }
+
+  /**
+   * Fetch Picker API key from backend
+   */
+  async function fetchPickerConfig() {
+    try {
+      const response = await fetch('/api/modules/customer-insights/auth/google/picker-config')
+      if (response.ok) {
+        const data = await response.json()
+        pickerApiKey = data.apiKey
+      }
+    } catch (err) {
+      console.error('Error fetching Picker config:', err)
     }
   }
 
@@ -171,8 +188,7 @@ export function useGoogleDrive() {
         return
       }
 
-      const apiKey = import.meta.env.VITE_GOOGLE_PICKER_API_KEY
-      if (!apiKey) {
+      if (!pickerApiKey) {
         reject(new Error('Google Picker API key not configured'))
         return
       }
@@ -182,7 +198,7 @@ export function useGoogleDrive() {
       const picker = new window.google.picker.PickerBuilder()
         .addView(window.google.picker.ViewId.DOCS)
         .setOAuthToken(oauthToken.value)
-        .setDeveloperKey(apiKey)
+        .setDeveloperKey(pickerApiKey)
         .setCallback((data) => {
           if (data.action === window.google.picker.Action.PICKED) {
             const file = data.docs[0]


### PR DESCRIPTION
## Summary
- Google Drive file picker always fails in production with "Google Picker API key not configured" because the key was read from `import.meta.env.VITE_GOOGLE_PICKER_API_KEY` — a build-time env var never set in the container image
- Changed `useGoogleDrive` composable to fetch the key at runtime from the existing `GET /auth/google/picker-config` backend endpoint, which reads it from module secrets

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm test` passes (no new failures)
- [ ] Deploy and verify Google Drive file picker opens without the "API key not configured" error (requires `GOOGLE_PICKER_API_KEY` in `team-tracker-secrets`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)