### PR TITLE
feat(releases): pre-select 18 product-family versions on TV/FV Delta

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -1,6 +1,6 @@
 /**
  * View-level tests for TvFvDeltaView — product filter, column sorting,
- * and target alignment column integration.
+ * target alignment column, and default version pre-selection.
  *
  * These tests mount the full view with mocked API responses and verify
  * the template renders the new UI elements correctly.
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import TvFvDeltaView from '../../../client/views/TvFvDeltaView.vue'
+import { DEFAULT_SELECTED_VERSIONS } from '../../../client/composables/tvFvDeltaDefaults'
 
 // ── Mock apiRequest ──
 
@@ -19,30 +20,38 @@ vi.mock('@shared/client', function () {
   }
 })
 
-// ── Test data ──
+// ── Test data (subset of default versions + one extra for family filter) ──
+
+function emptyRow(release) {
+  return { release: release, total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 0, ga_date: null }
+}
 
 function makeTestData() {
+  var detailed = {
+    '3.6 EA1 RHOAI RELEASE': { release: '3.6 EA1 RHOAI RELEASE', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
+    '3.6 EA2 RHOAI RELEASE': { release: '3.6 EA2 RHOAI RELEASE', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
+    '3.6 GA RHOAI RELEASE': { release: '3.6 GA RHOAI RELEASE', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
+    '3.5 GA RHOAI RELEASE': { release: '3.5 GA RHOAI RELEASE', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-07-15' },
+  }
+  var summary = DEFAULT_SELECTED_VERSIONS.map(function (v) {
+    return detailed[v] || emptyRow(v)
+  })
+  // Extra non-default release in cache — must not appear in the default picker
+  summary.push({ release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null })
+
+  var releases = {}
+  DEFAULT_SELECTED_VERSIONS.forEach(function (v) {
+    releases[v] = { aligned: [], tv_only: [], fv_only: [], mismatched: [] }
+  })
+
   return {
     metadata: {
       generated_at: '2026-06-17T10:00:00Z',
       data_timestamp: '2026-06-17T09:55:00Z',
-      releases: ['rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6', 'rhoai-3.5', 'RHELAI-3.2'],
-      all_components: ['Dashboard', 'Serving'],
+      releases: DEFAULT_SELECTED_VERSIONS.slice(),
     },
-    executive_summary: [
-      { release: 'rhoai-3.6.EA1', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
-      { release: 'rhoai-3.6.EA2', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
-      { release: 'rhoai-3.6', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
-      { release: 'rhoai-3.5', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-07-15' },
-      { release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null },
-    ],
-    releases: {
-      'rhoai-3.6.EA1': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
-      'rhoai-3.6.EA2': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
-      'rhoai-3.6': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
-      'rhoai-3.5': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
-      'RHELAI-3.2': { aligned: [], tv_only: [], fv_only: [], mismatched: [] },
-    },
+    executive_summary: summary,
+    releases: releases,
   }
 }
 
@@ -71,7 +80,38 @@ async function mountView() {
   return wrapper
 }
 
+/** Find the executive summary table (first table in the view) */
+function findSummaryTable(wrapper) {
+  return wrapper.findAll('table')[0]
+}
+
 // ── Tests ──
