### PR TITLE
feat(releases): add RHOAI Sustaining (CVEs) report

### DIFF
--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -1,0 +1,612 @@
+<template>
+  <div>
+    <!-- Header -->
+    <div class="flex items-center gap-3 mb-4">
+      <button
+        @click="goBack"
+        class="p-1.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+        title="Back to Reports"
+      >
+        <ArrowLeft :size="18" />
+      </button>
+      <div class="flex-1">
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">RHOAI Sustaining (CVEs)</h2>
+        <p v-if="data?.lastRefreshed" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+          Last refreshed: {{ formatDate(data.lastRefreshed) }}
+        </p>
+      </div>
+      <button
+        @click="handleRefresh"
+        :disabled="refreshing"
+        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border transition-colors"
+        :class="refreshing
+          ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 border-gray-200 dark:border-gray-600 cursor-not-allowed'
+          : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'"
+      >
+        <RefreshCw :size="14" :class="{ 'animate-spin': refreshing }" />
+        {{ refreshing ? 'Refreshing...' : 'Refresh from Jira' }}
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex justify-center items-center py-24">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500"></div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+      <p class="text-sm text-red-700 dark:text-red-300">{{ error }}</p>
+      <button @click="handleRefresh" class="mt-2 text-sm text-red-600 dark:text-red-400 underline hover:no-underline">
+        Try refreshing from Jira
+      </button>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!data" class="text-center py-24">
+      <Shield :size="48" class="mx-auto text-gray-300 dark:text-gray-600 mb-4" />
+      <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">No CVE data yet</h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Click "Refresh from Jira" to load CVE sustaining data.</p>
+      <button
+        @click="handleRefresh"
+        :disabled="refreshing"
+        class="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors text-sm"
+      >
+        {{ refreshing ? 'Loading...' : 'Refresh from Jira' }}
+      </button>
+    </div>
+
+    <!-- Data -->
+    <div v-else class="space-y-6">
+      <!-- Total count banner -->
+      <div class="bg-gradient-to-r from-red-600 to-orange-600 dark:from-red-700 dark:to-orange-700 rounded-lg px-6 py-4 text-white shadow">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-widest text-red-200">Open CVEs</p>
+            <a :href="data.totalOpen_jql" target="_blank" rel="noopener noreferrer"
+              class="text-3xl font-extrabold hover:underline decoration-dotted cursor-pointer inline-flex items-center gap-1.5"
+              title="View open CVEs in Jira">
+              {{ data.totalOpen.toLocaleString() }}
+              <svg class="w-4 h-4 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+            </a>
+          </div>
+          <div class="text-right">
+            <p class="text-xs font-semibold uppercase tracking-widest text-red-200">Total (all statuses)</p>
+            <a :href="data.totalAll_jql" target="_blank" rel="noopener noreferrer"
+              class="text-3xl font-extrabold hover:underline decoration-dotted cursor-pointer inline-flex items-center gap-1.5"
+              title="View all CVEs in Jira">
+              {{ data.totalAll.toLocaleString() }}
+              <svg class="w-4 h-4 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2. CVEs by Due Date -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by Due Date</h3>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <a v-for="bucket in dueDateBuckets" :key="bucket.key" :href="bucket.jql" target="_blank" rel="noopener noreferrer"
+            class="rounded-lg border p-4 text-center hover:shadow-md transition-shadow cursor-pointer block" :class="bucket.classes"
+            :title="`${bucket.label}: ${bucket.count} issues — click to view in Jira`">
+            <p class="text-3xl font-extrabold">{{ bucket.pct }}%</p>
+            <p class="text-[10px] font-semibold uppercase tracking-wide mt-1 opacity-80">{{ bucket.label }}</p>
+            <p class="text-xs mt-1 opacity-60">{{ bucket.count }} issues</p>
+          </a>
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
+          {{ data.cvesByDueDate.total.toLocaleString() }} issues
+        </p>
+      </section>
+
+      <!-- 1. RHOAI Open CVEs (bar chart) -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">RHOAI Open CVEs</h3>
+        <div style="height: 340px;">
+          <Bar :data="openCvesChartData" :options="openCvesChartOptions" />
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
+          Issues by Components &middot; {{ (data.openCvesByComponent || []).length }}
+        </p>
+      </section>
+
+      <!-- 4. Open RHOAI CVEs across all versions (pie) + 6. False Positive by VEX (doughnut) -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Open RHOAI CVEs across all versions</h3>
+          <div style="height: 300px;">
+            <Pie :data="versionPieData" :options="versionPieOptions" />
+          </div>
+          <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
+            {{ data.totalOpen.toLocaleString() }} issues &middot; Issues by Target Version
+          </p>
+        </section>
+
+        <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">False Positive by VEX Justification</h3>
+          <div style="height: 300px;">
+            <Doughnut :data="vexDoughnutData" :options="vexPieOptions" />
+          </div>
+          <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
+            {{ data.falsePositivesByVex.total.toLocaleString() }} issues &middot; Issues by VEX Justification
+          </p>
+        </section>
+      </div>
+
+      <!-- 3. CVEs across all versions (table) -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5 overflow-x-auto">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs across all versions</h3>
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="border-b border-gray-200 dark:border-gray-700">
+              <th class="text-left py-2 pr-3 font-semibold text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800 z-10">Components</th>
+              <th v-for="ver in data.cvesAcrossVersions.versions" :key="ver" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ ver }}</th>
+              <th class="text-right py-2 pl-3 font-bold text-gray-900 dark:text-gray-100">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in data.cvesAcrossVersions.rows" :key="row.component" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+              <td class="py-1.5 pr-3 text-gray-800 dark:text-gray-200 sticky left-0 bg-white dark:bg-gray-800 z-10">{{ row.component }}</td>
+              <td v-for="ver in data.cvesAcrossVersions.versions" :key="ver" class="text-right py-1.5 px-2 tabular-nums">
+                <ClickableCount v-if="row.cells[ver]" :count="row.cells[ver]" :jql="row.cellJqls[ver] || ''" />
+                <span v-else class="text-gray-400 dark:text-gray-500">0</span>
+              </td>
+              <td class="text-right py-1.5 pl-3 font-bold tabular-nums">
+                <ClickableCount :count="row.total" :jql="row.total_jql || ''" />
+              </td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr class="border-t-2 border-gray-300 dark:border-gray-600">
+              <td class="py-2 pr-3 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10">Total</td>
+              <td v-for="ver in data.cvesAcrossVersions.versions" :key="ver" class="text-right py-2 px-2 font-bold tabular-nums">
+                <ClickableCount :count="data.cvesAcrossVersions.columnTotals[ver] || 0" :jql="data.cvesAcrossVersions.columnJqls[ver] || ''" />
+              </td>
+              <td class="text-right py-2 pl-3 font-bold tabular-nums">
+                <ClickableCount :count="data.cvesAcrossVersions.grandTotal" :jql="data.cvesAcrossVersions.grandTotal_jql || ''" />
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
+          Issues by Target Version &middot; {{ data.cvesAcrossVersions.versions.length }} versions &middot; Components {{ data.cvesAcrossVersions.rows.length }}
+        </p>
+      </section>
+
+      <!-- 5. CVEs by RHOAI Sustaining (assignee x status table) -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5 overflow-x-auto">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by RHOAI Sustaining</h3>
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="border-b border-gray-200 dark:border-gray-700">
+              <th class="text-left py-2 pr-3 font-semibold text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800 z-10">Status</th>
+              <th v-for="a in data.cvesByAssigneeStatus.assignees" :key="a" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ a }}</th>
+              <th class="text-right py-2 pl-3 font-bold text-gray-900 dark:text-gray-100">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in data.cvesByAssigneeStatus.rows" :key="row.status" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+              <td class="py-1.5 pr-3 sticky left-0 bg-white dark:bg-gray-800 z-10">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide" :class="statusBadgeClass(row.status)">
+                  {{ row.status }}
+                </span>
+              </td>
+              <td v-for="a in data.cvesByAssigneeStatus.assignees" :key="a" class="text-right py-1.5 px-2 tabular-nums">
+                <ClickableCount v-if="row.cells[a]" :count="row.cells[a]" :jql="row.cellJqls[a] || ''" />
+                <span v-else class="text-gray-400 dark:text-gray-500">0</span>
+              </td>
+              <td class="text-right py-1.5 pl-3 font-bold tabular-nums">
+                <ClickableCount :count="row.total" :jql="row.total_jql || ''" />
+              </td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr class="border-t-2 border-gray-300 dark:border-gray-600">
+              <td class="py-2 pr-3 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10">Total</td>
+              <td v-for="a in data.cvesByAssigneeStatus.assignees" :key="a" class="text-right py-2 px-2 font-bold tabular-nums">
+                <ClickableCount :count="data.cvesByAssigneeStatus.columnTotals[a] || 0" :jql="data.cvesByAssigneeStatus.columnJqls[a] || ''" />
+              </td>
+              <td class="text-right py-2 pl-3 font-bold tabular-nums">
+                <ClickableCount :count="data.cvesByAssigneeStatus.grandTotal" :jql="data.cvesByAssigneeStatus.grandTotal_jql || ''" />
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
+          {{ data.cvesByAssigneeStatus.grandTotal }} issues &middot; Issues by Assignee + Status
+        </p>
+      </section>
+
+      <!-- 7. Created vs Resolved (line chart) -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Created vs Resolved Chart around CVEs</h3>
+        <div style="height: 300px;">
+          <Line :data="createdVsResolvedData" :options="createdResolvedOptions" />
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
+          Time (24 weeks) &middot; Created / Resolved
+        </p>
+      </section>
+
+      <!-- 8. Unresolved (line chart) -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Unresolved</h3>
+        <div style="height: 300px;">
+          <Line :data="unresolvedData" :options="unresolvedOptions" />
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
+          Time series &middot; 24 weeks &middot; Unresolved
+        </p>
+      </section>
+
+      <!-- 9. RHOAI False Positives (multi-series line) -->
+      <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">RHOAI False Positives</h3>
+        <div style="height: 300px;">
+          <Line :data="falsePositivesTrendData" :options="falsePositivesOptions" />
+        </div>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
+          Created (6 months) &middot; Time series
+        </p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, inject } from 'vue'
+import { ArrowLeft, RefreshCw, Shield } from 'lucide-vue-next'
+import { Bar, Pie, Doughnut, Line } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Filler,
+  Tooltip,
+  Legend
+} from 'chart.js'
+import { useCveSustaining } from './composables/useCveSustaining'
+import ClickableCount from '../components/ClickableCount.vue'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Filler, Tooltip, Legend)
+
+const nav = inject('moduleNav')
+const { data, loading, error, refreshing, loadData, refresh } = useCveSustaining()
+
+function goBack() {
+  nav.navigateTo('reports')
+}
+
+async function handleRefresh() {
+  await refresh()
+}
+
+onMounted(() => {
+  loadData()
+})
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  })
+}
+
+// ─── Due Date Buckets ────────────────────────────────────────────────────────
+
+const dueDateBuckets = computed(() => {
+  const dd = data.value?.cvesByDueDate
+  if (!dd) return []
+  return [
+    { key: 'passed', label: 'Due Date Passed', pct: dd.passed.pct, count: dd.passed.count, jql: dd.passed.jql, classes: 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800' },
+    { key: 'lt30', label: 'Due Date in Less Than 30 Days', pct: dd.lessThan30.pct, count: dd.lessThan30.count, jql: dd.lessThan30.jql, classes: 'text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-800' },
+    { key: '30-90', label: 'Due Date Between 30 and 90 Days', pct: dd.between30And90.pct, count: dd.between30And90.count, jql: dd.between30And90.jql, classes: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' },
+    { key: 'gt90', label: 'Due Date More Than 90 Days', pct: dd.moreThan90.pct, count: dd.moreThan90.count, jql: dd.moreThan90.jql, classes: 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800' },
+    { key: 'none', label: 'None', pct: dd.none.pct, count: dd.none.count, jql: dd.none.jql, classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700' }
+  ]
+})
+
+// ─── Chart Colors ────────────────────────────────────────────────────────────
+
+const CHART_COLORS = [
+  'rgba(99, 102, 241, 0.8)',
+  'rgba(239, 68, 68, 0.8)',
+  'rgba(245, 158, 11, 0.8)',
+  'rgba(16, 185, 129, 0.8)',
+  'rgba(59, 130, 246, 0.8)',
+  'rgba(139, 92, 246, 0.8)',
+  'rgba(236, 72, 153, 0.8)',
+  'rgba(20, 184, 166, 0.8)',
+  'rgba(249, 115, 22, 0.8)',
+  'rgba(107, 114, 128, 0.8)',
+  'rgba(168, 85, 247, 0.8)',
+  'rgba(6, 182, 212, 0.8)',
+  'rgba(132, 204, 22, 0.8)',
+  'rgba(244, 63, 94, 0.8)',
+  'rgba(34, 197, 94, 0.8)',
+  'rgba(251, 191, 36, 0.8)',
+  'rgba(167, 139, 250, 0.8)',
+  'rgba(56, 189, 248, 0.8)',
+  'rgba(251, 146, 60, 0.8)',
+  'rgba(156, 163, 175, 0.8)'
+]
+
+// ─── 1. Open CVEs Bar Chart ─────────────────────────────────────────────────
+
+const openCvesChartData = computed(() => {
+  const items = data.value?.openCvesByComponent || []
+  const top = items.slice(0, 20)
+  return {
+    labels: top.map(i => truncateLabel(i.component, 18)),
+    datasets: [{
+      label: 'Issue Count',
+      data: top.map(i => i.count),
+      backgroundColor: top.map((_, idx) => CHART_COLORS[idx % CHART_COLORS.length]),
+      borderWidth: 0,
+      borderRadius: 3
+    }]
+  }
+})
+
+const openCvesChartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  indexAxis: 'x',
+  onClick: (_event, elements) => {
+    if (elements.length > 0) {
+      const idx = elements[0].index
+      const items = data.value?.openCvesByComponent || []
+      const item = items[idx]
+      if (item?.jql) window.open(item.jql, '_blank', 'noopener,noreferrer')
+    }
+  },
+  onHover: (event, elements) => {
+    event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default'
+  },
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => {
+          const items = data.value?.openCvesByComponent || []
+          const item = items[ctx.dataIndex]
+          return item ? `${ctx.raw} issues (${item.pct}%) — click to view in Jira` : `${ctx.raw} issues`
+        }
+      }
+    }
+  },
+  scales: {
+    y: {
+      beginAtZero: true,
+      ticks: { color: '#9ca3af', font: { size: 11 } },
+      grid: { color: 'rgba(156, 163, 175, 0.15)' },
+      title: { display: true, text: 'Issue Count', color: '#9ca3af', font: { size: 11 } }
+    },
+    x: {
+      ticks: { color: '#9ca3af', font: { size: 10 }, maxRotation: 45, minRotation: 30 },
+      grid: { display: false }
+    }
+  }
+}))
+
+// ─── 4. Version Pie Chart ────────────────────────────────────────────────────
+
+const versionPieData = computed(() => {
+  const items = data.value?.openCvesByVersion || []
+  return {
+    labels: items.map(i => `${i.version} (${i.count} / ${i.pct}%)`),
+    datasets: [{
+      data: items.map(i => i.count),
+      backgroundColor: items.map((_, idx) => CHART_COLORS[idx % CHART_COLORS.length]),
+      borderWidth: 2,
+      borderColor: '#fff'
+    }]
+  }
+})
+
+// ─── 6. VEX Justification Doughnut ──────────────────────────────────────────
+
+const vexDoughnutData = computed(() => {
+  const items = data.value?.falsePositivesByVex?.items || []
+  return {
+    labels: items.map(i => `${i.justification} (${i.count} / ${i.pct}%)`),
+    datasets: [{
+      data: items.map(i => i.count),
+      backgroundColor: items.map((_, idx) => CHART_COLORS[idx % CHART_COLORS.length]),
+      borderWidth: 2,
+      borderColor: '#fff'
+    }]
+  }
+})
+
+function makePieOptions(dataKey, itemJqlAccessor) {
+  return computed(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    onClick: (_event, elements) => {
+      if (elements.length > 0) {
+        const idx = elements[0].index
+        const items = itemJqlAccessor()
+        const item = items[idx]
+        if (item?.jql) window.open(item.jql, '_blank', 'noopener,noreferrer')
+      }
+    },
+    onHover: (event, elements) => {
+      event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default'
+    },
+    plugins: {
+      legend: {
+        display: true,
+        position: 'right',
+        labels: {
+          padding: 8,
+          font: { size: 10 },
+          color: '#6b7280',
+          usePointStyle: true,
+          pointStyle: 'circle',
+          boxWidth: 8
+        }
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => `${ctx.raw} issues — click to view in Jira`
+        }
+      }
+    }
+  }))
+}
+
+const versionPieOptions = makePieOptions('openCvesByVersion', () => data.value?.openCvesByVersion || [])
+const vexPieOptions = makePieOptions('falsePositivesByVex', () => data.value?.falsePositivesByVex?.items || [])
+
+// ─── 7. Created vs Resolved Line Chart ──────────────────────────────────────
+
+const createdVsResolvedData = computed(() => {
+  const series = data.value?.createdVsResolved || []
+  return {
+    labels: series.map(s => s.label),
+    datasets: [
+      {
+        label: 'Created',
+        data: series.map(s => s.created),
+        borderColor: 'rgba(239, 68, 68, 1)',
+        backgroundColor: 'rgba(239, 68, 68, 0.15)',
+        fill: true,
+        tension: 0.3,
+        pointRadius: 3,
+        pointBackgroundColor: 'rgba(239, 68, 68, 1)'
+      },
+      {
+        label: 'Resolved',
+        data: series.map(s => s.resolved),
+        borderColor: 'rgba(34, 197, 94, 1)',
+        backgroundColor: 'rgba(34, 197, 94, 0.15)',
+        fill: true,
+        tension: 0.3,
+        pointRadius: 3,
+        pointBackgroundColor: 'rgba(34, 197, 94, 1)'
+      }
+    ]
+  }
+})
+
+// ─── 8. Unresolved Line Chart ───────────────────────────────────────────────
+
+const unresolvedData = computed(() => {
+  const series = data.value?.unresolved || []
+  return {
+    labels: series.map(s => s.label),
+    datasets: [{
+      label: 'Unresolved',
+      data: series.map(s => s.unresolved),
+      borderColor: 'rgba(59, 130, 246, 1)',
+      backgroundColor: 'rgba(59, 130, 246, 0.1)',
+      fill: true,
+      tension: 0.3,
+      pointRadius: 3,
+      pointBackgroundColor: 'rgba(59, 130, 246, 1)'
+    }]
+  }
+})
+
+// ─── 9. False Positives Trend (Multi-Series) ────────────────────────────────
+
+const FP_COLORS = {
+  'Not a bug': 'rgba(239, 68, 68, 1)',
+  'Duplicate': 'rgba(249, 115, 22, 1)',
+  "Won't Do": 'rgba(251, 191, 36, 1)',
+  'Obsolete': 'rgba(168, 85, 247, 1)',
+  "Can't Do": 'rgba(6, 182, 212, 1)'
+}
+
+const falsePositivesTrendData = computed(() => {
+  const fpData = data.value?.falsePositivesTrend
+  if (!fpData) return { labels: [], datasets: [] }
+
+  return {
+    labels: fpData.months.map(m => m.label),
+    datasets: fpData.resolutionTypes.map(type => ({
+      label: type,
+      data: fpData.months.map(m => m.series[type] || 0),
+      borderColor: FP_COLORS[type] || 'rgba(107, 114, 128, 1)',
+      backgroundColor: 'transparent',
+      tension: 0.3,
+      pointRadius: 3,
+      pointBackgroundColor: FP_COLORS[type] || 'rgba(107, 114, 128, 1)'
+    }))
+  }
+})
+
+// ─── Shared Chart Options ───────────────────────────────────────────────────
+
+function makeTimeSeriesOptions(jqlLookup) {
+  return computed(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    onClick: (_event, elements) => {
+      if (elements.length > 0 && jqlLookup) {
+        const el = elements[0]
+        const url = jqlLookup(el.datasetIndex, el.index)
+        if (url) window.open(url, '_blank', 'noopener,noreferrer')
+      }
+    },
+    onHover: (event, elements) => {
+      event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default'
+    },
+    plugins: {
+      legend: {
+        display: true,
+        position: 'bottom',
+        labels: { padding: 12, font: { size: 11 }, color: '#6b7280', usePointStyle: true, pointStyle: 'circle' }
+      }
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: { color: '#9ca3af', font: { size: 11 } },
+        grid: { color: 'rgba(156, 163, 175, 0.15)' }
+      },
+      x: {
+        ticks: { color: '#9ca3af', font: { size: 10 }, maxRotation: 45, minRotation: 30 },
+        grid: { display: false }
+      }
+    }
+  }))
+}
+
+const createdResolvedOptions = makeTimeSeriesOptions((dsIndex, pointIndex) => {
+  const series = data.value?.createdVsResolved || []
+  const point = series[pointIndex]
+  if (!point) return null
+  return dsIndex === 0 ? point.created_jql : point.resolved_jql
+})
+
+const unresolvedOptions = makeTimeSeriesOptions((_dsIndex, pointIndex) => {
+  const series = data.value?.unresolved || []
+  return series[pointIndex]?.jql || null
+})
+
+const falsePositivesOptions = makeTimeSeriesOptions()
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function statusBadgeClass(status) {
+  const s = (status || '').toUpperCase()
+  if (s === 'NEW') return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300'
+  if (s === 'IN PROGRESS') return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
+  if (s === 'REVIEW') return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300'
+  if (s === 'RESOLVED') return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300'
+  if (s === 'CLOSED') return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+}
+
+function truncateLabel(str, max) {
+  if (!str || str.length <= max) return str
+  return str.slice(0, max) + '...'
+}
+</script>

