### PR TITLE
fix(releases): PM Hub release filter — OR logic, version naming, and table UX

### DIFF
--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -141,15 +141,15 @@ function getLeads(componentName) {
 function extractProduct(versionName) {
   if (!versionName) return versionName
   var lower = versionName.toLowerCase()
-  if (lower.startsWith('rhoai')) return 'RHOAI'
-  if (lower.startsWith('rhelai')) return 'RHELAI'
-  if (lower.startsWith('rhaii')) return 'RHAII'
-  return versionName.split('-')[0] || versionName
+  if (lower.indexOf('rhoai') !== -1) return 'RHOAI'
+  if (lower.indexOf('rhelai') !== -1) return 'RHELAI'
+  if (lower.indexOf('rhaii') !== -1) return 'RHAII'
+  return null
 }
 
 function normalizeVersion(v) {
   if (!v || typeof v !== 'string') return v
-  return v.replace(/^rhoai-/i, '')
+  return v.replace(/\s*(RHOAI|RHELAI|RHAII)\s*RELEASE\s*$/i, '').trim()
 }
 
 var componentGroups = computed(function() {
@@ -294,8 +294,8 @@ defineExpose({ expandAll, collapseAll })
 </script>
 
 <template>
-  <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-    <table class="w-full text-sm border-collapse">
+  <div class="overflow-x-auto overflow-y-auto max-h-[calc(100vh-220px)] rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+    <table class="w-full text-sm border-collapse min-w-[1400px]">
       <tbody>
         <template v-for="comp in componentGroups" :key="comp.component">
           <!-- Component group header -->

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -752,12 +752,12 @@ var uniqueComponents = computed(function() {
 })
 
 var PORTFOLIO_VERSIONS = [
-  { label: '3.5 EA1', jiraVersions: ['rhoai-3.5.EA1', 'rhelai-3.5 EA1 release', 'RHAII-3.5 EA1'] },
-  { label: '3.5 EA2', jiraVersions: ['rhoai-3.5.EA2', 'rhelai-3.5 EA2 release', 'RHAII-3.5 EA2'] },
-  { label: '3.5', jiraVersions: ['rhoai-3.5', 'rhelai-3.5', 'RHAII-3.5'] },
-  { label: '3.6 EA1', jiraVersions: ['rhoai-3.6.EA1', 'rhelai-3.6 EA1 release', 'RHAII-3.6 EA1'] },
-  { label: '3.6 EA2', jiraVersions: ['rhoai-3.6.EA2', 'rhelai-3.6 EA2 release', 'RHAII-3.6 EA2'] },
-  { label: '3.6', jiraVersions: ['rhoai-3.6', 'rhelai-3.6', 'RHAII-3.6'] }
+  { label: '3.5 EA1', jiraVersions: ['3.5 EA1 RHOAI RELEASE', '3.5 EA1 RHELAI RELEASE', '3.5 EA1 RHAII RELEASE'] },
+  { label: '3.5 EA2', jiraVersions: ['3.5 EA2 RHOAI RELEASE', '3.5 EA2 RHELAI RELEASE', '3.5 EA2 RHAII RELEASE'] },
+  { label: '3.5', jiraVersions: ['3.5 GA RHOAI RELEASE', '3.5 GA RHELAI RELEASE', '3.5 GA RHAII RELEASE'] },
+  { label: '3.6 EA1', jiraVersions: ['3.6 EA1 RHOAI RELEASE', '3.6 EA1 RHELAI RELEASE', '3.6 EA1 RHAII RELEASE'] },
+  { label: '3.6 EA2', jiraVersions: ['3.6 EA2 RHOAI RELEASE', '3.6 EA2 RHELAI RELEASE', '3.6 EA2 RHAII RELEASE'] },
+  { label: '3.6', jiraVersions: ['3.6 GA RHOAI RELEASE', '3.6 GA RHELAI RELEASE', '3.6 GA RHAII RELEASE'] }
 ]
 
 var portfolioVersionLabels = PORTFOLIO_VERSIONS.map(function(v) { return v.label })

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -567,10 +567,10 @@ function clearAllFilters() {
 function extractProduct(versionName) {
   if (!versionName) return versionName
   var lower = versionName.toLowerCase()
-  if (lower.startsWith('rhoai')) return 'RHOAI'
-  if (lower.startsWith('rhelai')) return 'RHELAI'
-  if (lower.startsWith('rhaii')) return 'RHAII'
-  return versionName.split('-')[0] || versionName
+  if (lower.indexOf('rhoai') !== -1) return 'RHOAI'
+  if (lower.indexOf('rhelai') !== -1) return 'RHELAI'
+  if (lower.indexOf('rhaii') !== -1) return 'RHAII'
+  return null
 }
 
 function flattenFeatures() {

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -691,49 +691,90 @@ module.exports = async function registerPmHubRoutes(router, context) {
         return versionGroups[vName].components[cName]
       }
 
-      // Process requested issues (Target Version matches)
+      // Process all issues with OR display logic:
+      // Show issue if selected release matches fixVersion OR targetVersion.
+      // committedFeatures/Count = fixVersion matches only.
+      // requestedFeatures/Count = targetVersion matches only.
+      var allIssues = {}
+
       for (var ri = 0; ri < requestedIssues.length; ri++) {
         var raw = requestedIssues[ri]
-        var f = transformIssue(raw, {})
-        var tvNames = extractTargetVersions(raw)
+        if (!allIssues[raw.key]) allIssues[raw.key] = { raw: raw }
+      }
+      for (var cii = 0; cii < committedIssues.length; cii++) {
+        var rawC = committedIssues[cii]
+        if (!allIssues[rawC.key]) allIssues[rawC.key] = { raw: rawC }
+      }
+
+      var issueKeys = Object.keys(allIssues)
+      for (var ik = 0; ik < issueKeys.length; ik++) {
+        var entry = allIssues[issueKeys[ik]]
+        var rawIssue = entry.raw
+        var f = transformIssue(rawIssue, {})
+        var tvNames = extractTargetVersions(rawIssue)
+        var fvList = f.fixVersions && f.fixVersions.length > 0 ? f.fixVersions : []
         var compList = f.components && f.components.length > 0 ? f.components : ['No Component']
 
-        for (var tvi = 0; tvi < tvNames.length; tvi++) {
-          var tvName = tvNames[tvi]
-          if (versionNames.indexOf(tvName) === -1) continue
+        if (versionNames.length === 0) {
+          // Component-only mode: group by fixVersion, all go into committed
+          var groupFvList = fvList.length > 0 ? fvList : ['Unversioned']
+          for (var ufi = 0; ufi < groupFvList.length; ufi++) {
+            for (var uci = 0; uci < compList.length; uci++) {
+              var ucName = compList[uci]
+              if (componentNames.length > 0 && componentNames.indexOf(ucName) === -1) continue
+              var uGroup = ensureGroup(groupFvList[ufi], ucName)
+              if (!uGroup.committedFeatures.some(function(e) { return e.key === f.key })) {
+                uGroup.committedFeatures.push(buildFeatureObj(f, tvNames))
+                uGroup.committedCount++
+                if (f.isBlocked) uGroup.blockedCount++
+              }
+            }
+          }
+          continue
+        }
 
+        // Determine which selected versions match each field
+        var matchingFv = []
+        var matchingTv = []
+        for (var fvi = 0; fvi < fvList.length; fvi++) {
+          if (versionNames.indexOf(fvList[fvi]) !== -1) matchingFv.push(fvList[fvi])
+        }
+        for (var tvi = 0; tvi < tvNames.length; tvi++) {
+          if (versionNames.indexOf(tvNames[tvi]) !== -1) matchingTv.push(tvNames[tvi])
+        }
+
+        // OR logic: skip if neither field matches any selected version
+        if (matchingFv.length === 0 && matchingTv.length === 0) continue
+
+        // Determine group version keys — use all unique matching versions from either field
+        var groupVersions = {}
+        for (var mf = 0; mf < matchingFv.length; mf++) groupVersions[matchingFv[mf]] = true
+        for (var mt = 0; mt < matchingTv.length; mt++) groupVersions[matchingTv[mt]] = true
+        var groupVersionKeys = Object.keys(groupVersions)
+
+        var isCommitted = matchingFv.length > 0
+        var isRequested = matchingTv.length > 0
+        var featureObj = buildFeatureObj(f, tvNames)
+
+        for (var gvi = 0; gvi < groupVersionKeys.length; gvi++) {
+          var vKey = groupVersionKeys[gvi]
           for (var ci = 0; ci < compList.length; ci++) {
             var cName = compList[ci]
             if (componentNames.length > 0 && componentNames.indexOf(cName) === -1) continue
-            var group = ensureGroup(tvName, cName)
-            if (!group.requestedFeatures.some(function(e) { return e.key === f.key })) {
-              group.requestedFeatures.push(buildFeatureObj(f, tvNames))
-              group.requestedCount++
+            var group = ensureGroup(vKey, cName)
+
+            if (isCommitted && matchingFv.indexOf(vKey) !== -1) {
+              if (!group.committedFeatures.some(function(e) { return e.key === f.key })) {
+                group.committedFeatures.push(featureObj)
+                group.committedCount++
+                if (f.isBlocked) group.blockedCount++
+              }
             }
-          }
-        }
-      }
-
-      // Process committed issues (Fix Version matches)
-      for (var cii = 0; cii < committedIssues.length; cii++) {
-        var rawC = committedIssues[cii]
-        var fc = transformIssue(rawC, {})
-        var tvNamesC = extractTargetVersions(rawC)
-        var fvList = fc.fixVersions && fc.fixVersions.length > 0 ? fc.fixVersions : ['Unversioned']
-        var compListC = fc.components && fc.components.length > 0 ? fc.components : ['No Component']
-
-        for (var fvi = 0; fvi < fvList.length; fvi++) {
-          var fvName = fvList[fvi]
-          if (versionNames.length > 0 && versionNames.indexOf(fvName) === -1) continue
-
-          for (var cci = 0; cci < compListC.length; cci++) {
-            var cNameC = compListC[cci]
-            if (componentNames.length > 0 && componentNames.indexOf(cNameC) === -1) continue
-            var groupC = ensureGroup(fvName, cNameC)
-            if (!groupC.committedFeatures.some(function(e) { return e.key === fc.key })) {
-              groupC.committedFeatures.push(buildFeatureObj(fc, tvNamesC))
-              groupC.committedCount++
-              if (fc.isBlocked) groupC.blockedCount++
+            if (isRequested && matchingTv.indexOf(vKey) !== -1) {
+              if (!group.requestedFeatures.some(function(e) { return e.key === f.key })) {
+                group.requestedFeatures.push(featureObj)
+                group.requestedCount++
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- **Release filter OR logic**: Issues now display when the selected release matches either FixVersion OR TargetVersion. Metric counts remain field-specific — "Committed" counts fixVersion matches only, "Requested" counts targetVersion matches only.
- **Version name update**: Updated `PORTFOLIO_VERSIONS` to the new Jira naming convention (e.g., `3.5 EA1 RHOAI RELEASE`, `3.5 EA1 RHELAI RELEASE`, `3.5 EA1 RHAII RELEASE`). Updated `extractProduct` to detect product from the middle of the string (contains check) and `normalizeVersion` to strip the product suffix for clean display.
- **Table scrollability**: Wrapped the data table in a viewport-height-constrained scrollable container so the horizontal scrollbar is always accessible without scrolling to the bottom.

## Test plan

- [ ] Select a component (e.g., MLflow) and a release (e.g., 3.5 EA1) — verify issues appear if the release matches either Fix Version or Target Version
- [ ] Verify "Committed" count only includes issues where Fix Version matches the selected release
- [ ] Verify "Requested" count only includes issues where Target Version matches the selected release
- [ ] Use the Product filter (RHOAI/RHELAI/RHAII) — verify it correctly filters issues by product
- [ ] Verify Fix Version and Target Version columns show clean short names (e.g., "3.5 EA1" not "3.5 EA1 RHOAI RELEASE")
- [ ] Verify horizontal scrollbar is visible within the viewport without scrolling to the bottom of the table

Made with [Cursor](https://cursor.com)