### PR TITLE
feat: add Release Blockers sub-tab to Deliver view

### DIFF
--- a/fixtures/releases/delivery/blockers-3.5.json
+++ b/fixtures/releases/delivery/blockers-3.5.json
@@ -1,0 +1,178 @@
+{
+  "releaseNumber": "3.5",
+  "fetchedAt": "2026-07-15T10:00:00.000Z",
+  "summary": {
+    "proposed": 2,
+    "approved": 3,
+    "rejected": 1,
+    "noStatus": 1,
+    "total": 7
+  },
+  "timing": {
+    "proposedBeforeCodeFreeze": 4,
+    "proposedAfterCodeFreeze": 3
+  },
+  "aging": {
+    "proposalToDecision": { "avg": 4, "median": 3, "p90": 6, "max": 8, "count": 4 },
+    "approvalToResolution": { "avg": 6, "median": 5, "p90": 9, "max": 12, "count": 2 },
+    "byStatus": {
+      "proposed": { "avg": 2, "median": 2, "p90": 3, "max": 3, "count": 2 },
+      "approved": { "avg": 5, "median": 5, "p90": 6, "max": 6, "count": 3 },
+      "rejected": { "avg": 8, "median": 8, "p90": 8, "max": 8, "count": 1 }
+    }
+  },
+  "blockers": [
+    {
+      "key": "RHOAIENG-40001",
+      "summary": "Model serving crash on multi-GPU inference with large batch sizes",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40001",
+      "priority": "Blocker",
+      "status": "In Progress",
+      "components": ["Model Serving"],
+      "assignee": "Alice Chen",
+      "releaseBlockerStatus": "Approved",
+      "created": "2026-07-10",
+      "daysInCurrentState": 3,
+      "daysToDecision": 1,
+      "proposedBeforeCodeFreeze": true
+    },
+    {
+      "key": "RHOAIENG-40002",
+      "summary": "Dashboard login fails intermittently with SSO token refresh",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40002",
+      "priority": "Blocker",
+      "status": "Open",
+      "components": ["Dashboard"],
+      "assignee": "Bob Kim",
+      "releaseBlockerStatus": "Proposed",
+      "created": "2026-07-12",
+      "daysInCurrentState": 3,
+      "daysToDecision": null,
+      "proposedBeforeCodeFreeze": true
+    },
+    {
+      "key": "RHOAIENG-40003",
+      "summary": "Pipeline execution hangs when upstream dependency times out",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40003",
+      "priority": "Blocker",
+      "status": "Code Review",
+      "components": ["Data Science Pipelines"],
+      "assignee": "Carol Martinez",
+      "releaseBlockerStatus": "Approved",
+      "created": "2026-07-05",
+      "daysInCurrentState": 5,
+      "daysToDecision": 2,
+      "proposedBeforeCodeFreeze": true
+    },
+    {
+      "key": "RHOAIENG-40004",
+      "summary": "Notebook controller memory leak under sustained load",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40004",
+      "priority": "Blocker",
+      "status": "In Progress",
+      "components": ["Notebooks"],
+      "assignee": "David Park",
+      "releaseBlockerStatus": "Approved",
+      "created": "2026-07-08",
+      "daysInCurrentState": 6,
+      "daysToDecision": 3,
+      "proposedBeforeCodeFreeze": true
+    },
+    {
+      "key": "RHOAIENG-40005",
+      "summary": "TrustyAI bias metric returns incorrect values for multi-class models",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40005",
+      "priority": "Blocker",
+      "status": "Open",
+      "components": ["TrustyAI"],
+      "assignee": "Eve Johnson",
+      "releaseBlockerStatus": "Proposed",
+      "created": "2026-07-14",
+      "daysInCurrentState": 1,
+      "daysToDecision": null,
+      "proposedBeforeCodeFreeze": false
+    },
+    {
+      "key": "RHOAIENG-40006",
+      "summary": "KServe autoscaler does not respect custom resource limits",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40006",
+      "priority": "Blocker",
+      "status": "Closed",
+      "components": ["Model Serving"],
+      "assignee": "Frank Lee",
+      "releaseBlockerStatus": "Rejected",
+      "created": "2026-07-02",
+      "daysInCurrentState": 8,
+      "daysToDecision": 6,
+      "proposedBeforeCodeFreeze": false
+    },
+    {
+      "key": "RHOAIENG-40007",
+      "summary": "Operator upgrade path broken from 3.4 to 3.5",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40007",
+      "priority": "Blocker",
+      "status": "In Progress",
+      "components": ["Operator"],
+      "assignee": null,
+      "releaseBlockerStatus": null,
+      "created": "2026-07-13",
+      "daysInCurrentState": null,
+      "daysToDecision": null,
+      "proposedBeforeCodeFreeze": false
+    }
+  ],
+  "criticalMonitoring": [
+    {
+      "key": "RHOAIENG-40010",
+      "summary": "Dashboard timeout on large model registry with 500+ entries",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40010",
+      "priority": "Critical",
+      "status": "Open",
+      "components": ["Dashboard"],
+      "assignee": "Grace Wang",
+      "releaseBlockerStatus": null,
+      "created": "2026-07-05",
+      "daysOpen": 10,
+      "daysInCurrentState": 10
+    },
+    {
+      "key": "RHOAIENG-40011",
+      "summary": "Inference latency spikes during model cache eviction",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40011",
+      "priority": "Critical",
+      "status": "In Progress",
+      "components": ["Model Serving"],
+      "assignee": "Henry Zhang",
+      "releaseBlockerStatus": "Proposed",
+      "created": "2026-07-08",
+      "daysOpen": 7,
+      "daysInCurrentState": 4
+    },
+    {
+      "key": "RHOAIENG-40012",
+      "summary": "Workbench fails to start on disconnected cluster environments",
+      "link": "https://redhat.atlassian.net/browse/RHOAIENG-40012",
+      "priority": "Critical",
+      "status": "Open",
+      "components": ["Notebooks"],
+      "assignee": null,
+      "releaseBlockerStatus": null,
+      "created": "2026-07-11",
+      "daysOpen": 4,
+      "daysInCurrentState": 4
+    },
+    {
+      "key": "RHAIENG-40013",
+      "summary": "Model registry sync fails silently when namespace quota exceeded",
+      "link": "https://redhat.atlassian.net/browse/RHAIENG-40013",
+      "priority": "Blocker",
+      "status": "Open",
+      "components": ["Model Registry"],
+      "assignee": "Irene Lopez",
+      "releaseBlockerStatus": "Rejected",
+      "created": "2026-07-09",
+      "daysOpen": 6,
+      "daysInCurrentState": 3
+    }
+  ]
+}

