### PR TITLE
fix(product-builds): prevent oversized dots in nightly chart

### DIFF
--- a/modules/product-builds/client/views/NightlyAnalysisView.vue
+++ b/modules/product-builds/client/views/NightlyAnalysisView.vue
@@ -117,7 +117,7 @@ const chartLayout = computed(() => {
   const pts = timelinePipelines.value
   if (!pts.length) return null
   const pad = { left: 44, right: 16, top: 16, bottom: 32 }
-  const w = Math.max(pts.length * 56, 300)
+  const w = Math.max(pts.length * 56, 600)
   const h = 100
   const yPass = pad.top + 14
   const yFail = h - pad.bottom - 14


### PR DESCRIPTION
## Summary
- Increase minimum pipeline history chart viewBox width from 300 to 600
- Prevents fixed-radius SVG dots from appearing oversized when few data points are available (e.g., after the fondue migration reset nightly history)

## Test plan
- [x] Verified dots render at reasonable size with 4 data points on local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)