### PR TITLE
feat(releases): milestone multi-product select, EA1→GA order, TV/FV prominence

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/mergeReleaseDetails.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/mergeReleaseDetails.test.js
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for merging multi-product release detail buckets.
+ */
+import { describe, it, expect } from 'vitest'
+import { mergeReleaseDetails } from '../../../client/composables/mergeReleaseDetails'
+
+describe('mergeReleaseDetails', function () {
+  it('returns null when no names or missing map', function () {
+    expect(mergeReleaseDetails(null, ['a'])).toBeNull()
+    expect(mergeReleaseDetails({}, [])).toBeNull()
+    expect(mergeReleaseDetails({ a: { aligned: [] } }, ['missing'])).toBeNull()
+  })
+
+  it('merges categories across products and dedupes by key', function () {
+    var releases = {
+      '3.6 EA1 RHOAI RELEASE': {
+        aligned: [{ key: 'RHAISTRAT-1', summary: 'A' }],
+        tv_only: [{ key: 'RHAISTRAT-2', summary: 'B' }],
+        fv_only: [],
+        mismatched: [],
+      },
+      '3.6 EA1 RHAII RELEASE': {
+        aligned: [{ key: 'RHAISTRAT-1', summary: 'A-dup' }, { key: 'RHAISTRAT-3', summary: 'C' }],
+        tv_only: [],
+        fv_only: [{ key: 'RHAISTRAT-4', summary: 'D' }],
+        mismatched: [],
+      },
+    }
+
+    var merged = mergeReleaseDetails(releases, [
+      '3.6 EA1 RHOAI RELEASE',
+      '3.6 EA1 RHAII RELEASE',
+    ])
+
+    expect(merged.aligned.map(function (f) { return f.key })).toEqual(['RHAISTRAT-1', 'RHAISTRAT-3'])
+    expect(merged.tv_only.map(function (f) { return f.key })).toEqual(['RHAISTRAT-2'])
+    expect(merged.fv_only.map(function (f) { return f.key })).toEqual(['RHAISTRAT-4'])
+    expect(merged.mismatched).toEqual([])
+  })
+
+  it('skips names without detail data', function () {
+    var merged = mergeReleaseDetails(
+      { '3.6 EA1 RHOAI RELEASE': { aligned: [{ key: 'X' }], tv_only: [], fv_only: [], mismatched: [] } },
+      ['3.6 EA1 RHOAI RELEASE', '3.6 EA1 RHELAI RELEASE'],
+    )
+    expect(merged.aligned).toHaveLength(1)
+  })
+})

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -175,8 +175,8 @@ describe('TvFvDeltaView release cycle filter', function () {
       return labels.findIndex(function (t) { return t.indexOf(needle) !== -1 })
     }
     expect(indexOf('3.6 Release Cycle')).toBeLessThan(indexOf('3.5 Release Cycle'))
-    expect(indexOf('3.6 GA Release')).toBeLessThan(indexOf('3.6 EA2 Release'))
-    expect(indexOf('3.6 EA2 Release')).toBeLessThan(indexOf('3.6 EA1 Release'))
+    expect(indexOf('3.6 EA1 Release')).toBeLessThan(indexOf('3.6 EA2 Release'))
+    expect(indexOf('3.6 EA2 Release')).toBeLessThan(indexOf('3.6 GA Release'))
     expect(indexOf('3.6 GA RHOAI RELEASE')).toBeLessThan(indexOf('3.6 GA RHELAI RELEASE'))
 
     var selector = wrapper.find('div.mb-6.space-y-4')
@@ -191,8 +191,8 @@ describe('TvFvDeltaView release cycle filter', function () {
     }).map(function (b) {
       return b.text().replace(/×/g, '').replace(/\s+/g, ' ').trim()
     })
-    expect(chips[0]).toBe('3.6 GA RHOAI RELEASE')
-    expect(chips.indexOf('3.6 GA RHOAI RELEASE')).toBeLessThan(chips.indexOf('3.5 GA RHOAI RELEASE'))
+    expect(chips[0]).toBe('3.6 EA1 RHOAI RELEASE')
+    expect(chips.indexOf('3.6 EA1 RHOAI RELEASE')).toBeLessThan(chips.indexOf('3.5 EA1 RHOAI RELEASE'))
   })
 })
 
@@ -270,6 +270,81 @@ describe('TvFvDeltaView target alignment column', function () {
         expect(classes.some(function (c) { return c.includes('red') })).toBe(true)
       }
     }
+  })
+})
+
+describe('TvFvDeltaView milestone vs product selection', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('merges features when selecting a milestone group', async function () {
+    var wrapper = await mountView({
+      releases: {
+        '3.6 GA RHOAI RELEASE': {
+          aligned: [{ key: 'A1', summary: 'rhoai' }],
+          tv_only: [],
+          fv_only: [],
+          mismatched: [],
+        },
+        '3.6 GA RHAII RELEASE': {
+          aligned: [{ key: 'A2', summary: 'rhaii' }],
+          tv_only: [{ key: 'T1', summary: 'tv' }],
+          fv_only: [],
+          mismatched: [],
+        },
+      },
+    })
+
+    var msBtn = wrapper.findAll('button').find(function (b) {
+      return b.text().includes('3.6 GA Release') && b.text().includes('all products')
+    })
+    expect(msBtn).toBeTruthy()
+    await msBtn.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Showing features for')
+    expect(wrapper.text()).toContain('3.6 GA Release')
+    expect(wrapper.text()).toMatch(/all products \(2\)/)
+    expect(wrapper.text()).toContain('Aligned — TV == FV (2)')
+    expect(wrapper.text()).toContain('TV-Only — PM targeted, no ENG commitment (1)')
+  })
+
+  it('selects a single product chip after milestone scope', async function () {
+    var wrapper = await mountView({
+      releases: {
+        '3.6 GA RHOAI RELEASE': {
+          aligned: [{ key: 'A1', summary: 'rhoai' }],
+          tv_only: [],
+          fv_only: [],
+          mismatched: [],
+        },
+        '3.6 GA RHAII RELEASE': {
+          aligned: [{ key: 'A2', summary: 'rhaii' }],
+          tv_only: [],
+          fv_only: [],
+          mismatched: [],
+        },
+      },
+    })
+
+    var msBtn = wrapper.findAll('button').find(function (b) {
+      return b.text().includes('3.6 GA Release') && b.text().includes('all products')
+    })
+    await msBtn.trigger('click')
+    await flushPromises()
+
+    var chips = wrapper.findAll('button').filter(function (b) {
+      return b.find('span[title="Remove"]').exists()
+    })
+    var rhoai = chips.find(function (b) { return b.text().includes('3.6 GA RHOAI RELEASE') })
+    await rhoai.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Showing features for')
+    expect(wrapper.text()).toContain('3.6 GA RHOAI RELEASE')
+    expect(wrapper.text()).not.toMatch(/all products \(2\)/)
+    expect(wrapper.text()).toContain('Aligned — TV == FV (1)')
   })
 })
 

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -17,6 +17,7 @@ import {
   productLabel,
   getAlignmentTarget,
   buildNameRollup,
+  formatSortedVersions,
   useReleaseFamily,
 } from '../../../client/composables/useReleaseFamily'
 
