### PR TITLE
feat(ai-impact): add time-windowed trend charts to Test Plan and Feature Review

### DIFF
--- a/fixtures/ai-impact/features.json
+++ b/fixtures/ai-impact/features.json
@@ -1,5 +1,5 @@
 {
-  "lastSyncedAt": "2026-04-20T06:00:00Z",
+  "lastSyncedAt": "2026-07-15T00:00:00Z",
   "totalFeatures": 12,
   "features": {
     "RHAISTRAT-1168": {
@@ -13,23 +13,47 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "approved",
-        "scores": { "feasibility": 2, "testability": 1, "scope": 2, "architecture": 2, "total": 7 },
-        "reviewers": { "feasibility": "approve", "testability": "revise", "scope": "approve", "architecture": "approve" },
-        "components": ["Platform Core"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass", "tech-reviewed", "strat-creator-human-sign-off"],
-        "runId": "20260419-013035",
-        "runTimestamp": "2026-04-19T01:30:35Z",
-        "reviewedAt": "2026-04-19T01:30:35Z",
+        "scores": {
+          "feasibility": 2,
+          "testability": 1,
+          "scope": 2,
+          "architecture": 2,
+          "total": 7
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "revise",
+          "scope": "approve",
+          "architecture": "approve"
+        },
+        "components": [
+          "Platform Core"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass",
+          "tech-reviewed",
+          "strat-creator-human-sign-off"
+        ],
+        "runId": "20260714-013035",
+        "runTimestamp": "2026-07-14T00:00:00Z",
+        "reviewedAt": "2026-07-14T00:00:00Z",
         "approvedBy": "Alice Chen",
-        "approvedAt": "2026-04-20T03:00:00Z"
+        "approvedAt": "2026-07-15T00:00:00Z"
       },
       "history": [
         {
-          "scores": { "feasibility": 1, "testability": 1, "scope": 2, "architecture": 1, "total": 5 },
+          "scores": {
+            "feasibility": 1,
+            "testability": 1,
+            "scope": 2,
+            "architecture": 1,
+            "total": 5
+          },
           "recommendation": "revise",
           "needsAttention": true,
           "humanReviewStatus": "awaiting-review",
-          "reviewedAt": "2026-04-12T01:30:00Z"
+          "reviewedAt": "2026-07-07T00:00:00Z"
         }
       ]
     },
@@ -44,13 +68,30 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 2, "testability": 2, "scope": 2, "architecture": 2, "total": 8 },
-        "reviewers": { "feasibility": "approve", "testability": "approve", "scope": "approve", "architecture": "approve" },
-        "components": ["Platform Core"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass", "tech-reviewed"],
-        "runId": "20260419-013035",
-        "runTimestamp": "2026-04-19T01:30:35Z",
-        "reviewedAt": "2026-04-19T01:30:35Z"
+        "scores": {
+          "feasibility": 2,
+          "testability": 2,
+          "scope": 2,
+          "architecture": 2,
+          "total": 8
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "approve",
+          "scope": "approve",
+          "architecture": "approve"
+        },
+        "components": [
+          "Platform Core"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass",
+          "tech-reviewed"
+        ],
+        "runId": "20260709-013035",
+        "runTimestamp": "2026-07-09T00:00:00Z",
+        "reviewedAt": "2026-07-09T00:00:00Z"
       },
       "history": []
     },
@@ -65,21 +106,43 @@
         "recommendation": "revise",
         "needsAttention": true,
         "humanReviewStatus": "needs-review",
-        "scores": { "feasibility": 1, "testability": 1, "scope": 1, "architecture": 2, "total": 5 },
-        "reviewers": { "feasibility": "revise", "testability": "revise", "scope": "revise", "architecture": "approve" },
-        "components": ["ML Models"],
-        "labels": ["strat-creator-auto-created", "strat-creator-needs-attention"],
-        "runId": "20260419-013035",
-        "runTimestamp": "2026-04-19T01:30:35Z",
-        "reviewedAt": "2026-04-19T01:30:35Z"
+        "scores": {
+          "feasibility": 1,
+          "testability": 1,
+          "scope": 1,
+          "architecture": 2,
+          "total": 5
+        },
+        "reviewers": {
+          "feasibility": "revise",
+          "testability": "revise",
+          "scope": "revise",
+          "architecture": "approve"
+        },
+        "components": [
+          "ML Models"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-needs-attention"
+        ],
+        "runId": "20260704-013035",
+        "runTimestamp": "2026-07-04T00:00:00Z",
+        "reviewedAt": "2026-07-04T00:00:00Z"
       },
       "history": [
         {
-          "scores": { "feasibility": 0, "testability": 1, "scope": 1, "architecture": 1, "total": 3 },
+          "scores": {
+            "feasibility": 0,
+            "testability": 1,
+            "scope": 1,
+            "architecture": 1,
+            "total": 3
+          },
           "recommendation": "reject",
           "needsAttention": true,
           "humanReviewStatus": "awaiting-review",
-          "reviewedAt": "2026-04-12T01:30:00Z"
+          "reviewedAt": "2026-06-27T00:00:00Z"
         }
       ]
     },
@@ -94,13 +157,29 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 2, "testability": 2, "scope": 1, "architecture": 2, "total": 7 },
-        "reviewers": { "feasibility": "approve", "testability": "approve", "scope": "revise", "architecture": "approve" },
-        "components": ["ML Models"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass"],
-        "runId": "20260419-013035",
-        "runTimestamp": "2026-04-19T01:30:35Z",
-        "reviewedAt": "2026-04-19T01:30:35Z"
+        "scores": {
+          "feasibility": 2,
+          "testability": 2,
+          "scope": 1,
+          "architecture": 2,
+          "total": 7
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "approve",
+          "scope": "revise",
+          "architecture": "approve"
+        },
+        "components": [
+          "ML Models"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass"
+        ],
+        "runId": "20260629-013035",
+        "runTimestamp": "2026-06-29T00:00:00Z",
+        "reviewedAt": "2026-06-29T00:00:00Z"
       },
       "history": []
     },
@@ -115,13 +194,29 @@
         "recommendation": "reject",
         "needsAttention": true,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 0, "testability": 1, "scope": 0, "architecture": 1, "total": 2 },
-        "reviewers": { "feasibility": "reject", "testability": "revise", "scope": "reject", "architecture": "revise" },
-        "components": ["ML Models"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-fail"],
-        "runId": "20260419-013035",
-        "runTimestamp": "2026-04-19T01:30:35Z",
-        "reviewedAt": "2026-04-19T01:30:35Z"
+        "scores": {
+          "feasibility": 0,
+          "testability": 1,
+          "scope": 0,
+          "architecture": 1,
+          "total": 2
+        },
+        "reviewers": {
+          "feasibility": "reject",
+          "testability": "revise",
+          "scope": "reject",
+          "architecture": "revise"
+        },
+        "components": [
+          "ML Models"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-fail"
+        ],
+        "runId": "20260624-013035",
+        "runTimestamp": "2026-06-24T00:00:00Z",
+        "reviewedAt": "2026-06-24T00:00:00Z"
       },
       "history": []
     },
@@ -136,15 +231,33 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "approved",
-        "scores": { "feasibility": 2, "testability": 2, "scope": 2, "architecture": 2, "total": 8 },
-        "reviewers": { "feasibility": "approve", "testability": "approve", "scope": "approve", "architecture": "approve" },
-        "components": ["Platform Dashboard"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass", "tech-reviewed", "strat-creator-human-sign-off"],
-        "runId": "20260418-060000",
-        "runTimestamp": "2026-04-18T06:00:00Z",
-        "reviewedAt": "2026-04-18T06:00:00Z",
+        "scores": {
+          "feasibility": 2,
+          "testability": 2,
+          "scope": 2,
+          "architecture": 2,
+          "total": 8
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "approve",
+          "scope": "approve",
+          "architecture": "approve"
+        },
+        "components": [
+          "Platform Dashboard"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass",
+          "tech-reviewed",
+          "strat-creator-human-sign-off"
+        ],
+        "runId": "20260619-013035",
+        "runTimestamp": "2026-06-19T00:00:00Z",
+        "reviewedAt": "2026-06-19T00:00:00Z",
         "approvedBy": "Bob Smith",
-        "approvedAt": "2026-04-19T10:00:00Z"
+        "approvedAt": "2026-06-20T00:00:00Z"
       },
       "history": []
     },
@@ -159,13 +272,28 @@
         "recommendation": "revise",
         "needsAttention": false,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 2, "testability": 1, "scope": 1, "architecture": 1, "total": 5 },
-        "reviewers": { "feasibility": "approve", "testability": "revise", "scope": "revise", "architecture": "revise" },
-        "components": ["Data Pipelines"],
-        "labels": ["strat-creator-auto-created"],
-        "runId": "20260418-060000",
-        "runTimestamp": "2026-04-18T06:00:00Z",
-        "reviewedAt": "2026-04-18T06:00:00Z"
+        "scores": {
+          "feasibility": 2,
+          "testability": 1,
+          "scope": 1,
+          "architecture": 1,
+          "total": 5
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "revise",
+          "scope": "revise",
+          "architecture": "revise"
+        },
+        "components": [
+          "Data Pipelines"
+        ],
+        "labels": [
+          "strat-creator-auto-created"
+        ],
+        "runId": "20260614-013035",
+        "runTimestamp": "2026-06-14T00:00:00Z",
+        "reviewedAt": "2026-06-14T00:00:00Z"
       },
       "history": []
     },
@@ -180,13 +308,30 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 2, "testability": 2, "scope": 2, "architecture": 1, "total": 7 },
-        "reviewers": { "feasibility": "approve", "testability": "approve", "scope": "approve", "architecture": "revise" },
-        "components": ["Platform Core"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass", "tech-reviewed"],
-        "runId": "20260418-060000",
-        "runTimestamp": "2026-04-18T06:00:00Z",
-        "reviewedAt": "2026-04-18T06:00:00Z"
+        "scores": {
+          "feasibility": 2,
+          "testability": 2,
+          "scope": 2,
+          "architecture": 1,
+          "total": 7
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "approve",
+          "scope": "approve",
+          "architecture": "revise"
+        },
+        "components": [
+          "Platform Core"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass",
+          "tech-reviewed"
+        ],
+        "runId": "20260609-013035",
+        "runTimestamp": "2026-06-09T00:00:00Z",
+        "reviewedAt": "2026-06-09T00:00:00Z"
       },
       "history": []
     },
@@ -201,13 +346,30 @@
         "recommendation": "revise",
         "needsAttention": true,
         "humanReviewStatus": "needs-review",
-        "scores": { "feasibility": 1, "testability": 0, "scope": 2, "architecture": 1, "total": 4 },
-        "reviewers": { "feasibility": "revise", "testability": "reject", "scope": "approve", "architecture": "revise" },
-        "components": ["Platform Core", "Infrastructure Services"],
-        "labels": ["strat-creator-auto-created", "strat-creator-needs-attention"],
-        "runId": "20260418-060000",
-        "runTimestamp": "2026-04-18T06:00:00Z",
-        "reviewedAt": "2026-04-18T06:00:00Z"
+        "scores": {
+          "feasibility": 1,
+          "testability": 0,
+          "scope": 2,
+          "architecture": 1,
+          "total": 4
+        },
+        "reviewers": {
+          "feasibility": "revise",
+          "testability": "reject",
+          "scope": "approve",
+          "architecture": "revise"
+        },
+        "components": [
+          "Platform Core",
+          "Infrastructure Services"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-needs-attention"
+        ],
+        "runId": "20260604-013035",
+        "runTimestamp": "2026-06-04T00:00:00Z",
+        "reviewedAt": "2026-06-04T00:00:00Z"
       },
       "history": []
     },
@@ -222,13 +384,30 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 2, "testability": 2, "scope": 1, "architecture": 2, "total": 7 },
-        "reviewers": { "feasibility": "approve", "testability": "approve", "scope": "revise", "architecture": "approve" },
-        "components": ["ML Models", "Platform Core"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass"],
-        "runId": "20260417-060000",
-        "runTimestamp": "2026-04-17T06:00:00Z",
-        "reviewedAt": "2026-04-17T06:00:00Z"
+        "scores": {
+          "feasibility": 2,
+          "testability": 2,
+          "scope": 1,
+          "architecture": 2,
+          "total": 7
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "approve",
+          "scope": "revise",
+          "architecture": "approve"
+        },
+        "components": [
+          "ML Models",
+          "Platform Core"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass"
+        ],
+        "runId": "20260530-013035",
+        "runTimestamp": "2026-05-30T00:00:00Z",
+        "reviewedAt": "2026-05-30T00:00:00Z"
       },
       "history": []
     },
@@ -243,21 +422,43 @@
         "recommendation": "reject",
         "needsAttention": true,
         "humanReviewStatus": "awaiting-review",
-        "scores": { "feasibility": 1, "testability": 0, "scope": 0, "architecture": 0, "total": 1 },
-        "reviewers": { "feasibility": "revise", "testability": "reject", "scope": "reject", "architecture": "reject" },
-        "components": ["Infrastructure Services"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-fail"],
-        "runId": "20260417-060000",
-        "runTimestamp": "2026-04-17T06:00:00Z",
-        "reviewedAt": "2026-04-17T06:00:00Z"
+        "scores": {
+          "feasibility": 1,
+          "testability": 0,
+          "scope": 0,
+          "architecture": 0,
+          "total": 1
+        },
+        "reviewers": {
+          "feasibility": "revise",
+          "testability": "reject",
+          "scope": "reject",
+          "architecture": "reject"
+        },
+        "components": [
+          "Infrastructure Services"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-fail"
+        ],
+        "runId": "20260525-013035",
+        "runTimestamp": "2026-05-25T00:00:00Z",
+        "reviewedAt": "2026-05-25T00:00:00Z"
       },
       "history": [
         {
-          "scores": { "feasibility": 0, "testability": 0, "scope": 0, "architecture": 0, "total": 0 },
+          "scores": {
+            "feasibility": 0,
+            "testability": 0,
+            "scope": 0,
+            "architecture": 0,
+            "total": 0
+          },
           "recommendation": "reject",
           "needsAttention": true,
           "humanReviewStatus": "awaiting-review",
-          "reviewedAt": "2026-04-10T06:00:00Z"
+          "reviewedAt": "2026-05-18T00:00:00Z"
         }
       ]
     },
@@ -272,15 +473,33 @@
         "recommendation": "approve",
         "needsAttention": false,
         "humanReviewStatus": "approved",
-        "scores": { "feasibility": 2, "testability": 1, "scope": 2, "architecture": 2, "total": 7 },
-        "reviewers": { "feasibility": "approve", "testability": "revise", "scope": "approve", "architecture": "approve" },
-        "components": ["ML Models"],
-        "labels": ["strat-creator-auto-created", "strat-creator-rubric-pass", "tech-reviewed", "strat-creator-human-sign-off"],
-        "runId": "20260419-013035",
-        "runTimestamp": "2026-04-19T01:30:35Z",
-        "reviewedAt": "2026-04-19T01:30:35Z",
+        "scores": {
+          "feasibility": 2,
+          "testability": 1,
+          "scope": 2,
+          "architecture": 2,
+          "total": 7
+        },
+        "reviewers": {
+          "feasibility": "approve",
+          "testability": "revise",
+          "scope": "approve",
+          "architecture": "approve"
+        },
+        "components": [
+          "ML Models"
+        ],
+        "labels": [
+          "strat-creator-auto-created",
+          "strat-creator-rubric-pass",
+          "tech-reviewed",
+          "strat-creator-human-sign-off"
+        ],
+        "runId": "20260519-013035",
+        "runTimestamp": "2026-05-19T00:00:00Z",
+        "reviewedAt": "2026-05-19T00:00:00Z",
         "approvedBy": "Frank Johnson",
-        "approvedAt": "2026-04-20T08:00:00Z"
+        "approvedAt": "2026-05-20T00:00:00Z"
       },
       "history": []
     }

