### PR TITLE
fix: await async readFromStorage in jira-taxonomy extension

### DIFF
--- a/platform/jira-taxonomy/__tests__/server/index.test.js
+++ b/platform/jira-taxonomy/__tests__/server/index.test.js
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 function makeStorage(initial = {}) {
   const data = { ...initial }
   return {
-    readFromStorage: vi.fn((key) => data[key] ? JSON.parse(JSON.stringify(data[key])) : null),
-    writeToStorage: vi.fn((key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
+    readFromStorage: vi.fn(async (key) => data[key] ? JSON.parse(JSON.stringify(data[key])) : null),
+    writeToStorage: vi.fn(async (key, val) => { data[key] = JSON.parse(JSON.stringify(val)) }),
     _data: data
   }
 }

--- a/platform/jira-taxonomy/server/index.js
+++ b/platform/jira-taxonomy/server/index.js
@@ -22,8 +22,8 @@ module.exports = function registerJiraTaxonomyRoutes(router, context) {
    * Reads the "component" option set and reshapes richValues into the
    * component array format expected by the taxonomy browse UI.
    */
-  function buildComponentResponse() {
-    const data = readFromStorage('team-data/field-options/' + COMPONENT_OPTIONS_NAME + '.json');
+  async function buildComponentResponse() {
+    const data = await readFromStorage('team-data/field-options/' + COMPONENT_OPTIONS_NAME + '.json');
     if (!data || !data.values) {
       return { fetchedAt: null, project: null, components: [], source: null };
     }
@@ -61,9 +61,9 @@ module.exports = function registerJiraTaxonomyRoutes(router, context) {
    *       200:
    *         description: Component list
    */
-  router.get('/jira-components', requireScope('team-tracker:read'), function(req, res) {
+  router.get('/jira-components', requireScope('team-tracker:read'), async function(req, res) {
     try {
-      var result = buildComponentResponse();
+      var result = await buildComponentResponse();
       res.json(result);
     } catch (err) {
       console.error('[jira-taxonomy] Error building component response:', err.message);


### PR DESCRIPTION
## Summary

- The sync-to-async storage refactor (`216670e2`) converted `readFromStorage` to return a Promise, but the jira-taxonomy platform extension was not updated
- The unawaited Promise was truthy so the null-check passed, but `.values` was `undefined`, causing the `/api/modules/team-tracker/jira-components` endpoint to always return an empty component list
- Adds `async`/`await` to `buildComponentResponse()` and the route handler, and updates test mocks to return promises

## Test plan

- [x] Existing unit tests pass (updated mocks to async)
- [ ] Verify component list loads on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)