@@ -111,7 +112,7 @@ describe('cycleLabel / milestoneGroupLabel', function () {
 })
 
 describe('buildNameRollup', function () {
-  it('groups names cycle → milestone → product in numeric descending order', function () {
+  it('groups names cycle → milestone → product with EA1 before GA', function () {
     var rollup = buildNameRollup([
       '3.5 EA1 RHOAI RELEASE',
       '3.6 GA RHELAI RELEASE',
@@ -120,8 +121,8 @@ describe('buildNameRollup', function () {
       '3.5 GA RHOAI RELEASE',
     ])
     expect(rollup.map(function (c) { return c.key })).toEqual(['3.6', '3.5'])
-    expect(rollup[0].milestones.map(function (m) { return m.key })).toEqual(['3.6-GA', '3.6-EA1'])
-    expect(rollup[0].milestones[0].names).toEqual([
+    expect(rollup[0].milestones.map(function (m) { return m.key })).toEqual(['3.6-EA1', '3.6-GA'])
+    expect(rollup[0].milestones[1].names).toEqual([
       '3.6 GA RHOAI RELEASE',
       '3.6 GA RHELAI RELEASE',
     ])
@@ -151,10 +152,10 @@ describe('productLabel', function () {
 // ═══ compareReleases ═══
 
 describe('compareReleases', function () {
-  it('sorts GA before EA2 before EA1 within same version', function () {
+  it('sorts EA1 before EA2 before GA within same version', function () {
     var names = ['rhoai-3.6', 'rhoai-3.6.EA2', 'rhoai-3.6.EA1']
     var sorted = names.slice().sort(compareReleases)
-    expect(sorted).toEqual(['rhoai-3.6', 'rhoai-3.6.EA2', 'rhoai-3.6.EA1'])
+    expect(sorted).toEqual(['rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6'])
   })
 
   it('sorts newer minor versions first (descending)', function () {
@@ -183,7 +184,7 @@ describe('compareReleases', function () {
     expect(sorted).toEqual(['rhoai-3.6', 'rhoai-3.5', 'unknown-1.0'])
   })
 
-  it('handles product-family multi-milestone sort matching default picker order', function () {
+  it('handles product-family multi-milestone sort EA1 → EA2 → GA', function () {
     var names = [
       '3.5 EA1 RHOAI RELEASE',
       '3.6 EA1 RHOAI RELEASE',
@@ -193,12 +194,20 @@ describe('compareReleases', function () {
     ]
     var sorted = names.slice().sort(compareReleases)
     expect(sorted).toEqual([
-      '3.6 GA RHOAI RELEASE',
-      '3.6 EA2 RHOAI RELEASE',
       '3.6 EA1 RHOAI RELEASE',
-      '3.5 GA RHOAI RELEASE',
+      '3.6 EA2 RHOAI RELEASE',
+      '3.6 GA RHOAI RELEASE',
       '3.5 EA1 RHOAI RELEASE',
+      '3.5 GA RHOAI RELEASE',
     ])
+  })
+})
+
+describe('formatSortedVersions', function () {
+  it('orders comma-separated versions EA1 → EA2 → GA', function () {
+    expect(formatSortedVersions('3.6 GA RHOAI RELEASE, 3.6 EA2 RHOAI RELEASE, 3.6 EA1 RHOAI RELEASE')).toBe(
+      '3.6 EA1 RHOAI RELEASE, 3.6 EA2 RHOAI RELEASE, 3.6 GA RHOAI RELEASE',
+    )
   })
 })
 
@@ -251,6 +260,7 @@ function makeProductFamilyRows() {
     { release: '3.6 GA RHOAI RELEASE', total: 10, aligned: 4, tv_only: 3, fv_only: 1, mismatched: 2, alignment_pct: 40 },
     { release: '3.6 GA RHAII RELEASE', total: 5, aligned: 2, tv_only: 2, fv_only: 0, mismatched: 1, alignment_pct: 40 },
     { release: '3.6 GA RHELAI RELEASE', total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0, alignment_pct: 100 },
+    { release: '3.6 EA2 RHOAI RELEASE', total: 4, aligned: 1, tv_only: 2, fv_only: 0, mismatched: 1, alignment_pct: 25 },
     { release: '3.6 EA1 RHOAI RELEASE', total: 7, aligned: 2, tv_only: 3, fv_only: 1, mismatched: 1, alignment_pct: 28.6 },
     { release: '3.5 GA RHOAI RELEASE', total: 20, aligned: 10, tv_only: 5, fv_only: 2, mismatched: 3, alignment_pct: 50 },
   ]
@@ -307,8 +317,12 @@ describe('useReleaseFamily composable', function () {
       expect(rollup[1].label).toBe('3.5 Release Cycle')
 
       var milestones = rollup[0].milestones.map(function (m) { return m.label })
-      expect(milestones[0]).toBe('3.6 GA Release')
-      expect(milestones).toContain('3.6 EA1 Release')
+      expect(milestones[0]).toBe('3.6 EA1 Release')
+      expect(milestones).toEqual([
+        '3.6 EA1 Release',
+        '3.6 EA2 Release',
+        '3.6 GA Release',
+      ])
 
       var ga = rollup[0].milestones.find(function (m) { return m.key === '3.6-GA' })
       expect(ga.rows.map(function (r) { return r.release })).toEqual([
@@ -325,18 +339,18 @@ describe('useReleaseFamily composable', function () {
       var summary = ref(rows)
       var rf = useReleaseFamily(summary, makeDataRef(rows))
       var cycle36 = rf.summaryRollup.value[0]
-      // 10+5+1 + 7 = 23
-      expect(cycle36.totals.total).toBe(23)
+      // 10+5+1 + 4 + 7 = 27
+      expect(cycle36.totals.total).toBe(27)
     })
   })
 
   describe('sorting', function () {
-    it('default sort is GA → EA2 → EA1, newer cycle first', function () {
+    it('default sort is EA1 → EA2 → GA, newer cycle first', function () {
       var summary = ref(makeSummaryRows())
       var rf = useReleaseFamily(summary, makeDataRef())
       var names = rf.sortedSummary.value.map(function (r) { return r.release })
-      expect(names.indexOf('rhoai-3.6')).toBeLessThan(names.indexOf('rhoai-3.6.EA2'))
-      expect(names.indexOf('rhoai-3.6.EA2')).toBeLessThan(names.indexOf('rhoai-3.6.EA1'))
+      expect(names.indexOf('rhoai-3.6.EA1')).toBeLessThan(names.indexOf('rhoai-3.6.EA2'))
+      expect(names.indexOf('rhoai-3.6.EA2')).toBeLessThan(names.indexOf('rhoai-3.6'))
       expect(names.indexOf('rhoai-3.6')).toBeLessThan(names.indexOf('rhoai-3.5'))
     })
 
@@ -346,7 +360,7 @@ describe('useReleaseFamily composable', function () {
       rf.selectedFamily.value = '3.6'
       var names = rf.sortedSummary.value.map(function (r) { return r.release })
       expect(names).toEqual([
-        'rhoai-3.6', 'rhoai-3.6.EA2', 'rhoai-3.6.EA1',
+        'rhoai-3.6.EA1', 'rhoai-3.6.EA2', 'rhoai-3.6',
       ])
     })
 

--- a/modules/releases/client/components/FeatureTable.vue
+++ b/modules/releases/client/components/FeatureTable.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed } from 'vue'
+import { formatSortedVersions } from '../composables/useReleaseFamily'
 
 function parentKeyUrl(feat) {
   if (feat.url) {
@@ -17,6 +18,8 @@ const props = defineProps({
   },
   title: { type: String, default: '' },
   maxRows: { type: Number, default: 0 },
+  /** When true, emphasize TV vs FV cells (mismatched / delta category tables) */
+  highlightVersionDelta: { type: Boolean, default: false },
 })
 
 const sortCol = ref(null)
@@ -68,6 +71,20 @@ function colorBadgeClass(color) {
   if (c === 'green') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
   return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
 }
+
+function isVersionCol(col) {
+  return col === 'target_version' || col === 'fix_versions'
+}
+
+function versionCellClass(col) {
+  if (!props.highlightVersionDelta) {
+    return 'text-gray-700 dark:text-gray-300 text-xs whitespace-normal max-w-[14rem]'
+  }
+  if (col === 'target_version') {
+    return 'text-yellow-800 dark:text-yellow-300 text-xs font-medium whitespace-normal max-w-[14rem] bg-yellow-50/80 dark:bg-yellow-900/20'
+  }
+  return 'text-gray-800 dark:text-gray-200 text-xs font-medium whitespace-normal max-w-[14rem] bg-gray-100/80 dark:bg-gray-700/40'
+}
 </script>
 
 <template>
@@ -83,6 +100,7 @@ function colorBadgeClass(color) {
               v-for="col in columns"
               :key="col"
               class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+              :class="{ 'min-w-[8rem]': isVersionCol(col) }"
               @click="toggleSort(col)"
             >
               {{ columnLabels[col] || col }}
@@ -99,7 +117,8 @@ function colorBadgeClass(color) {
             <td
               v-for="col in columns"
               :key="col"
-              class="px-3 py-2 whitespace-nowrap"
+              class="px-3 py-2"
+              :class="isVersionCol(col) ? '' : 'whitespace-nowrap'"
             >
               <!-- Key column: clickable link to Jira -->
               <a
@@ -118,6 +137,14 @@ function colorBadgeClass(color) {
                 :title="feat.summary"
               >
                 {{ feat.summary }}
+              </span>
+              <!-- TV / FV: sorted EA1→EA2→GA, wrap so both stay visible -->
+              <span
+                v-else-if="isVersionCol(col)"
+                :class="versionCellClass(col)"
+                :title="formatSortedVersions(feat[col])"
+              >
+                {{ formatSortedVersions(feat[col]) || '—' }}
               </span>
               <!-- Color status: badge -->
               <span

--- a/modules/releases/client/composables/mergeReleaseDetails.js
+++ b/modules/releases/client/composables/mergeReleaseDetails.js
@@ -1,0 +1,35 @@
+/**
+ * Merge per-release TV/FV detail buckets across multiple product versions
+ * (e.g. 3.6 EA1 RHOAI + RHAII + RHELAI) into one view, deduping by issue key.
+ *
+ * @param {Record<string, { aligned?: object[], tv_only?: object[], fv_only?: object[], mismatched?: object[] }>|null|undefined} releasesMap
+ * @param {string[]} names
+ * @returns {{ aligned: object[], tv_only: object[], fv_only: object[], mismatched: object[] }|null}
+ */
+export function mergeReleaseDetails(releasesMap, names) {
+  if (!releasesMap || !names || !names.length) return null
+
+  var cats = ['aligned', 'tv_only', 'fv_only', 'mismatched']
+  var out = { aligned: [], tv_only: [], fv_only: [], mismatched: [] }
+  var seen = { aligned: {}, tv_only: {}, fv_only: {}, mismatched: {} }
+  var any = false
+
+  for (var i = 0; i < names.length; i++) {
+    var rd = releasesMap[names[i]]
+    if (!rd) continue
+    any = true
+    for (var ci = 0; ci < cats.length; ci++) {
+      var cat = cats[ci]
+      var list = rd[cat] || []
+      for (var fi = 0; fi < list.length; fi++) {
+        var feat = list[fi]
+        var key = feat && feat.key
+        if (!key || seen[cat][key]) continue
+        seen[cat][key] = true
+        out[cat].push(feat)
+      }
+    }
+  }
+
+  return any ? out : null
+}

--- a/modules/releases/client/composables/tvFvDeltaDefaults.js
+++ b/modules/releases/client/composables/tvFvDeltaDefaults.js
@@ -3,6 +3,8 @@
  * Users can still add/remove versions after load via the release picker.
  *
  * Product-family Jira version names for 3.5 and 3.6 (EA1, EA2, GA).
+ * Display order in the UI is handled by buildNameRollup (EA1 → EA2 → GA).
+ * List order here prefers GA when auto-selecting the initial detail release.
  */
 export const DEFAULT_SELECTED_VERSIONS = [
   '3.6 GA RHOAI RELEASE',

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -46,23 +46,35 @@ function parseReleaseName(name) {
 
 /**
  * Compare two release names for sorting.
- * Order: cycle desc → milestone GA/EA2/EA1 (desc) → product RHOAI/RHAII/RHELAI.
+ * Order: cycle desc → milestone EA1/EA2/GA (chronological) → product RHOAI/RHAII/RHELAI.
  */
 function compareReleases(a, b) {
   var pa = parseReleaseName(a)
   var pb = parseReleaseName(b)
-  if (!pa && !pb) return a.localeCompare(b)
+  if (!pa && !pb) return String(a || '').localeCompare(String(b || ''))
   if (!pa) return 1
   if (!pb) return -1
 
   if (pa.major !== pb.major) return pb.major - pa.major
   if (pa.minor !== pb.minor) return pb.minor - pa.minor
-  // GA (99) before EA2 before EA1
-  if (pa.milestoneOrder !== pb.milestoneOrder) return pb.milestoneOrder - pa.milestoneOrder
+  // EA1 before EA2 before GA
+  if (pa.milestoneOrder !== pb.milestoneOrder) return pa.milestoneOrder - pb.milestoneOrder
   var oa = PRODUCT_ORDER[pa.product] != null ? PRODUCT_ORDER[pa.product] : 99
   var ob = PRODUCT_ORDER[pb.product] != null ? PRODUCT_ORDER[pb.product] : 99
   if (oa !== ob) return oa - ob
   return pa.product.localeCompare(pb.product)
+}
+
+/**
+ * Sort a comma-separated version list into EA1 → EA2 → GA (within each cycle).
+ * @param {string} value
+ * @returns {string}
+ */
+function formatSortedVersions(value) {
+  if (value == null || value === '') return ''
+  var parts = String(value).split(/,\s*/).map(function (s) { return s.trim() }).filter(Boolean)
+  if (parts.length <= 1) return parts[0] || String(value)
+  return parts.slice().sort(compareReleases).join(', ')
 }
 
 /**
@@ -185,12 +197,12 @@ function compareCycleKeys(a, b) {
 }
 
 function compareMilestoneKeys(a, b) {
-  // "3.6-GA" / "3.6-EA2" — GA first, then higher EA
+  // "3.6-GA" / "3.6-EA2" — EA1 first, then EA2, then GA
   var ma = /-(EA(\d+)|GA)$/.exec(a)
   var mb = /-(EA(\d+)|GA)$/.exec(b)
   var oa = ma && ma[1] === 'GA' ? 99 : (ma ? parseInt(ma[2], 10) : 0)
   var ob = mb && mb[1] === 'GA' ? 99 : (mb ? parseInt(mb[2], 10) : 0)
-  return ob - oa
+  return oa - ob
 }
 
 /**
@@ -455,6 +467,7 @@ export function useReleaseFamily(filteredSummary, data) {
     productLabel,
     getAlignmentTarget,
     buildNameRollup,
+    formatSortedVersions,
   }
 }
 
@@ -472,5 +485,6 @@ export {
   productLabel,
   getAlignmentTarget,
   buildNameRollup,
+  formatSortedVersions,
   ALIGNMENT_TARGETS,
 }

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import ClickableCount from '../components/ClickableCount.vue'
 import FeatureTable from '../components/FeatureTable.vue'
 import { useReleasePicker } from '../composables/useReleasePicker'
@@ -7,9 +7,13 @@ import { useComponentBreakdown } from '../composables/useComponentBreakdown'
 import { useComponentLeads } from '../composables/useComponentLeads'
 import { useTvFvData } from '../composables/useTvFvData'
 import { useReleaseFamily, getAlignmentTarget, buildNameRollup } from '../composables/useReleaseFamily'
+import { mergeReleaseDetails } from '../composables/mergeReleaseDetails'
 import { DEFAULT_SELECTED_VERSIONS } from '../composables/tvFvDeltaDefaults'
 
-const FEATURE_COLS = ['key', 'summary', 'status', 'target_version', 'fix_versions', 'color_status', 'product_manager', 'assignee', 'team', 'component']
+const FEATURE_COLS = [
+  'key', 'summary', 'target_version', 'fix_versions',
+  'status', 'color_status', 'product_manager', 'assignee', 'team', 'component',
+]
 
 // ---------------------------------------------------------------------------
 // Composables
@@ -34,13 +38,82 @@ const {
 // Wrap triggerRefresh to pass the picker's allSelectedVersions
 const doRefresh = () => triggerRefresh(allSelectedVersions)
 
-const releaseData = computed(() => {
-  if (!data.value || !selectedRelease.value) return null
-  return data.value.releases[selectedRelease.value]
+/**
+ * Selection scope:
+ * - product: one release event chip (e.g. 3.6 EA1 RHOAI RELEASE)
+ * - milestone: all products in a release event (e.g. 3.6 EA1 → RHOAI/RHAII/RHELAI)
+ */
+const selectedMilestoneKey = ref(null)
+
+const activeReleaseNames = computed(() => {
+  if (selectedMilestoneKey.value) {
+    for (const cycle of chosenVersionsRollup.value) {
+      for (const ms of cycle.milestones) {
+        if (ms.key === selectedMilestoneKey.value) {
+          return ms.names.filter(n => data.value?.releases?.[n])
+        }
+      }
+    }
+    return []
+  }
+  if (selectedRelease.value && data.value?.releases?.[selectedRelease.value]) {
+    return [selectedRelease.value]
+  }
+  return []
 })
 
-const releaseSummary = computed(() => {
+const selectionLabel = computed(() => {
+  if (selectedMilestoneKey.value) {
+    for (const cycle of chosenVersionsRollup.value) {
+      for (const ms of cycle.milestones) {
+        if (ms.key === selectedMilestoneKey.value) {
+          const n = activeReleaseNames.value.length
+          return ms.label + (n ? ` — all products (${n})` : '')
+        }
+      }
+    }
+  }
+  return selectedRelease.value || ''
+})
+
+function selectProductRelease(name) {
+  if (!name || !isInCurrentData(name)) return
+  selectedMilestoneKey.value = null
+  selectedRelease.value = name
+}
+
+function selectMilestoneGroup(ms) {
+  if (!ms) return
+  // Selector rollup uses .names; executive summary rollup uses .rows[].release
+  const names = ms.names
+    || (ms.rows ? ms.rows.map(function (r) { return r.release }) : [])
+  if (!names.length) return
+  const available = names.filter(n => data.value?.releases?.[n])
+  if (!available.length) return
+  selectedMilestoneKey.value = ms.key
+  selectedRelease.value = available[0]
+}
+
+function isProductSelected(name) {
+  return !selectedMilestoneKey.value && name === selectedRelease.value
+}
+
+function isMilestoneSelected(msKey) {
+  return selectedMilestoneKey.value === msKey
+}
+
+function isReleaseInActiveScope(name) {
+  return activeReleaseNames.value.includes(name)
+}
+
+const releaseData = computed(() => {
   if (!data.value) return null
+  return mergeReleaseDetails(data.value.releases, activeReleaseNames.value)
+})
+
+/** Per-product Jira deep-links only apply in single-product mode */
+const releaseSummary = computed(() => {
+  if (!data.value || selectedMilestoneKey.value || !selectedRelease.value) return null
   return data.value.executive_summary.find(s => s.release === selectedRelease.value)
 })
 
@@ -272,11 +345,16 @@ onBeforeUnmount(() => {
                 </tr>
 
                 <template v-for="ms in cycle.milestones" :key="ms.key">
-                  <!-- Milestone rollup: e.g. 3.6 GA Release -->
-                  <tr class="bg-gray-50 dark:bg-gray-800/70">
+                  <!-- Milestone rollup: e.g. 3.6 GA Release — click to view all products -->
+                  <tr
+                    class="bg-gray-50 dark:bg-gray-800/70 cursor-pointer hover:bg-blue-50/40 dark:hover:bg-blue-900/20"
+                    :class="{ 'ring-1 ring-inset ring-blue-400/60 bg-blue-50/60 dark:bg-blue-900/25': isMilestoneSelected(ms.key) }"
+                    @click="selectMilestoneGroup(ms)"
+                  >
                     <td class="px-4 py-2 pl-8 text-xs font-medium text-gray-700 dark:text-gray-200">
                       {{ ms.label }}
                       <span class="ml-1 text-[10px] font-normal text-gray-400 dark:text-gray-500">(includes {{ ms.rows.length }})</span>
+                      <span class="ml-1.5 text-[10px] font-normal text-blue-600 dark:text-blue-400">all products</span>
                     </td>
                     <td class="px-4 py-2 text-right text-xs font-medium text-gray-600 dark:text-gray-300">{{ ms.totals.total }}</td>
                     <td class="px-4 py-2 text-right text-xs font-medium text-green-700 dark:text-green-400">{{ ms.totals.aligned }}</td>
@@ -298,8 +376,11 @@ onBeforeUnmount(() => {
                     v-for="row in ms.rows"
                     :key="row.release"
                     class="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer"
-                    :class="{ 'bg-blue-50/50 dark:bg-blue-900/10': row.release === selectedRelease }"
-                    @click="!row._pending ? selectedRelease = row.release : null"
+                    :class="{
+                      'bg-blue-50/50 dark:bg-blue-900/10': isProductSelected(row.release),
+                      'bg-blue-50/20 dark:bg-blue-900/5': isMilestoneSelected(ms.key) && isReleaseInActiveScope(row.release),
+                    }"
+                    @click="!row._pending ? selectProductRelease(row.release) : null"
                   >
                     <td class="px-4 py-2 pl-12 font-mono text-xs font-medium" :class="row._pending ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">
                       {{ row.release }}
@@ -395,21 +476,33 @@ onBeforeUnmount(() => {
             v-for="ms in cycle.milestones"
             :key="'sel-' + ms.key"
             class="px-3 py-2.5 border-t border-gray-100 dark:border-gray-700/80"
+            :class="{ 'bg-blue-50/40 dark:bg-blue-900/15': isMilestoneSelected(ms.key) }"
           >
-            <div class="text-[11px] font-medium text-gray-600 dark:text-gray-300 mb-1.5">
+            <button
+              type="button"
+              class="text-[11px] font-medium mb-1.5 inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 -ml-1.5 transition-colors"
+              :class="isMilestoneSelected(ms.key)
+                ? 'text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40'
+                : 'text-gray-600 dark:text-gray-300 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-gray-100 dark:hover:bg-gray-800'"
+              :title="'View all products for ' + ms.label"
+              @click="selectMilestoneGroup(ms)"
+            >
               {{ ms.label }}
-            </div>
+              <span class="text-[10px] font-normal opacity-70">all products</span>
+            </button>
             <div class="flex items-center gap-1.5 flex-wrap">
               <button
                 v-for="name in ms.names"
                 :key="name"
                 class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
                 :class="isInCurrentData(name)
-                  ? (name === selectedRelease
+                  ? (isProductSelected(name)
                     ? 'bg-blue-600 text-white border-blue-600 dark:border-blue-500'
-                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700')
+                    : (isMilestoneSelected(ms.key)
+                      ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700'))
                   : 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700 border-dashed'"
-                @click="isInCurrentData(name) ? selectedRelease = name : null"
+                @click="selectProductRelease(name)"
               >
                 {{ name }}
                 <span
@@ -485,8 +578,15 @@ onBeforeUnmount(() => {
         </div>
       </div>
 
-      <!-- Category lists for selected release -->
+      <!-- Category lists for selected release / milestone scope -->
       <div v-if="releaseData">
+        <p
+          v-if="selectionLabel"
+          class="text-sm text-gray-600 dark:text-gray-300 mb-3"
+        >
+          Showing features for
+          <span class="font-medium text-gray-900 dark:text-gray-100">{{ selectionLabel }}</span>
+        </p>
         <!-- TV-Only -->
         <details class="group bg-white dark:bg-gray-800 rounded-lg border border-yellow-200 dark:border-yellow-800 overflow-hidden mb-4">
           <summary class="list-none px-4 py-3 cursor-pointer hover:bg-yellow-50 dark:hover:bg-yellow-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
@@ -510,6 +610,7 @@ onBeforeUnmount(() => {
           <FeatureTable
             :features="releaseData.tv_only"
             :columns="FEATURE_COLS"
+            highlight-version-delta
           />
         </details>
 
@@ -536,6 +637,7 @@ onBeforeUnmount(() => {
           <FeatureTable
             :features="releaseData.fv_only"
             :columns="FEATURE_COLS"
+            highlight-version-delta
           />
         </details>
 
@@ -562,6 +664,7 @@ onBeforeUnmount(() => {
           <FeatureTable
             :features="releaseData.mismatched"
             :columns="FEATURE_COLS"
+            highlight-version-delta
           />
         </details>
 
@@ -588,6 +691,7 @@ onBeforeUnmount(() => {
           <FeatureTable
             :features="releaseData.aligned"
             :columns="FEATURE_COLS"
+            highlight-version-delta
           />
         </details>
       </div>

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -75,7 +75,17 @@ export const viewOwners = {
   'system-health/quality-analysis':                'Dana Gutride',
 
   // team-tracker
+  'team-tracker/home':                             'Dipanshu Gupta',
   'team-tracker/jira-taxonomy':                    'Alex Corvin',
+  'team-tracker/manage':                           'Alex Corvin',
+  'team-tracker/manager-dashboard':                'Alex Corvin',
+  'team-tracker/org-dashboard':                    'Alex Corvin',
+  'team-tracker/org-explorer':                     'Dipanshu Gupta',
+  'team-tracker/people':                           'Dipanshu Gupta',
+  'team-tracker/person-detail':                    'Dipanshu Gupta',
+  'team-tracker/reports':                          'Alex Corvin',
+  'team-tracker/team-detail':                      'Alex Corvin',
+  'team-tracker/unassigned':                       'Alex Corvin',
 
   // upstream-pulse
   'upstream-pulse/dashboard':                      'Dipanshu Gupta',
@@ -103,6 +113,12 @@ export const viewOwners = {
   // system-health > component-maturity
   'system-health/component-maturity/disconnected': 'Ajay Jaganathan',
 
+  // team-tracker > manage
+  'team-tracker/manage/data-quality':              'Alex Corvin',
+  'team-tracker/manage/field-options':             'Alex Corvin',
+  'team-tracker/manage/fields':                    'Alex Corvin',
+  'team-tracker/manage/teams':                     'Alex Corvin',
+
   // ── Report owners (module/view/reportId) ──
   // These override the view-level owner when a specific report is selected.
 
@@ -112,6 +128,11 @@ export const viewOwners = {
   'releases/reports/program-hygiene':              'Alex Corvin',
   'releases/reports/release-readiness':            'Arthy Loganathan',
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
+
+  // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
+  'team-tracker/reports/team-comparison':          'Alex Corvin',
+  'team-tracker/reports/trends':                   'Alex Corvin',
 }
 
 /**

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -72,6 +72,7 @@ const FIXTURE_DATA = {
   executive_summary: [
     ...DEFAULT_FIXTURE_RELEASES.filter(r => ![
       '3.5 EA1 RHOAI RELEASE',
+      '3.5 EA1 RHAII RELEASE',
       '3.5 EA2 RHOAI RELEASE',
       '3.5 GA RHOAI RELEASE',
     ].includes(r)).map(emptySummaryRow),
@@ -84,6 +85,16 @@ const FIXTURE_DATA = {
       tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-ea1',
       fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-ea1',
       mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea1'
+    },
+    {
+      release: '3.5 EA1 RHAII RELEASE',
+      total: 1, aligned: 1, tv_only: 0, fv_only: 0, mismatched: 0,
+      alignment_pct: 100,
+      total_jql: 'https://redhat.atlassian.net/issues/?jql=test-total-ea1-rhaii',
+      aligned_jql: 'https://redhat.atlassian.net/issues/?jql=test-aligned-ea1-rhaii',
+      tv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-tvonly-ea1-rhaii',
+      fv_only_jql: 'https://redhat.atlassian.net/issues/?jql=test-fvonly-ea1-rhaii',
+      mismatched_jql: 'https://redhat.atlassian.net/issues/?jql=test-mismatch-ea1-rhaii'
     },
     {
       release: '3.5 EA2 RHOAI RELEASE',
@@ -120,6 +131,14 @@ const FIXTURE_DATA = {
       mismatched: [
         { key: 'RHAISTRAT-300', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-300', summary: 'Mismatched feature Z', status: 'In Progress', color_status: 'Yellow', product_manager: 'PM Alpha', assignee: 'Dev Five', team: 'Team A', component: 'Serving, Training', target_version: '3.5 EA1 RHOAI RELEASE', fix_versions: '3.5 EA2 RHOAI RELEASE' }
       ]
+    },
+    '3.5 EA1 RHAII RELEASE': {
+      aligned: [
+        { key: 'RHAISTRAT-110', url: 'https://redhat.atlassian.net/browse/RHAISTRAT-110', summary: 'RHAII EA1 aligned', status: 'In Progress', color_status: 'Green', product_manager: 'PM Delta', assignee: 'Dev Seven', team: 'Team E', component: 'Serving' }
+      ],
+      tv_only: [],
+      fv_only: [],
+      mismatched: []
     },
     '3.5 EA2 RHOAI RELEASE': {
       aligned: [
@@ -539,15 +558,15 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
 
     // Cycles: newer first
     expectBefore(labels, '3.6 Release Cycle', '3.5 Release Cycle');
-    // Within 3.6: GA → EA2 → EA1
-    expectBefore(labels, '3.6 GA Release', '3.6 EA2 Release');
-    expectBefore(labels, '3.6 EA2 Release', '3.6 EA1 Release');
+    // Within 3.6: EA1 → EA2 → GA
+    expectBefore(labels, '3.6 EA1 Release', '3.6 EA2 Release');
+    expectBefore(labels, '3.6 EA2 Release', '3.6 GA Release');
     // Within a milestone: RHOAI → RHAII → RHELAI
     expectBefore(labels, '3.6 GA RHOAI RELEASE', '3.6 GA RHAII RELEASE');
     expectBefore(labels, '3.6 GA RHAII RELEASE', '3.6 GA RHELAI RELEASE');
     // Product rows sit under their milestone header
-    expectBefore(labels, '3.6 GA Release', '3.6 GA RHOAI RELEASE');
-    expectBefore(labels, '3.6 GA RHELAI RELEASE', '3.6 EA2 Release');
+    expectBefore(labels, '3.6 EA1 Release', '3.6 EA1 RHOAI RELEASE');
+    expectBefore(labels, '3.6 EA2 RHELAI RELEASE', '3.6 GA Release');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -699,19 +718,19 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
       .map(t => t.trim())
       .filter(t => /^(3\.6 (GA|EA\d+) Release)$/.test(t));
     expect(milestoneLabels).toEqual([
-      '3.6 GA Release',
-      '3.6 EA2 Release',
       '3.6 EA1 Release',
+      '3.6 EA2 Release',
+      '3.6 GA Release',
     ]);
 
-    // Product chips under the first milestone (GA), in product order
-    const gaGroup = cycle36.locator('div.border-t').first();
-    const gaChipTexts = (await gaGroup.locator('button').filter({ has: page.locator('span[title="Remove"]') }).allTextContents())
+    // Product chips under the first milestone (EA1), in product order
+    const ea1Group = cycle36.locator('div.border-t').first();
+    const ea1ChipTexts = (await ea1Group.locator('button').filter({ has: page.locator('span[title="Remove"]') }).allTextContents())
       .map(t => t.replace(/×/g, '').replace(/\s+/g, ' ').trim());
-    expect(gaChipTexts).toEqual([
-      '3.6 GA RHOAI RELEASE',
-      '3.6 GA RHAII RELEASE',
-      '3.6 GA RHELAI RELEASE',
+    expect(ea1ChipTexts).toEqual([
+      '3.6 EA1 RHOAI RELEASE',
+      '3.6 EA1 RHAII RELEASE',
+      '3.6 EA1 RHELAI RELEASE',
     ]);
 
     expect(relevantErrors(page)).toHaveLength(0);
@@ -735,7 +754,7 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     expectBefore(cycleLabels, '3.6 Release Cycle', '3.5 Release Cycle');
 
     const milestoneLabels = (await dropdown.locator('div.pt-2').allTextContents()).map(t => t.trim());
-    expectBefore(milestoneLabels, '3.6 GA Release', '3.6 EA1 Release');
+    expectBefore(milestoneLabels, '3.6 EA1 Release', '3.6 GA Release');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -776,6 +795,59 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     const ea1Tab = versionChip(page, '3.5 EA1 RHOAI RELEASE');
     const ea1Classes = await ea1Tab.getAttribute('class');
     expect(ea1Classes).not.toContain('bg-blue-600');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should select milestone group to show all products for a release event', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const selector = page.locator('div.mb-6.space-y-4');
+    await selector.getByRole('button', { name: /3\.5 EA1 Release\s+all products/ }).click();
+    await page.waitForTimeout(300);
+
+    await expect(page.getByText(/Showing features for\s+3\.5 EA1 Release/)).toBeVisible();
+    await expect(page.getByText(/all products \(2\)/)).toBeVisible();
+
+    // Product chips in the group get group highlight (not sole solid blue)
+    const rhoaiChip = versionChip(page, '3.5 EA1 RHOAI RELEASE');
+    const rhaiiChip = versionChip(page, '3.5 EA1 RHAII RELEASE');
+    await expect(rhoaiChip).toHaveClass(/bg-blue-100/);
+    await expect(rhaiiChip).toHaveClass(/bg-blue-100/);
+    expect(await rhoaiChip.getAttribute('class')).not.toContain('bg-blue-600');
+
+    // Merged aligned = RHOAI 3 + RHAII 1
+    await expect(page.locator('summary:has-text("Aligned")')).toContainText('(4)');
+    await page.locator('summary:has-text("Aligned")').click();
+    await page.waitForTimeout(200);
+    await expect(page.locator('text=RHAISTRAT-110')).toBeVisible();
+    await expect(page.locator('text=RHAISTRAT-100')).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should return to product-specific view when clicking a product chip', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const selector = page.locator('div.mb-6.space-y-4');
+    await selector.getByRole('button', { name: /3\.5 EA1 Release\s+all products/ }).click();
+    await page.waitForTimeout(200);
+
+    await versionChip(page, '3.5 EA1 RHOAI RELEASE').click();
+    await page.waitForTimeout(300);
+
+    await expect(page.getByText('Showing features for')).toContainText('3.5 EA1 RHOAI RELEASE');
+    await expect(page.getByText(/all products \(2\)/)).toHaveCount(0);
+
+    const rhoaiChip = versionChip(page, '3.5 EA1 RHOAI RELEASE');
+    expect(await rhoaiChip.getAttribute('class')).toContain('bg-blue-600');
+
+    // Single-product aligned count is 3 again
+    await expect(page.locator('summary:has-text("Aligned")')).toContainText('(3)');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -1030,8 +1102,8 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     const alignedDetails = page.locator('details:has(summary:has-text("Aligned"))');
     const headers = alignedDetails.locator('thead th');
 
-    // All categories now include: Key, Summary, Status, TV, FV, Color, PM, Assignee, Team, Component
-    const expectedHeaders = ['Key', 'Summary', 'Status', 'TV', 'FV', 'Color', 'PM', 'Assignee', 'Team', 'Component'];
+    // All categories now include: Key, Summary, TV, FV, Status, Color, PM, Assignee, Team, Component
+    const expectedHeaders = ['Key', 'Summary', 'TV', 'FV', 'Status', 'Color', 'PM', 'Assignee', 'Team', 'Component'];
     const count = await headers.count();
     expect(count).toBe(expectedHeaders.length);
 
@@ -1063,18 +1135,39 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
       // All categories have 10 columns including TV and FV
       expect(count).toBe(10);
 
-      // Verify TV and FV headers exist
+      // Verify TV and FV headers exist immediately after Summary
       const headerTexts = [];
       for (let i = 0; i < count; i++) {
         headerTexts.push(await headers.nth(i).textContent());
       }
-      expect(headerTexts.some(h => h.includes('TV'))).toBe(true);
-      expect(headerTexts.some(h => h.includes('FV'))).toBe(true);
+      expect(headerTexts.map(h => h.trim().replace(/[▲▼]/g, '').trim()).slice(0, 4)).toEqual([
+        'Key', 'Summary', 'TV', 'FV',
+      ]);
 
       // Collapse for next iteration
       await page.locator(`summary:has-text("${category}")`).click();
       await page.waitForTimeout(200);
     }
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should show mismatched TV and FV values side by side', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
+
+    await page.locator('summary:has-text("Mismatched")').click();
+    await page.waitForTimeout(300);
+
+    const mismatchDetails = page.locator('details:has(summary:has-text("Mismatched"))');
+    const row = mismatchDetails.locator('tbody tr', { hasText: 'RHAISTRAT-300' });
+    await expect(row).toBeVisible();
+    const cells = row.locator('td');
+    // Key, Summary, TV, FV
+    await expect(cells.nth(2)).toContainText('3.5 EA1 RHOAI RELEASE');
+    await expect(cells.nth(3)).toContainText('3.5 EA2 RHOAI RELEASE');
 
     expect(relevantErrors(page)).toHaveLength(0);
   });

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -714,9 +714,9 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await expect(cycleHeaders.nth(1)).toHaveText(/3\.5 Release Cycle/i);
 
     const cycle36 = selector.locator('div.rounded-lg.border').filter({ hasText: '3.6 Release Cycle' }).first();
-    const milestoneLabels = (await cycle36.locator('div.border-t > div').allTextContents())
-      .map(t => t.trim())
-      .filter(t => /^(3\.6 (GA|EA\d+) Release)$/.test(t));
+    // Milestone headers are buttons: "3.6 EA1 Release all products"
+    const milestoneLabels = (await cycle36.getByRole('button', { name: /all products/ }).allTextContents())
+      .map(t => t.replace(/\s+/g, ' ').trim().replace(/\s+all products$/i, ''));
     expect(milestoneLabels).toEqual([
       '3.6 EA1 Release',
       '3.6 EA2 Release',


### PR DESCRIPTION
## Summary
- Select a **release-event milestone** (e.g. 3.6 EA1 · all products) to view merged features across RHOAI/RHAII/RHELAI; product chips still select a single product.
- Executive summary / selector / version lists order milestones **EA1 → EA2 → GA** (top to bottom).
- Category feature tables put **TV and FV** immediately after Summary (with wrapping + highlight) so mismatches are visible without horizontal scrolling.

Follow-up to #1283 (merged before these changes landed).

## Test plan
- [ ] Open `/#/releases/reports?report=tv-fv-delta`
- [ ] Confirm milestone order is EA1 → EA2 → GA in Executive Summary and selector
- [ ] Click a milestone “all products” control and verify merged feature counts / “Showing features for … all products”
- [ ] Click a product chip and verify single-product scope
- [ ] Expand Mismatched and confirm Key · Summary · TV · FV are the first columns with distinct TV/FV values
- [ ] `npm test -- --run modules/releases/__tests__/client/tv-fv-delta/`


Made with [Cursor](https://cursor.com)