### PR TITLE
fix(ai-impact): persist only non-default config values

### DIFF
--- a/modules/ai-impact/__tests__/server/config.test.js
+++ b/modules/ai-impact/__tests__/server/config.test.js
@@ -20,9 +20,37 @@ describe('saveConfig', () => {
     const writeToStorage = vi.fn().mockResolvedValue(undefined);
     await saveConfig(writeToStorage, { jiraProject: 'MYPROJECT' });
     expect(writeToStorage).toHaveBeenCalledWith('ai-impact/config.json', expect.objectContaining({
-      jiraProject: 'MYPROJECT',
-      linkedProject: 'RHAISTRAT'
+      jiraProject: 'MYPROJECT'
     }));
+  });
+
+  it('only persists fields that differ from defaults', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await saveConfig(writeToStorage, { jiraProject: 'CUSTOM' });
+    const saved = writeToStorage.mock.calls[0][1];
+    expect(saved.jiraProject).toBe('CUSTOM');
+    expect(saved).not.toHaveProperty('linkedProject');
+    expect(saved).not.toHaveProperty('autofixProjects');
+  });
+
+  it('writes empty object when all values match defaults', async () => {
+    const writeToStorage = vi.fn().mockResolvedValue(undefined);
+    await saveConfig(writeToStorage, { ...DEFAULT_CONFIG });
+    expect(writeToStorage.mock.calls[0][1]).toEqual({});
+  });
+
+  it('round-trips correctly: delta save then getConfig returns full config', async () => {
+    let stored = null;
+    const writeFn = vi.fn((_key, data) => { stored = data; });
+    const readFn = vi.fn(() => stored);
+
+    await saveConfig(writeFn, { jiraProject: 'CUSTOM' });
+    const config = await getConfig(readFn);
+
+    expect(config.jiraProject).toBe('CUSTOM');
+    expect(config.linkedProject).toBe('RHAISTRAT');
+    expect(config.autofixProjects).toEqual(DEFAULT_CONFIG.autofixProjects);
+    expect(config).toEqual({ ...DEFAULT_CONFIG, jiraProject: 'CUSTOM' });
   });
 
   it('rejects JQL-unsafe characters in string fields', async () => {

--- a/modules/ai-impact/server/config.js
+++ b/modules/ai-impact/server/config.js
@@ -128,7 +128,16 @@ async function saveConfig(writeToStorage, config) {
     merged.autofixProjects = config.autofixProjects;
   }
 
-  await writeToStorage('ai-impact/config.json', merged);
+  // Only persist fields that differ from defaults so that future default
+  // changes (e.g. adding new autofix projects) take effect automatically
+  // on deployments that never customized those fields.
+  const delta = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (JSON.stringify(value) !== JSON.stringify(DEFAULT_CONFIG[key])) {
+      delta[key] = value;
+    }
+  }
+  await writeToStorage('ai-impact/config.json', delta);
 }
 
 module.exports = { DEFAULT_CONFIG, getConfig, saveConfig, validateJqlSafeString };


### PR DESCRIPTION
## Summary

- `saveConfig()` was writing the full merged config to disk, freezing default values. This meant changes to `DEFAULT_CONFIG` (like adding new autofix projects in #1264) had no effect on existing deployments because the old defaults were already persisted.
- Now `saveConfig()` computes a delta and only persists fields the user actually customized. `getConfig()` still merges defaults, so new defaults flow through automatically.
- Adds a test verifying that unchanged defaults are not persisted.

**Note for admins**: Existing deployments still have the old config on disk. Re-saving any setting in the AI Impact Settings page will clean up the persisted file. For the immediate autofix projects issue, update the field manually in Settings to include all six projects, then save.

## Test plan

- [x] `npm test` passes (config tests + full suite)
- [x] `npm run lint` passes
- [ ] Verify Settings UI still loads and saves correctly
- [ ] Verify that after saving, only customized fields appear in `data/ai-impact/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)