### PR TITLE
feat(jira-taxonomy): add component request form with Google Form proxy

### DIFF
--- a/platform/jira-taxonomy/__tests__/client/JiraTaxonomyView.test.js
+++ b/platform/jira-taxonomy/__tests__/client/JiraTaxonomyView.test.js
@@ -9,8 +9,9 @@ vi.mock('@shared/client/services/api', () => ({
 }))
 
 const mockIsAdmin = ref(false)
+const mockUser = ref({ email: 'testuser@redhat.com' })
 vi.mock('@shared/client/composables/useAuth', () => ({
-  useAuth: () => ({ isAdmin: mockIsAdmin })
+  useAuth: () => ({ isAdmin: mockIsAdmin, user: mockUser })
 }))
 
 const sampleComponents = {
@@ -188,9 +189,43 @@ describe('JiraTaxonomyView', () => {
     const wrapper = mountView()
     await flushPromises()
 
-    const btn = wrapper.find('button')
+    const btn = wrapper.find('button[aria-label*="Sync available"]')
+    expect(btn.exists()).toBe(true)
     expect(btn.attributes('disabled')).toBeDefined()
     // Should show countdown text (e.g., "4m 59s")
     expect(btn.text()).toMatch(/\d+m \d+s/)
+  })
+
+  it('shows request form on Request Component tab', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    // Click Request Component tab
+    const tabs = wrapper.findAll('.border-b button')
+    const requestTab = tabs.find(t => t.text().includes('Request Component'))
+    expect(requestTab).toBeTruthy()
+    await requestTab.trigger('click')
+    expect(wrapper.text()).toContain('Naming Standards')
+    expect(wrapper.text()).toContain('Pre-Request Checklist')
+    expect(wrapper.text()).toContain('Proposed Component Name/Rename')
+    expect(wrapper.text()).toContain('Submit Request')
+  })
+
+  it('shows submitting-as email on request tab', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const tabs = wrapper.findAll('.border-b button')
+    const requestTab = tabs.find(t => t.text().includes('Request Component'))
+    await requestTab.trigger('click')
+    expect(wrapper.text()).toContain('testuser@redhat.com')
+  })
+
+  it('disables submit button when form is incomplete', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    const tabs = wrapper.findAll('.border-b button')
+    const requestTab = tabs.find(t => t.text().includes('Request Component'))
+    await requestTab.trigger('click')
+    const submitBtn = wrapper.find('button.bg-primary-600')
+    expect(submitBtn.attributes('disabled')).toBeDefined()
   })
 })