--- a/modules/releases/client/deliver/composables/useReleaseBlockers.js
+++ b/modules/releases/client/deliver/composables/useReleaseBlockers.js
@@ -1,0 +1,44 @@
+import { ref, watch } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+export function useReleaseBlockers(releaseNumberRef, codeFreezeRef) {
+  const data = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function fetchBlockers(releaseNumber, codeFreezeDate) {
+    if (!releaseNumber) {
+      data.value = null
+      return
+    }
+    loading.value = true
+    error.value = null
+    try {
+      let url = `/modules/releases/delivery/blockers/${encodeURIComponent(releaseNumber)}`
+      if (codeFreezeDate) {
+        url += `?codeFreezeDate=${encodeURIComponent(codeFreezeDate)}`
+      }
+      data.value = await apiRequest(url)
+    } catch (err) {
+      error.value = err.status === 404
+        ? 'No blocker data available for this release.'
+        : (err.message || 'Failed to load blocker data.')
+      data.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  watch(
+    [releaseNumberRef, codeFreezeRef],
+    function ([rn, cf]) { fetchBlockers(rn, cf) },
+    { immediate: true }
+  )
+
+  return {
+    data,
+    loading,
+    error,
+    refresh: function () { fetchBlockers(releaseNumberRef.value, codeFreezeRef.value) }
+  }
+}

--- a/modules/releases/client/deliver/views/ReleaseBlockersView.vue
+++ b/modules/releases/client/deliver/views/ReleaseBlockersView.vue
@@ -1,0 +1,553 @@
+<template>
+  <div>
+    <!-- Version input + chip bar navigation -->
+    <div class="flex items-center gap-3 mb-4 flex-wrap">
+      <label class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">Version:</label>
+      <input
+        v-model="manualVersion"
+        type="text"
+        :placeholder="effectiveReleaseNumber || 'e.g. rhoai-3.5.EA1'"
+        class="max-w-xs bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+        @keydown.enter="applyManualVersion"
+      />
+      <button
+        @click="applyManualVersion"
+        :disabled="!manualVersion.trim()"
+        class="px-3 py-1.5 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >Load</button>
+      <span v-if="appliedManualVersion" class="text-xs text-gray-400 dark:text-gray-500">
+        Showing: <strong class="text-gray-600 dark:text-gray-300">{{ appliedManualVersion }}</strong>
+        <button @click="clearManualVersion" class="ml-1 text-blue-500 hover:underline">&times; clear</button>
+      </span>
+      <!-- Chip bar navigation (when no manual override) -->
+      <div v-if="!appliedManualVersion && filteredReleases.length > 1" class="flex items-center gap-2 ml-auto">
+        <button :disabled="releaseIndex <= 0" @click="releaseIndex--" class="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 disabled:opacity-30">&larr;</button>
+        <span class="text-xs text-gray-500 dark:text-gray-400">{{ selectedRelease?.releaseNumber }} ({{ releaseIndex + 1 }}/{{ filteredReleases.length }})</span>
+        <button :disabled="releaseIndex >= filteredReleases.length - 1" @click="releaseIndex++" class="px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 disabled:opacity-30">&rarr;</button>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+      <p class="text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+    </div>
+
+    <!-- Empty / no release selected -->
+    <div v-else-if="!data && !effectiveReleaseNumber" class="text-center py-12">
+      <p class="text-gray-500 dark:text-gray-400">Enter a release version above or select one from the filter bar to view blockers.</p>
+    </div>
+
+    <!-- Content -->
+    <div v-else-if="data">
+      <!-- Summary Cards (clickable as filters) -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6">
+        <button
+          @click="toggleStatusFilter(null)"
+          class="text-left rounded-lg border p-4 transition-all"
+          :class="activeStatusFilter === null
+            ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 ring-2 ring-blue-300 dark:ring-blue-700'
+            : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'"
+        >
+          <p class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Total Blockers</p>
+          <p class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ data.summary.total }}</p>
+        </button>
+        <button
+          @click="toggleStatusFilter('Proposed')"
+          class="text-left rounded-lg border p-4 transition-all"
+          :class="activeStatusFilter === 'Proposed'
+            ? 'bg-amber-50 dark:bg-amber-900/20 border-amber-400 dark:border-amber-600 ring-2 ring-amber-300 dark:ring-amber-700'
+            : 'bg-white dark:bg-gray-800 border-amber-200 dark:border-amber-800 hover:border-amber-300 dark:hover:border-amber-700'"
+        >
+          <p class="text-xs font-medium text-amber-600 dark:text-amber-400 uppercase tracking-wide mb-1">Proposed</p>
+          <p class="text-2xl font-bold text-amber-700 dark:text-amber-300">{{ data.summary.proposed }}</p>
+        </button>
+        <button
+          @click="toggleStatusFilter('Approved')"
+          class="text-left rounded-lg border p-4 transition-all"
+          :class="activeStatusFilter === 'Approved'
+            ? 'bg-red-50 dark:bg-red-900/20 border-red-400 dark:border-red-600 ring-2 ring-red-300 dark:ring-red-700'
+            : 'bg-white dark:bg-gray-800 border-red-200 dark:border-red-800 hover:border-red-300 dark:hover:border-red-700'"
+        >
+          <p class="text-xs font-medium text-red-600 dark:text-red-400 uppercase tracking-wide mb-1">Approved</p>
+          <p class="text-2xl font-bold text-red-700 dark:text-red-300">{{ data.summary.approved }}</p>
+        </button>
+        <button
+          @click="toggleStatusFilter('Rejected')"
+          class="text-left rounded-lg border p-4 transition-all"
+          :class="activeStatusFilter === 'Rejected'
+            ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-400 dark:border-emerald-600 ring-2 ring-emerald-300 dark:ring-emerald-700'
+            : 'bg-white dark:bg-gray-800 border-emerald-200 dark:border-emerald-800 hover:border-emerald-300 dark:hover:border-emerald-700'"
+        >
+          <p class="text-xs font-medium text-emerald-600 dark:text-emerald-400 uppercase tracking-wide mb-1">Rejected</p>
+          <p class="text-2xl font-bold text-emerald-700 dark:text-emerald-300">{{ data.summary.rejected }}</p>
+        </button>
+        <button
+          @click="toggleStatusFilter('None')"
+          class="text-left rounded-lg border p-4 transition-all"
+          :class="activeStatusFilter === 'None'
+            ? 'bg-gray-100 dark:bg-gray-700 border-gray-400 dark:border-gray-500 ring-2 ring-gray-300 dark:ring-gray-600'
+            : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'"
+        >
+          <p class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">No Status</p>
+          <p class="text-2xl font-bold text-gray-600 dark:text-gray-400">{{ data.summary.noStatus }}</p>
+        </button>
+      </div>
+
+      <!-- Timing Breakdown + Aging Metrics row -->
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Code Freeze Timing</h3>
+          <div class="space-y-2">
+            <button @click="toggleTimingFilter(true)" class="w-full flex items-center justify-between rounded px-2 py-1 transition-colors"
+              :class="activeTimingFilter === true ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-750'">
+              <span class="text-xs" :class="activeTimingFilter === true ? 'text-blue-700 dark:text-blue-300 font-medium' : 'text-gray-500 dark:text-gray-400'">Before Code Freeze</span>
+              <span class="text-sm font-bold text-blue-600 dark:text-blue-400">{{ data.timing.proposedBeforeCodeFreeze }}</span>
+            </button>
+            <button @click="toggleTimingFilter(false)" class="w-full flex items-center justify-between rounded px-2 py-1 transition-colors"
+              :class="activeTimingFilter === false ? 'bg-orange-50 dark:bg-orange-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-750'">
+              <span class="text-xs" :class="activeTimingFilter === false ? 'text-orange-700 dark:text-orange-300 font-medium' : 'text-gray-500 dark:text-gray-400'">After Code Freeze</span>
+              <span class="text-sm font-bold text-orange-600 dark:text-orange-400">{{ data.timing.proposedAfterCodeFreeze }}</span>
+            </button>
+          </div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Proposal → Decision</h3>
+          <div v-if="data.aging.proposalToDecision.count" class="space-y-2">
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-500 dark:text-gray-400">Avg</span>
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ data.aging.proposalToDecision.avg }}d</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-500 dark:text-gray-400">Median</span>
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ data.aging.proposalToDecision.median }}d</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-500 dark:text-gray-400">Max</span>
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ data.aging.proposalToDecision.max }}d</span>
+            </div>
+            <div class="text-xs text-gray-400 dark:text-gray-500 pt-1 border-t border-gray-100 dark:border-gray-700">
+              Based on {{ data.aging.proposalToDecision.count }} transition(s)
+            </div>
+          </div>
+          <p v-else class="text-xs text-gray-400 dark:text-gray-500 italic">No transitions yet</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Approval → Resolution</h3>
+          <div v-if="data.aging.approvalToResolution.count" class="space-y-2">
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-500 dark:text-gray-400">Avg</span>
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ data.aging.approvalToResolution.avg }}d</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-500 dark:text-gray-400">Median</span>
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ data.aging.approvalToResolution.median }}d</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-500 dark:text-gray-400">Max</span>
+              <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ data.aging.approvalToResolution.max }}d</span>
+            </div>
+            <div class="text-xs text-gray-400 dark:text-gray-500 pt-1 border-t border-gray-100 dark:border-gray-700">
+              Based on {{ data.aging.approvalToResolution.count }} resolution(s)
+            </div>
+          </div>
+          <p v-else class="text-xs text-gray-400 dark:text-gray-500 italic">No resolutions yet</p>
+        </div>
+      </div>
+
+      <!-- Time in Status -->
+      <div v-if="data.aging.byStatus" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 mb-6">
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Time in Status</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div v-for="s in statusDurations" :key="s.key" class="rounded-lg border p-3" :class="s.borderClass">
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-xs font-medium uppercase tracking-wide" :class="s.labelClass">{{ s.label }}</span>
+              <span class="text-xs text-gray-400 dark:text-gray-500">{{ s.stats.count }} issue(s)</span>
+            </div>
+            <div v-if="s.stats.count" class="flex items-baseline gap-4">
+              <div class="text-center">
+                <p class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ s.stats.avg }}d</p>
+                <p class="text-xs text-gray-400 dark:text-gray-500">avg</p>
+              </div>
+              <div class="text-center">
+                <p class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ s.stats.median }}d</p>
+                <p class="text-xs text-gray-400 dark:text-gray-500">median</p>
+              </div>
+              <div class="text-center">
+                <p class="text-lg font-bold text-gray-900 dark:text-gray-100">{{ s.stats.max }}d</p>
+                <p class="text-xs text-gray-400 dark:text-gray-500">max</p>
+              </div>
+            </div>
+            <p v-else class="text-xs text-gray-400 dark:text-gray-500 italic">No issues in this status</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Critical / Blocker Monitoring -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-amber-200 dark:border-amber-800 overflow-hidden mb-6">
+        <div class="px-4 py-3 border-b border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <h3 class="text-sm font-semibold text-amber-700 dark:text-amber-400">Critical / Blocker Monitoring</h3>
+            <span class="text-xs text-amber-600 dark:text-amber-500">Issues that may escalate to release blockers</span>
+          </div>
+          <span class="text-xs text-amber-600 dark:text-amber-500 font-medium">{{ data.criticalMonitoring.length }} issues</span>
+        </div>
+        <div v-if="data.criticalMonitoring.length" class="overflow-x-auto scrollable-table">
+          <table class="w-full text-sm">
+            <thead class="sticky top-0 z-10">
+              <tr class="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+                <th v-for="col in criticalColumns" :key="col.key"
+                  class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide"
+                  :class="col.sortable
+                    ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 select-none text-gray-500 dark:text-gray-400'
+                    : 'text-gray-500 dark:text-gray-400'"
+                  @click="col.sortable && toggleCriticalSort(col.key)"
+                >
+                  {{ col.label }}
+                  <span v-if="col.sortable" class="ml-0.5 inline-block w-3 text-center"
+                    :class="criticalSortKey === col.key ? 'text-blue-600 dark:text-blue-400' : 'text-gray-300 dark:text-gray-600'"
+                  >{{ criticalSortKey === col.key ? (criticalSortDir === 'asc' ? '▲' : '▼') : '⇅' }}</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+              <tr v-for="c in sortedCritical" :key="c.key" class="hover:bg-gray-50 dark:hover:bg-gray-750">
+                <td class="px-3 py-2">
+                  <a :href="c.link" target="_blank" rel="noopener" class="text-xs text-blue-600 dark:text-blue-400 font-mono hover:underline">{{ c.key }}</a>
+                </td>
+                <td class="px-3 py-2 text-xs text-gray-700 dark:text-gray-300 max-w-xs truncate">{{ c.summary }}</td>
+                <td class="px-3 py-2">
+                  <span :class="c.priority === 'Blocker' ? 'text-red-600 dark:text-red-400' : 'text-orange-600 dark:text-orange-400'" class="text-xs font-medium">{{ c.priority }}</span>
+                </td>
+                <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400">{{ c.components.join(', ') || '—' }}</td>
+                <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400">{{ c.status }}</td>
+                <td class="px-3 py-2">
+                  <span :class="blockerStatusClass(c.releaseBlockerStatus)" class="text-xs px-2 py-0.5 rounded-full font-medium">
+                    {{ c.releaseBlockerStatus || 'None' }}
+                  </span>
+                </td>
+                <td class="px-3 py-2 text-xs font-medium" :class="agingColor(c.daysInCurrentState !== null ? c.daysInCurrentState : c.daysOpen)">
+                  {{ c.daysInCurrentState !== null ? c.daysInCurrentState + 'd' : c.daysOpen + 'd' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-else class="px-4 py-6 text-center">
+          <p class="text-xs text-amber-500 dark:text-amber-400">No critical or blocker-priority issues outside approved blockers.</p>
+        </div>
+      </div>
+
+      <!-- Blockers Table -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-6">
+        <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <div class="flex items-center justify-between mb-2">
+            <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Release Blockers</h3>
+            <span class="text-xs text-gray-400 dark:text-gray-500">{{ visibleBlockers.length }} of {{ data.blockers.length }} issues</span>
+          </div>
+          <div v-if="activeStatusFilter !== null || activeTimingFilter !== null" class="flex items-center gap-2 flex-wrap">
+            <span class="text-xs text-gray-500 dark:text-gray-400">Filters:</span>
+            <button v-if="activeStatusFilter !== null" @click="activeStatusFilter = null"
+              class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium"
+              :class="blockerStatusClass(activeStatusFilter === 'None' ? null : activeStatusFilter)">
+              {{ activeStatusFilter }} &times;
+            </button>
+            <button v-if="activeTimingFilter !== null" @click="activeTimingFilter = null"
+              class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium"
+              :class="activeTimingFilter ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400'">
+              {{ activeTimingFilter ? 'Pre-CF' : 'Post-CF' }} &times;
+            </button>
+            <button @click="clearFilters" class="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 underline">Clear all</button>
+          </div>
+        </div>
+        <div v-if="visibleBlockers.length" class="overflow-x-auto scrollable-table">
+          <table class="w-full text-sm">
+            <thead class="sticky top-0 z-10">
+              <tr class="border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+                <th v-for="col in blockerColumns" :key="col.key"
+                  class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide"
+                  :class="col.sortable
+                    ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200 select-none text-gray-500 dark:text-gray-400'
+                    : 'text-gray-500 dark:text-gray-400'"
+                  @click="col.sortable && toggleSort(col.key)"
+                >
+                  {{ col.label }}
+                  <span v-if="col.sortable" class="ml-0.5 inline-block w-3 text-center"
+                    :class="sortKey === col.key ? 'text-blue-600 dark:text-blue-400' : 'text-gray-300 dark:text-gray-600'"
+                  >{{ sortKey === col.key ? (sortDir === 'asc' ? '▲' : '▼') : '⇅' }}</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+              <tr v-for="b in visibleBlockers" :key="b.key" class="hover:bg-gray-50 dark:hover:bg-gray-750">
+                <td class="px-3 py-2">
+                  <a :href="b.link" target="_blank" rel="noopener" class="text-xs text-blue-600 dark:text-blue-400 font-mono hover:underline">{{ b.key }}</a>
+                </td>
+                <td class="px-3 py-2 text-xs text-gray-700 dark:text-gray-300 max-w-xs truncate">{{ b.summary }}</td>
+                <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400">{{ b.components.join(', ') || '—' }}</td>
+                <td class="px-3 py-2 text-xs text-gray-600 dark:text-gray-400">{{ b.status }}</td>
+                <td class="px-3 py-2">
+                  <span :class="blockerStatusClass(b.releaseBlockerStatus)" class="text-xs px-2 py-0.5 rounded-full font-medium">
+                    {{ b.releaseBlockerStatus || 'None' }}
+                  </span>
+                </td>
+                <td class="px-3 py-2 text-xs font-medium" :class="agingColor(b.daysInCurrentState)">
+                  {{ b.daysInCurrentState !== null ? b.daysInCurrentState + 'd' : '—' }}
+                </td>
+                <td class="px-3 py-2">
+                  <span v-if="b.proposedBeforeCodeFreeze" class="text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 font-medium">Pre-CF</span>
+                  <span v-else class="text-xs px-1.5 py-0.5 rounded bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 font-medium">Post-CF</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-else class="px-4 py-6 text-center">
+          <p v-if="data.blockers.length" class="text-xs text-gray-400 dark:text-gray-500">No blockers match the active filters.</p>
+          <p v-else class="text-xs text-gray-400 dark:text-gray-500">No release blockers found for this version.</p>
+        </div>
+      </div>
+
+      <!-- Updated timestamp -->
+      <div v-if="data.fetchedAt" class="mt-4 flex items-center justify-between">
+        <p class="text-xs text-gray-400 dark:text-gray-500">
+          Data fetched {{ formatDate(data.fetchedAt) }}
+        </p>
+        <button @click="refresh" :disabled="loading"
+          class="text-xs text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50">
+          Refresh
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, inject, watch } from 'vue'
+import { useReleaseBlockers } from '../composables/useReleaseBlockers.js'
+
+const filter = inject('releaseFilter')
+const moduleNav = inject('moduleNav', null)
+
+const filteredReleases = computed(function () {
+  return filter.filteredReleases.value || []
+})
+
+const releaseIndex = ref(0)
+
+watch(filteredReleases, function () {
+  releaseIndex.value = 0
+})
+
+const selectedRelease = computed(function () {
+  var releases = filteredReleases.value
+  if (!releases.length) return null
+  var idx = Math.min(releaseIndex.value, releases.length - 1)
+  return releases[idx] || null
+})
+
+// Restore manual version from URL params on mount
+function getParam(key) {
+  var params = moduleNav && moduleNav.params ? moduleNav.params.value : {}
+  return params[key] || null
+}
+
+function updateParams(updates) {
+  if (moduleNav && moduleNav.updateParams) {
+    moduleNav.updateParams(updates, { push: false })
+  }
+}
+
+const manualVersion = ref(getParam('version') || '')
+const appliedManualVersion = ref(getParam('version') || '')
+
+function applyManualVersion() {
+  var v = manualVersion.value.trim()
+  if (v) {
+    appliedManualVersion.value = v
+    updateParams({ version: v })
+  }
+}
+
+function clearManualVersion() {
+  appliedManualVersion.value = ''
+  manualVersion.value = ''
+  updateParams({ version: '' })
+}
+
+const effectiveReleaseNumber = computed(function () {
+  if (appliedManualVersion.value) return appliedManualVersion.value
+  if (selectedRelease.value) return selectedRelease.value.releaseNumber
+  return null
+})
+
+const codeFreezeDate = computed(function () {
+  return selectedRelease.value ? (selectedRelease.value.codeFreezeDate || null) : null
+})
+
+const { data, loading, error, refresh } = useReleaseBlockers(effectiveReleaseNumber, codeFreezeDate)
+
+// Filters — restore from URL params
+var savedStatus = getParam('blockerStatus')
+var savedTiming = getParam('timing')
+const activeStatusFilter = ref(savedStatus || null)
+const activeTimingFilter = ref(savedTiming === 'pre' ? true : savedTiming === 'post' ? false : null)
+
+watch(data, function () {
+  if (!getParam('blockerStatus')) activeStatusFilter.value = null
+  if (!getParam('timing')) activeTimingFilter.value = null
+})
+
+function toggleStatusFilter(status) {
+  activeStatusFilter.value = activeStatusFilter.value === status ? null : status
+  updateParams({ blockerStatus: activeStatusFilter.value || '' })
+}
+
+function toggleTimingFilter(isBeforeCF) {
+  activeTimingFilter.value = activeTimingFilter.value === isBeforeCF ? null : isBeforeCF
+  var val = activeTimingFilter.value === true ? 'pre' : activeTimingFilter.value === false ? 'post' : ''
+  updateParams({ timing: val })
+}
+
+function clearFilters() {
+  activeStatusFilter.value = null
+  activeTimingFilter.value = null
+  updateParams({ blockerStatus: '', timing: '' })
+}
+
+// Blocker table sorting
+const sortKey = ref('daysInCurrentState')
+const sortDir = ref('desc')
+
+const blockerColumns = [
+  { key: 'key', label: 'Key', sortable: true },
+  { key: 'summary', label: 'Summary', sortable: false },
+  { key: 'components', label: 'Component', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'releaseBlockerStatus', label: 'Blocker Status', sortable: true },
+  { key: 'daysInCurrentState', label: 'Days in State', sortable: true },
+  { key: 'proposedBeforeCodeFreeze', label: 'Timing', sortable: true }
+]
+
+function toggleSort(key) {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDir.value = 'desc'
+  }
+}
+
+function sortRows(rows, key, dir) {
+  var mult = dir === 'asc' ? 1 : -1
+  return rows.sort(function (a, b) {
+    var av = key === 'components' ? (a.components[0] || '') : a[key]
+    var bv = key === 'components' ? (b.components[0] || '') : b[key]
+    if (av === null && bv === null) return 0
+    if (av === null) return mult
+    if (bv === null) return -mult
+    if (typeof av === 'number') return (av - bv) * mult
+    if (typeof av === 'boolean') return ((av ? 1 : 0) - (bv ? 1 : 0)) * mult
+    return String(av).localeCompare(String(bv)) * mult
+  })
+}
+
+const visibleBlockers = computed(function () {
+  var rows = (data.value && data.value.blockers) ? data.value.blockers.slice() : []
+  if (activeStatusFilter.value !== null) {
+    if (activeStatusFilter.value === 'None') {
+      rows = rows.filter(function (b) { return !b.releaseBlockerStatus })
+    } else {
+      rows = rows.filter(function (b) { return b.releaseBlockerStatus === activeStatusFilter.value })
+    }
+  }
+  if (activeTimingFilter.value !== null) {
+    rows = rows.filter(function (b) { return b.proposedBeforeCodeFreeze === activeTimingFilter.value })
+  }
+  return sortRows(rows, sortKey.value, sortDir.value)
+})
+
+// Critical monitoring table sorting
+const criticalSortKey = ref('daysOpen')
+const criticalSortDir = ref('desc')
+
+const criticalColumns = [
+  { key: 'key', label: 'Key', sortable: true },
+  { key: 'summary', label: 'Summary', sortable: false },
+  { key: 'priority', label: 'Priority', sortable: true },
+  { key: 'components', label: 'Component', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'releaseBlockerStatus', label: 'Blocker Status', sortable: true },
+  { key: 'daysOpen', label: 'Days Open', sortable: true }
+]
+
+function toggleCriticalSort(key) {
+  if (criticalSortKey.value === key) {
+    criticalSortDir.value = criticalSortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    criticalSortKey.value = key
+    criticalSortDir.value = 'desc'
+  }
+}
+
+const sortedCritical = computed(function () {
+  var rows = (data.value && data.value.criticalMonitoring) ? data.value.criticalMonitoring.slice() : []
+  return sortRows(rows, criticalSortKey.value, criticalSortDir.value)
+})
+
+var emptyStats = { avg: null, median: null, p90: null, max: null, count: 0 }
+
+const statusDurations = computed(function () {
+  var byStatus = (data.value && data.value.aging && data.value.aging.byStatus) || {}
+  return [
+    { key: 'proposed', label: 'Proposed', stats: byStatus.proposed || emptyStats, borderClass: 'border-amber-200 dark:border-amber-800', labelClass: 'text-amber-600 dark:text-amber-400' },
+    { key: 'approved', label: 'Approved', stats: byStatus.approved || emptyStats, borderClass: 'border-red-200 dark:border-red-800', labelClass: 'text-red-600 dark:text-red-400' },
+    { key: 'rejected', label: 'Rejected', stats: byStatus.rejected || emptyStats, borderClass: 'border-emerald-200 dark:border-emerald-800', labelClass: 'text-emerald-600 dark:text-emerald-400' }
+  ]
+})
+
+function blockerStatusClass(status) {
+  if (status === 'Proposed') return 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+  if (status === 'Approved') return 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+  if (status === 'Rejected') return 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+  return 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+}
+
+function agingColor(days) {
+  if (days === null || days === undefined) return 'text-gray-400 dark:text-gray-500'
+  if (days >= 7) return 'text-red-600 dark:text-red-400'
+  if (days >= 3) return 'text-amber-600 dark:text-amber-400'
+  return 'text-gray-700 dark:text-gray-300'
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleString()
+}
+</script>
+
+<style scoped>
+.scrollable-table {
+  max-height: 24rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+.scrollable-table::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.scrollable-table::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollable-table::-webkit-scrollbar-thumb {
+  background-color: rgba(156, 163, 175, 0.4);
+  border-radius: 4px;
+}
+.scrollable-table::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(156, 163, 175, 0.6);
+}
+</style>

