### PR TITLE
fix(jira-taxonomy): pass submitter email to Google Form

### DIFF
--- a/platform/jira-taxonomy/server/index.js
+++ b/platform/jira-taxonomy/server/index.js
@@ -253,6 +253,8 @@ module.exports = function registerJiraTaxonomyRoutes(router, context) {
 
       // Build Google Form URL-encoded body
       var formParams = new URLSearchParams();
+      // Built-in email collection field (not an entry.* — Google Forms uses 'emailAddress')
+      formParams.append('emailAddress', submitterEmail);
       // Pre-request confirmation (repeated checkbox entries)
       for (var i = 0; i < body.preRequestConfirmation.length; i++) {
         formParams.append(FORM_ENTRY.PRE_REQUEST_CONFIRMATION, body.preRequestConfirmation[i]);


### PR DESCRIPTION
## Summary

- The Jira taxonomy component request form was not passing the submitter's identity to the Google Form
- The form uses Google Forms' built-in email collection (`emailCollectionType: RESPONDER_INPUT`), which accepts an `emailAddress` parameter
- Now passes the resolved `@redhat.com` email (via registry lookup in `resolveSubmitterEmail`) so submissions are properly attributed in the linked Google Sheet

## Test plan

- [ ] Submit a component request in dev/preprod and verify the submitter's `@redhat.com` email appears in the Google Sheet's "Email Address" column
- [ ] Verify the email comes through as `@redhat.com` (not `@cluster.local`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)