### PR TITLE
feat(releases): clearer All products button on TV/FV selector

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -297,12 +297,13 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     })
 
     var msBtn = wrapper.findAll('button').find(function (b) {
-      return b.text().includes('3.6 GA Release') && b.text().includes('all products')
+      return b.text().includes('All products') && b.attributes('title') === 'View all products for 3.6 GA Release'
     })
     expect(msBtn).toBeTruthy()
     await msBtn.trigger('click')
     await flushPromises()
 
+    expect(msBtn.attributes('aria-pressed')).toBe('true')
     expect(wrapper.text()).toContain('Showing features for')
     expect(wrapper.text()).toContain('3.6 GA Release')
     expect(wrapper.text()).toMatch(/all products \(2\)/)
@@ -329,7 +330,7 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     })
 
     var msBtn = wrapper.findAll('button').find(function (b) {
-      return b.text().includes('3.6 GA Release') && b.text().includes('all products')
+      return b.text().includes('All products') && b.attributes('title') === 'View all products for 3.6 GA Release'
     })
     await msBtn.trigger('click')
     await flushPromises()
@@ -341,6 +342,7 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     await rhoai.trigger('click')
     await flushPromises()
 
+    expect(msBtn.attributes('aria-pressed')).toBe('false')
     expect(wrapper.text()).toContain('Showing features for')
     expect(wrapper.text()).toContain('3.6 GA RHOAI RELEASE')
     expect(wrapper.text()).not.toMatch(/all products \(2\)/)

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -478,18 +478,27 @@ onBeforeUnmount(() => {
             class="px-3 py-2.5 border-t border-gray-100 dark:border-gray-700/80"
             :class="{ 'bg-blue-50/40 dark:bg-blue-900/15': isMilestoneSelected(ms.key) }"
           >
-            <button
-              type="button"
-              class="text-[11px] font-medium mb-1.5 inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 -ml-1.5 transition-colors"
-              :class="isMilestoneSelected(ms.key)
-                ? 'text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40'
-                : 'text-gray-600 dark:text-gray-300 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-gray-100 dark:hover:bg-gray-800'"
-              :title="'View all products for ' + ms.label"
-              @click="selectMilestoneGroup(ms)"
-            >
-              {{ ms.label }}
-              <span class="text-[10px] font-normal opacity-70">all products</span>
-            </button>
+            <div class="mb-1.5 flex items-center gap-2 flex-wrap">
+              <span class="text-[11px] font-medium text-gray-600 dark:text-gray-300">
+                {{ ms.label }}
+              </span>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors"
+                :class="isMilestoneSelected(ms.key)
+                  ? 'bg-blue-600 text-white border-blue-600 dark:border-blue-500 shadow-sm'
+                  : 'bg-white dark:bg-gray-900 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30'"
+                :aria-pressed="isMilestoneSelected(ms.key) ? 'true' : 'false'"
+                :title="'View all products for ' + ms.label"
+                @click="selectMilestoneGroup(ms)"
+              >
+                All products
+                <span
+                  class="text-[10px] font-normal"
+                  :class="isMilestoneSelected(ms.key) ? 'text-blue-100' : 'text-blue-500/80 dark:text-blue-400/80'"
+                >({{ ms.names.length }})</span>
+              </button>
+            </div>
             <div class="flex items-center gap-1.5 flex-wrap">
               <button
                 v-for="name in ms.names"

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -714,9 +714,10 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await expect(cycleHeaders.nth(1)).toHaveText(/3\.5 Release Cycle/i);
 
     const cycle36 = selector.locator('div.rounded-lg.border').filter({ hasText: '3.6 Release Cycle' }).first();
-    // Milestone headers are buttons: "3.6 EA1 Release all products"
-    const milestoneLabels = (await cycle36.getByRole('button', { name: /all products/ }).allTextContents())
-      .map(t => t.replace(/\s+/g, ' ').trim().replace(/\s+all products$/i, ''));
+    // Milestone "All products" buttons: title encodes the event label
+    const milestoneLabels = (await cycle36.getByRole('button', { name: /All products/ }).evaluateAll(
+      (btns) => btns.map((b) => (b.getAttribute('title') || '').replace(/^View all products for\s+/i, '')),
+    ));
     expect(milestoneLabels).toEqual([
       '3.6 EA1 Release',
       '3.6 EA2 Release',
@@ -805,9 +806,11 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     const selector = page.locator('div.mb-6.space-y-4');
-    await selector.getByRole('button', { name: /3\.5 EA1 Release\s+all products/ }).click();
+    const allProductsBtn = selector.locator('button[title="View all products for 3.5 EA1 Release"]');
+    await allProductsBtn.click();
     await page.waitForTimeout(300);
 
+    await expect(allProductsBtn).toHaveAttribute('aria-pressed', 'true');
     await expect(page.getByText(/Showing features for\s+3\.5 EA1 Release/)).toBeVisible();
     await expect(page.getByText(/all products \(2\)/)).toBeVisible();
 
@@ -834,12 +837,14 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
     const selector = page.locator('div.mb-6.space-y-4');
-    await selector.getByRole('button', { name: /3\.5 EA1 Release\s+all products/ }).click();
+    const allProductsBtn = selector.locator('button[title="View all products for 3.5 EA1 Release"]');
+    await allProductsBtn.click();
     await page.waitForTimeout(200);
 
     await versionChip(page, '3.5 EA1 RHOAI RELEASE').click();
     await page.waitForTimeout(300);
 
+    await expect(allProductsBtn).toHaveAttribute('aria-pressed', 'false');
     await expect(page.getByText('Showing features for')).toContainText('3.5 EA1 RHOAI RELEASE');
     await expect(page.getByText(/all products \(2\)/)).toHaveCount(0);
 


### PR DESCRIPTION
## Summary
- Restyle the TV/FV milestone **All products** control as a chip-style selectable button (outlined idle, solid blue when active).
- Show product count on the button and set `aria-pressed` for the selected state.
- Update unit and integration tests for the new accessible name / title selectors.

## Test plan
- [ ] Open TV/FV Delta report; each EA1/EA2/GA row shows an **All products (N)** button
- [ ] Click **All products** → button turns solid blue; feature lists merge RHOAI/RHAII/RHELAI for that event
- [ ] Click a product chip → returns to single-product view; All products button unselected
- [ ] `npm test -- modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js`


Made with [Cursor](https://cursor.com)