### PR TITLE
feat: add Epic Creator enablement links to AI Workflows section

### DIFF
--- a/modules/ai-impact/client/enablement-links.js
+++ b/modules/ai-impact/client/enablement-links.js
@@ -101,6 +101,17 @@ export const enablementCategories = [
     ],
   },
   {
+    id: 'epic-creator',
+    title: 'Epic Creator',
+    section: 'ai-workflows',
+    links: [
+      { label: 'Enablement Slides', icon: 'Presentation', url: 'https://docs.google.com/presentation/d/1it2DXpN3CAWgNd-6MrzsTb8B7uG0wQrck_Tw06cghDg/edit?slide=id.ecs01#slide=id.ecs01' },
+      { label: 'Enablement Recording', icon: 'Video', url: 'https://drive.google.com/file/d/1ZV-irsI5DJ57Kdjc7DezVw9hBEgukqKs/view' },
+      { label: 'Enablement Chat', icon: 'MessageSquare', url: 'https://drive.google.com/file/d/1KZkuEzCAQyy3nU56af4BdBour8w1M78I/view' },
+      { label: 'Enablement Notes', icon: 'StickyNote', url: 'https://docs.google.com/document/d/1dJ9iueSJRXuUiMle7gKOi8pl-4_ZtzfeuvaV3UpFPcE/edit?tab=t.bd5xpweg9otp' },
+    ],
+  },
+  {
     id: 'agent-eval-harness',
     title: 'Agent Eval Harness',
     section: 'other',


### PR DESCRIPTION
## Summary
- Adds "Epic Creator" enablement entry to the AI Workflows section in the AI Factory Guide, after the existing Jira Autofix entry
- Includes links to enablement slides, recording, chat, and notes

Closes red-hat-data-services/org-pulse-core#35

## Test plan
- [ ] Verify the Epic Creator card appears under "AI Workflows Enablement" on the AI Factory Guide page
- [ ] Verify all four links open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)