+
+describe('TvFvDeltaView default version selection', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('pre-selects the 18 default product-family versions on load', async function () {
+    var wrapper = await mountView()
+    // Version picker chips include a Remove control; family filter pills do not
+    var chips = wrapper.findAll('button').filter(function (b) {
+      return b.find('span[title="Remove"]').exists()
+    })
+    expect(chips.length).toBe(DEFAULT_SELECTED_VERSIONS.length)
+    DEFAULT_SELECTED_VERSIONS.forEach(function (v) {
+      expect(chips.some(function (b) { return b.text().includes(v) })).toBe(true)
+    })
+  })
+
+  it('does not include non-default versions from cache in the picker chips', async function () {
+    var wrapper = await mountView()
+    var rhelaiChip = wrapper.findAll('button').find(function (b) {
+      return b.find('span[title="Remove"]').exists() && b.text().includes('RHELAI-3.2')
+    })
+    expect(rhelaiChip).toBeFalsy()
+  })
+})
 
 describe('TvFvDeltaView release family filter', function () {
   beforeEach(function () {
@@ -82,49 +122,21 @@ describe('TvFvDeltaView release family filter', function () {
     var wrapper = await mountView()
     var buttons = wrapper.findAll('button').filter(function (b) {
       var text = b.text()
-      return text === 'All' || text === 'RHOAI 3.6' || text === 'RHOAI 3.5' || text === 'RHELAI 3.2'
+      return text === 'All' || text.includes('3.6') || text.includes('3.5')
     })
-    expect(buttons.length).toBeGreaterThanOrEqual(4)
+    expect(buttons.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('defaults to All — shows all releases', async function () {
+  it('defaults to All — shows default-selected releases present in data', async function () {
     var wrapper = await mountView()
     var table = findSummaryTable(wrapper)
     var allText = table.find('tbody').text()
-    expect(allText).toContain('RHELAI')
-    expect(allText).toContain('rhoai')
-  })
-
-  it('filters to RHOAI 3.6 family when clicked', async function () {
-    var wrapper = await mountView()
-    var famButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHOAI 3.6' })
-    await famButton.trigger('click')
-    await flushPromises()
-    var table = findSummaryTable(wrapper)
-    var rows = table.findAll('tbody tr')
-    expect(rows.length).toBe(3) // EA1, EA2, GA
-    var releaseTexts = rows.map(function (r) { return r.find('td').text() })
-    for (var i = 0; i < releaseTexts.length; i++) {
-      expect(releaseTexts[i]).toContain('3.6')
-    }
-  })
-
-  it('filters to RHELAI 3.2 when clicked', async function () {
-    var wrapper = await mountView()
-    var famButton = wrapper.findAll('button').find(function (b) { return b.text() === 'RHELAI 3.2' })
-    await famButton.trigger('click')
-    await flushPromises()
-    var table = findSummaryTable(wrapper)
-    var rows = table.findAll('tbody tr')
-    expect(rows.length).toBe(1)
-    expect(rows[0].text()).toContain('RHELAI')
+    expect(allText).toContain('3.6 EA1 RHOAI RELEASE')
+    expect(allText).toContain('3.5 GA RHOAI RELEASE')
+    // Non-default RHELAI-3.2 must not appear
+    expect(allText).not.toContain('RHELAI-3.2')
   })
 })
-
-/** Find the executive summary table (first table in the view) */
-function findSummaryTable(wrapper) {
-  return wrapper.findAll('table')[0]
-}
 
 describe('TvFvDeltaView executive summary sorting', function () {
   beforeEach(function () {
@@ -139,19 +151,15 @@ describe('TvFvDeltaView executive summary sorting', function () {
     expect(headers.length).toBe(11)
   })
 
-  it('default sort is release family order (EA1 < EA2 < GA)', async function () {
+  it('default sort includes 3.6 and 3.5 default versions from data', async function () {
     var wrapper = await mountView()
     var table = findSummaryTable(wrapper)
     var rows = table.findAll('tbody tr')
-    var releases = rows.map(function (r) { return r.find('td').text().trim() })
-    // Default is All — RHELAI first (alpha), then rhoai families
-    expect(releases[0]).toBe('RHELAI-3.2')
-    // rhoai 3.6 family in order, then 3.5
-    var rhoaiReleases = releases.filter(function (r) { return r.toLowerCase().startsWith('rhoai') })
-    expect(rhoaiReleases[0]).toBe('rhoai-3.6.EA1')
-    expect(rhoaiReleases[1]).toBe('rhoai-3.6.EA2')
-    expect(rhoaiReleases[2]).toBe('rhoai-3.6')
-    expect(rhoaiReleases[3]).toBe('rhoai-3.5')
+    var releases = rows.map(function (r) { return r.find('td').text().trim().replace(/\s*\(refreshing data\.\.\.\)\s*$/, '') })
+    expect(releases).toContain('3.6 EA1 RHOAI RELEASE')
+    expect(releases).toContain('3.6 EA2 RHOAI RELEASE')
+    expect(releases).toContain('3.6 GA RHOAI RELEASE')
+    expect(releases).toContain('3.5 GA RHOAI RELEASE')
   })
 
   it('clicking Total header sorts by total', async function () {
@@ -169,7 +177,7 @@ describe('TvFvDeltaView executive summary sorting', function () {
       var countEl = cells[1].find('.clickable-count')
       if (countEl.exists()) totals.push(parseInt(countEl.text(), 10))
     })
-    // Ascending order
+    // Ascending order among rows with real counts
     for (var i = 1; i < totals.length; i++) {
       expect(totals[i]).toBeGreaterThanOrEqual(totals[i - 1])
     }
@@ -211,25 +219,13 @@ describe('TvFvDeltaView target alignment column', function () {
     expect(html).toMatch(/\d+%\*/)
   })
 
-  it('shows dash for releases without GA dates', async function () {
-    var wrapper = await mountView()
-    // Default is All, so RHELAI-3.2 (no ga_date) is already visible
-    var table = findSummaryTable(wrapper)
-    var rows = table.findAll('tbody tr')
-    var rhelaiRow = rows.find(function (r) { return r.text().includes('RHELAI') })
-    expect(rhelaiRow).toBeTruthy()
-    // The target cell (8th column, index 7) should have a dash
-    var cells = rhelaiRow.findAll('td')
-    expect(cells[7].text()).toBe('—')
-  })
-
   it('colors target red when actual alignment is below target', async function () {
     var wrapper = await mountView()
     var table = findSummaryTable(wrapper)
-    // rhoai-3.5 has alignment_pct: 32.3% and ga_date: 2026-07-15 (~28 days from June 17)
+    // 3.5 GA RHOAI has alignment_pct: 32.3% and ga_date: 2026-07-15 (~28 days from June 17)
     // Target for ≤30 days = 100%*, so actual (32.3%) < target (100%) → red
     var rows = table.findAll('tbody tr')
-    var row35 = rows.find(function (r) { return r.text().includes('rhoai-3.5') && !r.text().includes('EA') })
+    var row35 = rows.find(function (r) { return r.text().includes('3.5 GA RHOAI RELEASE') })
     if (row35) {
       var targetCell = row35.findAll('td')[7]
       var targetSpan = targetCell.find('span.font-semibold')

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -441,8 +441,13 @@ describe('buildExport', () => {
 // ---------------------------------------------------------------------------
 
 describe('DEFAULT_RELEASES', () => {
-  it('contains EA1, EA2, and GA in that order', () => {
-    expect(DEFAULT_RELEASES).toEqual(['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']);
+  it('contains the 18 product-family versions for 3.5 and 3.6', () => {
+    expect(DEFAULT_RELEASES).toHaveLength(18);
+    expect(DEFAULT_RELEASES).toContain('3.6 GA RHOAI RELEASE');
+    expect(DEFAULT_RELEASES).toContain('3.6 EA1 RHAII RELEASE');
+    expect(DEFAULT_RELEASES).toContain('3.5 EA2 RHELAI RELEASE');
+    expect(DEFAULT_RELEASES[0]).toBe('3.6 GA RHOAI RELEASE');
+    expect(DEFAULT_RELEASES[17]).toBe('3.5 EA1 RHELAI RELEASE');
   });
 });
 

--- a/modules/releases/client/composables/tvFvDeltaDefaults.js
+++ b/modules/releases/client/composables/tvFvDeltaDefaults.js
@@ -1,0 +1,26 @@
+/**
+ * Default versions pre-selected on TV vs FV Delta page load.
+ * Users can still add/remove versions after load via the release picker.
+ *
+ * Product-family Jira version names for 3.5 and 3.6 (EA1, EA2, GA).
+ */
+export const DEFAULT_SELECTED_VERSIONS = [
+  '3.6 GA RHOAI RELEASE',
+  '3.6 GA RHAII RELEASE',
+  '3.6 GA RHELAI RELEASE',
+  '3.6 EA2 RHOAI RELEASE',
+  '3.6 EA2 RHAII RELEASE',
+  '3.6 EA2 RHELAI RELEASE',
+  '3.6 EA1 RHOAI RELEASE',
+  '3.6 EA1 RHAII RELEASE',
+  '3.6 EA1 RHELAI RELEASE',
+  '3.5 GA RHOAI RELEASE',
+  '3.5 GA RHAII RELEASE',
+  '3.5 GA RHELAI RELEASE',
+  '3.5 EA2 RHOAI RELEASE',
+  '3.5 EA2 RHAII RELEASE',
+  '3.5 EA2 RHELAI RELEASE',
+  '3.5 EA1 RHOAI RELEASE',
+  '3.5 EA1 RHAII RELEASE',
+  '3.5 EA1 RHELAI RELEASE',
+]

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -6,6 +6,7 @@ import { useReleasePicker } from '../composables/useReleasePicker'
 import { useComponentBreakdown } from '../composables/useComponentBreakdown'
 import { useTvFvData } from '../composables/useTvFvData'
 import { useReleaseFamily, getAlignmentTarget } from '../composables/useReleaseFamily'
+import { DEFAULT_SELECTED_VERSIONS } from '../composables/tvFvDeltaDefaults'
 
 const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
 
@@ -22,11 +23,11 @@ const {
 } = useTvFvData()
 
 const {
-  chosenReleases, pickerOpen, pickerRef,
+  pickerOpen, pickerRef,
   chosenVersionNames, versionSearch,
   availableVersions, filteredVersions, allSelectedVersions,
   chosenVersionsDisplay,
-  autoSelectReleases, formatDate, isInCurrentData,
+  formatDate, isInCurrentData,
   toggleVersion, removeVersion, handleClickOutside,
 } = useReleasePicker(data, registryReleases, jiraVersions)
 
@@ -112,22 +113,16 @@ watch(chosenVersionNames, (names) => {
 onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
   await Promise.all([fetchRegistry(), fetchVersions()])
-  // Seed picker from registry auto-selection
-  if (!chosenReleases.value.length && registryReleases.value.length) {
-    const auto = autoSelectReleases(registryReleases.value)
-    chosenReleases.value = auto
-    const names = new Set()
-    for (const rel of auto) {
-      for (const fv of (rel.fixVersions || [])) names.add(fv)
-    }
-    if (names.size) chosenVersionNames.value = names
+  // Pre-populate with the default 3.5/3.6 product-family versions (users can add/remove after load)
+  if (!chosenVersionNames.value.size) {
+    chosenVersionNames.value = new Set(DEFAULT_SELECTED_VERSIONS)
   }
   await fetchData()
-  // If registry was empty and we have cached data, seed from cached releases
-  if (!chosenVersionNames.value.size && data.value?.metadata?.releases?.length) {
-    chosenVersionNames.value = new Set(data.value.metadata.releases)
+  // Prefer a default version that already has detail data in the cache
+  if (data.value?.releases) {
+    const firstWithDetail = DEFAULT_SELECTED_VERSIONS.find(v => data.value.releases[v])
+    if (firstWithDetail) selectedRelease.value = firstWithDetail
   }
-
 })
 
 onBeforeUnmount(() => {

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -8,9 +8,29 @@ const CACHE_MAX_AGE_MS = 60 * 60 * 1000 // 1 hour
 const VERSIONS_CACHE_KEY = 'releases/tv-fv-delta-versions.json'
 const VERSIONS_CACHE_MAX_AGE_MS = 4 * 60 * 60 * 1000 // 4 hours
 
-// Default releases — EA1, EA2, then GA (timeline order)
-// Fallback if Smartsheet/planning releases are not configured
-const DEFAULT_RELEASES = ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']
+// Default releases — 3.5/3.6 product-family Jira versions (EA1, EA2, GA × RHOAI/RHAII/RHELAI)
+// Fallback if Smartsheet/planning releases are not configured.
+// Keep in sync with client DEFAULT_SELECTED_VERSIONS (tvFvDeltaDefaults.js).
+const DEFAULT_RELEASES = [
+  '3.6 GA RHOAI RELEASE',
+  '3.6 GA RHAII RELEASE',
+  '3.6 GA RHELAI RELEASE',
+  '3.6 EA2 RHOAI RELEASE',
+  '3.6 EA2 RHAII RELEASE',
+  '3.6 EA2 RHELAI RELEASE',
+  '3.6 EA1 RHOAI RELEASE',
+  '3.6 EA1 RHAII RELEASE',
+  '3.6 EA1 RHELAI RELEASE',
+  '3.5 GA RHOAI RELEASE',
+  '3.5 GA RHAII RELEASE',
+  '3.5 GA RHELAI RELEASE',
+  '3.5 EA2 RHOAI RELEASE',
+  '3.5 EA2 RHAII RELEASE',
+  '3.5 EA2 RHELAI RELEASE',
+  '3.5 EA1 RHOAI RELEASE',
+  '3.5 EA1 RHAII RELEASE',
+  '3.5 EA1 RHELAI RELEASE',
+]
 const DEFAULT_JIRA_PROJECT = 'RHAISTRAT'
 
 // JQL-safe release name pattern — allows spaces for version names like "RHAII-3.5 EA1"
@@ -576,7 +596,7 @@ async function registerRoutes(router, context) {
    *               releases:
    *                 type: array
    *                 items: { type: string }
-   *                 description: Release versions to analyse (defaults to EA1, EA2, 3.5)
+   *                 description: Release versions to analyse (defaults to 3.5/3.6 product-family versions)
    *     responses:
    *       200:
    *         description: Refresh started or already running

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -7,7 +7,7 @@ const { setupErrorTracking, logCapturedErrors } = require('./helpers');
  *
  * Tests verify:
  * - View loads via Reports hub (/#/releases/reports?report=tv-fv-delta)
- * - Release picker renders with auto-selected versions
+ * - Release picker renders with the 18 default product-family versions
  * - API endpoints are called (registry, versions, tv-fv-delta)
  * - Executive summary table renders with correct columns
  * - Release tab switching works
@@ -25,16 +25,57 @@ const { setupErrorTracking, logCapturedErrors } = require('./helpers');
 // Fixture data for deterministic tests
 // ---------------------------------------------------------------------------
 
+/** Empty summary row for default versions without detailed fixture features */
+function emptySummaryRow(release) {
+  return {
+    release,
+    total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0,
+    alignment_pct: 0,
+    total_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
+    aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
+    tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
+    fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
+    mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty'
+  };
+}
+
+/** Matches client DEFAULT_SELECTED_VERSIONS — keep fixture in sync */
+const DEFAULT_FIXTURE_RELEASES = [
+  '3.6 GA RHOAI RELEASE',
+  '3.6 GA RHAII RELEASE',
+  '3.6 GA RHELAI RELEASE',
+  '3.6 EA2 RHOAI RELEASE',
+  '3.6 EA2 RHAII RELEASE',
+  '3.6 EA2 RHELAI RELEASE',
+  '3.6 EA1 RHOAI RELEASE',
+  '3.6 EA1 RHAII RELEASE',
+  '3.6 EA1 RHELAI RELEASE',
+  '3.5 GA RHOAI RELEASE',
+  '3.5 GA RHAII RELEASE',
+  '3.5 GA RHELAI RELEASE',
+  '3.5 EA2 RHOAI RELEASE',
+  '3.5 EA2 RHAII RELEASE',
+  '3.5 EA2 RHELAI RELEASE',
+  '3.5 EA1 RHOAI RELEASE',
+  '3.5 EA1 RHAII RELEASE',
+  '3.5 EA1 RHELAI RELEASE',
+];
+
 const FIXTURE_DATA = {
   metadata: {
     generated_at: '2026-05-17T10:00:00.000Z',
     data_timestamp: '2026-05-17T09:00:00.000Z',
-    releases: ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5'],
+    releases: DEFAULT_FIXTURE_RELEASES.slice(),
     total_features: 12
   },
   executive_summary: [
+    ...DEFAULT_FIXTURE_RELEASES.filter(r => ![
+      '3.5 EA1 RHOAI RELEASE',
+      '3.5 EA2 RHOAI RELEASE',
+      '3.5 GA RHOAI RELEASE',
+    ].includes(r)).map(emptySummaryRow),
     {
-      release: 'rhoai-3.5.EA1',
+      release: '3.5 EA1 RHOAI RELEASE',
       total: 5, aligned: 3, tv_only: 1, fv_only: 0, mismatched: 1,
       alignment_pct: 60,
       total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea1',
@@ -44,7 +85,7 @@ const FIXTURE_DATA = {
       mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea1'
     },
     {
-      release: 'rhoai-3.5.EA2',
+      release: '3.5 EA2 RHOAI RELEASE',
       total: 4, aligned: 2, tv_only: 1, fv_only: 1, mismatched: 0,
       alignment_pct: 50,
       total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea2',
@@ -54,7 +95,7 @@ const FIXTURE_DATA = {
       mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea2'
     },
     {
-      release: 'rhoai-3.5',
+      release: '3.5 GA RHOAI RELEASE',
       total: 3, aligned: 3, tv_only: 0, fv_only: 0, mismatched: 0,
       alignment_pct: 100,
       total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-35',
@@ -65,7 +106,7 @@ const FIXTURE_DATA = {
     }
   ],
   releases: {
-    'rhoai-3.5.EA1': {
+    '3.5 EA1 RHOAI RELEASE': {
       aligned: [
         { key: 'RHAISTRAT-100', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-100', summary: 'Aligned feature A', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
         { key: 'RHAISTRAT-101', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-101', summary: 'Aligned feature B', status: 'New', color_status: 'Yellow', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Training' },
@@ -76,10 +117,10 @@ const FIXTURE_DATA = {
       ],
       fv_only: [],
       mismatched: [
-        { key: 'RHAISTRAT-300', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-300', summary: 'Mismatched feature Z', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Alpha', assignee: 'Dev Five', team: 'Team A', component: 'Serving, Training', target_version: 'rhoai-3.5.EA1', fix_versions: 'rhoai-3.5.EA2' }
+        { key: 'RHAISTRAT-300', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-300', summary: 'Mismatched feature Z', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Alpha', assignee: 'Dev Five', team: 'Team A', component: 'Serving, Training', target_version: '3.5 EA1 RHOAI RELEASE', fix_versions: '3.5 EA2 RHOAI RELEASE' }
       ]
     },
-    'rhoai-3.5.EA2': {
+    '3.5 EA2 RHOAI RELEASE': {
       aligned: [
         { key: 'RHAISTRAT-400', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-400', summary: 'EA2 aligned A', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
         { key: 'RHAISTRAT-401', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-401', summary: 'EA2 aligned B', status: 'New', color_status: '', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Notebooks' }
@@ -92,7 +133,7 @@ const FIXTURE_DATA = {
       ],
       mismatched: []
     },
-    'rhoai-3.5': {
+    '3.5 GA RHOAI RELEASE': {
       aligned: [
         { key: 'RHAISTRAT-700', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-700', summary: 'GA aligned A', status: 'Done', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
         { key: 'RHAISTRAT-701', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-701', summary: 'GA aligned B', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Training' },
@@ -141,21 +182,21 @@ const REGISTRY_DATA = {
       id: 'rhoai-3.5-ea1',
       displayName: 'RHOAI 3.5 EA1',
       state: 'active',
-      fixVersions: ['rhoai-3.5.EA1'],
+      fixVersions: ['3.5 EA1 RHOAI RELEASE'],
       milestones: { codeFreeze: '2026-06-01', ga: '2026-07-01' },
     },
     {
       id: 'rhoai-3.5-ea2',
       displayName: 'RHOAI 3.5 EA2',
       state: 'active',
-      fixVersions: ['rhoai-3.5.EA2'],
+      fixVersions: ['3.5 EA2 RHOAI RELEASE'],
       milestones: { codeFreeze: '2026-07-01', ga: '2026-08-01' },
     },
     {
       id: 'rhoai-3.5',
       displayName: 'RHOAI 3.5',
       state: 'active',
-      fixVersions: ['rhoai-3.5'],
+      fixVersions: ['3.5 GA RHOAI RELEASE'],
       milestones: { codeFreeze: '2026-08-01', ga: '2026-09-01' },
     },
   ],
@@ -165,12 +206,17 @@ const REGISTRY_DATA = {
 // bug fixes only, not features, so they don't appear in TV/FV analysis.
 const JIRA_VERSIONS_DATA = {
   versions: [
-    { name: 'rhoai-3.5.EA1', released: false, releaseDate: '2026-07-01' },
-    { name: 'rhoai-3.5.EA2', released: false, releaseDate: '2026-08-01' },
-    { name: 'rhoai-3.5', released: false, releaseDate: '2026-09-01' },
+    { name: '3.5 EA1 RHOAI RELEASE', released: false, releaseDate: '2026-07-01' },
+    { name: '3.5 EA2 RHOAI RELEASE', released: false, releaseDate: '2026-08-01' },
+    { name: '3.5 GA RHOAI RELEASE', released: false, releaseDate: '2026-09-01' },
     { name: 'rhoai-3.4', released: true, releaseDate: '2026-03-01' },
   ],
 };
+
+/** Version picker chip (has Remove control) — distinct from family-filter pills */
+function versionChip(page, release) {
+  return page.locator('button', { hasText: release }).filter({ has: page.locator('span[title="Remove"]') });
+}
 
 // ---------------------------------------------------------------------------
 // Helper: mock all API endpoints the app needs to boot + TV/FV data
@@ -258,6 +304,15 @@ async function mockAllApis(page, tvfvData) {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ running: false })
+    });
+  });
+
+  // Mock refresh trigger
+  await page.route('**/api/modules/releases/tv-fv-delta/refresh', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'started' })
     });
   });
 
@@ -405,7 +460,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     expect(relevantErrors(page)).toHaveLength(0);
   });
 
-  test('should render one row per release in timeline order', async ({ page }) => {
+  test('should render one row per default release version', async ({ page }) => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
@@ -413,15 +468,13 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     // Find the executive summary table
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
     const rows = summarySection.locator('tbody tr');
-    await expect(rows).toHaveCount(3);
+    await expect(rows).toHaveCount(18);
 
-    // Verify release order: EA1, EA2, 3.5
-    const firstRow = rows.nth(0);
-    await expect(firstRow).toContainText('rhoai-3.5.EA1');
-    const secondRow = rows.nth(1);
-    await expect(secondRow).toContainText('rhoai-3.5.EA2');
-    const thirdRow = rows.nth(2);
-    await expect(thirdRow).toContainText('rhoai-3.5');
+    // Verify key default versions are present
+    await expect(summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' })).toBeVisible();
+    await expect(summarySection.locator('tbody tr', { hasText: '3.5 EA2 RHOAI RELEASE' })).toBeVisible();
+    await expect(summarySection.locator('tbody tr', { hasText: '3.5 GA RHOAI RELEASE' })).toBeVisible();
+    await expect(summarySection.locator('tbody tr', { hasText: '3.6 GA RHOAI RELEASE' })).toBeVisible();
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -434,11 +487,11 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
     // EA1 row: total=5, aligned=3, tv_only=1, fv_only=0, mismatched=1, alignment=60%
-    const ea1Row = summarySection.locator('tbody tr').nth(0);
+    const ea1Row = summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' });
     await expect(ea1Row).toContainText('60%');
 
-    // rhoai-3.5 row: 100% alignment
-    const gaRow = summarySection.locator('tbody tr').nth(2);
+    // 3.5 GA RHOAI RELEASE row: 100% alignment
+    const gaRow = summarySection.locator('tbody tr', { hasText: '3.5 GA RHOAI RELEASE' });
     await expect(gaRow).toContainText('100%');
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -452,12 +505,12 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
     // EA2 has 50% alignment → yellow
-    const ea2Pct = summarySection.locator('tbody tr').nth(1).locator('span.font-semibold').last();
+    const ea2Pct = summarySection.locator('tbody tr', { hasText: '3.5 EA2 RHOAI RELEASE' }).locator('span.font-semibold').last();
     const ea2Classes = await ea2Pct.getAttribute('class');
     expect(ea2Classes).toContain('text-yellow-600');
 
-    // rhoai-3.5 has 100% alignment → green
-    const gaPct = summarySection.locator('tbody tr').nth(2).locator('span.font-semibold').last();
+    // 3.5 GA has 100% alignment → green
+    const gaPct = summarySection.locator('tbody tr', { hasText: '3.5 GA RHOAI RELEASE' }).locator('span.font-semibold').last();
     const gaClasses = await gaPct.getAttribute('class');
     expect(gaClasses).toContain('text-green-600');
 
@@ -471,8 +524,8 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
 
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
-    // First release (EA1) should be selected by default
-    const ea1Row = summarySection.locator('tbody tr').nth(0);
+    // First default version with detail data (3.5 EA1 RHOAI) should be selected
+    const ea1Row = summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' });
     const ea1Classes = await ea1Row.getAttribute('class');
     expect(ea1Classes).toContain('bg-blue-50');
 
@@ -487,7 +540,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
     // Click on the EA2 row
-    const ea2Row = summarySection.locator('tbody tr').nth(1);
+    const ea2Row = summarySection.locator('tbody tr', { hasText: '3.5 EA2 RHOAI RELEASE' });
     await ea2Row.click();
     await page.waitForTimeout(500);
 
@@ -496,7 +549,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     expect(ea2Classes).toContain('bg-blue-50');
 
     // EA1 row should no longer be highlighted
-    const ea1Row = summarySection.locator('tbody tr').nth(0);
+    const ea1Row = summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' });
     const ea1Classes = await ea1Row.getAttribute('class');
     expect(ea1Classes).not.toContain('bg-blue-50');
 
@@ -512,8 +565,8 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
     const jiraLinks = summarySection.locator('tbody a[href*="atlassian.net"]');
     const linkCount = await jiraLinks.count();
-    // Each row has Total, Aligned, TV-Only, FV-Only, Mismatched = 5 links per row × 3 rows = 15
-    expect(linkCount).toBeGreaterThanOrEqual(9); // at least 3 per row
+    // Each row has Total, Aligned, TV-Only, FV-Only, Mismatched = 5 links per row × 18 rows
+    expect(linkCount).toBeGreaterThanOrEqual(18);
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -530,13 +583,13 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     logCapturedErrors(page, testInfo);
   });
 
-  test('should render release chip buttons for all releases', async ({ page }) => {
+  test('should render release chip buttons for all default releases', async ({ page }) => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    for (const release of ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']) {
-      const chip = page.locator('button', { hasText: release }).first();
+    for (const release of DEFAULT_FIXTURE_RELEASES) {
+      const chip = versionChip(page, release);
       await expect(chip).toBeVisible();
     }
 
@@ -549,12 +602,12 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // EA1 is selected by default → should have blue background
-    const ea1Tab = page.locator('button', { hasText: 'rhoai-3.5.EA1' });
+    const ea1Tab = versionChip(page, '3.5 EA1 RHOAI RELEASE');
     const ea1Classes = await ea1Tab.getAttribute('class');
     expect(ea1Classes).toContain('bg-blue-600');
 
     // EA2 should NOT have blue background
-    const ea2Tab = page.locator('button', { hasText: 'rhoai-3.5.EA2' });
+    const ea2Tab = versionChip(page, '3.5 EA2 RHOAI RELEASE');
     const ea2Classes = await ea2Tab.getAttribute('class');
     expect(ea2Classes).not.toContain('bg-blue-600');
 
@@ -567,7 +620,7 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // Click EA2 tab
-    const ea2Tab = page.locator('button', { hasText: 'rhoai-3.5.EA2' });
+    const ea2Tab = versionChip(page, '3.5 EA2 RHOAI RELEASE');
     await ea2Tab.click();
     await page.waitForTimeout(500);
 
@@ -576,7 +629,7 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     expect(ea2Classes).toContain('bg-blue-600');
 
     // EA1 tab should no longer be active
-    const ea1Tab = page.locator('button', { hasText: 'rhoai-3.5.EA1' });
+    const ea1Tab = versionChip(page, '3.5 EA1 RHOAI RELEASE');
     const ea1Classes = await ea1Tab.getAttribute('class');
     expect(ea1Classes).not.toContain('bg-blue-600');
 
@@ -631,7 +684,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     // EA1: tv_only=1
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
 
-    // Switch to rhoai-3.5 (GA): tv_only=0, aligned=3
+    // Switch to 3.5 GA RHOAI RELEASE (GA): tv_only=0, aligned=3
     // Use negative lookahead to match only the GA chip (not EA1/EA2)
     await page.locator('button', { hasText: /rhoai-3\.5(?!\.)/ }).click();
     await page.waitForTimeout(500);
@@ -661,7 +714,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     // Switch to EA2 which has 0 mismatched
-    await page.locator('button', { hasText: 'rhoai-3.5.EA2' }).click();
+    await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
     // Mismatched section should be hidden (v-if="releaseData.mismatched.length")
@@ -744,7 +797,7 @@ test.describe('TV/FV Delta — Collapsible Behaviour @tv-fv-delta', () => {
     expect(fvOnlyClosed).toBeNull();
 
     // Switch to EA2
-    await page.locator('button', { hasText: 'rhoai-3.5.EA2' }).click();
+    await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
     // TV-Only and Aligned should STILL be open
@@ -963,7 +1016,7 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await expect(rows).toHaveCount(3);
 
     // Switch to EA2 — has 2 aligned
-    await page.locator('button', { hasText: 'rhoai-3.5.EA2' }).click();
+    await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
     rows = alignedDetails.locator('tbody tr');
@@ -1031,7 +1084,7 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     const ea1Rows = await compSection.locator('tbody tr').count();
     expect(ea1Rows).toBeGreaterThan(0);
 
-    // Switch to rhoai-3.5 (GA) — different components
+    // Switch to 3.5 GA RHOAI RELEASE (GA) — different components
     await page.locator('button', { hasText: /rhoai-3\.5(?!\.)/ }).click();
     await page.waitForTimeout(500);
 
@@ -1113,9 +1166,9 @@ test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
     const mismatchedDetails = page.locator('details:has(summary:has-text("Mismatched"))');
     const firstRow = mismatchedDetails.locator('tbody tr').first();
 
-    // Should show rhoai-3.5.EA1 in TV column and rhoai-3.5.EA2 in FV column (from fixture)
-    await expect(firstRow).toContainText('rhoai-3.5.EA1');
-    await expect(firstRow).toContainText('rhoai-3.5.EA2');
+    // Should show 3.5 EA1 RHOAI RELEASE in TV column and 3.5 EA2 RHOAI RELEASE in FV column (from fixture)
+    await expect(firstRow).toContainText('3.5 EA1 RHOAI RELEASE');
+    await expect(firstRow).toContainText('3.5 EA2 RHOAI RELEASE');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -1160,22 +1213,22 @@ test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
     // Click EA2 row in executive summary
-    const ea2Row = summarySection.locator('tbody tr').nth(1);
+    const ea2Row = summarySection.locator('tbody tr', { hasText: '3.5 EA2 RHOAI RELEASE' });
     await ea2Row.click();
     await page.waitForTimeout(500);
 
     // EA2 tab should now be active (highlighted)
-    const ea2Tab = page.locator('button', { hasText: 'rhoai-3.5.EA2' });
+    const ea2Tab = versionChip(page, '3.5 EA2 RHOAI RELEASE');
     const ea2Classes = await ea2Tab.getAttribute('class');
     expect(ea2Classes).toContain('bg-blue-600');
 
     // Now click EA1 tab
-    const ea1Tab = page.locator('button', { hasText: 'rhoai-3.5.EA1' });
+    const ea1Tab = versionChip(page, '3.5 EA1 RHOAI RELEASE');
     await ea1Tab.click();
     await page.waitForTimeout(500);
 
     // EA1 executive summary row should now be highlighted
-    const ea1ExecRow = summarySection.locator('tbody tr').nth(0);
+    const ea1ExecRow = summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' });
     const ea1RowClasses = await ea1ExecRow.getAttribute('class');
     expect(ea1RowClasses).toContain('bg-blue-50');
 
@@ -1298,14 +1351,14 @@ test.describe('TV/FV Delta — Release Picker @tv-fv-delta', () => {
     logCapturedErrors(page, testInfo);
   });
 
-  test('should render release chips from auto-selected registry versions', async ({ page }) => {
+  test('should render release chips from default-selected product-family versions', async ({ page }) => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Auto-selected versions appear as chip buttons below exec summary
-    for (const release of ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']) {
-      await expect(page.locator('button', { hasText: release }).first()).toBeVisible();
+    // All 18 default-selected versions appear as chip buttons below exec summary
+    for (const release of DEFAULT_FIXTURE_RELEASES) {
+      await expect(versionChip(page, release)).toBeVisible();
     }
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -1391,8 +1444,8 @@ test.describe('TV/FV Delta — Release Picker @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // All 3 release chips should be visible
-    const ea1Chip = page.locator('button', { hasText: 'rhoai-3.5.EA1' }).first();
+    // Default EA1 chip should be visible
+    const ea1Chip = versionChip(page, '3.5 EA1 RHOAI RELEASE').first();
     await expect(ea1Chip).toBeVisible();
 
     // Click the x (×) on the EA1 chip
@@ -1402,7 +1455,7 @@ test.describe('TV/FV Delta — Release Picker @tv-fv-delta', () => {
     // EA1 chip should be gone
     await expect(ea1Chip).not.toBeVisible();
     // Others still present
-    await expect(page.locator('button', { hasText: 'rhoai-3.5.EA2' }).first()).toBeVisible();
+    await expect(versionChip(page, '3.5 EA2 RHOAI RELEASE').first()).toBeVisible();
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -1479,9 +1532,9 @@ test.describe('TV/FV Delta — Registry fixVersions Edge Cases @tv-fv-delta', ()
     // (after migrateNormalizedIds merged .z entries and carried fixVersions over)
     const migratedRegistry = {
       releases: [
-        { id: 'rhoai-3.5-ea1', displayName: 'RHOAI 3.5 EA1', state: 'active', fixVersions: ['rhoai-3.5.EA1'], milestones: { ga: '2026-07-01' } },
-        { id: 'rhoai-3.5-ea2', displayName: 'RHOAI 3.5 EA2', state: 'active', fixVersions: ['rhoai-3.5.EA2'], milestones: { ga: '2026-08-01' } },
-        { id: 'rhoai-3.5', displayName: 'RHOAI 3.5', state: 'active', fixVersions: ['rhoai-3.5'], milestones: { ga: '2026-09-01' } },
+        { id: 'rhoai-3.5-ea1', displayName: 'RHOAI 3.5 EA1', state: 'active', fixVersions: ['3.5 EA1 RHOAI RELEASE'], milestones: { ga: '2026-07-01' } },
+        { id: 'rhoai-3.5-ea2', displayName: 'RHOAI 3.5 EA2', state: 'active', fixVersions: ['3.5 EA2 RHOAI RELEASE'], milestones: { ga: '2026-08-01' } },
+        { id: 'rhoai-3.5', displayName: 'RHOAI 3.5', state: 'active', fixVersions: ['3.5 GA RHOAI RELEASE'], milestones: { ga: '2026-09-01' } },
       ],
     };
 
@@ -1501,14 +1554,14 @@ test.describe('TV/FV Delta — Registry fixVersions Edge Cases @tv-fv-delta', ()
 
     expect(relevantErrors(page)).toHaveLength(0);
 
-    // All three releases should appear as chips (auto-selected because fixVersions are populated)
-    for (const release of ['rhoai-3.5.EA1', 'rhoai-3.5.EA2', 'rhoai-3.5']) {
-      await expect(page.locator('button', { hasText: release }).first()).toBeVisible();
+    // Default product-family versions should appear as chips
+    for (const release of DEFAULT_FIXTURE_RELEASES) {
+      await expect(versionChip(page, release)).toBeVisible();
     }
 
-    // Executive summary should render with all three releases
+    // Executive summary should render with all 18 default releases
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
     const rows = summarySection.locator('tbody tr');
-    await expect(rows).toHaveCount(3);
+    await expect(rows).toHaveCount(18);
   });
 });

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -685,8 +685,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
 
     // Switch to 3.5 GA RHOAI RELEASE (GA): tv_only=0, aligned=3
-    // Use negative lookahead to match only the GA chip (not EA1/EA2)
-    await page.locator('button', { hasText: /rhoai-3\.5(?!\.)/ }).click();
+    await versionChip(page, '3.5 GA RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
     await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
@@ -1085,7 +1084,7 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     expect(ea1Rows).toBeGreaterThan(0);
 
     // Switch to 3.5 GA RHOAI RELEASE (GA) — different components
-    await page.locator('button', { hasText: /rhoai-3\.5(?!\.)/ }).click();
+    await versionChip(page, '3.5 GA RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
     // GA has Serving (RHAISTRAT-700, 702) = 2 features

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -218,6 +218,18 @@ function versionChip(page, release) {
   return page.locator('button', { hasText: release }).filter({ has: page.locator('span[title="Remove"]') });
 }
 
+/**
+ * First default version that has detail fixture data (GA before EA in DEFAULT list).
+ * Auto-selection prefers this when present in data.releases.
+ */
+const DEFAULT_SELECTED_DETAIL_RELEASE = '3.5 GA RHOAI RELEASE';
+
+/** Select a version chip (used when a test needs EA1/EA2 detail instead of the auto-selected GA). */
+async function selectVersion(page, release) {
+  await versionChip(page, release).click();
+  await page.waitForTimeout(300);
+}
+
 // ---------------------------------------------------------------------------
 // Helper: mock all API endpoints the app needs to boot + TV/FV data
 // ---------------------------------------------------------------------------
@@ -524,10 +536,10 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
 
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
-    // First default version with detail data (3.5 EA1 RHOAI) should be selected
-    const ea1Row = summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' });
-    const ea1Classes = await ea1Row.getAttribute('class');
-    expect(ea1Classes).toContain('bg-blue-50');
+    // Auto-selects first default version that has detail data (3.5 GA precedes EA in the list)
+    const gaRow = summarySection.locator('tbody tr', { hasText: DEFAULT_SELECTED_DETAIL_RELEASE });
+    const gaClasses = await gaRow.getAttribute('class');
+    expect(gaClasses).toContain('bg-blue-50');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -601,10 +613,10 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // EA1 is selected by default → should have blue background
-    const ea1Tab = versionChip(page, '3.5 EA1 RHOAI RELEASE');
-    const ea1Classes = await ea1Tab.getAttribute('class');
-    expect(ea1Classes).toContain('bg-blue-600');
+    // Auto-selected GA chip should have blue background
+    const gaTab = versionChip(page, DEFAULT_SELECTED_DETAIL_RELEASE);
+    const gaClasses = await gaTab.getAttribute('class');
+    expect(gaClasses).toContain('bg-blue-600');
 
     // EA2 should NOT have blue background
     const ea2Tab = versionChip(page, '3.5 EA2 RHOAI RELEASE');
@@ -652,6 +664,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // EA1 has: aligned (3), tv_only (1), fv_only (0), mismatched (1)
     await expect(page.locator('summary:has-text("TV-Only")')).toBeVisible();
@@ -667,8 +680,8 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // EA1 selected by default
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
     await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
     await expect(page.locator('summary:has-text("Mismatched")')).toContainText('(1)');
@@ -680,13 +693,13 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // EA1: tv_only=1
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
 
-    // Switch to 3.5 GA RHOAI RELEASE (GA): tv_only=0, aligned=3
-    await versionChip(page, '3.5 GA RHOAI RELEASE').click();
-    await page.waitForTimeout(500);
+    // Switch to GA: tv_only=0, aligned=3
+    await selectVersion(page, DEFAULT_SELECTED_DETAIL_RELEASE);
 
     await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(0)');
@@ -858,6 +871,7 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // Expand TV-Only section
     await page.locator('summary:has-text("TV-Only")').click();
@@ -900,6 +914,8 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    // EA1 has Mismatched + TV-Only sections; GA does not
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // Test that TV-Only, Aligned, and Mismatched all have TV/FV columns
     const categories = ['TV-Only', 'Aligned', 'Mismatched'];
@@ -959,6 +975,7 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // Expand Aligned section (3 features)
     await page.locator('summary:has-text("Aligned")').click();
@@ -1157,6 +1174,7 @@ test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // Expand Mismatched section (has both TV and FV populated)
     await page.locator('summary:has-text("Mismatched")').click();
@@ -1238,6 +1256,7 @@ test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // Expand Mismatched section (RHAISTRAT-300 has "Serving, Training")
     await page.locator('summary:has-text("Mismatched")').click();


### PR DESCRIPTION
## Summary
- Pre-populate the TV vs FV Delta view with the 18 current product-family Jira versions (3.5/3.6 × EA1/EA2/GA × RHOAI/RHAII/RHELAI) on initial load
- Keep add/remove via the existing release picker after load
- Align the server `DEFAULT_RELEASES` fallback with the same list so cold-start/refresh uses the same set

## Test plan
- [ ] Open `/#/releases/reports?report=tv-fv-delta` and confirm all 18 default version chips are selected
- [ ] Confirm executive summary shows those 18 versions (pending rows OK until refresh completes)
- [ ] Remove a version with × and add a different one via **+ Add release**
- [ ] Click **Refresh from Jira** and confirm the selected set is posted
- [ ] `npm test -- --run modules/releases/__tests__/client/tv-fv-delta/ modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js`


Made with [Cursor](https://cursor.com)