### PR TITLE
fix(releases): show full release name in PM Hub table columns

### DIFF
--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -149,7 +149,7 @@ function extractProduct(versionName) {
 
 function normalizeVersion(v) {
   if (!v || typeof v !== 'string') return v
-  return v.replace(/\s*(RHOAI|RHELAI|RHAII)\s*RELEASE\s*$/i, '').trim()
+  return v
 }
 
 var componentGroups = computed(function() {

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -147,11 +147,6 @@ function extractProduct(versionName) {
   return null
 }
 
-function normalizeVersion(v) {
-  if (!v || typeof v !== 'string') return v
-  return v
-}
-
 var componentGroups = computed(function() {
   var compMap = {}
 
@@ -468,7 +463,7 @@ defineExpose({ expandAll, collapseAll })
                     v-for="fv in feature.fixVersions"
                     :key="fv"
                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
-                  >{{ normalizeVersion(fv) }}</span>
+                  >{{ fv }}</span>
                 </div>
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>
@@ -478,7 +473,7 @@ defineExpose({ expandAll, collapseAll })
                     v-for="tv in feature.targetVersions"
                     :key="tv"
                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300"
-                  >{{ normalizeVersion(tv) }}</span>
+                  >{{ tv }}</span>
                 </div>
                 <span v-else class="text-gray-300 dark:text-gray-600 text-xs">--</span>
               </td>


### PR DESCRIPTION
## Summary

- Display the complete version name (e.g., "3.6 GA RHOAI RELEASE") in the Fix Version and Target Version table columns instead of the abbreviated form ("3.6 GA")

## Test plan

- [ ] Open PM Hub Component Release Load Tracking, select a component and release
- [ ] Verify Fix Version and Target Version columns show the full release name (e.g., "3.6 GA RHOAI RELEASE")

Made with [Cursor](https://cursor.com)