### PR TITLE
feat(releases): gate Draft Plans UI behind viewer allowlist

### DIFF
--- a/modules/releases/__tests__/client/plan/plan-view.test.js
+++ b/modules/releases/__tests__/client/plan/plan-view.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+import PlanView from '../../../client/views/PlanView.vue'
+
+vi.mock('@shared/client/services/api', function() {
+  return {
+    apiRequest: vi.fn()
+  }
+})
+
+vi.mock('../../../client/plan/views/DashboardView.vue', function() {
+  return { default: { name: 'DashboardView', template: '<div>Big Rocks</div>' } }
+})
+vi.mock('../../../client/plan/views/FeatureReadinessView.vue', function() {
+  return { default: { name: 'FeatureReadinessView', template: '<div>Features</div>' } }
+})
+vi.mock('../../../client/plan/views/DraftPlansView.vue', function() {
+  return { default: { name: 'DraftPlansView', template: '<div>Draft Plans Body</div>' } }
+})
+vi.mock('../../../client/plan/views/BuFeedbackView.vue', function() {
+  return { default: { name: 'BuFeedbackView', template: '<div>Feedback</div>' } }
+})
+vi.mock('../../../client/plan/views/PmHubView.vue', function() {
+  return { default: { name: 'PmHubView', template: '<div>PM Hub</div>' } }
+})
+
+import { apiRequest } from '@shared/client/services/api'
+
+function mountPlanView(params) {
+  var paramsRef = ref(params || {})
+  return mount(PlanView, {
+    global: {
+      provide: {
+        moduleNav: {
+          params: paramsRef,
+          updateParams: vi.fn()
+        }
+      }
+    }
+  })
+}
+
+describe('PlanView Draft Plans gate', function() {
+  beforeEach(function() {
+    vi.clearAllMocks()
+  })
+
+  afterEach(function() {
+    vi.clearAllMocks()
+  })
+
+  it('hides Draft Plans tab when access is denied', async function() {
+    apiRequest.mockResolvedValue({ canViewDraftPlans: false })
+    var wrapper = mountPlanView()
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Draft Plans')
+    expect(apiRequest).toHaveBeenCalledWith('/modules/releases/draft-plans/access')
+  })
+
+  it('shows Draft Plans tab when access is allowed', async function() {
+    apiRequest.mockResolvedValue({ canViewDraftPlans: true })
+    var wrapper = mountPlanView()
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Draft Plans')
+  })
+
+  it('does not deep-link into Draft Plans when gated', async function() {
+    apiRequest.mockResolvedValue({ canViewDraftPlans: false })
+    var wrapper = mountPlanView({ tab: 'draft-plans' })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Draft Plans Body')
+    expect(wrapper.text()).toContain('Big Rocks')
+  })
+})

--- a/modules/releases/__tests__/server/draft-plans/acl.test.js
+++ b/modules/releases/__tests__/server/draft-plans/acl.test.js
@@ -107,6 +107,48 @@ describe('draft-plans acl', function() {
     expect(tiffany.isPlanAdmin).toBe(true)
   })
 