--- a/fixtures/ai-impact/rfe-data.json
+++ b/fixtures/ai-impact/rfe-data.json
@@ -1,16 +1,22 @@
 {
-  "fetchedAt": "2026-06-11T12:00:00Z",
+  "fetchedAt": "2026-07-21T12:00:00Z",
   "issues": [
     {
       "key": "RHAIRFE-1001",
       "summary": "Implement model serving autoscaling for high-throughput inference",
       "status": "In Progress",
       "priority": "High",
-      "created": "2026-03-15T10:00:00Z",
+      "created": "2026-04-24T10:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "components": ["Platform Core"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "customer-request"],
+      "components": [
+        "Platform Core"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "customer-request"
+      ],
       "aiInvolvement": "both",
       "needsAttentionSince": null,
       "rubricPassSince": null,
@@ -18,7 +24,9 @@
         "key": "RHAISTRAT-1168",
         "summary": "GPU-as-a-Service Observability Dashboard",
         "status": "Refined",
-        "fixVersions": ["RHOAI 2.16"]
+        "fixVersions": [
+          "RHOAI 2.16"
+        ]
       }
     },
     {
@@ -26,14 +34,20 @@
       "summary": "Add GPU memory monitoring dashboard for notebook users",
       "status": "New",
       "priority": "Medium",
-      "created": "2026-03-12T14:30:00Z",
+      "created": "2026-04-21T14:30:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
-      "components": ["Platform Dashboard"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-autofix-rubric-pass", "strat-creator-3.5"],
+      "components": [
+        "Platform Dashboard"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-autofix-rubric-pass",
+        "strat-creator-3.5"
+      ],
       "aiInvolvement": "created",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-03-25T14:00:00Z",
+      "rubricPassSince": "2026-05-04T14:00:00Z",
       "linkedFeature": null
     },
     {
@@ -41,19 +55,28 @@
       "summary": "Support for fine-tuning LLMs with custom datasets",
       "status": "In Review",
       "priority": "Critical",
-      "created": "2026-03-10T09:15:00Z",
+      "created": "2026-04-19T09:15:00Z",
       "creator": "mgarcia",
       "creatorDisplayName": "Maria Garcia",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "tech-reviewed", "strategic"],
+      "components": [
+        "ML Models"
+      ],
+      "labels": [
+        "rfe-creator-auto-revised",
+        "rfe-creator-autofix-rubric-pass",
+        "tech-reviewed",
+        "strategic"
+      ],
       "aiInvolvement": "revised",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-03-18T10:30:00Z",
+      "rubricPassSince": "2026-04-27T10:30:00Z",
       "linkedFeature": {
         "key": "RHAISTRAT-502",
         "summary": "Strat: LLM fine-tuning capability",
         "status": "Planning",
-        "fixVersions": ["RHOAI 2.17"]
+        "fixVersions": [
+          "RHOAI 2.17"
+        ]
       }
     },
     {
@@ -61,10 +84,12 @@
       "summary": "Integrate OpenTelemetry tracing for pipeline debugging",
       "status": "New",
       "priority": "Low",
-      "created": "2026-03-08T11:00:00Z",
+      "created": "2026-04-17T11:00:00Z",
       "creator": "akim",
       "creatorDisplayName": "Alex Kim",
-      "components": ["Infrastructure Services"],
+      "components": [
+        "Infrastructure Services"
+      ],
       "labels": [],
       "aiInvolvement": "none",
       "needsAttentionSince": null,
@@ -76,14 +101,21 @@
       "summary": "Multi-model A/B testing framework for inference endpoints",
       "status": "In Progress",
       "priority": "High",
-      "created": "2026-02-28T16:45:00Z",
+      "created": "2026-04-09T16:45:00Z",
       "creator": "lwong",
       "creatorDisplayName": "Lisa Wong",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "rfe-creator-needs-attention"],
+      "components": [
+        "ML Models"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-autofix-rubric-pass",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "both",
-      "needsAttentionSince": "2026-03-14T10:00:00Z",
-      "rubricPassSince": "2026-03-10T08:00:00Z",
+      "needsAttentionSince": "2026-04-23T10:00:00Z",
+      "rubricPassSince": "2026-04-19T08:00:00Z",
       "linkedFeature": null
     },
     {
@@ -91,13 +123,18 @@
       "summary": "Automated data quality validation for training pipelines",
       "status": "New",
       "priority": "Medium",
-      "created": "2026-02-20T08:30:00Z",
+      "created": "2026-04-01T08:30:00Z",
       "creator": "rpatel",
       "creatorDisplayName": "Raj Patel",
-      "components": ["Data Pipelines"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
+      "components": [
+        "Data Pipelines"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "created",
-      "needsAttentionSince": "2026-04-15T09:00:00Z",
+      "needsAttentionSince": "2026-05-25T09:00:00Z",
       "rubricPassSince": null,
       "linkedFeature": null
     },
@@ -106,14 +143,19 @@
       "summary": "Role-based access control for shared model registry",
       "status": "In Review",
       "priority": "High",
-      "created": "2026-02-15T13:20:00Z",
+      "created": "2026-03-27T13:20:00Z",
       "creator": "emiller",
       "creatorDisplayName": "Emily Miller",
-      "components": ["Platform Core"],
-      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass"],
+      "components": [
+        "Platform Core"
+      ],
+      "labels": [
+        "rfe-creator-auto-revised",
+        "rfe-creator-autofix-rubric-pass"
+      ],
       "aiInvolvement": "revised",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-04-10T11:00:00Z",
+      "rubricPassSince": "2026-05-20T11:00:00Z",
       "linkedFeature": null
     },
     {
@@ -121,14 +163,21 @@
       "summary": "Support custom runtime images for Jupyter notebooks",
       "status": "New",
       "priority": "Medium",
-      "created": "2026-02-10T10:00:00Z",
+      "created": "2026-03-22T10:00:00Z",
       "creator": "dlee",
       "creatorDisplayName": "David Lee",
-      "components": ["Platform Core", "Infrastructure Services"],
-      "labels": ["rfe-creator-autofix-rubric-pass", "tech-reviewed", "strat-creator-3.5"],
+      "components": [
+        "Platform Core",
+        "Infrastructure Services"
+      ],
+      "labels": [
+        "rfe-creator-autofix-rubric-pass",
+        "tech-reviewed",
+        "strat-creator-3.5"
+      ],
       "aiInvolvement": "none",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-04-01T08:30:00Z",
+      "rubricPassSince": "2026-05-11T08:30:00Z",
       "linkedFeature": null
     },
     {
@@ -136,14 +185,21 @@
       "summary": "Federated learning support for distributed model training",
       "status": "In Progress",
       "priority": "Critical",
-      "created": "2026-01-25T15:00:00Z",
+      "created": "2026-03-06T15:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "innovation"],
+      "components": [
+        "ML Models"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-autofix-rubric-pass",
+        "innovation"
+      ],
       "aiInvolvement": "both",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-04-20T09:00:00Z",
+      "rubricPassSince": "2026-05-30T09:00:00Z",
       "linkedFeature": null
     },
     {
@@ -151,10 +207,13 @@
       "summary": "Improve model deployment latency for real-time applications",
       "status": "New",
       "priority": "High",
-      "created": "2026-01-15T09:45:00Z",
+      "created": "2026-02-24T09:45:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
-      "components": ["ML Models", "Platform Core"],
+      "components": [
+        "ML Models",
+        "Platform Core"
+      ],
       "labels": [],
       "aiInvolvement": "none",
       "needsAttentionSince": null,
@@ -166,11 +225,16 @@
       "summary": "Enable custom metrics collection for deployed model endpoints",
       "status": "New",
       "priority": "Medium",
-      "created": "2026-01-18T10:30:00Z",
+      "created": "2026-02-27T10:30:00Z",
       "creator": "bsanders",
       "creatorDisplayName": "Ben Sanders",
-      "components": ["Platform Dashboard"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-fail"],
+      "components": [
+        "Platform Dashboard"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-feasibility-fail"
+      ],
       "aiInvolvement": "created",
       "needsAttentionSince": null,
       "rubricPassSince": null,
@@ -181,13 +245,19 @@
       "summary": "Implement batch inference scheduling with priority queues",
       "status": "In Review",
       "priority": "High",
-      "created": "2026-02-03T14:00:00Z",
+      "created": "2026-03-15T14:00:00Z",
       "creator": "lchang",
       "creatorDisplayName": "Lin Chang",
-      "components": ["ML Models"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-needs-attention"],
+      "components": [
+        "ML Models"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "both",
-      "needsAttentionSince": "2026-05-01T11:00:00Z",
+      "needsAttentionSince": "2026-06-10T11:00:00Z",
       "rubricPassSince": null,
       "linkedFeature": null
     },
@@ -196,11 +266,16 @@
       "summary": "Add support for neuromorphic hardware accelerators in serving runtime",
       "status": "New",
       "priority": "Low",
-      "created": "2026-02-25T09:00:00Z",
+      "created": "2026-04-06T09:00:00Z",
       "creator": "nthomas",
       "creatorDisplayName": "Nina Thomas",
-      "components": ["Infrastructure Services"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-feasibility-unknown"],
+      "components": [
+        "Infrastructure Services"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-feasibility-unknown"
+      ],
       "aiInvolvement": "created",
       "needsAttentionSince": null,
       "rubricPassSince": null,
@@ -211,13 +286,18 @@
       "summary": "Expose per-request latency percentiles in model serving metrics",
       "status": "New",
       "priority": "Medium",
-      "created": "2026-01-28T11:00:00Z",
+      "created": "2026-03-09T11:00:00Z",
       "creator": "dlee",
       "creatorDisplayName": "David Lee",
-      "components": ["Platform Dashboard"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
+      "components": [
+        "Platform Dashboard"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "created",
-      "needsAttentionSince": "2026-05-28T09:30:00Z",
+      "needsAttentionSince": "2026-07-07T09:30:00Z",
       "rubricPassSince": null,
       "linkedFeature": null
     },
@@ -226,13 +306,20 @@
       "summary": "Add experiment comparison view for hyperparameter tuning runs",
       "status": "New",
       "priority": "High",
-      "created": "2026-02-12T13:30:00Z",
+      "created": "2026-03-24T13:30:00Z",
       "creator": "lchang",
       "creatorDisplayName": "Lin Chang",
-      "components": ["ML Models", "Platform Dashboard"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-needs-attention"],
+      "components": [
+        "ML Models",
+        "Platform Dashboard"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "both",
-      "needsAttentionSince": "2026-06-05T08:00:00Z",
+      "needsAttentionSince": "2026-07-15T08:00:00Z",
       "rubricPassSince": null,
       "linkedFeature": null
     },
@@ -241,11 +328,17 @@
       "summary": "Cross-cluster model weight synchronization for geo-distributed serving",
       "status": "New",
       "priority": "Critical",
-      "created": "2026-03-05T09:45:00Z",
+      "created": "2026-04-14T09:45:00Z",
       "creator": "akim",
       "creatorDisplayName": "Alex Kim",
-      "components": ["Platform Core"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-feasibility-fail"],
+      "components": [
+        "Platform Core"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-feasibility-fail"
+      ],
       "aiInvolvement": "both",
       "needsAttentionSince": null,
       "rubricPassSince": null,
@@ -256,13 +349,19 @@
       "summary": "Automated model drift detection with configurable alert thresholds",
       "status": "New",
       "priority": "High",
-      "created": "2026-03-20T11:15:00Z",
+      "created": "2026-04-29T11:15:00Z",
       "creator": "rpatel",
       "creatorDisplayName": "Raj Patel",
-      "components": ["Platform Dashboard", "ML Models"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-needs-attention"],
+      "components": [
+        "Platform Dashboard",
+        "ML Models"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "created",
-      "needsAttentionSince": "2026-05-20T14:00:00Z",
+      "needsAttentionSince": "2026-06-29T14:00:00Z",
       "rubricPassSince": null,
       "linkedFeature": null
     },
@@ -271,11 +370,17 @@
       "summary": "Real-time feature store integration with sub-millisecond retrieval latency",
       "status": "New",
       "priority": "Critical",
-      "created": "2026-04-08T13:45:00Z",
+      "created": "2026-05-18T13:45:00Z",
       "creator": "emiller",
       "creatorDisplayName": "Emily Miller",
-      "components": ["Data Pipelines"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-feasibility-fail"],
+      "components": [
+        "Data Pipelines"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-feasibility-fail"
+      ],
       "aiInvolvement": "both",
       "needsAttentionSince": null,
       "rubricPassSince": null,
@@ -286,14 +391,20 @@
       "summary": "Improve pipeline step caching for faster iterative reruns",
       "status": "In Review",
       "priority": "Medium",
-      "created": "2026-04-25T10:00:00Z",
+      "created": "2026-06-04T10:00:00Z",
       "creator": "schen",
       "creatorDisplayName": "Sarah Chen",
-      "components": ["Data Pipelines"],
-      "labels": ["rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "tech-reviewed"],
+      "components": [
+        "Data Pipelines"
+      ],
+      "labels": [
+        "rfe-creator-auto-revised",
+        "rfe-creator-autofix-rubric-pass",
+        "tech-reviewed"
+      ],
       "aiInvolvement": "revised",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-05-10T10:00:00Z",
+      "rubricPassSince": "2026-06-19T10:00:00Z",
       "linkedFeature": null
     },
     {
@@ -301,14 +412,21 @@
       "summary": "Multi-cluster model serving with automatic traffic failover",
       "status": "In Progress",
       "priority": "High",
-      "created": "2026-05-18T09:30:00Z",
+      "created": "2026-06-27T09:30:00Z",
       "creator": "jpark",
       "creatorDisplayName": "James Park",
-      "components": ["Platform Core"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-auto-revised", "rfe-creator-autofix-rubric-pass", "strat-creator-3.5"],
+      "components": [
+        "Platform Core"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-auto-revised",
+        "rfe-creator-autofix-rubric-pass",
+        "strat-creator-3.5"
+      ],
       "aiInvolvement": "both",
       "needsAttentionSince": null,
-      "rubricPassSince": "2026-06-01T09:00:00Z",
+      "rubricPassSince": "2026-07-11T09:00:00Z",
       "linkedFeature": null
     },
     {
@@ -316,14 +434,21 @@
       "summary": "Integrate compliance audit logging for regulated ML workloads",
       "status": "In Review",
       "priority": "High",
-      "created": "2026-06-04T14:00:00Z",
+      "created": "2026-07-14T14:00:00Z",
       "creator": "mgarcia",
       "creatorDisplayName": "Maria Garcia",
-      "components": ["Platform Core", "Infrastructure Services"],
-      "labels": ["rfe-creator-auto-created", "rfe-creator-autofix-rubric-pass", "rfe-creator-needs-attention"],
+      "components": [
+        "Platform Core",
+        "Infrastructure Services"
+      ],
+      "labels": [
+        "rfe-creator-auto-created",
+        "rfe-creator-autofix-rubric-pass",
+        "rfe-creator-needs-attention"
+      ],
       "aiInvolvement": "created",
-      "needsAttentionSince": "2026-06-09T10:00:00Z",
-      "rubricPassSince": "2026-06-08T09:00:00Z",
+      "needsAttentionSince": "2026-07-19T10:00:00Z",
+      "rubricPassSince": "2026-07-18T09:00:00Z",
       "linkedFeature": null
     }
   ]

--- a/fixtures/ai-impact/test-plans.json
+++ b/fixtures/ai-impact/test-plans.json
@@ -1,6 +1,6 @@
 {
-  "lastSyncedAt": "2026-05-10T18:00:00Z",
-  "lastJiraSyncAt": "2026-05-10T18:05:00Z",
+  "lastSyncedAt": "2026-07-15T00:00:00Z",
+  "lastJiraSyncAt": "2026-07-15T00:00:00Z",
   "totalTestPlans": 7,
   "testPlans": {
     "RHAISTRAT-1168": {
@@ -10,10 +10,22 @@
         "sourceKey": "RHAISTRAT-1168",
         "score": 9,
         "verdict": "Ready",
-        "scores": { "specificity": 2, "grounding": 2, "scope_fidelity": 2, "actionability": 2, "consistency": 1 },
+        "scores": {
+          "specificity": 2,
+          "grounding": 2,
+          "scope_fidelity": 2,
+          "actionability": 2,
+          "consistency": 1
+        },
         "autoRevised": true,
         "beforeScore": 6,
-        "beforeScores": { "specificity": 1, "grounding": 1, "scope_fidelity": 2, "actionability": 1, "consistency": 1 },
+        "beforeScores": {
+          "specificity": 1,
+          "grounding": 1,
+          "scope_fidelity": 2,
+          "actionability": 1,
+          "consistency": 1
+        },
         "criterionNotes": {
           "specificity": "Test steps reference specific API endpoints and expected response codes.",
           "grounding": "All endpoints traced back to source strategy.",
@@ -23,25 +35,39 @@
         },
         "feedback": "Strong test plan. Fix Section 2.3 priority definitions to match Section 4.",
         "error": null,
-        "components": ["dashboard", "model-serving"],
+        "components": [
+          "dashboard",
+          "model-serving"
+        ],
         "testCaseCount": 24,
         "jiraTitle": "GPU-as-a-Service Observability Dashboard",
         "jiraStatus": "In Progress",
         "jiraPriority": "Critical",
-        "labels": ["test-plan-auto-created", "test-plan-auto-revised", "test-plan-rubric-pass", "test-plan-human-sign-off"],
+        "labels": [
+          "test-plan-auto-created",
+          "test-plan-auto-revised",
+          "test-plan-rubric-pass",
+          "test-plan-human-sign-off"
+        ],
         "humanReviewStatus": "approved",
         "approvedBy": "Alice Nguyen",
-        "approvedAt": "2026-05-10T14:30:00Z",
-        "reviewedAt": "2026-05-10T12:00:00Z",
+        "approvedAt": "2026-07-15T00:00:00Z",
+        "reviewedAt": "2026-07-14T00:00:00Z",
         "gitlabPath": "RHAISTRAT/20260510-120000-RHAISTRAT-1168/gpu_observability_dashboard"
       },
       "history": [
         {
-          "scores": { "specificity": 1, "grounding": 1, "scope_fidelity": 2, "actionability": 1, "consistency": 1 },
+          "scores": {
+            "specificity": 1,
+            "grounding": 1,
+            "scope_fidelity": 2,
+            "actionability": 1,
+            "consistency": 1
+          },
           "score": 6,
           "verdict": "Revise",
           "autoRevised": false,
-          "reviewedAt": "2026-05-03T12:00:00Z"
+          "reviewedAt": "2026-07-07T00:00:00Z"
         }
       ]
     },
@@ -52,22 +78,34 @@
         "sourceKey": "RHAISTRAT-1169",
         "score": 5,
         "verdict": "Revise",
-        "scores": { "specificity": 1, "grounding": 1, "scope_fidelity": 2, "actionability": 0, "consistency": 1 },
+        "scores": {
+          "specificity": 1,
+          "grounding": 1,
+          "scope_fidelity": 2,
+          "actionability": 0,
+          "consistency": 1
+        },
         "autoRevised": false,
         "beforeScore": null,
         "beforeScores": null,
         "criterionNotes": {},
-        "feedback": "Actionability is the main gap — test data requirements are too vague for QE to start.",
-        "gapAnalysis": "## Scope & Endpoints\n\n- **Autoscaling metrics API specification (CPU, memory,\n  custom metrics)** — Strategy references CPU/memory-based\n  scaling but does not specify which Prometheus metrics trigger\n  scale-up/down or custom metrics API endpoints. Would be\n  resolved by: API spec or KServe autoscaler design doc.\n- **InferenceService autoscaler configuration schema** — HPA settings (minReplicas, maxReplicas, targetUtilizationPercentage) are mentioned but field names and validation rules not provided. Would be resolved by: KServe CRD specification.\n- **Throughput measurement endpoint** — Strategy requires \"high-throughput inference\" validation but does not specify how requests/second is measured or logged. Would be resolved by: API spec for metrics endpoints.\n\n## Test Strategy & Risks\n\n- **Baseline performance targets** — Strategy requires validating autoscaling improves throughput but does not define baseline latency/throughput SLOs (e.g., \"< 200ms p95 latency at 100 req/s\"). Would be resolved by: NFR specification or feature refinement.\n- **Load pattern specifications** — Test plan needs realistic\n  traffic patterns (burst vs sustained load, request size\n  distribution) but these are not defined. Would be resolved\n  by: Test data specification or design doc.\n- **Scale-down delay configuration** — KServe scale-to-zero behavior impacts testing but cooldown periods and grace periods are not specified. Would be resolved by: Feature refinement or KServe configuration guide.\n\n## Environment & Infrastructure\n\n- **GPU resource requirements** — Strategy implies GPU-accelerated models but does not specify GPU types, memory sizes, or multi-GPU configurations needed for testing. Would be resolved by: Infrastructure requirements doc.\n- **Model artifact specifications** — No sample models specified (framework, size, format). Test plan cannot define model deployment without concrete examples. Would be resolved by: Test data catalog or design doc.\n- **Cluster sizing for realistic load** — Node count, CPU/memory limits, and network bandwidth requirements for load testing are not specified. Would be resolved by: Infrastructure design doc.",
+        "feedback": "Actionability is the main gap \u2014 test data requirements are too vague for QE to start.",
+        "gapAnalysis": "## Scope & Endpoints\n\n- **Autoscaling metrics API specification (CPU, memory,\n  custom metrics)** \u2014 Strategy references CPU/memory-based\n  scaling but does not specify which Prometheus metrics trigger\n  scale-up/down or custom metrics API endpoints. Would be\n  resolved by: API spec or KServe autoscaler design doc.\n- **InferenceService autoscaler configuration schema** \u2014 HPA settings (minReplicas, maxReplicas, targetUtilizationPercentage) are mentioned but field names and validation rules not provided. Would be resolved by: KServe CRD specification.\n- **Throughput measurement endpoint** \u2014 Strategy requires \"high-throughput inference\" validation but does not specify how requests/second is measured or logged. Would be resolved by: API spec for metrics endpoints.\n\n## Test Strategy & Risks\n\n- **Baseline performance targets** \u2014 Strategy requires validating autoscaling improves throughput but does not define baseline latency/throughput SLOs (e.g., \"< 200ms p95 latency at 100 req/s\"). Would be resolved by: NFR specification or feature refinement.\n- **Load pattern specifications** \u2014 Test plan needs realistic\n  traffic patterns (burst vs sustained load, request size\n  distribution) but these are not defined. Would be resolved\n  by: Test data specification or design doc.\n- **Scale-down delay configuration** \u2014 KServe scale-to-zero behavior impacts testing but cooldown periods and grace periods are not specified. Would be resolved by: Feature refinement or KServe configuration guide.\n\n## Environment & Infrastructure\n\n- **GPU resource requirements** \u2014 Strategy implies GPU-accelerated models but does not specify GPU types, memory sizes, or multi-GPU configurations needed for testing. Would be resolved by: Infrastructure requirements doc.\n- **Model artifact specifications** \u2014 No sample models specified (framework, size, format). Test plan cannot define model deployment without concrete examples. Would be resolved by: Test data catalog or design doc.\n- **Cluster sizing for realistic load** \u2014 Node count, CPU/memory limits, and network bandwidth requirements for load testing are not specified. Would be resolved by: Infrastructure design doc.",
         "error": null,
-        "components": ["model-serving", "kserve"],
+        "components": [
+          "model-serving",
+          "kserve"
+        ],
         "testCaseCount": 8,
         "jiraTitle": "Model Serving Autoscaling for High-Throughput Inference",
         "jiraStatus": "Refined",
         "jiraPriority": "Major",
-        "labels": ["test-plan-auto-created", "test-plan-rubric-fail"],
+        "labels": [
+          "test-plan-auto-created",
+          "test-plan-rubric-fail"
+        ],
         "humanReviewStatus": "needs-review",
-        "reviewedAt": "2026-05-09T14:00:00Z"
+        "reviewedAt": "2026-07-07T00:00:00Z"
       },
       "history": []
     },
@@ -78,22 +116,33 @@
         "sourceKey": "RHAISTRAT-1170",
         "score": 3,
         "verdict": "Rework",
-        "scores": { "specificity": 0, "grounding": 1, "scope_fidelity": 1, "actionability": 0, "consistency": 1 },
+        "scores": {
+          "specificity": 0,
+          "grounding": 1,
+          "scope_fidelity": 1,
+          "actionability": 0,
+          "consistency": 1
+        },
         "autoRevised": false,
         "beforeScore": null,
         "beforeScores": null,
         "criterionNotes": {},
-        "feedback": "Test plan is too generic — reads like a template, not a feature-specific plan.",
-        "gapAnalysis": "## Scope & Endpoints\n\n- **Training Operator API extensions for GPU scheduling** — Strategy describes \"GPU scheduling improvements\" but does not reference specific PyTorchJob, TFJob, or MPIJob CRD field changes. Would be resolved by: ADR or Training Operator API specification.\n- **GPU topology awareness implementation** — Strategy mentions topology-aware scheduling but does not specify Kubernetes node labels, device plugin APIs, or scheduler plugin interfaces used. Would be resolved by: Design doc or Kubernetes scheduler integration spec.\n- **Resource quota enforcement mechanism** — Strategy requires multi-tenant GPU sharing but does not specify ResourceQuota or LimitRange configurations or namespace-level enforcement. Would be resolved by: Design doc.\n\n## Test Strategy & Risks\n\n- **Concrete GPU scheduling scenarios** — Test plan lists generic \"verify GPU allocation\" steps without specific node topologies (single-node 8xGPU vs multi-node 4xGPU), affinity rules, or failure modes. Would be resolved by: Feature refinement with concrete use cases.\n- **Scheduler plugin decision points** — Strategy implies custom scheduler logic but does not define scoring/filtering criteria, preemption policies, or fallback behavior. Would be resolved by: Design doc or Kubernetes scheduler plugin specification.\n- **Performance degradation acceptance criteria** — Strategy requires \"no performance regression\" but does not specify job startup latency, scheduling throughput, or GPU utilization targets. Would be resolved by: NFR specification.\n- **Integration with existing GPU device plugins** — Test plan does not specify which NVIDIA device plugin version, driver version, or CUDA runtime is assumed. Would be resolved by: Compatibility matrix or infrastructure requirements.\n\n## Environment & Infrastructure\n\n- **GPU hardware topology configurations** — No specification of test configurations (NVLink vs PCIe, single vs multi-GPU nodes, GPU memory sizes). Would be resolved by: Test environment design doc.\n- **Training Operator version compatibility** — Minimum Training Operator version for this feature not specified. Would be resolved by: Release planning documentation.\n- **Multi-tenant namespace setup** — How many tenants, resource quota values per tenant, and RBAC roles for testing are not defined. Would be resolved by: Test environment setup guide.",
+        "feedback": "Test plan is too generic \u2014 reads like a template, not a feature-specific plan.",
+        "gapAnalysis": "## Scope & Endpoints\n\n- **Training Operator API extensions for GPU scheduling** \u2014 Strategy describes \"GPU scheduling improvements\" but does not reference specific PyTorchJob, TFJob, or MPIJob CRD field changes. Would be resolved by: ADR or Training Operator API specification.\n- **GPU topology awareness implementation** \u2014 Strategy mentions topology-aware scheduling but does not specify Kubernetes node labels, device plugin APIs, or scheduler plugin interfaces used. Would be resolved by: Design doc or Kubernetes scheduler integration spec.\n- **Resource quota enforcement mechanism** \u2014 Strategy requires multi-tenant GPU sharing but does not specify ResourceQuota or LimitRange configurations or namespace-level enforcement. Would be resolved by: Design doc.\n\n## Test Strategy & Risks\n\n- **Concrete GPU scheduling scenarios** \u2014 Test plan lists generic \"verify GPU allocation\" steps without specific node topologies (single-node 8xGPU vs multi-node 4xGPU), affinity rules, or failure modes. Would be resolved by: Feature refinement with concrete use cases.\n- **Scheduler plugin decision points** \u2014 Strategy implies custom scheduler logic but does not define scoring/filtering criteria, preemption policies, or fallback behavior. Would be resolved by: Design doc or Kubernetes scheduler plugin specification.\n- **Performance degradation acceptance criteria** \u2014 Strategy requires \"no performance regression\" but does not specify job startup latency, scheduling throughput, or GPU utilization targets. Would be resolved by: NFR specification.\n- **Integration with existing GPU device plugins** \u2014 Test plan does not specify which NVIDIA device plugin version, driver version, or CUDA runtime is assumed. Would be resolved by: Compatibility matrix or infrastructure requirements.\n\n## Environment & Infrastructure\n\n- **GPU hardware topology configurations** \u2014 No specification of test configurations (NVLink vs PCIe, single vs multi-GPU nodes, GPU memory sizes). Would be resolved by: Test environment design doc.\n- **Training Operator version compatibility** \u2014 Minimum Training Operator version for this feature not specified. Would be resolved by: Release planning documentation.\n- **Multi-tenant namespace setup** \u2014 How many tenants, resource quota values per tenant, and RBAC roles for testing are not defined. Would be resolved by: Test environment setup guide.",
         "error": null,
-        "components": ["training-operator"],
+        "components": [
+          "training-operator"
+        ],
         "testCaseCount": 4,
         "jiraTitle": "Training Operator GPU Scheduling Improvements",
         "jiraStatus": "New",
         "jiraPriority": "Normal",
-        "labels": ["test-plan-auto-created", "test-plan-rubric-fail"],
+        "labels": [
+          "test-plan-auto-created",
+          "test-plan-rubric-fail"
+        ],
         "humanReviewStatus": "needs-review",
-        "reviewedAt": "2026-05-08T10:00:00Z"
+        "reviewedAt": "2026-06-30T00:00:00Z"
       },
       "history": []
     },
@@ -104,7 +153,13 @@
         "sourceKey": "RHAISTRAT-1171",
         "score": 10,
         "verdict": "Ready",
-        "scores": { "specificity": 2, "grounding": 2, "scope_fidelity": 2, "actionability": 2, "consistency": 2 },
+        "scores": {
+          "specificity": 2,
+          "grounding": 2,
+          "scope_fidelity": 2,
+          "actionability": 2,
+          "consistency": 2
+        },
         "autoRevised": false,
         "beforeScore": null,
         "beforeScores": null,
@@ -113,20 +168,26 @@
           "grounding": "All endpoints from the strategy are covered with cross-reference table.",
           "scope_fidelity": "In-scope and out-of-scope perfectly match strategy.",
           "actionability": "Test data, users, and cluster config fully specified.",
-          "consistency": "All sections align — priorities, endpoints, coverage matrix."
+          "consistency": "All sections align \u2014 priorities, endpoints, coverage matrix."
         },
         "feedback": "Exemplary test plan. Ready for test case generation.",
         "error": null,
-        "components": ["model-registry"],
+        "components": [
+          "model-registry"
+        ],
         "testCaseCount": 18,
         "jiraTitle": "Model Registry RBAC and Multi-Tenancy Support",
         "jiraStatus": "In Progress",
         "jiraPriority": "Critical",
-        "labels": ["test-plan-auto-created", "test-plan-rubric-pass", "test-plan-human-sign-off"],
+        "labels": [
+          "test-plan-auto-created",
+          "test-plan-rubric-pass",
+          "test-plan-human-sign-off"
+        ],
         "humanReviewStatus": "approved",
         "approvedBy": "Bob Chen",
-        "approvedAt": "2026-05-10T16:45:00Z",
-        "reviewedAt": "2026-05-10T16:00:00Z"
+        "approvedAt": "2026-06-24T00:00:00Z",
+        "reviewedAt": "2026-06-23T00:00:00Z"
       },
       "history": []
     },
@@ -137,21 +198,33 @@
         "sourceKey": "RHAISTRAT-1172",
         "score": 8,
         "verdict": "Ready",
-        "scores": { "specificity": 2, "grounding": 2, "scope_fidelity": 2, "actionability": 1, "consistency": 1 },
+        "scores": {
+          "specificity": 2,
+          "grounding": 2,
+          "scope_fidelity": 2,
+          "actionability": 1,
+          "consistency": 1
+        },
         "autoRevised": false,
         "beforeScore": null,
         "beforeScores": null,
         "criterionNotes": {},
         "feedback": "Good plan overall. Minor consistency issue in priority assignments.",
         "error": null,
-        "components": ["notebooks", "dashboard"],
+        "components": [
+          "notebooks",
+          "dashboard"
+        ],
         "testCaseCount": 15,
         "jiraTitle": "Notebook Image Lifecycle Management",
         "jiraStatus": "Refined",
         "jiraPriority": "Major",
-        "labels": ["test-plan-auto-created", "test-plan-rubric-pass"],
+        "labels": [
+          "test-plan-auto-created",
+          "test-plan-rubric-pass"
+        ],
         "humanReviewStatus": "awaiting-review",
-        "reviewedAt": "2026-05-10T17:00:00Z"
+        "reviewedAt": "2026-06-16T00:00:00Z"
       },
       "history": []
     },
@@ -162,30 +235,54 @@
         "sourceKey": "RHOAIENG-48676",
         "score": 7,
         "verdict": "Revise",
-        "scores": { "specificity": 2, "grounding": 1, "scope_fidelity": 2, "actionability": 1, "consistency": 1 },
+        "scores": {
+          "specificity": 2,
+          "grounding": 1,
+          "scope_fidelity": 2,
+          "actionability": 1,
+          "consistency": 1
+        },
         "autoRevised": true,
         "beforeScore": 4,
-        "beforeScores": { "specificity": 1, "grounding": 0, "scope_fidelity": 2, "actionability": 0, "consistency": 1 },
+        "beforeScores": {
+          "specificity": 1,
+          "grounding": 0,
+          "scope_fidelity": 2,
+          "actionability": 0,
+          "consistency": 1
+        },
         "criterionNotes": {},
         "feedback": "Grounding improved after auto-revision but still references undocumented retry API.",
-        "gapAnalysis": "## Scope & Endpoints\n\n- **Retry configuration API specification** — Strategy describes \"step-level retry configuration\" but does not provide the PipelineRun or PipelineSpec YAML field names (e.g., retries, backoffLimit, retryStrategy). Would be resolved by: Tekton Pipelines API reference or ADR for RHOAI-specific extensions.\n- **Error recovery trigger conditions** — Strategy states \"automatic error recovery\" but does not specify which exit codes, error types, or condition statuses trigger retry vs fail-fast behavior. Would be resolved by: Feature refinement or design doc.\n- **Retry status observability endpoints** — Test plan needs to verify retry count and backoff state via API, but no .status.retriesAttempted or similar field is documented. Would be resolved by: API spec.\n\n## Test Strategy & Risks\n\n- **Backoff algorithm specification** — Strategy mentions \"exponential backoff\" but does not define initial delay, multiplier, max delay, or jitter parameters. Would be resolved by: Design doc or algorithm specification.\n- **Failure classification logic** — Which failures are retryable (transient network errors, OOMKilled) vs non-retryable (invalid configuration, authentication failures) is not defined. Would be resolved by: Feature refinement or error taxonomy document.\n- **Pipeline state consistency during retry** — How PipelineRun artifacts, workspace state, and downstream steps are affected by mid-pipeline retries is not specified. Would be resolved by: Design doc.\n\n## Environment & Infrastructure\n\n- **Data Science Pipelines version requirements** — Minimum Kubeflow Pipelines / Tekton Pipelines version supporting retry APIs is not specified. Would be resolved by: Compatibility matrix or release planning documentation.\n- **Fault injection tooling** — Test plan requires simulating transient failures (network flakiness, pod evictions) but no tooling or methodology is specified. Would be resolved by: Test infrastructure design doc.",
+        "gapAnalysis": "## Scope & Endpoints\n\n- **Retry configuration API specification** \u2014 Strategy describes \"step-level retry configuration\" but does not provide the PipelineRun or PipelineSpec YAML field names (e.g., retries, backoffLimit, retryStrategy). Would be resolved by: Tekton Pipelines API reference or ADR for RHOAI-specific extensions.\n- **Error recovery trigger conditions** \u2014 Strategy states \"automatic error recovery\" but does not specify which exit codes, error types, or condition statuses trigger retry vs fail-fast behavior. Would be resolved by: Feature refinement or design doc.\n- **Retry status observability endpoints** \u2014 Test plan needs to verify retry count and backoff state via API, but no .status.retriesAttempted or similar field is documented. Would be resolved by: API spec.\n\n## Test Strategy & Risks\n\n- **Backoff algorithm specification** \u2014 Strategy mentions \"exponential backoff\" but does not define initial delay, multiplier, max delay, or jitter parameters. Would be resolved by: Design doc or algorithm specification.\n- **Failure classification logic** \u2014 Which failures are retryable (transient network errors, OOMKilled) vs non-retryable (invalid configuration, authentication failures) is not defined. Would be resolved by: Feature refinement or error taxonomy document.\n- **Pipeline state consistency during retry** \u2014 How PipelineRun artifacts, workspace state, and downstream steps are affected by mid-pipeline retries is not specified. Would be resolved by: Design doc.\n\n## Environment & Infrastructure\n\n- **Data Science Pipelines version requirements** \u2014 Minimum Kubeflow Pipelines / Tekton Pipelines version supporting retry APIs is not specified. Would be resolved by: Compatibility matrix or release planning documentation.\n- **Fault injection tooling** \u2014 Test plan requires simulating transient failures (network flakiness, pod evictions) but no tooling or methodology is specified. Would be resolved by: Test infrastructure design doc.",
         "error": null,
-        "components": ["data-science-pipelines"],
+        "components": [
+          "data-science-pipelines"
+        ],
         "testCaseCount": 11,
         "jiraTitle": "Pipeline Step Retry and Error Recovery",
         "jiraStatus": "In Progress",
         "jiraPriority": "Major",
-        "labels": ["test-plan-auto-created", "test-plan-auto-revised", "test-plan-rubric-fail"],
+        "labels": [
+          "test-plan-auto-created",
+          "test-plan-auto-revised",
+          "test-plan-rubric-fail"
+        ],
         "humanReviewStatus": "needs-review",
-        "reviewedAt": "2026-05-10T15:00:00Z"
+        "reviewedAt": "2026-06-09T00:00:00Z"
       },
       "history": [
         {
-          "scores": { "specificity": 1, "grounding": 0, "scope_fidelity": 2, "actionability": 0, "consistency": 1 },
+          "scores": {
+            "specificity": 1,
+            "grounding": 0,
+            "scope_fidelity": 2,
+            "actionability": 0,
+            "consistency": 1
+          },
           "score": 4,
           "verdict": "Rework",
           "autoRevised": false,
-          "reviewedAt": "2026-05-07T10:00:00Z"
+          "reviewedAt": "2026-06-02T00:00:00Z"
         }
       ]
     },
@@ -196,21 +293,32 @@
         "sourceKey": "RHAISTRAT-1175",
         "score": 6,
         "verdict": "Revise",
-        "scores": { "specificity": 1, "grounding": 2, "scope_fidelity": 1, "actionability": 1, "consistency": 1 },
+        "scores": {
+          "specificity": 1,
+          "grounding": 2,
+          "scope_fidelity": 1,
+          "actionability": 1,
+          "consistency": 1
+        },
         "autoRevised": false,
         "beforeScore": null,
         "beforeScores": null,
         "criterionNotes": {},
         "feedback": "",
         "error": "Review timed out during auto-revision cycle 2. Partial scores retained.",
-        "components": ["ray", "training-operator"],
+        "components": [
+          "ray",
+          "training-operator"
+        ],
         "testCaseCount": 9,
         "jiraTitle": "Distributed Training with Ray on OpenShift AI",
         "jiraStatus": "Closed",
         "jiraPriority": "Minor",
-        "labels": ["test-plan-auto-created"],
+        "labels": [
+          "test-plan-auto-created"
+        ],
         "humanReviewStatus": "awaiting-review",
-        "reviewedAt": "2026-05-09T08:00:00Z"
+        "reviewedAt": "2026-06-02T00:00:00Z"
       },
       "history": []
     }