--- a/modules/releases/client/views/DeliverView.vue
+++ b/modules/releases/client/views/DeliverView.vue
@@ -39,6 +39,7 @@ import { useConformaExceptions } from '../deliver/composables/useConformaExcepti
 import ReleaseChipBar from '../deliver/components/ReleaseChipBar.vue'
 
 const RiskDashboard = defineAsyncComponent(() => import('../deliver/views/MainView.vue'))
+const ReleaseBlockers = defineAsyncComponent(() => import('../deliver/views/ReleaseBlockersView.vue'))
 const ConformaInsights = defineAsyncComponent(() => import('../deliver/views/ConformaExceptionsView.vue'))
 
 const { loading, refreshing, error, analysis, refreshAnalysis } = useReleaseAnalysis()
@@ -61,6 +62,7 @@ provide('conformaState', conformaState)
 
 const tabs = [
   { id: 'risk-dashboard', label: 'Risk Dashboard' },
+  { id: 'release-blockers', label: 'Release Blockers' },
   { id: 'conforma-insights', label: 'Conforma Insights' },
 ]
 
@@ -91,6 +93,7 @@ if (moduleNav && moduleNav.params) {
 
 const componentMap = {
   'risk-dashboard': RiskDashboard,
+  'release-blockers': ReleaseBlockers,
   'conforma-insights': ConformaInsights,
 }
 

--- a/modules/releases/server/delivery/blockers.js
+++ b/modules/releases/server/delivery/blockers.js
@@ -1,0 +1,394 @@
+'use strict'
+
+const sharedJira = require('../../../../shared/server/jira')
+
+const DEMO_MODE = process.env.DEMO_MODE === 'true'
+
+const BLOCKER_FIELD_ID = 'customfield_10847'
+const TARGET_VERSION_FIELD_ID = 'customfield_10855'
+
+const BLOCKER_FIELDS = [
+  'summary', 'status', 'priority', 'components', 'assignee',
+  'created', 'updated', 'resolutiondate',
+  BLOCKER_FIELD_ID, TARGET_VERSION_FIELD_ID, 'fixVersions', 'labels'
+].join(',')
+
+const CACHE_TTL_MS = 5 * 60 * 1000
+const CACHE_MAX_ENTRIES = 50
+const blockersCache = new Map()
+
+const RELEASE_NUMBER_RE = /^[a-zA-Z0-9._\- ]+$/
+
+// Escapes single quotes for safe JQL string interpolation (input already validated by RELEASE_NUMBER_RE)
+function sanitizeForJql(value) {
+  return value.replace(/'/g, "\\'")
+}
+
+function buildBlockerJql(version) {
+  var safe = sanitizeForJql(version)
+  return (
+    'project in (RHAIENG, RHOAIENG) ' +
+    'AND (labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is empty) ' +
+    'AND component not in (Documentation, PXE) ' +
+    'AND status not in (Closed, Resolved) ' +
+    "AND (affectedVersion IN ('" + safe + "') OR cf[10855] IN ('" + safe + "')) " +
+    'AND priority in (Blocker)'
+  )
+}
+
+function buildCriticalMonitoringJql(version) {
+  var safe = sanitizeForJql(version)
+  return (
+    'project in (RHAIENG, RHOAIENG) ' +
+    'AND (labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is empty) ' +
+    'AND component not in (Documentation, PXE) ' +
+    'AND status not in (Closed, Resolved) ' +
+    "AND (affectedVersion IN ('" + safe + "') OR cf[10855] IN ('" + safe + "')) " +
+    'AND priority in (Critical, Blocker) ' +
+    'AND (cf[10847] is EMPTY OR cf[10847] not in (Approved))'
+  )
+}
+
+function parseBlockerHistory(issue) {
+  var now = new Date()
+  var histories = (issue.changelog && issue.changelog.histories) || []
+
+  var transitions = []
+  for (var h = 0; h < histories.length; h++) {
+    var history = histories[h]
+    var items = history.items || []
+    for (var k = 0; k < items.length; k++) {
+      var item = items[k]
+      if (item.fieldId === BLOCKER_FIELD_ID || item.field === 'Release Blocker') {
+        transitions.push({
+          date: new Date(history.created),
+          from: item.fromString || null,
+          to: item.toString || null
+        })
+      }
+    }
+  }
+  transitions.sort(function (a, b) { return a.date - b.date })
+
+  var fieldValue = issue.fields && issue.fields[BLOCKER_FIELD_ID]
+  var currentStatus = (fieldValue && fieldValue.value) || null
+
+  var enteredCurrentStateAt = null
+  if (transitions.length > 0) {
+    var last = transitions[transitions.length - 1]
+    if (last.to === currentStatus) {
+      enteredCurrentStateAt = last.date
+    }
+  }
+  if (!enteredCurrentStateAt && currentStatus) {
+    enteredCurrentStateAt = new Date(issue.fields.created)
+  }
+
+  var daysInCurrentState = null
+  if (enteredCurrentStateAt) {
+    daysInCurrentState = Math.floor((now - enteredCurrentStateAt) / (1000 * 60 * 60 * 24))
+  }
+
+  var proposedDate = null
+  var decisionDate = null
+  for (var i = 0; i < transitions.length; i++) {
+    var t = transitions[i]
+    if (t.to === 'Proposed' && !proposedDate) proposedDate = t.date
+    if (proposedDate && (t.to === 'Approved' || t.to === 'Rejected')) {
+      decisionDate = t.date
+      break
+    }
+  }
+  if (!proposedDate && currentStatus === 'Proposed') {
+    proposedDate = new Date(issue.fields.created)
+  }
+
+  var daysToDecision = null
+  if (proposedDate && decisionDate) {
+    daysToDecision = Math.floor((decisionDate - proposedDate) / (1000 * 60 * 60 * 24))
+  }
+
+  return {
+    currentStatus: currentStatus,
+    daysInCurrentState: daysInCurrentState,
+    proposedDate: proposedDate ? proposedDate.toISOString() : null,
+    decisionDate: decisionDate ? decisionDate.toISOString() : null,
+    daysToDecision: daysToDecision
+  }
+}
+
+function computeMedian(values) {
+  if (!values.length) return null
+  var sorted = values.slice().sort(function (a, b) { return a - b })
+  var mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 !== 0 ? sorted[mid] : Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+}
+
+function computePercentile(values, p) {
+  if (!values.length) return null
+  var sorted = values.slice().sort(function (a, b) { return a - b })
+  var idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))
+  return sorted[idx]
+}
+
+function computeAvg(values) {
+  if (!values.length) return null
+  return Math.round(values.reduce(function (a, b) { return a + b }, 0) / values.length)
+}
+
+function buildAgingStats(values) {
+  return {
+    avg: computeAvg(values),
+    median: computeMedian(values),
+    p90: computePercentile(values, 90),
+    max: values.length ? Math.max.apply(null, values) : null,
+    count: values.length
+  }
+}
+
+function buildResponse(releaseNumber, blockerIssues, criticalIssues, codeFreezeDate, jiraHost) {
+  var now = new Date()
+
+  var proposed = 0
+  var approved = 0
+  var rejected = 0
+  var noStatus = 0
+  var beforeCF = 0
+  var afterCF = 0
+  var decisionDays = []
+  var resolutionDays = []
+  var daysInProposed = []
+  var daysInApproved = []
+  var daysInRejected = []
+
+  var blockers = []
+  var blockerKeys = new Set()
+
+  for (var i = 0; i < blockerIssues.length; i++) {
+    var issue = blockerIssues[i]
+    var key = issue.key
+    blockerKeys.add(key)
+
+    var history = parseBlockerHistory(issue)
+    var components = ((issue.fields && issue.fields.components) || [])
+      .map(function (c) { return (c.name || '').trim() })
+      .filter(Boolean)
+    var assigneeObj = issue.fields && issue.fields.assignee
+    var assignee = assigneeObj ? (assigneeObj.displayName || null) : null
+
+    var status = history.currentStatus
+    if (status === 'Proposed') {
+      proposed++
+      if (history.daysInCurrentState !== null) daysInProposed.push(history.daysInCurrentState)
+    } else if (status === 'Approved') {
+      approved++
+      if (history.daysInCurrentState !== null) daysInApproved.push(history.daysInCurrentState)
+    } else if (status === 'Rejected') {
+      rejected++
+      if (history.daysInCurrentState !== null) daysInRejected.push(history.daysInCurrentState)
+    } else {
+      noStatus++
+    }
+
+    var isBeforeCF = false
+    if (codeFreezeDate && issue.fields && issue.fields.created) {
+      isBeforeCF = issue.fields.created.slice(0, 10) <= codeFreezeDate
+    }
+    if (isBeforeCF) beforeCF++
+    else afterCF++
+
+    if (history.daysToDecision !== null) {
+      decisionDays.push(history.daysToDecision)
+    }
+
+    if (status === 'Approved' && issue.fields && issue.fields.resolutiondate && history.decisionDate) {
+      var resolvedAt = new Date(issue.fields.resolutiondate)
+      var approvedAt = new Date(history.decisionDate)
+      var days = Math.floor((resolvedAt - approvedAt) / (1000 * 60 * 60 * 24))
+      if (days >= 0) resolutionDays.push(days)
+    }
+
+    blockers.push({
+      key: key,
+      summary: (issue.fields && issue.fields.summary) || '',
+      link: jiraHost + '/browse/' + encodeURIComponent(key),
+      priority: (issue.fields && issue.fields.priority && issue.fields.priority.name) || 'Unknown',
+      status: (issue.fields && issue.fields.status && issue.fields.status.name) || 'Unknown',
+      components: components,
+      assignee: assignee,
+      releaseBlockerStatus: history.currentStatus,
+      created: issue.fields && issue.fields.created ? issue.fields.created.slice(0, 10) : null,
+      daysInCurrentState: history.daysInCurrentState,
+      daysToDecision: history.daysToDecision,
+      proposedBeforeCodeFreeze: isBeforeCF
+    })
+  }
+
+  var criticalMonitoring = []
+  for (var j = 0; j < criticalIssues.length; j++) {
+    var ci = criticalIssues[j]
+    if (blockerKeys.has(ci.key)) continue
+
+    var cComponents = ((ci.fields && ci.fields.components) || [])
+      .map(function (c) { return (c.name || '').trim() })
+      .filter(Boolean)
+    var cAssigneeObj = ci.fields && ci.fields.assignee
+    var cAssignee = cAssigneeObj ? (cAssigneeObj.displayName || null) : null
+
+    var cHistory = parseBlockerHistory(ci)
+
+    var daysOpen = 0
+    if (ci.fields && ci.fields.created) {
+      daysOpen = Math.floor((now - new Date(ci.fields.created)) / (1000 * 60 * 60 * 24))
+    }
+
+    criticalMonitoring.push({
+      key: ci.key,
+      summary: (ci.fields && ci.fields.summary) || '',
+      link: jiraHost + '/browse/' + encodeURIComponent(ci.key),
+      priority: (ci.fields && ci.fields.priority && ci.fields.priority.name) || 'Unknown',
+      status: (ci.fields && ci.fields.status && ci.fields.status.name) || 'Unknown',
+      components: cComponents,
+      assignee: cAssignee,
+      releaseBlockerStatus: cHistory.currentStatus,
+      created: ci.fields && ci.fields.created ? ci.fields.created.slice(0, 10) : null,
+      daysOpen: daysOpen,
+      daysInCurrentState: cHistory.daysInCurrentState
+    })
+  }
+
+  return {
+    releaseNumber: releaseNumber,
+    fetchedAt: now.toISOString(),
+    summary: {
+      proposed: proposed,
+      approved: approved,
+      rejected: rejected,
+      noStatus: noStatus,
+      total: proposed + approved + rejected + noStatus
+    },
+    timing: {
+      proposedBeforeCodeFreeze: beforeCF,
+      proposedAfterCodeFreeze: afterCF
+    },
+    aging: {
+      proposalToDecision: buildAgingStats(decisionDays),
+      approvalToResolution: buildAgingStats(resolutionDays),
+      byStatus: {
+        proposed: buildAgingStats(daysInProposed),
+        approved: buildAgingStats(daysInApproved),
+        rejected: buildAgingStats(daysInRejected)
+      }
+    },
+    blockers: blockers,
+    criticalMonitoring: criticalMonitoring
+  }
+}
+
+module.exports = async function registerBlockerRoutes(router, context) {
+  var storage = context.storage
+  var requireAuth = context.requireAuth
+  var requireScope = context.requireScope
+  var readFromStorage = storage.readFromStorage
+
+  var jiraHost = sharedJira.JIRA_HOST
+  var fetchJql
+  if (context.jira) {
+    jiraHost = context.jira.JIRA_HOST
+    fetchJql = function (jql, fields, opts) {
+      return context.jira.fetchAllJqlResults(jql, fields, opts)
+    }
+  } else {
+    fetchJql = function (jql, fields, opts) {
+      return sharedJira.fetchAllJqlResults(sharedJira.jiraRequest, jql, fields, opts)
+    }
+  }
+
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/blockers/{releaseNumber}:
+   *   get:
+   *     tags: ['Releases: Delivery']
+   *     summary: Get release blockers data with aging metrics for a specific release
+   *     parameters:
+   *       - in: path
+   *         name: releaseNumber
+   *         required: true
+   *         schema: { type: string }
+   *         description: Release version identifier (e.g., "rhoai-3.5.EA1")
+   *       - in: query
+   *         name: codeFreezeDate
+   *         schema: { type: string, format: date }
+   *         description: Code freeze date (YYYY-MM-DD) for timing breakdown
+   *     responses:
+   *       200:
+   *         description: Release blockers with aging metrics
+   *       400:
+   *         description: Invalid release number format
+   */
+  router.get('/blockers/:releaseNumber', requireAuth, requireScope('releases:read'), async function (req, res) {
+    var releaseNumber = req.params.releaseNumber
+    var codeFreezeDate = req.query.codeFreezeDate || null
+
+    if (!releaseNumber || !RELEASE_NUMBER_RE.test(releaseNumber)) {
+      return res.status(400).json({ error: 'Invalid release number format' })
+    }
+
+    if (codeFreezeDate && !/^\d{4}-\d{2}-\d{2}$/.test(codeFreezeDate)) {
+      codeFreezeDate = null
+    }
+
+    if (DEMO_MODE) {
+      var fixture = await readFromStorage('releases/delivery/blockers-' + releaseNumber + '.json')
+      if (fixture) return res.json(fixture)
+      var emptyStats = { avg: null, median: null, p90: null, max: null, count: 0 }
+      return res.json({
+        releaseNumber: releaseNumber,
+        fetchedAt: new Date().toISOString(),
+        summary: { proposed: 0, approved: 0, rejected: 0, noStatus: 0, total: 0 },
+        timing: { proposedBeforeCodeFreeze: 0, proposedAfterCodeFreeze: 0 },
+        aging: {
+          proposalToDecision: emptyStats,
+          approvalToResolution: emptyStats,
+          byStatus: { proposed: emptyStats, approved: emptyStats, rejected: emptyStats }
+        },
+        blockers: [],
+        criticalMonitoring: []
+      })
+    }
+
+    var cacheKey = releaseNumber + ':' + (codeFreezeDate || '')
+    var cached = blockersCache.get(cacheKey)
+    if (cached && (Date.now() - cached.timestamp) < CACHE_TTL_MS) {
+      return res.json(cached.data)
+    }
+
+    try {
+      var blockerJql = buildBlockerJql(releaseNumber)
+      var criticalJql = buildCriticalMonitoringJql(releaseNumber)
+
+      // Blockers: fetch with changelog for aging metrics
+      // Critical monitoring: fetch without changelog (larger result set, Jira chokes on expand)
+      var results = await Promise.all([
+        fetchJql(blockerJql, BLOCKER_FIELDS, { expand: 'changelog', maxResults: 100 }),
+        fetchJql(criticalJql, BLOCKER_FIELDS, { maxResults: 100 })
+      ])
+
+      var blockerIssues = results[0] || []
+      var criticalIssues = results[1] || []
+
+      var response = buildResponse(releaseNumber, blockerIssues, criticalIssues, codeFreezeDate, jiraHost)
+
+      blockersCache.set(cacheKey, { data: response, timestamp: Date.now() })
+      if (blockersCache.size > CACHE_MAX_ENTRIES) {
+        var oldest = blockersCache.keys().next().value
+        blockersCache.delete(oldest)
+      }
+
+      res.json(response)
+    } catch (err) {
+      console.error('[releases/delivery] blockers fetch error:', err)
+      res.status(500).json({ error: 'Failed to fetch release blockers: ' + err.message })
+    }
+  })
+}

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -5,6 +5,7 @@ const productPages = require('./product-pages')
 const { fetchProductsByShortname, fetchAllProducts, getProductPagesToken, getAuthStatus } = productPages
 const registerConformaRoutes = require('./conforma')
 const { registerConformaFetcher } = require('./conforma-fetcher')
