### PR TITLE
feat(releases): sticky Draft Plans audit panel

### DIFF
--- a/modules/releases/__tests__/client/plan/draft-plan-model.test.js
+++ b/modules/releases/__tests__/client/plan/draft-plan-model.test.js
@@ -16,7 +16,8 @@ import {
   canEditRow,
   isAdmin,
   setApproved,
-  summaryCounts
+  summaryCounts,
+  formatAuditDetail
 } from '../../../client/plan/utils/draft-plan-model.js'
 
 function sampleDraft() {
@@ -279,5 +280,16 @@ describe('draft-plan-model', function() {
     expect(stats.belowCut).toBe(0)
     expect(stats.descoped).toBe(1)
     expect(stats.approved).toBe(1)
+  })
+
+  it('formatAuditDetail prefers detail and falls back to key/from/to/action', function() {
+    expect(formatAuditDetail({ detail: 'Freeze EA1 (admin)' })).toBe('Freeze EA1 (admin)')
+    expect(formatAuditDetail({
+      key: 'A-1',
+      from: 'Below cut',
+      to: 'EA1',
+      action: 'decision'
+    })).toBe('A-1 · Below cut → EA1 · decision')
+    expect(formatAuditDetail({ action: 'reset' })).toBe('reset')
   })
 })

--- a/modules/releases/__tests__/client/plan/draft-plans-view.test.js
+++ b/modules/releases/__tests__/client/plan/draft-plans-view.test.js
@@ -190,6 +190,68 @@ describe('DraftPlansView', function() {
     wrapper.unmount()
   })
 