--- a/modules/ai-impact/__tests__/client/FeatureReviewContent.test.js
+++ b/modules/ai-impact/__tests__/client/FeatureReviewContent.test.js
@@ -4,13 +4,17 @@ import FeatureReviewContent from '../../client/components/FeatureReviewContent.v
 
 // Mock chart.js to avoid canvas errors in tests
 vi.mock('vue-chartjs', () => ({
-  Bar: { template: '<div class="mock-bar-chart" />' }
+  Bar: { template: '<div class="mock-bar-chart" />' },
+  Line: { template: '<div class="mock-line-chart" />' }
 }));
 vi.mock('chart.js', () => ({
   Chart: { register: vi.fn() },
   CategoryScale: {},
   LinearScale: {},
+  PointElement: {},
+  LineElement: {},
   BarElement: {},
+  Filler: {},
   Title: {},
   Tooltip: {},
   Legend: {}
@@ -64,11 +68,14 @@ describe('FeatureReviewContent', () => {
         reviewedAt: '2026-04-19T12:00:00Z'
       }
     };
+    const metrics = {
+      windowTotal: 1, priorWindowTotal: 0, volumeChange: 1, trend: 'growing',
+      approvalRate: 100, needsAttentionCount: 0, priorNeedsAttentionCount: 0, totalFeatures: 1
+    };
     const wrapper = mount(FeatureReviewContent, {
-      props: { features }
+      props: { features, metrics }
     });
-    // Should render metrics row with total count
     expect(wrapper.text()).toContain('1');
-    expect(wrapper.text()).toContain('100%'); // approval rate
+    expect(wrapper.text()).toContain('100%');
   });
 });

