### PR TITLE
fix: increase backend memory limit to 1Gi

### DIFF
--- a/deploy/openshift/overlays/ai-eng/backend-secrets-patch.yaml
+++ b/deploy/openshift/overlays/ai-eng/backend-secrets-patch.yaml
@@ -7,6 +7,13 @@ spec:
     spec:
       containers:
         - name: backend
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
           env:
             # AI Eng module secrets — appended via strategic merge patch
             - name: PRODUCT_PAGES_CLIENT_ID


### PR DESCRIPTION
## Summary

- Backend pod is getting OOMKilled with the core base's 512Mi memory limit
- AI Eng deployment runs 7+ modules with in-memory caches and heavy Jira/GitHub/GitLab data processing during refresh cycles (cronjob every 15 min)
- Adds a strategic merge patch in the AI Eng overlay to increase memory to **1Gi limit / 256Mi request** (from 512Mi / 128Mi) and CPU to **1 core** (from 500m)

## Root cause

Multiple unbounded in-memory caches across modules accumulate data over time without cleanup. Combined with refresh cycles that load large datasets, 512Mi is insufficient. Cache fixes will follow in a separate PR to address the underlying leak patterns.

## Changes

| Field | Before (core base) | After (AI Eng overlay) |
|-------|-------------------|----------------------|
| Memory request | 128Mi | 256Mi |
| Memory limit | 512Mi | **1Gi** |
| CPU request | 100m | 100m |
| CPU limit | 500m | 1 |

## Test plan

- [x] `kustomize build` validates successfully — resource block renders correctly in final manifest
- [ ] Verify pod no longer OOMKills after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)