+  it('gates Draft Plans view to viewer allowlist (default: emarion only)', async function() {
+    var emarion = await resolveDraftPlanSession(
+      { userEmail: 'emarion@redhat.com' },
+      makeStorage()
+    )
+    expect(emarion.canViewDraftPlans).toBe(true)
+
+    var tiffany = await resolveDraftPlanSession(
+      { userEmail: 'trozell@redhat.com' },
+      makeStorage()
+    )
+    expect(tiffany.isPlanAdmin).toBe(true)
+    expect(tiffany.canViewDraftPlans).toBe(false)
+
+    var alice = await resolveDraftPlanSession(
+      { userEmail: 'alice@redhat.com' },
+      makeStorage()
+    )
+    expect(alice.canViewDraftPlans).toBe(false)
+  })
+
+  it('honors draftPlansViewerEmails config override', async function() {
+    var storage = makeStorage({
+      'releases/draft-plans/config.json': {
+        draftPlansViewerEmails: ['trozell@redhat.com', 'alice@redhat.com']
+      }
+    })
+    var tiffany = await resolveDraftPlanSession({ userEmail: 'trozell@redhat.com' }, storage)
+    expect(tiffany.canViewDraftPlans).toBe(true)
+    var emarion = await resolveDraftPlanSession({ userEmail: 'emarion@redhat.com' }, storage)
+    expect(emarion.canViewDraftPlans).toBe(false)
+  })
+
+  it('opens Draft Plans view to everyone in DEMO_MODE', async function() {
+    process.env.DEMO_MODE = 'true'
+    var alice = await resolveDraftPlanSession(
+      { userEmail: 'alice@redhat.com' },
+      makeStorage()
+    )
+    expect(alice.canViewDraftPlans).toBe(true)
+  })
+
   it('allows impersonation only in DEMO_MODE', async function() {
     process.env.DEMO_MODE = 'true'
     var session = await resolveDraftPlanSession(

--- a/modules/releases/__tests__/server/draft-plans/routes.test.js
+++ b/modules/releases/__tests__/server/draft-plans/routes.test.js
@@ -461,6 +461,56 @@ describe('draft-plans routes', () => {
     })
   })
 
+  describe('GET /access', () => {
+    it('returns canViewDraftPlans for any authenticated user', async () => {
+      const { router } = await setupRouter()
+      const res = await callRoute(router, 'get', '/access', {
+        userEmail: 'alice@redhat.com'
+      })
+      expect(res._status).toBe(200)
+      expect(res._json.canViewDraftPlans).toBe(true) // DEMO_MODE in beforeEach
+      expect(res._json.session).toBeTruthy()
+    })
+
+    it('reports false for non-viewers when DEMO_MODE is off', async () => {
+      process.env.DEMO_MODE = 'false'
+      const { router } = await setupRouter()
+      const denied = await callRoute(router, 'get', '/access', {
+        userEmail: 'alice@redhat.com'
+      })
+      expect(denied._json.canViewDraftPlans).toBe(false)
+
+      const allowed = await callRoute(router, 'get', '/access', {
+        userEmail: 'emarion@redhat.com'
+      })
+      expect(allowed._json.canViewDraftPlans).toBe(true)
+    })
+  })
+
+  describe('viewer allowlist gate', () => {
+    it('returns 403 on draft-plans routes for non-viewers outside DEMO_MODE', async () => {
+      process.env.DEMO_MODE = 'false'
+      const { router } = await setupRouter()
+      const res = await callRoute(router, 'get', '/cycles', {
+        query: { product: 'RHOAI' },
+        userEmail: 'alice@redhat.com'
+      })
+      expect(res._status).toBe(403)
+      expect(res._json.error).toMatch(/not enabled/i)
+    })
+
+    it('allows allowlisted viewer outside DEMO_MODE', async () => {
+      process.env.DEMO_MODE = 'false'
+      const { router } = await setupRouter()
+      const res = await callRoute(router, 'get', '/cycles', {
+        query: { product: 'RHOAI' },
+        userEmail: 'emarion@redhat.com'
+      })
+      expect(res._status).toBe(200)
+      expect(res._json.defaultVersion).toBe('3.6')
+    })
+  })
+
   describe('GET /cycles', () => {
     it('returns demo 3.6 cycle and both products', async () => {
       const { router } = await setupRouter()
@@ -598,6 +648,11 @@ describe('draft-plans routes', () => {
       process.env.DEMO_MODE = 'false'
       process.env.VITE_DEMO_MODE = 'false'
       const { router, storage } = await setupRouter({
+        // Allow this non-admin user through the preview viewer gate so the
+        // test exercises row-level ACL (assignee/PM), not the UI allowlist.
+        [`${DATA_PREFIX}/config.json`]: {
+          draftPlansViewerEmails: ['abellusci@redhat.com']
+        },
         [`${DATA_PREFIX}/drafts/RHOAI/3.6.json`]: {
           version: '3.6',
           candidates: [
@@ -621,6 +676,7 @@ describe('draft-plans routes', () => {
         }
       })
       expect(foreign._status).toBe(403)
+      expect(foreign._json.error).toMatch(/assignee or PM/i)
 
       const own = await callRoute(router, 'put', '/editor/:version', {
         params: { version: '3.6' },

--- a/modules/releases/client/views/PlanView.vue
+++ b/modules/releases/client/views/PlanView.vue
@@ -18,7 +18,7 @@
     <div class="p-6">
       <DashboardView v-if="activeTab === 'outcomes'" />
       <FeatureReadinessView v-else-if="activeTab === 'feature-readiness'" />
-      <DraftPlansView v-else-if="activeTab === 'draft-plans'" />
+      <DraftPlansView v-else-if="activeTab === 'draft-plans' && canViewDraftPlans" />
       <BuFeedbackView v-else-if="activeTab === 'bu-feedback'" />
       <PmHubView v-else-if="activeTab === 'pm-hub'" />
     </div>
@@ -26,14 +26,15 @@
 </template>
 
 <script setup>
-import { ref, inject, watch } from 'vue'
+import { ref, computed, inject, watch, onMounted } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
 import DashboardView from '../plan/views/DashboardView.vue'
 import FeatureReadinessView from '../plan/views/FeatureReadinessView.vue'
 import DraftPlansView from '../plan/views/DraftPlansView.vue'
 import BuFeedbackView from '../plan/views/BuFeedbackView.vue'
 import PmHubView from '../plan/views/PmHubView.vue'
 
-const tabs = [
+var ALL_TABS = [
   { id: 'outcomes', label: 'Big Rocks' },
   { id: 'pm-hub', label: 'PM Hub' },
   { id: 'feature-readiness', label: 'Features List (1-n)' },
@@ -41,17 +42,40 @@ const tabs = [
   { id: 'bu-feedback', label: 'Field and BU Feedback' },
 ]
 
+var canViewDraftPlans = ref(false)
+
+var tabs = computed(function() {
+  return ALL_TABS.filter(function(tab) {
+    if (tab.id === 'draft-plans') return canViewDraftPlans.value
+    return true
+  })
+})
+
 var moduleNav = inject('moduleNav', null)
-var validTabIds = tabs.map(function(t) { return t.id })
+
+function validTabIds() {
+  return tabs.value.map(function(t) { return t.id })
+}
 
 function getTabFromParams() {
   var params = moduleNav && moduleNav.params ? moduleNav.params.value : {}
   var tab = params.tab
-  if (tab && validTabIds.indexOf(tab) !== -1) return tab
+  var ids = validTabIds()
+  if (tab && ids.indexOf(tab) !== -1) return tab
   return 'outcomes'
 }
 
-const activeTab = ref(getTabFromParams())
+const activeTab = ref('outcomes')
+
+function syncActiveTab() {
+  var tab = getTabFromParams()
+  // Deep-link to draft-plans while gated → fall back until access resolves or deny.
+  if (tab === 'draft-plans' && !canViewDraftPlans.value) {
+    activeTab.value = 'outcomes'
+    return
+  }
+  activeTab.value = tab
+}
 
 watch(activeTab, function(tab) {
   if (moduleNav && moduleNav.updateParams) {
@@ -62,7 +86,25 @@ watch(activeTab, function(tab) {
 if (moduleNav && moduleNav.params) {
   watch(moduleNav.params, function() {
     var tab = getTabFromParams()
+    if (tab === 'draft-plans' && !canViewDraftPlans.value) {
+      if (activeTab.value !== 'outcomes') activeTab.value = 'outcomes'
+      return
+    }
     if (tab !== activeTab.value) activeTab.value = tab
   })
 }
+
+watch(canViewDraftPlans, function() {
+  syncActiveTab()
+})
+
+onMounted(async function() {
+  try {
+    var res = await apiRequest('/modules/releases/draft-plans/access')
+    canViewDraftPlans.value = !!(res && res.canViewDraftPlans)
+  } catch {
+    canViewDraftPlans.value = false
+  }
+  syncActiveTab()
+})
 </script>

--- a/modules/releases/server/draft-plans/acl.js
+++ b/modules/releases/server/draft-plans/acl.js
@@ -1,15 +1,18 @@
 /**
  * Draft Plans identity + ACL.
  * Production: actor is the signed-in user (roster-resolved); no impersonation.
- * DEMO_MODE: keep Acting-as impersonation for local review.
+ * DEMO_MODE: keep Acting-as impersonation for local review; UI/API visible to all.
  * Plan admin (freeze / Final GA / reset): allowlisted emails only.
+ * Viewer preview gate: draftPlansViewerEmails (default: emarion only) when not DEMO_MODE.
  */
 
 const roster = require('../../../../shared/server/roster')
 const { DATA_PREFIX } = require('./fetch')
 const {
   loadAdminEmails,
+  loadViewerEmails,
   isPlanAdminEmail,
+  isDraftPlansViewerEmail,
   isPlanAdminName,
   resolvePlanAdminNames,
   namesMatch
@@ -85,8 +88,11 @@ async function resolveDraftPlanSession(req, storage) {
   var cfg = await loadDraftPlansConfig(storage)
   var planAdminEmails = loadAdminEmails(cfg)
   var planAdminNames = resolvePlanAdminNames(planAdminEmails, people)
+  var viewerEmails = loadViewerEmails(cfg)
   // Draft Plans admin is allowlist-only (not general platform ADMIN_EMAILS).
   var isPlanAdmin = isPlanAdminEmail(email, planAdminEmails)
+  // Preview gate: allowlisted viewers in prod; DEMO_MODE opens the surface locally.
+  var canViewDraftPlans = demo || isDraftPlansViewerEmail(email, viewerEmails)
 
   return {
     email: email,
@@ -94,11 +100,30 @@ async function resolveDraftPlanSession(req, storage) {
     actor: actor,
     rosterMatched: !!person,
     isPlanAdmin: isPlanAdmin,
+    canViewDraftPlans: canViewDraftPlans,
     canImpersonate: demo,
     demoMode: demo,
     planAdminEmails: planAdminEmails,
-    planAdminNames: planAdminNames
+    planAdminNames: planAdminNames,
+    viewerEmails: viewerEmails
   }
+}
+
+/**
+ * @returns {{ ok: true } | { ok: false, status: number, error: string }}
+ */
+function assertCanViewDraftPlans(session) {
+  if (!session) {
+    return { ok: false, status: 401, error: 'Authentication required' }
+  }
+  if (!session.canViewDraftPlans) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'Draft Plans is not enabled for your account'
+    }
+  }
+  return { ok: true }
 }
 
 function applySessionToMeta(meta, session, requestedUser) {
@@ -207,5 +232,6 @@ module.exports = {
   resolveDraftPlanSession,
   applySessionToMeta,
   authorizeEditorSave,
+  assertCanViewDraftPlans,
   _setGetAllPeople
 }

--- a/modules/releases/server/draft-plans/plan-admins.js
+++ b/modules/releases/server/draft-plans/plan-admins.js
@@ -1,9 +1,13 @@
 /**
- * Draft Plans plan-admin allowlist (freeze / Final GA / reset).
+ * Draft Plans plan-admin allowlist (freeze / Final GA / reset)
+ * and UI/API viewer allowlist (who can see Draft Plans at all).
  * Keep emails + fallback display names in sync with product owners.
  */
 
 var DEFAULT_PLAN_ADMIN_EMAILS = ['emarion@redhat.com', 'trozell@redhat.com']
+
+/** Preview gate: who can see the Draft Plans tab and call draft-plans APIs. */
+var DEFAULT_VIEWER_EMAILS = ['emarion@redhat.com']
 
 var DEFAULT_PLAN_ADMIN_NAMES_BY_EMAIL = {
   'emarion@redhat.com': 'Emarion',
@@ -33,14 +37,28 @@ function loadAdminEmails(config) {
   return DEFAULT_PLAN_ADMIN_EMAILS.slice()
 }
 
-function isPlanAdminEmail(email, adminEmails) {
+function loadViewerEmails(config) {
+  if (config && Array.isArray(config.draftPlansViewerEmails) && config.draftPlansViewerEmails.length > 0) {
+    return config.draftPlansViewerEmails.map(normalizeEmail).filter(Boolean)
+  }
+  return DEFAULT_VIEWER_EMAILS.slice()
+}
+
+function emailInList(email, list) {
   var e = normalizeEmail(email)
   if (!e) return false
-  var list = adminEmails || DEFAULT_PLAN_ADMIN_EMAILS
   for (var i = 0; i < list.length; i++) {
     if (normalizeEmail(list[i]) === e) return true
   }
   return false
+}
+
+function isPlanAdminEmail(email, adminEmails) {
+  return emailInList(email, adminEmails || DEFAULT_PLAN_ADMIN_EMAILS)
+}
+
+function isDraftPlansViewerEmail(email, viewerEmails) {
+  return emailInList(email, viewerEmails || DEFAULT_VIEWER_EMAILS)
 }
 
 function isPlanAdminName(name, adminNames) {
@@ -85,9 +103,12 @@ function resolvePlanAdminNames(adminEmails, people) {
 
 module.exports = {
   DEFAULT_PLAN_ADMIN_EMAILS,
+  DEFAULT_VIEWER_EMAILS,
   DEFAULT_PLAN_ADMIN_NAMES_BY_EMAIL,
   loadAdminEmails,
+  loadViewerEmails,
   isPlanAdminEmail,
+  isDraftPlansViewerEmail,
   isPlanAdminName,
   resolvePlanAdminNames,
   namesMatch

--- a/modules/releases/server/draft-plans/routes.js
+++ b/modules/releases/server/draft-plans/routes.js
@@ -4,7 +4,8 @@ const { normalizeDraft } = require('./normalize');
 const {
   resolveDraftPlanSession,
   applySessionToMeta,
-  authorizeEditorSave
+  authorizeEditorSave,
+  assertCanViewDraftPlans
 } = require('./acl');
 const rateLimit = require('express-rate-limit');
 const fs = require('fs');
@@ -154,6 +155,35 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
     await storage.writeToStorage(DATA_PREFIX + '/config.json', config);
   }
 
+  async function requireDraftPlansViewer(req, res, next) {
+    try {
+      var session = await resolveDraftPlanSession(req, storage);
+      var gate = assertCanViewDraftPlans(session);
+      if (!gate.ok) {
+        return res.status(gate.status).json({ error: gate.error });
+      }
+      req.draftPlanSession = session;
+      next();
+    } catch (err) {
+      console.warn('[releases/draft-plans] viewer gate failed:', err.message);
+      return res.status(500).json({ error: 'Failed to resolve Draft Plans access' });
+    }
+  }
+
+  function sessionPayload(session) {
+    return {
+      actor: session.actor,
+      email: session.email,
+      uid: session.uid,
+      rosterMatched: session.rosterMatched,
+      isPlanAdmin: session.isPlanAdmin,
+      canViewDraftPlans: session.canViewDraftPlans,
+      canImpersonate: session.canImpersonate,
+      demoMode: session.demoMode,
+      planAdminNames: session.planAdminNames || [],
+      planAdminEmails: session.planAdminEmails || []
+    };
+  }
 
   // express-rate-limit is recognized by CodeQL js/missing-rate-limiting (custom
   // Map middleware is not). Per-user key keeps interactive red-pen editing usable.
@@ -193,6 +223,16 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
     if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
       throw new Error('enabled must be a boolean');
     }
+    if (input.draftPlansViewerEmails !== undefined) {
+      if (!Array.isArray(input.draftPlansViewerEmails)) {
+        throw new Error('draftPlansViewerEmails must be an array of emails');
+      }
+      for (var vi = 0; vi < input.draftPlansViewerEmails.length; vi++) {
+        if (typeof input.draftPlansViewerEmails[vi] !== 'string') {
+          throw new Error('draftPlansViewerEmails must be an array of emails');
+        }
+      }
+    }
   }
 
   async function doFetch() {
@@ -227,6 +267,25 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
 
   /**
    * @openapi
+   * /api/modules/releases/draft-plans/access:
+   *   get:
+   *     tags: [Releases]
+   *     summary: Whether the signed-in user may view Draft Plans (preview allowlist)
+   *     responses:
+   *       200:
+   *         description: Access flags for Draft Plans UI
+   */
+  router.get('/access', requireAuth, requireScope('releases:read'), async function(req, res) {
+    var session = await resolveDraftPlanSession(req, storage);
+    res.json({
+      canViewDraftPlans: !!session.canViewDraftPlans,
+      demoMode: !!session.demoMode,
+      session: sessionPayload(session)
+    });
+  });
+
+  /**
+   * @openapi
    * /api/modules/releases/draft-plans/cycles:
    *   get:
    *     tags: [Releases]
@@ -239,8 +298,10 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *     responses:
    *       200:
    *         description: Available cycles (pipeline drafts, release-plan catalog, demo fixture)
+   *       403:
+   *         description: Draft Plans not enabled for this account
    */
-  router.get('/cycles', requireAuth, requireScope('releases:read'), async function(req, res) {
+  router.get('/cycles', requireAuth, requireScope('releases:read'), requireDraftPlansViewer, async function(req, res) {
     var product = req.query.product || 'RHOAI';
     if (KNOWN_PRODUCTS.indexOf(product) === -1) {
       return res.status(400).json({ error: 'Unknown product. Expected one of: ' + KNOWN_PRODUCTS.join(', ') });
@@ -277,7 +338,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       200:
    *         description: Draft plan releases with health data
    */
-  router.get('/releases', requireAuth, requireScope('releases:read'), async function(req, res) {
+  router.get('/releases', requireAuth, requireScope('releases:read'), requireDraftPlansViewer, async function(req, res) {
     var productFilter = req.query.product || null;
     var results = [];
 
@@ -348,7 +409,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       500:
    *         description: No token configured or fetch error
    */
-  router.post('/refresh', requireAuth, requireScope('releases:write'), async function(req, res) {
+  router.post('/refresh', requireAuth, requireScope('releases:write'), requireDraftPlansViewer, async function(req, res) {
     if (isRefreshRunning && isRefreshRunning()) {
       return res.status(409).json({ status: 'error', message: 'A global refresh is already in progress' });
     }
@@ -399,7 +460,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       200:
    *         description: Refresh status
    */
-  router.get('/refresh/status', requireAuth, requireScope('releases:read'), async function(req, res) {
+  router.get('/refresh/status', requireAuth, requireScope('releases:read'), requireDraftPlansViewer, async function(req, res) {
     var lastFetch = await storage.readFromStorage(DATA_PREFIX + '/last-fetch.json');
     res.json({
       running: refreshState.running,
@@ -419,7 +480,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       200:
    *         description: Current configuration with token status
    */
-  router.get('/config', requireAuth, requireScope('releases:write'), async function(req, res) {
+  router.get('/config', requireAuth, requireScope('releases:write'), requireDraftPlansViewer, async function(req, res) {
     var config = await loadConfig();
     res.json(Object.assign({}, config, {
       tokenConfigured: !!getToken(),
@@ -439,7 +500,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       400:
    *         description: Invalid configuration values
    */
-  router.post('/config', requireAuth, requireScope('releases:write'), async function(req, res) {
+  router.post('/config', requireAuth, requireScope('releases:write'), requireDraftPlansViewer, async function(req, res) {
     try {
       validateConfig(req.body);
       var oldConfig = await loadConfig();
@@ -492,7 +553,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       404:
    *         description: No draft plan data found
    */
-  router.get('/editor/:version', requireAuth, requireScope('releases:read'), async function(req, res) {
+  router.get('/editor/:version', requireAuth, requireScope('releases:read'), requireDraftPlansViewer, async function(req, res) {
     var version = req.params.version;
     if (!VERSION_RE.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
@@ -526,7 +587,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
       if (Array.isArray(stored.audit)) envelope.audit = stored.audit;
     }
 
-    var session = await resolveDraftPlanSession(req, storage);
+    var session = req.draftPlanSession || await resolveDraftPlanSession(req, storage);
     envelope.meta = applySessionToMeta(
       envelope.meta,
       session,
@@ -539,17 +600,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
       edits: envelope.edits,
       meta: envelope.meta,
       audit: envelope.audit,
-      session: {
-        actor: session.actor,
-        email: session.email,
-        uid: session.uid,
-        rosterMatched: session.rosterMatched,
-        isPlanAdmin: session.isPlanAdmin,
-        canImpersonate: session.canImpersonate,
-        demoMode: session.demoMode,
-        planAdminNames: session.planAdminNames || [],
-        planAdminEmails: session.planAdminEmails || []
-      }
+      session: sessionPayload(session)
     });
   });
 
@@ -577,7 +628,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       429:
    *         description: Rate limit exceeded
    */
-  router.put('/editor/:version', requireAuth, requireScope('releases:write'), editorSaveRateLimit, async function(req, res) {
+  router.put('/editor/:version', requireAuth, requireScope('releases:write'), requireDraftPlansViewer, editorSaveRateLimit, async function(req, res) {
     var version = req.params.version;
     if (!VERSION_RE.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
@@ -598,7 +649,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
       return res.status(400).json({ error: 'audit must be an array' });
     }
 
-    var session = await resolveDraftPlanSession(req, storage);
+    var session = req.draftPlanSession || await resolveDraftPlanSession(req, storage);
     var editorKey = DATA_PREFIX + '/editor/' + product + '/' + version + '.json';
     var previous = await storage.readFromStorage(editorKey);
     if (!previous) previous = emptyEditorEnvelope(version, null);
@@ -643,14 +694,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
       status: 'saved',
       savedAt: payload.savedAt,
       meta: payload.meta,
-      session: {
-        actor: session.actor,
-        email: session.email,
-        isPlanAdmin: session.isPlanAdmin,
-        canImpersonate: session.canImpersonate,
-        planAdminNames: session.planAdminNames || [],
-        planAdminEmails: session.planAdminEmails || []
-      }
+      session: sessionPayload(session)
     });
   });
 
@@ -680,7 +724,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       404:
    *         description: No data found for version
    */
-  router.get('/:version', requireAuth, requireScope('releases:read'), async function(req, res) {
+  router.get('/:version', requireAuth, requireScope('releases:read'), requireDraftPlansViewer, async function(req, res) {
     var version = req.params.version;
     if (!VERSION_RE.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });
@@ -745,7 +789,7 @@ module.exports = async function registerDraftPlanRoutes(router, context) {
    *       404:
    *         description: No health data found for version
    */
-  router.get('/:version/health', requireAuth, requireScope('releases:read'), async function(req, res) {
+  router.get('/:version/health', requireAuth, requireScope('releases:read'), requireDraftPlansViewer, async function(req, res) {
     var version = req.params.version;
     if (!VERSION_RE.test(version)) {
       return res.status(400).json({ error: 'Invalid version format' });


### PR DESCRIPTION
## Summary
- Hide the Plan → Draft Plans tab unless the signed-in user is on the viewer allowlist (default: `emarion@redhat.com` only).
- Enforce the same gate on draft-plans API routes (403); add `GET /draft-plans/access` for the UI check.
- `DEMO_MODE` keeps the surface open locally; widen in prod via `draftPlansViewerEmails` in draft-plans config without a code change.
- Plan-admin (freeze/reset) allowlist is unchanged and separate from view access.

## Test plan
- [ ] Sign in as `emarion@redhat.com` in a non-demo environment → Draft Plans tab visible; editor loads
- [ ] Sign in as another user (including `trozell@redhat.com`) → tab hidden; `/draft-plans/cycles` returns 403
- [ ] Deep-link `?tab=draft-plans` while gated → falls back to Big Rocks
- [ ] Local `DEMO_MODE=true` → tab visible for any user
- [ ] `npx vitest run modules/releases/__tests__/server/draft-plans/acl.test.js modules/releases/__tests__/server/draft-plans/routes.test.js modules/releases/__tests__/client/plan/plan-view.test.js`


Made with [Cursor](https://cursor.com)