### PR TITLE
fix(deps): clear npm audit high (brace-expansion under swagger-jsdoc)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8382,15 +8382,15 @@
       }
     },
     "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/swagger-jsdoc/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -66,5 +66,10 @@
   },
   "lint-staged": {
     "*.{js,mjs,cjs,vue}": "eslint --fix"
+  },
+  "overrides": {
+    "swagger-jsdoc": {
+      "brace-expansion": "5.0.8"
+    }
   }
 }


### PR DESCRIPTION
## Problem

CI's **Security audit** step (`npm audit --omit=dev --audit-level=high`) fails on every PR with one high-severity finding:

```
brace-expansion  <=5.0.7  (high) — GHSA-mh99-v99m-4gvg (DoS via unbounded expansion)
node_modules/swagger-jsdoc/node_modules/brace-expansion
```

`swagger-jsdoc` comes transitively from `@org-pulse/core`, so this is a newly-published advisory breaking `Test & Build` repo-wide, not specific to any feature branch.

## Fix

Scoped npm `overrides` bumping **only** swagger-jsdoc's transitive `brace-expansion` to the patched `5.0.8`:

```json
"overrides": {
  "swagger-jsdoc": { "brace-expansion": "5.0.8" }
}
```

- Leaves the dev-only `brace-expansion` copies and the `2.x` line untouched (no forced major bumps).
- `minimatch@10` requires `^5.0.5`, so `5.0.8` satisfies cleanly.
- Lockfile regenerated with **Node 22 / npm 10** (matching CI) → minimal **4-line** lock diff, no unrelated churn.

## Verification (Node 22)

- `npm ci` → exit 0
- `npm audit --omit=dev --audit-level=high` → **found 0 vulnerabilities** (exit 0)

Ideal longer-term fix is bumping `swagger-jsdoc` in `@org-pulse/core`; this override unblocks CI in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)