--- a/modules/ai-impact/__tests__/client/useFeatures.test.js
+++ b/modules/ai-impact/__tests__/client/useFeatures.test.js
@@ -35,7 +35,7 @@ describe('useFeatures', () => {
     const { features, featureMeta, loadFeatures } = useFeatures();
     await loadFeatures();
 
-    expect(mockApiRequest).toHaveBeenCalledWith('/modules/ai-impact/features');
+    expect(mockApiRequest).toHaveBeenCalledWith('/modules/ai-impact/features?timeWindow=month');
     expect(features.value).toEqual(mockData.features);
     expect(featureMeta.value.totalFeatures).toBe(2);
   });

--- a/modules/ai-impact/__tests__/server/feature-metrics.test.js
+++ b/modules/ai-impact/__tests__/server/feature-metrics.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { computeFeatureMetrics, computeMetrics, buildTrendData, buildBreakdownData } from '../../server/features/metrics.js';
+
+function makeFeature(daysAgo, recommendation = 'approve', { needsAttention = false, humanReviewStatus = 'awaiting-review' } = {}) {
+  const reviewedAt = new Date();
+  reviewedAt.setDate(reviewedAt.getDate() - daysAgo);
+  return {
+    key: `RHAISTRAT-${Math.random().toString(36).slice(2, 6)}`,
+    title: 'Test Feature',
+    recommendation,
+    needsAttention,
+    humanReviewStatus,
+    scores: { feasibility: 2, testability: 2, scope: 2, architecture: 2, total: 8 },
+    reviewedAt: reviewedAt.toISOString()
+  };
+}
+
+describe('computeMetrics', () => {
+  it('computes volume and approval rate for "month" window', () => {
+    const features = [
+      makeFeature(5, 'approve'),
+      makeFeature(10, 'approve'),
+      makeFeature(15, 'revise'),
+      makeFeature(45, 'approve'),
+      makeFeature(50, 'reject'),
+    ];
+
+    const result = computeMetrics(features, 'month', { trendThresholdPp: 2 });
+
+    expect(result.approvalRate).toBe(67);
+    expect(result.windowTotal).toBe(3);
+    expect(result.priorWindowTotal).toBe(2);
+    expect(result.totalFeatures).toBe(5);
+  });
+
+  it('classifies trend as growing when current volume > prior', () => {
+    const features = [
+      makeFeature(5, 'approve'),
+      makeFeature(10, 'approve'),
+    ];
+
+    const result = computeMetrics(features, 'month', { trendThresholdPp: 2 });
+
+    expect(result.trend).toBe('growing');
+    expect(result.volumeChange).toBe(2);
+  });
+
+  it('classifies trend as declining when current volume < prior', () => {
+    const features = [
+      makeFeature(35, 'approve'),
+      makeFeature(40, 'approve'),
+    ];
+
+    const result = computeMetrics(features, 'month', { trendThresholdPp: 2 });
+
+    expect(result.trend).toBe('declining');
+  });
+
+  it('classifies trend as stable when volume unchanged', () => {
+    const features = [
+      makeFeature(5, 'approve'),
+      makeFeature(35, 'approve'),
+    ];
+
+    const result = computeMetrics(features, 'month', { trendThresholdPp: 2 });
+
+    expect(result.trend).toBe('stable');
+  });
+
+  it('counts needs-attention features', () => {
+    const features = [
+      makeFeature(5, 'revise', { needsAttention: true }),
+      makeFeature(10, 'approve', { needsAttention: false }),
+      makeFeature(35, 'revise', { needsAttention: true }),
+      makeFeature(40, 'revise', { needsAttention: true }),
+    ];
+
+    const result = computeMetrics(features, 'month', { trendThresholdPp: 2 });
+
+    expect(result.needsAttentionCount).toBe(1);
+    expect(result.priorNeedsAttentionCount).toBe(2);
+  });
+
+  it('handles empty features', () => {
+    const result = computeMetrics([], 'month', { trendThresholdPp: 2 });
+
+    expect(result.approvalRate).toBe(0);
+    expect(result.windowTotal).toBe(0);
+    expect(result.totalFeatures).toBe(0);
+    expect(result.trend).toBe('stable');
+  });
+});
+
+describe('buildTrendData', () => {
+  it('returns correct number of weeks for each window', () => {
+    expect(buildTrendData([], 'week')).toHaveLength(4);
+    expect(buildTrendData([], 'month')).toHaveLength(8);
+    expect(buildTrendData([], '3months')).toHaveLength(13);
+  });
+
+  it('buckets features by week using reviewedAt', () => {
+    const features = [
+      makeFeature(1, 'approve'),
+      makeFeature(2, 'revise', { needsAttention: true }),
+    ];
+
+    const points = buildTrendData(features, 'month');
+    const lastPoint = points[points.length - 1];
+    expect(lastPoint.total).toBe(2);
+    expect(lastPoint.needsAttentionCount).toBe(1);
+  });
+
+  it('returns 0 for weeks with no features', () => {
+    const points = buildTrendData([], 'week');
+    for (const p of points) {
+      expect(p.total).toBe(0);
+      expect(p.needsAttentionCount).toBe(0);
+    }
+  });
+});
+
+describe('buildBreakdownData', () => {
+  it('counts by recommendation', () => {
+    const features = [
+      makeFeature(1, 'approve'),
+      makeFeature(2, 'approve'),
+      makeFeature(3, 'revise'),
+      makeFeature(4, 'reject'),
+    ];
+
+    const result = buildBreakdownData(features);
+
+    expect(result).toEqual([
+      { name: 'Approve', value: 2 },
+      { name: 'Revise', value: 1 },
+      { name: 'Reject', value: 1 },
+    ]);
+  });
+
+  it('handles empty features', () => {
+    expect(buildBreakdownData([])).toEqual([
+      { name: 'Approve', value: 0 },
+      { name: 'Revise', value: 0 },
+      { name: 'Reject', value: 0 },
+    ]);
+  });
+});
+
+describe('computeFeatureMetrics', () => {
+  it('returns metrics, trendData, breakdown, and reviewStatus', () => {
+    const features = [makeFeature(5, 'approve')];
+    const result = computeFeatureMetrics(features, 'month', { trendThresholdPp: 2 });
+
+    expect(result).toHaveProperty('metrics');
+    expect(result).toHaveProperty('trendData');
+    expect(result).toHaveProperty('breakdown');
+    expect(result).toHaveProperty('reviewStatus');
+    expect(result.trendData).toHaveLength(8);
+  });
+});

--- a/modules/ai-impact/__tests__/server/test-plan-metrics.test.js
+++ b/modules/ai-impact/__tests__/server/test-plan-metrics.test.js
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import { computeTestPlanMetrics, computeMetrics, buildTrendData, buildBreakdownData, computeReviewStatusMetrics } from '../../server/test-plans/metrics.js';
+
+function makePlan(daysAgo, verdict = 'Ready', { autoRevised = false, humanReviewStatus = 'awaiting-review' } = {}) {
+  const reviewedAt = new Date();
+  reviewedAt.setDate(reviewedAt.getDate() - daysAgo);
+  return {
+    key: `RHAISTRAT-${Math.random().toString(36).slice(2, 6)}`,
+    feature: 'Test Feature',
+    verdict,
+    score: verdict === 'Ready' ? 9 : verdict === 'Revise' ? 6 : 3,
+    autoRevised,
+    humanReviewStatus,
+    reviewedAt: reviewedAt.toISOString()
+  };
+}
+
+describe('computeMetrics', () => {
+  it('computes pass rate for "month" time window', () => {
+    const plans = [
+      makePlan(5, 'Ready'),
+      makePlan(10, 'Ready'),
+      makePlan(15, 'Revise'),
+      makePlan(45, 'Ready'),
+      makePlan(50, 'Rework'),
+    ];
+
+    const result = computeMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.passRate).toBe(67);
+    expect(result.windowTotal).toBe(3);
+    expect(result.totalPlans).toBe(5);
+  });
+
+  it('computes "week" time window', () => {
+    const plans = [
+      makePlan(2, 'Ready'),
+      makePlan(3, 'Revise'),
+      makePlan(5, 'Rework'),
+    ];
+
+    const result = computeMetrics(plans, 'week', { trendThresholdPp: 2 });
+
+    expect(result.windowTotal).toBe(3);
+    expect(result.passRate).toBe(33);
+  });
+
+  it('computes "3months" time window', () => {
+    const plans = [
+      makePlan(10, 'Ready'),
+      makePlan(30, 'Ready'),
+      makePlan(60, 'Revise'),
+      makePlan(85, 'Rework'),
+    ];
+
+    const result = computeMetrics(plans, '3months', { trendThresholdPp: 2 });
+
+    expect(result.windowTotal).toBe(4);
+  });
+
+  it('classifies trend as growing when current volume > prior', () => {
+    const plans = [
+      makePlan(5, 'Ready'),
+      makePlan(10, 'Ready'),
+    ];
+
+    const result = computeMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.trend).toBe('growing');
+    expect(result.volumeChange).toBe(2);
+  });
+
+  it('classifies trend as declining when current volume < prior', () => {
+    const plans = [
+      makePlan(35, 'Ready'),
+      makePlan(40, 'Ready'),
+    ];
+
+    const result = computeMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.trend).toBe('declining');
+    expect(result.volumeChange).toBe(-2);
+  });
+
+  it('classifies trend as stable when volume unchanged', () => {
+    const plans = [
+      makePlan(5, 'Ready'),
+      makePlan(35, 'Ready'),
+    ];
+
+    const result = computeMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.trend).toBe('stable');
+    expect(result.volumeChange).toBe(0);
+  });
+
+  it('counts auto-revised plans in current and prior windows', () => {
+    const plans = [
+      makePlan(5, 'Ready', { autoRevised: true }),
+      makePlan(10, 'Ready', { autoRevised: false }),
+      makePlan(35, 'Ready', { autoRevised: true }),
+      makePlan(40, 'Ready', { autoRevised: true }),
+    ];
+
+    const result = computeMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.autoRevisedCount).toBe(1);
+    expect(result.priorAutoRevisedCount).toBe(2);
+  });
+
+  it('handles empty plans', () => {
+    const result = computeMetrics([], 'month', { trendThresholdPp: 2 });
+
+    expect(result.passRate).toBe(0);
+    expect(result.autoRevisedCount).toBe(0);
+    expect(result.windowTotal).toBe(0);
+    expect(result.totalPlans).toBe(0);
+    expect(result.trend).toBe('stable');
+  });
+
+  it('handles all same verdict', () => {
+    const plans = [
+      makePlan(5, 'Ready'),
+      makePlan(10, 'Ready'),
+    ];
+
+    const result = computeMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.passRate).toBe(100);
+    expect(result.priorWindowTotal).toBe(0);
+  });
+
+  it('uses default threshold of 2 when config is null', () => {
+    const result = computeMetrics([], 'month', null);
+    expect(result.trend).toBe('stable');
+  });
+});
+
+describe('computeReviewStatusMetrics', () => {
+  it('computes needs-review percentage', () => {
+    const plans = [
+      makePlan(5, 'Ready', { humanReviewStatus: 'needs-review' }),
+      makePlan(10, 'Ready', { humanReviewStatus: 'approved' }),
+      makePlan(15, 'Ready', { humanReviewStatus: 'awaiting-review' }),
+    ];
+
+    const result = computeReviewStatusMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.needsReviewPct).toBe(33);
+  });
+
+  it('computes awaiting sign-off percentage', () => {
+    const plans = [
+      makePlan(5, 'Ready', { humanReviewStatus: 'awaiting-review' }),
+      makePlan(10, 'Ready', { humanReviewStatus: 'awaiting-review' }),
+      makePlan(15, 'Ready', { humanReviewStatus: 'approved' }),
+    ];
+
+    const result = computeReviewStatusMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.awaitingSignoffPct).toBe(67);
+  });
+
+  it('computes period-over-period change', () => {
+    const plans = [
+      makePlan(5, 'Ready', { humanReviewStatus: 'needs-review' }),
+      makePlan(10, 'Ready', { humanReviewStatus: 'approved' }),
+      makePlan(35, 'Ready', { humanReviewStatus: 'approved' }),
+      makePlan(40, 'Ready', { humanReviewStatus: 'approved' }),
+    ];
+
+    const result = computeReviewStatusMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.needsReviewPct).toBe(50);
+    expect(result.needsReviewChange).toBe(50);
+    expect(result.needsReviewTrend).toBe('worsening');
+  });
+
+  it('classifies improving trend', () => {
+    const plans = [
+      makePlan(5, 'Ready', { humanReviewStatus: 'approved' }),
+      makePlan(35, 'Ready', { humanReviewStatus: 'needs-review' }),
+    ];
+
+    const result = computeReviewStatusMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result.needsReviewTrend).toBe('improving');
+  });
+
+  it('handles empty plans', () => {
+    const result = computeReviewStatusMetrics([], 'month', { trendThresholdPp: 2 });
+
+    expect(result.needsReviewPct).toBe(0);
+    expect(result.needsReviewChange).toBe(0);
+    expect(result.needsReviewTrend).toBe('stable');
+    expect(result.awaitingSignoffPct).toBe(0);
+    expect(result.awaitingSignoffChange).toBe(0);
+    expect(result.awaitingSignoffTrend).toBe('stable');
+  });
+});
+
+describe('buildTrendData', () => {
+  it('returns correct number of weeks for each window', () => {
+    expect(buildTrendData([], 'week')).toHaveLength(4);
+    expect(buildTrendData([], 'month')).toHaveLength(8);
+    expect(buildTrendData([], '3months')).toHaveLength(13);
+  });
+
+  it('buckets plans by week using reviewedAt', () => {
+    const plans = [
+      makePlan(1, 'Ready'),
+      makePlan(2, 'Revise'),
+      makePlan(10, 'Rework'),
+    ];
+
+    const points = buildTrendData(plans, 'month');
+
+    const lastPoint = points[points.length - 1];
+    expect(lastPoint.total).toBeGreaterThan(0);
+    expect(lastPoint.date).toBeTruthy();
+  });
+
+  it('computes per-week pass rate correctly', () => {
+    const plans = [
+      makePlan(1, 'Ready'),
+      makePlan(2, 'Ready'),
+      makePlan(3, 'Revise'),
+      makePlan(3, 'Rework'),
+    ];
+
+    const points = buildTrendData(plans, 'week');
+
+    const withData = points.find(p => p.total === 4);
+    if (withData) {
+      expect(withData.passRate).toBe(50);
+    }
+  });
+
+  it('returns 0 for weeks with no plans', () => {
+    const points = buildTrendData([], 'week');
+    for (const p of points) {
+      expect(p.passRate).toBe(0);
+      expect(p.autoRevisedCount).toBe(0);
+      expect(p.total).toBe(0);
+    }
+  });
+
+  it('counts auto-revised per week', () => {
+    const plans = [
+      makePlan(1, 'Ready', { autoRevised: true }),
+      makePlan(2, 'Ready', { autoRevised: false }),
+    ];
+
+    const points = buildTrendData(plans, 'week');
+    const lastPoint = points[points.length - 1];
+    expect(lastPoint.autoRevisedCount).toBe(1);
+  });
+});
+
+describe('buildBreakdownData', () => {
+  it('counts by verdict', () => {
+    const plans = [
+      makePlan(1, 'Ready'),
+      makePlan(2, 'Ready'),
+      makePlan(3, 'Revise'),
+      makePlan(4, 'Rework'),
+      makePlan(5, 'Rework'),
+      makePlan(6, 'Rework'),
+    ];
+
+    const result = buildBreakdownData(plans);
+
+    expect(result).toEqual([
+      { name: 'Ready', value: 2 },
+      { name: 'Revise', value: 1 },
+      { name: 'Rework', value: 3 },
+    ]);
+  });
+
+  it('handles empty plans', () => {
+    const result = buildBreakdownData([]);
+    expect(result).toEqual([
+      { name: 'Ready', value: 0 },
+      { name: 'Revise', value: 0 },
+      { name: 'Rework', value: 0 },
+    ]);
+  });
+});
+
+describe('computeTestPlanMetrics', () => {
+  it('returns metrics, trendData, breakdown, and reviewStatus', () => {
+    const plans = [makePlan(5, 'Ready')];
+    const result = computeTestPlanMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    expect(result).toHaveProperty('metrics');
+    expect(result).toHaveProperty('trendData');
+    expect(result).toHaveProperty('breakdown');
+    expect(result).toHaveProperty('reviewStatus');
+    expect(result.trendData).toHaveLength(8);
+    expect(result.reviewStatus).toHaveProperty('needsReviewPct');
+    expect(result.reviewStatus).toHaveProperty('awaitingSignoffPct');
+  });
+
+  it('breakdown uses only window plans', () => {
+    const plans = [
+      makePlan(5, 'Ready'),
+      makePlan(100, 'Rework'),
+    ];
+
+    const result = computeTestPlanMetrics(plans, 'month', { trendThresholdPp: 2 });
+
+    const readyCount = result.breakdown.find(b => b.name === 'Ready').value;
+    const reworkCount = result.breakdown.find(b => b.name === 'Rework').value;
+    expect(readyCount).toBe(1);
+    expect(reworkCount).toBe(0);
+  });
+});

