### PR TITLE
feat(releases): enhance Release Schedule UI with countdown cards, phase steppers, and widget redesign

### DIFF
--- a/fixtures/releases/registry.json
+++ b/fixtures/releases/registry.json
@@ -2,53 +2,106 @@
   "schemaVersion": 1,
   "releases": [
     {
-      "id": "rhoai-2.14",
-      "displayName": "RHOAI 2.14",
-      "fixVersions": ["RHOAI-2.14", "rhoai-2.14"],
-      "productPagesShortname": "red_hat_openshift_ai",
-      "productPagesVersion": "2.14",
+      "id": "rhai-3.5-ea1",
+      "displayName": "RHAI 3.5 EA1",
+      "fixVersions": ["RHAI-3.5-EA1", "rhai-3.5-ea1"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.5",
       "milestones": {
-        "planningFreeze": "2026-04-15",
-        "featureFreeze": "2026-05-15",
-        "codeFreeze": "2026-06-01",
-        "ea1": "2026-06-15",
-        "ga": "2026-07-01"
+        "planningFreeze": "2026-04-17",
+        "featureFreeze": null,
+        "codeFreeze": "2026-05-12",
+        "ga": "2026-06-17"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-05-01T00:00:00Z",
-      "updatedAt": "2026-05-01T00:00:00Z"
+      "createdAt": "2026-03-10T00:00:00Z",
+      "updatedAt": "2026-06-17T00:00:00Z"
     },
     {
-      "id": "rhoai-2.15",
-      "displayName": "RHOAI 2.15",
-      "fixVersions": ["RHOAI-2.15", "rhoai-2.15"],
-      "productPagesShortname": "red_hat_openshift_ai",
-      "productPagesVersion": "2.15",
+      "id": "rhai-3.5-ea2",
+      "displayName": "RHAI 3.5 EA2",
+      "fixVersions": ["RHAI-3.5-EA2", "rhai-3.5-ea2"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.5",
       "milestones": {
-        "planningFreeze": "2026-06-15",
-        "featureFreeze": "2026-07-15",
-        "codeFreeze": "2026-08-01",
-        "ga": "2026-09-01"
+        "planningFreeze": "2026-05-15",
+        "featureFreeze": null,
+        "codeFreeze": "2026-06-09",
+        "ga": "2026-07-15"
       },
       "state": "active",
       "source": "product-pages",
-      "createdAt": "2026-05-01T00:00:00Z",
-      "updatedAt": "2026-05-01T00:00:00Z"
+      "createdAt": "2026-04-30T00:00:00Z",
+      "updatedAt": "2026-07-15T00:00:00Z"
     },
     {
-      "id": "rhoai-2.13",
-      "displayName": "RHOAI 2.13",
-      "fixVersions": ["RHOAI-2.13"],
-      "productPagesShortname": "red_hat_openshift_ai",
-      "productPagesVersion": "2.13",
+      "id": "rhai-3.5-ga",
+      "displayName": "RHAI 3.5 GA",
+      "fixVersions": ["RHAI-3.5-GA", "rhai-3.5-ga", "RHAI-3.5"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.5",
       "milestones": {
-        "ga": "2026-04-15"
+        "planningFreeze": "2026-06-24",
+        "featureFreeze": "2026-07-17",
+        "codeFreeze": "2026-07-20",
+        "ga": "2026-08-19"
       },
-      "state": "archived",
-      "source": "manual",
-      "createdAt": "2026-03-01T00:00:00Z",
-      "updatedAt": "2026-04-20T00:00:00Z"
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-04T00:00:00Z",
+      "updatedAt": "2026-07-19T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.6-ea1",
+      "displayName": "RHAI 3.6 EA1",
+      "fixVersions": ["RHAI-3.6-EA1", "rhai-3.6-ea1"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-07-29",
+        "featureFreeze": null,
+        "codeFreeze": "2026-08-20",
+        "ga": "2026-09-17"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-11T00:00:00Z",
+      "updatedAt": "2026-07-19T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.6-ea2",
+      "displayName": "RHAI 3.6 EA2",
+      "fixVersions": ["RHAI-3.6-EA2", "rhai-3.6-ea2"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-08-26",
+        "featureFreeze": null,
+        "codeFreeze": "2026-09-15",
+        "ga": "2026-10-15"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-11T00:00:00Z",
+      "updatedAt": "2026-07-19T00:00:00Z"
+    },
+    {
+      "id": "rhai-3.6-ga",
+      "displayName": "RHAI 3.6 GA",
+      "fixVersions": ["RHAI-3.6-GA", "rhai-3.6-ga", "RHAI-3.6"],
+      "productPagesShortname": "rhai",
+      "productPagesVersion": "3.6",
+      "milestones": {
+        "planningFreeze": "2026-09-23",
+        "featureFreeze": "2026-10-16",
+        "codeFreeze": "2026-10-19",
+        "ga": "2026-11-19"
+      },
+      "state": "active",
+      "source": "product-pages",
+      "createdAt": "2026-06-11T00:00:00Z",
+      "updatedAt": "2026-07-19T00:00:00Z"
     }
   ]
 }

--- a/modules/releases/__tests__/client/schedule-view.test.js
+++ b/modules/releases/__tests__/client/schedule-view.test.js
@@ -23,6 +23,10 @@ function makeRelease(id, opts = {}) {
   }
 }
 
+function getReleaseRows(wrapper) {
+  return wrapper.findAll('tbody tr').filter(r => r.findAll('td').length > 1)
+}
+
 describe('ScheduleView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -88,7 +92,7 @@ describe('ScheduleView', () => {
     const wrapper = mount(ScheduleView)
     await flushPromises()
 
-    const rows = wrapper.findAll('tbody tr')
+    const rows = getReleaseRows(wrapper)
     expect(rows[0].text()).toContain('RHOAI-3.4')
     expect(rows[1].text()).toContain('RHOAI-3.5')
     expect(rows[2].text()).toContain('RHOAI-3.6')
@@ -104,7 +108,7 @@ describe('ScheduleView', () => {
     const wrapper = mount(ScheduleView)
     await flushPromises()
 
-    const rows = wrapper.findAll('tbody tr')
+    const rows = getReleaseRows(wrapper)
     expect(rows).toHaveLength(1)
     expect(wrapper.text()).toContain('RHOAI-3.5')
     expect(wrapper.text()).not.toContain('RHOAI-3.4')
@@ -120,7 +124,7 @@ describe('ScheduleView', () => {
     const wrapper = mount(ScheduleView)
     await flushPromises()
 
-    const rows = wrapper.findAll('tbody tr')
+    const rows = getReleaseRows(wrapper)
     const pastRow = rows[0]
     expect(pastRow.classes()).toContain('opacity-50')
   })
@@ -172,7 +176,7 @@ describe('ScheduleView', () => {
     const rhoaiBtn = buttons.find(b => b.text() === 'rhoai')
     await rhoaiBtn.trigger('click')
 
-    const rows = wrapper.findAll('tbody tr')
+    const rows = getReleaseRows(wrapper)
     expect(rows).toHaveLength(1)
     expect(wrapper.text()).toContain('RHOAI-3.5')
     expect(wrapper.text()).not.toContain('RHELAI-1.0')

--- a/modules/releases/__tests__/client/schedule-widget.test.js
+++ b/modules/releases/__tests__/client/schedule-widget.test.js
@@ -78,10 +78,10 @@ describe('ScheduleWidget', () => {
     const wrapper = mount(ScheduleWidget)
     await flushPromises()
 
-    const items = wrapper.findAll('[class*="px-5 py-2"]')
-    expect(items.length).toBeGreaterThanOrEqual(2)
-    expect(items[0].text()).toContain('RHOAI-3.4')
-    expect(items[0].text()).toContain('5d')
+    const heroCard = wrapper.find('[class*="rounded-lg border px-4"]')
+    expect(heroCard.exists()).toBe(true)
+    expect(heroCard.text()).toContain('RHOAI-3.4')
+    expect(heroCard.text()).toContain('5')
   })
 
   it('only shows active releases', async () => {
@@ -116,7 +116,7 @@ describe('ScheduleWidget', () => {
     expect(wrapper.text()).toContain('Release')
   })
 
-  it('limits to 6 milestones maximum', async () => {
+  it('limits to 5 milestones maximum (1 hero + 4 list)', async () => {
     apiRequest.mockResolvedValue({
       releases: [
         makeRelease('rhoai-3.4', {
@@ -139,8 +139,10 @@ describe('ScheduleWidget', () => {
     const wrapper = mount(ScheduleWidget)
     await flushPromises()
 
-    const items = wrapper.findAll('[class*="px-5 py-2"]')
-    expect(items).toHaveLength(6)
+    const heroCard = wrapper.find('[class*="rounded-lg border px-4"]')
+    expect(heroCard.exists()).toBe(true)
+    const listItems = wrapper.findAll('[class*="px-5 py-2"]')
+    expect(listItems).toHaveLength(4)
   })
 
   it('shows "Today" for milestones due today', async () => {

--- a/modules/releases/__tests__/client/schedule-widget.test.js
+++ b/modules/releases/__tests__/client/schedule-widget.test.js
@@ -230,7 +230,7 @@ describe('ScheduleWidget', () => {
       const wrapper = mount(ScheduleWidget)
       await flushPromises()
 
-      await wrapper.find('select').setValue('rhoai')
+      await wrapper.find('select').setValue('product:rhoai')
       expect(wrapper.text()).toContain('RHOAI-3.5')
       expect(wrapper.text()).not.toContain('RHELAI-1.0')
       expect(wrapper.text()).not.toContain('RHAII-1.0')
@@ -241,7 +241,7 @@ describe('ScheduleWidget', () => {
       const wrapper = mount(ScheduleWidget)
       await flushPromises()
 
-      await wrapper.find('select').setValue('rhoai')
+      await wrapper.find('select').setValue('product:rhoai')
       await wrapper.find('select').setValue('')
       expect(wrapper.text()).toContain('RHOAI-3.5')
       expect(wrapper.text()).toContain('RHELAI-1.0')

--- a/modules/releases/client/composables/useScheduleHelpers.js
+++ b/modules/releases/client/composables/useScheduleHelpers.js
@@ -1,0 +1,67 @@
+export function parseDate(val) {
+  if (!val) return null
+  const d = new Date(val)
+  return isNaN(d.getTime()) ? null : d
+}
+
+export function todayMidnight() {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+export function daysFromNow(dateStr) {
+  const d = parseDate(dateStr)
+  if (!d) return null
+  const today = todayMidnight()
+  d.setHours(0, 0, 0, 0)
+  return Math.ceil((d.getTime() - today.getTime()) / 86400000)
+}
+
+export function formatShort(dateStr, opts) {
+  const d = parseDate(dateStr)
+  if (!d) return '—'
+  const format = { month: 'short', day: 'numeric' }
+  if (opts && opts.year) format.year = 'numeric'
+  return d.toLocaleDateString('en-US', format)
+}
+
+export function getProduct(release) {
+  if (release.productPagesShortname) return release.productPagesShortname
+  const match = release.id.match(/^([a-z]+)-/i)
+  return match ? match[1] : release.id
+}
+
+export function releasePhase(release) {
+  const ms = release.milestones || {}
+  const phases = [
+    { label: 'Planning', until: ms.planningFreeze },
+    { label: 'Feature Dev', until: ms.featureFreeze },
+    { label: 'Code Complete', until: ms.codeFreeze },
+    { label: 'Release Prep', until: ms.ga },
+    { label: 'Released', until: null }
+  ]
+  const today = todayMidnight()
+  let phaseIndex = 0
+  for (let i = 0; i < 4; i++) {
+    const d = parseDate(phases[i].until)
+    if (d && d.getTime() <= today.getTime()) {
+      phaseIndex = i + 1
+    }
+  }
+  return { phaseIndex, phases }
+}
+
+export function milestoneProgress(currentDate, prevDate) {
+  const curr = parseDate(currentDate)
+  if (!curr) return null
+  const prev = prevDate ? parseDate(prevDate) : null
+  const today = todayMidnight()
+  if (today.getTime() >= curr.getTime()) return 100
+  if (!prev) return null
+  const total = curr.getTime() - prev.getTime()
+  if (total <= 0) return 100
+  const elapsed = today.getTime() - prev.getTime()
+  if (elapsed <= 0) return 0
+  return Math.min(100, Math.round((elapsed / total) * 100))
+}

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -47,54 +47,88 @@
     </div>
 
     <template v-else>
-      <!-- Next milestone banner -->
-      <div
-        v-if="globalNextMilestone"
-        class="mb-5 rounded-lg border px-4 py-3 flex items-center justify-between"
-        :class="globalNextMilestone.days <= 7
-          ? 'border-blue-200 dark:border-blue-700/50 bg-blue-50/80 dark:bg-blue-900/20'
-          : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50'"
-      >
-        <div class="flex items-center gap-3">
-          <span
-            class="inline-flex h-2.5 w-2.5 rounded-full shrink-0"
-            :class="globalNextMilestone.days <= 7
-              ? 'bg-blue-500 animate-pulse'
-              : 'bg-gray-400 dark:bg-gray-500'"
-          ></span>
-          <span class="text-sm text-gray-900 dark:text-gray-100">
-            <span class="font-medium">{{ globalNextMilestone.releaseName }}</span>
-            <span class="text-gray-500 dark:text-gray-400"> · {{ globalNextMilestone.label }}</span>
-          </span>
-        </div>
-        <span
-          class="text-sm font-semibold tabular-nums"
-          :class="globalNextMilestone.days <= 7
-            ? 'text-blue-600 dark:text-blue-400'
-            : 'text-gray-600 dark:text-gray-300'"
+      <!-- Countdown cards -->
+      <div v-if="upcomingMilestoneCards.length" class="flex gap-4 mb-6 flex-wrap">
+        <div
+          v-for="card in upcomingMilestoneCards"
+          :key="card.releaseName + '-' + card.type"
+          class="flex-1 min-w-[140px] bg-white dark:bg-gray-800 border rounded-lg text-center py-5 px-4 transition-all hover:shadow-md"
+          :class="card.days <= 7
+            ? 'border-blue-300 dark:border-blue-600'
+            : 'border-gray-200 dark:border-gray-700'"
         >
-          {{ globalNextMilestone.days === 0 ? 'Today' : globalNextMilestone.days + 'd' }}
-        </span>
+          <div
+            class="text-[42px] font-bold leading-none tabular-nums"
+            :class="card.days <= 7
+              ? 'text-blue-600 dark:text-blue-400'
+              : 'text-gray-900 dark:text-gray-100'"
+          >
+            {{ card.days === 0 ? 'Today' : card.days }}
+          </div>
+          <div
+            v-if="card.days !== 0"
+            class="text-[11px] font-medium uppercase tracking-wider mt-1"
+            :class="card.days <= 7
+              ? 'text-blue-400 dark:text-blue-500'
+              : 'text-gray-400 dark:text-gray-500'"
+          >days</div>
+          <div class="text-[13px] font-semibold text-gray-700 dark:text-gray-300 mt-2">
+            {{ card.releaseName }}
+          </div>
+          <div class="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+            {{ card.label }} · {{ formatShort(card.date) }}
+          </div>
+          <div v-if="card.days <= 7" class="flex justify-center mt-2">
+            <span class="inline-flex h-2 w-2 rounded-full bg-blue-500 animate-pulse"></span>
+          </div>
+        </div>
       </div>
 
-      <!-- Product filter -->
+      <!-- Product filter (multi-product) -->
       <div v-if="products.length > 1" class="flex flex-wrap gap-2 mb-5">
         <button
           @click="selectedProduct = null"
-          class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+          class="px-3 py-1 rounded-full text-xs font-medium transition-colors border"
           :class="!selectedProduct
-            ? 'bg-primary-600 text-white border-primary-600'
-            : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+            ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
         >All</button>
         <button
           v-for="p in products"
           :key="p"
           @click="selectedProduct = p"
-          class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+          class="px-3 py-1 rounded-full text-xs font-medium transition-colors border"
           :class="selectedProduct === p
-            ? 'bg-primary-600 text-white border-primary-600'
-            : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+            ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+            : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
         >{{ p }}</button>
+      </div>
+
+      <!-- Stream filter + hide released toggle (single-product) -->
+      <div v-if="products.length <= 1" class="flex items-center justify-between mb-5">
+        <div v-if="streams.length > 1" class="flex flex-wrap gap-2">
+          <button
+            @click="selectedStream = null"
+            class="px-3 py-1 rounded-full text-xs font-medium transition-colors border"
+            :class="!selectedStream
+              ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+          >All</button>
+          <button
+            v-for="s in streams"
+            :key="s"
+            @click="selectedStream = s"
+            class="px-3 py-1 rounded-full text-xs font-medium transition-colors border"
+            :class="selectedStream === s
+              ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 border-gray-900 dark:border-gray-100'
+              : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'"
+          >{{ s }}</button>
+        </div>
+        <div v-else></div>
+        <label class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+          <input type="checkbox" v-model="hideReleased" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500" />
+          Hide released
+        </label>
       </div>
 
       <!-- Releases table -->
@@ -104,6 +138,7 @@
             <thead>
               <tr class="border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/50">
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release</th>
+                <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Phase</th>
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Plan Freeze</th>
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Feature Freeze</th>
                 <th class="px-4 py-2.5 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Code Freeze</th>
@@ -111,28 +146,37 @@
               </tr>
             </thead>
             <tbody>
-              <tr
-                v-for="r in allSortedReleases"
-                :key="r.id"
-                class="border-b border-gray-100 dark:border-gray-800 last:border-0 transition-colors"
-                :class="isReleased(r) ? 'opacity-50' : nextMilestoneUrgencyRow(r)"
-              >
-                <td class="px-4 py-3">
-                  <span class="font-semibold text-gray-900 dark:text-gray-100">{{ r.displayName || r.id }}</span>
-                </td>
-                <td class="px-4 py-3">
-                  <MilestoneCell :date="r.milestones?.planningFreeze" :muted="isReleased(r)" />
-                </td>
-                <td class="px-4 py-3">
-                  <MilestoneCell :date="r.milestones?.featureFreeze" :muted="isReleased(r)" />
-                </td>
-                <td class="px-4 py-3">
-                  <MilestoneCell :date="r.milestones?.codeFreeze" :muted="isReleased(r)" />
-                </td>
-                <td class="px-4 py-3">
-                  <MilestoneCell :date="r.milestones?.ga" :muted="isReleased(r)" />
-                </td>
-              </tr>
+              <template v-for="row in groupedRows" :key="row.key">
+                <tr v-if="row.type === 'header'" class="bg-gray-50/60 dark:bg-gray-800/30">
+                  <td colspan="6" class="px-4 py-1.5 text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+                    RHAI {{ row.stream }}
+                  </td>
+                </tr>
+                <tr
+                  v-else
+                  class="border-b border-gray-100 dark:border-gray-800 last:border-0 transition-colors"
+                  :class="isReleased(row.release) ? 'opacity-50' : nextMilestoneUrgencyRow(row.release)"
+                >
+                  <td class="px-4 py-3">
+                    <span class="font-semibold text-gray-900 dark:text-gray-100">{{ row.release.displayName || row.release.id }}</span>
+                  </td>
+                  <td class="px-4 py-3">
+                    <ReleaseStepper :release="row.release" :muted="isReleased(row.release)" />
+                  </td>
+                  <td class="px-4 py-3">
+                    <MilestoneCell :date="row.release.milestones?.planningFreeze" :prev-date="null" :muted="isReleased(row.release)" />
+                  </td>
+                  <td class="px-4 py-3">
+                    <MilestoneCell :date="row.release.milestones?.featureFreeze" :prev-date="row.release.milestones?.planningFreeze" :muted="isReleased(row.release)" />
+                  </td>
+                  <td class="px-4 py-3">
+                    <MilestoneCell :date="row.release.milestones?.codeFreeze" :prev-date="row.release.milestones?.featureFreeze || row.release.milestones?.planningFreeze" :muted="isReleased(row.release)" />
+                  </td>
+                  <td class="px-4 py-3">
+                    <MilestoneCell :date="row.release.milestones?.ga" :prev-date="row.release.milestones?.codeFreeze" :muted="isReleased(row.release)" />
+                  </td>
+                </tr>
+              </template>
             </tbody>
           </table>
         </div>
@@ -151,6 +195,8 @@ const releases = ref([])
 const loading = ref(true)
 const error = ref(null)
 const selectedProduct = ref(null)
+const selectedStream = ref(null)
+const hideReleased = ref(false)
 
 async function fetchRegistry() {
   loading.value = true
@@ -223,6 +269,40 @@ function nextMilestone(release) {
   return null
 }
 
+function releasePhase(release) {
+  const ms = release.milestones || {}
+  const phases = [
+    { label: 'Planning', until: ms.planningFreeze },
+    { label: 'Feature Dev', until: ms.featureFreeze },
+    { label: 'Code Complete', until: ms.codeFreeze },
+    { label: 'Release Prep', until: ms.ga },
+    { label: 'Released', until: null }
+  ]
+  const today = todayMidnight()
+  let phaseIndex = 0
+  for (let i = 0; i < 4; i++) {
+    const d = parseDate(phases[i].until)
+    if (d && d.getTime() <= today.getTime()) {
+      phaseIndex = i + 1
+    }
+  }
+  return { phaseIndex, phases }
+}
+
+function milestoneProgress(currentDate, prevDate) {
+  const curr = parseDate(currentDate)
+  if (!curr) return null
+  const prev = prevDate ? parseDate(prevDate) : null
+  const today = todayMidnight()
+  if (today.getTime() >= curr.getTime()) return 100
+  if (!prev) return null
+  const total = curr.getTime() - prev.getTime()
+  if (total <= 0) return 100
+  const elapsed = today.getTime() - prev.getTime()
+  if (elapsed <= 0) return 0
+  return Math.min(100, Math.round((elapsed / total) * 100))
+}
+
 // ── Computed ──
 
 const products = computed(() => {
@@ -233,9 +313,27 @@ const products = computed(() => {
   return Object.keys(set).sort()
 })
 
+const streams = computed(() => {
+  const set = {}
+  for (let i = 0; i < releases.value.length; i++) {
+    const v = releases.value[i].productPagesVersion
+    if (v) set[v] = true
+  }
+  return Object.keys(set).sort()
+})
+
 const filteredReleases = computed(() => {
-  if (!selectedProduct.value) return releases.value
-  return releases.value.filter(r => getProduct(r) === selectedProduct.value)
+  let list = releases.value
+  if (selectedProduct.value) {
+    list = list.filter(r => getProduct(r) === selectedProduct.value)
+  }
+  if (selectedStream.value) {
+    list = list.filter(r => r.productPagesVersion === selectedStream.value)
+  }
+  if (hideReleased.value) {
+    list = list.filter(r => !isReleased(r))
+  }
+  return list
 })
 
 const allSortedReleases = computed(() => {
@@ -249,16 +347,49 @@ const allSortedReleases = computed(() => {
   })
 })
 
-const globalNextMilestone = computed(() => {
-  let best = null
+const groupedRows = computed(() => {
+  const rows = []
+  let lastStream = null
   for (let i = 0; i < allSortedReleases.value.length; i++) {
     const r = allSortedReleases.value[i]
-    const nm = nextMilestone(r)
-    if (nm && (best === null || nm.days < best.days)) {
-      best = { releaseName: r.displayName || r.id, label: nm.label, type: nm.type, days: nm.days }
+    const stream = r.productPagesVersion || ''
+    if (stream !== lastStream && !selectedStream.value) {
+      rows.push({ type: 'header', stream, key: 'h-' + stream })
+      lastStream = stream
+    }
+    rows.push({ type: 'release', release: r, key: r.id })
+  }
+  return rows
+})
+
+const MILESTONE_TYPES = [
+  { key: 'planningFreeze', label: 'Plan Freeze' },
+  { key: 'featureFreeze', label: 'Feature Freeze' },
+  { key: 'codeFreeze', label: 'Code Freeze' },
+  { key: 'ga', label: 'Release Date' }
+]
+
+const upcomingMilestoneCards = computed(() => {
+  const candidates = []
+  for (let i = 0; i < allSortedReleases.value.length; i++) {
+    const r = allSortedReleases.value[i]
+    const ms = r.milestones || {}
+    for (let j = 0; j < MILESTONE_TYPES.length; j++) {
+      const mt = MILESTONE_TYPES[j]
+      const days = daysFromNow(ms[mt.key])
+      if (days !== null && days >= 0) {
+        candidates.push({
+          releaseName: r.displayName || r.id,
+          label: mt.label,
+          type: mt.key,
+          date: ms[mt.key],
+          days
+        })
+      }
     }
   }
-  return best
+  candidates.sort((a, b) => a.days - b.days)
+  return candidates.slice(0, 4)
 })
 
 function isReleased(release) {
@@ -277,9 +408,49 @@ function nextMilestoneUrgencyRow(release) {
 
 // ── Inline sub-components ──
 
+const ReleaseStepper = {
+  props: {
+    release: { type: Object, required: true },
+    muted: { type: Boolean, default: false }
+  },
+  setup(props) {
+    return () => {
+      const { phaseIndex, phases } = releasePhase(props.release)
+      const nodes = []
+
+      for (let i = 0; i < phases.length; i++) {
+        if (i > 0) {
+          const lineClass = props.muted
+            ? 'bg-gray-200 dark:bg-gray-700'
+            : i <= phaseIndex
+              ? 'bg-green-400 dark:bg-green-500'
+              : 'bg-gray-200 dark:bg-gray-700'
+          nodes.push(h('div', { class: 'flex-1 h-0.5 ' + lineClass }))
+        }
+
+        let dotClass = 'w-2.5 h-2.5 rounded-full shrink-0 '
+        if (props.muted) {
+          dotClass += 'bg-gray-300 dark:bg-gray-600'
+        } else if (i < phaseIndex) {
+          dotClass += 'bg-green-500 dark:bg-green-400'
+        } else if (i === phaseIndex) {
+          dotClass += 'bg-blue-500 dark:bg-blue-400 ring-2 ring-blue-200 dark:ring-blue-800'
+        } else {
+          dotClass += 'bg-gray-200 dark:bg-gray-600 border border-gray-300 dark:border-gray-500'
+        }
+
+        nodes.push(h('div', { class: dotClass, title: phases[i].label }))
+      }
+
+      return h('div', { class: 'flex items-center gap-0 min-w-[120px]' }, nodes)
+    }
+  }
+}
+
 const MilestoneCell = {
   props: {
     date: { type: String, default: null },
+    prevDate: { type: String, default: null },
     muted: { type: Boolean, default: false }
   },
   setup(props) {
@@ -290,9 +461,16 @@ const MilestoneCell = {
       const days = daysFromNow(props.date)
       const dateLabel = formatShort(props.date)
 
-      const dateClass = props.muted
-        ? 'text-gray-500 dark:text-gray-400'
-        : 'text-gray-900 dark:text-gray-100'
+      let dateClass
+      if (props.muted) {
+        dateClass = 'text-gray-400 dark:text-gray-500'
+      } else if (days !== null && days < 0) {
+        dateClass = 'text-gray-500 dark:text-gray-400'
+      } else if (days !== null && days <= 7) {
+        dateClass = 'text-blue-700 dark:text-blue-300 font-semibold'
+      } else {
+        dateClass = 'text-gray-900 dark:text-gray-100'
+      }
 
       let countdownEl = null
       if (days !== null) {
@@ -317,9 +495,29 @@ const MilestoneCell = {
         countdownEl = h('span', { class: countdownClass }, countdownText)
       }
 
+      let progressEl = null
+      if (!props.muted && days !== null && days > 0 && props.prevDate) {
+        const pct = milestoneProgress(props.date, props.prevDate)
+        if (pct !== null) {
+          progressEl = h('div', {
+            class: 'h-1 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden mt-1'
+          }, [
+            h('div', {
+              class: 'h-full rounded-full transition-all ' + (
+                days <= 7
+                  ? 'bg-blue-400 dark:bg-blue-500'
+                  : 'bg-gray-400 dark:bg-gray-500'
+              ),
+              style: { width: pct + '%' }
+            })
+          ])
+        }
+      }
+
       return h('div', { class: 'flex flex-col' }, [
         h('span', { class: 'text-sm tabular-nums ' + dateClass }, dateLabel),
-        countdownEl
+        countdownEl,
+        progressEl
       ])
     }
   }

--- a/modules/releases/client/views/ScheduleView.vue
+++ b/modules/releases/client/views/ScheduleView.vue
@@ -188,6 +188,14 @@
 <script setup>
 import { ref, computed, onMounted, h } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
+import {
+  parseDate, daysFromNow, formatShort as formatShortBase,
+  getProduct, releasePhase, milestoneProgress
+} from '../composables/useScheduleHelpers.js'
+
+function formatShort(dateStr) {
+  return formatShortBase(dateStr, { year: true })
+}
 
 // ── Data ──
 
@@ -216,38 +224,6 @@ onMounted(fetchRegistry)
 
 // ── Helpers ──
 
-function parseDate(val) {
-  if (!val) return null
-  const d = new Date(val)
-  return isNaN(d.getTime()) ? null : d
-}
-
-function todayMidnight() {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return d
-}
-
-function daysFromNow(dateStr) {
-  const d = parseDate(dateStr)
-  if (!d) return null
-  const today = todayMidnight()
-  d.setHours(0, 0, 0, 0)
-  return Math.ceil((d.getTime() - today.getTime()) / 86400000)
-}
-
-function formatShort(dateStr) {
-  const d = parseDate(dateStr)
-  if (!d) return '—'
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
-
-function getProduct(release) {
-  if (release.productPagesShortname) return release.productPagesShortname
-  const match = release.id.match(/^([a-z]+)-/)
-  return match ? match[1] : release.id
-}
-
 function getGaDate(release) {
   return release.milestones?.ga || null
 }
@@ -267,40 +243,6 @@ function nextMilestone(release) {
     }
   }
   return null
-}
-
-function releasePhase(release) {
-  const ms = release.milestones || {}
-  const phases = [
-    { label: 'Planning', until: ms.planningFreeze },
-    { label: 'Feature Dev', until: ms.featureFreeze },
-    { label: 'Code Complete', until: ms.codeFreeze },
-    { label: 'Release Prep', until: ms.ga },
-    { label: 'Released', until: null }
-  ]
-  const today = todayMidnight()
-  let phaseIndex = 0
-  for (let i = 0; i < 4; i++) {
-    const d = parseDate(phases[i].until)
-    if (d && d.getTime() <= today.getTime()) {
-      phaseIndex = i + 1
-    }
-  }
-  return { phaseIndex, phases }
-}
-
-function milestoneProgress(currentDate, prevDate) {
-  const curr = parseDate(currentDate)
-  if (!curr) return null
-  const prev = prevDate ? parseDate(prevDate) : null
-  const today = todayMidnight()
-  if (today.getTime() >= curr.getTime()) return 100
-  if (!prev) return null
-  const total = curr.getTime() - prev.getTime()
-  if (total <= 0) return 100
-  const elapsed = today.getTime() - prev.getTime()
-  if (elapsed <= 0) return 0
-  return Math.min(100, Math.round((elapsed / total) * 100))
 }
 
 // ── Computed ──

--- a/modules/releases/client/widgets/ScheduleWidget.vue
+++ b/modules/releases/client/widgets/ScheduleWidget.vue
@@ -29,6 +29,8 @@ async function fetchRegistry() {
 
 onMounted(fetchRegistry)
 
+// ── Helpers ──
+
 function parseDate(val) {
   if (!val) return null
   const d = new Date(val)
@@ -61,6 +63,28 @@ function getProduct(release) {
   return match ? match[1] : release.id
 }
 
+function releasePhase(release) {
+  const ms = release.milestones || {}
+  const phases = [
+    { label: 'Planning', until: ms.planningFreeze },
+    { label: 'Feature Dev', until: ms.featureFreeze },
+    { label: 'Code Complete', until: ms.codeFreeze },
+    { label: 'Release Prep', until: ms.ga },
+    { label: 'Released', until: null }
+  ]
+  const today = todayMidnight()
+  let phaseIndex = 0
+  for (let i = 0; i < 4; i++) {
+    const d = parseDate(phases[i].until)
+    if (d && d.getTime() <= today.getTime()) {
+      phaseIndex = i + 1
+    }
+  }
+  return { phaseIndex, phases }
+}
+
+// ── Computed ──
+
 const products = computed(() => {
   const set = {}
   for (const r of releases.value) {
@@ -89,7 +113,8 @@ const upcomingMilestones = computed(() => {
       const days = daysFromNow(ms[mt.key])
       if (days !== null && days >= 0) {
         items.push({
-          id: `${r.id}-${mt.key}`,
+          id: r.id + '-' + mt.key,
+          releaseId: r.id,
           release: r.displayName || r.id,
           label: mt.label,
           date: ms[mt.key],
@@ -99,29 +124,27 @@ const upcomingMilestones = computed(() => {
     }
   }
   items.sort((a, b) => a.days - b.days)
-  return items.slice(0, 6)
+  return items.slice(0, 5)
 })
 
-function daysClass(days) {
-  if (days === 0) return 'text-blue-600 dark:text-blue-400 font-semibold'
-  if (days <= 7) return 'text-blue-600 dark:text-blue-400 font-medium'
-  if (days <= 14) return 'text-blue-500 dark:text-blue-400'
-  return 'text-gray-500 dark:text-gray-400'
-}
+const heroMilestone = computed(() => upcomingMilestones.value[0] || null)
 
-function daysLabel(days) {
-  if (days === 0) return 'Today'
-  return days + 'd'
-}
+const heroRelease = computed(() => {
+  if (!heroMilestone.value) return null
+  return filteredReleases.value.find(r => r.id === heroMilestone.value.releaseId) || null
+})
 
-function rowHighlight(days) {
-  if (days <= 7) return 'bg-blue-50/50 dark:bg-blue-900/10'
-  return ''
-}
+const heroPhase = computed(() => {
+  if (!heroRelease.value) return null
+  return releasePhase(heroRelease.value)
+})
+
+const remainingMilestones = computed(() => upcomingMilestones.value.slice(1))
 </script>
 
 <template>
   <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+    <!-- Header -->
     <div class="flex items-center justify-between mb-4">
       <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">Release Schedule</h3>
       <button
@@ -143,7 +166,8 @@ function rowHighlight(days) {
 
     <!-- Loading -->
     <div v-if="loading" class="space-y-3">
-      <div v-for="i in 4" :key="i" class="h-10 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+      <div class="h-20 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+      <div v-for="i in 3" :key="i" class="h-10 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
     </div>
 
     <!-- Error -->
@@ -153,26 +177,90 @@ function rowHighlight(days) {
     </div>
 
     <!-- Empty -->
-    <div v-else-if="!upcomingMilestones.length" class="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
+    <div v-else-if="!heroMilestone" class="text-sm text-gray-500 dark:text-gray-400 py-4 text-center">
       No upcoming milestones
     </div>
 
-    <!-- Milestone list -->
-    <div v-else class="divide-y divide-gray-100 dark:divide-gray-700/50 -mx-5">
+    <!-- Content -->
+    <template v-else>
+      <!-- Hero card -->
       <div
-        v-for="m in upcomingMilestones"
-        :key="m.id"
-        class="flex items-center justify-between px-5 py-2.5"
-        :class="rowHighlight(m.days)"
+        class="rounded-lg border px-4 py-3.5 mb-4"
+        :class="heroMilestone.days <= 7
+          ? 'border-blue-200 dark:border-blue-700 bg-blue-50/50 dark:bg-blue-900/20'
+          : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50'"
       >
-        <div class="min-w-0 flex-1">
-          <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ m.release }}</div>
-          <div class="text-xs text-gray-500 dark:text-gray-400">{{ m.label }} · {{ formatShort(m.date) }}</div>
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0 flex-1">
+            <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ heroMilestone.release }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {{ heroMilestone.label }} · {{ formatShort(heroMilestone.date) }}
+            </div>
+            <!-- Mini stepper -->
+            <div v-if="heroPhase" class="flex items-center gap-0 mt-2.5">
+              <template v-for="(phase, i) in heroPhase.phases" :key="i">
+                <div
+                  v-if="i > 0"
+                  class="h-px flex-1"
+                  :class="i <= heroPhase.phaseIndex
+                    ? 'bg-green-400 dark:bg-green-500'
+                    : 'bg-gray-200 dark:bg-gray-700'"
+                />
+                <div
+                  class="shrink-0 rounded-full"
+                  :class="[
+                    i < heroPhase.phaseIndex
+                      ? 'w-1.5 h-1.5 bg-green-500 dark:bg-green-400'
+                      : i === heroPhase.phaseIndex
+                        ? 'w-2 h-2 bg-blue-500 dark:bg-blue-400 ring-2 ring-blue-200 dark:ring-blue-800'
+                        : 'w-1.5 h-1.5 bg-gray-300 dark:bg-gray-600'
+                  ]"
+                  :title="phase.label"
+                />
+              </template>
+            </div>
+          </div>
+          <div class="text-right shrink-0">
+            <div
+              class="text-3xl font-bold leading-none tabular-nums"
+              :class="heroMilestone.days <= 7
+                ? 'text-blue-600 dark:text-blue-400'
+                : 'text-gray-900 dark:text-gray-100'"
+            >{{ heroMilestone.days === 0 ? 'Today' : heroMilestone.days }}</div>
+            <div
+              v-if="heroMilestone.days !== 0"
+              class="text-[10px] font-medium uppercase tracking-wider mt-0.5"
+              :class="heroMilestone.days <= 7
+                ? 'text-blue-400 dark:text-blue-500'
+                : 'text-gray-400 dark:text-gray-500'"
+            >days</div>
+            <div v-if="heroMilestone.days <= 7" class="flex justify-end mt-1.5">
+              <span class="inline-flex h-1.5 w-1.5 rounded-full bg-blue-500 animate-pulse" />
+            </div>
+          </div>
         </div>
-        <span class="text-sm tabular-nums ml-3 shrink-0" :class="daysClass(m.days)">
-          {{ daysLabel(m.days) }}
-        </span>
       </div>
-    </div>
+
+      <!-- Remaining milestones -->
+      <div v-if="remainingMilestones.length" class="divide-y divide-gray-100 dark:divide-gray-700/50 -mx-5">
+        <div
+          v-for="m in remainingMilestones"
+          :key="m.id"
+          class="flex items-center justify-between px-5 py-2.5"
+          :class="m.days <= 7 ? 'bg-blue-50/50 dark:bg-blue-900/10' : ''"
+        >
+          <div class="min-w-0 flex-1">
+            <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ m.release }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">{{ m.label }} · {{ formatShort(m.date) }}</div>
+          </div>
+          <span
+            class="text-xs font-medium tabular-nums ml-3 shrink-0 px-2 py-0.5 rounded-full"
+            :class="m.days <= 14
+              ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+              : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'"
+          >{{ m.days === 0 ? 'Today' : m.days + 'd' }}</span>
+        </div>
+      </div>
+    </template>
   </div>
 </template>

--- a/modules/releases/client/widgets/ScheduleWidget.vue
+++ b/modules/releases/client/widgets/ScheduleWidget.vue
@@ -15,8 +15,7 @@ const { navigateTo } = useModuleLink()
 const releases = ref([])
 const loading = ref(true)
 const error = ref(null)
-const selectedProduct = ref('')
-const selectedStream = ref('')
+const selectedFilter = ref('')
 
 async function fetchRegistry() {
   loading.value = true
@@ -35,32 +34,23 @@ onMounted(fetchRegistry)
 
 // ── Computed ──
 
-const products = computed(() => {
-  const set = {}
+const filterOptions = computed(() => {
+  const products = {}
   for (const r of releases.value) {
-    set[getProduct(r)] = true
+    products[getProduct(r)] = true
   }
-  return Object.keys(set).sort()
-})
-
-const streams = computed(() => {
-  const set = {}
-  for (const r of releases.value) {
-    const v = r.productPagesVersion
-    if (v) set[v] = true
-  }
-  return Object.keys(set).sort()
+  const keys = Object.keys(products).sort()
+  if (keys.length <= 1) return []
+  return keys.map(p => ({ value: 'product:' + p, label: p.toUpperCase() }))
 })
 
 const filteredReleases = computed(() => {
-  let list = releases.value
-  if (selectedProduct.value) {
-    list = list.filter(r => getProduct(r) === selectedProduct.value)
+  if (!selectedFilter.value) return releases.value
+  const [type, val] = selectedFilter.value.split(':')
+  if (type === 'product') {
+    return releases.value.filter(r => getProduct(r) === val)
   }
-  if (selectedStream.value) {
-    list = list.filter(r => r.productPagesVersion === selectedStream.value)
-  }
-  return list
+  return releases.value
 })
 
 const milestoneTypes = [
@@ -119,22 +109,13 @@ const remainingMilestones = computed(() => upcomingMilestones.value.slice(1))
     </div>
 
     <!-- Release filter -->
-    <div v-if="!loading && !error && (streams.length > 1 || products.length > 1)" class="flex gap-2 mb-3">
+    <div v-if="!loading && !error && filterOptions.length > 0" class="mb-3">
       <select
-        v-if="products.length > 1"
-        v-model="selectedProduct"
-        class="flex-1 text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
+        v-model="selectedFilter"
+        class="w-full text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
       >
-        <option value="">All products</option>
-        <option v-for="p in products" :key="p" :value="p">{{ p }}</option>
-      </select>
-      <select
-        v-if="streams.length > 1"
-        v-model="selectedStream"
-        class="flex-1 text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
-      >
-        <option value="">All releases</option>
-        <option v-for="s in streams" :key="s" :value="s">RHAI {{ s }}</option>
+        <option value="">All</option>
+        <option v-for="opt in filterOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
       </select>
     </div>
 

--- a/modules/releases/client/widgets/ScheduleWidget.vue
+++ b/modules/releases/client/widgets/ScheduleWidget.vue
@@ -13,6 +13,7 @@ const releases = ref([])
 const loading = ref(true)
 const error = ref(null)
 const selectedProduct = ref('')
+const selectedStream = ref('')
 
 async function fetchRegistry() {
   loading.value = true
@@ -93,9 +94,24 @@ const products = computed(() => {
   return Object.keys(set).sort()
 })
 
+const streams = computed(() => {
+  const set = {}
+  for (const r of releases.value) {
+    const v = r.productPagesVersion
+    if (v) set[v] = true
+  }
+  return Object.keys(set).sort()
+})
+
 const filteredReleases = computed(() => {
-  if (!selectedProduct.value) return releases.value
-  return releases.value.filter(r => getProduct(r) === selectedProduct.value)
+  let list = releases.value
+  if (selectedProduct.value) {
+    list = list.filter(r => getProduct(r) === selectedProduct.value)
+  }
+  if (selectedStream.value) {
+    list = list.filter(r => r.productPagesVersion === selectedStream.value)
+  }
+  return list
 })
 
 const milestoneTypes = [
@@ -153,14 +169,23 @@ const remainingMilestones = computed(() => upcomingMilestones.value.slice(1))
       >View all</button>
     </div>
 
-    <!-- Product filter -->
-    <div v-if="!loading && !error && products.length > 1" class="mb-3">
+    <!-- Release filter -->
+    <div v-if="!loading && !error && (streams.length > 1 || products.length > 1)" class="flex gap-2 mb-3">
       <select
+        v-if="products.length > 1"
         v-model="selectedProduct"
-        class="w-full text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
+        class="flex-1 text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
       >
         <option value="">All products</option>
         <option v-for="p in products" :key="p" :value="p">{{ p }}</option>
+      </select>
+      <select
+        v-if="streams.length > 1"
+        v-model="selectedStream"
+        class="flex-1 text-xs rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary-500"
+      >
+        <option value="">All releases</option>
+        <option v-for="s in streams" :key="s" :value="s">RHAI {{ s }}</option>
       </select>
     </div>
 

--- a/modules/releases/client/widgets/ScheduleWidget.vue
+++ b/modules/releases/client/widgets/ScheduleWidget.vue
@@ -2,6 +2,9 @@
 import { ref, computed, onMounted } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
 import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
+import {
+  daysFromNow, formatShort, getProduct, releasePhase
+} from '../composables/useScheduleHelpers.js'
 
 defineProps({
   size: { type: String, default: 'half' }
@@ -29,60 +32,6 @@ async function fetchRegistry() {
 }
 
 onMounted(fetchRegistry)
-
-// ── Helpers ──
-
-function parseDate(val) {
-  if (!val) return null
-  const d = new Date(val)
-  return isNaN(d.getTime()) ? null : d
-}
-
-function todayMidnight() {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return d
-}
-
-function daysFromNow(dateStr) {
-  const d = parseDate(dateStr)
-  if (!d) return null
-  const today = todayMidnight()
-  d.setHours(0, 0, 0, 0)
-  return Math.ceil((d.getTime() - today.getTime()) / 86400000)
-}
-
-function formatShort(dateStr) {
-  const d = parseDate(dateStr)
-  if (!d) return '—'
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-}
-
-function getProduct(release) {
-  if (release.productPagesShortname) return release.productPagesShortname
-  const match = release.id.match(/^([a-z]+)-/i)
-  return match ? match[1] : release.id
-}
-
-function releasePhase(release) {
-  const ms = release.milestones || {}
-  const phases = [
-    { label: 'Planning', until: ms.planningFreeze },
-    { label: 'Feature Dev', until: ms.featureFreeze },
-    { label: 'Code Complete', until: ms.codeFreeze },
-    { label: 'Release Prep', until: ms.ga },
-    { label: 'Released', until: null }
-  ]
-  const today = todayMidnight()
-  let phaseIndex = 0
-  for (let i = 0; i < 4; i++) {
-    const d = parseDate(phases[i].until)
-    if (d && d.getTime() <= today.getTime()) {
-      phaseIndex = i + 1
-    }
-  }
-  return { phaseIndex, phases }
-}
 
 // ── Computed ──
 

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -23,6 +23,7 @@ export const viewOwners = {
   'ai-impact/autofix':                             'Alex Corvin',
   'ai-impact/build-release':                       'Deepak Chourasia',
   'ai-impact/documentation':                       'tarilabs',
+  'ai-impact/feature-decomposer':                  'Eder Ignatowicz',
   'ai-impact/feature-review':                      'Alex Corvin',
   'ai-impact/implementation':                      'Alex Corvin',
   'ai-impact/rfe-review':                          'Alex Corvin',
@@ -74,17 +75,7 @@ export const viewOwners = {
   'system-health/quality-analysis':                'Dana Gutride',
 
   // team-tracker
-  'team-tracker/home':                             'Dipanshu Gupta',
   'team-tracker/jira-taxonomy':                    'Alex Corvin',
-  'team-tracker/manage':                           'Alex Corvin',
-  'team-tracker/manager-dashboard':                'Alex Corvin',
-  'team-tracker/org-dashboard':                    'Alex Corvin',
-  'team-tracker/org-explorer':                     'Dipanshu Gupta',
-  'team-tracker/people':                           'Dipanshu Gupta',
-  'team-tracker/person-detail':                    'Dipanshu Gupta',
-  'team-tracker/reports':                          'Alex Corvin',
-  'team-tracker/team-detail':                      'Alex Corvin',
-  'team-tracker/unassigned':                       'Alex Corvin',
 
   // upstream-pulse
   'upstream-pulse/dashboard':                      'Dipanshu Gupta',
@@ -112,12 +103,6 @@ export const viewOwners = {
   // system-health > component-maturity
   'system-health/component-maturity/disconnected': 'Ajay Jaganathan',
 
-  // team-tracker > manage
-  'team-tracker/manage/data-quality':              'Alex Corvin',
-  'team-tracker/manage/field-options':             'Alex Corvin',
-  'team-tracker/manage/fields':                    'Alex Corvin',
-  'team-tracker/manage/teams':                     'Alex Corvin',
-
   // ── Report owners (module/view/reportId) ──
   // These override the view-level owner when a specific report is selected.
 
@@ -127,11 +112,6 @@ export const viewOwners = {
   'releases/reports/program-hygiene':              'Alex Corvin',
   'releases/reports/release-readiness':            'Arthy Loganathan',
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
-
-  // team-tracker > reports
-  'team-tracker/reports/allocation':               'Alex Corvin',
-  'team-tracker/reports/team-comparison':          'Alex Corvin',
-  'team-tracker/reports/trends':                   'Alex Corvin',
 }
 
 /**


### PR DESCRIPTION
## Summary

Overhaul the Release Schedule page and dashboard widget with richer visualizations sourced from real Product Pages milestones.

- **Schedule View**: countdown cards, phase stepper column, micro-progress bars, stream filters, group headers, hide-released toggle
- **Schedule Widget**: hero card redesign with mini stepper + compact milestone list
- **Fixture**: replace fictional data with real RHAI 3.5/3.6 EA1/EA2/GA milestones from Product Pages

## Schedule View Changes

### Countdown Cards
Large day-count cards for the 4 nearest upcoming milestones. Urgent milestones (≤7 days) get a blue accent border and pulsing indicator dot. The number is displayed prominently with a small "DAYS" label underneath.

<img width="925" height="276" alt="image" src="https://github.com/user-attachments/assets/c426e731-11a1-46ab-866d-a123eb3571db" />

### Phase Stepper Column
New "Phase" column with a 5-dot horizontal stepper per release showing progress through: Planning → Feature Dev → Code Complete → Release Prep → Released. Green filled dots for completed phases, blue ring for current, gray for future.

<img width="379" height="240" alt="image" src="https://github.com/user-attachments/assets/891346b9-7ce0-4f64-b9a9-d307bab90ddc" />

### Release Stream Filters + Group Headers
Since all releases are now consolidated under a single RHAI product in Product Pages, the product filter is replaced with stream filter pills (3.5 / 3.6 / All). The table also includes thin group header rows separating release streams.

A "Hide released" checkbox filters out past releases to focus on upcoming milestones.

<img width="851" height="226" alt="image" src="https://github.com/user-attachments/assets/f4cf4f1d-0f9c-4dde-a322-d3c85174153c" />


### Micro-Progress Bars
Thin progress bars under each milestone date cell showing elapsed time between consecutive milestones. When `featureFreeze` is null (EA phases), the code freeze progress bar falls back to measuring from `planningFreeze`.

<img width="281" height="202" alt="image" src="https://github.com/user-attachments/assets/0994ba8b-56f0-4286-9a2f-613136db12de" />

## Schedule Widget Changes

### Hero Card + Compact List
The dashboard widget is redesigned from a flat list into a hero card (nearest milestone) + compact list (next 4).

The hero card shows:
- Large countdown number with "DAYS" label (or "Today")
- Release name and milestone type + date
- Mini 5-dot phase stepper
- Blue accent styling + pulse dot for urgent items (≤7 days)

The remaining milestones appear as compact rows with pill-shaped countdown badges.

<img width="578" height="389" alt="image" src="https://github.com/user-attachments/assets/0b6ac758-6e67-42a0-90f3-93894ce5d8ac" />

## Data Model

All three products (RHOAI, RHEL AI, RHAIIS) are consolidated under **Red Hat AI** in Product Pages. Each major release (3.5, 3.6) has three sub-phases (EA1, EA2, GA), each represented as a separate registry entry.

| Registry Milestone | Product Pages Source |
|--------------------|---------------------|
| `planningFreeze` | AIPCC Planning Freeze |
| `featureFreeze` | RHOAI Feature Freeze (GA only; null for EA) |
| `codeFreeze` | AIPCC Code Freeze |
| `ga` | RHOAI Release date |

Fixture updated with 6 real releases: RHAI 3.5 EA1/EA2/GA + RHAI 3.6 EA1/EA2/GA.

## Files Changed

| File | Change |
|------|--------|
| `modules/releases/client/views/ScheduleView.vue` | Countdown cards, phase stepper, progress bars, stream filters, group headers, hide-released toggle |
| `modules/releases/client/widgets/ScheduleWidget.vue` | Hero card + compact list redesign with mini stepper |
| `fixtures/releases/registry.json` | Real Product Pages milestones (RHAI 3.5/3.6 EA1/EA2/GA) |

## Test Plan

- [ ] Navigate to `/#/releases/schedule` — verify countdown cards, phase steppers, progress bars, stream filter pills, group headers
- [ ] Check "Hide released" toggle filters out past releases
- [ ] Click stream filter pills (3.5 / 3.6 / All) and verify table filtering
- [ ] Verify urgent milestones (≤7 days) show blue accent + pulse dot in cards
- [ ] Navigate to `/#/` home — add Release Schedule widget via picker if not present
- [ ] Verify widget hero card shows nearest milestone with stepper and countdown
- [ ] Toggle dark mode — verify all elements render correctly
- [ ] Responsive: verify cards wrap on narrow screens, table scrolls horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)