### PR TITLE
feat(releases): TV/FV temporal alignment formula with planning freeze

### DIFF
--- a/fixtures/releases/delivery/product-pages-releases-cache.json
+++ b/fixtures/releases/delivery/product-pages-releases-cache.json
@@ -1,0 +1,149 @@
+{
+  "fetchedAt": "2026-07-27T15:57:48.373Z",
+  "releases": [
+    {
+      "productName": "rhoai",
+      "releaseNumber": "rhoai-3.6.EA1",
+      "dueDate": "2026-09-17",
+      "planningFreezeDate": "2026-07-29",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhoai",
+      "releaseNumber": "rhoai-3.6.EA2",
+      "dueDate": "2026-10-15",
+      "planningFreezeDate": "2026-08-26",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhoai",
+      "releaseNumber": "rhoai-3.6",
+      "dueDate": "2026-11-19",
+      "planningFreezeDate": "2026-09-23",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhoai",
+      "releaseNumber": "rhoai-3.5.EA1",
+      "dueDate": "2026-06-17",
+      "planningFreezeDate": "2026-04-17",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhoai",
+      "releaseNumber": "rhoai-3.5.EA2",
+      "dueDate": "2026-07-15",
+      "planningFreezeDate": "2026-05-15",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhoai",
+      "releaseNumber": "rhoai-3.5",
+      "dueDate": "2026-08-19",
+      "planningFreezeDate": "2026-06-24",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhaii",
+      "releaseNumber": "rhaii-3.6.EA1",
+      "dueDate": "2026-09-17",
+      "planningFreezeDate": "2026-07-29",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhaii",
+      "releaseNumber": "rhaii-3.6.EA2",
+      "dueDate": "2026-10-15",
+      "planningFreezeDate": "2026-08-26",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhaii",
+      "releaseNumber": "rhaii-3.6",
+      "dueDate": "2026-11-19",
+      "planningFreezeDate": "2026-09-23",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhaii",
+      "releaseNumber": "rhaii-3.5.EA1",
+      "dueDate": "2026-06-17",
+      "planningFreezeDate": "2026-04-17",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhaii",
+      "releaseNumber": "rhaii-3.5.EA2",
+      "dueDate": "2026-07-15",
+      "planningFreezeDate": "2026-05-15",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhaii",
+      "releaseNumber": "rhaii-3.5",
+      "dueDate": "2026-08-19",
+      "planningFreezeDate": "2026-06-24",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhelai",
+      "releaseNumber": "rhelai-3.6.EA1",
+      "dueDate": "2026-09-17",
+      "planningFreezeDate": "2026-07-29",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhelai",
+      "releaseNumber": "rhelai-3.6.EA2",
+      "dueDate": "2026-10-15",
+      "planningFreezeDate": "2026-08-26",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhelai",
+      "releaseNumber": "rhelai-3.6",
+      "dueDate": "2026-11-19",
+      "planningFreezeDate": "2026-09-23",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhelai",
+      "releaseNumber": "rhelai-3.5.EA1",
+      "dueDate": "2026-06-17",
+      "planningFreezeDate": "2026-04-17",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhelai",
+      "releaseNumber": "rhelai-3.5.EA2",
+      "dueDate": "2026-07-15",
+      "planningFreezeDate": "2026-05-15",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    },
+    {
+      "productName": "rhelai",
+      "releaseNumber": "rhelai-3.5",
+      "dueDate": "2026-08-19",
+      "planningFreezeDate": "2026-06-24",
+      "codeFreezeDate": null,
+      "featureFreezeDate": null
+    }
+  ]
+}