+const registerBlockerRoutes = require('./blockers')
 const { logAudit } = require('../planning/audit-log')
 const { stripZStream: sharedStripZStream, normalizeVersionName, extractProduct: sharedExtractProduct } = require('../version-utils')
 
@@ -1051,6 +1052,7 @@ module.exports = async function registerRoutes(router, context) {
 
   registerConformaRoutes(router, context)
   registerConformaFetcher(router, context)
+  registerBlockerRoutes(router, context)
 
   const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage } = storage

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -850,3 +850,102 @@ test.describe('Releases Release Readiness @releases', () => {
     expect(body).not.toHaveProperty('director_summary');
   });
 });
+
+/**
+ * Release Blockers (Deliver tab)
+ *
+ * Verify the Release Blockers sub-tab is visible and clickable in the Deliver
+ * view, the API returns the expected response shape, and the view renders
+ * summary cards, tables, and the version input.
+ */
+test.describe('Releases Blockers @releases', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('Release Blockers tab is visible and clickable in Deliver view', async ({ page }) => {
+    await page.goto('/#/releases/deliver');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    var blockerTab = page.locator('button', { hasText: 'Release Blockers' });
+    await expect(blockerTab).toBeVisible();
+
+    await blockerTab.click();
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('Release Blockers view loads without errors via deep link', async ({ page }) => {
+    await page.goto('/#/releases/deliver?tab=release-blockers');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    var mainContent = page.locator('main, [role="main"], .min-h-screen').first();
+    await expect(mainContent).toBeVisible();
+
+    // Version input or summary cards should be visible (depends on whether analysis data is cached)
+    var hasInput = await page.locator('input[placeholder*="rhoai"]').count() > 0;
+    var hasCards = await page.locator('text=TOTAL BLOCKERS').count() > 0;
+    expect(hasInput || hasCards).toBe(true);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('Release Blockers view renders summary cards for a version', async ({ page }) => {
+    // Use version param to load data directly via URL
+    await page.goto('/#/releases/deliver?tab=release-blockers&version=3.5');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('text=TOTAL BLOCKERS').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=PROPOSED').first()).toBeVisible();
+    await expect(page.locator('text=APPROVED').first()).toBeVisible();
+    await expect(page.locator('text=REJECTED').first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('blockers API returns expected response shape', async ({ request }) => {
+    var res = await request.get('/api/modules/releases/delivery/blockers/3.5');
+    expect(res.ok()).toBe(true);
+    var body = await res.json();
+
+    expect(body).toHaveProperty('releaseNumber', '3.5');
+    expect(body).toHaveProperty('fetchedAt');
+    expect(body).toHaveProperty('summary');
+    expect(body.summary).toHaveProperty('proposed');
+    expect(body.summary).toHaveProperty('approved');
+    expect(body.summary).toHaveProperty('rejected');
+    expect(body.summary).toHaveProperty('noStatus');
+    expect(body.summary).toHaveProperty('total');
+
+    expect(body).toHaveProperty('timing');
+    expect(body.timing).toHaveProperty('proposedBeforeCodeFreeze');
+    expect(body.timing).toHaveProperty('proposedAfterCodeFreeze');
+
+    expect(body).toHaveProperty('aging');
+    expect(body.aging).toHaveProperty('proposalToDecision');
+    expect(body.aging.proposalToDecision).toHaveProperty('avg');
+    expect(body.aging.proposalToDecision).toHaveProperty('count');
+    expect(body.aging).toHaveProperty('approvalToResolution');
+    expect(body.aging).toHaveProperty('byStatus');
+
+    expect(body).toHaveProperty('blockers');
+    expect(Array.isArray(body.blockers)).toBe(true);
+    expect(body).toHaveProperty('criticalMonitoring');
+    expect(Array.isArray(body.criticalMonitoring)).toBe(true);
+  });
+
+  test('blockers API rejects invalid release number', async ({ request }) => {
+    var res = await request.get('/api/modules/releases/delivery/blockers/; DROP TABLE');
+    expect(res.status()).toBe(400);
+    var body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
### Summary
Adds a Release Blockers tab to Releases → Deliver (between Risk Dashboard and Conforma Insights) that shows release blocker status, aging metrics, and critical issue monitoring from live Jira data.

### What's included

- Backend endpoint — Queries Jira for blockers by release version, parses cf[10847] (Release Blocker: Proposed/Approved/Rejected), uses changelog expansion for aging metrics (days in state, proposal→decision latency, approval→resolution latency)
- Summary cards — Clickable filters for Proposed/Approved/Rejected/No Status counts
- Aging metrics — Avg/median/max days for state transitions and per-status durations
- Two sortable tables — Critical/Blocker monitoring (potential escalations) and Release Blockers with scrollable max-height and sticky headers
- Manual version input — Query any Jira version directly when chip bar isn't sufficient
- Filter persistence — Status and timing filters preserved in URL params
- Demo fixture for 3.5

### Test plan

-  Releases → Deliver → Release Blockers — verify data loads for a release version
-  Click summary cards and timing rows to filter the blocker table
-  Sort columns in both tables
-  Type a version manually and click Load
-  Switch tabs and return — filters preserved
-  Demo mode: `DEMO_MODE=true VITE_DEMO_MODE=true npm run dev:full`

### JQLs integrated for reference
Blockers:

```
project in (RHAIENG, RHOAIENG)
AND (labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is empty)
AND component not in (Documentation, PXE)
AND status not in (Closed, Resolved)
AND (affectedVersion IN ('{version}') OR cf[10855] IN ('{version}'))
AND priority in (Blocker)
```

Critical Monitoring:

```
project in (RHAIENG, RHOAIENG)
AND (labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is empty)
AND component not in (Documentation, PXE)
AND status not in (Closed, Resolved)
AND (affectedVersion IN ('{version}') OR cf[10855] IN ('{version}'))
AND priority in (Critical, Blocker)
AND (cf[10847] is EMPTY OR cf[10847] not in (Approved))
```

`{version}` is replaced by the selected release (e.g., 3.5 EA2 RHOAI RELEASE).

### Screenshots
<img width="2642" height="1376" alt="image" src="https://github.com/user-attachments/assets/4f7dc231-eae6-4ac2-8f0d-a2b503a44833" />

<img width="2642" height="1748" alt="image" src="https://github.com/user-attachments/assets/fea47b5c-e523-4e5b-924c-a22db088fc95" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)