--- a/platform/jira-taxonomy/__tests__/server/index.test.js
+++ b/platform/jira-taxonomy/__tests__/server/index.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
 function makeStorage(initial = {}) {
   const data = { ...initial }
   return {
@@ -115,5 +118,135 @@ describe('GET /jira-components', () => {
     const { handlers } = setupRoutes({ 'team-data/field-options/component.json': noSync })
     const res = await callHandler(handlers['GET /jira-components'], {})
     expect(res._body.fetchedAt).toBe('2026-06-15T00:00:00Z')
+  })
+})
+
+describe('POST /jira-components/request', () => {
+  let testUserCounter = 0
+
+  beforeEach(() => {
+    vi.resetModules()
+    mockFetch.mockReset()
+    delete process.env.DEMO_MODE
+    // Each test gets a unique email to avoid cross-test rate limiting
+    testUserCounter++
+  })
+
+  function uniqueEmail() {
+    return `test${testUserCounter}@redhat.com`
+  }
+
+  const validPayload = {
+    preRequestConfirmation: ['item1', 'item2', 'item3', 'item4'],
+    proposedName: 'Test Component',
+    description: 'A test component',
+    justification: 'Needed for testing',
+    owningPm: 'Jane Doe',
+    pmDirectorApproval: 'John Smith',
+    engineeringTeamAndManager: 'Platform Team - Bob Jones',
+    componentLead: 'Alice Williams',
+    leadershipAlignment: ['PM approved', 'Eng approved']
+  }
+
+  it('submits valid request to Google Form and returns success', async () => {
+    mockFetch.mockResolvedValue({ ok: true })
+    const email = uniqueEmail()
+    const { handlers } = setupRoutes({})
+    const res = await callHandler(handlers['POST /jira-components/request'], {
+      body: validPayload,
+      userEmail: email
+    })
+    expect(res._status).toBe(200)
+    expect(res._body.success).toBe(true)
+    expect(res._body.submittedBy).toBe(email)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('google.com/forms'),
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('returns 400 for missing required fields', async () => {
+    const { handlers } = setupRoutes({})
+    const res = await callHandler(handlers['POST /jira-components/request'], {
+      body: { proposedName: 'Test' },
+      userEmail: uniqueEmail()
+    })
+    expect(res._status).toBe(400)
+    expect(res._body.error).toBe('Validation failed')
+    expect(res._body.details.length).toBeGreaterThan(0)
+  })
+
+  it('returns 502 when Google Form fails but saves locally', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 })
+    const email = uniqueEmail()
+    const { handlers, storage } = setupRoutes({})
+    const res = await callHandler(handlers['POST /jira-components/request'], {
+      body: validPayload,
+      userEmail: email
+    })
+    expect(res._status).toBe(502)
+    expect(res._body.savedLocally).toBe(true)
+    expect(storage.writeToStorage).toHaveBeenCalledWith(
+      'component-requests-log.json',
+      expect.objectContaining({ submissions: expect.any(Array) })
+    )
+  })
+
+  it('logs submission in component-requests-log.json', async () => {
+    mockFetch.mockResolvedValue({ ok: true })
+    const email = uniqueEmail()
+    const { handlers, storage } = setupRoutes({})
+    await callHandler(handlers['POST /jira-components/request'], {
+      body: validPayload,
+      userEmail: email
+    })
+    expect(storage.writeToStorage).toHaveBeenCalledWith(
+      'component-requests-log.json',
+      expect.objectContaining({
+        submissions: expect.arrayContaining([
+          expect.objectContaining({
+            submittedBy: email,
+            payload: validPayload
+          })
+        ])
+      })
+    )
+  })
+
+  it('returns 400 for proposedName exceeding 200 characters', async () => {
+    const { handlers } = setupRoutes({})
+    const res = await callHandler(handlers['POST /jira-components/request'], {
+      body: { ...validPayload, proposedName: 'x'.repeat(201) },
+      userEmail: uniqueEmail()
+    })
+    expect(res._status).toBe(400)
+    expect(res._body.details).toContain('proposedName must be 200 characters or fewer')
+  })
+
+  it('skips Google Form POST in demo mode', async () => {
+    process.env.DEMO_MODE = 'true'
+    const { handlers } = setupRoutes({})
+    const res = await callHandler(handlers['POST /jira-components/request'], {
+      body: validPayload,
+      userEmail: uniqueEmail()
+    })
+    expect(res._status).toBe(200)
+    expect(res._body.demo).toBe(true)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('resolves submitter email from registry when userUid is present', async () => {
+    mockFetch.mockResolvedValue({ ok: true })
+    const registry = {
+      people: { 'uid123': { email: 'resolved@redhat.com' } }
+    }
+    const { handlers } = setupRoutes({ 'team-data/registry.json': registry })
+    const res = await callHandler(handlers['POST /jira-components/request'], {
+      body: validPayload,
+      userEmail: uniqueEmail(),
+      userUid: 'uid123'
+    })
+    expect(res._status).toBe(200)
+    expect(res._body.submittedBy).toBe('resolved@redhat.com')
   })
 })

--- a/platform/jira-taxonomy/client/JiraTaxonomyView.vue
+++ b/platform/jira-taxonomy/client/JiraTaxonomyView.vue
@@ -2,138 +2,338 @@
   <div class="max-w-7xl mx-auto px-4 py-6">
     <Toast v-if="toastMessage" :message="toastMessage" :type="toastType" @close="toastMessage = ''" />
     <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Jira Taxonomy</h2>
-    <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">Browse Jira classification systems</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">Browse and manage Jira classification systems</p>
 
-    <!-- Info card -->
-    <div
-      v-if="project && !loading"
-      class="mb-4 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-3 flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400"
-    >
-      <svg class="h-5 w-5 text-gray-400 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-      </svg>
-      <span class="flex-1">
-        This list is sourced from the
-        <a :href="`https://redhat.atlassian.net/projects/${project}/components`" target="_blank" rel="noopener noreferrer" class="font-medium text-primary-600 dark:text-primary-400 hover:underline">{{ project }}</a>
-        Jira project's component registry.
-        <template v-if="fetchedAt">Last synced {{ formatDate(fetchedAt) }}.</template>
-        Components are synced automatically from Jira.
-      </span>
+    <!-- Tabs -->
+    <div class="flex space-x-4 border-b border-gray-200 dark:border-gray-700 mb-6">
       <button
-        v-if="isAdmin"
-        :disabled="syncing || syncCooldown"
-        @click="triggerSync"
-        class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
-        :class="syncCooldown
-          ? 'border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed'
-          : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed'"
-        :aria-label="syncing ? 'Syncing components from Jira' : syncCooldown ? `Sync available in ${cooldownRemaining}` : 'Refresh components from Jira'"
+        v-for="tab in tabs"
+        :key="tab.id"
+        @click="switchTab(tab.id)"
+        class="pb-2 px-1 text-sm font-medium border-b-2 transition-colors"
+        :class="activeTab === tab.id
+          ? 'border-primary-600 text-primary-600'
+          : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
       >
-        <svg v-if="syncing" class="animate-spin h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-        </svg>
-        <svg v-else class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-        {{ syncing ? 'Syncing...' : syncCooldown ? cooldownRemaining : 'Refresh' }}
+        {{ tab.label }}
       </button>
     </div>
 
-    <!-- Loading -->
-    <div v-if="loading" class="flex items-center justify-center py-12">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
-    </div>
+    <!-- Components Tab -->
+    <div v-if="activeTab === 'components'">
+      <!-- Info card -->
+      <div
+        v-if="project && !loading"
+        class="mb-4 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-3 flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400"
+      >
+        <svg class="h-5 w-5 text-gray-400 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="flex-1">
+          This list is sourced from the
+          <a :href="`https://redhat.atlassian.net/projects/${project}/components`" target="_blank" rel="noopener noreferrer" class="font-medium text-primary-600 dark:text-primary-400 hover:underline">{{ project }}</a>
+          Jira project's component registry.
+          <template v-if="fetchedAt">Last synced {{ formatDate(fetchedAt) }}.</template>
+          Components are synced automatically from Jira.
+        </span>
+        <button
+          v-if="isAdmin"
+          :disabled="syncing || syncCooldown"
+          @click="triggerSync"
+          class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+          :class="syncCooldown
+            ? 'border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+            : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed'"
+          :aria-label="syncing ? 'Syncing components from Jira' : syncCooldown ? `Sync available in ${cooldownRemaining}` : 'Refresh components from Jira'"
+        >
+          <svg v-if="syncing" class="animate-spin h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          <svg v-else class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          {{ syncing ? 'Syncing...' : syncCooldown ? cooldownRemaining : 'Refresh' }}
+        </button>
+      </div>
 
-    <!-- Error -->
-    <div v-else-if="error && !components.length" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-4">
-      <p class="text-red-700 dark:text-red-400 text-sm">{{ error }}</p>
-    </div>
+      <!-- Loading -->
+      <div v-if="loading" class="flex items-center justify-center py-12">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+      </div>
 
-    <template v-else>
-      <!-- Component Browser -->
-      <div class="mb-8">
-        <div class="flex items-center justify-between mb-4">
-          <div class="flex items-center gap-3">
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Components</h3>
-            <span class="text-sm text-gray-500 dark:text-gray-400">{{ filteredComponents.length }} component{{ filteredComponents.length !== 1 ? 's' : '' }}</span>
+      <!-- Error -->
+      <div v-else-if="error && !components.length" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-4">
+        <p class="text-red-700 dark:text-red-400 text-sm">{{ error }}</p>
+      </div>
+
+      <template v-else>
+        <!-- Component Browser -->
+        <div class="mb-8">
+          <div class="flex items-center justify-between mb-4">
+            <div class="flex items-center gap-3">
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Components</h3>
+              <span class="text-sm text-gray-500 dark:text-gray-400">{{ filteredComponents.length }} component{{ filteredComponents.length !== 1 ? 's' : '' }}</span>
+            </div>
+            <div class="relative">
+              <input
+                v-model="searchQuery"
+                type="text"
+                placeholder="Search by name, description, or lead..."
+                class="pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 w-80"
+              />
+              <svg class="absolute left-3 top-2.5 h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </div>
           </div>
-          <div class="relative">
-            <input
-              v-model="searchQuery"
-              type="text"
-              placeholder="Search by name, description, or lead..."
-              class="pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 w-80"
-            />
-            <svg class="absolute left-3 top-2.5 h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
+
+          <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead class="bg-gray-50 dark:bg-gray-900/50">
+                <tr>
+                  <th
+                    @click="toggleSort('name')"
+                    class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none"
+                  >
+                    Name {{ sortColumn === 'name' ? (sortAsc ? '\u25B2' : '\u25BC') : '' }}
+                  </th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Description
+                  </th>
+                  <th
+                    @click="toggleSort('lead')"
+                    class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none"
+                  >
+                    Lead {{ sortColumn === 'lead' ? (sortAsc ? '\u25B2' : '\u25BC') : '' }}
+                  </th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Assignee Type
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                <tr
+                  v-for="comp in filteredComponents"
+                  :key="comp.name"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                >
+                  <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                    {{ comp.name }}
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-md truncate" :title="comp.description">
+                    {{ comp.description || '\u2014' }}
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                    {{ comp.lead ? comp.lead.displayName : '\u2014' }}
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                    {{ formatAssigneeType(comp.assigneeType) }}
+                  </td>
+                </tr>
+                <tr v-if="filteredComponents.length === 0">
+                  <td colspan="4" class="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                    {{ searchQuery ? 'No components match your search.' : 'No components found.' }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
+      </template>
+    </div>
 
-        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead class="bg-gray-50 dark:bg-gray-900/50">
-              <tr>
-                <th
-                  @click="toggleSort('name')"
-                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none"
-                >
-                  Name {{ sortColumn === 'name' ? (sortAsc ? '\u25B2' : '\u25BC') : '' }}
-                </th>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Description
-                </th>
-                <th
-                  @click="toggleSort('lead')"
-                  class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none"
-                >
-                  Lead {{ sortColumn === 'lead' ? (sortAsc ? '\u25B2' : '\u25BC') : '' }}
-                </th>
-                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  Assignee Type
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-              <tr
-                v-for="comp in filteredComponents"
-                :key="comp.name"
-                class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
-              >
-                <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
-                  {{ comp.name }}
-                </td>
-                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-md truncate" :title="comp.description">
-                  {{ comp.description || '\u2014' }}
-                </td>
-                <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
-                  {{ comp.lead ? comp.lead.displayName : '\u2014' }}
-                </td>
-                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                  {{ formatAssigneeType(comp.assigneeType) }}
-                </td>
-              </tr>
-              <tr v-if="filteredComponents.length === 0">
-                <td colspan="4" class="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
-                  {{ searchQuery ? 'No components match your search.' : 'No components found.' }}
-                </td>
-              </tr>
-            </tbody>
-          </table>
+    <!-- Request Component Tab -->
+    <div v-if="activeTab === 'request'" class="space-y-6">
+      <!-- Naming Standards -->
+      <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
+        <h4 class="text-sm font-semibold text-blue-800 dark:text-blue-300 mb-2">Naming Standards</h4>
+        <ul class="text-sm text-blue-700 dark:text-blue-400 space-y-1 list-disc list-inside">
+          <li>Use Title Case</li>
+          <li>Be singular unless accepted product name is plural</li>
+          <li>Match official product terminology</li>
+          <li>Avoid abbreviations unless universally recognized</li>
+          <li>Avoid punctuation unless required</li>
+          <li>Avoid creating duplicate concepts</li>
+        </ul>
+      </div>
+
+      <!-- Submitting as -->
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        Submitting as: <span class="font-medium text-gray-700 dark:text-gray-300">{{ userEmail }}</span>
+      </p>
+
+      <!-- Pre-request checklist -->
+      <div>
+        <div class="flex items-center gap-2 mb-3">
+          <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Pre-Request Checklist</h4>
+          <span
+            class="text-xs px-1.5 py-0.5 rounded-full font-medium"
+            :class="preRequestCheckedCount === preRequestItems.length
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+              : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'"
+          >{{ preRequestCheckedCount }}/{{ preRequestItems.length }}</span>
+        </div>
+        <div class="space-y-2">
+          <label v-for="(item, idx) in preRequestItems" :key="idx" class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              v-model="form.preRequestConfirmation[idx]"
+              class="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+            />
+            <span>{{ item }}</span>
+          </label>
         </div>
       </div>
-    </template>
+
+      <!-- Form Fields -->
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Proposed Component Name/Rename <span class="text-red-500">*</span></label>
+        <input
+          v-model="form.proposedName"
+          type="text"
+          class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="e.g., Model Registry"
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Component Description &amp; Customer Capability <span class="text-red-500">*</span></label>
+        <textarea
+          v-model="form.description"
+          rows="3"
+          class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="Describe the component and the customer capability it delivers"
+        ></textarea>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Justification for New Component/Renamed Component <span class="text-red-500">*</span></label>
+        <textarea
+          v-model="form.justification"
+          rows="3"
+          class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="Why is a new component needed?"
+        ></textarea>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Owning Product Manager <span class="text-red-500">*</span></label>
+          <input
+            v-model="form.owningPm"
+            type="text"
+            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            placeholder="Name of the owning PM"
+          />
+        </div>
+        <div>
+          <div class="flex items-center gap-1 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">PM Leadership Approval - Director <span class="text-red-500">*</span></label>
+            <div
+              class="relative"
+              @mouseenter="showPmApprovalHelp = true"
+              @mouseleave="showPmApprovalHelp = false"
+            >
+              <svg class="h-4 w-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-label="Help: PM Leadership Approval">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div
+                v-if="showPmApprovalHelp"
+                class="absolute z-10 left-6 -top-2 w-72 p-3 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg"
+              >
+                <p>The PM Director who has reviewed and approved this component request. This ensures new components align with the product strategy and avoids duplication across teams.</p>
+              </div>
+            </div>
+          </div>
+          <input
+            v-model="form.pmDirectorApproval"
+            type="text"
+            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            placeholder="Name of approving PM Director"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Primary Engineering Team and Manager <span class="text-red-500">*</span></label>
+          <input
+            v-model="form.engineeringTeamAndManager"
+            type="text"
+            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            placeholder="e.g., Platform Team - Bob Jones"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Component Lead <span class="text-red-500">*</span></label>
+          <input
+            v-model="form.componentLead"
+            type="text"
+            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            placeholder="Name of the component lead"
+          />
+        </div>
+      </div>
+
+      <!-- Leadership Alignment -->
+      <div>
+        <div class="flex items-center gap-2 mb-3">
+          <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Leadership Alignment</h4>
+          <span
+            class="text-xs px-1.5 py-0.5 rounded-full font-medium"
+            :class="leadershipCheckedCount === leadershipItems.length
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+              : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'"
+          >{{ leadershipCheckedCount }}/{{ leadershipItems.length }}</span>
+        </div>
+        <div class="space-y-2">
+          <label v-for="(item, idx) in leadershipItems" :key="idx" class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              v-model="form.leadershipAlignment[idx]"
+              class="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+            />
+            <span>{{ item }}</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- Submit -->
+      <div>
+        <div class="flex items-center gap-4">
+          <button
+            @click="submitRequest"
+            :disabled="!formValid || submitting"
+            class="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {{ submitting ? 'Submitting...' : 'Submit Request' }}
+          </button>
+          <span v-if="submitMessage" :class="submitMessageClass" class="text-sm">{{ submitMessage }}</span>
+        </div>
+        <p v-if="!formValid && !submitting" class="mt-2 text-xs text-amber-600 dark:text-amber-400">
+          {{ formIncompleteHint }}
+        </p>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, inject } from 'vue'
 import { apiRequest } from '@shared/client/services/api'
 import { useAuth } from '@shared/client/composables/useAuth'
 import Toast from '@shared/client/components/Toast.vue'
 