--- a/modules/ai-impact/client/components/FeatureCharts.vue
+++ b/modules/ai-impact/client/components/FeatureCharts.vue
@@ -1,39 +1,110 @@
 <script setup>
-import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
-import { Bar } from 'vue-chartjs'
+import { computed } from 'vue'
+import { Line, Bar } from 'vue-chartjs'
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
+  PointElement,
+  LineElement,
   BarElement,
+  Filler,
   Title,
   Tooltip,
   Legend
 } from 'chart.js'
+import { useChartTheme } from '../composables/useChartTheme.js'
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Filler, Title, Tooltip, Legend)
 
 const props = defineProps({
+  trendData: { type: Array, default: () => [] },
+  breakdown: { type: Array, default: () => [] },
+  expanded: { type: Boolean, default: true },
+  timeWindow: { type: String, default: 'month' },
   features: { type: Object, default: () => ({}) }
 })
 
+const emit = defineEmits(['toggle'])
+
+const { textColor, gridColor } = useChartTheme()
+
 const featureList = computed(() => Object.values(props.features))
 
-const isDark = ref(false)
-onMounted(() => {
-  isDark.value = document.documentElement.classList.contains('dark') ||
-    (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  const observer = new MutationObserver(() => {
-    isDark.value = document.documentElement.classList.contains('dark')
-  })
-  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-  onBeforeUnmount(() => observer.disconnect())
+const trailingWeeks = computed(() => {
+  if (props.timeWindow === 'week') return 4
+  if (props.timeWindow === '3months') return 13
+  return 8
 })
 
-const textColor = computed(() => isDark.value ? 'rgba(209, 213, 219, 1)' : 'rgba(107, 114, 128, 1)')
-const gridColor = computed(() => isDark.value ? 'rgba(75, 85, 99, 0.5)' : 'rgba(229, 231, 235, 1)')
+const trailingLabel = computed(() => `Weekly trend · trailing ${trailingWeeks.value} weeks`)
 
-// Score Distribution: histogram of scores.total (0-8)
+// ─── Trend charts ───
+
+const featuresProcessedChartData = computed(() => ({
+  labels: props.trendData.map(p => p.date),
+  datasets: [{
+    label: 'Features Processed via AI',
+    data: props.trendData.map(p => p.total),
+    borderColor: '#10b981',
+    backgroundColor: 'rgba(16, 185, 129, 0.1)',
+    fill: true,
+    tension: 0.3
+  }]
+}))
+
+const featuresProcessedChartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, color: textColor.value, precision: 0 }, title: { display: true, text: 'Features (count)', color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+const needsAttentionChartData = computed(() => ({
+  labels: props.trendData.map(p => p.date),
+  datasets: [{
+    label: 'Needs Attention',
+    data: props.trendData.map(p => p.needsAttentionCount),
+    backgroundColor: 'rgba(245, 158, 11, 0.6)',
+    borderColor: 'rgba(245, 158, 11, 0.8)',
+    borderWidth: 1
+  }]
+}))
+
+const needsAttentionChartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, color: textColor.value, precision: 0 }, title: { display: true, text: 'Needs Attention (count)', color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+const breakdownChartData = computed(() => ({
+  labels: props.breakdown.map(b => b.name),
+  datasets: [{
+    data: props.breakdown.map(b => b.value),
+    backgroundColor: ['#10b981', '#f59e0b', '#ef4444']
+  }]
+}))
+
+const breakdownChartOptions = computed(() => ({
+  indexAxis: 'y',
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+// ─── Existing quality charts ───
+
 const scoreDistributionData = computed(() => {
   const buckets = Array(9).fill(0)
   for (const f of featureList.value) {
@@ -46,9 +117,9 @@ const scoreDistributionData = computed(() => {
       label: 'Features',
       data: buckets,
       backgroundColor: buckets.map((_, i) => {
-        if (i <= 2) return 'rgba(239, 68, 68, 0.7)'    // red for low
-        if (i <= 5) return 'rgba(245, 158, 11, 0.7)'    // amber for mid
-        return 'rgba(16, 185, 129, 0.7)'                 // green for high
+        if (i <= 2) return 'rgba(239, 68, 68, 0.7)'
+        if (i <= 5) return 'rgba(245, 158, 11, 0.7)'
+        return 'rgba(16, 185, 129, 0.7)'
       })
     }]
   }
@@ -67,7 +138,6 @@ const scoreDistributionOptions = computed(() => ({
   }
 }))
 
-// Dimension Breakdown: stacked bar showing pass(2)/partial(1)/fail(0) per dimension
 const dimensionBreakdownData = computed(() => {
   const dims = ['feasibility', 'testability', 'scope', 'architecture']
   const counts = { pass: [], partial: [], fail: [] }
@@ -110,13 +180,98 @@ const dimensionBreakdownOptions = computed(() => ({
 </script>
 
 <template>
-  <div v-if="featureList.length > 0" class="p-6 border-b border-gray-200 dark:border-gray-700">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <div class="h-64">
-        <Bar :data="scoreDistributionData" :options="scoreDistributionOptions" />
+  <div class="border-b border-gray-200 dark:border-gray-700">
+    <button
+      @click="emit('toggle')"
+      class="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+    >
+      <span class="flex items-center gap-2 text-sm font-medium dark:text-gray-300">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+        Trend Visualization
+        <span class="text-xs font-normal text-gray-400 dark:text-gray-500">{{ trailingLabel }}</span>
+      </span>
+      <svg
+        class="h-4 w-4 transition-transform dark:text-gray-300"
+        :class="{ 'rotate-180': expanded }"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+
+    <div v-if="expanded" class="px-6 pb-6 space-y-6">
+      <!-- Trend charts -->
+      <div class="flex flex-wrap gap-6">
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium dark:text-gray-300">Features Processed via AI</h3>
+            <div class="relative group">
+              <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                Number of features processed via AI per week over the selected time window.
+              </div>
+            </div>
+          </div>
+          <div class="h-[180px]">
+            <Line :data="featuresProcessedChartData" :options="featuresProcessedChartOptions" />
+          </div>
+        </div>
+
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium dark:text-gray-300">Needs Attention</h3>
+            <div class="relative group">
+              <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                Count of features flagged as needing attention per week over the selected time window.
+              </div>
+            </div>
+          </div>
+          <div class="h-[180px]">
+            <Bar :data="needsAttentionChartData" :options="needsAttentionChartOptions" />
+          </div>
+        </div>
+
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium dark:text-gray-300">Recommendation Breakdown</h3>
+            <div class="relative group">
+              <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                Counts of features by AI recommendation: Approve, Revise, or Reject for the selected time window.
+              </div>
+            </div>
+          </div>
+          <div class="h-[180px]">
+            <Bar :data="breakdownChartData" :options="breakdownChartOptions" />
+          </div>
+        </div>
       </div>
-      <div class="h-64">
-        <Bar :data="dimensionBreakdownData" :options="dimensionBreakdownOptions" />
+
+      <!-- Quality distribution charts -->
+      <div v-if="featureList.length > 0" class="flex flex-wrap gap-6">
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="h-[200px]">
+            <Bar :data="scoreDistributionData" :options="scoreDistributionOptions" />
+          </div>
+        </div>
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="h-[200px]">
+            <Bar :data="dimensionBreakdownData" :options="dimensionBreakdownOptions" />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/modules/ai-impact/client/components/FeatureMetricsRow.vue
+++ b/modules/ai-impact/client/components/FeatureMetricsRow.vue
@@ -69,8 +69,8 @@ defineProps({
       <!-- Total Features -->
       <div class="space-y-1">
         <p class="text-sm text-gray-500 dark:text-gray-400">Total Features</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.windowTotal }}</span>
-        <p class="text-xs text-gray-400 dark:text-gray-500">{{ metrics.totalFeatures }} all time</p>
+        <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.totalFeatures }}</span>
+        <p class="text-xs text-gray-400 dark:text-gray-500">{{ metrics.windowTotal }} this period</p>
       </div>
 
       <!-- Trend Status -->

--- a/modules/ai-impact/client/components/FeatureMetricsRow.vue
+++ b/modules/ai-impact/client/components/FeatureMetricsRow.vue
@@ -1,66 +1,93 @@
 <script setup>
-import { computed } from 'vue'
+import { getTrendClass, formatFrictionChange } from '../utils/format-helpers.js'
 
-const props = defineProps({
-  features: { type: Object, default: () => ({}) }
-})
-
-const featureList = computed(() => Object.values(props.features))
-
-const totalFeatures = computed(() => featureList.value.length)
-
-const approvalRate = computed(() => {
-  if (totalFeatures.value === 0) return 0
-  const approved = featureList.value.filter(f => f.recommendation === 'approve').length
-  return Math.round((approved / totalFeatures.value) * 100)
-})
-
-const avgScore = computed(() => {
-  if (totalFeatures.value === 0) return 0
-  const sum = featureList.value.reduce((acc, f) => acc + (f.scores?.total || 0), 0)
-  return (sum / totalFeatures.value).toFixed(1)
-})
-
-const needsActionCount = computed(() => {
-  return featureList.value.filter(f => f.humanReviewStatus === 'needs-review' || f.humanReviewStatus === 'awaiting-review').length
-})
-
-const signedOffCount = computed(() => {
-  return featureList.value.filter(f => f.humanReviewStatus === 'approved').length
+defineProps({
+  metrics: {
+    type: Object,
+    default: null
+  },
+  reviewStatus: {
+    type: Object,
+    default: null
+  }
 })
 </script>
 
 <template>
-  <div class="p-6 border-b border-gray-200 dark:border-gray-700">
-    <div class="grid gap-6 grid-cols-2 lg:grid-cols-5">
+  <div v-if="metrics" class="p-6 border-b border-gray-200 dark:border-gray-700">
+    <div class="grid gap-6 grid-cols-2 lg:grid-cols-4">
+      <!-- Features Processed via AI -->
+      <div class="space-y-1">
+        <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+          </svg>
+          Features Processed via AI
+        </p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.windowTotal }}</span>
+          <span class="text-sm flex items-center gap-1" :class="getTrendClass(metrics.trend)">
+            <svg v-if="metrics.trend === 'growing'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+            </svg>
+            <svg v-else-if="metrics.trend === 'declining'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6" />
+            </svg>
+            <svg v-else class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
+            </svg>
+            {{ metrics.priorWindowTotal }} prev period
+          </span>
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500">
+          {{ metrics.approvalRate }}% approval rate
+        </p>
+      </div>
+
+      <!-- Needs Attention -->
+      <div class="space-y-1">
+        <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          Needs Attention
+        </p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.needsAttentionCount }}</span>
+          <span v-if="metrics.priorNeedsAttentionCount != null" class="text-xs text-gray-400 dark:text-gray-500">
+            {{ metrics.priorNeedsAttentionCount }} prev period
+          </span>
+        </div>
+        <p v-if="reviewStatus" class="text-xs text-gray-400 dark:text-gray-500">
+          {{ reviewStatus.awaitingSignoffPct }}% awaiting sign-off
+          <span class="ml-1">{{ formatFrictionChange(reviewStatus.awaitingSignoffChange) }}</span>
+        </p>
+      </div>
+
+      <!-- Total Features -->
       <div class="space-y-1">
         <p class="text-sm text-gray-500 dark:text-gray-400">Total Features</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ totalFeatures }}</span>
+        <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.windowTotal }}</span>
+        <p class="text-xs text-gray-400 dark:text-gray-500">{{ metrics.totalFeatures }} all time</p>
       </div>
 
+      <!-- Trend Status -->
       <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Approval Rate</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ approvalRate }}%</span>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Avg Score</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ avgScore }}</span>
-        <p class="text-xs text-gray-400 dark:text-gray-500">out of 8</p>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Needs Action</p>
-        <span class="text-3xl font-bold" :class="needsActionCount > 0 ? 'text-amber-600 dark:text-amber-400' : 'dark:text-gray-100'">
-          {{ needsActionCount }}
-        </span>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Signed Off</p>
-        <span class="text-3xl font-bold" :class="signedOffCount > 0 ? 'text-green-600 dark:text-green-400' : 'dark:text-gray-100'">
-          {{ signedOffCount }}
-        </span>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Trend Status</p>
+        <div class="flex items-center gap-2">
+          <svg v-if="metrics.trend === 'growing'" class="h-5 w-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+          </svg>
+          <svg v-else-if="metrics.trend === 'declining'" class="h-5 w-5 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6" />
+          </svg>
+          <svg v-else class="h-5 w-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
+          </svg>
+          <span class="text-lg font-semibold capitalize dark:text-gray-100">{{ metrics.trend }}</span>
+        </div>
       </div>
     </div>
   </div>

