### PR TITLE
Fix Package Analysis tab URL sync

### DIFF
--- a/modules/product-builds/client/views/PackageAnalysisView.vue
+++ b/modules/product-builds/client/views/PackageAnalysisView.vue
@@ -65,7 +65,7 @@ function getInitialTab() {
   if (qIdx !== -1) {
     const params = new URLSearchParams(hash.slice(qIdx + 1))
     const tab = params.get('tab')
-    if (tab === 'search' || tab === 'nightly' || tab === 'versions' || tab === 'tracker' || tab === 'pre-built') return tab
+    if (tab === 'daily' || tab === 'search' || tab === 'nightly' || tab === 'versions' || tab === 'tracker' || tab === 'pre-built') return tab
   }
   return 'onboarded'
 }

--- a/modules/product-builds/client/views/PackageAnalysisView.vue
+++ b/modules/product-builds/client/views/PackageAnalysisView.vue
@@ -74,11 +74,8 @@ const activeTab = ref(getInitialTab())
 watch(activeTab, (tab) => {
   const hash = window.location.hash || ''
   const base = hash.split('?')[0] || '#/product-builds/package-analysis'
-  if (tab === 'onboarded') {
-    window.location.hash = base
-  } else {
-    window.location.hash = `${base}?tab=${tab}`
-  }
+  const newHash = tab === 'onboarded' ? base : `${base}?tab=${tab}`
+  history.replaceState(null, '', window.location.pathname + window.location.search + newHash)
 })
 
 const reports = ref([])

--- a/modules/product-builds/client/views/PackageAnalysisView.vue
+++ b/modules/product-builds/client/views/PackageAnalysisView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, defineAsyncComponent } from 'vue'
+import { ref, computed, watch, onMounted, defineAsyncComponent } from 'vue'
 import { apiRequest } from '@shared/client/services/api'
 import { useAuth } from '@shared/client/composables/useAuth'
 
@@ -70,6 +70,17 @@ function getInitialTab() {
   return 'onboarded'
 }
 const activeTab = ref(getInitialTab())
+
+watch(activeTab, (tab) => {
+  const hash = window.location.hash || ''
+  const base = hash.split('?')[0] || '#/product-builds/package-analysis'
+  if (tab === 'onboarded') {
+    window.location.hash = base
+  } else {
+    window.location.hash = `${base}?tab=${tab}`
+  }
+})
+
 const reports = ref([])
 const loading = ref(true)
 const error = ref(null)


### PR DESCRIPTION
## Summary
- Package Analysis tabs now update the URL hash when switching between them
- Previously the URL was only read on page load (`getInitialTab()`) but never written on tab click
- Now, when moving between tabs, the URL is maintained so the active tab persists on refresh and shared links open the correct tab

## Test plan
- [ ] Navigate to Package Analysis, click between tabs — URL updates to `?tab=<name>`
- [ ] Clicking "Packages Onboarded" (default tab) strips the `?tab=` param
- [ ] Copy the URL while on a non-default tab, paste in new window — correct tab loads
- [ ] Refresh the page on any tab — same tab is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)