### PR TITLE
fix(product-builds): update nightly defaults for fondue monorepo

### DIFF
--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -42,12 +42,12 @@
       },
       {
         "key": "NIGHTLY_PIPELINE_GITLAB_PROJECT",
-        "description": "URL-encoded GitLab project path (defaults to redhat%2Frhel-ai%2Frhai%2Fpipeline)",
+        "description": "URL-encoded GitLab project path (defaults to redhat%2Frhel-ai%2Fwheels%2Ffondue)",
         "required": false
       },
       {
         "key": "NIGHTLY_PIPELINE_SCHEDULE_ID",
-        "description": "GitLab pipeline schedule ID (defaults to 4256496)",
+        "description": "GitLab pipeline schedule ID (defaults to 4358047)",
         "required": false
       },
       {

--- a/modules/product-builds/server/nightly-pipeline.js
+++ b/modules/product-builds/server/nightly-pipeline.js
@@ -15,8 +15,8 @@ let _supportedVariantsCacheTime = 0;
 
 const DEFAULTS = {
   gitlabBaseUrl: 'https://gitlab.com',
-  gitlabProject: 'redhat%2Frhel-ai%2Frhai%2Fpipeline',
-  scheduleId: '4256496',
+  gitlabProject: 'redhat%2Frhel-ai%2Fwheels%2Ffondue',
+  scheduleId: '4358047',
   rcaProject: 'redhat%2Frhel-ai%2Fagentic-ci%2Fpipeline-failure-analyzer',
 };
 


### PR DESCRIPTION
## Summary
- Update default GitLab project path from `rhai/pipeline` to `wheels/fondue` for nightly pipeline queries
- Update default schedule ID to fondue's nightly schedule (`4358047`)
- Part of the AIPCC-13307 fondue monorepo migration — `rhai/pipeline` nightly schedules have moved to the consolidated repo

## Test plan
- [x] Verified fondue schedule is accessible via GitLab API
- [x] Verified Nightly Analysis tab loads data from fondue on local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)