--- a/modules/ai-impact/client/components/FeatureReviewContent.vue
+++ b/modules/ai-impact/client/components/FeatureReviewContent.vue
@@ -9,6 +9,12 @@ defineProps({
   error: { type: String, default: null },
   features: { type: Object, default: () => ({}) },
   featureMeta: { type: Object, default: () => ({}) },
+  metrics: { type: Object, default: null },
+  trendData: { type: Array, default: () => [] },
+  breakdown: { type: Array, default: () => [] },
+  reviewStatus: { type: Object, default: null },
+  timeWindow: { type: String, default: 'month' },
+  chartExpanded: { type: Boolean, default: true },
   searchQuery: { type: String, default: '' },
   recommendationFilter: { type: String, default: 'all' },
   priorityFilter: { type: String, default: 'all' },
@@ -18,6 +24,8 @@ defineProps({
 })
 
 const emit = defineEmits([
+  'update:timeWindow',
+  'update:chartExpanded',
   'update:searchQuery',
   'update:recommendationFilter',
   'update:priorityFilter',
@@ -29,55 +37,86 @@ const emit = defineEmits([
 </script>
 
 <template>
-  <main class="flex-1 flex flex-col overflow-auto">
-    <!-- Loading -->
-    <LoadingOverlay v-if="loading" message="Loading feature reviews..." />
-
-    <!-- Error -->
-    <div v-else-if="error" class="flex-1 flex flex-col items-center justify-center">
-      <div class="text-red-500 dark:text-red-400 mb-2">Failed to load feature data</div>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ error }}</p>
-      <button
-        @click="emit('retry')"
-        class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700"
-      >
-        Retry
-      </button>
-    </div>
-
-    <!-- Empty state -->
-    <div v-else-if="Object.keys(features).length === 0" class="flex-1 flex flex-col items-center justify-center">
-      <div class="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-4">
-        <svg class="h-8 w-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-        </svg>
+  <div class="flex-1 flex flex-col min-w-0">
+    <!-- Top Bar -->
+    <header class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-3 flex items-center justify-between">
+      <div>
+        <h2 class="text-lg font-semibold dark:text-gray-100">Feature Review</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400">AI adoption metrics and feature tracking</p>
       </div>
-      <h2 class="text-xl font-semibold mb-2 dark:text-gray-100">No Feature Reviews Yet</h2>
-      <p class="text-gray-500 dark:text-gray-400 text-center max-w-md">
-        Feature review data will appear here once the strat creator pipeline pushes results.
-      </p>
-    </div>
+      <div class="flex items-center gap-2">
+        <label for="fr-time-window" class="text-sm text-gray-500 dark:text-gray-400">Showing:</label>
+        <select
+          id="fr-time-window"
+          :value="timeWindow"
+          @change="emit('update:timeWindow', $event.target.value)"
+          class="border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300"
+        >
+          <option value="week">This Week</option>
+          <option value="month">This Month</option>
+          <option value="3months">Last 3 Months</option>
+        </select>
+      </div>
+    </header>
 
-    <!-- Data loaded -->
-    <template v-else>
-      <FeatureMetricsRow :features="features" />
-      <FeatureCharts :features="features" />
-      <FeatureList
-        :features="features"
-        :selectedFeature="selectedFeature"
-        :searchQuery="searchQuery"
-        :recommendationFilter="recommendationFilter"
-        :priorityFilter="priorityFilter"
-        :humanReviewFilter="humanReviewFilter"
-        :sortBy="sortBy"
-        @update:searchQuery="emit('update:searchQuery', $event)"
-        @update:recommendationFilter="emit('update:recommendationFilter', $event)"
-        @update:priorityFilter="emit('update:priorityFilter', $event)"
-        @update:humanReviewFilter="emit('update:humanReviewFilter', $event)"
-        @update:sortBy="emit('update:sortBy', $event)"
-        @selectFeature="emit('selectFeature', $event)"
-      />
-    </template>
-  </main>
+    <!-- Content -->
+    <main class="flex-1 flex flex-col overflow-auto">
+      <!-- Loading -->
+      <LoadingOverlay v-if="loading" message="Loading feature reviews..." />
+
+      <!-- Error -->
+      <div v-else-if="error" class="flex-1 flex flex-col items-center justify-center">
+        <div class="text-red-500 dark:text-red-400 mb-2">Failed to load feature data</div>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ error }}</p>
+        <button
+          @click="emit('retry')"
+          class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700"
+        >
+          Retry
+        </button>
+      </div>
+
+      <!-- Empty state -->
+      <div v-else-if="Object.keys(features).length === 0" class="flex-1 flex flex-col items-center justify-center">
+        <div class="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-4">
+          <svg class="h-8 w-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+          </svg>
+        </div>
+        <h2 class="text-xl font-semibold mb-2 dark:text-gray-100">No Feature Reviews Yet</h2>
+        <p class="text-gray-500 dark:text-gray-400 text-center max-w-md">
+          Feature review data will appear here once the strat creator pipeline pushes results.
+        </p>
+      </div>
+
+      <!-- Data loaded -->
+      <template v-else>
+        <FeatureMetricsRow :metrics="metrics" :reviewStatus="reviewStatus" />
+        <FeatureCharts
+          :trendData="trendData"
+          :breakdown="breakdown"
+          :expanded="chartExpanded"
+          :timeWindow="timeWindow"
+          :features="features"
+          @toggle="emit('update:chartExpanded', !chartExpanded)"
+        />
+        <FeatureList
+          :features="features"
+          :selectedFeature="selectedFeature"
+          :searchQuery="searchQuery"
+          :recommendationFilter="recommendationFilter"
+          :priorityFilter="priorityFilter"
+          :humanReviewFilter="humanReviewFilter"
+          :sortBy="sortBy"
+          @update:searchQuery="emit('update:searchQuery', $event)"
+          @update:recommendationFilter="emit('update:recommendationFilter', $event)"
+          @update:priorityFilter="emit('update:priorityFilter', $event)"
+          @update:humanReviewFilter="emit('update:humanReviewFilter', $event)"
+          @update:sortBy="emit('update:sortBy', $event)"
+          @selectFeature="emit('selectFeature', $event)"
+        />
+      </template>
+    </main>
+  </div>
 </template>

--- a/modules/ai-impact/client/components/MetricsRow.vue
+++ b/modules/ai-impact/client/components/MetricsRow.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { getTrendClass, formatChange, formatFrictionChange } from '../utils/format-helpers.js'
+
 defineProps({
   metrics: {
     type: Object,
@@ -9,23 +11,6 @@ defineProps({
     default: null
   }
 })
-
-function getTrendClass(trend) {
-  if (trend === 'growing') return 'text-green-600 dark:text-green-400'
-  if (trend === 'declining') return 'text-red-600 dark:text-red-400'
-  return 'text-gray-500 dark:text-gray-400'
-}
-
-function formatChange(change) {
-  if (change > 0) return `+${change}%`
-  return `${change}%`
-}
-
-function formatFrictionChange(change) {
-  if (change > 0) return `+${change}pp`
-  if (change < 0) return `${change}pp`
-  return '—'
-}
 </script>
 
 <template>

--- a/modules/ai-impact/client/components/TestPlanCharts.vue
+++ b/modules/ai-impact/client/components/TestPlanCharts.vue
@@ -1,37 +1,117 @@
 <script setup>
-import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
-import { Bar } from 'vue-chartjs'
+import { computed } from 'vue'
+import { Line, Bar } from 'vue-chartjs'
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
+  PointElement,
+  LineElement,
   BarElement,
+  Filler,
   Title,
   Tooltip,
   Legend
 } from 'chart.js'
+import { useChartTheme } from '../composables/useChartTheme.js'
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Filler, Title, Tooltip, Legend)
 
 const props = defineProps({
+  trendData: { type: Array, default: () => [] },
+  breakdown: { type: Array, default: () => [] },
+  expanded: { type: Boolean, default: true },
+  timeWindow: { type: String, default: 'month' },
   testPlans: { type: Object, default: () => ({}) }
 })
 
+const emit = defineEmits(['toggle'])
+
+const { textColor, gridColor } = useChartTheme()
+
 const planList = computed(() => Object.values(props.testPlans))
 
-const isDark = ref(false)
-onMounted(() => {
-  isDark.value = document.documentElement.classList.contains('dark') ||
-    (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  const observer = new MutationObserver(() => {
-    isDark.value = document.documentElement.classList.contains('dark')
-  })
-  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-  onBeforeUnmount(() => observer.disconnect())
+const trailingWeeks = computed(() => {
+  if (props.timeWindow === 'week') return 4
+  if (props.timeWindow === '3months') return 13
+  return 8
 })
 
-const textColor = computed(() => isDark.value ? 'rgba(209, 213, 219, 1)' : 'rgba(107, 114, 128, 1)')
-const gridColor = computed(() => isDark.value ? 'rgba(75, 85, 99, 0.5)' : 'rgba(229, 231, 235, 1)')
+const trailingLabel = computed(() => `Weekly trend · trailing ${trailingWeeks.value} weeks`)
+
+// ─── Trend charts ───
+
+const plansProcessedChartData = computed(() => ({
+  labels: props.trendData.map(p => p.date),
+  datasets: [{
+    label: 'Plans Processed via AI',
+    data: props.trendData.map(p => p.total),
+    borderColor: '#10b981',
+    backgroundColor: 'rgba(16, 185, 129, 0.1)',
+    fill: true,
+    tension: 0.3
+  }]
+}))
+
+const plansProcessedChartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, color: textColor.value, precision: 0 }, title: { display: true, text: 'Plans (count)', color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+const autoRevisedChartData = computed(() => ({
+  labels: props.trendData.map(p => p.date),
+  datasets: [{
+    label: 'Auto-Revised',
+    data: props.trendData.map(p => p.autoRevisedCount),
+    backgroundColor: 'rgba(245, 158, 11, 0.6)',
+    borderColor: 'rgba(245, 158, 11, 0.8)',
+    borderWidth: 1
+  }]
+}))
+
+const autoRevisedChartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { beginAtZero: true, ticks: { font: { size: 10 }, color: textColor.value, precision: 0 }, title: { display: true, text: 'Auto-Revised (count)', color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+const breakdownChartData = computed(() => ({
+  labels: props.breakdown.map(b => b.name),
+  datasets: [{
+    data: props.breakdown.map(b => b.value),
+    backgroundColor: ['#10b981', '#f59e0b', '#ef4444']
+  }]
+}))
+
+const breakdownChartOptions = computed(() => ({
+  indexAxis: 'y',
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    x: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } },
+    y: { ticks: { font: { size: 10 }, color: textColor.value }, grid: { color: gridColor.value } }
+  }
+}))
+
+// ─── Existing quality charts ───
+
+const DIMENSIONS = [
+  { key: 'specificity', label: 'Specificity' },
+  { key: 'grounding', label: 'Grounding' },
+  { key: 'scope_fidelity', label: 'Scope Fidelity' },
+  { key: 'actionability', label: 'Actionability' },
+  { key: 'consistency', label: 'Consistency' }
+]
 
 const scoreDistributionData = computed(() => {
   const buckets = Array(11).fill(0)
@@ -65,14 +145,6 @@ const scoreDistributionOptions = computed(() => ({
     y: { title: { display: true, text: 'Count', color: textColor.value }, beginAtZero: true, ticks: { stepSize: 1, color: textColor.value }, grid: { color: gridColor.value } }
   }
 }))
-
-const DIMENSIONS = [
-  { key: 'specificity', label: 'Specificity' },
-  { key: 'grounding', label: 'Grounding' },
-  { key: 'scope_fidelity', label: 'Scope Fidelity' },
-  { key: 'actionability', label: 'Actionability' },
-  { key: 'consistency', label: 'Consistency' }
-]
 
 const dimensionBreakdownData = computed(() => {
   const counts = { pass: [], partial: [], fail: [] }
@@ -115,13 +187,98 @@ const dimensionBreakdownOptions = computed(() => ({
 </script>
 
 <template>
-  <div v-if="planList.length > 0" class="p-6 border-b border-gray-200 dark:border-gray-700">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <div class="h-64">
-        <Bar :data="scoreDistributionData" :options="scoreDistributionOptions" />
+  <div class="border-b border-gray-200 dark:border-gray-700">
+    <button
+      @click="emit('toggle')"
+      class="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+    >
+      <span class="flex items-center gap-2 text-sm font-medium dark:text-gray-300">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+        Trend Visualization
+        <span class="text-xs font-normal text-gray-400 dark:text-gray-500">{{ trailingLabel }}</span>
+      </span>
+      <svg
+        class="h-4 w-4 transition-transform dark:text-gray-300"
+        :class="{ 'rotate-180': expanded }"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+
+    <div v-if="expanded" class="px-6 pb-6 space-y-6">
+      <!-- Trend charts -->
+      <div class="flex flex-wrap gap-6">
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium dark:text-gray-300">Plans Processed via AI</h3>
+            <div class="relative group">
+              <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                Number of test plans processed via AI per week over the selected time window.
+              </div>
+            </div>
+          </div>
+          <div class="h-[180px]">
+            <Line :data="plansProcessedChartData" :options="plansProcessedChartOptions" />
+          </div>
+        </div>
+
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium dark:text-gray-300">Auto-Revised</h3>
+            <div class="relative group">
+              <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                Count of auto-revised test plans per week over the selected time window.
+              </div>
+            </div>
+          </div>
+          <div class="h-[180px]">
+            <Bar :data="autoRevisedChartData" :options="autoRevisedChartOptions" />
+          </div>
+        </div>
+
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium dark:text-gray-300">Verdict Breakdown</h3>
+            <div class="relative group">
+              <svg class="h-4 w-4 text-gray-400 dark:text-gray-500 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div class="absolute right-0 top-6 z-10 hidden group-hover:block w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-gray-900/50">
+                Counts of test plans by verdict: Ready, Revise, or Rework for the selected time window.
+              </div>
+            </div>
+          </div>
+          <div class="h-[180px]">
+            <Bar :data="breakdownChartData" :options="breakdownChartOptions" />
+          </div>
+        </div>
       </div>
-      <div class="h-64">
-        <Bar :data="dimensionBreakdownData" :options="dimensionBreakdownOptions" />
+
+      <!-- Quality distribution charts -->
+      <div v-if="planList.length > 0" class="flex flex-wrap gap-6">
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="h-[200px]">
+            <Bar :data="scoreDistributionData" :options="scoreDistributionOptions" />
+          </div>
+        </div>
+        <div class="min-w-[280px] flex-1 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <div class="h-[200px]">
+            <Bar :data="dimensionBreakdownData" :options="dimensionBreakdownOptions" />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/modules/ai-impact/client/components/TestPlanMetricsRow.vue
+++ b/modules/ai-impact/client/components/TestPlanMetricsRow.vue
@@ -1,79 +1,93 @@
 <script setup>
-import { computed } from 'vue'
+import { getTrendClass, formatFrictionChange } from '../utils/format-helpers.js'
 
-const props = defineProps({
-  testPlans: { type: Object, default: () => ({}) }
-})
-
-const planList = computed(() => Object.values(props.testPlans))
-
-const stats = computed(() => {
-  let sum = 0, ready = 0, revise = 0, rework = 0, autoRevised = 0
-  for (const p of planList.value) {
-    sum += (p.score || 0)
-    if (p.verdict === 'Ready') ready++
-    else if (p.verdict === 'Revise') revise++
-    else if (p.verdict === 'Rework') rework++
-    if (p.autoRevised) autoRevised++
-  }
-  const total = planList.value.length
-  return {
-    total,
-    avg: total ? (sum / total).toFixed(1) : 0,
-    passRate: total ? Math.round((ready / total) * 100) : 0,
-    ready,
-    revise,
-    rework,
-    autoRevised
+defineProps({
+  metrics: {
+    type: Object,
+    default: null
+  },
+  reviewStatus: {
+    type: Object,
+    default: null
   }
 })
 </script>
 
 <template>
-  <div class="p-6 border-b border-gray-200 dark:border-gray-700">
-    <div class="grid gap-6 grid-cols-2 lg:grid-cols-7">
+  <div v-if="metrics" class="p-6 border-b border-gray-200 dark:border-gray-700">
+    <div class="grid gap-6 grid-cols-2 lg:grid-cols-4">
+      <!-- Plans Processed -->
+      <div class="space-y-1">
+        <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+          </svg>
+          Plans Processed via AI
+        </p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.windowTotal }}</span>
+          <span class="text-sm flex items-center gap-1" :class="getTrendClass(metrics.trend)">
+            <svg v-if="metrics.trend === 'growing'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+            </svg>
+            <svg v-else-if="metrics.trend === 'declining'" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6" />
+            </svg>
+            <svg v-else class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
+            </svg>
+            {{ metrics.priorWindowTotal }} prev period
+          </span>
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500">
+          {{ metrics.passRate }}% pass rate
+        </p>
+      </div>
+
+      <!-- Auto-Revised -->
+      <div class="space-y-1">
+        <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+          </svg>
+          Auto-Revised
+        </p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.autoRevisedCount }}</span>
+          <span v-if="metrics.priorAutoRevisedCount != null" class="text-xs text-gray-400 dark:text-gray-500">
+            {{ metrics.priorAutoRevisedCount }} prev period
+          </span>
+        </div>
+        <p v-if="reviewStatus" class="text-xs text-gray-400 dark:text-gray-500">
+          {{ reviewStatus.awaitingSignoffPct }}% awaiting sign-off
+          <span class="ml-1">{{ formatFrictionChange(reviewStatus.awaitingSignoffChange) }}</span>
+        </p>
+      </div>
+
+      <!-- Total Plans -->
       <div class="space-y-1">
         <p class="text-sm text-gray-500 dark:text-gray-400">Total Plans</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ stats.total }}</span>
+        <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.windowTotal }}</span>
+        <p class="text-xs text-gray-400 dark:text-gray-500">{{ metrics.totalPlans }} all time</p>
       </div>
 
+      <!-- Trend Status -->
       <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Pass Rate</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ stats.passRate }}%</span>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Avg Score</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ stats.avg }}</span>
-        <p class="text-xs text-gray-400 dark:text-gray-500">out of 10</p>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Ready</p>
-        <span class="text-3xl font-bold" :class="stats.ready > 0 ? 'text-green-600 dark:text-green-400' : 'dark:text-gray-100'">
-          {{ stats.ready }}
-        </span>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Revise</p>
-        <span class="text-3xl font-bold" :class="stats.revise > 0 ? 'text-amber-600 dark:text-amber-400' : 'dark:text-gray-100'">
-          {{ stats.revise }}
-        </span>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Rework</p>
-        <span class="text-3xl font-bold" :class="stats.rework > 0 ? 'text-red-600 dark:text-red-400' : 'dark:text-gray-100'">
-          {{ stats.rework }}
-        </span>
-      </div>
-
-      <div class="space-y-1">
-        <p class="text-sm text-gray-500 dark:text-gray-400">Auto-revised</p>
-        <span class="text-3xl font-bold" :class="stats.autoRevised > 0 ? 'text-blue-600 dark:text-blue-400' : 'dark:text-gray-100'">
-          {{ stats.autoRevised }}
-        </span>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Trend Status</p>
+        <div class="flex items-center gap-2">
+          <svg v-if="metrics.trend === 'growing'" class="h-5 w-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+          </svg>
+          <svg v-else-if="metrics.trend === 'declining'" class="h-5 w-5 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6" />
+          </svg>
+          <svg v-else class="h-5 w-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
+          </svg>
+          <span class="text-lg font-semibold capitalize dark:text-gray-100">{{ metrics.trend }}</span>
+        </div>
       </div>
     </div>
   </div>

--- a/modules/ai-impact/client/components/TestPlanMetricsRow.vue
+++ b/modules/ai-impact/client/components/TestPlanMetricsRow.vue
@@ -69,8 +69,8 @@ defineProps({
       <!-- Total Plans -->
       <div class="space-y-1">
         <p class="text-sm text-gray-500 dark:text-gray-400">Total Plans</p>
-        <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.windowTotal }}</span>
-        <p class="text-xs text-gray-400 dark:text-gray-500">{{ metrics.totalPlans }} all time</p>
+        <span class="text-3xl font-bold dark:text-gray-100">{{ metrics.totalPlans }}</span>
+        <p class="text-xs text-gray-400 dark:text-gray-500">{{ metrics.windowTotal }} this period</p>
       </div>
 
       <!-- Trend Status -->

--- a/modules/ai-impact/client/components/TestPlanReviewContent.vue
+++ b/modules/ai-impact/client/components/TestPlanReviewContent.vue
@@ -9,6 +9,12 @@ defineProps({
   error: { type: String, default: null },
   testPlans: { type: Object, default: () => ({}) },
   testPlanMeta: { type: Object, default: () => ({}) },
+  metrics: { type: Object, default: null },
+  trendData: { type: Array, default: () => [] },
+  breakdown: { type: Array, default: () => [] },
+  reviewStatus: { type: Object, default: null },
+  timeWindow: { type: String, default: 'month' },
+  chartExpanded: { type: Boolean, default: true },
   searchQuery: { type: String, default: '' },
   verdictFilter: { type: String, default: 'all' },
   sortBy: { type: String, default: 'default' },
@@ -16,6 +22,8 @@ defineProps({
 })
 
 const emit = defineEmits([
+  'update:timeWindow',
+  'update:chartExpanded',
   'update:searchQuery',
   'update:verdictFilter',
   'update:sortBy',
@@ -25,51 +33,82 @@ const emit = defineEmits([
 </script>
 
 <template>
-  <main class="flex-1 flex flex-col overflow-auto">
-    <!-- Loading -->
-    <LoadingOverlay v-if="loading" message="Loading test plan reviews..." />
-
-    <!-- Error -->
-    <div v-else-if="error" class="flex-1 flex flex-col items-center justify-center">
-      <div class="text-red-500 dark:text-red-400 mb-2">Failed to load test plan data</div>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ error }}</p>
-      <button
-        @click="emit('retry')"
-        class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700"
-      >
-        Retry
-      </button>
-    </div>
-
-    <!-- Empty state -->
-    <div v-else-if="Object.keys(testPlans).length === 0" class="flex-1 flex flex-col items-center justify-center">
-      <div class="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-4">
-        <svg class="h-8 w-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
-        </svg>
+  <div class="flex-1 flex flex-col min-w-0">
+    <!-- Top Bar -->
+    <header class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-3 flex items-center justify-between">
+      <div>
+        <h2 class="text-lg font-semibold dark:text-gray-100">Test Plan Review</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Quality metrics and test plan tracking</p>
       </div>
-      <h2 class="text-xl font-semibold mb-2 dark:text-gray-100">No Test Plan Reviews Yet</h2>
-      <p class="text-gray-500 dark:text-gray-400 text-center max-w-md">
-        Test plan review data will appear here once the assessment pipeline pushes results.
-      </p>
-    </div>
+      <div class="flex items-center gap-2">
+        <label for="tp-time-window" class="text-sm text-gray-500 dark:text-gray-400">Showing:</label>
+        <select
+          id="tp-time-window"
+          :value="timeWindow"
+          @change="emit('update:timeWindow', $event.target.value)"
+          class="border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm bg-white dark:bg-gray-800 dark:text-gray-300"
+        >
+          <option value="week">This Week</option>
+          <option value="month">This Month</option>
+          <option value="3months">Last 3 Months</option>
+        </select>
+      </div>
+    </header>
 
-    <!-- Data loaded -->
-    <template v-else>
-      <TestPlanMetricsRow :testPlans="testPlans" />
-      <TestPlanCharts :testPlans="testPlans" />
-      <TestPlanList
-        :testPlans="testPlans"
-        :selectedPlan="selectedPlan"
-        :searchQuery="searchQuery"
-        :verdictFilter="verdictFilter"
-        :sortBy="sortBy"
-        @update:searchQuery="emit('update:searchQuery', $event)"
-        @update:verdictFilter="emit('update:verdictFilter', $event)"
-        @update:sortBy="emit('update:sortBy', $event)"
-        @selectPlan="emit('selectPlan', $event)"
-      />
-    </template>
-  </main>
+    <!-- Content -->
+    <main class="flex-1 flex flex-col overflow-auto">
+      <!-- Loading -->
+      <LoadingOverlay v-if="loading" message="Loading test plan reviews..." />
+
+      <!-- Error -->
+      <div v-else-if="error" class="flex-1 flex flex-col items-center justify-center">
+        <div class="text-red-500 dark:text-red-400 mb-2">Failed to load test plan data</div>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ error }}</p>
+        <button
+          @click="emit('retry')"
+          class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700"
+        >
+          Retry
+        </button>
+      </div>
+
+      <!-- Empty state -->
+      <div v-else-if="Object.keys(testPlans).length === 0" class="flex-1 flex flex-col items-center justify-center">
+        <div class="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-4">
+          <svg class="h-8 w-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+          </svg>
+        </div>
+        <h2 class="text-xl font-semibold mb-2 dark:text-gray-100">No Test Plan Reviews Yet</h2>
+        <p class="text-gray-500 dark:text-gray-400 text-center max-w-md">
+          Test plan review data will appear here once the assessment pipeline pushes results.
+        </p>
+      </div>
+
+      <!-- Data loaded -->
+      <template v-else>
+        <TestPlanMetricsRow :metrics="metrics" :reviewStatus="reviewStatus" />
+        <TestPlanCharts
+          :trendData="trendData"
+          :breakdown="breakdown"
+          :expanded="chartExpanded"
+          :timeWindow="timeWindow"
+          :testPlans="testPlans"
+          @toggle="emit('update:chartExpanded', !chartExpanded)"
+        />
+        <TestPlanList
+          :testPlans="testPlans"
+          :selectedPlan="selectedPlan"
+          :searchQuery="searchQuery"
+          :verdictFilter="verdictFilter"
+          :sortBy="sortBy"
+          @update:searchQuery="emit('update:searchQuery', $event)"
+          @update:verdictFilter="emit('update:verdictFilter', $event)"
+          @update:sortBy="emit('update:sortBy', $event)"
+          @selectPlan="emit('selectPlan', $event)"
+        />
+      </template>
+    </main>
+  </div>
 </template>

--- a/modules/ai-impact/client/composables/useChartTheme.js
+++ b/modules/ai-impact/client/composables/useChartTheme.js
@@ -1,0 +1,20 @@
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+
+export function useChartTheme() {
+  const isDark = ref(false)
+
+  onMounted(() => {
+    isDark.value = document.documentElement.classList.contains('dark') ||
+      (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    const observer = new MutationObserver(() => {
+      isDark.value = document.documentElement.classList.contains('dark')
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    onBeforeUnmount(() => observer.disconnect())
+  })
+
+  const textColor = computed(() => isDark.value ? 'rgba(209, 213, 219, 1)' : 'rgba(107, 114, 128, 1)')
+  const gridColor = computed(() => isDark.value ? 'rgba(75, 85, 99, 0.5)' : 'rgba(229, 231, 235, 1)')
+
+  return { isDark, textColor, gridColor }
+}

--- a/modules/ai-impact/client/composables/useFeatures.js
+++ b/modules/ai-impact/client/composables/useFeatures.js
@@ -1,25 +1,35 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 
-// Singleton state — fetch once, share refs
 const features = ref({})
 const featureMeta = ref({ lastSyncedAt: null, totalFeatures: 0 })
+const metrics = ref(null)
+const trendData = ref([])
+const breakdown = ref([])
+const reviewStatus = ref(null)
 const featureLoading = ref(false)
 const featureError = ref(null)
 const detailCache = ref({})
+
+const timeWindow = ref('month')
 let hasFetched = false
 
 async function loadFeatures() {
   featureLoading.value = true
   featureError.value = null
   try {
-    const data = await apiRequest('/modules/ai-impact/features')
+    const tw = timeWindow.value || 'month'
+    const data = await apiRequest(`/modules/ai-impact/features?timeWindow=${tw}`)
     features.value = data.features || {}
     detailCache.value = {}
     featureMeta.value = {
       lastSyncedAt: data.lastSyncedAt,
       totalFeatures: data.totalFeatures
     }
+    metrics.value = data.metrics || null
+    trendData.value = data.trendData || []
+    breakdown.value = data.breakdown || []
+    reviewStatus.value = data.reviewStatus || null
   } catch (e) {
     featureError.value = e.message
   } finally {
@@ -43,7 +53,12 @@ async function loadFeatureDetail(key) {
   }
 }
 
-export function useFeatures() {
+watch(timeWindow, () => loadFeatures())
+
+export function useFeatures(tw) {
+  if (tw) {
+    timeWindow.value = tw.value || tw
+  }
   if (!hasFetched) {
     hasFetched = true
     loadFeatures()
@@ -51,19 +66,28 @@ export function useFeatures() {
   return {
     features,
     featureMeta,
+    metrics,
+    trendData,
+    breakdown,
+    reviewStatus,
     featureLoading,
     featureError,
     loadFeatures,
     loadFeatureDetail,
-    detailCache
+    detailCache,
+    timeWindow
   }
 }
 
 export function _resetForTesting() {
   features.value = {}
   featureMeta.value = { lastSyncedAt: null, totalFeatures: 0 }
+  metrics.value = null
+  trendData.value = []
+  breakdown.value = []
+  reviewStatus.value = null
   featureLoading.value = false
   featureError.value = null
   detailCache.value = {}
-  hasFetched = true // prevent auto-fetch so tests control when loading happens
+  hasFetched = true
 }

--- a/modules/ai-impact/client/composables/useTestPlans.js
+++ b/modules/ai-impact/client/composables/useTestPlans.js
@@ -1,61 +1,79 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 
-/**
- * Composable for loading and caching test plan quality data.
- * - testPlans: Map<string, SlimTestPlan> (keyed by RHAISTRAT key)
- * - loadTestPlans(): fetches GET /test-plans (slim projection)
- * - loadTestPlanDetail(key): fetches GET /test-plans/:key (full + history)
- */
-export function useTestPlans() {
-  const testPlans = ref({})
-  const testPlanMeta = ref({ lastSyncedAt: null, totalTestPlans: 0 })
-  const testPlanLoading = ref(false)
-  const testPlanError = ref(null)
+const testPlans = ref({})
+const testPlanMeta = ref({ lastSyncedAt: null, totalTestPlans: 0 })
+const metrics = ref(null)
+const trendData = ref([])
+const breakdown = ref([])
+const reviewStatus = ref(null)
+const testPlanLoading = ref(false)
+const testPlanError = ref(null)
+const detailCache = ref({})
 
-  // Cache for full detail fetches (keyed by RHAISTRAT key)
-  const detailCache = ref({})
+const timeWindow = ref('month')
+let hasFetched = false
 
-  async function loadTestPlans() {
-    testPlanLoading.value = true
-    testPlanError.value = null
-    try {
-      const data = await apiRequest('/modules/ai-impact/test-plans')
-      testPlans.value = data.testPlans || {}
-      detailCache.value = {}
-      testPlanMeta.value = {
-        lastSyncedAt: data.lastSyncedAt,
-        totalTestPlans: data.totalTestPlans
-      }
-    } catch (e) {
-      testPlanError.value = e.message
-    } finally {
-      testPlanLoading.value = false
+async function loadTestPlans() {
+  testPlanLoading.value = true
+  testPlanError.value = null
+  try {
+    const tw = timeWindow.value || 'month'
+    const data = await apiRequest(`/modules/ai-impact/test-plans?timeWindow=${tw}`)
+    testPlans.value = data.testPlans || {}
+    detailCache.value = {}
+    testPlanMeta.value = {
+      lastSyncedAt: data.lastSyncedAt,
+      totalTestPlans: data.totalTestPlans
     }
+    metrics.value = data.metrics || null
+    trendData.value = data.trendData || []
+    breakdown.value = data.breakdown || []
+    reviewStatus.value = data.reviewStatus || null
+  } catch (e) {
+    testPlanError.value = e.message
+  } finally {
+    testPlanLoading.value = false
   }
+}
 
-  async function loadTestPlanDetail(key) {
-    if (detailCache.value[key]) {
-      return detailCache.value[key]
-    }
-    try {
-      const data = await apiRequest(`/modules/ai-impact/test-plans/${encodeURIComponent(key)}`)
-      detailCache.value[key] = data
-      return data
-    } catch (e) {
-      if (e.message && e.message.includes('404')) {
-        return null
-      }
-      throw e
-    }
+async function loadTestPlanDetail(key) {
+  if (detailCache.value[key]) {
+    return detailCache.value[key]
   }
+  try {
+    const data = await apiRequest(`/modules/ai-impact/test-plans/${encodeURIComponent(key)}`)
+    detailCache.value[key] = data
+    return data
+  } catch (e) {
+    if (e.message && e.message.includes('404')) {
+      return null
+    }
+    throw e
+  }
+}
 
+watch(timeWindow, () => loadTestPlans())
+
+export function useTestPlans(tw) {
+  if (tw) {
+    timeWindow.value = tw.value || tw
+  }
+  if (!hasFetched) {
+    hasFetched = true
+    loadTestPlans()
+  }
   return {
     testPlans,
     testPlanMeta,
+    metrics,
+    trendData,
+    breakdown,
+    reviewStatus,
     testPlanLoading,
     testPlanError,
     loadTestPlans,
-    loadTestPlanDetail
+    loadTestPlanDetail,
+    timeWindow
   }
 }

--- a/modules/ai-impact/client/composables/useTestPlans.js
+++ b/modules/ai-impact/client/composables/useTestPlans.js
@@ -55,6 +55,19 @@ async function loadTestPlanDetail(key) {
 
 watch(timeWindow, () => loadTestPlans())
 
+export function _resetForTesting() {
+  testPlans.value = {}
+  testPlanMeta.value = { lastSyncedAt: null, totalTestPlans: 0 }
+  metrics.value = null
+  trendData.value = []
+  breakdown.value = []
+  reviewStatus.value = null
+  testPlanLoading.value = false
+  testPlanError.value = null
+  detailCache.value = {}
+  hasFetched = true
+}
+
 export function useTestPlans(tw) {
   if (tw) {
     timeWindow.value = tw.value || tw

--- a/modules/ai-impact/client/utils/format-helpers.js
+++ b/modules/ai-impact/client/utils/format-helpers.js
@@ -1,0 +1,16 @@
+export function getTrendClass(trend) {
+  if (trend === 'growing') return 'text-green-600 dark:text-green-400'
+  if (trend === 'declining') return 'text-red-600 dark:text-red-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+export function formatChange(change) {
+  if (change > 0) return `+${change}%`
+  return `${change}%`
+}
+
+export function formatFrictionChange(change) {
+  if (change > 0) return `+${change}pp`
+  if (change < 0) return `${change}pp`
+  return '—'
+}

--- a/modules/ai-impact/client/views/FeatureReviewView.vue
+++ b/modules/ai-impact/client/views/FeatureReviewView.vue
@@ -17,14 +17,17 @@ const recommendationFilter = ref('all')
 const priorityFilter = ref('all')
 const humanReviewFilter = ref('all')
 const sortBy = ref('default')
+const chartExpanded = ref(true)
+const timeWindow = ref('month')
 
-const { features, featureMeta, featureLoading, featureError, loadFeatures, loadFeatureDetail } = useFeatures()
-
-loadFeatures()
+const {
+  features, featureMeta, metrics, trendData, breakdown, reviewStatus,
+  featureLoading, featureError, loadFeatures, loadFeatureDetail
+} = useFeatures(timeWindow)
 
 // Load RFE data only for jiraHost (used by detail panel links)
-const timeWindow = ref('month')
-const { rfeData } = useAIImpact(timeWindow)
+const rfeTimeWindow = ref('month')
+const { rfeData } = useAIImpact(rfeTimeWindow)
 
 function handleRetry() {
   loadFeatures()
@@ -32,7 +35,6 @@ function handleRetry() {
 
 function handleSelectFeature(feature) {
   if (feature) {
-    // Navigate to the consolidated Feature Traffic Feature page
     crossNavigate('releases', 'feature-detail', {
       key: feature.key,
       fromFeatureReview: '1'
@@ -87,12 +89,20 @@ watch(() => Object.keys(features.value).length, () => {
       :error="featureError"
       :features="features"
       :featureMeta="featureMeta"
+      :metrics="metrics"
+      :trendData="trendData"
+      :breakdown="breakdown"
+      :reviewStatus="reviewStatus"
+      :timeWindow="timeWindow"
+      :chartExpanded="chartExpanded"
       :searchQuery="searchQuery"
       :recommendationFilter="recommendationFilter"
       :priorityFilter="priorityFilter"
       :humanReviewFilter="humanReviewFilter"
       :sortBy="sortBy"
       :selectedFeature="selectedFeature"
+      @update:timeWindow="timeWindow = $event"
+      @update:chartExpanded="chartExpanded = $event"
       @update:searchQuery="searchQuery = $event"
       @update:recommendationFilter="recommendationFilter = $event"
       @update:priorityFilter="priorityFilter = $event"

--- a/modules/ai-impact/client/views/FeatureReviewView.vue
+++ b/modules/ai-impact/client/views/FeatureReviewView.vue
@@ -18,12 +18,12 @@ const priorityFilter = ref('all')
 const humanReviewFilter = ref('all')
 const sortBy = ref('default')
 const chartExpanded = ref(true)
-const timeWindow = ref('month')
 
 const {
   features, featureMeta, metrics, trendData, breakdown, reviewStatus,
-  featureLoading, featureError, loadFeatures, loadFeatureDetail
-} = useFeatures(timeWindow)
+  featureLoading, featureError, loadFeatures, loadFeatureDetail,
+  timeWindow
+} = useFeatures()
 
 // Load RFE data only for jiraHost (used by detail panel links)
 const rfeTimeWindow = ref('month')

--- a/modules/ai-impact/client/views/TestPlanView.vue
+++ b/modules/ai-impact/client/views/TestPlanView.vue
@@ -13,14 +13,17 @@ const selectedPlan = ref(null)
 const searchQuery = ref('')
 const verdictFilter = ref('all')
 const sortBy = ref('default')
+const chartExpanded = ref(true)
+const timeWindow = ref('month')
 
-const { testPlans, testPlanMeta, testPlanLoading, testPlanError, loadTestPlans, loadTestPlanDetail } = useTestPlans()
-
-loadTestPlans()
+const {
+  testPlans, testPlanMeta, metrics, trendData, breakdown, reviewStatus,
+  testPlanLoading, testPlanError, loadTestPlans, loadTestPlanDetail
+} = useTestPlans(timeWindow)
 
 // Load RFE data only for jiraHost (used by detail panel links)
-const timeWindow = ref('month')
-const { rfeData } = useAIImpact(timeWindow)
+const rfeTimeWindow = ref('month')
+const { rfeData } = useAIImpact(rfeTimeWindow)
 
 function handleRetry() {
   loadTestPlans()
@@ -78,10 +81,18 @@ watch(() => Object.keys(testPlans.value).length, () => {
       :error="testPlanError"
       :testPlans="testPlans"
       :testPlanMeta="testPlanMeta"
+      :metrics="metrics"
+      :trendData="trendData"
+      :breakdown="breakdown"
+      :reviewStatus="reviewStatus"
+      :timeWindow="timeWindow"
+      :chartExpanded="chartExpanded"
       :searchQuery="searchQuery"
       :verdictFilter="verdictFilter"
       :sortBy="sortBy"
       :selectedPlan="selectedPlan"
+      @update:timeWindow="timeWindow = $event"
+      @update:chartExpanded="chartExpanded = $event"
       @update:searchQuery="searchQuery = $event"
       @update:verdictFilter="verdictFilter = $event"
       @update:sortBy="sortBy = $event"

--- a/modules/ai-impact/client/views/TestPlanView.vue
+++ b/modules/ai-impact/client/views/TestPlanView.vue
@@ -14,12 +14,12 @@ const searchQuery = ref('')
 const verdictFilter = ref('all')
 const sortBy = ref('default')
 const chartExpanded = ref(true)
-const timeWindow = ref('month')
 
 const {
   testPlans, testPlanMeta, metrics, trendData, breakdown, reviewStatus,
-  testPlanLoading, testPlanError, loadTestPlans, loadTestPlanDetail
-} = useTestPlans(timeWindow)
+  testPlanLoading, testPlanError, loadTestPlans, loadTestPlanDetail,
+  timeWindow
+} = useTestPlans()
 
 // Load RFE data only for jiraHost (used by detail panel links)
 const rfeTimeWindow = ref('month')

--- a/modules/ai-impact/server/features/metrics.js
+++ b/modules/ai-impact/server/features/metrics.js
@@ -1,0 +1,130 @@
+const { getTimeWindowDates } = require('../metrics');
+
+function computeReviewStatusMetrics(features, timeWindow, config) {
+  const threshold = config?.trendThresholdPp || 2;
+  const now = new Date();
+  const { cutoff, priorCutoff } = getTimeWindowDates(now, timeWindow);
+
+  const currentFeatures = features.filter(f =>
+    new Date(f.reviewedAt) >= cutoff);
+  const priorFeatures = features.filter(f => {
+    const d = new Date(f.reviewedAt);
+    return d >= priorCutoff && d < cutoff;
+  });
+
+  function pct(subset, total) {
+    return total > 0 ? Math.round((subset / total) * 100) : 0;
+  }
+
+  function reviewTrend(change) {
+    if (change > threshold) return 'worsening';
+    if (change < -threshold) return 'improving';
+    return 'stable';
+  }
+
+  const currentNeedsReview = currentFeatures.filter(f =>
+    f.humanReviewStatus === 'needs-review').length;
+  const priorNeedsReview = priorFeatures.filter(f =>
+    f.humanReviewStatus === 'needs-review').length;
+
+  const needsReviewPct = pct(currentNeedsReview, currentFeatures.length);
+  const priorNeedsReviewPct = pct(priorNeedsReview, priorFeatures.length);
+  const needsReviewChange = needsReviewPct - priorNeedsReviewPct;
+
+  const currentAwaiting = currentFeatures.filter(f =>
+    f.humanReviewStatus === 'awaiting-review').length;
+  const priorAwaiting = priorFeatures.filter(f =>
+    f.humanReviewStatus === 'awaiting-review').length;
+
+  const awaitingSignoffPct = pct(currentAwaiting, currentFeatures.length);
+  const priorAwaitingSignoffPct = pct(priorAwaiting, priorFeatures.length);
+  const awaitingSignoffChange = awaitingSignoffPct - priorAwaitingSignoffPct;
+
+  return {
+    needsReviewPct,
+    needsReviewChange,
+    needsReviewTrend: reviewTrend(needsReviewChange),
+    awaitingSignoffPct,
+    awaitingSignoffChange,
+    awaitingSignoffTrend: reviewTrend(awaitingSignoffChange)
+  };
+}
+
+function computeMetrics(features, timeWindow, _config) {
+  const now = new Date();
+  const { cutoff, priorCutoff } = getTimeWindowDates(now, timeWindow);
+
+  const currentFeatures = features.filter(f => new Date(f.reviewedAt) >= cutoff);
+  const priorFeatures = features.filter(f => {
+    const d = new Date(f.reviewedAt);
+    return d >= priorCutoff && d < cutoff;
+  });
+
+  const currentApproved = currentFeatures.filter(f => f.recommendation === 'approve').length;
+  const currentTotal = currentFeatures.length;
+  const priorTotal = priorFeatures.length;
+
+  const approvalRate = currentTotal > 0 ? Math.round((currentApproved / currentTotal) * 100) : 0;
+
+  const volumeChange = currentTotal - priorTotal;
+  const trend = volumeChange > 0 ? 'growing' : volumeChange < 0 ? 'declining' : 'stable';
+
+  const needsAttentionCount = currentFeatures.filter(f => f.needsAttention).length;
+  const priorNeedsAttentionCount = priorFeatures.filter(f => f.needsAttention).length;
+
+  return {
+    windowTotal: currentTotal,
+    priorWindowTotal: priorTotal,
+    volumeChange, trend,
+    approvalRate,
+    needsAttentionCount, priorNeedsAttentionCount,
+    totalFeatures: features.length
+  };
+}
+
+function buildTrendData(features, timeWindow) {
+  const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13;
+  const now = new Date();
+  const points = [];
+
+  for (let w = weekCounts - 1; w >= 0; w--) {
+    const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000);
+    const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    const weekFeatures = features.filter(f => {
+      const d = new Date(f.reviewedAt);
+      return d >= weekStart && d < weekEnd;
+    });
+    const total = weekFeatures.length;
+    const needsAttention = weekFeatures.filter(f => f.needsAttention).length;
+
+    points.push({
+      date: weekEnd.toISOString().slice(0, 10),
+      total,
+      needsAttentionCount: needsAttention
+    });
+  }
+
+  return points;
+}
+
+function buildBreakdownData(features) {
+  return [
+    { name: 'Approve', value: features.filter(f => f.recommendation === 'approve').length },
+    { name: 'Revise', value: features.filter(f => f.recommendation === 'revise').length },
+    { name: 'Reject', value: features.filter(f => f.recommendation === 'reject').length }
+  ];
+}
+
+function computeFeatureMetrics(features, timeWindow, config) {
+  const { cutoff } = getTimeWindowDates(new Date(), timeWindow);
+  const windowFeatures = features.filter(f => new Date(f.reviewedAt) >= cutoff);
+  return {
+    metrics: computeMetrics(features, timeWindow, config),
+    trendData: buildTrendData(features, timeWindow),
+    breakdown: buildBreakdownData(windowFeatures),
+    reviewStatus: computeReviewStatusMetrics(features, timeWindow, config)
+  };
+}
+
+module.exports = { computeFeatureMetrics, computeMetrics, buildTrendData, buildBreakdownData, computeReviewStatusMetrics };

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -5,6 +5,8 @@ const {
   getLatestProjection,
   countHistoryEntries
 } = require('./storage');
+const { computeFeatureMetrics } = require('./metrics');
+const { getConfig } = require('../config');
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true';
 const jsonLimit = express.json({ limit: '10mb' });
@@ -222,10 +224,27 @@ module.exports = function registerFeatureRoutes(router, context) {
     res.json({ status: 'cleared' });
   });
 
-  // GET /features — list all features (slim projection)
+  const VALID_TIME_WINDOWS = ['week', 'month', '3months'];
+
+  // GET /features — list all features with computed metrics
   router.get('/features', requireScope('ai-impact:read'), async function(req, res) {
+    const timeWindow = VALID_TIME_WINDOWS.includes(req.query.timeWindow)
+      ? req.query.timeWindow
+      : 'month';
+
     const data = await readFeatures(readFromStorage);
-    res.json(getLatestProjection(data));
+    const projection = getLatestProjection(data);
+    const featureList = Object.values(projection.features);
+    const config = await getConfig(readFromStorage);
+    const { metrics, trendData, breakdown, reviewStatus } = computeFeatureMetrics(featureList, timeWindow, config);
+
+    res.json({
+      ...projection,
+      metrics,
+      trendData,
+      breakdown,
+      reviewStatus
+    });
   });
 
   // ─── 2. Parameterized routes AFTER ───

--- a/modules/ai-impact/server/features/routes.js
+++ b/modules/ai-impact/server/features/routes.js
@@ -226,7 +226,24 @@ module.exports = function registerFeatureRoutes(router, context) {
 
   const VALID_TIME_WINDOWS = ['week', 'month', '3months'];
 
-  // GET /features — list all features with computed metrics
+  /**
+   * @openapi
+   * /api/modules/ai-impact/features:
+   *   get:
+   *     summary: List all features with computed metrics
+   *     tags: [AI Impact - Features]
+   *     parameters:
+   *       - in: query
+   *         name: timeWindow
+   *         schema:
+   *           type: string
+   *           enum: [week, month, 3months]
+   *           default: month
+   *         description: Time window for metric computation
+   *     responses:
+   *       200:
+   *         description: All features with latest scores and trend metrics
+   */
   router.get('/features', requireScope('ai-impact:read'), async function(req, res) {
     const timeWindow = VALID_TIME_WINDOWS.includes(req.query.timeWindow)
       ? req.query.timeWindow

--- a/modules/ai-impact/server/test-plans/metrics.js
+++ b/modules/ai-impact/server/test-plans/metrics.js
@@ -1,0 +1,132 @@
+const { getTimeWindowDates } = require('../metrics');
+
+function computeReviewStatusMetrics(plans, timeWindow, config) {
+  const threshold = config?.trendThresholdPp || 2;
+  const now = new Date();
+  const { cutoff, priorCutoff } = getTimeWindowDates(now, timeWindow);
+
+  const currentPlans = plans.filter(p =>
+    new Date(p.reviewedAt) >= cutoff);
+  const priorPlans = plans.filter(p => {
+    const d = new Date(p.reviewedAt);
+    return d >= priorCutoff && d < cutoff;
+  });
+
+  function pct(subset, total) {
+    return total > 0 ? Math.round((subset / total) * 100) : 0;
+  }
+
+  function reviewTrend(change) {
+    if (change > threshold) return 'worsening';
+    if (change < -threshold) return 'improving';
+    return 'stable';
+  }
+
+  const currentNeedsReview = currentPlans.filter(p =>
+    p.humanReviewStatus === 'needs-review').length;
+  const priorNeedsReview = priorPlans.filter(p =>
+    p.humanReviewStatus === 'needs-review').length;
+
+  const needsReviewPct = pct(currentNeedsReview, currentPlans.length);
+  const priorNeedsReviewPct = pct(priorNeedsReview, priorPlans.length);
+  const needsReviewChange = needsReviewPct - priorNeedsReviewPct;
+
+  const currentAwaiting = currentPlans.filter(p =>
+    p.humanReviewStatus === 'awaiting-review').length;
+  const priorAwaiting = priorPlans.filter(p =>
+    p.humanReviewStatus === 'awaiting-review').length;
+
+  const awaitingSignoffPct = pct(currentAwaiting, currentPlans.length);
+  const priorAwaitingSignoffPct = pct(priorAwaiting, priorPlans.length);
+  const awaitingSignoffChange = awaitingSignoffPct - priorAwaitingSignoffPct;
+
+  return {
+    needsReviewPct,
+    needsReviewChange,
+    needsReviewTrend: reviewTrend(needsReviewChange),
+    awaitingSignoffPct,
+    awaitingSignoffChange,
+    awaitingSignoffTrend: reviewTrend(awaitingSignoffChange)
+  };
+}
+
+function computeMetrics(plans, timeWindow, _config) {
+  const now = new Date();
+  const { cutoff, priorCutoff } = getTimeWindowDates(now, timeWindow);
+
+  const currentPlans = plans.filter(p => new Date(p.reviewedAt) >= cutoff);
+  const priorPlans = plans.filter(p => {
+    const d = new Date(p.reviewedAt);
+    return d >= priorCutoff && d < cutoff;
+  });
+
+  const currentReady = currentPlans.filter(p => p.verdict === 'Ready').length;
+  const currentTotal = currentPlans.length;
+  const priorTotal = priorPlans.length;
+
+  const passRate = currentTotal > 0 ? Math.round((currentReady / currentTotal) * 100) : 0;
+
+  const volumeChange = currentTotal - priorTotal;
+  const trend = volumeChange > 0 ? 'growing' : volumeChange < 0 ? 'declining' : 'stable';
+
+  const autoRevisedCount = currentPlans.filter(p => p.autoRevised).length;
+  const priorAutoRevisedCount = priorPlans.filter(p => p.autoRevised).length;
+
+  return {
+    windowTotal: currentTotal,
+    priorWindowTotal: priorTotal,
+    volumeChange, trend,
+    passRate,
+    autoRevisedCount, priorAutoRevisedCount,
+    totalPlans: plans.length
+  };
+}
+
+function buildTrendData(plans, timeWindow) {
+  const weekCounts = timeWindow === 'week' ? 4 : timeWindow === 'month' ? 8 : 13;
+  const now = new Date();
+  const points = [];
+
+  for (let w = weekCounts - 1; w >= 0; w--) {
+    const weekEnd = new Date(now.getTime() - w * 7 * 24 * 60 * 60 * 1000);
+    const weekStart = new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    const weekPlans = plans.filter(p => {
+      const d = new Date(p.reviewedAt);
+      return d >= weekStart && d < weekEnd;
+    });
+    const total = weekPlans.length;
+    const ready = weekPlans.filter(p => p.verdict === 'Ready').length;
+    const autoRevised = weekPlans.filter(p => p.autoRevised).length;
+
+    points.push({
+      date: weekEnd.toISOString().slice(0, 10),
+      passRate: total > 0 ? Math.round((ready / total) * 100) : 0,
+      autoRevisedCount: autoRevised,
+      total
+    });
+  }
+
+  return points;
+}
+
+function buildBreakdownData(plans) {
+  return [
+    { name: 'Ready', value: plans.filter(p => p.verdict === 'Ready').length },
+    { name: 'Revise', value: plans.filter(p => p.verdict === 'Revise').length },
+    { name: 'Rework', value: plans.filter(p => p.verdict === 'Rework').length }
+  ];
+}
+
+function computeTestPlanMetrics(plans, timeWindow, config) {
+  const { cutoff } = getTimeWindowDates(new Date(), timeWindow);
+  const windowPlans = plans.filter(p => new Date(p.reviewedAt) >= cutoff);
+  return {
+    metrics: computeMetrics(plans, timeWindow, config),
+    trendData: buildTrendData(plans, timeWindow),
+    breakdown: buildBreakdownData(windowPlans),
+    reviewStatus: computeReviewStatusMetrics(plans, timeWindow, config)
+  };
+}
+
+module.exports = { computeTestPlanMetrics, computeMetrics, buildTrendData, buildBreakdownData, computeReviewStatusMetrics };

--- a/modules/ai-impact/server/test-plans/routes.js
+++ b/modules/ai-impact/server/test-plans/routes.js
@@ -8,6 +8,8 @@ const {
   countHistoryEntries
 } = require('./storage');
 const { syncTestPlansFromJira, acquireLock, releaseLock } = require('./jira-sync');
+const { computeTestPlanMetrics } = require('./metrics');
+const { getConfig } = require('../config');
 
 const DEMO_MODE = process.env.DEMO_MODE === 'true';
 const jsonLimit = express.json({ limit: '10mb' });
@@ -218,19 +220,44 @@ module.exports = function registerTestPlanRoutes(router, context) {
     res.json({ status: 'cleared' });
   });
 
+  const VALID_TIME_WINDOWS = ['week', 'month', '3months'];
+
   /**
    * @openapi
    * /api/modules/ai-impact/test-plans:
    *   get:
-   *     summary: List all test plans (slim projection)
+   *     summary: List all test plans with computed metrics
    *     tags: [AI Impact - Test Plans]
+   *     parameters:
+   *       - in: query
+   *         name: timeWindow
+   *         schema:
+   *           type: string
+   *           enum: [week, month, 3months]
+   *           default: month
+   *         description: Time window for metric computation
    *     responses:
    *       200:
-   *         description: All test plans with latest scores
+   *         description: All test plans with latest scores and trend metrics
    */
   router.get('/test-plans', requireScope('ai-impact:read'), async function(req, res) {
+    const timeWindow = VALID_TIME_WINDOWS.includes(req.query.timeWindow)
+      ? req.query.timeWindow
+      : 'month';
+
     const data = await readTestPlans(readFromStorage);
-    res.json(getLatestProjection(data));
+    const projection = getLatestProjection(data);
+    const plans = Object.values(projection.testPlans);
+    const config = await getConfig(readFromStorage);
+    const { metrics, trendData, breakdown, reviewStatus } = computeTestPlanMetrics(plans, timeWindow, config);
+
+    res.json({
+      ...projection,
+      metrics,
+      trendData,
+      breakdown,
+      reviewStatus
+    });
   });
 
   // ─── 2. Parameterized routes AFTER ───

--- a/tests/integration/ai-impact.spec.js
+++ b/tests/integration/ai-impact.spec.js
@@ -235,6 +235,34 @@ test.describe('AI Impact Views @ai-impact', () => {
     await testView(page, 'test-plan-review', 'Test Plan Review');
   });
 
+  test('Test Plan Review renders trend charts and time window selector', async ({ page }) => {
+    await page.goto('/#/ai-impact/test-plan-review');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const timeWindowSelect = page.locator('select#tp-time-window');
+    await expect(timeWindowSelect).toBeVisible();
+
+    const trendHeading = page.locator('text=Trend Visualization');
+    await expect(trendHeading).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('Feature Review renders trend charts and time window selector', async ({ page }) => {
+    await page.goto('/#/ai-impact/feature-review');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const timeWindowSelect = page.locator('select#fr-time-window');
+    await expect(timeWindowSelect).toBeVisible();
+
+    const trendHeading = page.locator('text=Trend Visualization');
+    await expect(trendHeading).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
   test('should load Build & Release view', async ({ page }) => {
     await testView(page, 'build-release', 'Build & Release');
   });


### PR DESCRIPTION
Add adoption trend visualization to Test Plan Review and Feature Review, matching the existing RFE Review pattern.

<img width="1308" height="699" alt="Screenshot 2026-07-16 at 15 08 32" src="https://github.com/user-attachments/assets/d909344e-dd84-4ede-8fe8-c7e2a94c1470" />
<img width="1310" height="687" alt="Screenshot 2026-07-16 at 15 08 46" src="https://github.com/user-attachments/assets/67d2af4c-1765-4549-8016-9e83cdf71cfe" />