-const { isAdmin } = useAuth()
+const { user, isAdmin } = useAuth()
+const moduleNav = inject('moduleNav')
+
+const tabs = [
+  { id: 'components', label: 'Browse Components' },
+  { id: 'request', label: 'Request Component' }
+]
+
+// Support deep-linking via ?tab=<tabId>
+const tabIds = tabs.map(t => t.id)
+const initialTab = moduleNav?.params?.value?.tab
+const activeTab = ref(tabIds.includes(initialTab) ? initialTab : 'components')
 
 // Component browser state
 const loading = ref(false)
@@ -155,10 +355,95 @@ const syncCooldown = ref(false)
 const cooldownRemaining = ref('')
 let cooldownTimer = null
 
-// Sync trigger — coupled to the "component" field-options name,
-// which is the backing store for the /jira-components read endpoint.
+const DEFAULT_TAB = 'components'
+
+function switchTab(tabId) {
+  activeTab.value = tabId
+  if (moduleNav && moduleNav.updateParams) {
+    moduleNav.updateParams({ tab: tabId === DEFAULT_TAB ? undefined : tabId })
+  }
+}
+
 const SYNC_OPTION_SET = 'component'
-const COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes, matches server-side cooldown
+const COOLDOWN_MS = 5 * 60 * 1000
+
+// Form state
+const preRequestItems = [
+  'I have searched the existing inventory; no duplicate or similar naming variations exist.',
+  'This work cannot reasonably fit under an existing component.',
+  'This represents a long-lived capability, not a short-term project effort.',
+  'I understand that duplicate, confusing, or vague components will be rejected.'
+]
+
+const leadershipItems = [
+  'The Owning PM has approved this request.',
+  'The Engineering Manager of the impacted team has approved'
+]
+
+function createEmptyForm() {
+  return {
+    preRequestConfirmation: [false, false, false, false],
+    proposedName: '',
+    description: '',
+    justification: '',
+    owningPm: '',
+    pmDirectorApproval: '',
+    engineeringTeamAndManager: '',
+    componentLead: '',
+    leadershipAlignment: [false, false]
+  }
+}
+
+const showPmApprovalHelp = ref(false)
+const form = ref(createEmptyForm())
+const submitting = ref(false)
+const submitMessage = ref('')
+const submitMessageType = ref('success')
+
+const userEmail = computed(() => user.value?.email || 'unknown')
+
+const formValid = computed(() => {
+  const f = form.value
+  return f.preRequestConfirmation.every(Boolean)
+    && f.proposedName.trim()
+    && f.description.trim()
+    && f.justification.trim()
+    && f.owningPm.trim()
+    && f.pmDirectorApproval.trim()
+    && f.engineeringTeamAndManager.trim()
+    && f.componentLead.trim()
+    && f.leadershipAlignment.every(Boolean)
+})
+
+const preRequestCheckedCount = computed(() => form.value.preRequestConfirmation.filter(Boolean).length)
+const leadershipCheckedCount = computed(() => form.value.leadershipAlignment.filter(Boolean).length)
+
+const formIncompleteHint = computed(() => {
+  const missing = []
+  if (preRequestCheckedCount.value < preRequestItems.length) {
+    missing.push(`pre-request checklist (${preRequestCheckedCount.value}/${preRequestItems.length})`)
+  }
+  if (leadershipCheckedCount.value < leadershipItems.length) {
+    missing.push(`leadership alignment (${leadershipCheckedCount.value}/${leadershipItems.length})`)
+  }
+  const f = form.value
+  const emptyFields = []
+  if (!f.proposedName.trim()) emptyFields.push('proposed name')
+  if (!f.description.trim()) emptyFields.push('description')
+  if (!f.justification.trim()) emptyFields.push('justification')
+  if (!f.owningPm.trim()) emptyFields.push('owning PM')
+  if (!f.pmDirectorApproval.trim()) emptyFields.push('PM director approval')
+  if (!f.engineeringTeamAndManager.trim()) emptyFields.push('engineering team')
+  if (!f.componentLead.trim()) emptyFields.push('component lead')
+  if (emptyFields.length) missing.push(emptyFields.length === 1 ? `${emptyFields[0]} is required` : `${emptyFields.length} required fields`)
+  return missing.length ? 'Still needed: ' + missing.join(', ') + '.' : ''
+})
+
+const submitMessageClass = computed(() => {
+  return submitMessageType.value === 'error'
+    ? 'text-red-600 dark:text-red-400'
+    : 'text-green-600 dark:text-green-400'
+})
 
 const filteredComponents = computed(() => {
   let result = components.value
@@ -257,7 +542,6 @@ async function triggerSync() {
     toastMessage.value = `Synced ${result.valuesCount} components from Jira.`
   } catch (err) {
     if (err.status === 429) {
-      // Server-side cooldown — start client timer from the last sync time
       startCooldown(fetchedAt.value || new Date().toISOString())
     } else {
       toastType.value = 'error'
@@ -268,9 +552,50 @@ async function triggerSync() {
   }
 }
 
+async function submitRequest() {
+  if (!formValid.value || submitting.value) return
+  submitting.value = true
+  submitMessage.value = ''
+
+  const f = form.value
+  const payload = {
+    preRequestConfirmation: preRequestItems.filter((_, i) => f.preRequestConfirmation[i]),
+    proposedName: f.proposedName.trim(),
+    description: f.description.trim(),
+    justification: f.justification.trim(),
+    owningPm: f.owningPm.trim(),
+    pmDirectorApproval: f.pmDirectorApproval.trim(),
+    engineeringTeamAndManager: f.engineeringTeamAndManager.trim(),
+    componentLead: f.componentLead.trim(),
+    leadershipAlignment: leadershipItems.filter((_, i) => f.leadershipAlignment[i])
+  }
+
+  try {
+    await apiRequest('/modules/team-tracker/jira-components/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    submitMessage.value = 'Component request submitted successfully!'
+    submitMessageType.value = 'success'
+    form.value = createEmptyForm()
+  } catch (err) {
+    if (err.status === 429) {
+      const retryAfter = err.retryAfter || 60
+      submitMessage.value = `Please wait ${retryAfter} seconds before submitting another request.`
+    } else if (err.data?.details?.length) {
+      submitMessage.value = err.data.details.join('; ')
+    } else {
+      submitMessage.value = err.message || 'Failed to submit request'
+    }
+    submitMessageType.value = 'error'
+  } finally {
+    submitting.value = false
+  }
+}
+
 onMounted(() => {
   fetchComponents().then(() => {
-    // If recently synced, start the cooldown timer
     if (fetchedAt.value) {
       const elapsed = Date.now() - new Date(fetchedAt.value).getTime()
       if (elapsed < COOLDOWN_MS) {

--- a/platform/jira-taxonomy/server/index.js
+++ b/platform/jira-taxonomy/server/index.js
@@ -1,21 +1,50 @@
 /**
  * Jira Taxonomy platform extension — server routes.
- * Browse components sourced from the field-options store.
+ * Browse components sourced from the field-options store and submit new
+ * component requests via proxy to Google Form.
  *
  * Mounted as a module-views extension targeting team-tracker.
  * Routes are served at /api/modules/team-tracker/jira-components*.
  *
  * The Jira component sync itself lives in core's field-options-sync engine.
- * This extension provides a read endpoint that reshapes rich field-options
- * data into the browse-friendly format.
+ * This extension provides: (1) a read endpoint that reshapes rich field-options
+ * data into the browse-friendly format, and (2) the Google Form submission proxy.
  */
 
+const crypto = require('crypto');
+const { appendAuditEntry } = require('../../../shared/server/audit-log');
+
+// Google Form: "RHAI Component Request"
+// Form ID: 19eEmOqZ1_VA5U0oibZprzr1rgn5b3Jsa9Vk3XSa0ysE
+// Published URL: https://docs.google.com/forms/d/e/1FAIpQLSc0wnopIa3UOaunMfy4SNuLtWfOa8FcPmcMKwJuBxZVQtZycg/formResponse
+//
+// To find/update entry IDs: open the Google Form in edit mode,
+// View > Source, search for "entry." — each form field has a numeric ID.
+// Alternatively, inspect the live form's HTML input elements.
+var FORM_ENTRY = {
+  PRE_REQUEST_CONFIRMATION: 'entry.1824675397',  // checkbox (repeated)
+  PROPOSED_NAME:            'entry.785780764',    // text
+  DESCRIPTION:              'entry.819357237',    // paragraph
+  JUSTIFICATION:            'entry.9653251',      // paragraph
+  OWNING_PM:                'entry.1227842864',   // text
+  PM_DIRECTOR_APPROVAL:     'entry.2007074061',   // text
+  ENGINEERING_TEAM:         'entry.600587289',    // text
+  COMPONENT_LEAD:           'entry.1930553058',   // text
+  LEADERSHIP_ALIGNMENT:     'entry.744210354'     // checkbox (repeated)
+};
+var GOOGLE_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSc0wnopIa3UOaunMfy4SNuLtWfOa8FcPmcMKwJuBxZVQtZycg/formResponse';
+
 const COMPONENT_OPTIONS_NAME = 'component';
+var SUBMISSIONS_LOG_KEY = 'component-requests-log.json';
+// Rate limiting: per-user cooldown (1 submission per 60 seconds)
+var rateLimitMap = new Map();
 
 module.exports = function registerJiraTaxonomyRoutes(router, context) {
   const storage = context.storage;
   const requireScope = context.requireScope;
   const readFromStorage = storage.readFromStorage;
+  const writeToStorage = storage.writeToStorage;
+  var DEMO_MODE = process.env.DEMO_MODE === 'true';
 
   /**
    * Build the component browse response from the field-options store.
@@ -48,6 +77,25 @@ module.exports = function registerJiraTaxonomyRoutes(router, context) {
     };
   }
 
+  /**
+   * Resolve the submitter's canonical @redhat.com email.
+   * Uses roster registry lookup by userUid, falls back to req.userEmail.
+   */
+  async function resolveSubmitterEmail(req) {
+    if (req.userUid) {
+      try {
+        var registry = await readFromStorage('team-data/registry.json');
+        if (registry && registry.people && registry.people[req.userUid]) {
+          var personEmail = registry.people[req.userUid].email;
+          if (personEmail) return personEmail;
+        }
+      } catch (err) {
+        console.warn('[jira-taxonomy] Failed to resolve email from registry:', err.message);
+      }
+    }
+    return req.userEmail || 'unknown';
+  }
+
   // ─── GET /jira-components ───
 
   /**
@@ -68,6 +116,206 @@ module.exports = function registerJiraTaxonomyRoutes(router, context) {
     } catch (err) {
       console.error('[jira-taxonomy] Error building component response:', err.message);
       res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // ─── POST /jira-components/request ───
+
+  /**
+   * @openapi
+   * /api/modules/team-tracker/jira-components/request:
+   *   post:
+   *     tags: ['TT: Jira Taxonomy']
+   *     summary: Submit a new component request
+   *     description: Proxies the request to the Google Form and maintains a local submission log.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *     responses:
+   *       200:
+   *         description: Request submitted successfully
+   *       400:
+   *         description: Validation error
+   *       429:
+   *         description: Rate limit exceeded
+   *       502:
+   *         description: Google Form submission failed (saved locally)
+   */
+  router.post('/jira-components/request', requireScope('team-tracker:write'), async function(req, res) {
+    try {
+      // Rate limiting: 1 submission per 60 seconds per user
+      var userEmail = req.userEmail || 'anonymous';
+      var now = Date.now();
+      var lastSubmission = rateLimitMap.get(userEmail);
+      if (lastSubmission && (now - lastSubmission) < 60000) {
+        var retryAfter = Math.ceil((60000 - (now - lastSubmission)) / 1000);
+        res.set('Retry-After', String(retryAfter));
+        return res.status(429).json({ error: 'Rate limit exceeded. Please wait before submitting another request.', retryAfter: retryAfter });
+      }
+
+      var body = req.body || {};
+
+      // Validation
+      var errors = [];
+      if (!Array.isArray(body.preRequestConfirmation) || body.preRequestConfirmation.length !== 4) {
+        errors.push('preRequestConfirmation must have exactly 4 items');
+      } else if (!body.preRequestConfirmation.every(function(item) { return typeof item === 'string'; })) {
+        errors.push('preRequestConfirmation items must be strings');
+      }
+      if (!body.proposedName || typeof body.proposedName !== 'string' || !body.proposedName.trim()) {
+        errors.push('proposedName is required');
+      } else if (body.proposedName.length > 200) {
+        errors.push('proposedName must be 200 characters or fewer');
+      }
+      if (!body.description || typeof body.description !== 'string' || !body.description.trim()) {
+        errors.push('description is required');
+      } else if (body.description.length > 2000) {
+        errors.push('description must be 2000 characters or fewer');
+      }
+      if (!body.justification || typeof body.justification !== 'string' || !body.justification.trim()) {
+        errors.push('justification is required');
+      } else if (body.justification.length > 2000) {
+        errors.push('justification must be 2000 characters or fewer');
+      }
+      if (!body.owningPm || typeof body.owningPm !== 'string' || !body.owningPm.trim()) {
+        errors.push('owningPm is required');
+      } else if (body.owningPm.length > 200) {
+        errors.push('owningPm must be 200 characters or fewer');
+      }
+      if (!body.pmDirectorApproval || typeof body.pmDirectorApproval !== 'string' || !body.pmDirectorApproval.trim()) {
+        errors.push('pmDirectorApproval is required');
+      } else if (body.pmDirectorApproval.length > 200) {
+        errors.push('pmDirectorApproval must be 200 characters or fewer');
+      }
+      if (!body.engineeringTeamAndManager || typeof body.engineeringTeamAndManager !== 'string' || !body.engineeringTeamAndManager.trim()) {
+        errors.push('engineeringTeamAndManager is required');
+      } else if (body.engineeringTeamAndManager.length > 200) {
+        errors.push('engineeringTeamAndManager must be 200 characters or fewer');
+      }
+      if (!body.componentLead || typeof body.componentLead !== 'string' || !body.componentLead.trim()) {
+        errors.push('componentLead is required');
+      } else if (body.componentLead.length > 200) {
+        errors.push('componentLead must be 200 characters or fewer');
+      }
+      if (!Array.isArray(body.leadershipAlignment) || body.leadershipAlignment.length !== 2) {
+        errors.push('leadershipAlignment must have exactly 2 items');
+      } else if (!body.leadershipAlignment.every(function(item) { return typeof item === 'string'; })) {
+        errors.push('leadershipAlignment items must be strings');
+      }
+
+      if (errors.length > 0) {
+        return res.status(400).json({ error: 'Validation failed', details: errors });
+      }
+
+      // Resolve submitter email
+      var submitterEmail = await resolveSubmitterEmail(req);
+
+      // Create submission log entry
+      var submissionId = crypto.randomUUID();
+      var submission = {
+        id: submissionId,
+        submittedAt: new Date().toISOString(),
+        submittedBy: submitterEmail,
+        googleFormStatus: 'pending',
+        payload: body
+      };
+
+      // Write initial log entry (pending)
+      var log = await readFromStorage(SUBMISSIONS_LOG_KEY) || { submissions: [] };
+      log.submissions.push(submission);
+      await writeToStorage(SUBMISSIONS_LOG_KEY, log);
+
+      // Update rate limit
+      rateLimitMap.set(userEmail, now);
+
+      // Demo mode: skip Google Form POST
+      if (DEMO_MODE) {
+        submission.googleFormStatus = 'success';
+        var demoLog = await readFromStorage(SUBMISSIONS_LOG_KEY) || { submissions: [] };
+        var demoEntry = demoLog.submissions.find(function(s) { return s.id === submissionId; });
+        if (demoEntry) demoEntry.googleFormStatus = 'success';
+        await writeToStorage(SUBMISSIONS_LOG_KEY, demoLog);
+
+        appendAuditEntry(storage, {
+          action: 'components.request-submitted',
+          actor: submitterEmail,
+          entityType: 'component-request',
+          entityId: submissionId,
+          detail: 'Component request submitted (demo mode)',
+          newValue: { proposedName: body.proposedName, googleFormStatus: 'success' }
+        });
+
+        return res.json({ success: true, submittedBy: submitterEmail, demo: true });
+      }
+
+      // Build Google Form URL-encoded body
+      var formParams = new URLSearchParams();
+      // Pre-request confirmation (repeated checkbox entries)
+      for (var i = 0; i < body.preRequestConfirmation.length; i++) {
+        formParams.append(FORM_ENTRY.PRE_REQUEST_CONFIRMATION, body.preRequestConfirmation[i]);
+      }
+      formParams.append(FORM_ENTRY.PROPOSED_NAME, body.proposedName);
+      formParams.append(FORM_ENTRY.DESCRIPTION, body.description);
+      formParams.append(FORM_ENTRY.JUSTIFICATION, body.justification);
+      formParams.append(FORM_ENTRY.OWNING_PM, body.owningPm);
+      formParams.append(FORM_ENTRY.PM_DIRECTOR_APPROVAL, body.pmDirectorApproval);
+      formParams.append(FORM_ENTRY.ENGINEERING_TEAM, body.engineeringTeamAndManager);
+      formParams.append(FORM_ENTRY.COMPONENT_LEAD, body.componentLead);
+      // Leadership alignment (repeated checkbox entries)
+      for (var j = 0; j < body.leadershipAlignment.length; j++) {
+        formParams.append(FORM_ENTRY.LEADERSHIP_ALIGNMENT, body.leadershipAlignment[j]);
+      }
+
+      // POST to Google Form
+      var googleFormStatus = 'failed';
+      try {
+        var response = await fetch(GOOGLE_FORM_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formParams.toString()
+        });
+
+        if (response.ok) {
+          googleFormStatus = 'success';
+        } else {
+          var responseBody = await response.text().catch(function() { return ''; });
+          console.error('[jira-taxonomy] Google Form returned non-200:', response.status, responseBody);
+        }
+      } catch (fetchErr) {
+        console.error('[jira-taxonomy] Google Form fetch failed:', fetchErr.message);
+      }
+
+      // Update submission log with final status
+      var updatedLog = await readFromStorage(SUBMISSIONS_LOG_KEY) || { submissions: [] };
+      var entry = updatedLog.submissions.find(function(s) { return s.id === submissionId; });
+      if (entry) entry.googleFormStatus = googleFormStatus;
+      await writeToStorage(SUBMISSIONS_LOG_KEY, updatedLog);
+
+      // Audit log
+      appendAuditEntry(storage, {
+        action: 'components.request-submitted',
+        actor: submitterEmail,
+        entityType: 'component-request',
+        entityId: submissionId,
+        detail: 'Component request submitted',
+        newValue: { proposedName: body.proposedName, googleFormStatus: googleFormStatus }
+      });
+
+      if (googleFormStatus === 'success') {
+        return res.json({ success: true, submittedBy: submitterEmail });
+      } else {
+        return res.status(502).json({
+          error: 'Failed to submit to Google Form, but your request has been saved locally. An admin can retrieve it.',
+          submittedBy: submitterEmail,
+          savedLocally: true
+        });
+      }
+    } catch (err) {
+      console.error('[jira-taxonomy] Error submitting request:', err.message);
+      return res.status(500).json({ error: 'Internal server error' });
     }
   });
 };


### PR DESCRIPTION
## Summary

- Adds a **Request Component** tab to the Jira Taxonomy page with a full form for submitting new Jira component requests
- Server proxies submissions to a Google Form and maintains a local submission log as backup (502 fallback)
- Includes validation, per-user rate limiting (1/60s), audit logging, demo mode support, and registry-based email resolution

## Details

**Client (`JiraTaxonomyView.vue`):**
- Tabbed UI (Browse Components / Request Component) with deep-linking via `moduleNav.updateParams()`
- Pre-request checklist (4 items) and leadership alignment (2 items) with completion badge pills
- Form fields: proposed name, description, justification, owning PM, PM director approval, engineering team, component lead
- Hover tooltip on PM Leadership Approval field
- Inline completion hints below submit button showing what's still needed
- Error display shows server validation details

**Server (`server/index.js`):**
- `POST /jira-components/request` — validates payload, resolves submitter email from registry, logs submission, proxies to Google Form
- Rate limiting via in-memory Map (60s cooldown per user)
- Audit logging via `appendAuditEntry`
- Demo mode skips Google Form POST

**Tests:** 29 tests across server (12) and client (17)

## Test plan

- [x] All 29 jira-taxonomy tests pass
- [ ] CI passes (lint, test, build)
- [ ] Manual: verify Browse Components tab still works
- [ ] Manual: submit a test component request and verify Google Form receives it

🤖 Generated with [Claude Code](https://claude.com/claude-code)