### PR TITLE
fix(ai-impact): add missing autofix projects to default config

### DIFF
--- a/modules/ai-impact/client/components/AIImpactSettings.vue
+++ b/modules/ai-impact/client/components/AIImpactSettings.vue
@@ -382,7 +382,7 @@ function getAutofixProjectsDisplay() {
             :value="getAutofixProjectsDisplay()"
             @input="config.autofixProjects = $event.target.value.split(',').map(s => s.trim()).filter(Boolean)"
             type="text"
-            placeholder="AIPCC, RHOAIENG"
+            placeholder="AIPCC, RHOAIENG, RHAIENG, RHAIFIRST, INFERENG, JN"
             class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-800 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500"
           />
           <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">Comma-separated Jira project keys to scan for autofix labels</p>

--- a/modules/ai-impact/server/config.js
+++ b/modules/ai-impact/server/config.js
@@ -8,7 +8,7 @@ const DEFAULT_CONFIG = {
   excludedStatuses: ['Closed'],
   lookbackMonths: 0,
   trendThresholdPp: 2,
-  autofixProjects: ['AIPCC', 'RHOAIENG'],
+  autofixProjects: ['AIPCC', 'RHOAIENG', 'RHAIENG', 'RHAIFIRST', 'INFERENG', 'JN'],
   autofixCreatedAfter: null,
   docProject: 'RHAISTRAT',
   docRequiredStatuses: ['Review', 'Release Pending'],


### PR DESCRIPTION
## Summary

- Added RHAIENG, RHAIFIRST, INFERENG, and JN to the default `autofixProjects` config, matching the projects supported by the [autofix pipeline config](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/blob/main/autofix.json)
- Updated the Settings UI placeholder text to reflect all 6 projects

## Note for existing deployments

Deployments with a previously saved `ai-impact/config.json` will keep their saved `autofixProjects` value. An admin will need to update the project list in Settings > AI Impact > Jira AutoFix to add the new projects.

## Test plan

- [x] All 629 ai-impact tests pass (6 unrelated failures in releases module due to missing `express-rate-limit`)
- [x] Adversarial code review confirmed no other hardcoded project references were missed
- [ ] Verify project filter dropdown shows all 6 projects after data refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)