+  it('renders sticky audit panel with entries and empty state', async function() {
+    mockApiRequest.mockImplementation(function(path) {
+      if (String(path).indexOf('/cycles') !== -1) {
+        return Promise.resolve({
+          product: 'RHOAI',
+          products: ['RHOAI', 'RHAII'],
+          defaultVersion: '3.6',
+          cycles: [{ version: '3.6', label: 'RHOAI 3.6', source: 'demo', demoMode: true }]
+        })
+      }
+      var data = JSON.parse(JSON.stringify(FIXTURE))
+      data.audit = [
+        {
+          ts: '2026-07-17T13:27:56.082Z',
+          actor: 'Admin',
+          action: 'unfreeze_event',
+          detail: 'Unfreeze EA1 (admin)'
+        }
+      ]
+      return Promise.resolve(data)
+    })
+
+    var wrapper = mountView()
+    await flushPromises()
+
+    var panel = wrapper.find('[aria-label="Draft plan audit log"]')
+    expect(panel.exists()).toBe(true)
+    expect(panel.text()).toContain('Audit')
+    expect(panel.text()).toContain('(1)')
+    expect(panel.text()).toContain('Unfreeze EA1 (admin)')
+    expect(panel.text()).toContain('Admin')
+    expect(wrapper.find('[data-testid="draft-plan-audit-list"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('shows audit empty state before any edits', async function() {
+    var wrapper = mountView()
+    await flushPromises()
+
+    var panel = wrapper.find('[aria-label="Draft plan audit log"]')
+    expect(panel.exists()).toBe(true)
+    expect(panel.text()).toContain('No changes yet.')
+    expect(panel.text()).toContain('(0)')
+    wrapper.unmount()
+  })
+
+  it('appends audit entries after freeze action', async function() {
+    var wrapper = mountView()
+    await flushPromises()
+
+    var freezeBtn = wrapper.findAll('button').find(function(b) {
+      return b.text() === 'Freeze EA1'
+    })
+    await freezeBtn.trigger('click')
+    await flushPromises()
+
+    var panel = wrapper.find('[aria-label="Draft plan audit log"]')
+    expect(panel.text()).toMatch(/Freeze EA1/)
+    expect(panel.text()).not.toContain('No changes yet.')
+    wrapper.unmount()
+  })
+
   it('shows empty state when load fails', async function() {
     mockApiRequest.mockImplementation(function(path) {
       if (String(path).indexOf('/cycles') !== -1) {

--- a/modules/releases/client/plan/components/DraftPlanAuditPanel.vue
+++ b/modules/releases/client/plan/components/DraftPlanAuditPanel.vue
@@ -1,0 +1,53 @@
+<script setup>
+import { computed } from 'vue'
+import { AUDIT_DISPLAY_CAP, formatAuditDetail } from '../utils/draft-plan-model'
+
+var props = defineProps({
+  audit: { type: Array, default: function() { return [] } }
+})
+
+var displayEntries = computed(function() {
+  return props.audit.slice(0, AUDIT_DISPLAY_CAP)
+})
+
+function formatTs(ts) {
+  if (!ts) return ''
+  var d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return String(ts)
+  return d.toLocaleString()
+}
+</script>
+
+<template>
+  <aside
+    role="complementary"
+    aria-label="Draft plan audit log"
+    class="mx-4 mt-3 mb-3 xl:mx-0 xl:mt-0 xl:mb-0 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 xl:sticky xl:top-3 xl:max-h-[calc(100vh-1.5rem)] xl:overflow-y-auto shrink-0"
+  >
+    <h2 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+      Audit
+      <span class="font-normal text-gray-400 dark:text-gray-500">({{ audit.length }})</span>
+    </h2>
+
+    <ul
+      v-if="displayEntries.length"
+      class="list-none m-0 p-0 text-xs leading-snug"
+      data-testid="draft-plan-audit-list"
+    >
+      <li
+        v-for="(entry, idx) in displayEntries"
+        :key="entry.ts + '-' + idx"
+        class="py-2 border-b border-gray-100 dark:border-gray-800 last:border-b-0"
+      >
+        <div class="text-[11px] text-gray-400 dark:text-gray-500 tabular-nums">{{ formatTs(entry.ts) }}</div>
+        <div class="text-gray-700 dark:text-gray-200">
+          <span class="font-semibold text-gray-900 dark:text-gray-100">{{ entry.actor || '—' }}</span>
+          <span class="text-gray-400 dark:text-gray-500"> — </span>
+          {{ formatAuditDetail(entry) }}
+        </div>
+      </li>
+    </ul>
+
+    <p v-else class="text-xs text-gray-400 dark:text-gray-500 m-0">No changes yet.</p>
+  </aside>
+</template>

--- a/modules/releases/client/plan/utils/draft-plan-model.js
+++ b/modules/releases/client/plan/utils/draft-plan-model.js
@@ -347,6 +347,18 @@ function auditEntriesEqual(a, b) {
   )
 }
 
+const AUDIT_DISPLAY_CAP = 80
+
+function formatAuditDetail(entry) {
+  if (!entry) return ''
+  if (entry.detail) return entry.detail
+  var parts = []
+  if (entry.key) parts.push(entry.key)
+  if (entry.from != null) parts.push(entry.from + ' → ' + entry.to)
+  if (entry.action) parts.push(entry.action)
+  return parts.filter(Boolean).join(' · ')
+}
+
 function appendAudit(audit, entry, actor) {
   var next = {
     ts: new Date().toISOString(),
@@ -731,7 +743,9 @@ export {
   capacityCheckForMove,
   componentLoad,
   cycleLoad,
+  AUDIT_DISPLAY_CAP,
   appendAudit,
+  formatAuditDetail,
   viewRow,
   applyMove,
   applyDescope,

--- a/modules/releases/client/plan/views/DraftPlansView.vue
+++ b/modules/releases/client/plan/views/DraftPlansView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useDraftPlans } from '../composables/useDraftPlans'
 import DraftPlanRow from '../components/DraftPlanRow.vue'
 import DraftPlanDrawer from '../components/DraftPlanDrawer.vue'
+import DraftPlanAuditPanel from '../components/DraftPlanAuditPanel.vue'
 
 var jiraBaseUrl = 'https://issues.redhat.com/browse'
 
@@ -439,8 +440,78 @@ onMounted(async function() {
       {{ error }}
     </div>
 
-    <!-- Dense table -->
-    <div class="overflow-x-auto">
+    <!-- Table + sticky audit panel (mirrors red-pen panel-grid) -->
+    <div
+      v-if="draft"
+      class="xl:grid xl:grid-cols-[minmax(0,1fr)_260px] xl:gap-3 xl:items-start xl:px-4 xl:pb-3"
+    >
+      <div class="min-w-0">
+        <div class="overflow-x-auto">
+          <table role="table" class="w-full text-xs">
+            <thead role="rowgroup" class="bg-gray-50 dark:bg-gray-800/60 border-b border-gray-200 dark:border-gray-700">
+              <tr role="row">
+                <th
+                  v-for="header in headers"
+                  :key="header.id"
+                  role="columnheader"
+                  scope="col"
+                  class="px-3 py-2.5 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide"
+                  :class="header.id === 'h-num' ? 'px-2 text-center w-8' : ''"
+                >
+                  {{ header.label }}
+                </th>
+              </tr>
+            </thead>
+            <tbody role="rowgroup">
+              <template v-if="loading && filteredRows.length === 0">
+                <tr v-for="i in 5" :key="'skel-' + i" role="row" class="border-b border-gray-100 dark:border-gray-800">
+                  <td v-for="j in headers.length" :key="j" class="px-3 py-3">
+                    <div class="h-3 rounded animate-pulse bg-gray-200 dark:bg-gray-700" :class="j === 3 ? 'w-24' : 'w-16'" />
+                  </td>
+                </tr>
+              </template>
+
+              <DraftPlanRow
+                v-for="(row, idx) in filteredRows"
+                :key="row.key"
+                :feature="row"
+                :index="idx + 1"
+                :jira-base-url="jiraBaseUrl"
+                :placements="PLACEMENTS"
+                @select="onSelectFeature"
+                @move="onMove"
+                @descope="descopeFeature"
+                @undescope="undescopeFeature"
+                @approve="approveFeature"
+              />
+
+              <tr v-if="!loading && !draft" role="row">
+                <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
+                  No draft plan loaded
+                </td>
+              </tr>
+              <tr v-else-if="!loading && filteredRows.length === 0" role="row">
+                <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
+                  No features match filters
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div
+          class="px-4 py-2 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900"
+        >
+          <span v-if="draft.generatedAt">Generated {{ formatTs(draft.generatedAt) }}</span>
+          <span v-if="activeCycleMeta && activeCycleMeta.source"> · source: {{ activeCycleMeta.source }}</span>
+          <span> · click a row for details</span>
+        </div>
+      </div>
+
+      <DraftPlanAuditPanel :audit="editor.audit" />
+    </div>
+
+    <div v-else class="overflow-x-auto">
       <table role="table" class="w-full text-xs">
         <thead role="rowgroup" class="bg-gray-50 dark:bg-gray-800/60 border-b border-gray-200 dark:border-gray-700">
           <tr role="row">
@@ -457,50 +528,13 @@ onMounted(async function() {
           </tr>
         </thead>
         <tbody role="rowgroup">
-          <template v-if="loading && filteredRows.length === 0">
-            <tr v-for="i in 5" :key="'skel-' + i" role="row" class="border-b border-gray-100 dark:border-gray-800">
-              <td v-for="j in headers.length" :key="j" class="px-3 py-3">
-                <div class="h-3 rounded animate-pulse bg-gray-200 dark:bg-gray-700" :class="j === 3 ? 'w-24' : 'w-16'" />
-              </td>
-            </tr>
-          </template>
-
-          <DraftPlanRow
-            v-for="(row, idx) in filteredRows"
-            :key="row.key"
-            :feature="row"
-            :index="idx + 1"
-            :jira-base-url="jiraBaseUrl"
-            :placements="PLACEMENTS"
-            @select="onSelectFeature"
-            @move="onMove"
-            @descope="descopeFeature"
-            @undescope="undescopeFeature"
-            @approve="approveFeature"
-          />
-
-          <tr v-if="!loading && !draft" role="row">
+          <tr role="row">
             <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
               No draft plan loaded
             </td>
           </tr>
-          <tr v-else-if="!loading && filteredRows.length === 0" role="row">
-            <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
-              No features match filters
-            </td>
-          </tr>
         </tbody>
       </table>
-    </div>
-
-    <div
-      v-if="draft"
-      class="px-4 py-2 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900"
-    >
-      <span v-if="draft.generatedAt">Generated {{ formatTs(draft.generatedAt) }}</span>
-      <span v-if="activeCycleMeta && activeCycleMeta.source"> · source: {{ activeCycleMeta.source }}</span>
-      <span> · click a row for details</span>
-      <span v-if="editor.audit.length"> · {{ editor.audit.length }} audit entries</span>
     </div>
 
     <DraftPlanDrawer

--- a/modules/releases/client/plan/views/DraftPlansView.vue
+++ b/modules/releases/client/plan/views/DraftPlansView.vue
@@ -485,12 +485,7 @@ onMounted(async function() {
                 @approve="approveFeature"
               />
 
-              <tr v-if="!loading && !draft" role="row">
-                <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
-                  No draft plan loaded
-                </td>
-              </tr>
-              <tr v-else-if="!loading && filteredRows.length === 0" role="row">
+              <tr v-if="!loading && filteredRows.length === 0" role="row">
                 <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
                   No features match filters
                 </td>
@@ -528,7 +523,14 @@ onMounted(async function() {
           </tr>
         </thead>
         <tbody role="rowgroup">
-          <tr role="row">
+          <template v-if="loading">
+            <tr v-for="i in 5" :key="'skel-' + i" role="row" class="border-b border-gray-100 dark:border-gray-800">
+              <td v-for="j in headers.length" :key="j" class="px-3 py-3">
+                <div class="h-3 rounded animate-pulse bg-gray-200 dark:bg-gray-700" :class="j === 3 ? 'w-24' : 'w-16'" />
+              </td>
+            </tr>
+          </template>
+          <tr v-else role="row">
             <td :colspan="headers.length" class="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
               No draft plan loaded
             </td>


### PR DESCRIPTION
## Summary
- Add a scrollable sticky audit panel beside the Draft Plans table (matches red-pen `panel-grid` layout on xl+).
- Render `editor.audit` entries with timestamp, actor, and formatted detail via shared `formatAuditDetail`.
- Replace the footer audit entry count with the full panel; empty state shows "No changes yet."

Fast-follow to #1249.

## Test plan
- [x] `npm test -- modules/releases/__tests__/client/plan/draft-plan-model.test.js modules/releases/__tests__/client/plan/draft-plans-view.test.js` (20 passed)
- [x] `npm run lint` on changed files
- [ ] Manual: open Draft Plans, confirm audit panel sticks on wide viewport and updates on move/freeze/reset


Made with [Cursor](https://cursor.com)