--- a/modules/releases/client/reports/composables/useCveSustaining.js
+++ b/modules/releases/client/reports/composables/useCveSustaining.js
@@ -1,0 +1,64 @@
+import { ref } from 'vue'
+
+const API_BASE = '/api/modules/releases/cve-sustaining'
+
+const data = ref(null)
+const loading = ref(false)
+const error = ref(null)
+const refreshing = ref(false)
+
+export function useCveSustaining() {
+
+  async function loadData() {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await fetch(API_BASE)
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          data.value = null
+          return
+        }
+        throw new Error(`Failed to load CVE data: ${response.statusText}`)
+      }
+
+      data.value = await response.json()
+    } catch (err) {
+      error.value = err.message || 'Failed to load CVE sustaining data'
+      data.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refresh() {
+    refreshing.value = true
+    error.value = null
+
+    try {
+      const response = await fetch(`${API_BASE}/refresh`, { method: 'POST' })
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        throw new Error(body.error || `Refresh failed: ${response.statusText}`)
+      }
+
+      data.value = await response.json()
+    } catch (err) {
+      error.value = err.message || 'Failed to refresh CVE data from Jira'
+    } finally {
+      refreshing.value = false
+    }
+  }
+
+  return {
+    data,
+    loading,
+    error,
+    refreshing,
+    loadData,
+    refresh
+  }
+}

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -36,5 +36,13 @@ export const reports = [
     icon: 'Shield',
     tags: ['Executive', 'Readiness', 'RAG'],
     component: defineAsyncComponent(() => import('./ReleaseReadinessDirector.vue'))
+  },
+  {
+    id: 'cve-sustaining',
+    label: 'RHOAI Sustaining (CVEs)',
+    description: 'Open CVE tracking across RHOAI components and versions — due dates, assignee workload, VEX justifications, and trends.',
+    icon: 'ShieldAlert',
+    tags: ['Security', 'CVE', 'Sustaining'],
+    component: defineAsyncComponent(() => import('./CveSustainingReport.vue'))
   }
 ]

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -1,0 +1,544 @@
+/**
+ * CVE Sustaining sub-router.
+ *
+ * Serves cached CVE sustaining metrics for the RHOAI Sustaining (CVEs)
+ * report. Data is fetched from Jira on demand via POST /refresh and
+ * cached to local storage for fast subsequent reads.
+ *
+ * Mount: /api/modules/releases/cve-sustaining/
+ */
+
+const STORAGE_PREFIX = 'releases/cve-sustaining';
+const STORAGE_FILE = `${STORAGE_PREFIX}/latest.json`;
+
+const BASE_JQL = [
+  'project in (RHAIENG, RHOAIENG)',
+  '(labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is EMPTY)',
+  'component not in (Documentation, PXE, Devops, testops)',
+  'issuetype in (vulnerability)',
+  'status not in (Closed, Resolved)'
+].join(' AND ');
+
+const ALL_STATUSES_JQL = [
+  'project in (RHAIENG, RHOAIENG)',
+  '(labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is EMPTY)',
+  'component not in (Documentation, PXE, Devops, testops)',
+  'issuetype in (vulnerability)'
+].join(' AND ');
+
+const TARGET_VERSION_FIELD = 'customfield_10855';
+const JIRA_FIELDS = `status,components,fixVersions,${TARGET_VERSION_FIELD},duedate,assignee,resolution,created,resolutiondate,labels,customfield_10873`;
+
+const VEX_FIELD = 'customfield_10873';
+
+const JIRA_HOST = process.env.JIRA_HOST || 'https://redhat.atlassian.net';
+const JIRA_SEARCH = JIRA_HOST + '/issues/?jql=';
+
+function jqlUrl(jql) {
+  return JIRA_SEARCH + encodeURIComponent(jql);
+}
+
+function quoteComponent(name) {
+  return name === 'None' ? '' : ` AND component = "${name}"`;
+}
+
+function quoteVersion(name) {
+  return name === 'None' ? ' AND "Target Version" is EMPTY' : ` AND "Target Version" = "${name}"`;
+}
+
+function quoteAssignee(name) {
+  return name === 'Unassigned' ? ' AND assignee is EMPTY' : ` AND assignee = "${name}"`;
+}
+
+function quoteStatus(name) {
+  return ` AND status = "${name}"`;
+}
+
+/**
+ * @openapi
+ * /api/modules/releases/cve-sustaining:
+ *   get:
+ *     tags: [Releases]
+ *     summary: Get cached CVE sustaining metrics
+ *     responses:
+ *       200:
+ *         description: Aggregated CVE sustaining metrics payload
+ *       404:
+ *         description: No cached data — run a refresh first
+ */
+
+/**
+ * @openapi
+ * /api/modules/releases/cve-sustaining/refresh:
+ *   post:
+ *     tags: [Releases]
+ *     summary: Refresh CVE sustaining metrics from Jira
+ *     description: Fetches all matching CVEs from Jira, aggregates into visualization buckets, and caches results
+ *     responses:
+ *       200:
+ *         description: Refreshed CVE sustaining metrics payload
+ *       500:
+ *         description: Jira fetch or aggregation failed
+ */
+
+function registerCveSustainingRoutes(router, { storage, requireAuth, requireScope, jira }) {
+
+  router.get('/', requireAuth, requireScope('releases:read'), async (req, res) => {
+    const data = await storage.readFromStorage(STORAGE_FILE);
+    if (!data) {
+      return res.status(404).json({ error: 'No cached CVE sustaining data. Trigger a refresh first.' });
+    }
+    res.json(data);
+  });
+
+  router.post('/refresh', requireAuth, requireScope('releases:write'), async (req, res) => {
+    try {
+      const [openIssues, allIssues] = await Promise.all([
+        jira.fetchAllJqlResults(BASE_JQL, JIRA_FIELDS),
+        jira.fetchAllJqlResults(ALL_STATUSES_JQL, JIRA_FIELDS)
+      ]);
+
+      const payload = aggregateMetrics(openIssues, allIssues);
+      await storage.writeToStorage(STORAGE_FILE, payload);
+
+      res.json(payload);
+    } catch (err) {
+      console.error('[cve-sustaining] Refresh failed:', err.message);
+      res.status(500).json({ error: `Refresh failed: ${err.message}` });
+    }
+  });
+}
+
+// ─── Aggregation ─────────────────────────────────────────────────────────────
+
+function aggregateMetrics(openIssues, allIssues) {
+  const now = new Date();
+
+  return {
+    lastRefreshed: now.toISOString(),
+    totalOpen: openIssues.length,
+    totalOpen_jql: jqlUrl(BASE_JQL),
+    totalAll: allIssues.length,
+    totalAll_jql: jqlUrl(ALL_STATUSES_JQL),
+    openCvesByComponent: buildComponentCounts(openIssues),
+    cvesByDueDate: buildDueDateBuckets(openIssues, now),
+    cvesAcrossVersions: buildVersionComponentMatrix(openIssues),
+    openCvesByVersion: buildVersionCounts(openIssues),
+    cvesByAssigneeStatus: buildAssigneeStatusMatrix(openIssues),
+    falsePositivesByVex: buildVexJustification(allIssues),
+    createdVsResolved: buildCreatedVsResolved(allIssues, now),
+    unresolved: buildUnresolvedTimeSeries(allIssues, now),
+    falsePositivesTrend: buildFalsePositivesTrend(allIssues, now)
+  };
+}
+
+function getComponentName(issue) {
+  const comps = issue.fields?.components;
+  if (!comps || comps.length === 0) return 'None';
+  return comps[0].name || 'None';
+}
+
+function getAllComponentNames(issue) {
+  const comps = issue.fields?.components;
+  if (!comps || comps.length === 0) return ['None'];
+  return comps.map(c => c.name || 'None');
+}
+
+function getTargetVersions(issue) {
+  const tv = issue.fields?.[TARGET_VERSION_FIELD];
+  if (!tv) return ['None'];
+  const arr = Array.isArray(tv) ? tv : [tv];
+  if (arr.length === 0) return ['None'];
+  return arr.map(v => (typeof v === 'string' ? v : v.name || v.value || 'None')).filter(Boolean);
+}
+
+function getStatus(issue) {
+  return issue.fields?.status?.name || 'Unknown';
+}
+
+function getAssignee(issue) {
+  return issue.fields?.assignee?.displayName || 'Unassigned';
+}
+
+// 1. Open CVEs by component (bar chart)
+function buildComponentCounts(issues) {
+  const counts = {};
+  for (const issue of issues) {
+    const comp = getComponentName(issue);
+    counts[comp] = (counts[comp] || 0) + 1;
+  }
+  const total = issues.length || 1;
+  return Object.entries(counts)
+    .map(([component, count]) => ({
+      component,
+      count,
+      pct: parseFloat(((count / total) * 100).toFixed(2)),
+      jql: jqlUrl(BASE_JQL + quoteComponent(component))
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+// 2. CVEs by due date (summary cards)
+function buildDueDateBuckets(issues, now) {
+  const buckets = { passed: 0, lessThan30: 0, between30And90: 0, moreThan90: 0, none: 0 };
+  const total = issues.length || 1;
+
+  for (const issue of issues) {
+    const duedate = issue.fields?.duedate;
+    if (!duedate) {
+      buckets.none++;
+      continue;
+    }
+    const due = new Date(duedate);
+    const diffDays = Math.floor((due - now) / (1000 * 60 * 60 * 24));
+    if (diffDays < 0) buckets.passed++;
+    else if (diffDays < 30) buckets.lessThan30++;
+    else if (diffDays <= 90) buckets.between30And90++;
+    else buckets.moreThan90++;
+  }
+
+  const today = now.toISOString().slice(0, 10);
+  const in30 = new Date(now.getTime() + 30 * 86400000).toISOString().slice(0, 10);
+  const in90 = new Date(now.getTime() + 90 * 86400000).toISOString().slice(0, 10);
+
+  return {
+    passed: { count: buckets.passed, pct: Math.round((buckets.passed / total) * 100), jql: jqlUrl(BASE_JQL + ` AND duedate < "${today}"`) },
+    lessThan30: { count: buckets.lessThan30, pct: Math.round((buckets.lessThan30 / total) * 100), jql: jqlUrl(BASE_JQL + ` AND duedate >= "${today}" AND duedate < "${in30}"`) },
+    between30And90: { count: buckets.between30And90, pct: Math.round((buckets.between30And90 / total) * 100), jql: jqlUrl(BASE_JQL + ` AND duedate >= "${in30}" AND duedate <= "${in90}"`) },
+    moreThan90: { count: buckets.moreThan90, pct: Math.round((buckets.moreThan90 / total) * 100), jql: jqlUrl(BASE_JQL + ` AND duedate > "${in90}"`) },
+    none: { count: buckets.none, pct: Math.round((buckets.none / total) * 100), jql: jqlUrl(BASE_JQL + ' AND duedate is EMPTY') },
+    total: issues.length,
+    total_jql: jqlUrl(BASE_JQL)
+  };
+}
+
+// 3. CVEs across all versions (component x version matrix)
+function buildVersionComponentMatrix(issues) {
+  const components = new Set();
+  const versions = new Set();
+  const matrix = {};
+
+  for (const issue of issues) {
+    for (const comp of getAllComponentNames(issue)) {
+      components.add(comp);
+      for (const ver of getTargetVersions(issue)) {
+        versions.add(ver);
+        const key = `${comp}||${ver}`;
+        matrix[key] = (matrix[key] || 0) + 1;
+      }
+    }
+  }
+
+  const sortedComponents = [...components].sort();
+  const sortedVersions = [...versions].sort();
+
+  const rows = sortedComponents.map(comp => {
+    const cells = {};
+    const cellJqls = {};
+    let rowTotal = 0;
+    for (const ver of sortedVersions) {
+      const val = matrix[`${comp}||${ver}`] || 0;
+      cells[ver] = val;
+      if (val > 0) cellJqls[ver] = jqlUrl(BASE_JQL + quoteComponent(comp) + quoteVersion(ver));
+      rowTotal += val;
+    }
+    return {
+      component: comp,
+      cells,
+      cellJqls,
+      total: rowTotal,
+      total_jql: rowTotal > 0 ? jqlUrl(BASE_JQL + quoteComponent(comp)) : null
+    };
+  });
+
+  const columnTotals = {};
+  const columnJqls = {};
+  let grandTotal = 0;
+  for (const ver of sortedVersions) {
+    const sum = rows.reduce((acc, r) => acc + (r.cells[ver] || 0), 0);
+    columnTotals[ver] = sum;
+    if (sum > 0) columnJqls[ver] = jqlUrl(BASE_JQL + quoteVersion(ver));
+    grandTotal += sum;
+  }
+
+  return { versions: sortedVersions, rows, columnTotals, columnJqls, grandTotal, grandTotal_jql: jqlUrl(BASE_JQL) };
+}
+
+// 4. Open CVEs by version (pie chart)
+function buildVersionCounts(issues) {
+  const counts = {};
+  for (const issue of issues) {
+    for (const ver of getTargetVersions(issue)) {
+      counts[ver] = (counts[ver] || 0) + 1;
+    }
+  }
+  const total = Object.values(counts).reduce((a, b) => a + b, 0) || 1;
+  return Object.entries(counts)
+    .map(([version, count]) => ({
+      version,
+      count,
+      pct: parseFloat(((count / total) * 100).toFixed(2)),
+      jql: jqlUrl(BASE_JQL + quoteVersion(version))
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+// 5. CVEs by assignee and status (matrix table)
+function buildAssigneeStatusMatrix(issues) {
+  const assignees = new Set();
+  const statuses = new Set();
+  const matrix = {};
+
+  for (const issue of issues) {
+    const assignee = getAssignee(issue);
+    const status = getStatus(issue);
+    assignees.add(assignee);
+    statuses.add(status);
+    const key = `${status}||${assignee}`;
+    matrix[key] = (matrix[key] || 0) + 1;
+  }
+
+  const statusOrder = ['NEW', 'IN PROGRESS', 'REVIEW', 'RESOLVED', 'CLOSED'];
+  const sortedStatuses = [...statuses].sort((a, b) => {
+    const ai = statusOrder.indexOf(a.toUpperCase());
+    const bi = statusOrder.indexOf(b.toUpperCase());
+    if (ai === -1 && bi === -1) return a.localeCompare(b);
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+  const sortedAssignees = [...assignees].sort();
+
+  const rows = sortedStatuses.map(status => {
+    const cells = {};
+    const cellJqls = {};
+    let rowTotal = 0;
+    for (const assignee of sortedAssignees) {
+      const val = matrix[`${status}||${assignee}`] || 0;
+      cells[assignee] = val;
+      if (val > 0) cellJqls[assignee] = jqlUrl(BASE_JQL + quoteStatus(status) + quoteAssignee(assignee));
+      rowTotal += val;
+    }
+    return {
+      status,
+      cells,
+      cellJqls,
+      total: rowTotal,
+      total_jql: rowTotal > 0 ? jqlUrl(BASE_JQL + quoteStatus(status)) : null
+    };
+  });
+
+  const columnTotals = {};
+  const columnJqls = {};
+  let grandTotal = 0;
+  for (const assignee of sortedAssignees) {
+    const sum = rows.reduce((acc, r) => acc + (r.cells[assignee] || 0), 0);
+    columnTotals[assignee] = sum;
+    if (sum > 0) columnJqls[assignee] = jqlUrl(BASE_JQL + quoteAssignee(assignee));
+    grandTotal += sum;
+  }
+
+  return { assignees: sortedAssignees, rows, columnTotals, columnJqls, grandTotal, grandTotal_jql: jqlUrl(BASE_JQL) };
+}
+
+// 6. False Positives by VEX justification (doughnut)
+const FP_RESOLUTIONS = ['Not a Bug', 'Obsolete', "Won't Do", 'Duplicate', "Can't Do"];
+const FP_RESOLUTION_JQL = 'resolution in ("Not a Bug", Obsolete, "Won\'t Do", Duplicate, "Can\'t Do")';
+const VEX_RECENCY_WEEKS = 24;
+
+function buildVexJustification(allIssues) {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - VEX_RECENCY_WEEKS * 7);
+
+  const fpIssues = allIssues.filter(i => {
+    const status = (i.fields?.status?.name || '').toLowerCase();
+    if (status !== 'closed' && status !== 'resolved') return false;
+    const res = i.fields?.resolution?.name;
+    if (!res || !FP_RESOLUTIONS.some(r => r.toLowerCase() === res.toLowerCase())) return false;
+    const created = i.fields?.created;
+    return created && new Date(created) >= cutoff;
+  });
+
+  const counts = {};
+  for (const issue of fpIssues) {
+    const vex = extractVexValue(issue.fields?.[VEX_FIELD]) || 'None';
+    counts[vex] = (counts[vex] || 0) + 1;
+  }
+  const total = Object.values(counts).reduce((a, b) => a + b, 0) || 1;
+  const vexJql = ALL_STATUSES_JQL + ' AND status in (Closed, Resolved) AND ' + FP_RESOLUTION_JQL + ' AND createdDate >= -24w';
+  return {
+    items: Object.entries(counts)
+      .map(([justification, count]) => {
+        const vexClause = justification === 'None'
+          ? ` AND "${VEX_FIELD}" is EMPTY`
+          : ` AND "${VEX_FIELD}" = "${justification}"`;
+        return {
+          justification,
+          count,
+          pct: parseFloat(((count / total) * 100).toFixed(2)),
+          jql: jqlUrl(vexJql + vexClause)
+        };
+      })
+      .sort((a, b) => b.count - a.count),
+    total,
+    total_jql: jqlUrl(vexJql)
+  };
+}
+
+function extractVexValue(field) {
+  if (!field) return null;
+  if (typeof field === 'string') return field;
+  if (field.value) return field.value;
+  if (field.name) return field.name;
+  return String(field);
+}
+
+// 7. Created vs Resolved (24-week time series)
+function buildCreatedVsResolved(allIssues, now) {
+  const weeks = buildWeekBuckets(now, 24);
+
+  for (const issue of allIssues) {
+    const created = issue.fields?.created ? new Date(issue.fields.created) : null;
+    const resolved = issue.fields?.resolutiondate ? new Date(issue.fields.resolutiondate) : null;
+
+    if (created) {
+      const bucket = findWeekBucket(weeks, created);
+      if (bucket) bucket.created++;
+    }
+    if (resolved) {
+      const bucket = findWeekBucket(weeks, resolved);
+      if (bucket) bucket.resolved++;
+    }
+  }
+
+  return weeks.map(w => {
+    const ws = w.start.toISOString().slice(0, 10);
+    const nextWs = new Date(w.end.getTime() + 1).toISOString().slice(0, 10);
+    return {
+      label: w.label,
+      weekStart: ws,
+      created: w.created,
+      created_jql: jqlUrl(ALL_STATUSES_JQL + ` AND created >= "${ws}" AND created < "${nextWs}"`),
+      resolved: w.resolved,
+      resolved_jql: jqlUrl(ALL_STATUSES_JQL + ` AND resolved >= "${ws}" AND resolved < "${nextWs}"`)
+    };
+  });
+}
+
+// 8. Unresolved time series (24 weeks)
+function buildUnresolvedTimeSeries(allIssues, now) {
+  const weeks = buildWeekBuckets(now, 24);
+
+  return weeks.map(w => {
+    const weekEnd = new Date(w.end);
+    let count = 0;
+    for (const issue of allIssues) {
+      const created = issue.fields?.created ? new Date(issue.fields.created) : null;
+      const resolved = issue.fields?.resolutiondate ? new Date(issue.fields.resolutiondate) : null;
+      if (!created || created > weekEnd) continue;
+      if (resolved && resolved <= weekEnd) continue;
+      count++;
+    }
+    const ws = w.end.toISOString().slice(0, 10);
+    return {
+      label: w.label,
+      weekStart: w.start.toISOString().slice(0, 10),
+      unresolved: count,
+      jql: jqlUrl(ALL_STATUSES_JQL + ` AND created <= "${ws}" AND (resolved is EMPTY OR resolved > "${ws}")`)
+    };
+  });
+}
+
+// 9. False positives trend (6 months)
+function buildFalsePositivesTrend(allIssues, now) {
+  const resolutionTypes = ['Not a bug', 'Duplicate', "Won't Do", 'Obsolete', "Can't Do"];
+  const months = buildMonthBuckets(now, 6);
+
+  const fpIssues = allIssues.filter(i => {
+    const res = i.fields?.resolution?.name;
+    return res && resolutionTypes.some(r => r.toLowerCase() === res.toLowerCase());
+  });
+
+  for (const issue of fpIssues) {
+    const created = issue.fields?.created ? new Date(issue.fields.created) : null;
+    if (!created) continue;
+    const resolution = issue.fields?.resolution?.name || 'Unknown';
+    const bucket = findMonthBucket(months, created);
+    if (bucket) {
+      bucket.series[resolution] = (bucket.series[resolution] || 0) + 1;
+    }
+  }
+
+  return {
+    resolutionTypes,
+    months: months.map(m => ({
+      label: m.label,
+      monthStart: m.start.toISOString().slice(0, 10),
+      series: m.series
+    }))
+  };
+}
+
+// ─── Date Helpers ────────────────────────────────────────────────────────────
+
+function buildWeekBuckets(now, count) {
+  const weeks = [];
+  const current = new Date(now);
+  current.setHours(0, 0, 0, 0);
+  const dayOfWeek = current.getDay();
+  const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  current.setDate(current.getDate() - mondayOffset);
+
+  for (let i = count - 1; i >= 0; i--) {
+    const start = new Date(current);
+    start.setDate(start.getDate() - i * 7);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+    end.setHours(23, 59, 59, 999);
+    const weekNum = getISOWeek(start);
+    const monthName = start.toLocaleString('en-US', { month: 'short', day: 'numeric' });
+    weeks.push({
+      label: `W${weekNum}, ${monthName}`,
+      start,
+      end,
+      created: 0,
+      resolved: 0,
+      series: {}
+    });
+  }
+  return weeks;
+}
+
+function buildMonthBuckets(now, count) {
+  const months = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const start = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 0, 23, 59, 59, 999);
+    const label = start.toLocaleString('en-US', { month: 'short', year: 'numeric' });
+    months.push({ label, start, end, series: {} });
+  }
+  return months;
+}
+
+function findWeekBucket(weeks, date) {
+  for (const w of weeks) {
+    if (date >= w.start && date <= w.end) return w;
+  }
+  return null;
+}
+
+function findMonthBucket(months, date) {
+  for (const m of months) {
+    if (date >= m.start && date <= m.end) return m;
+  }
+  return null;
+}
+
+function getISOWeek(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+}
+
+module.exports = registerCveSustainingRoutes;

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -31,15 +31,14 @@ const JIRA_FIELDS = `status,components,fixVersions,${TARGET_VERSION_FIELD},dueda
 
 const VEX_FIELD = 'customfield_10873';
 
-const JIRA_HOST = process.env.JIRA_HOST || 'https://redhat.atlassian.net';
-const JIRA_SEARCH = JIRA_HOST + '/issues/?jql=';
+let JIRA_SEARCH = '';
 
 function jqlUrl(jql) {
   return JIRA_SEARCH + encodeURIComponent(jql);
 }
 
 function quoteComponent(name) {
-  return name === 'None' ? '' : ` AND component = "${name}"`;
+  return name === 'None' ? ' AND component is EMPTY' : ` AND component = "${name}"`;
 }
 
 function quoteVersion(name) {
@@ -82,6 +81,7 @@ function quoteStatus(name) {
  */
 
 function registerCveSustainingRoutes(router, { storage, requireAuth, requireScope, jira }) {
+  JIRA_SEARCH = (jira.JIRA_HOST || 'https://redhat.atlassian.net') + '/issues/?jql=';
 
   router.get('/', requireAuth, requireScope('releases:read'), async (req, res) => {
     const data = await storage.readFromStorage(STORAGE_FILE);
@@ -462,7 +462,8 @@ function buildFalsePositivesTrend(allIssues, now) {
   for (const issue of fpIssues) {
     const created = issue.fields?.created ? new Date(issue.fields.created) : null;
     if (!created) continue;
-    const resolution = issue.fields?.resolution?.name || 'Unknown';
+    const rawRes = issue.fields?.resolution?.name || 'Unknown';
+    const resolution = resolutionTypes.find(r => r.toLowerCase() === rawRes.toLowerCase()) || rawRes;
     const bucket = findMonthBucket(months, created);
     if (bucket) {
       bucket.series[resolution] = (bucket.series[resolution] || 0) + 1;

--- a/modules/releases/server/index.js
+++ b/modules/releases/server/index.js
@@ -18,6 +18,7 @@ const registerFeaturePressureRoutes = require('./feature-pressure/routes');
 const registerPmHubRoutes = require('./pm-hub/routes');
 const registerDraftPlanRoutes = require('./draft-plans/routes');
 const registerReleaseReadinessRoutes = require('./release-readiness/routes');
+const registerCveSustainingRoutes = require('./cve-sustaining/routes');
 const { getAuditLog } = require('./planning/audit-log');
 
 /**
@@ -307,6 +308,16 @@ module.exports = async function registerRoutes(router, context) {
     requireScope
   });
   router.use('/release-readiness', releaseReadinessRouter);
+
+  // CVE Sustaining sub-router (mounted at /api/modules/releases/cve-sustaining/)
+  const cveSustainingRouter = express.Router();
+  registerCveSustainingRoutes(cveSustainingRouter, {
+    storage,
+    requireAuth,
+    requireScope,
+    jira
+  });
+  router.use('/cve-sustaining', cveSustainingRouter);
 
   // ─── Unified Audit Routes ───
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@vue-flow/minimap": "^1.5.4",
         "@vueuse/core": "^14.3.0",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.5.2",
+        "express-rate-limit": "^8.6.0",
         "js-yaml": "^5.2.1",
         "mermaid": "^11.16.0"
       },
@@ -5155,11 +5155,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@vue-flow/minimap": "^1.5.4",
     "@vueuse/core": "^14.3.0",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.5.2",
+    "express-rate-limit": "^8.6.0",
     "js-yaml": "^5.2.1",
     "mermaid": "^11.16.0"
   },


### PR DESCRIPTION
## Summary

- Adds a new **RHOAI Sustaining (CVEs)** report to the releases module with 9 visualizations mirroring the Jira CVE sustaining dashboard: open CVEs by component, due date breakdown, version distribution (using Target Version custom field), assignee/status matrix, VEX justification doughnut, created vs resolved trend, unresolved age chart, and false positives trend.
- All data points are clickable, linking directly to the corresponding Jira JQL queries for drill-down.
- Uses the cached Jira refresh pattern (GET for reads, POST /refresh for Jira fetch + aggregation + cache) with `customfield_10855` (Target Version) and `customfield_10873` (VEX Justification).

## Test plan

- [ ] Run `npm run dev:full`, navigate to Releases → Reports → RHOAI Sustaining (CVEs)
- [ ] Click "Refresh from Jira" and verify all 9 visualizations populate
- [ ] Verify clickable counts/chart segments open correct Jira JQL queries in a new tab
- [ ] Compare VEX justification doughnut totals against the Jira dashboard
- [ ] Verify `npm run lint` and `npm run validate:openapi` pass

Made with [Cursor](https://cursor.com)