--- a/fixtures/releases/tv-fv-delta.json
+++ b/fixtures/releases/tv-fv-delta.json
@@ -1,0 +1,951 @@
+{
+  "metadata": {
+    "generated_at": "2026-07-27T15:57:48.373Z",
+    "data_timestamp": "2026-07-27T15:57:48.373Z",
+    "releases": [
+      "3.6 GA RHOAI RELEASE",
+      "3.6 GA RHAII RELEASE",
+      "3.6 GA RHELAI RELEASE",
+      "3.6 EA2 RHOAI RELEASE",
+      "3.6 EA2 RHAII RELEASE",
+      "3.6 EA2 RHELAI RELEASE",
+      "3.6 EA1 RHOAI RELEASE",
+      "3.6 EA1 RHAII RELEASE",
+      "3.6 EA1 RHELAI RELEASE",
+      "3.5 GA RHOAI RELEASE",
+      "3.5 GA RHAII RELEASE",
+      "3.5 GA RHELAI RELEASE",
+      "3.5 EA2 RHOAI RELEASE",
+      "3.5 EA2 RHAII RELEASE",
+      "3.5 EA2 RHELAI RELEASE",
+      "3.5 EA1 RHOAI RELEASE",
+      "3.5 EA1 RHAII RELEASE",
+      "3.5 EA1 RHELAI RELEASE"
+    ],
+    "total_features": 37
+  },
+  "executive_summary": [
+    {
+      "release": "3.6 GA RHOAI RELEASE",
+      "total": 8,
+      "aligned_on_time": 4,
+      "aligned_late": 0,
+      "tv_only": 2,
+      "fv_only": 1,
+      "misaligned": 1,
+      "alignment_pct": 50.0,
+      "ga_date": "2026-11-19",
+      "planning_freeze": "2026-09-23"
+    },
+    {
+      "release": "3.6 GA RHAII RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-11-19",
+      "planning_freeze": "2026-09-23"
+    },
+    {
+      "release": "3.6 GA RHELAI RELEASE",
+      "total": 1,
+      "aligned_on_time": 1,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 100.0,
+      "ga_date": "2026-11-19",
+      "planning_freeze": "2026-09-23"
+    },
+    {
+      "release": "3.6 EA2 RHOAI RELEASE",
+      "total": 5,
+      "aligned_on_time": 2,
+      "aligned_late": 0,
+      "tv_only": 1,
+      "fv_only": 1,
+      "misaligned": 1,
+      "alignment_pct": 40.0,
+      "ga_date": "2026-10-15",
+      "planning_freeze": "2026-08-26"
+    },
+    {
+      "release": "3.6 EA2 RHAII RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-10-15",
+      "planning_freeze": "2026-08-26"
+    },
+    {
+      "release": "3.6 EA2 RHELAI RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-10-15",
+      "planning_freeze": "2026-08-26"
+    },
+    {
+      "release": "3.6 EA1 RHOAI RELEASE",
+      "total": 8,
+      "aligned_on_time": 3,
+      "aligned_late": 0,
+      "tv_only": 1,
+      "fv_only": 1,
+      "misaligned": 3,
+      "alignment_pct": 37.5,
+      "ga_date": "2026-09-17",
+      "planning_freeze": "2026-07-29"
+    },
+    {
+      "release": "3.6 EA1 RHAII RELEASE",
+      "total": 2,
+      "aligned_on_time": 1,
+      "aligned_late": 0,
+      "tv_only": 1,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 50.0,
+      "ga_date": "2026-09-17",
+      "planning_freeze": "2026-07-29"
+    },
+    {
+      "release": "3.6 EA1 RHELAI RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-09-17",
+      "planning_freeze": "2026-07-29"
+    },
+    {
+      "release": "3.5 GA RHOAI RELEASE",
+      "total": 3,
+      "aligned_on_time": 3,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 100,
+      "ga_date": "2026-08-19",
+      "planning_freeze": "2026-06-24"
+    },
+    {
+      "release": "3.5 GA RHAII RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-08-19",
+      "planning_freeze": "2026-06-24"
+    },
+    {
+      "release": "3.5 GA RHELAI RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-08-19",
+      "planning_freeze": "2026-06-24"
+    },
+    {
+      "release": "3.5 EA2 RHOAI RELEASE",
+      "total": 4,
+      "aligned_on_time": 2,
+      "aligned_late": 0,
+      "tv_only": 1,
+      "fv_only": 1,
+      "misaligned": 0,
+      "alignment_pct": 50,
+      "ga_date": "2026-07-15",
+      "planning_freeze": "2026-05-15"
+    },
+    {
+      "release": "3.5 EA2 RHAII RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-07-15",
+      "planning_freeze": "2026-05-15"
+    },
+    {
+      "release": "3.5 EA2 RHELAI RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-07-15",
+      "planning_freeze": "2026-05-15"
+    },
+    {
+      "release": "3.5 EA1 RHOAI RELEASE",
+      "total": 6,
+      "aligned_on_time": 2,
+      "aligned_late": 1,
+      "tv_only": 1,
+      "fv_only": 0,
+      "misaligned": 2,
+      "alignment_pct": 50,
+      "ga_date": "2026-06-17",
+      "planning_freeze": "2026-04-17"
+    },
+    {
+      "release": "3.5 EA1 RHAII RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-06-17",
+      "planning_freeze": "2026-04-17"
+    },
+    {
+      "release": "3.5 EA1 RHELAI RELEASE",
+      "total": 0,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 0,
+      "ga_date": "2026-06-17",
+      "planning_freeze": "2026-04-17"
+    }
+  ],
+  "releases": {
+    "3.6 GA RHOAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-8800",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8800",
+          "summary": "3.6 GA on-time A",
+          "status": "Done",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev One",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8801",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8801",
+          "summary": "3.6 GA on-time B",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Two",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8802",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8802",
+          "summary": "3.6 GA on-time C",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Three",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8803",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8803",
+          "summary": "3.6 GA on-time D",
+          "status": "New",
+          "color_status": "Green",
+          "product_manager": "PM Gamma",
+          "assignee": "Dev Four",
+          "team": "Team C",
+          "component": "Dashboard",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [
+        {
+          "key": "RHAISTRAT-8900",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8900",
+          "summary": "3.6 GA TV-only",
+          "status": "New",
+          "color_status": "Red",
+          "product_manager": "PM Gamma",
+          "assignee": "Dev Four",
+          "team": "Team C",
+          "component": "Dashboard",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": ""
+        },
+        {
+          "key": "RHAISTRAT-8901",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8901",
+          "summary": "3.6 GA TV-only B",
+          "status": "Backlog",
+          "color_status": "",
+          "product_manager": "PM Beta",
+          "assignee": "",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": ""
+        }
+      ],
+      "fv_only": [
+        {
+          "key": "RHAISTRAT-8950",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8950",
+          "summary": "3.6 GA FV-only",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "",
+          "assignee": "Dev Six",
+          "team": "Team D",
+          "component": "Model Registry",
+          "target_version": "",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        }
+      ],
+      "misaligned": [
+        {
+          "key": "RHAISTRAT-8970",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8970",
+          "summary": "3.6 GA misaligned \u2014 different product",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Five",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 GA RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHAII RELEASE"
+        }
+      ]
+    },
+    "3.6 GA RHAII RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.6 GA RHELAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-8810",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8810",
+          "summary": "3.6 GA RHELAI on-time",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Epsilon",
+          "assignee": "Dev Eight",
+          "team": "Team F",
+          "component": "Serving",
+          "target_version": "3.6 GA RHELAI RELEASE",
+          "fix_versions": "3.6 GA RHELAI RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.6 EA2 RHOAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-8400",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8400",
+          "summary": "3.6 EA2 on-time A",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev One",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 EA2 RHOAI RELEASE",
+          "fix_versions": "3.6 EA2 RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8401",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8401",
+          "summary": "3.6 EA2 on-time B",
+          "status": "New",
+          "color_status": "",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Two",
+          "team": "Team B",
+          "component": "Notebooks",
+          "target_version": "3.6 EA2 RHOAI RELEASE",
+          "fix_versions": "3.6 EA2 RHOAI RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [
+        {
+          "key": "RHAISTRAT-8500",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8500",
+          "summary": "3.6 EA2 TV-only",
+          "status": "Backlog",
+          "color_status": "",
+          "product_manager": "PM Gamma",
+          "assignee": "",
+          "team": "",
+          "component": "Pipelines",
+          "target_version": "3.6 EA2 RHOAI RELEASE",
+          "fix_versions": ""
+        }
+      ],
+      "fv_only": [
+        {
+          "key": "RHAISTRAT-8600",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8600",
+          "summary": "3.6 EA2 FV-only",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "",
+          "assignee": "Dev Six",
+          "team": "Team D",
+          "component": "Model Registry",
+          "target_version": "",
+          "fix_versions": "3.6 EA2 RHOAI RELEASE"
+        }
+      ],
+      "misaligned": [
+        {
+          "key": "RHAISTRAT-8700",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8700",
+          "summary": "3.6 EA2 misaligned \u2014 FV later while freeze still open",
+          "status": "In Progress",
+          "color_status": "Red",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Five",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 EA2 RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        }
+      ]
+    },
+    "3.6 EA2 RHAII RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.6 EA2 RHELAI RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.6 EA1 RHOAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-8100",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8100",
+          "summary": "3.6 EA1 on-time A",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev One",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": "3.6 EA1 RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8101",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8101",
+          "summary": "3.6 EA1 on-time B",
+          "status": "New",
+          "color_status": "Yellow",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Two",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": "3.6 EA1 RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8102",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8102",
+          "summary": "3.6 EA1 on-time C",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Three",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": "3.6 EA1 RHOAI RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [
+        {
+          "key": "RHAISTRAT-8200",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8200",
+          "summary": "3.6 EA1 TV-only",
+          "status": "New",
+          "color_status": "Red",
+          "product_manager": "PM Gamma",
+          "assignee": "Dev Four",
+          "team": "Team C",
+          "component": "Dashboard",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": ""
+        }
+      ],
+      "fv_only": [
+        {
+          "key": "RHAISTRAT-8250",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8250",
+          "summary": "3.6 EA1 FV-only",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "",
+          "assignee": "Dev Six",
+          "team": "Team D",
+          "component": "Model Registry",
+          "target_version": "",
+          "fix_versions": "3.6 EA1 RHOAI RELEASE"
+        }
+      ],
+      "misaligned": [
+        {
+          "key": "RHAISTRAT-8300",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8300",
+          "summary": "3.6 EA1 misaligned \u2014 FV later while freeze still open",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Five",
+          "team": "Team A",
+          "component": "Serving, Training",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": "3.6 EA2 RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8301",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8301",
+          "summary": "3.6 EA1 misaligned \u2014 different product (RHAII)",
+          "status": "In Progress",
+          "color_status": "Red",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Six",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": "3.6 EA1 RHAII RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-8302",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8302",
+          "summary": "3.6 EA1 misaligned \u2014 FV later to GA while freeze open",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Five",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.6 EA1 RHOAI RELEASE",
+          "fix_versions": "3.6 GA RHOAI RELEASE"
+        }
+      ]
+    },
+    "3.6 EA1 RHAII RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-8110",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8110",
+          "summary": "3.6 EA1 RHAII on-time",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Delta",
+          "assignee": "Dev Seven",
+          "team": "Team E",
+          "component": "Serving",
+          "target_version": "3.6 EA1 RHAII RELEASE",
+          "fix_versions": "3.6 EA1 RHAII RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [
+        {
+          "key": "RHAISTRAT-8210",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-8210",
+          "summary": "3.6 EA1 RHAII TV-only",
+          "status": "Backlog",
+          "color_status": "",
+          "product_manager": "PM Delta",
+          "assignee": "",
+          "team": "Team E",
+          "component": "Serving",
+          "target_version": "3.6 EA1 RHAII RELEASE",
+          "fix_versions": ""
+        }
+      ],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.6 EA1 RHELAI RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 GA RHOAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-700",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-700",
+          "summary": "GA aligned A",
+          "status": "Done",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev One",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.5 GA RHOAI RELEASE",
+          "fix_versions": "3.5 GA RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-701",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-701",
+          "summary": "GA aligned B",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Two",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.5 GA RHOAI RELEASE",
+          "fix_versions": "3.5 GA RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-702",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-702",
+          "summary": "GA aligned C",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Three",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.5 GA RHOAI RELEASE",
+          "fix_versions": "3.5 GA RHOAI RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 GA RHAII RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 GA RHELAI RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 EA2 RHOAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-400",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-400",
+          "summary": "EA2 aligned A",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev One",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.5 EA2 RHOAI RELEASE",
+          "fix_versions": "3.5 EA2 RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-401",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-401",
+          "summary": "EA2 aligned B",
+          "status": "New",
+          "color_status": "",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Two",
+          "team": "Team B",
+          "component": "Notebooks",
+          "target_version": "3.5 EA2 RHOAI RELEASE",
+          "fix_versions": "3.5 EA2 RHOAI RELEASE"
+        }
+      ],
+      "aligned_late": [],
+      "tv_only": [
+        {
+          "key": "RHAISTRAT-500",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-500",
+          "summary": "EA2 TV-only",
+          "status": "Backlog",
+          "color_status": "",
+          "product_manager": "PM Gamma",
+          "assignee": "",
+          "team": "",
+          "component": "Pipelines",
+          "target_version": "3.5 EA2 RHOAI RELEASE",
+          "fix_versions": ""
+        }
+      ],
+      "fv_only": [
+        {
+          "key": "RHAISTRAT-600",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-600",
+          "summary": "EA2 FV-only",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "",
+          "assignee": "Dev Six",
+          "team": "Team D",
+          "component": "Model Registry",
+          "target_version": "",
+          "fix_versions": "3.5 EA2 RHOAI RELEASE"
+        }
+      ],
+      "misaligned": []
+    },
+    "3.5 EA2 RHAII RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 EA2 RHELAI RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 EA1 RHOAI RELEASE": {
+      "aligned_on_time": [
+        {
+          "key": "RHAISTRAT-100",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-100",
+          "summary": "On-time aligned A",
+          "status": "In Progress",
+          "color_status": "Green",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev One",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.5 EA1 RHOAI RELEASE",
+          "fix_versions": "3.5 EA1 RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-101",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-101",
+          "summary": "On-time aligned B",
+          "status": "New",
+          "color_status": "Yellow",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Two",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.5 EA1 RHOAI RELEASE",
+          "fix_versions": "3.5 EA1 RHOAI RELEASE"
+        }
+      ],
+      "aligned_late": [
+        {
+          "key": "RHAISTRAT-150",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-150",
+          "summary": "Late but aligned (frozen TV)",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Five",
+          "team": "Team A",
+          "component": "Serving",
+          "target_version": "3.5 EA1 RHOAI RELEASE",
+          "fix_versions": "3.5 EA2 RHOAI RELEASE"
+        }
+      ],
+      "tv_only": [
+        {
+          "key": "RHAISTRAT-200",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-200",
+          "summary": "TV-only feature X",
+          "status": "New",
+          "color_status": "Red",
+          "product_manager": "PM Gamma",
+          "assignee": "Dev Four",
+          "team": "Team C",
+          "component": "Dashboard",
+          "target_version": "3.5 EA1 RHOAI RELEASE",
+          "fix_versions": ""
+        }
+      ],
+      "fv_only": [],
+      "misaligned": [
+        {
+          "key": "RHAISTRAT-300",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-300",
+          "summary": "Misaligned \u2014 FV after unfrozen TV",
+          "status": "In Progress",
+          "color_status": "Yellow",
+          "product_manager": "PM Alpha",
+          "assignee": "Dev Five",
+          "team": "Team A",
+          "component": "Serving, Training",
+          "target_version": "3.5 EA1 RHOAI RELEASE",
+          "fix_versions": "3.5 GA RHOAI RELEASE"
+        },
+        {
+          "key": "RHAISTRAT-301",
+          "url": "https://redhat.atlassian.net/browse/RHAISTRAT-301",
+          "summary": "Misaligned \u2014 cross-product",
+          "status": "In Progress",
+          "color_status": "Red",
+          "product_manager": "PM Beta",
+          "assignee": "Dev Six",
+          "team": "Team B",
+          "component": "Training",
+          "target_version": "3.5 EA1 RHOAI RELEASE",
+          "fix_versions": "3.5 EA1 RHAII RELEASE"
+        }
+      ]
+    },
+    "3.5 EA1 RHAII RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    },
+    "3.5 EA1 RHELAI RELEASE": {
+      "aligned_on_time": [],
+      "aligned_late": [],
+      "tv_only": [],
+      "fv_only": [],
+      "misaligned": []
+    }
+  },
+  "component_breakdown": [
+    {
+      "component": "Serving",
+      "pm": "PM Alpha",
+      "eng": "Lead One",
+      "total": 12,
+      "aligned_on_time": 6,
+      "aligned_late": 2,
+      "tv_only": 1,
+      "fv_only": 0,
+      "misaligned": 3,
+      "alignment_pct": 66.7
+    },
+    {
+      "component": "Training",
+      "pm": "PM Beta",
+      "eng": "Lead Two",
+      "total": 5,
+      "aligned_on_time": 3,
+      "aligned_late": 0,
+      "tv_only": 1,
+      "fv_only": 0,
+      "misaligned": 1,
+      "alignment_pct": 60.0
+    },
+    {
+      "component": "Dashboard",
+      "pm": "PM Gamma",
+      "eng": "Lead Three",
+      "total": 3,
+      "aligned_on_time": 1,
+      "aligned_late": 0,
+      "tv_only": 2,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 33.3
+    },
+    {
+      "component": "Model Registry",
+      "pm": "",
+      "eng": "Lead Four",
+      "total": 3,
+      "aligned_on_time": 0,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 3,
+      "misaligned": 0,
+      "alignment_pct": 0.0
+    },
+    {
+      "component": "Pipelines",
+      "pm": "PM Gamma",
+      "eng": "Lead Five",
+      "total": 2,
+      "aligned_on_time": 0,
+      "aligned_late": 1,
+      "tv_only": 1,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 50.0
+    },
+    {
+      "component": "Notebooks",
+      "pm": "PM Beta",
+      "eng": "Lead Two",
+      "total": 1,
+      "aligned_on_time": 1,
+      "aligned_late": 0,
+      "tv_only": 0,
+      "fv_only": 0,
+      "misaligned": 0,
+      "alignment_pct": 100.0
+    }
+  ]
+}

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -23,25 +23,25 @@ vi.mock('@shared/client', function () {
 // ── Test data (subset of default versions + one extra for family filter) ──
 
 function emptyRow(release) {
-  return { release: release, total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 0, ga_date: null }
+  return { release: release, total: 0, aligned_on_time: 0, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0, alignment_pct: 0, ga_date: null, planning_freeze: null }
 }
 
 function makeTestData() {
   var detailed = {
-    '3.6 EA1 RHOAI RELEASE': { release: '3.6 EA1 RHOAI RELEASE', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
-    '3.6 EA2 RHOAI RELEASE': { release: '3.6 EA2 RHOAI RELEASE', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
-    '3.6 GA RHOAI RELEASE': { release: '3.6 GA RHOAI RELEASE', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
-    '3.5 GA RHOAI RELEASE': { release: '3.5 GA RHOAI RELEASE', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-07-15' },
+    '3.6 EA1 RHOAI RELEASE': { release: '3.6 EA1 RHOAI RELEASE', total: 7, aligned_on_time: 2, aligned_late: 0, tv_only: 3, fv_only: 1, misaligned: 1, alignment_pct: 28.6, ga_date: '2026-09-17', planning_freeze: '2026-08-17' },
+    '3.6 EA2 RHOAI RELEASE': { release: '3.6 EA2 RHOAI RELEASE', total: 4, aligned_on_time: 0, aligned_late: 0, tv_only: 2, fv_only: 1, misaligned: 1, alignment_pct: 0, ga_date: '2026-10-15', planning_freeze: '2026-09-15' },
+    '3.6 GA RHOAI RELEASE': { release: '3.6 GA RHOAI RELEASE', total: 12, aligned_on_time: 3, aligned_late: 0, tv_only: 5, fv_only: 2, misaligned: 2, alignment_pct: 25, ga_date: '2026-11-19', planning_freeze: '2026-10-19' },
+    '3.5 GA RHOAI RELEASE': { release: '3.5 GA RHOAI RELEASE', total: 155, aligned_on_time: 50, aligned_late: 0, tv_only: 60, fv_only: 25, misaligned: 20, alignment_pct: 32.3, ga_date: '2026-07-15', planning_freeze: '2026-06-15' },
   }
   var summary = DEFAULT_SELECTED_VERSIONS.map(function (v) {
     return detailed[v] || emptyRow(v)
   })
   // Extra non-default release in cache — must not appear in the default picker
-  summary.push({ release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null })
+  summary.push({ release: 'RHELAI-3.2', total: 1, aligned_on_time: 1, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0, alignment_pct: 100, ga_date: null, planning_freeze: null })
 
   var releases = {}
   DEFAULT_SELECTED_VERSIONS.forEach(function (v) {
-    releases[v] = { aligned: [], tv_only: [], fv_only: [], mismatched: [] }
+    releases[v] = { aligned_on_time: [], aligned_late: [], tv_only: [], fv_only: [], misaligned: [] }
   })
 
   return {
@@ -205,8 +205,8 @@ describe('TvFvDeltaView executive summary sorting', function () {
     var wrapper = await mountView()
     var table = findSummaryTable(wrapper)
     var headers = table.findAll('thead th')
-    // Should have: Release, Total, Aligned, TV-Only, FV-Only, Mismatched, Alignment, Target, GA Date, Days to GA, Planning Freeze
-    expect(headers.length).toBe(11)
+    // Should have: Release, Total, On Time, Late, TV-Only, FV-Only, Misaligned, Alignment, Target, GA Date, Days to GA, Planning Freeze, Days to Freeze
+    expect(headers.length).toBe(13)
   })
 
   it('default view includes 3.6 and 3.5 default versions from data', async function () {
@@ -258,12 +258,12 @@ describe('TvFvDeltaView target alignment column', function () {
   it('colors target red when actual alignment is below target', async function () {
     var wrapper = await mountView()
     var table = findSummaryTable(wrapper)
-    // 3.5 GA RHOAI has alignment_pct: 32.3% and ga_date: 2026-07-15 (~28 days from June 17)
-    // Target for ≤30 days = 100%*, so actual (32.3%) < target (100%) → red
+    // 3.5 GA RHOAI has alignment_pct: 32.3% and planning_freeze: 2026-06-15 (frozen)
+    // Target for frozen (≤0 days) = 100%*, so actual (32.3%) < target (100%) → red
     var rows = table.findAll('tbody tr')
     var row35 = rows.find(function (r) { return r.text().includes('3.5 GA RHOAI RELEASE') })
     if (row35) {
-      var targetCell = row35.findAll('td')[7]
+      var targetCell = row35.findAll('td')[8]
       var targetSpan = targetCell.find('span.font-semibold')
       if (targetSpan.exists()) {
         var classes = targetSpan.classes()
@@ -288,13 +288,14 @@ describe('TvFvDeltaView component breakdown PM/ENG columns', function () {
       },
       releases: {
         '3.6 GA RHOAI RELEASE': {
-          aligned: [
+          aligned_on_time: [
             { key: 'RHAISTRAT-1', component: 'Serving' },
             { key: 'RHAISTRAT-2', component: 'Training' },
           ],
+          aligned_late: [],
           tv_only: [],
           fv_only: [],
-          mismatched: [],
+          misaligned: [],
         },
       },
     })
@@ -307,7 +308,7 @@ describe('TvFvDeltaView component breakdown PM/ENG columns', function () {
     var table = details.find('table')
     var headers = table.findAll('thead th').map(function (th) { return th.text().trim() })
     expect(headers).toEqual([
-      'Component', 'PM', 'ENG', 'Total', 'Aligned', 'TV-Only', 'FV-Only', 'Mismatched', 'Alignment',
+      'Component', 'PM', 'ENG', 'Total', 'On Time', 'Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment',
     ])
 
     var servingRow = table.findAll('tbody tr').find(function (r) {

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -205,8 +205,12 @@ describe('TvFvDeltaView executive summary sorting', function () {
     var wrapper = await mountView()
     var table = findSummaryTable(wrapper)
     var headers = table.findAll('thead th')
-    // Should have: Release, Total, On Time, Late, TV-Only, FV-Only, Misaligned, Alignment, Target, GA Date, Days to GA, Planning Freeze, Days to Freeze
+    // Should have: Release, Total, Aligned On Time, Aligned Late, TV-Only, FV-Only, Misaligned, Alignment %, Align Target, GA Date, Days to GA, Planning Freeze, Days to Freeze
     expect(headers.length).toBe(13)
+    var headerText = headers.map(function (th) { return th.text().replace(/ⓘ/g, '').trim() })
+    expect(headerText).toContain('Aligned On Time')
+    expect(headerText).toContain('Aligned Late')
+    expect(headerText).toContain('Align Target')
   })
 
   it('default view includes 3.6 and 3.5 default versions from data', async function () {
@@ -308,9 +312,9 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     expect(wrapper.text()).toContain('Showing features for')
     expect(wrapper.text()).toContain('3.6 GA Release')
     expect(wrapper.text()).toMatch(/all products \(2\)/)
-    expect(wrapper.text()).toContain('Aligned (on time)')
+    expect(wrapper.text()).toContain('Aligned On Time')
     expect(wrapper.text()).toContain('(2)')
-    expect(wrapper.text()).toContain('TV-Only — PM targeted, no ENG commitment (1)')
+    expect(wrapper.text()).toContain('TV-Only — Target Version set, no Fix Version (1)')
   })
 
   it('selects a single product chip after milestone scope', async function () {
@@ -349,7 +353,7 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     expect(wrapper.text()).toContain('Showing features for')
     expect(wrapper.text()).toContain('3.6 GA RHOAI RELEASE')
     expect(wrapper.text()).not.toMatch(/all products \(2\)/)
-    expect(wrapper.text()).toContain('Aligned (on time)')
+    expect(wrapper.text()).toContain('Aligned On Time')
     expect(wrapper.text()).toContain('(1)')
   })
 })
@@ -389,7 +393,7 @@ describe('TvFvDeltaView component breakdown PM/ENG columns', function () {
     var table = details.find('table')
     var headers = table.findAll('thead th').map(function (th) { return th.text().trim() })
     expect(headers).toEqual([
-      'Component', 'PM', 'ENG', 'Total', 'On Time', 'Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment',
+      'Component', 'PM', 'ENG', 'Total', 'Aligned On Time', 'Aligned Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment %',
     ])
 
     var servingRow = table.findAll('tbody tr').find(function (r) {

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -236,23 +236,23 @@ describe('familyLabel', function () {
 
 function makeSummaryRows() {
   return [
-    { release: 'rhoai-3.6.EA1', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
-    { release: 'rhoai-3.6.EA2', total: 4, aligned: 0, tv_only: 2, fv_only: 1, mismatched: 1, alignment_pct: 0, ga_date: '2026-10-15' },
-    { release: 'rhoai-3.6', total: 12, aligned: 3, tv_only: 5, fv_only: 2, mismatched: 2, alignment_pct: 25, ga_date: '2026-11-19' },
-    { release: 'rhoai-3.5', total: 155, aligned: 50, tv_only: 60, fv_only: 25, mismatched: 20, alignment_pct: 32.3, ga_date: '2026-08-20' },
-    { release: 'rhoai-3.5.EA1', total: 24, aligned: 14, tv_only: 5, fv_only: 3, mismatched: 2, alignment_pct: 58.3, ga_date: null },
-    { release: 'RHELAI-3.2', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100, ga_date: null },
-    { release: 'RHAII-3.2.3', total: 3, aligned: 2, tv_only: 1, fv_only: 0, mismatched: 0, alignment_pct: 66.7, ga_date: null },
+    { release: 'rhoai-3.6.EA1', total: 7, aligned_on_time: 2, aligned_late: 0, tv_only: 3, fv_only: 1, misaligned: 1, alignment_pct: 28.6, ga_date: '2026-09-17' },
+    { release: 'rhoai-3.6.EA2', total: 4, aligned_on_time: 0, aligned_late: 0, tv_only: 2, fv_only: 1, misaligned: 1, alignment_pct: 0, ga_date: '2026-10-15' },
+    { release: 'rhoai-3.6', total: 12, aligned_on_time: 3, aligned_late: 0, tv_only: 5, fv_only: 2, misaligned: 2, alignment_pct: 25, ga_date: '2026-11-19' },
+    { release: 'rhoai-3.5', total: 155, aligned_on_time: 50, aligned_late: 0, tv_only: 60, fv_only: 25, misaligned: 20, alignment_pct: 32.3, ga_date: '2026-08-20' },
+    { release: 'rhoai-3.5.EA1', total: 24, aligned_on_time: 14, aligned_late: 0, tv_only: 5, fv_only: 3, misaligned: 2, alignment_pct: 58.3, ga_date: null },
+    { release: 'RHELAI-3.2', total: 1, aligned_on_time: 1, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0, alignment_pct: 100, ga_date: null },
+    { release: 'RHAII-3.2.3', total: 3, aligned_on_time: 2, aligned_late: 0, tv_only: 1, fv_only: 0, misaligned: 0, alignment_pct: 66.7, ga_date: null },
   ]
 }
 
 function makeProductFamilyRows() {
   return [
-    { release: '3.6 GA RHOAI RELEASE', total: 10, aligned: 4, tv_only: 3, fv_only: 1, mismatched: 2, alignment_pct: 40 },
-    { release: '3.6 GA RHAII RELEASE', total: 5, aligned: 2, tv_only: 2, fv_only: 0, mismatched: 1, alignment_pct: 40 },
-    { release: '3.6 GA RHELAI RELEASE', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100 },
-    { release: '3.6 EA1 RHOAI RELEASE', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6 },
-    { release: '3.5 GA RHOAI RELEASE', total: 20, aligned: 10, tv_only: 5, fv_only: 2, mismatched: 3, alignment_pct: 50 },
+    { release: '3.6 GA RHOAI RELEASE', total: 10, aligned_on_time: 4, aligned_late: 0, tv_only: 3, fv_only: 1, misaligned: 2, alignment_pct: 40 },
+    { release: '3.6 GA RHAII RELEASE', total: 5, aligned_on_time: 2, aligned_late: 0, tv_only: 2, fv_only: 0, misaligned: 1, alignment_pct: 40 },
+    { release: '3.6 GA RHELAI RELEASE', total: 1, aligned_on_time: 1, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0, alignment_pct: 100 },
+    { release: '3.6 EA1 RHOAI RELEASE', total: 7, aligned_on_time: 2, aligned_late: 0, tv_only: 3, fv_only: 1, misaligned: 1, alignment_pct: 28.6 },
+    { release: '3.5 GA RHOAI RELEASE', total: 20, aligned_on_time: 10, aligned_late: 0, tv_only: 5, fv_only: 2, misaligned: 3, alignment_pct: 50 },
   ]
 }
 
@@ -317,7 +317,7 @@ describe('useReleaseFamily composable', function () {
         '3.6 GA RHELAI RELEASE',
       ])
       expect(ga.totals.total).toBe(16) // 10+5+1
-      expect(ga.totals.aligned).toBe(7) // 4+2+1
+      expect(ga.totals.aligned_on_time).toBe(7) // 4+2+1
     })
 
     it('rolls up cycle totals across milestones', function () {

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -5,6 +5,11 @@ const {
   parseVersions,
   extractVersionNames,
   isZStream,
+  parseReleaseName,
+  compareReleases,
+  compareReleasesTemporally,
+  extractProduct,
+  isReleaseFrozen,
   normalizeIssue,
   classifyFeatures,
   buildExport,
@@ -132,6 +137,214 @@ describe('isZStream', () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseReleaseName
+// ---------------------------------------------------------------------------
+
+describe('parseReleaseName', () => {
+  it('parses standard GA release', () => {
+    const result = parseReleaseName('rhoai-3.5');
+    expect(result).toEqual({
+      product: 'rhoai',
+      major: 3,
+      minor: 5,
+      milestone: 'GA',
+      milestoneOrder: 99,
+      raw: 'rhoai-3.5',
+    });
+  });
+
+  it('parses EA1 milestone', () => {
+    const result = parseReleaseName('rhoai-3.6.EA1');
+    expect(result).toEqual({
+      product: 'rhoai',
+      major: 3,
+      minor: 6,
+      milestone: 'EA1',
+      milestoneOrder: 1,
+      raw: 'rhoai-3.6.EA1',
+    });
+  });
+
+  it('parses EA2 milestone', () => {
+    const result = parseReleaseName('rhelai-3.2.EA2');
+    expect(result).toEqual({
+      product: 'rhelai',
+      major: 3,
+      minor: 2,
+      milestone: 'EA2',
+      milestoneOrder: 2,
+      raw: 'rhelai-3.2.EA2',
+    });
+  });
+
+  it('is case insensitive', () => {
+    const result = parseReleaseName('RHOAI-3.5');
+    expect(result.product).toBe('rhoai');
+    expect(result.major).toBe(3);
+    expect(result.minor).toBe(5);
+  });
+
+  it('returns null for unparseable versions', () => {
+    expect(parseReleaseName('some-random-version')).toBeNull();
+    expect(parseReleaseName('v1.2.3')).toBeNull();
+  });
+
+  it('does not parse z-streams (major.minor.patch)', () => {
+    expect(parseReleaseName('rhoai-3.5.1')).toBeNull();
+  });
+
+  it('handles all products', () => {
+    expect(parseReleaseName('rhoai-3.5').product).toBe('rhoai');
+    expect(parseReleaseName('rhelai-3.2').product).toBe('rhelai');
+    expect(parseReleaseName('rhaii-3.6').product).toBe('rhaii');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareReleases
+// ---------------------------------------------------------------------------
+
+describe('compareReleases', () => {
+  it('orders same product by minor version (later version has lower number)', () => {
+    expect(compareReleases('rhoai-3.6', 'rhoai-3.5')).toBeLessThan(0); // 3.6 before 3.5
+    expect(compareReleases('rhoai-3.5', 'rhoai-3.6')).toBeGreaterThan(0);
+  });
+
+  it('orders same product/version by milestone (EA1 < EA2 < GA)', () => {
+    expect(compareReleases('rhoai-3.6.EA1', 'rhoai-3.6.EA2')).toBeLessThan(0);
+    expect(compareReleases('rhoai-3.6.EA2', 'rhoai-3.6')).toBeLessThan(0); // EA2 before GA
+    expect(compareReleases('rhoai-3.6.EA1', 'rhoai-3.6')).toBeLessThan(0); // EA1 before GA
+  });
+
+  it('orders different products alphabetically', () => {
+    expect(compareReleases('rhelai-3.5', 'rhoai-3.5')).toBeLessThan(0); // rhelai < rhoai
+    expect(compareReleases('rhaii-3.5', 'rhoai-3.5')).toBeLessThan(0); // rhaii < rhoai
+  });
+
+  it('sorts unparseable releases last, alphabetically', () => {
+    expect(compareReleases('unparseable-a', 'unparseable-b')).toBeLessThan(0);
+    expect(compareReleases('rhoai-3.5', 'unparseable')).toBeLessThan(0); // parseable before unparseable
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareReleasesTemporally
+// ---------------------------------------------------------------------------
+
+describe('compareReleasesTemporally', () => {
+  it('returns positive when first arg is temporally later (higher minor)', () => {
+    expect(compareReleasesTemporally('rhoai-3.6', 'rhoai-3.5')).toBeGreaterThan(0);
+  });
+
+  it('returns negative when first arg is temporally earlier (lower minor)', () => {
+    expect(compareReleasesTemporally('rhoai-3.5', 'rhoai-3.6')).toBeLessThan(0);
+  });
+
+  it('returns 0 for same release', () => {
+    expect(compareReleasesTemporally('rhoai-3.5', 'rhoai-3.5')).toBe(0);
+  });
+
+  it('EA1 before EA2 before GA (same minor)', () => {
+    expect(compareReleasesTemporally('rhoai-3.6.EA1', 'rhoai-3.6.EA2')).toBeLessThan(0);
+    expect(compareReleasesTemporally('rhoai-3.6.EA2', 'rhoai-3.6.EA1')).toBeGreaterThan(0);
+    expect(compareReleasesTemporally('rhoai-3.6.EA1', 'rhoai-3.6')).toBeLessThan(0); // EA1 before GA
+    expect(compareReleasesTemporally('rhoai-3.6.EA2', 'rhoai-3.6')).toBeLessThan(0); // EA2 before GA
+    expect(compareReleasesTemporally('rhoai-3.6', 'rhoai-3.6.EA1')).toBeGreaterThan(0); // GA after EA1
+  });
+
+  it('returns null for cross-product comparison', () => {
+    expect(compareReleasesTemporally('rhoai-3.5', 'rhelai-3.5')).toBeNull();
+  });
+
+  it('returns null when either release is unparseable', () => {
+    expect(compareReleasesTemporally('rhoai-3.5', 'unparseable')).toBeNull();
+    expect(compareReleasesTemporally('unparseable', 'rhoai-3.5')).toBeNull();
+    expect(compareReleasesTemporally('rhoai-3.5.1', 'rhoai-3.5')).toBeNull(); // z-stream
+  });
+
+  it('handles major version differences', () => {
+    expect(compareReleasesTemporally('rhoai-4.0', 'rhoai-3.5')).toBeGreaterThan(0);
+    expect(compareReleasesTemporally('rhoai-2.5', 'rhoai-3.5')).toBeLessThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractProduct
+// ---------------------------------------------------------------------------
+
+describe('extractProduct', () => {
+  it('extracts product from valid release names', () => {
+    expect(extractProduct('rhoai-3.5')).toBe('rhoai');
+    expect(extractProduct('rhelai-3.2')).toBe('rhelai');
+    expect(extractProduct('rhaii-3.6.EA1')).toBe('rhaii');
+  });
+
+  it('is case insensitive', () => {
+    expect(extractProduct('RHOAI-3.5')).toBe('rhoai');
+  });
+
+  it('returns null for unparseable names', () => {
+    expect(extractProduct('unparseable')).toBeNull();
+    expect(extractProduct('v1.2.3')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isReleaseFrozen
+// ---------------------------------------------------------------------------
+
+describe('isReleaseFrozen', () => {
+  const now = new Date('2026-07-24T00:00:00Z');
+
+  it('returns true when planning freeze is in the past', () => {
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01', dueDate: '2026-08-01' },
+    };
+    expect(isReleaseFrozen('rhoai-3.5', releaseDates)).toBe(true);
+  });
+
+  it('returns false when planning freeze is in the future', () => {
+    const releaseDates = {
+      'rhoai-3.6': { planningFreezeDate: '2026-09-01', dueDate: '2026-10-01' },
+    };
+    expect(isReleaseFrozen('rhoai-3.6', releaseDates)).toBe(false);
+  });
+
+  it('falls back to GA date when planning freeze is missing', () => {
+    const releaseDates = {
+      'rhoai-3.5': { dueDate: '2026-06-01' }, // GA in past
+    };
+    expect(isReleaseFrozen('rhoai-3.5', releaseDates)).toBe(true);
+  });
+
+  it('returns false when GA is in future (and no planning freeze)', () => {
+    const releaseDates = {
+      'rhoai-3.6': { dueDate: '2026-09-01' }, // GA in future
+    };
+    expect(isReleaseFrozen('rhoai-3.6', releaseDates)).toBe(false);
+  });
+
+  it('returns false when no dates are available (conservative)', () => {
+    const releaseDates = {
+      'rhoai-3.5': {},
+    };
+    expect(isReleaseFrozen('rhoai-3.5', releaseDates)).toBe(false);
+  });
+
+  it('returns false when release not in releaseDates map', () => {
+    const releaseDates = {};
+    expect(isReleaseFrozen('rhoai-3.5', releaseDates)).toBe(false);
+  });
+
+  it('uses normalized key lookup', () => {
+    const releaseDates = {
+      'rhoai 3 5': { planningFreezeDate: '2026-06-01' },
+    };
+    expect(isReleaseFrozen('RHOAI-3.5', releaseDates)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // normalizeIssue
 // ---------------------------------------------------------------------------
 
@@ -218,7 +431,7 @@ describe('normalizeIssue', () => {
 });
 
 // ---------------------------------------------------------------------------
-// classifyFeatures
+// classifyFeatures — ALL spec examples
 // ---------------------------------------------------------------------------
 
 describe('classifyFeatures', () => {
@@ -240,59 +453,491 @@ describe('classifyFeatures', () => {
     };
   }
 
-  it('classifies aligned features (TV == FV)', () => {
+  // Example A: TV=rhoai-3.5, FV=rhoai-3.5 → aligned_on_time
+  it('Example A: TV==FV → aligned_on_time', () => {
     const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
     expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('aligned');
+    expect(result[0].category).toBe('aligned_on_time');
   });
 
-  it('classifies tv_only (TV set, no FV at all)', () => {
+  // Example B: TV=rhoai-3.6, FV=rhoai-3.5 → aligned_on_time (ahead)
+  it('Example B: FV before TV → aligned_on_time', () => {
+    const feats = [makeFeat('rhoai-3.6', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.6'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Example B2: TV=[rhoai-3.6, rhoai-3.7], FV=rhoai-3.5 → aligned_on_time (ahead of all)
+  it('Example B2: FV before all TVs → aligned_on_time', () => {
+    const feats = [makeFeat('rhoai-3.6, rhoai-3.7', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.6'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Example C: TV=rhoai-3.5, FV=rhoai-3.6, 3.5 frozen → aligned_late
+  it('Example C: FV after frozen TV → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // Example D: TV=rhoai-3.5, FV=rhoai-3.6, 3.5 NOT frozen → misaligned
+  it('Example D: FV after unfrozen TV → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-09-01' }, // future
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Example E: TV=[rhoai-3.5, rhoai-3.6], FV=rhoai-3.6 → aligned_on_time (FV matches TV)
+  it('Example E: FV matches one of multiple TVs → aligned_on_time', () => {
+    const feats = [makeFeat('rhoai-3.5, rhoai-3.6', 'rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.6'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Example F: TV=[rhoai-3.5, rhoai-3.6], FV=rhoai-3.7, 3.5 frozen, 3.6 NOT frozen → misaligned
+  it('Example F: FV after mixed freeze state TVs, any unfrozen → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5, rhoai-3.6', 'rhoai-3.7')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01' },
+      'rhoai-3.6': { planningFreezeDate: '2026-09-01' }, // future
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.7'], releaseDates);
+    // FV=rhoai-3.7 doesn't match any TV in the release list, so no classification
+    // Let me fix the test - we're classifying for rhoai-3.7, but TVs are 3.5/3.6
+    // This should classify for rhoai-3.5 and rhoai-3.6, not 3.7
+    const result2 = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result2).toHaveLength(1);
+    expect(result2[0].category).toBe('misaligned'); // 3.5 frozen but FV after 3.6 which isn't
+  });
+
+  // Example G: TV=[rhoai-3.5, rhoai-3.6], FV=rhoai-3.7, both frozen → aligned_late
+  it('Example G: FV after all frozen TVs → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.5, rhoai-3.6', 'rhoai-3.7')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01' },
+      'rhoai-3.6': { planningFreezeDate: '2026-06-15' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // Example H: TV=rhoai-3.5, FV=rhelai-3.2 → misaligned (cross-product)
+  it('Example H: Cross-product TV/FV → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhelai-3.2')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Example I: TV=rhoai-3.5, FV=rhoai-3.5.1 → test z-stream behavior
+  it('Example I: Z-stream FV (unparseable) → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5.1')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    // rhoai-3.5.1 won't parse, so it won't match normalized version
+    // This means FV is set but doesn't match → compare temporally
+    // But since 3.5.1 doesn't parse, it won't be in the comparison
+    // The feat will have fv_set with normalized value from normVer
+    // Let me check what normVer does with z-stream
+    // Actually, the issue is that the FV won't match the release, so it will be treated as misaligned
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Example J: TV=rhoai-3.5, FV=rhoai-3.6, no dates → misaligned (conservative)
+  it('Example J: FV after TV, no dates → misaligned (conservative)', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Example K: TV=rhoai-3.5, FV=rhoai-3.6, no freeze but GA past → aligned_late
+  it('Example K: FV after TV, no freeze but GA in past → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { dueDate: '2026-06-01' }, // GA in past
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // Example L: TV=[rhoai-3.5, rhelai-3.2], FV=rhoai-3.6
+  it('Example L: Cross-product multi-TV, compare FV only against same product', () => {
+    const feats = [makeFeat('rhoai-3.5, rhelai-3.2', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late'); // rhoai-3.5 frozen
+  });
+
+  // Example M: TV=rhelai-3.2, FV=rhoai-3.6 → misaligned (all TVs different product)
+  it('Example M: All TVs different product from FV → misaligned', () => {
+    const feats = [makeFeat('rhelai-3.2', 'rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.6'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // TV-only
+  it('TV-only: TV set, no FV → tv_only', () => {
     const feats = [makeFeat('rhoai-3.5', '')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
     expect(result).toHaveLength(1);
     expect(result[0].category).toBe('tv_only');
   });
 
-  it('classifies fv_only (FV set, no TV at all)', () => {
+  // FV-only
+  it('FV-only: no TV, FV set → fv_only', () => {
     const feats = [makeFeat('', 'rhoai-3.5')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
     expect(result).toHaveLength(1);
     expect(result[0].category).toBe('fv_only');
   });
 
-  it('classifies mismatched (TV set, FV set to different release)', () => {
-    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5.EA1')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('mismatched');
-  });
-
-  it('classifies mismatched (FV set, TV set to different release)', () => {
-    const feats = [makeFeat('rhoai-3.5.EA1', 'rhoai-3.5')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('mismatched');
-  });
-
-  it('skips features with no match to any release', () => {
+  // Neither TV nor FV match release
+  it('Neither TV nor FV match release → skipped (not in output)', () => {
     const feats = [makeFeat('rhoai-3.4', 'rhoai-3.4')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
     expect(result).toHaveLength(0);
   });
 
   it('creates one classification per release match', () => {
     const feats = [makeFeat('rhoai-3.5, rhoai-3.5.EA1', 'rhoai-3.5, rhoai-3.5.EA1')];
-    const result = classifyFeatures(feats, ['rhoai-3.5', 'rhoai-3.5.EA1']);
+    const result = classifyFeatures(feats, ['rhoai-3.5', 'rhoai-3.5.EA1'], {});
     expect(result).toHaveLength(2);
-    expect(result.every(r => r.category === 'aligned')).toBe(true);
+    expect(result.every(r => r.category === 'aligned_on_time')).toBe(true);
   });
 
   it('handles case-insensitive matching via normVer', () => {
     const feats = [makeFeat('RHOAI-3.5', 'rhoai-3.5')];
-    const result = classifyFeatures(feats, ['rhoai-3.5']);
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
     expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('aligned');
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // ── Additional edge cases ──
+
+  // Z-stream FV against GA TV — z-stream is unparseable → misaligned
+  it('z-stream FV rhoai-3.5.1 against GA TV rhoai-3.5 → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5.1')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Z-stream TV against GA FV — z-stream TV is unparseable → misaligned
+  it('z-stream TV rhoai-3.5.1 against GA FV rhoai-3.5 → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5.1', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Unparseable FV (random string) → misaligned
+  it('completely unparseable FV → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'some-random-version')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Unparseable TV with valid FV match → misaligned
+  it('unparseable TV with valid FV → misaligned', () => {
+    const feats = [makeFeat('some-random-version', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // EA milestone: TV=EA1, FV=EA2 (same release family) → FV after TV
+  it('EA1 TV, EA2 FV same family, EA1 not frozen → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.6.EA1', 'rhoai-3.6.EA2')];
+    const result = classifyFeatures(feats, ['rhoai-3.6.EA1'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  it('EA1 TV, EA2 FV same family, EA1 frozen → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.6.EA1', 'rhoai-3.6.EA2')];
+    const releaseDates = {
+      'rhoai-3.6.EA1': { planningFreezeDate: '2026-06-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.6.EA1'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // EA to GA: TV=EA1, FV=GA (same product/version) → FV after EA1
+  it('EA1 TV, GA FV (same minor version), EA1 not frozen → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.6.EA1', 'rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.6.EA1'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  it('EA1 TV, GA FV (same minor version), EA1 frozen → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.6.EA1', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.6.EA1': { planningFreezeDate: '2026-06-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.6.EA1'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // GA to EA: TV=GA, FV=EA1 (same product/version) → FV before TV (ahead)
+  it('GA TV, EA1 FV (same minor version) → aligned_on_time (ahead)', () => {
+    const feats = [makeFeat('rhoai-3.6', 'rhoai-3.6.EA1')];
+    const result = classifyFeatures(feats, ['rhoai-3.6'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Multiple FVs: one matches TV, should be aligned
+  it('multiple FVs where one matches TV → aligned_on_time', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.5, rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // All three products
+  it('rhaii product parses and classifies correctly', () => {
+    const feats = [makeFeat('rhaii-3.5', 'rhaii-3.5')];
+    const result = classifyFeatures(feats, ['rhaii-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  it('rhelai product parses and classifies correctly', () => {
+    const feats = [makeFeat('rhelai-3.2', 'rhelai-3.2')];
+    const result = classifyFeatures(feats, ['rhelai-3.2'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Cross-product: TV=rhoai, FV=rhaii → misaligned
+  it('cross-product rhoai TV / rhaii FV → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhaii-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Cross-product multi-TV: only same-product TVs compared (spec rule 4)
+  it('cross-product multi-TV: ignores cross-product TVs, checks same-product TV freeze', () => {
+    // TV=[rhoai-3.5, rhelai-3.2], FV=rhoai-3.6
+    // Only compare against rhoai-3.5 (same product as FV)
+    // rhoai-3.5 NOT frozen → misaligned
+    const feats = [makeFeat('rhoai-3.5, rhelai-3.2', 'rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Planning freeze boundary: freeze date = today (edge)
+  it('planning freeze exactly today → frozen (boundary)', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: today },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // GA date fallback with future GA → not frozen (conservative)
+  it('no planning freeze, GA in future → not frozen → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { dueDate: '2027-06-01' }, // far future
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Both planning freeze and GA: planning freeze takes precedence
+  it('planning freeze in past overrides GA in future', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-3.6')];
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01', dueDate: '2027-12-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // Major version difference: TV=rhoai-2.5, FV=rhoai-3.5
+  it('FV with higher major version than TV → FV after TV', () => {
+    const feats = [makeFeat('rhoai-2.5', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-2.5'], {});
+    expect(result).toHaveLength(1);
+    // No freeze dates → misaligned (conservative)
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  it('FV with lower major version than TV → FV before TV (ahead)', () => {
+    const feats = [makeFeat('rhoai-3.5', 'rhoai-2.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Feature with multiple TVs all frozen and FV after all → aligned_late
+  it('three TVs all frozen, FV after all → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.4, rhoai-3.5, rhoai-3.6', 'rhoai-3.7')];
+    const releaseDates = {
+      'rhoai-3.4': { planningFreezeDate: '2026-01-01' },
+      'rhoai-3.5': { planningFreezeDate: '2026-03-01' },
+      'rhoai-3.6': { planningFreezeDate: '2026-06-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  // Feature with multiple TVs, one not frozen → misaligned
+  it('three TVs, last one not frozen → misaligned', () => {
+    const feats = [makeFeat('rhoai-3.4, rhoai-3.5, rhoai-3.6', 'rhoai-3.7')];
+    const releaseDates = {
+      'rhoai-3.4': { planningFreezeDate: '2026-01-01' },
+      'rhoai-3.5': { planningFreezeDate: '2026-03-01' },
+      'rhoai-3.6': { planningFreezeDate: '2026-12-01' }, // future
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  // Feature with TV matching FV (exact match via normVer despite case diff)
+  it('case-insensitive TV/FV match → aligned_on_time', () => {
+    const feats = [makeFeat('RHOAI_3_5', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Feature with RHAISTRAT-style version names
+  it('RHAISTRAT version naming (3.5 GA RHOAI RELEASE) → aligns via normVer', () => {
+    const feats = [makeFeat('3.5 GA RHOAI RELEASE', '3.5 GA RHOAI RELEASE')];
+    const result = classifyFeatures(feats, ['3.5 GA RHOAI RELEASE'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  // Feature with TV and FV both empty → skipped
+  it('both TV and FV empty → not classified', () => {
+    const feats = [makeFeat('', '')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(0);
+  });
+
+  // Deduplication: same feature key, different releases
+  it('same feature appears under two releases with correct categories', () => {
+    const feats = [makeFeat('rhoai-3.5, rhoai-3.6', 'rhoai-3.6')];
+    const result = classifyFeatures(feats, ['rhoai-3.5', 'rhoai-3.6'], {});
+    expect(result).toHaveLength(2);
+    const on35 = result.find(r => r.release === 'rhoai-3.5');
+    const on36 = result.find(r => r.release === 'rhoai-3.6');
+    // On 3.5: TV matches, FV doesn't → FV=3.6 matches TV=3.6 → aligned_on_time (FV matches one of the TVs)
+    // Actually: TV has 3.5 and 3.6, FV has 3.6. For release 3.5: tvMatch=true, fvMatch=false.
+    // Compare FV=3.6 against all TVs=[3.5, 3.6]. FV matches TV=3.6 → but we're in the temporal
+    // branch because fvMatch is false for this release. FV=3.6 is after TV=3.5, 3.5 not frozen → misaligned
+    // BUT FV=3.6 matches TV=3.6 (cmp=0) → no action (cmp not < 0 and not > 0)
+    // The worst from the loop is the unfrozen check on 3.5
+    expect(on35.category).toBe('misaligned');
+    // On 3.6: tvMatch=true, fvMatch=true → aligned_on_time
+    expect(on36.category).toBe('aligned_on_time');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyFeatures — Case 3 (FV matches, TV doesn't) edge cases
+// ---------------------------------------------------------------------------
+
+describe('classifyFeatures — Case 3 edge cases', () => {
+  function makeFeat(tv, fv) {
+    return {
+      key: 'X-1',
+      url: '',
+      summary: 'test',
+      status: '',
+      target_version: tv,
+      fix_versions: fv,
+      tv_set: parseVersions(tv),
+      fv_set: parseVersions(fv),
+      color_status: '',
+      product_manager: '',
+      assignee: '',
+      components: [],
+      component: '',
+    };
+  }
+
+  it('FV matches release, TV is earlier → FV slipped (no freeze = misaligned)', () => {
+    // TV=3.4, FV=3.5 → feature targeted for 3.4 but committed to 3.5 (slipped)
+    const feats = [makeFeat('rhoai-3.4', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned'); // no freeze dates → conservative
+  });
+
+  it('FV matches release, TV is earlier, TV frozen → aligned_late', () => {
+    const feats = [makeFeat('rhoai-3.4', 'rhoai-3.5')];
+    const releaseDates = {
+      'rhoai-3.4': { planningFreezeDate: '2026-01-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_late');
+  });
+
+  it('FV matches release, TV is later → FV ahead of schedule → aligned_on_time', () => {
+    // TV=3.6, FV=3.5 → feature targeted for 3.6 but committed to 3.5 (ahead!)
+    const feats = [makeFeat('rhoai-3.6', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  it('FV matches release, TV is from different product → misaligned', () => {
+    const feats = [makeFeat('rhelai-3.2', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
+  });
+
+  it('FV matches release, multiple TVs, all same product ahead → aligned_on_time', () => {
+    const feats = [makeFeat('rhoai-3.6, rhoai-3.7', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('aligned_on_time');
+  });
+
+  it('FV matches release, unparseable TV → misaligned', () => {
+    const feats = [makeFeat('some-random-thing', 'rhoai-3.5')];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('misaligned');
   });
 });
 
@@ -301,28 +946,109 @@ describe('classifyFeatures', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildExport', () => {
-  it('produces executive_summary with correct structure', () => {
+  it('produces executive_summary with 5-category structure', () => {
     const classifications = [
-      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
-      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_late', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
 
     expect(result.metadata.releases).toEqual(['rhoai-3.5']);
-    expect(result.metadata.total_features).toBe(2);
+    expect(result.metadata.total_features).toBe(3);
     expect(result.executive_summary).toHaveLength(1);
 
     const summary = result.executive_summary[0];
     expect(summary.release).toBe('rhoai-3.5');
-    expect(summary.total).toBe(2);
-    expect(summary.aligned).toBe(1);
+    expect(summary.total).toBe(3);
+    expect(summary.aligned_on_time).toBe(1);
+    expect(summary.aligned_late).toBe(1);
     expect(summary.tv_only).toBe(1);
-    expect(summary.alignment_pct).toBe(50);
+    expect(summary.fv_only).toBe(0);
+    expect(summary.misaligned).toBe(0);
+  });
+
+  it('computes alignment_pct as (on_time + late) / total', () => {
+    const classifications = [
+      { release: 'v1', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'v1', category: 'aligned_late', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'v1', category: 'tv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'v1', category: 'misaligned', key: 'X-4', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['v1'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    expect(result.executive_summary[0].alignment_pct).toBe(50); // (1+1)/4 = 50%
+  });
+
+  it('sets JQL to null for aligned_late and misaligned', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned_late', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'misaligned', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const summary = result.executive_summary[0];
+    expect(summary.aligned_late_jql).toBeNull();
+    expect(summary.misaligned_jql).toBeNull();
+  });
+
+  it('generates JQL for aligned_on_time, tv_only, fv_only', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'fv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const summary = result.executive_summary[0];
+    expect(summary.aligned_on_time_jql).toBeTruthy();
+    expect(summary.tv_only_jql).toBeTruthy();
+    expect(summary.fv_only_jql).toBeTruthy();
+    expect(summary.total_jql).toBeTruthy();
+  });
+
+  it('includes resolution filter in base JQL', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].total_jql);
+    expect(jql).toContain('resolution = Unresolved OR resolution IN ("Done", "Done-Errata")');
+  });
+
+  it('component breakdown has 5 categories', () => {
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_late', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'fv_only', key: 'X-4', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'misaligned', key: 'X-5', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', ['Dashboard'], 'RHAISTRAT');
+    const comp = result.component_breakdown.find(c => c.component === 'Dashboard');
+    expect(comp.aligned_on_time).toBe(1);
+    expect(comp.aligned_late).toBe(1);
+    expect(comp.tv_only).toBe(1);
+    expect(comp.fv_only).toBe(1);
+    expect(comp.misaligned).toBe(1);
+    expect(comp.total).toBe(5);
+  });
+
+  it('CATEGORY_PRIORITY uses correct ordering for dedup', () => {
+    // When a feature appears in multiple releases, worst category wins
+    // misaligned > tv_only > fv_only > aligned_late > aligned_on_time
+    const classifications = [
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.6', category: 'misaligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, ['rhoai-3.5', 'rhoai-3.6'], '2026-01-01T00:00:00Z', ['Dashboard'], 'RHAISTRAT');
+    const comp = result.component_breakdown.find(c => c.component === 'Dashboard');
+    // Worst is misaligned (priority 4), so that should win
+    expect(comp.misaligned).toBe(1);
+    expect(comp.aligned_on_time).toBe(0);
+    expect(comp.total).toBe(1); // deduped
   });
 
   it('includes ga_date and planning_freeze from releaseDates', () => {
     const classifications = [
-      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const releaseDates = {
       'rhoai-3.5': { dueDate: '2026-08-20', planningFreezeDate: '2026-06-24' },
@@ -335,7 +1061,7 @@ describe('buildExport', () => {
 
   it('sets ga_date and planning_freeze to null when releaseDates is not provided', () => {
     const classifications = [
-      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
     const summary = result.executive_summary[0];
@@ -345,7 +1071,7 @@ describe('buildExport', () => {
 
   it('falls back to normVer lookup when release key does not match directly', () => {
     const classifications = [
-      { release: 'RHOAI-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'RHOAI-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const releaseDates = {
       'rhoai 3 5': { dueDate: '2026-08-20', planningFreezeDate: '2026-06-24' },
@@ -358,7 +1084,7 @@ describe('buildExport', () => {
 
   it('handles partial releaseDates (only ga_date, no planning_freeze)', () => {
     const classifications = [
-      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const releaseDates = {
       'rhoai-3.5': { dueDate: '2026-08-20' },
@@ -392,40 +1118,13 @@ describe('buildExport', () => {
 
   it('buckets features into per-release category lists', () => {
     const classifications = [
-      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
-      { release: 'rhoai-3.5', category: 'mismatched', key: 'X-2', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'aligned_on_time', key: 'X-1', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+      { release: 'rhoai-3.5', category: 'misaligned', key: 'X-2', url: '', summary: 's', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
     ];
     const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
-    expect(result.releases['rhoai-3.5'].aligned).toHaveLength(1);
-    expect(result.releases['rhoai-3.5'].mismatched).toHaveLength(1);
+    expect(result.releases['rhoai-3.5'].aligned_on_time).toHaveLength(1);
+    expect(result.releases['rhoai-3.5'].misaligned).toHaveLength(1);
     expect(result.releases['rhoai-3.5'].tv_only).toHaveLength(0);
-  });
-
-  it('builds component breakdown from classifications', () => {
-    const classifications = [
-      { release: 'rhoai-3.5', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
-      { release: 'rhoai-3.5', category: 'tv_only', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: ['Dashboard'], component: 'Dashboard', target_version: '', fix_versions: '' },
-    ];
-    const result = buildExport(classifications, ['rhoai-3.5'], '2026-01-01T00:00:00Z', ['Dashboard', 'Notebooks'], 'RHAISTRAT');
-    expect(result.component_breakdown).toHaveLength(2);
-
-    const dash = result.component_breakdown.find(c => c.component === 'Dashboard');
-    expect(dash.total).toBe(2);
-    expect(dash.aligned).toBe(1);
-    expect(dash.tv_only).toBe(1);
-
-    const nb = result.component_breakdown.find(c => c.component === 'Notebooks');
-    expect(nb.total).toBe(0);
-  });
-
-  it('computes alignment_pct correctly', () => {
-    const classifications = [
-      { release: 'v1', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
-      { release: 'v1', category: 'aligned', key: 'X-2', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
-      { release: 'v1', category: 'tv_only', key: 'X-3', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
-    ];
-    const result = buildExport(classifications, ['v1'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
-    expect(result.executive_summary[0].alignment_pct).toBe(66.7);
   });
 
   it('handles empty classifications gracefully', () => {
@@ -487,73 +1186,82 @@ describe('jqlSafePattern', () => {
 });
 
 // ---------------------------------------------------------------------------
-// RHAII version handling (space-separated milestone names)
+// Integration-style tests
 // ---------------------------------------------------------------------------
 
-describe('RHAII version handling', () => {
-  it('normVer lowercases RHAII versions with spaces', () => {
-    expect(normVer('RHAII-3.5 EA1')).toBe('rhaii 3 5 ea1');
-    expect(normVer('RHAII-3.5 EA2')).toBe('rhaii 3 5 ea2');
-  });
-
-  it('parseVersions handles RHAII versions', () => {
-    const result = parseVersions('RHAII-3.5 EA1');
-    expect(result.size).toBe(1);
-    expect(result.has('rhaii 3 5 ea1')).toBe(true);
-  });
-
-  it('classifyFeatures matches RHAII releases correctly', () => {
-    const feat = {
-      key: 'RHAISTRAT-200',
+describe('Integration tests', () => {
+  function makeFeat(key, tv, fv) {
+    return {
+      key: key,
       url: '',
-      summary: 'RHAII feature',
-      status: 'In Progress',
-      target_version: 'RHAII-3.5 EA1',
-      fix_versions: 'RHAII-3.5 EA1',
-      tv_set: parseVersions('RHAII-3.5 EA1'),
-      fv_set: parseVersions('RHAII-3.5 EA1'),
+      summary: 'test',
+      status: '',
+      target_version: tv,
+      fix_versions: fv,
+      tv_set: parseVersions(tv),
+      fv_set: parseVersions(fv),
       color_status: '',
       product_manager: '',
       assignee: '',
       components: [],
       component: '',
     };
-    const result = classifyFeatures([feat], ['RHAII-3.5 EA1']);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('aligned');
-  });
+  }
 
-  it('classifyFeatures detects tv_only for RHAII releases', () => {
-    const feat = {
-      key: 'RHAISTRAT-201',
-      url: '',
-      summary: 'RHAII feature no FV',
-      status: 'New',
-      target_version: 'RHAII-3.5 EA1',
-      fix_versions: '',
-      tv_set: parseVersions('RHAII-3.5 EA1'),
-      fv_set: parseVersions(''),
-      color_status: '',
-      product_manager: '',
-      assignee: '',
-      components: [],
-      component: '',
-    };
-    const result = classifyFeatures([feat], ['RHAII-3.5 EA1']);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('tv_only');
-  });
-
-  it('buildExport generates valid JQL links for RHAII releases with spaces', () => {
-    const classifications = [
-      { release: 'RHAII-3.5 EA1', category: 'aligned', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+  it('multiple features across multiple releases', () => {
+    const feats = [
+      makeFeat('X-1', 'rhoai-3.5', 'rhoai-3.5'),
+      makeFeat('X-2', 'rhoai-3.5', 'rhoai-3.6'),
+      makeFeat('X-3', 'rhoai-3.6', 'rhoai-3.6'),
     ];
-    const result = buildExport(classifications, ['RHAII-3.5 EA1'], '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
-    const summary = result.executive_summary[0];
-    expect(summary.release).toBe('RHAII-3.5 EA1');
-    expect(summary.total).toBe(1);
-    // JQL links should contain the quoted release name
-    const totalJql = decodeURIComponent(summary.total_jql);
-    expect(totalJql).toContain('"RHAII-3.5 EA1"');
+    const releaseDates = {
+      'rhoai-3.5': { planningFreezeDate: '2026-06-01' },
+    };
+    const result = classifyFeatures(feats, ['rhoai-3.5', 'rhoai-3.6'], releaseDates);
+    // X-1: aligned_on_time on 3.5 (TV=FV=3.5)
+    // X-2: aligned_late on 3.5 (TV=3.5 frozen, FV=3.6)
+    // X-2: aligned_late on 3.6 (FV=3.6, TV=3.5 frozen → late)
+    // X-3: aligned_on_time on 3.6 (TV=FV=3.6)
+    expect(result).toHaveLength(4);
+    const x1 = result.find(r => r.key === 'X-1');
+    const x2_on35 = result.find(r => r.key === 'X-2' && r.release === 'rhoai-3.5');
+    const x2_on36 = result.find(r => r.key === 'X-2' && r.release === 'rhoai-3.6');
+    const x3 = result.find(r => r.key === 'X-3');
+    expect(x1.category).toBe('aligned_on_time');
+    expect(x2_on35.category).toBe('aligned_late');
+    expect(x2_on36.category).toBe('aligned_late');
+    expect(x3.category).toBe('aligned_on_time');
+  });
+
+  it('features appearing in multiple release rows', () => {
+    const feats = [
+      makeFeat('X-1', 'rhoai-3.5, rhoai-3.6', 'rhoai-3.5, rhoai-3.6'),
+    ];
+    const result = classifyFeatures(feats, ['rhoai-3.5', 'rhoai-3.6'], {});
+    expect(result).toHaveLength(2); // one for 3.5, one for 3.6
+    expect(result.every(r => r.category === 'aligned_on_time')).toBe(true);
+  });
+
+  it('empty feature set', () => {
+    const result = classifyFeatures([], ['rhoai-3.5'], {});
+    expect(result).toHaveLength(0);
+  });
+
+  it('all features aligned', () => {
+    const feats = [
+      makeFeat('X-1', 'rhoai-3.5', 'rhoai-3.5'),
+      makeFeat('X-2', 'rhoai-3.5', 'rhoai-3.5'),
+    ];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {});
+    expect(result.every(r => r.category === 'aligned_on_time')).toBe(true);
+  });
+
+  it('all features misaligned', () => {
+    const feats = [
+      makeFeat('X-1', 'rhoai-3.5', 'rhoai-3.6'),
+      makeFeat('X-2', 'rhoai-3.5', 'rhoai-3.7'),
+    ];
+    const result = classifyFeatures(feats, ['rhoai-3.5'], {}); // no freeze dates
+    expect(result.every(r => r.category === 'misaligned')).toBe(true);
   });
 });

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -294,8 +294,6 @@ describe('extractProduct', () => {
 // ---------------------------------------------------------------------------
 
 describe('isReleaseFrozen', () => {
-  const now = new Date('2026-07-24T00:00:00Z');
-
   it('returns true when planning freeze is in the past', () => {
     const releaseDates = {
       'rhoai-3.5': { planningFreezeDate: '2026-06-01', dueDate: '2026-08-01' },
@@ -514,10 +512,7 @@ describe('classifyFeatures', () => {
       'rhoai-3.5': { planningFreezeDate: '2026-06-01' },
       'rhoai-3.6': { planningFreezeDate: '2026-09-01' }, // future
     };
-    const result = classifyFeatures(feats, ['rhoai-3.7'], releaseDates);
-    // FV=rhoai-3.7 doesn't match any TV in the release list, so no classification
-    // Let me fix the test - we're classifying for rhoai-3.7, but TVs are 3.5/3.6
-    // This should classify for rhoai-3.5 and rhoai-3.6, not 3.7
+    // Classify against rhoai-3.5 (a TV that the feature targets)
     const result2 = classifyFeatures(feats, ['rhoai-3.5'], releaseDates);
     expect(result2).toHaveLength(1);
     expect(result2[0].category).toBe('misaligned'); // 3.5 frozen but FV after 3.6 which isn't

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -9,6 +9,7 @@ const {
   compareReleases,
   compareReleasesTemporally,
   extractProduct,
+  buildReleaseDatesMap,
   isReleaseFrozen,
   normalizeIssue,
   classifyFeatures,
@@ -197,6 +198,44 @@ describe('parseReleaseName', () => {
     expect(parseReleaseName('rhoai-3.5').product).toBe('rhoai');
     expect(parseReleaseName('rhelai-3.2').product).toBe('rhelai');
     expect(parseReleaseName('rhaii-3.6').product).toBe('rhaii');
+  });
+
+  it('parses Jira Target/Fix Version names', () => {
+    expect(parseReleaseName('3.6 EA1 RHOAI RELEASE')).toEqual({
+      product: 'rhoai',
+      major: 3,
+      minor: 6,
+      milestone: 'EA1',
+      milestoneOrder: 1,
+      raw: '3.6 EA1 RHOAI RELEASE',
+    });
+    expect(parseReleaseName('3.6 GA RHOAI RELEASE')).toMatchObject({
+      product: 'rhoai',
+      milestone: 'GA',
+      milestoneOrder: 99,
+    });
+    expect(parseReleaseName('3.5 EA2 RHAII RELEASE').product).toBe('rhaii');
+    expect(parseReleaseName('3.6 GA RHELAI RELEASE').product).toBe('rhelai');
+  });
+});
+
+describe('buildReleaseDatesMap', () => {
+  it('indexes Product Pages dates under normVer so Jira release names resolve', () => {
+    const map = buildReleaseDatesMap([
+      {
+        productName: 'rhoai',
+        releaseNumber: 'rhoai-3.6.EA1',
+        dueDate: '2026-09-17',
+        planningFreezeDate: '2026-07-29',
+      },
+    ]);
+    const key = normVer('3.6 EA1 RHOAI RELEASE');
+    expect(key).toBe('rhoai 3 6 ea1');
+    expect(map[key]).toEqual({
+      dueDate: '2026-09-17',
+      planningFreezeDate: '2026-07-29',
+    });
+    expect(map['rhoai-3.6.ea1']).toEqual(map[key]);
   });
 });
 

--- a/modules/releases/client/composables/useComponentBreakdown.js
+++ b/modules/releases/client/composables/useComponentBreakdown.js
@@ -6,10 +6,11 @@ export function useComponentBreakdown(data, releaseData) {
     if (!releaseData.value || !data.value) return []
 
     const allFeatures = [
-      ...releaseData.value.aligned.map(f => ({ ...f, category: 'aligned' })),
+      ...releaseData.value.aligned_on_time.map(f => ({ ...f, category: 'aligned_on_time' })),
+      ...releaseData.value.aligned_late.map(f => ({ ...f, category: 'aligned_late' })),
       ...releaseData.value.tv_only.map(f => ({ ...f, category: 'tv_only' })),
       ...releaseData.value.fv_only.map(f => ({ ...f, category: 'fv_only' })),
-      ...releaseData.value.mismatched.map(f => ({ ...f, category: 'mismatched' })),
+      ...releaseData.value.misaligned.map(f => ({ ...f, category: 'misaligned' })),
     ]
 
     const compMap = {}
@@ -20,8 +21,8 @@ export function useComponentBreakdown(data, releaseData) {
       for (const comp of comps) {
         if (!compMap[comp]) {
           compMap[comp] = {
-            component: comp, total: 0, aligned: 0,
-            tv_only: 0, fv_only: 0, mismatched: 0, keys: new Set(),
+            component: comp, total: 0, aligned_on_time: 0, aligned_late: 0,
+            tv_only: 0, fv_only: 0, misaligned: 0, keys: new Set(),
           }
         }
         if (!compMap[comp].keys.has(feat.key)) {
@@ -39,18 +40,18 @@ export function useComponentBreakdown(data, releaseData) {
       compList = allComponentNames.map(compName => {
         const c = compMap[compName]
         if (!c) {
-          return { component: compName, total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 0 }
+          return { component: compName, total: 0, aligned_on_time: 0, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0, alignment_pct: 0 }
         }
         return {
-          component: compName, total: c.total, aligned: c.aligned,
-          tv_only: c.tv_only, fv_only: c.fv_only, mismatched: c.mismatched,
-          alignment_pct: c.total ? Math.round(1000 * c.aligned / c.total) / 10 : 0,
+          component: compName, total: c.total, aligned_on_time: c.aligned_on_time, aligned_late: c.aligned_late,
+          tv_only: c.tv_only, fv_only: c.fv_only, misaligned: c.misaligned,
+          alignment_pct: c.total ? Math.round(1000 * (c.aligned_on_time + c.aligned_late) / c.total) / 10 : 0,
         }
       })
     } else {
       compList = Object.values(compMap).map(c => ({
-        component: c.component, total: c.total, aligned: c.aligned, tv_only: c.tv_only, fv_only: c.fv_only, mismatched: c.mismatched,
-        alignment_pct: c.total ? Math.round(1000 * c.aligned / c.total) / 10 : 0,
+        component: c.component, total: c.total, aligned_on_time: c.aligned_on_time, aligned_late: c.aligned_late, tv_only: c.tv_only, fv_only: c.fv_only, misaligned: c.misaligned,
+        alignment_pct: c.total ? Math.round(1000 * (c.aligned_on_time + c.aligned_late) / c.total) / 10 : 0,
       }))
     }
 

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -117,11 +117,15 @@ var ALIGNMENT_TARGETS = [
   { maxDays: 90, target: 90, label: '90%*' },
 ]
 
-function getAlignmentTarget(daysToGa) {
-  if (daysToGa === null || daysToGa === undefined) return null
-  if (daysToGa <= 0) return { target: 100, label: '100%*', maxDays: 0 }
+/**
+ * Get the target alignment percentage for a given number of days (to planning freeze or GA).
+ * Returns { target, label } or null if no target applies (>90 days out).
+ */
+function getAlignmentTarget(days) {
+  if (days === null || days === undefined) return null
+  if (days <= 0) return { target: 100, label: '100%*', maxDays: 0 }
   for (var i = 0; i < ALIGNMENT_TARGETS.length; i++) {
-    if (daysToGa <= ALIGNMENT_TARGETS[i].maxDays) return ALIGNMENT_TARGETS[i]
+    if (days <= ALIGNMENT_TARGETS[i].maxDays) return ALIGNMENT_TARGETS[i]
   }
   return null
 }
@@ -148,10 +152,11 @@ function familyLabel(familyKey) {
 
 function sumRows(rows) {
   var total = 0
-  var aligned = 0
+  var alignedOnTime = 0
+  var alignedLate = 0
   var tvOnly = 0
   var fvOnly = 0
-  var mismatched = 0
+  var misaligned = 0
   var pending = 0
   for (var i = 0; i < rows.length; i++) {
     var r = rows[i]
@@ -160,18 +165,20 @@ function sumRows(rows) {
       continue
     }
     total += r.total || 0
-    aligned += r.aligned || 0
+    alignedOnTime += r.aligned_on_time || 0
+    alignedLate += r.aligned_late || 0
     tvOnly += r.tv_only || 0
     fvOnly += r.fv_only || 0
-    mismatched += r.mismatched || 0
+    misaligned += r.misaligned || 0
   }
-  var alignmentPct = total > 0 ? Math.round((1000 * aligned) / total) / 10 : 0
+  var alignmentPct = total > 0 ? Math.round((1000 * (alignedOnTime + alignedLate)) / total) / 10 : 0
   return {
     total: total,
-    aligned: aligned,
+    aligned_on_time: alignedOnTime,
+    aligned_late: alignedLate,
     tv_only: tvOnly,
     fv_only: fvOnly,
-    mismatched: mismatched,
+    misaligned: misaligned,
     alignment_pct: alignmentPct,
     _allPending: pending > 0 && pending === rows.length,
   }
@@ -337,8 +344,8 @@ export function useReleaseFamily(filteredSummary, data) {
       if (col === 'release') {
         return compareReleases(a.release, b.release) * dir
       }
-      if (col === 'alignment_pct' || col === 'total' || col === 'aligned' ||
-          col === 'tv_only' || col === 'fv_only' || col === 'mismatched') {
+      if (col === 'alignment_pct' || col === 'total' || col === 'aligned_on_time' || col === 'aligned_late' ||
+          col === 'tv_only' || col === 'fv_only' || col === 'misaligned') {
         va = a[col] ?? 0
         vb = b[col] ?? 0
         return (va - vb) * dir

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -75,7 +75,7 @@ const {
   summaryRollup,
 } = useReleaseFamily(filteredSummary, data)
 
-const SUMMARY_COL_COUNT = 11
+const SUMMARY_COL_COUNT = 13
 
 /** Selected version chips grouped: cycle → milestone → products (numeric desc) */
 const chosenVersionsRollup = computed(() => buildNameRollup(allSelectedVersions.value))
@@ -90,14 +90,21 @@ function versionInfo(name) {
   return availableVersions.value.find(v => v.name === name) || { name, displayName: name, source: 'manual' }
 }
 
-/** Compute target alignment for a row based on days to GA */
+/** Compute target alignment for a row based on days to planning freeze */
 function targetForRow(row) {
-  var d = daysToGa(row.ga_date)
+  var d = daysToFreeze(row.planning_freeze)
   return getAlignmentTarget(d)
 }
 
 const { releaseComponentBreakdown } = useComponentBreakdown(data, releaseData)
 const { leadsFor } = useComponentLeads()
+
+/** Compute days until planning freeze from an ISO date string. Returns null if no date. */
+function daysToFreeze(freezeDate) {
+  if (!freezeDate) return null
+  const diff = new Date(freezeDate + 'T00:00:00Z') - new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z')
+  return Math.ceil(diff / 86400000)
+}
 
 /** Compute days until GA from an ISO date string. Returns null if no date. */
 function daysToGa(gaDate) {
@@ -224,8 +231,11 @@ onBeforeUnmount(() => {
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('total')">
                   <span class="inline-flex items-center gap-1 justify-end">Total<svg v-if="summarySortIcon('total') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('total') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned')">
-                  <span class="inline-flex items-center gap-1 justify-end">Aligned<svg v-if="summarySortIcon('aligned') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned_on_time')">
+                  <span class="inline-flex items-center gap-1 justify-end">On Time<svg v-if="summarySortIcon('aligned_on_time') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned_on_time') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned_late')">
+                  <span class="inline-flex items-center gap-1 justify-end">Late<svg v-if="summarySortIcon('aligned_late') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned_late') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('tv_only')">
                   <span class="inline-flex items-center gap-1 justify-end">TV-Only<svg v-if="summarySortIcon('tv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('tv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
@@ -233,8 +243,8 @@ onBeforeUnmount(() => {
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('fv_only')">
                   <span class="inline-flex items-center gap-1 justify-end">FV-Only<svg v-if="summarySortIcon('fv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('fv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('mismatched')">
-                  <span class="inline-flex items-center gap-1 justify-end">Mismatched<svg v-if="summarySortIcon('mismatched') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('mismatched') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('misaligned')">
+                  <span class="inline-flex items-center gap-1 justify-end">Misaligned<svg v-if="summarySortIcon('misaligned') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('misaligned') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('alignment_pct')">
                   <span class="inline-flex items-center gap-1 justify-end">Alignment<svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
@@ -247,6 +257,7 @@ onBeforeUnmount(() => {
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('planning_freeze')">
                   <span class="inline-flex items-center gap-1">Planning Freeze<svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to Freeze</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -257,10 +268,11 @@ onBeforeUnmount(() => {
                     {{ cycle.label }}
                   </td>
                   <td class="px-4 py-2.5 text-right text-xs font-semibold text-gray-700 dark:text-gray-200">{{ cycle.totals.total }}</td>
-                  <td class="px-4 py-2.5 text-right text-xs font-semibold text-green-700 dark:text-green-400">{{ cycle.totals.aligned }}</td>
+                  <td class="px-4 py-2.5 text-right text-xs font-semibold text-green-700 dark:text-green-400">{{ cycle.totals.aligned_on_time }}</td>
+                  <td class="px-4 py-2.5 text-right text-xs font-semibold text-amber-600 dark:text-amber-400">{{ cycle.totals.aligned_late }}</td>
                   <td class="px-4 py-2.5 text-right text-xs font-semibold text-yellow-700 dark:text-yellow-400">{{ cycle.totals.tv_only }}</td>
                   <td class="px-4 py-2.5 text-right text-xs font-semibold text-gray-500 dark:text-gray-400">{{ cycle.totals.fv_only }}</td>
-                  <td class="px-4 py-2.5 text-right text-xs font-semibold text-red-700 dark:text-red-400">{{ cycle.totals.mismatched }}</td>
+                  <td class="px-4 py-2.5 text-right text-xs font-semibold text-red-700 dark:text-red-400">{{ cycle.totals.misaligned }}</td>
                   <td class="px-4 py-2.5 text-right text-xs font-semibold"
                     :class="{
                       'text-red-600 dark:text-red-400': cycle.totals.alignment_pct < 50,
@@ -279,10 +291,11 @@ onBeforeUnmount(() => {
                       <span class="ml-1 text-[10px] font-normal text-gray-400 dark:text-gray-500">(includes {{ ms.rows.length }})</span>
                     </td>
                     <td class="px-4 py-2 text-right text-xs font-medium text-gray-600 dark:text-gray-300">{{ ms.totals.total }}</td>
-                    <td class="px-4 py-2 text-right text-xs font-medium text-green-700 dark:text-green-400">{{ ms.totals.aligned }}</td>
+                    <td class="px-4 py-2 text-right text-xs font-medium text-green-700 dark:text-green-400">{{ ms.totals.aligned_on_time }}</td>
+                    <td class="px-4 py-2 text-right text-xs font-medium text-amber-600 dark:text-amber-400">{{ ms.totals.aligned_late }}</td>
                     <td class="px-4 py-2 text-right text-xs font-medium text-yellow-700 dark:text-yellow-400">{{ ms.totals.tv_only }}</td>
                     <td class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">{{ ms.totals.fv_only }}</td>
-                    <td class="px-4 py-2 text-right text-xs font-medium text-red-700 dark:text-red-400">{{ ms.totals.mismatched }}</td>
+                    <td class="px-4 py-2 text-right text-xs font-medium text-red-700 dark:text-red-400">{{ ms.totals.misaligned }}</td>
                     <td class="px-4 py-2 text-right text-xs font-medium"
                       :class="{
                         'text-red-600 dark:text-red-400': ms.totals.alignment_pct < 50,
@@ -312,7 +325,11 @@ onBeforeUnmount(() => {
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <ClickableCount v-if="!row._pending" :count="row.aligned" :jql="row.aligned_jql" color="green" label="Aligned" />
+                      <ClickableCount v-if="!row._pending" :count="row.aligned_on_time" :jql="row.aligned_on_time_jql" color="green" label="On Time" />
+                      <span v-else class="text-gray-400">&mdash;</span>
+                    </td>
+                    <td class="px-4 py-2 text-right">
+                      <span v-if="!row._pending" class="text-xs font-medium text-amber-600 dark:text-amber-400">{{ row.aligned_late }}</span>
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
@@ -324,7 +341,7 @@ onBeforeUnmount(() => {
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <ClickableCount v-if="!row._pending" :count="row.mismatched" :jql="row.mismatched_jql" color="red" label="Mismatched" />
+                      <span v-if="!row._pending" class="text-xs font-medium text-red-600 dark:text-red-400">{{ row.misaligned }}</span>
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
@@ -348,7 +365,7 @@ onBeforeUnmount(() => {
                             'text-red-600 dark:text-red-400': row.alignment_pct < targetForRow(row).target,
                             'text-green-600 dark:text-green-400': row.alignment_pct >= targetForRow(row).target,
                           }"
-                          :title="'Target: ' + targetForRow(row).label + ' (based on ' + daysToGa(row.ga_date) + ' days to GA)'"
+                          :title="'Target: ' + targetForRow(row).label + ' (based on ' + daysToFreeze(row.planning_freeze) + ' days to planning freeze)'"
                         >{{ targetForRow(row).label }}</span>
                       </template>
                       <span v-else class="text-gray-400">&mdash;</span>
@@ -372,6 +389,20 @@ onBeforeUnmount(() => {
                     </td>
                     <td class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
                       {{ row.planning_freeze ? formatDate(row.planning_freeze) : '—' }}
+                    </td>
+                    <td class="px-4 py-2 text-right text-xs whitespace-nowrap"
+                      :class="{
+                        'text-gray-400': row._pending || daysToFreeze(row.planning_freeze) === null,
+                        'text-green-600 dark:text-green-400': daysToFreeze(row.planning_freeze) !== null && daysToFreeze(row.planning_freeze) <= 0,
+                        'text-red-600 dark:text-red-400': daysToFreeze(row.planning_freeze) > 0 && daysToFreeze(row.planning_freeze) <= 30,
+                        'text-yellow-600 dark:text-yellow-400': daysToFreeze(row.planning_freeze) > 30 && daysToFreeze(row.planning_freeze) <= 60,
+                        'text-gray-500 dark:text-gray-400': daysToFreeze(row.planning_freeze) > 60,
+                      }"
+                    >
+                      <template v-if="daysToFreeze(row.planning_freeze) !== null">
+                        {{ daysToFreeze(row.planning_freeze) > 0 ? daysToFreeze(row.planning_freeze) + 'd' : 'Frozen' }}
+                      </template>
+                      <template v-else>&mdash;</template>
                     </td>
                   </tr>
                 </template>
@@ -539,44 +570,18 @@ onBeforeUnmount(() => {
           />
         </details>
 
-        <!-- Mismatched -->
-        <details v-if="releaseData.mismatched.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-red-200 dark:border-red-800 overflow-hidden mb-4">
-          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-            <span class="flex items-center gap-2">
-              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-red-700 dark:text-red-400">
-                Mismatched — TV and FV disagree ({{ releaseData.mismatched.length }})
-              </span>
-            </span>
-            <a
-              v-if="releaseSummary"
-              :href="releaseSummary.mismatched_jql"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-              @click.stop
-            >
-              View in Jira &rarr;
-            </a>
-          </summary>
-          <FeatureTable
-            :features="releaseData.mismatched"
-            :columns="FEATURE_COLS"
-          />
-        </details>
-
-        <!-- Aligned -->
+        <!-- Aligned (on time) -->
         <details class="group bg-white dark:bg-gray-800 rounded-lg border border-green-200 dark:border-green-800 overflow-hidden mb-4">
           <summary class="list-none px-4 py-3 cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
             <span class="flex items-center gap-2">
               <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
               <span class="text-sm font-semibold text-green-700 dark:text-green-400">
-                Aligned — TV == FV ({{ releaseData.aligned.length }})
+                Aligned (on time) — FV matches or is ahead of TV ({{ releaseData.aligned_on_time.length }})
               </span>
             </span>
             <a
-              v-if="releaseSummary"
-              :href="releaseSummary.aligned_jql"
+              v-if="releaseSummary && releaseSummary.aligned_on_time_jql"
+              :href="releaseSummary.aligned_on_time_jql"
               target="_blank"
               rel="noopener noreferrer"
               class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
@@ -586,7 +591,39 @@ onBeforeUnmount(() => {
             </a>
           </summary>
           <FeatureTable
-            :features="releaseData.aligned"
+            :features="releaseData.aligned_on_time"
+            :columns="FEATURE_COLS"
+          />
+        </details>
+
+        <!-- Aligned (late) -->
+        <details v-if="releaseData.aligned_late.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-amber-200 dark:border-amber-800 overflow-hidden mb-4">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
+              <span class="text-sm font-semibold text-amber-600 dark:text-amber-400">
+                Aligned (late) — FV after TV, but TV planning freeze has passed ({{ releaseData.aligned_late.length }})
+              </span>
+            </span>
+          </summary>
+          <FeatureTable
+            :features="releaseData.aligned_late"
+            :columns="FEATURE_COLS"
+          />
+        </details>
+
+        <!-- Misaligned -->
+        <details v-if="releaseData.misaligned.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-red-200 dark:border-red-800 overflow-hidden mb-4">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
+              <span class="text-sm font-semibold text-red-700 dark:text-red-400">
+                Misaligned — FV after unfrozen TV or cross-product ({{ releaseData.misaligned.length }})
+              </span>
+            </span>
+          </summary>
+          <FeatureTable
+            :features="releaseData.misaligned"
             :columns="FEATURE_COLS"
           />
         </details>
@@ -606,10 +643,11 @@ onBeforeUnmount(() => {
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">PM</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">ENG</th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Total</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Aligned</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">On Time</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Late</th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">TV-Only</th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">FV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Mismatched</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Misaligned</th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Alignment</th>
               </tr>
             </thead>
@@ -627,10 +665,11 @@ onBeforeUnmount(() => {
                   {{ leadsFor(comp.component)?.engLead || '—' }}
                 </td>
                 <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">{{ comp.total }}</td>
-                <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">{{ comp.aligned }}</td>
+                <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">{{ comp.aligned_on_time }}</td>
+                <td class="px-4 py-2 text-right text-amber-600 dark:text-amber-400">{{ comp.aligned_late }}</td>
                 <td class="px-4 py-2 text-right text-yellow-600 dark:text-yellow-400">{{ comp.tv_only }}</td>
                 <td class="px-4 py-2 text-right text-gray-500 dark:text-gray-400">{{ comp.fv_only }}</td>
-                <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">{{ comp.mismatched }}</td>
+                <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">{{ comp.misaligned }}</td>
                 <td class="px-4 py-2 text-right">
                   <span
                     class="font-semibold"

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -250,10 +250,6 @@ onBeforeUnmount(() => {
                   <span class="inline-flex items-center gap-1 justify-end">Alignment<svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Target</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('ga_date')">
-                  <span class="inline-flex items-center gap-1">GA Date<svg v-if="summarySortIcon('ga_date') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('ga_date') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
-                </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to GA</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('planning_freeze')">
                   <span class="inline-flex items-center gap-1">Planning Freeze<svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -57,7 +57,7 @@ const filteredSummary = computed(() => {
   for (const name of chosenVersionNames.value) {
     if (!existingReleases.has(name)) {
       rows.push({
-        release: name, total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0,
+        release: name, total: 0, aligned_on_time: 0, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0,
         alignment_pct: 0, _pending: true,
       })
     }

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -15,6 +15,23 @@ const FEATURE_COLS = [
   'status', 'color_status', 'product_manager', 'assignee', 'team', 'component',
 ]
 
+/** Plain-English explanations for executive summary / component table headers */
+const COLUMN_HELP = {
+  release: 'Jira Target Version / Fix Version name for this product release.',
+  total: 'All features that have this release on Target Version (TV) or Fix Version (FV).',
+  aligned_on_time: 'Aligned on time: Fix Version matches Target Version, or ships earlier than planned.',
+  aligned_late: 'Aligned late: Fix Version is later than Target Version, but planning freeze for that Target Version has already passed — accepted slip.',
+  tv_only: 'TV-only: Target Version is set for this release, but Fix Version is empty.',
+  fv_only: 'FV-only: Fix Version is set for this release, but Target Version is empty.',
+  misaligned: 'Misaligned: Fix Version slips past Target Version before planning freeze, or TV/FV point at different products (for example RHOAI vs RHAII).',
+  alignment_pct: 'Alignment % = (Aligned on time + Aligned late) ÷ Total features.',
+  target: 'Suggested alignment goal based on how many days remain until planning freeze.',
+  ga_date: 'Release / GA date from Product Pages for this version.',
+  days_to_ga: 'Days remaining until the Product Pages release / GA date.',
+  planning_freeze: 'Planning freeze date from Product Pages. After this date, late FV slips count as Aligned late instead of Misaligned.',
+  days_to_freeze: 'Days remaining until planning freeze.',
+}
+
 // ---------------------------------------------------------------------------
 // Composables
 // ---------------------------------------------------------------------------
@@ -298,39 +315,45 @@ onBeforeUnmount(() => {
           <table class="min-w-full text-sm">
             <thead>
               <tr class="bg-gray-50 dark:bg-gray-800/50">
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('release')">
-                  <span class="inline-flex items-center gap-1">Release<svg v-if="summarySortIcon('release') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('release') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.release" @click="toggleSummarySort('release')">
+                  <span class="inline-flex items-center gap-1">Release<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('release') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('release') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('total')">
-                  <span class="inline-flex items-center gap-1 justify-end">Total<svg v-if="summarySortIcon('total') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('total') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.total" @click="toggleSummarySort('total')">
+                  <span class="inline-flex items-center gap-1 justify-end">Total<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('total') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('total') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned_on_time')">
-                  <span class="inline-flex items-center gap-1 justify-end">On Time<svg v-if="summarySortIcon('aligned_on_time') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned_on_time') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.aligned_on_time" @click="toggleSummarySort('aligned_on_time')">
+                  <span class="inline-flex items-center gap-1 justify-end">Aligned On Time<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('aligned_on_time') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned_on_time') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('aligned_late')">
-                  <span class="inline-flex items-center gap-1 justify-end">Late<svg v-if="summarySortIcon('aligned_late') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned_late') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.aligned_late" @click="toggleSummarySort('aligned_late')">
+                  <span class="inline-flex items-center gap-1 justify-end">Aligned Late<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('aligned_late') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('aligned_late') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('tv_only')">
-                  <span class="inline-flex items-center gap-1 justify-end">TV-Only<svg v-if="summarySortIcon('tv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('tv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.tv_only" @click="toggleSummarySort('tv_only')">
+                  <span class="inline-flex items-center gap-1 justify-end">TV-Only<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('tv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('tv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('fv_only')">
-                  <span class="inline-flex items-center gap-1 justify-end">FV-Only<svg v-if="summarySortIcon('fv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('fv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.fv_only" @click="toggleSummarySort('fv_only')">
+                  <span class="inline-flex items-center gap-1 justify-end">FV-Only<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('fv_only') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('fv_only') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('misaligned')">
-                  <span class="inline-flex items-center gap-1 justify-end">Misaligned<svg v-if="summarySortIcon('misaligned') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('misaligned') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.misaligned" @click="toggleSummarySort('misaligned')">
+                  <span class="inline-flex items-center gap-1 justify-end">Misaligned<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('misaligned') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('misaligned') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('alignment_pct')">
-                  <span class="inline-flex items-center gap-1 justify-end">Alignment<svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.alignment_pct" @click="toggleSummarySort('alignment_pct')">
+                  <span class="inline-flex items-center gap-1 justify-end">Alignment %<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Target</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('ga_date')">
-                  <span class="inline-flex items-center gap-1">GA Date<svg v-if="summarySortIcon('ga_date') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('ga_date') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase" :title="COLUMN_HELP.target">
+                  <span class="inline-flex items-center gap-1 justify-end">Align Target<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to GA</th>
-                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('planning_freeze')">
-                  <span class="inline-flex items-center gap-1">Planning Freeze<svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.ga_date" @click="toggleSummarySort('ga_date')">
+                  <span class="inline-flex items-center gap-1">GA Date<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('ga_date') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('ga_date') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to Freeze</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase" :title="COLUMN_HELP.days_to_ga">
+                  <span class="inline-flex items-center gap-1 justify-end">Days to GA<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span></span>
+                </th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" :title="COLUMN_HELP.planning_freeze" @click="toggleSummarySort('planning_freeze')">
+                  <span class="inline-flex items-center gap-1">Planning Freeze<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span><svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase" :title="COLUMN_HELP.days_to_freeze">
+                  <span class="inline-flex items-center gap-1 justify-end">Days to Freeze<span class="normal-case text-[10px] text-gray-400" aria-hidden="true">ⓘ</span></span>
+                </th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -406,11 +429,11 @@ onBeforeUnmount(() => {
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <ClickableCount v-if="!row._pending" :count="row.aligned_on_time" :jql="row.aligned_on_time_jql" color="green" label="On Time" />
+                      <ClickableCount v-if="!row._pending" :count="row.aligned_on_time" :jql="row.aligned_on_time_jql" color="green" label="Aligned on time" />
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <span v-if="!row._pending" class="text-xs font-medium text-amber-600 dark:text-amber-400">{{ row.aligned_late }}</span>
+                      <span v-if="!row._pending" class="text-xs font-medium text-amber-600 dark:text-amber-400" :title="COLUMN_HELP.aligned_late">{{ row.aligned_late }}</span>
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
@@ -624,7 +647,7 @@ onBeforeUnmount(() => {
             <span class="flex items-center gap-2">
               <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
               <span class="text-sm font-semibold text-yellow-700 dark:text-yellow-400">
-                TV-Only — PM targeted, no ENG commitment ({{ releaseData.tv_only.length }})
+                TV-Only — Target Version set, no Fix Version ({{ releaseData.tv_only.length }})
               </span>
             </span>
             <a
@@ -650,8 +673,8 @@ onBeforeUnmount(() => {
           <summary class="list-none px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 flex items-center justify-between [&::-webkit-details-marker]:hidden">
             <span class="flex items-center gap-2">
               <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-gray-600 dark:text-gray-400">
-                FV-Only — ENG committed, not PM-planned ({{ releaseData.fv_only.length }})
+              <span class="text-sm font-semibold text-gray-600 dark:text-gray-400" :title="COLUMN_HELP.fv_only">
+                FV-Only — Fix Version set, no Target Version ({{ releaseData.fv_only.length }})
               </span>
             </span>
             <a
@@ -677,8 +700,8 @@ onBeforeUnmount(() => {
           <summary class="list-none px-4 py-3 cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
             <span class="flex items-center gap-2">
               <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-green-700 dark:text-green-400">
-                Aligned (on time) — FV matches or is ahead of TV ({{ releaseData.aligned_on_time.length }})
+              <span class="text-sm font-semibold text-green-700 dark:text-green-400" :title="COLUMN_HELP.aligned_on_time">
+                Aligned On Time — shipping on or ahead of plan ({{ releaseData.aligned_on_time.length }})
               </span>
             </span>
             <a
@@ -704,8 +727,8 @@ onBeforeUnmount(() => {
           <summary class="list-none px-4 py-3 cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
             <span class="flex items-center gap-2">
               <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-amber-600 dark:text-amber-400">
-                Aligned (late) — FV after TV, but TV planning freeze has passed ({{ releaseData.aligned_late.length }})
+              <span class="text-sm font-semibold text-amber-600 dark:text-amber-400" :title="COLUMN_HELP.aligned_late">
+                Aligned Late — slipped after planning freeze ({{ releaseData.aligned_late.length }})
               </span>
             </span>
           </summary>
@@ -720,8 +743,8 @@ onBeforeUnmount(() => {
           <summary class="list-none px-4 py-3 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
             <span class="flex items-center gap-2">
               <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-red-700 dark:text-red-400">
-                Misaligned — FV after unfrozen TV or cross-product ({{ releaseData.misaligned.length }})
+              <span class="text-sm font-semibold text-red-700 dark:text-red-400" :title="COLUMN_HELP.misaligned">
+                Misaligned — slip before freeze, or different products ({{ releaseData.misaligned.length }})
               </span>
             </span>
           </summary>
@@ -746,13 +769,13 @@ onBeforeUnmount(() => {
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Component</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">PM</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">ENG</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Total</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">On Time</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Late</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">TV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">FV-Only</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Misaligned</th>
-                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Alignment</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.total">Total</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.aligned_on_time">Aligned On Time</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.aligned_late">Aligned Late</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.tv_only">TV-Only</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.fv_only">FV-Only</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.misaligned">Misaligned</th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase" :title="COLUMN_HELP.alignment_pct">Alignment %</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -250,6 +250,10 @@ onBeforeUnmount(() => {
                   <span class="inline-flex items-center gap-1 justify-end">Alignment<svg v-if="summarySortIcon('alignment_pct') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('alignment_pct') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
                 <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Target</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('ga_date')">
+                  <span class="inline-flex items-center gap-1">GA Date<svg v-if="summarySortIcon('ga_date') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('ga_date') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
+                </th>
+                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Days to GA</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSummarySort('planning_freeze')">
                   <span class="inline-flex items-center gap-1">Planning Freeze<svg v-if="summarySortIcon('planning_freeze') !== 'none'" class="w-3 h-3 inline-block transition-transform" :class="{ 'rotate-180': summarySortIcon('planning_freeze') === 'desc' }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" /></svg></span>
                 </th>
@@ -276,7 +280,7 @@ onBeforeUnmount(() => {
                       'text-green-600 dark:text-green-400': cycle.totals.alignment_pct >= 75,
                     }"
                   >{{ cycle.totals.alignment_pct }}%</td>
-                  <td :colspan="SUMMARY_COL_COUNT - 7" class="px-4 py-2.5"></td>
+                  <td :colspan="SUMMARY_COL_COUNT - 8" class="px-4 py-2.5"></td>
                 </tr>
 
                 <template v-for="ms in cycle.milestones" :key="ms.key">
@@ -299,7 +303,7 @@ onBeforeUnmount(() => {
                         'text-green-600 dark:text-green-400': ms.totals.alignment_pct >= 75,
                       }"
                     >{{ ms.totals.alignment_pct }}%</td>
-                    <td :colspan="SUMMARY_COL_COUNT - 7" class="px-4 py-2"></td>
+                    <td :colspan="SUMMARY_COL_COUNT - 8" class="px-4 py-2"></td>
                   </tr>
 
                   <!-- Product rows -->

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -338,8 +338,6 @@ function classifyFeatures(features, releases, releaseDates) {
   for (let ri = 0; ri < releases.length; ri++) {
     const release = releases[ri]
     const relNorm = normVer(release)
-    const relParsed = parseReleaseName(release)
-    const relProduct = extractProduct(release)
 
     for (let fi = 0; fi < features.length; fi++) {
       const feat = features[fi]
@@ -820,7 +818,7 @@ async function registerRoutes(router, context) {
     }
 
     // No cache — trigger first fetch using planning config if available
-    triggerBackgroundRefresh(await fetchReleasesFromPlanning(storage).releases)
+    triggerBackgroundRefresh((await fetchReleasesFromPlanning(storage)).releases)
     res.status(202).json({
       _refreshing: true,
       _noCache: true,
@@ -860,7 +858,7 @@ async function registerRoutes(router, context) {
       releases = req.body.releases
     } else {
       // Auto-discover from planning module (Smartsheet SSOT)
-      releases = await fetchReleasesFromPlanning(storage).releases
+      releases = (await fetchReleasesFromPlanning(storage)).releases
     }
 
     // Cap releases array to prevent excessive API load

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -94,6 +94,108 @@ const JQL_FIELDS = [
 ].join(',')
 
 // ---------------------------------------------------------------------------
+// Release Name Parsing and Comparison
+// ---------------------------------------------------------------------------
+
+// Release pattern: {product}-{major}.{minor}[.EA{n}]
+var RELEASE_PATTERN = /^(rhoai|rhelai|rhaii)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
+
+/**
+ * Parse a release name into structured parts.
+ * e.g. "rhoai-3.6.EA1" → { product: "rhoai", major: 3, minor: 6, milestone: "EA1", milestoneOrder: 1 }
+ * e.g. "rhoai-3.5"     → { product: "rhoai", major: 3, minor: 5, milestone: "GA",  milestoneOrder: 99 }
+ */
+function parseReleaseName(name) {
+  var m = RELEASE_PATTERN.exec(name)
+  if (!m) return null
+  var eaNum = m[4] ? parseInt(m[4], 10) : 0
+  return {
+    product: m[1].toLowerCase(),
+    major: parseInt(m[2], 10),
+    minor: parseInt(m[3], 10),
+    milestone: eaNum ? 'EA' + eaNum : 'GA',
+    milestoneOrder: eaNum || 99,
+    raw: name,
+  }
+}
+
+/**
+ * Compare two release names for sorting.
+ * Order: product alpha → major desc → minor desc → milestone asc (EA1 < EA2 < GA).
+ */
+function compareReleases(a, b) {
+  var pa = parseReleaseName(a)
+  var pb = parseReleaseName(b)
+  // Unparseable releases sort last, alphabetically
+  if (!pa && !pb) return a.localeCompare(b)
+  if (!pa) return 1
+  if (!pb) return -1
+
+  // Product alphabetical (rhelai < rhaii < rhoai)
+  if (pa.product !== pb.product) return pa.product.localeCompare(pb.product)
+  // Major descending (3.6 before 3.5)
+  if (pa.major !== pb.major) return pb.major - pa.major
+  // Minor descending
+  if (pa.minor !== pb.minor) return pb.minor - pa.minor
+  // Milestone ascending (EA1 before EA2 before GA)
+  return pa.milestoneOrder - pb.milestoneOrder
+}
+
+/**
+ * Compare two releases temporally (earlier release = negative, later = positive).
+ * Unlike compareReleases (which is for display sorting), this gives a consistent
+ * temporal ordering: major ASC → minor ASC → milestone ASC.
+ * Returns null if either release is unparseable or from different products.
+ */
+function compareReleasesTemporally(a, b) {
+  var pa = parseReleaseName(a)
+  var pb = parseReleaseName(b)
+  if (!pa || !pb) return null
+  if (pa.product !== pb.product) return null
+  if (pa.major !== pb.major) return pa.major - pb.major
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor
+  return pa.milestoneOrder - pb.milestoneOrder
+}
+
+/**
+ * Extract the product prefix from a release name.
+ * Returns lowercase: "rhoai", "rhelai", "rhaii", or null.
+ */
+function extractProduct(name) {
+  var m = /^(rhoai|rhelai|rhaii)/i.exec(name)
+  return m ? m[1].toLowerCase() : null
+}
+
+/**
+ * Check if a release has passed planning freeze.
+ * - If planning freeze date exists and is in the past → true
+ * - If no planning freeze but GA date exists and is in the past → true
+ * - Otherwise → false
+ */
+function isReleaseFrozen(releaseName, releaseDates) {
+  if (!releaseDates) return false
+
+  var normName = normVer(releaseName)
+  var dates = releaseDates[releaseName] || releaseDates[normName] || {}
+
+  var now = new Date()
+
+  // Check planning freeze date first
+  if (dates.planningFreezeDate) {
+    var freezeDate = new Date(dates.planningFreezeDate + 'T00:00:00Z')
+    if (freezeDate <= now) return true
+  }
+
+  // Fallback to GA date
+  if (dates.dueDate) {
+    var gaDate = new Date(dates.dueDate + 'T00:00:00Z')
+    if (gaDate <= now) return true
+  }
+
+  return false
+}
+
+// ---------------------------------------------------------------------------
 // Version normalisation
 // ---------------------------------------------------------------------------
 
@@ -230,12 +332,14 @@ function normalizeIssue(issue) {
 // Classification engine
 // ---------------------------------------------------------------------------
 
-function classifyFeatures(features, releases) {
+function classifyFeatures(features, releases, releaseDates) {
   const classifications = []
 
   for (let ri = 0; ri < releases.length; ri++) {
     const release = releases[ri]
     const relNorm = normVer(release)
+    const relParsed = parseReleaseName(release)
+    const relProduct = extractProduct(release)
 
     for (let fi = 0; fi < features.length; fi++) {
       const feat = features[fi]
@@ -245,12 +349,145 @@ function classifyFeatures(features, releases) {
       if (!tvMatch && !fvMatch) continue
 
       let cat
+
+      // Case 1: FV matches this release AND TV matches this release
       if (tvMatch && fvMatch) {
-        cat = 'aligned'
-      } else if (tvMatch && !fvMatch) {
-        cat = feat.fv_set.size > 0 ? 'mismatched' : 'tv_only'
-      } else {
-        cat = feat.tv_set.size > 0 ? 'mismatched' : 'fv_only'
+        cat = 'aligned_on_time'
+      }
+      // Case 2: TV matches this release but FV doesn't
+      else if (tvMatch && !fvMatch) {
+        if (feat.fv_set.size === 0) {
+          // No FV at all
+          cat = 'tv_only'
+        } else {
+          // FV is set — compare each FV against ALL TVs (spec rule 3).
+          // This ensures multi-TV features correctly detect unfrozen TVs.
+          var fvRaw = feat.fix_versions.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+          var tvRawAll = feat.target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+
+          var worstCategory = 'aligned_on_time'
+          var hasSameProductComparison = false
+
+          for (var fvi = 0; fvi < fvRaw.length; fvi++) {
+            var fvParsed = parseReleaseName(fvRaw[fvi])
+            var fvProduct = fvParsed ? fvParsed.product : null
+
+            // Unparseable FV = distinct product (spec rule 5) → misaligned
+            if (!fvParsed) {
+              worstCategory = 'misaligned'
+              break
+            }
+
+            // Compare this FV against each TV
+            for (var tvi = 0; tvi < tvRawAll.length; tvi++) {
+              var tvParsed = parseReleaseName(tvRawAll[tvi])
+              var tvProduct = tvParsed ? tvParsed.product : null
+
+              // Unparseable TV = distinct product → misaligned
+              if (!tvParsed) {
+                worstCategory = 'misaligned'
+                break
+              }
+
+              // Different product = misaligned (spec rule 4)
+              if (fvProduct !== tvProduct) {
+                continue // Skip cross-product TVs (spec rule 4: only compare same product)
+              }
+
+              hasSameProductComparison = true
+              var cmp = compareReleasesTemporally(fvRaw[fvi], tvRawAll[tvi])
+
+              // compareReleasesTemporally: positive = FV later, negative = FV earlier
+              if (cmp !== null && cmp < 0) {
+                // FV before this TV (ahead) - aligned_on_time (best)
+                // Keep current worstCategory
+              } else if (cmp !== null && cmp > 0) {
+                // FV after this TV - check freeze
+                var frozen = isReleaseFrozen(tvRawAll[tvi], releaseDates)
+                if (!frozen) {
+                  // Not frozen = misaligned (worst)
+                  worstCategory = 'misaligned'
+                  break
+                } else if (worstCategory !== 'misaligned') {
+                  // Frozen = aligned_late (middle)
+                  worstCategory = 'aligned_late'
+                }
+              }
+            }
+
+            if (worstCategory === 'misaligned') break
+          }
+
+          // No same-product comparisons = all cross-product = misaligned
+          if (!hasSameProductComparison && worstCategory !== 'misaligned') {
+            worstCategory = 'misaligned'
+          }
+
+          cat = worstCategory
+        }
+      }
+      // Case 3: FV matches this release but TV doesn't
+      else if (fvMatch && !tvMatch) {
+        if (feat.tv_set.size === 0) {
+          // No TV at all
+          cat = 'fv_only'
+        } else {
+          // TV is set — compare FV (= release) against all TVs
+          var tvRaw = feat.target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+          var relParsed2 = parseReleaseName(release)
+
+          var worstCategory = 'aligned_on_time'
+          var hasSameProductTV = false
+
+          for (var tvi = 0; tvi < tvRaw.length; tvi++) {
+            var tvParsed = parseReleaseName(tvRaw[tvi])
+
+            // Unparseable TV = distinct product (spec rule 5) → misaligned
+            if (!tvParsed) {
+              worstCategory = 'misaligned'
+              break
+            }
+
+            // Unparseable FV (release) = distinct product → misaligned
+            if (!relParsed2) {
+              worstCategory = 'misaligned'
+              break
+            }
+
+            // Different product = skip (spec rule 4: only compare same product)
+            if (tvParsed.product !== relParsed2.product) {
+              continue
+            }
+
+            hasSameProductTV = true
+            var cmp = compareReleasesTemporally(release, tvRaw[tvi])  // FV (release) vs TV
+
+            // compareReleasesTemporally: positive = FV later, negative = FV earlier
+            if (cmp !== null && cmp < 0) {
+              // FV before TV (ahead) - aligned_on_time (best)
+              // Keep current worstCategory
+            } else if (cmp !== null && cmp > 0) {
+              // FV after TV - check freeze
+              var frozen = isReleaseFrozen(tvRaw[tvi], releaseDates)
+              if (!frozen) {
+                // Any unfrozen TV where FV is after = misaligned (worst)
+                worstCategory = 'misaligned'
+                break
+              } else if (worstCategory !== 'misaligned') {
+                // All TVs frozen = aligned_late (middle)
+                worstCategory = 'aligned_late'
+              }
+            }
+            // else cmp === 0 means same release (shouldn't happen since fvMatch && !tvMatch)
+          }
+
+          // All TVs from different product = misaligned
+          if (!hasSameProductTV && worstCategory !== 'misaligned') {
+            worstCategory = 'misaligned'
+          }
+
+          cat = worstCategory
+        }
       }
 
       classifications.push({
@@ -280,7 +517,7 @@ function classifyFeatures(features, releases) {
 // ---------------------------------------------------------------------------
 
 function buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject, releaseDates) {
-  const baseJql = 'project = ' + jiraProject + ' AND issuetype = Feature'
+  const baseJql = 'project = ' + jiraProject + ' AND issuetype = Feature AND (resolution = Unresolved OR resolution IN ("Done", "Done-Errata"))'
 
   const executiveSummary = []
   const releaseBuckets = {}
@@ -290,12 +527,12 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
     const items = classifications.filter(function(c) { return c.release === release })
     const nTotal = items.length
 
-    const cats = { aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0 }
+    const cats = { aligned_on_time: 0, aligned_late: 0, misaligned: 0, tv_only: 0, fv_only: 0 }
     for (let i = 0; i < items.length; i++) {
       cats[items[i].category]++
     }
 
-    const alignPct = nTotal > 0 ? Math.round(1000 * cats.aligned / nTotal) / 10 : 0
+    const alignPct = nTotal > 0 ? Math.round(1000 * (cats.aligned_on_time + cats.aligned_late) / nTotal) / 10 : 0
 
     // Look up release dates from Product Pages cache
     let dates = {}
@@ -307,21 +544,23 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
       release: release,
       total: nTotal,
       total_jql: jqlUrl(baseJql + ' AND ("Target Version" in (' + quoteRelease(release) + ') OR fixVersion in (' + quoteRelease(release) + '))'),
-      aligned: cats.aligned,
-      aligned_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion in (' + quoteRelease(release) + ')'),
+      aligned_on_time: cats.aligned_on_time,
+      aligned_on_time_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion in (' + quoteRelease(release) + ')'),
+      aligned_late: cats.aligned_late,
+      aligned_late_jql: null, // Cannot express temporal + freeze logic in JQL
+      misaligned: cats.misaligned,
+      misaligned_jql: null, // Cannot express temporal + freeze logic in JQL
       tv_only: cats.tv_only,
       tv_only_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion is EMPTY'),
       fv_only: cats.fv_only,
       fv_only_jql: jqlUrl(baseJql + ' AND fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is EMPTY'),
-      mismatched: cats.mismatched,
-      mismatched_jql: jqlUrl(baseJql + ' AND (("Target Version" in (' + quoteRelease(release) + ') AND fixVersion is not EMPTY AND fixVersion not in (' + quoteRelease(release) + ')) OR (fixVersion in (' + quoteRelease(release) + ') AND "Target Version" is not EMPTY AND "Target Version" not in (' + quoteRelease(release) + ')))'),
       alignment_pct: alignPct,
       ga_date: dates.dueDate || null,
       planning_freeze: dates.planningFreezeDate || null,
     })
 
     // Per-release feature lists
-    const bucket = { aligned: [], tv_only: [], fv_only: [], mismatched: [] }
+    const bucket = { aligned_on_time: [], aligned_late: [], misaligned: [], tv_only: [], fv_only: [] }
     for (let ci = 0; ci < items.length; ci++) {
       const item = items[ci]
       const row = {
@@ -345,8 +584,8 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
 
   // Component breakdown — deduplicate by issue key per component
   // When a feature appears in multiple releases, pick the worst category:
-  // mismatched > tv_only > fv_only > aligned (show the most actionable state)
-  const CATEGORY_PRIORITY = { mismatched: 3, tv_only: 2, fv_only: 1, aligned: 0 }
+  // misaligned > tv_only > fv_only > aligned_late > aligned_on_time
+  const CATEGORY_PRIORITY = { misaligned: 4, tv_only: 3, fv_only: 2, aligned_late: 1, aligned_on_time: 0 }
   const compMap = {}
   for (let ki = 0; ki < classifications.length; ki++) {
     const cl = classifications[ki]
@@ -372,19 +611,21 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
     const name = allCompNames[cn]
     const data = compMap[name]
     let total = 0
-    let aligned = 0
+    let aligned_on_time = 0
+    let aligned_late = 0
     let tv_only = 0
     let fv_only = 0
-    let mismatched = 0
+    let misaligned = 0
 
     if (data) {
       const entries = Object.values(data)
       total = entries.length
       for (let ei = 0; ei < entries.length; ei++) {
-        if (entries[ei] === 'aligned') aligned++
+        if (entries[ei] === 'aligned_on_time') aligned_on_time++
+        else if (entries[ei] === 'aligned_late') aligned_late++
         else if (entries[ei] === 'tv_only') tv_only++
         else if (entries[ei] === 'fv_only') fv_only++
-        else if (entries[ei] === 'mismatched') mismatched++
+        else if (entries[ei] === 'misaligned') misaligned++
       }
     }
 
@@ -393,11 +634,12 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
       component: name,
       total: total,
       total_jql: jqlUrl(baseJql + ' AND component = ' + compQ + ' AND ("Target Version" in (' + releases.map(quoteRelease).join(', ') + ') OR fixVersion in (' + releases.map(quoteRelease).join(', ') + '))'),
-      aligned: aligned,
+      aligned_on_time: aligned_on_time,
+      aligned_late: aligned_late,
       tv_only: tv_only,
       fv_only: fv_only,
-      mismatched: mismatched,
-      alignment_pct: total > 0 ? Math.round(1000 * aligned / total) / 10 : 0
+      misaligned: misaligned,
+      alignment_pct: total > 0 ? Math.round(1000 * (aligned_on_time + aligned_late) / total) / 10 : 0
     })
   }
   componentBreakdown.sort(function(a, b) { return b.total - a.total || a.component.localeCompare(b.component) })
@@ -428,22 +670,7 @@ async function fetchAndClassify(releases, storage, jiraProject) {
   const allComponents = await fetchAllComponents(jiraProject)
   console.log('[releases/tv-fv-delta] Fetched ' + allComponents.length + ' components from Jira')
 
-  // Build JQL: features that have TV or FV in any of the target releases
-  const releaseList = releases.map(quoteRelease).join(', ')
-  const jql = 'project = ' + jiraProject + ' AND issuetype = Feature AND ("Target Version" in (' + releaseList + ') OR fixVersion in (' + releaseList + '))'
-
-  console.log('[releases/tv-fv-delta] Fetching features: ' + jql)
-  const issues = await fetchAllJqlResults(jiraRequest, jql, JQL_FIELDS)
-  console.log('[releases/tv-fv-delta] Fetched ' + issues.length + ' issues from Jira')
-
-  // Normalise
-  const features = issues.map(normalizeIssue)
-
-  // Classify
-  const classifications = classifyFeatures(features, releases)
-  console.log('[releases/tv-fv-delta] Classified ' + classifications.length + ' feature-release pairs')
-
-  // Look up release dates from Product Pages delivery cache
+  // Look up release dates from Product Pages delivery cache (needed for classification)
   const releaseDates = {}
   const ppCache = await storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
   if (ppCache && Array.isArray(ppCache.releases)) {
@@ -458,6 +685,22 @@ async function fetchAndClassify(releases, storage, jiraProject) {
       }
     }
   }
+
+  // Build JQL: features that have TV or FV in any of the target releases
+  // Filter resolution: exclude dead features (Duplicate, Obsolete, WontDo)
+  const releaseList = releases.map(quoteRelease).join(', ')
+  const jql = 'project = ' + jiraProject + ' AND issuetype = Feature AND (resolution = Unresolved OR resolution IN ("Done", "Done-Errata")) AND ("Target Version" in (' + releaseList + ') OR fixVersion in (' + releaseList + '))'
+
+  console.log('[releases/tv-fv-delta] Fetching features: ' + jql)
+  const issues = await fetchAllJqlResults(jiraRequest, jql, JQL_FIELDS)
+  console.log('[releases/tv-fv-delta] Fetched ' + issues.length + ' issues from Jira')
+
+  // Normalise
+  const features = issues.map(normalizeIssue)
+
+  // Classify
+  const classifications = classifyFeatures(features, releases, releaseDates)
+  console.log('[releases/tv-fv-delta] Classified ' + classifications.length + ' feature-release pairs')
 
   // Build export
   const result = buildExport(classifications, releases, fetchTimestamp, allComponents, jiraProject, releaseDates)
@@ -479,6 +722,11 @@ module.exports.normVer = normVer
 module.exports.parseVersions = parseVersions
 module.exports.extractVersionNames = extractVersionNames
 module.exports.isZStream = isZStream
+module.exports.parseReleaseName = parseReleaseName
+module.exports.compareReleases = compareReleases
+module.exports.compareReleasesTemporally = compareReleasesTemporally
+module.exports.extractProduct = extractProduct
+module.exports.isReleaseFrozen = isReleaseFrozen
 module.exports.normalizeIssue = normalizeIssue
 module.exports.classifyFeatures = classifyFeatures
 module.exports.buildExport = buildExport
@@ -701,7 +949,7 @@ async function registerRoutes(router, context) {
         return res.json(result)
       }
       const versions = allVersions
-        .filter(function(v) { return !v.archived && !isZStream(v.name) })
+        .filter(function(v) { return !v.archived })
         .sort(function(a, b) { return (a.name || '').localeCompare(b.name || '') })
 
       const result = { versions: versions, fetchedAt: new Date().toISOString() }

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -97,26 +97,51 @@ const JQL_FIELDS = [
 // Release Name Parsing and Comparison
 // ---------------------------------------------------------------------------
 
-// Release pattern: {product}-{major}.{minor}[.EA{n}]
+// Compact pattern: {product}-{major}.{minor}[.EA{n}]
 var RELEASE_PATTERN = /^(rhoai|rhelai|rhaii)[- _](\d+)\.(\d+)(?:\.EA(\d+))?$/i
+// Jira version pattern: "{major}.{minor} [EA{n}|GA] {PRODUCT} RELEASE"
+var JIRA_RELEASE_PATTERN = /^(\d+)\.(\d+)(?:\s+(EA\d+|GA))?\s+(RHOAI|RHAII|RHELAI)(?:\s+RELEASE)?$/i
+
+var PRODUCT_ALIASES = { rhoai: 'rhoai', rhelai: 'rhelai', rhaii: 'rhaii' }
 
 /**
  * Parse a release name into structured parts.
  * e.g. "rhoai-3.6.EA1" → { product: "rhoai", major: 3, minor: 6, milestone: "EA1", milestoneOrder: 1 }
  * e.g. "rhoai-3.5"     → { product: "rhoai", major: 3, minor: 5, milestone: "GA",  milestoneOrder: 99 }
+ * e.g. "3.6 EA1 RHOAI RELEASE" → same structure (Jira Target/Fix Version format)
  */
 function parseReleaseName(name) {
-  var m = RELEASE_PATTERN.exec(name)
-  if (!m) return null
-  var eaNum = m[4] ? parseInt(m[4], 10) : 0
-  return {
-    product: m[1].toLowerCase(),
-    major: parseInt(m[2], 10),
-    minor: parseInt(m[3], 10),
-    milestone: eaNum ? 'EA' + eaNum : 'GA',
-    milestoneOrder: eaNum || 99,
-    raw: name,
+  if (!name) return null
+  var m = RELEASE_PATTERN.exec(String(name).trim())
+  if (m) {
+    var eaNum = m[4] ? parseInt(m[4], 10) : 0
+    return {
+      product: m[1].toLowerCase(),
+      major: parseInt(m[2], 10),
+      minor: parseInt(m[3], 10),
+      milestone: eaNum ? 'EA' + eaNum : 'GA',
+      milestoneOrder: eaNum || 99,
+      raw: name,
+    }
   }
+
+  var jm = JIRA_RELEASE_PATTERN.exec(String(name).trim())
+  if (jm) {
+    var product = PRODUCT_ALIASES[jm[4].toLowerCase()]
+    if (!product) return null
+    var phaseLabel = jm[3] ? String(jm[3]).toUpperCase() : 'GA'
+    var eaFromJira = /^EA(\d+)$/.test(phaseLabel) ? parseInt(phaseLabel.slice(2), 10) : 0
+    return {
+      product: product,
+      major: parseInt(jm[1], 10),
+      minor: parseInt(jm[2], 10),
+      milestone: eaFromJira ? 'EA' + eaFromJira : 'GA',
+      milestoneOrder: eaFromJira || 99,
+      raw: name,
+    }
+  }
+
+  return null
 }
 
 /**
@@ -162,8 +187,37 @@ function compareReleasesTemporally(a, b) {
  * Returns lowercase: "rhoai", "rhelai", "rhaii", or null.
  */
 function extractProduct(name) {
-  var m = /^(rhoai|rhelai|rhaii)/i.exec(name)
+  var parsed = parseReleaseName(name)
+  if (parsed) return parsed.product
+  var m = /^(rhoai|rhelai|rhaii)/i.exec(name || '')
   return m ? m[1].toLowerCase() : null
+}
+
+/**
+ * Build a release-date lookup map from Product Pages cache entries.
+ * Keys include both the raw releaseNumber and its normVer form so Jira
+ * version names like "3.6 EA1 RHOAI RELEASE" resolve to the same dates.
+ */
+function buildReleaseDatesMap(ppReleases) {
+  var releaseDates = {}
+  if (!Array.isArray(ppReleases)) return releaseDates
+
+  for (var pi = 0; pi < ppReleases.length; pi++) {
+    var ppRel = ppReleases[pi]
+    var releaseNumber = ppRel && ppRel.releaseNumber
+    if (!releaseNumber) continue
+
+    var dates = {
+      dueDate: ppRel.dueDate || null,
+      planningFreezeDate: ppRel.planningFreezeDate || null,
+    }
+    var rawKey = String(releaseNumber).toLowerCase()
+    releaseDates[rawKey] = dates
+    var nv = normVer(releaseNumber)
+    if (nv) releaseDates[nv] = dates
+  }
+
+  return releaseDates
 }
 
 /**
@@ -668,21 +722,9 @@ async function fetchAndClassify(releases, storage, jiraProject) {
   const allComponents = await fetchAllComponents(jiraProject)
   console.log('[releases/tv-fv-delta] Fetched ' + allComponents.length + ' components from Jira')
 
-  // Look up release dates from Product Pages delivery cache (needed for classification)
-  const releaseDates = {}
+  // Look up release dates from Product Pages delivery cache (needed for classification + summary columns)
   const ppCache = await storage.readFromStorage('releases/delivery/product-pages-releases-cache.json')
-  if (ppCache && Array.isArray(ppCache.releases)) {
-    for (let pi = 0; pi < ppCache.releases.length; pi++) {
-      const ppRel = ppCache.releases[pi]
-      const ppKey = (ppRel.releaseNumber || '').toLowerCase()
-      if (ppKey) {
-        releaseDates[ppKey] = {
-          dueDate: ppRel.dueDate || null,
-          planningFreezeDate: ppRel.planningFreezeDate || null,
-        }
-      }
-    }
-  }
+  const releaseDates = buildReleaseDatesMap(ppCache && ppCache.releases)
 
   // Build JQL: features that have TV or FV in any of the target releases
   // Filter resolution: exclude dead features (Duplicate, Obsolete, WontDo)
@@ -724,6 +766,7 @@ module.exports.parseReleaseName = parseReleaseName
 module.exports.compareReleases = compareReleases
 module.exports.compareReleasesTemporally = compareReleasesTemporally
 module.exports.extractProduct = extractProduct
+module.exports.buildReleaseDatesMap = buildReleaseDatesMap
 module.exports.isReleaseFrozen = isReleaseFrozen
 module.exports.normalizeIssue = normalizeIssue
 module.exports.classifyFeatures = classifyFeatures

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -360,15 +360,15 @@ function classifyFeatures(features, releases, releaseDates) {
         } else {
           // FV is set — compare each FV against ALL TVs (spec rule 3).
           // This ensures multi-TV features correctly detect unfrozen TVs.
-          var fvRaw = feat.fix_versions.split(',').map(function(s) { return s.trim() }).filter(Boolean)
-          var tvRawAll = feat.target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+          let fvRaw = feat.fix_versions.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+          let tvRawAll = feat.target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean)
 
-          var worstCategory = 'aligned_on_time'
-          var hasSameProductComparison = false
+          let worstCategory = 'aligned_on_time'
+          let hasSameProductComparison = false
 
-          for (var fvi = 0; fvi < fvRaw.length; fvi++) {
-            var fvParsed = parseReleaseName(fvRaw[fvi])
-            var fvProduct = fvParsed ? fvParsed.product : null
+          for (let fvi = 0; fvi < fvRaw.length; fvi++) {
+            let fvParsed = parseReleaseName(fvRaw[fvi])
+            let fvProduct = fvParsed ? fvParsed.product : null
 
             // Unparseable FV = distinct product (spec rule 5) → misaligned
             if (!fvParsed) {
@@ -377,9 +377,9 @@ function classifyFeatures(features, releases, releaseDates) {
             }
 
             // Compare this FV against each TV
-            for (var tvi = 0; tvi < tvRawAll.length; tvi++) {
-              var tvParsed = parseReleaseName(tvRawAll[tvi])
-              var tvProduct = tvParsed ? tvParsed.product : null
+            for (let tvi = 0; tvi < tvRawAll.length; tvi++) {
+              let tvParsed = parseReleaseName(tvRawAll[tvi])
+              let tvProduct = tvParsed ? tvParsed.product : null
 
               // Unparseable TV = distinct product → misaligned
               if (!tvParsed) {
@@ -393,7 +393,7 @@ function classifyFeatures(features, releases, releaseDates) {
               }
 
               hasSameProductComparison = true
-              var cmp = compareReleasesTemporally(fvRaw[fvi], tvRawAll[tvi])
+              let cmp = compareReleasesTemporally(fvRaw[fvi], tvRawAll[tvi])
 
               // compareReleasesTemporally: positive = FV later, negative = FV earlier
               if (cmp !== null && cmp < 0) {
@@ -401,7 +401,7 @@ function classifyFeatures(features, releases, releaseDates) {
                 // Keep current worstCategory
               } else if (cmp !== null && cmp > 0) {
                 // FV after this TV - check freeze
-                var frozen = isReleaseFrozen(tvRawAll[tvi], releaseDates)
+                let frozen = isReleaseFrozen(tvRawAll[tvi], releaseDates)
                 if (!frozen) {
                   // Not frozen = misaligned (worst)
                   worstCategory = 'misaligned'
@@ -431,14 +431,14 @@ function classifyFeatures(features, releases, releaseDates) {
           cat = 'fv_only'
         } else {
           // TV is set — compare FV (= release) against all TVs
-          var tvRaw = feat.target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean)
-          var relParsed2 = parseReleaseName(release)
+          let tvRaw = feat.target_version.split(',').map(function(s) { return s.trim() }).filter(Boolean)
+          let relParsed2 = parseReleaseName(release)
 
-          var worstCategory = 'aligned_on_time'
-          var hasSameProductTV = false
+          let worstCategory = 'aligned_on_time'
+          let hasSameProductTV = false
 
-          for (var tvi = 0; tvi < tvRaw.length; tvi++) {
-            var tvParsed = parseReleaseName(tvRaw[tvi])
+          for (let tvi = 0; tvi < tvRaw.length; tvi++) {
+            let tvParsed = parseReleaseName(tvRaw[tvi])
 
             // Unparseable TV = distinct product (spec rule 5) → misaligned
             if (!tvParsed) {
@@ -458,7 +458,7 @@ function classifyFeatures(features, releases, releaseDates) {
             }
 
             hasSameProductTV = true
-            var cmp = compareReleasesTemporally(release, tvRaw[tvi])  // FV (release) vs TV
+            let cmp = compareReleasesTemporally(release, tvRaw[tvi])  // FV (release) vs TV
 
             // compareReleasesTemporally: positive = FV later, negative = FV earlier
             if (cmp !== null && cmp < 0) {
@@ -466,7 +466,7 @@ function classifyFeatures(features, releases, releaseDates) {
               // Keep current worstCategory
             } else if (cmp !== null && cmp > 0) {
               // FV after TV - check freeze
-              var frozen = isReleaseFrozen(tvRaw[tvi], releaseDates)
+              let frozen = isReleaseFrozen(tvRaw[tvi], releaseDates)
               if (!frozen) {
                 // Any unfrozen TV where FV is after = misaligned (worst)
                 worstCategory = 'misaligned'

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -23,6 +23,7 @@ export const viewOwners = {
   'ai-impact/autofix':                             'Alex Corvin',
   'ai-impact/build-release':                       'Deepak Chourasia',
   'ai-impact/documentation':                       'tarilabs',
+  'ai-impact/feature-decomposer':                  'Eder Ignatowicz',
   'ai-impact/feature-review':                      'Alex Corvin',
   'ai-impact/implementation':                      'Alex Corvin',
   'ai-impact/rfe-review':                          'Alex Corvin',

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -525,7 +525,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     await expect(summaryHeading).toBeVisible();
 
     // Verify all column headers
-    const headers = ['Release', 'Total', 'On Time', 'Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment'];
+    const headers = ['Release', 'Total', 'Aligned On Time', 'Aligned Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment %'];
     for (const header of headers) {
       const th = page.locator('th', { hasText: new RegExp(`^${header}$`, 'i') }).first();
       await expect(th).toBeVisible();
@@ -823,8 +823,8 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     expect(await rhoaiChip.getAttribute('class')).not.toContain('bg-blue-600');
 
     // Merged aligned on time = RHOAI 3 + RHAII 1
-    await expect(page.locator('summary:has-text("Aligned (on time)")')).toContainText('(4)');
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    await expect(page.locator('summary:has-text("Aligned On Time")')).toContainText('(4)');
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(200);
     await expect(page.locator('text=RHAISTRAT-110')).toBeVisible();
     await expect(page.locator('text=RHAISTRAT-100')).toBeVisible();
@@ -851,7 +851,7 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     expect(await rhoaiChip.getAttribute('class')).toContain('bg-blue-600');
 
     // Single-product aligned on time count is 3 again
-    await expect(page.locator('summary:has-text("Aligned (on time)")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("Aligned On Time")')).toContainText('(3)');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -876,7 +876,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
 
     // EA1 has: aligned_on_time (3), aligned_late (0), tv_only (1), fv_only (0), misaligned (1)
     await expect(page.locator('summary:has-text("TV-Only")')).toBeVisible();
-    await expect(page.locator('summary:has-text("Aligned (on time)")')).toBeVisible();
+    await expect(page.locator('summary:has-text("Aligned On Time")')).toBeVisible();
     await expect(page.locator('summary:has-text("Misaligned")')).toBeVisible();
     // FV-Only should render even with 0 items (empty table)
     await expect(page.locator('summary:has-text("FV-Only")')).toBeVisible();
@@ -891,7 +891,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
-    await expect(page.locator('summary:has-text("Aligned (on time)")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("Aligned On Time")')).toContainText('(3)');
     await expect(page.locator('summary:has-text("Misaligned")')).toContainText('(1)');
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -909,7 +909,7 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     // Switch to GA: tv_only=0, aligned_on_time=3
     await selectVersion(page, DEFAULT_SELECTED_DETAIL_RELEASE);
 
-    await expect(page.locator('summary:has-text("Aligned (on time)")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("Aligned On Time")')).toContainText('(3)');
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(0)');
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -1001,15 +1001,15 @@ test.describe('TV/FV Delta — Collapsible Behaviour @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Open TV-Only and Aligned (on time) sections
+    // Open TV-Only and Aligned On Time sections
     await page.locator('summary:has-text("TV-Only")').click();
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(300);
 
     // Verify they're open
     const tvOnlyOpen = await page.locator('details:has(summary:has-text("TV-Only"))').getAttribute('open');
     expect(tvOnlyOpen).not.toBeNull();
-    const alignedOpen = await page.locator('details:has(summary:has-text("Aligned (on time)"))').getAttribute('open');
+    const alignedOpen = await page.locator('details:has(summary:has-text("Aligned On Time"))').getAttribute('open');
     expect(alignedOpen).not.toBeNull();
 
     // FV-Only should still be closed
@@ -1020,10 +1020,10 @@ test.describe('TV/FV Delta — Collapsible Behaviour @tv-fv-delta', () => {
     await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
-    // TV-Only and Aligned (on time) should STILL be open
+    // TV-Only and Aligned On Time should STILL be open
     const tvOnlyStillOpen = await page.locator('details:has(summary:has-text("TV-Only"))').getAttribute('open');
     expect(tvOnlyStillOpen).not.toBeNull();
-    const alignedStillOpen = await page.locator('details:has(summary:has-text("Aligned (on time)"))').getAttribute('open');
+    const alignedStillOpen = await page.locator('details:has(summary:has-text("Aligned On Time"))').getAttribute('open');
     expect(alignedStillOpen).not.toBeNull();
 
     // FV-Only should still be closed
@@ -1064,11 +1064,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned (on time) section (has 3 features for EA1)
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    // Expand Aligned On Time section (has 3 features for EA1)
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned On Time"))');
     const rows = alignedDetails.locator('tbody tr');
     await expect(rows).toHaveCount(3);
 
@@ -1099,11 +1099,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned (on time) section
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    // Expand Aligned On Time section
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned On Time"))');
     const headers = alignedDetails.locator('thead th');
 
     // All categories now include: Key, Summary, TV, FV, Status, Color, PM, Assignee, Team, Component
@@ -1125,8 +1125,8 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     // EA1 has Misaligned + TV-Only sections; GA does not
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // Test that TV-Only, Aligned (on time), and Misaligned all have TV/FV columns
-    const categories = ['TV-Only', 'Aligned (on time)', 'Misaligned'];
+    // Test that TV-Only, Aligned On Time, and Misaligned all have TV/FV columns
+    const categories = ['TV-Only', 'Aligned On Time', 'Misaligned'];
 
     for (const category of categories) {
       await page.locator(`summary:has-text("${category}")`).click();
@@ -1181,11 +1181,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned (on time) section
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    // Expand Aligned On Time section
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned On Time"))');
     // Color badges have rounded-full class
     const badges = alignedDetails.locator('span.rounded-full');
     const badgeCount = await badges.count();
@@ -1206,11 +1206,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // Expand Aligned (on time) section (3 features)
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    // Expand Aligned On Time section (3 features)
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned On Time"))');
 
     // Get initial key order
     const getKeys = async () => {
@@ -1252,11 +1252,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned (on time) section — EA1 has 3 aligned_on_time
-    await page.locator('summary:has-text("Aligned (on time)")').click();
+    // Expand Aligned On Time section — EA1 has 3 aligned_on_time
+    await page.locator('summary:has-text("Aligned On Time")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned On Time"))');
     let rows = alignedDetails.locator('tbody tr');
     await expect(rows).toHaveCount(3);
 

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -524,10 +524,12 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     const summaryHeading = page.locator('h2:has-text("Executive Summary")');
     await expect(summaryHeading).toBeVisible();
 
-    // Verify all column headers
+    // Verify bucket/summary column headers (ⓘ help marker may follow the label)
+    const summaryTable = page.locator('div:has(> div > h2:has-text("Executive Summary")) table').first();
     const headers = ['Release', 'Total', 'Aligned On Time', 'Aligned Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment %'];
     for (const header of headers) {
-      const th = page.locator('th', { hasText: new RegExp(`^${header}$`, 'i') }).first();
+      const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const th = summaryTable.locator('th', { hasText: new RegExp(escaped, 'i') }).first();
       await expect(th).toBeVisible();
     }
 

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1354,7 +1354,7 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
     const headers = compSection.locator('thead th');
 
-    const expectedHeaders = ['Component', 'PM', 'ENG', 'Total', 'On Time', 'Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment'];
+    const expectedHeaders = ['Component', 'PM', 'ENG', 'Total', 'Aligned On Time', 'Aligned Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment %'];
     const count = await headers.count();
     expect(count).toBe(expectedHeaders.length);
     for (let i = 0; i < expectedHeaders.length; i++) {

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -12,7 +12,7 @@ const { setupErrorTracking, logCapturedErrors } = require('./helpers');
  * - Executive summary table renders with correct columns
  * - Executive summary / selector ordered cycle → milestone → product (numeric desc)
  * - Release tab switching works
- * - Category sections (TV-Only, FV-Only, Mismatched, Aligned) render
+ * - Category sections (TV-Only, FV-Only, Misaligned, Aligned on time, Aligned late) render
  * - Component breakdown updates per release
  * - Collapsible sections work (details/summary)
  * - Feature tables are sortable
@@ -30,13 +30,13 @@ const { setupErrorTracking, logCapturedErrors } = require('./helpers');
 function emptySummaryRow(release) {
   return {
     release,
-    total: 0, aligned: 0, tv_only: 0, fv_only: 0, mismatched: 0,
+    total: 0, aligned_on_time: 0, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0,
     alignment_pct: 0,
     total_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
-    aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
+    aligned_on_time_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
     tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
     fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty',
-    mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty'
+    misaligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-empty'
   };
 }
 
@@ -77,72 +77,75 @@ const FIXTURE_DATA = {
     ].includes(r)).map(emptySummaryRow),
     {
       release: '3.5 EA1 RHOAI RELEASE',
-      total: 5, aligned: 3, tv_only: 1, fv_only: 0, mismatched: 1,
+      total: 5, aligned_on_time: 3, aligned_late: 0, tv_only: 1, fv_only: 0, misaligned: 1,
       alignment_pct: 60,
       total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea1',
-      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea1',
+      aligned_on_time_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea1',
       tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-ea1',
       fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-ea1',
-      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea1'
+      misaligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea1'
     },
     {
       release: '3.5 EA2 RHOAI RELEASE',
-      total: 4, aligned: 2, tv_only: 1, fv_only: 1, mismatched: 0,
+      total: 4, aligned_on_time: 2, aligned_late: 0, tv_only: 1, fv_only: 1, misaligned: 0,
       alignment_pct: 50,
       total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea2',
-      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea2',
+      aligned_on_time_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea2',
       tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-ea2',
       fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-ea2',
-      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea2'
+      misaligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea2'
     },
     {
       release: '3.5 GA RHOAI RELEASE',
-      total: 3, aligned: 3, tv_only: 0, fv_only: 0, mismatched: 0,
+      total: 3, aligned_on_time: 3, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0,
       alignment_pct: 100,
       total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-35',
-      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-35',
+      aligned_on_time_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-35',
       tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-35',
       fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-35',
-      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-35'
+      misaligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-35'
     }
   ],
   releases: {
     '3.5 EA1 RHOAI RELEASE': {
-      aligned: [
+      aligned_on_time: [
         { key: 'RHAISTRAT-100', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-100', summary: 'Aligned feature A', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
         { key: 'RHAISTRAT-101', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-101', summary: 'Aligned feature B', status: 'New', color_status: 'Yellow', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Training' },
         { key: 'RHAISTRAT-102', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-102', summary: 'Aligned feature C', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev Three', team: 'Team A', component: 'Serving' }
       ],
+      aligned_late: [],
       tv_only: [
         { key: 'RHAISTRAT-200', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-200', summary: 'TV-only feature X', status: 'New', color_status: 'Red', product_manager: 'PM Gamma', assignee: 'Dev Four', team: 'Team C', component: 'Dashboard' }
       ],
       fv_only: [],
-      mismatched: [
-        { key: 'RHAISTRAT-300', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-300', summary: 'Mismatched feature Z', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Alpha', assignee: 'Dev Five', team: 'Team A', component: 'Serving, Training', target_version: '3.5 EA1 RHOAI RELEASE', fix_versions: '3.5 EA2 RHOAI RELEASE' }
+      misaligned: [
+        { key: 'RHAISTRAT-300', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-300', summary: 'Misaligned feature Z', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Alpha', assignee: 'Dev Five', team: 'Team A', component: 'Serving, Training', target_version: '3.5 EA1 RHOAI RELEASE', fix_versions: '3.5 EA2 RHOAI RELEASE' }
       ]
     },
     '3.5 EA2 RHOAI RELEASE': {
-      aligned: [
+      aligned_on_time: [
         { key: 'RHAISTRAT-400', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-400', summary: 'EA2 aligned A', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
         { key: 'RHAISTRAT-401', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-401', summary: 'EA2 aligned B', status: 'New', color_status: '', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Notebooks' }
       ],
+      aligned_late: [],
       tv_only: [
         { key: 'RHAISTRAT-500', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-500', summary: 'EA2 TV-only', status: 'Backlog', color_status: '', product_manager: 'PM Gamma', assignee: '', team: '', component: 'Pipelines' }
       ],
       fv_only: [
         { key: 'RHAISTRAT-600', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-600', summary: 'EA2 FV-only', status: 'In Progress', color_status: 'Green', product_manager: '', assignee: 'Dev Six', team: 'Team D', component: 'Model Registry' }
       ],
-      mismatched: []
+      misaligned: []
     },
     '3.5 GA RHOAI RELEASE': {
-      aligned: [
+      aligned_on_time: [
         { key: 'RHAISTRAT-700', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-700', summary: 'GA aligned A', status: 'Done', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev One', team: 'Team A', component: 'Serving' },
         { key: 'RHAISTRAT-701', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-701', summary: 'GA aligned B', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Beta', assignee: 'Dev Two', team: 'Team B', component: 'Training' },
         { key: 'RHAISTRAT-702', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-702', summary: 'GA aligned C', status: 'In Progress', color_status: 'Green', product_manager: 'PM Alpha', assignee: 'Dev Three', team: 'Team A', component: 'Serving' }
       ],
+      aligned_late: [],
       tv_only: [],
       fv_only: [],
-      mismatched: []
+      misaligned: []
     }
   },
   component_breakdown: []
@@ -502,7 +505,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     await expect(summaryHeading).toBeVisible();
 
     // Verify all column headers
-    const headers = ['Release', 'Total', 'Aligned', 'TV-Only', 'FV-Only', 'Mismatched', 'Alignment'];
+    const headers = ['Release', 'Total', 'On Time', 'Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment'];
     for (const header of headers) {
       const th = page.locator('th', { hasText: new RegExp(`^${header}$`, 'i') }).first();
       await expect(th).toBeVisible();
@@ -572,7 +575,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
 
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
 
-    // EA1 row: total=5, aligned=3, tv_only=1, fv_only=0, mismatched=1, alignment=60%
+    // EA1 row: total=5, aligned_on_time=3, aligned_late=0, tv_only=1, fv_only=0, misaligned=1, alignment=60%
     const ea1Row = summarySection.locator('tbody tr', { hasText: '3.5 EA1 RHOAI RELEASE' });
     await expect(ea1Row).toContainText('60%');
 
@@ -651,7 +654,7 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
     const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
     const jiraLinks = summarySection.locator('tbody a[href*="atlassian.net"]');
     const linkCount = await jiraLinks.count();
-    // Each row has Total, Aligned, TV-Only, FV-Only, Mismatched = 5 links per row × 18 rows
+    // Each row has Total, On Time, TV-Only, FV-Only = 4 clickable links per row × 18 rows
     expect(linkCount).toBeGreaterThanOrEqual(18);
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -798,10 +801,10 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // EA1 has: aligned (3), tv_only (1), fv_only (0), mismatched (1)
+    // EA1 has: aligned_on_time (3), aligned_late (0), tv_only (1), fv_only (0), misaligned (1)
     await expect(page.locator('summary:has-text("TV-Only")')).toBeVisible();
-    await expect(page.locator('summary:has-text("Aligned")')).toBeVisible();
-    await expect(page.locator('summary:has-text("Mismatched")')).toBeVisible();
+    await expect(page.locator('summary:has-text("Aligned (on time)")')).toBeVisible();
+    await expect(page.locator('summary:has-text("Misaligned")')).toBeVisible();
     // FV-Only should render even with 0 items (empty table)
     await expect(page.locator('summary:has-text("FV-Only")')).toBeVisible();
 
@@ -815,8 +818,8 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
-    await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
-    await expect(page.locator('summary:has-text("Mismatched")')).toContainText('(1)');
+    await expect(page.locator('summary:has-text("Aligned (on time)")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("Misaligned")')).toContainText('(1)');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -830,10 +833,10 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     // EA1: tv_only=1
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(1)');
 
-    // Switch to GA: tv_only=0, aligned=3
+    // Switch to GA: tv_only=0, aligned_on_time=3
     await selectVersion(page, DEFAULT_SELECTED_DETAIL_RELEASE);
 
-    await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
+    await expect(page.locator('summary:has-text("Aligned (on time)")')).toContainText('(3)');
     await expect(page.locator('summary:has-text("TV-Only")')).toContainText('(0)');
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -852,18 +855,18 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     expect(relevantErrors(page)).toHaveLength(0);
   });
 
-  test('should hide Mismatched section when count is zero', async ({ page }) => {
+  test('should hide Misaligned section when count is zero', async ({ page }) => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Switch to EA2 which has 0 mismatched
+    // Switch to EA2 which has 0 misaligned
     await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
-    // Mismatched section should be hidden (v-if="releaseData.mismatched.length")
-    const mismatched = page.locator('summary:has-text("Mismatched")');
-    await expect(mismatched).toHaveCount(0);
+    // Misaligned section should be hidden (v-if="releaseData.misaligned.length")
+    const misaligned = page.locator('summary:has-text("Misaligned")');
+    await expect(misaligned).toHaveCount(0);
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -925,15 +928,15 @@ test.describe('TV/FV Delta — Collapsible Behaviour @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Open TV-Only and Aligned sections
+    // Open TV-Only and Aligned (on time) sections
     await page.locator('summary:has-text("TV-Only")').click();
-    await page.locator('summary:has-text("Aligned")').click();
+    await page.locator('summary:has-text("Aligned (on time)")').click();
     await page.waitForTimeout(300);
 
     // Verify they're open
     const tvOnlyOpen = await page.locator('details:has(summary:has-text("TV-Only"))').getAttribute('open');
     expect(tvOnlyOpen).not.toBeNull();
-    const alignedOpen = await page.locator('details:has(summary:has-text("Aligned"))').getAttribute('open');
+    const alignedOpen = await page.locator('details:has(summary:has-text("Aligned (on time)"))').getAttribute('open');
     expect(alignedOpen).not.toBeNull();
 
     // FV-Only should still be closed
@@ -944,10 +947,10 @@ test.describe('TV/FV Delta — Collapsible Behaviour @tv-fv-delta', () => {
     await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
-    // TV-Only and Aligned should STILL be open
+    // TV-Only and Aligned (on time) should STILL be open
     const tvOnlyStillOpen = await page.locator('details:has(summary:has-text("TV-Only"))').getAttribute('open');
     expect(tvOnlyStillOpen).not.toBeNull();
-    const alignedStillOpen = await page.locator('details:has(summary:has-text("Aligned"))').getAttribute('open');
+    const alignedStillOpen = await page.locator('details:has(summary:has-text("Aligned (on time)"))').getAttribute('open');
     expect(alignedStillOpen).not.toBeNull();
 
     // FV-Only should still be closed
@@ -988,11 +991,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned section (has 3 features for EA1)
-    await page.locator('summary:has-text("Aligned")').click();
+    // Expand Aligned (on time) section (has 3 features for EA1)
+    await page.locator('summary:has-text("Aligned (on time)")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
     const rows = alignedDetails.locator('tbody tr');
     await expect(rows).toHaveCount(3);
 
@@ -1023,11 +1026,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned section
-    await page.locator('summary:has-text("Aligned")').click();
+    // Expand Aligned (on time) section
+    await page.locator('summary:has-text("Aligned (on time)")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
     const headers = alignedDetails.locator('thead th');
 
     // All categories now include: Key, Summary, Status, TV, FV, Color, PM, Assignee, Team, Component
@@ -1046,11 +1049,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
-    // EA1 has Mismatched + TV-Only sections; GA does not
+    // EA1 has Misaligned + TV-Only sections; GA does not
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // Test that TV-Only, Aligned, and Mismatched all have TV/FV columns
-    const categories = ['TV-Only', 'Aligned', 'Mismatched'];
+    // Test that TV-Only, Aligned (on time), and Misaligned all have TV/FV columns
+    const categories = ['TV-Only', 'Aligned (on time)', 'Misaligned'];
 
     for (const category of categories) {
       await page.locator(`summary:has-text("${category}")`).click();
@@ -1084,11 +1087,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned section
-    await page.locator('summary:has-text("Aligned")').click();
+    // Expand Aligned (on time) section
+    await page.locator('summary:has-text("Aligned (on time)")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
     // Color badges have rounded-full class
     const badges = alignedDetails.locator('span.rounded-full');
     const badgeCount = await badges.count();
@@ -1109,11 +1112,11 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // Expand Aligned section (3 features)
-    await page.locator('summary:has-text("Aligned")').click();
+    // Expand Aligned (on time) section (3 features)
+    await page.locator('summary:has-text("Aligned (on time)")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
 
     // Get initial key order
     const getKeys = async () => {
@@ -1155,15 +1158,15 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
-    // Expand Aligned section — EA1 has 3 aligned
-    await page.locator('summary:has-text("Aligned")').click();
+    // Expand Aligned (on time) section — EA1 has 3 aligned_on_time
+    await page.locator('summary:has-text("Aligned (on time)")').click();
     await page.waitForTimeout(300);
 
-    const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
+    const alignedDetails = page.locator('details:has(summary:has-text("Aligned (on time)"))');
     let rows = alignedDetails.locator('tbody tr');
     await expect(rows).toHaveCount(3);
 
-    // Switch to EA2 — has 2 aligned
+    // Switch to EA2 — has 2 aligned_on_time
     await versionChip(page, '3.5 EA2 RHOAI RELEASE').click();
     await page.waitForTimeout(500);
 
@@ -1257,7 +1260,7 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
     const headers = compSection.locator('thead th');
 
-    const expectedHeaders = ['Component', 'PM', 'ENG', 'Total', 'Aligned', 'TV-Only', 'FV-Only', 'Mismatched', 'Alignment'];
+    const expectedHeaders = ['Component', 'PM', 'ENG', 'Total', 'On Time', 'Late', 'TV-Only', 'FV-Only', 'Misaligned', 'Alignment'];
     const count = await headers.count();
     expect(count).toBe(expectedHeaders.length);
     for (let i = 0; i < expectedHeaders.length; i++) {
@@ -1333,12 +1336,12 @@ test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // Expand Mismatched section (has both TV and FV populated)
-    await page.locator('summary:has-text("Mismatched")').click();
+    // Expand Misaligned section (has both TV and FV populated)
+    await page.locator('summary:has-text("Misaligned")').click();
     await page.waitForTimeout(300);
 
-    const mismatchedDetails = page.locator('details:has(summary:has-text("Mismatched"))');
-    const firstRow = mismatchedDetails.locator('tbody tr').first();
+    const misalignedDetails = page.locator('details:has(summary:has-text("Misaligned"))');
+    const firstRow = misalignedDetails.locator('tbody tr').first();
 
     // Should show 3.5 EA1 RHOAI RELEASE in TV column and 3.5 EA2 RHOAI RELEASE in FV column (from fixture)
     await expect(firstRow).toContainText('3.5 EA1 RHOAI RELEASE');
@@ -1417,12 +1420,12 @@ test.describe('TV/FV Delta — Data Completeness @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    // Expand Mismatched section (RHAISTRAT-300 has "Serving, Training")
-    await page.locator('summary:has-text("Mismatched")').click();
+    // Expand Misaligned section (RHAISTRAT-300 has "Serving, Training")
+    await page.locator('summary:has-text("Misaligned")').click();
     await page.waitForTimeout(300);
 
-    const mismatchedDetails = page.locator('details:has(summary:has-text("Mismatched"))');
-    const componentCell = mismatchedDetails.locator('tbody tr:has-text("RHAISTRAT-300")').locator('td').last();
+    const misalignedDetails = page.locator('details:has(summary:has-text("Misaligned"))');
+    const componentCell = misalignedDetails.locator('tbody tr:has-text("RHAISTRAT-300")').locator('td').last();
 
     // Should show both components
     await expect(componentCell).toContainText('Serving');

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1156,16 +1156,16 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     expect(relevantErrors(page)).toHaveLength(0);
   });
 
-  test('should show mismatched TV and FV values side by side', async ({ page }) => {
+  test('should show misaligned TV and FV values side by side', async ({ page }) => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
     await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
-    await page.locator('summary:has-text("Mismatched")').click();
+    await page.locator('summary:has-text("Misaligned")').click();
     await page.waitForTimeout(300);
 
-    const mismatchDetails = page.locator('details:has(summary:has-text("Mismatched"))');
+    const mismatchDetails = page.locator('details:has(summary:has-text("Misaligned"))');
     const row = mismatchDetails.locator('tbody tr', { hasText: 'RHAISTRAT-300' });
     await expect(row).toBeVisible();
     const cells = row.locator('td');


### PR DESCRIPTION
## Summary

- Replace simple TV==FV equality check with temporal alignment formula using planning freeze dates
- **5 categories**: aligned on time (green), aligned late (amber), misaligned (red), TV-only (yellow), FV-only (grey)
- Compare FV against ALL TVs with cross-product detection, z-stream quality gate, planning freeze fallback
- Frontend: 5-category executive summary, days-to-freeze thresholds, appendix documentation
- **132 tests** covering all 13 spec examples (A-M), EA/GA milestones, z-streams, cross-product, multi-TV freeze states, unparseable releases, and integration scenarios

## Key design decisions

- `compareReleasesTemporally()` — dedicated temporal comparison (major/minor/milestone all ascending), separate from `compareReleases()` which is display-order (descending minor)
- Classification checks FV against ALL TVs (not just the matched release) per spec rule 3
- Unparseable releases treated as distinct product → always misaligned (spec rule 5)
- Planning freeze fallback: freeze date → GA date → conservative (not frozen)
- JQL links are null for aligned_late and misaligned (temporal logic not expressible in JQL)

## Spec

~/redhat/mgmt/jira_process/local_features/tv-fv-alignment-formula/spec.md

## Test plan

- [x] All 132 unit tests pass (`npx vitest run modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js`)
- [ ] Manual verification on staging with live data
- [ ] Verify appendix renders correctly in browser
- [ ] Confirm alignment percentages shift upward (previously mismatched features with frozen TVs now count as aligned late)

🤖 Generated with [Claude Code](https://claude.com/claude-code)