### PR TITLE
fix(releases): bridge legacy TV/FV cache to 5-category schema

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/mergeReleaseDetails.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/mergeReleaseDetails.test.js
@@ -56,4 +56,21 @@ describe('mergeReleaseDetails', function () {
     )
     expect(merged.aligned_on_time).toHaveLength(1)
   })
+
+  it('falls back to legacy aligned/mismatched buckets', function () {
+    var merged = mergeReleaseDetails(
+      {
+        '3.6 EA1 RHOAI RELEASE': {
+          aligned: [{ key: 'LEGACY-A' }],
+          mismatched: [{ key: 'LEGACY-M' }],
+          tv_only: [],
+          fv_only: [],
+        },
+      },
+      ['3.6 EA1 RHOAI RELEASE'],
+    )
+    expect(merged.aligned_on_time.map(function (f) { return f.key })).toEqual(['LEGACY-A'])
+    expect(merged.misaligned.map(function (f) { return f.key })).toEqual(['LEGACY-M'])
+    expect(merged.aligned_late).toEqual([])
+  })
 })

--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -14,6 +14,7 @@ const {
   normalizeIssue,
   classifyFeatures,
   buildExport,
+  normalizeLegacyTvFvCache,
   DEFAULT_RELEASES,
   jqlSafePattern,
 } = require('../../../server/tv-fv-delta/routes');
@@ -236,6 +237,63 @@ describe('buildReleaseDatesMap', () => {
       planningFreezeDate: '2026-07-29',
     });
     expect(map['rhoai-3.6.ea1']).toEqual(map[key]);
+  });
+});
+
+describe('normalizeLegacyTvFvCache', () => {
+  it('maps aligned/mismatched summary + buckets to 5-category fields', () => {
+    const legacy = {
+      metadata: { generated_at: '2026-07-27T00:00:00.000Z', releases: ['3.6 EA1 RHOAI RELEASE'] },
+      executive_summary: [{
+        release: '3.6 EA1 RHOAI RELEASE',
+        total: 140,
+        aligned: 49,
+        aligned_jql: 'https://example/aligned',
+        mismatched: 10,
+        mismatched_jql: 'https://example/mismatch',
+        tv_only: 72,
+        fv_only: 9,
+        alignment_pct: 35,
+      }],
+      releases: {
+        '3.6 EA1 RHOAI RELEASE': {
+          aligned: [{ key: 'A-1' }],
+          mismatched: [{ key: 'M-1' }],
+          tv_only: [{ key: 'T-1' }],
+          fv_only: [{ key: 'F-1' }],
+        },
+      },
+      component_breakdown: [{
+        component: 'Serving', total: 10, aligned: 4, mismatched: 1, tv_only: 4, fv_only: 1, alignment_pct: 40,
+      }],
+    };
+
+    const normalized = normalizeLegacyTvFvCache(legacy);
+    expect(normalized).not.toBe(legacy);
+    expect(normalized.executive_summary[0].aligned_on_time).toBe(49);
+    expect(normalized.executive_summary[0].aligned_late).toBe(0);
+    expect(normalized.executive_summary[0].misaligned).toBe(10);
+    expect(normalized.executive_summary[0].aligned_on_time_jql).toBe('https://example/aligned');
+    expect(normalized.executive_summary[0].alignment_pct).toBe(35);
+    expect(normalized.releases['3.6 EA1 RHOAI RELEASE'].aligned_on_time).toEqual([{ key: 'A-1' }]);
+    expect(normalized.releases['3.6 EA1 RHOAI RELEASE'].aligned_late).toEqual([]);
+    expect(normalized.releases['3.6 EA1 RHOAI RELEASE'].misaligned).toEqual([{ key: 'M-1' }]);
+    expect(normalized.component_breakdown[0].aligned_on_time).toBe(4);
+    expect(normalized.component_breakdown[0].misaligned).toBe(1);
+    expect(normalized.metadata.legacy_migrated).toBe(true);
+  });
+
+  it('leaves already-migrated payloads unchanged by reference', () => {
+    const current = {
+      metadata: { generated_at: '2026-07-27T00:00:00.000Z' },
+      executive_summary: [{
+        release: 'x', total: 2, aligned_on_time: 1, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 1, alignment_pct: 50,
+      }],
+      releases: {
+        x: { aligned_on_time: [], aligned_late: [], tv_only: [], fv_only: [], misaligned: [] },
+      },
+    };
+    expect(normalizeLegacyTvFvCache(current)).toBe(current);
   });
 });
 

--- a/modules/releases/client/composables/mergeReleaseDetails.js
+++ b/modules/releases/client/composables/mergeReleaseDetails.js
@@ -44,7 +44,10 @@ export function mergeReleaseDetails(releasesMap, names) {
     any = true
     for (var ci = 0; ci < cats.length; ci++) {
       var cat = cats[ci]
+      // Fall back to pre-5-category bucket names if present
       var list = rd[cat] || []
+      if (!list.length && cat === 'aligned_on_time' && Array.isArray(rd.aligned)) list = rd.aligned
+      if (!list.length && cat === 'misaligned' && Array.isArray(rd.mismatched)) list = rd.mismatched
       for (var fi = 0; fi < list.length; fi++) {
         var feat = list[fi]
         var key = feat && feat.key

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -177,11 +177,12 @@ function sumRows(rows) {
       continue
     }
     total += r.total || 0
-    alignedOnTime += r.aligned_on_time || 0
+    // Prefer 5-category fields; fall back to pre-migration `aligned` / `mismatched`
+    alignedOnTime += r.aligned_on_time != null ? r.aligned_on_time : (r.aligned || 0)
     alignedLate += r.aligned_late || 0
     tvOnly += r.tv_only || 0
     fvOnly += r.fv_only || 0
-    misaligned += r.misaligned || 0
+    misaligned += r.misaligned != null ? r.misaligned : (r.mismatched || 0)
   }
   var alignmentPct = total > 0 ? Math.round((1000 * (alignedOnTime + alignedLate)) / total) / 10 : 0
   return {

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -429,11 +429,17 @@ onBeforeUnmount(() => {
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <ClickableCount v-if="!row._pending" :count="row.aligned_on_time" :jql="row.aligned_on_time_jql" color="green" label="Aligned on time" />
+                      <ClickableCount
+                        v-if="!row._pending"
+                        :count="row.aligned_on_time != null ? row.aligned_on_time : (row.aligned || 0)"
+                        :jql="row.aligned_on_time_jql || row.aligned_jql"
+                        color="green"
+                        label="Aligned on time"
+                      />
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <span v-if="!row._pending" class="text-xs font-medium text-amber-600 dark:text-amber-400" :title="COLUMN_HELP.aligned_late">{{ row.aligned_late }}</span>
+                      <span v-if="!row._pending" class="text-xs font-medium text-amber-600 dark:text-amber-400" :title="COLUMN_HELP.aligned_late">{{ row.aligned_late || 0 }}</span>
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
@@ -445,7 +451,7 @@ onBeforeUnmount(() => {
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">
-                      <span v-if="!row._pending" class="text-xs font-medium text-red-600 dark:text-red-400">{{ row.misaligned }}</span>
+                      <span v-if="!row._pending" class="text-xs font-medium text-red-600 dark:text-red-400">{{ row.misaligned != null ? row.misaligned : (row.mismatched || 0) }}</span>
                       <span v-else class="text-gray-400">&mdash;</span>
                     </td>
                     <td class="px-4 py-2 text-right">

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -753,6 +753,150 @@ async function fetchAndClassify(releases, storage, jiraProject) {
 }
 
 // ---------------------------------------------------------------------------
+// Legacy cache compatibility (pre-5-category model)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a cached TV/FV payload from the old 4-category schema
+ * (`aligned` / `mismatched`) to the current 5-category schema
+ * (`aligned_on_time` / `aligned_late` / `misaligned`).
+ *
+ * Safe to call on already-migrated payloads — returns input unchanged when
+ * new fields are already present.
+ *
+ * @param {object|null} data
+ * @returns {object|null}
+ */
+function normalizeLegacyTvFvCache(data) {
+  if (!data || typeof data !== 'object') return data
+
+  var migrated = false
+  var out = data
+
+  function ensureClone() {
+    if (out === data) {
+      out = Object.assign({}, data)
+      if (data.metadata) out.metadata = Object.assign({}, data.metadata)
+    }
+  }
+
+  // Executive summary rows
+  if (Array.isArray(data.executive_summary)) {
+    var summary = data.executive_summary
+    var needsSummary = false
+    for (var si = 0; si < summary.length; si++) {
+      var row = summary[si]
+      if (!row || typeof row !== 'object') continue
+      if (row.aligned_on_time == null && row.aligned != null) { needsSummary = true; break }
+      if (row.misaligned == null && row.mismatched != null) { needsSummary = true; break }
+      if (row.aligned_late == null && (row.aligned != null || row.mismatched != null)) { needsSummary = true; break }
+    }
+    if (needsSummary) {
+      ensureClone()
+      migrated = true
+      out.executive_summary = summary.map(function (row) {
+        if (!row || typeof row !== 'object') return row
+        var next = Object.assign({}, row)
+        if (next.aligned_on_time == null && next.aligned != null) {
+          next.aligned_on_time = next.aligned
+        }
+        if (next.aligned_on_time_jql == null && next.aligned_jql != null) {
+          next.aligned_on_time_jql = next.aligned_jql
+        }
+        if (next.aligned_late == null) next.aligned_late = 0
+        if (next.misaligned == null && next.mismatched != null) {
+          next.misaligned = next.mismatched
+        }
+        if (next.misaligned_jql == null && next.mismatched_jql != null) {
+          next.misaligned_jql = next.mismatched_jql
+        }
+        var total = next.total || 0
+        var onTime = next.aligned_on_time || 0
+        var late = next.aligned_late || 0
+        next.alignment_pct = total > 0
+          ? Math.round(1000 * (onTime + late) / total) / 10
+          : 0
+        return next
+      })
+    }
+  }
+
+  // Per-release feature buckets
+  if (data.releases && typeof data.releases === 'object') {
+    var releaseNames = Object.keys(data.releases)
+    var needsReleases = false
+    for (var ri = 0; ri < releaseNames.length; ri++) {
+      var bucket = data.releases[releaseNames[ri]]
+      if (!bucket || typeof bucket !== 'object') continue
+      if (!Array.isArray(bucket.aligned_on_time) && Array.isArray(bucket.aligned)) { needsReleases = true; break }
+      if (!Array.isArray(bucket.misaligned) && Array.isArray(bucket.mismatched)) { needsReleases = true; break }
+      if (!Array.isArray(bucket.aligned_late) && (Array.isArray(bucket.aligned) || Array.isArray(bucket.mismatched))) {
+        needsReleases = true
+        break
+      }
+    }
+    if (needsReleases) {
+      ensureClone()
+      migrated = true
+      out.releases = Object.assign({}, data.releases)
+      for (var rj = 0; rj < releaseNames.length; rj++) {
+        var name = releaseNames[rj]
+        var src = data.releases[name]
+        if (!src || typeof src !== 'object') continue
+        var nextBucket = Object.assign({}, src)
+        if (!Array.isArray(nextBucket.aligned_on_time) && Array.isArray(nextBucket.aligned)) {
+          nextBucket.aligned_on_time = nextBucket.aligned
+        }
+        if (!Array.isArray(nextBucket.aligned_late)) nextBucket.aligned_late = []
+        if (!Array.isArray(nextBucket.misaligned) && Array.isArray(nextBucket.mismatched)) {
+          nextBucket.misaligned = nextBucket.mismatched
+        }
+        if (!Array.isArray(nextBucket.aligned_on_time)) nextBucket.aligned_on_time = []
+        if (!Array.isArray(nextBucket.misaligned)) nextBucket.misaligned = []
+        if (!Array.isArray(nextBucket.tv_only)) nextBucket.tv_only = []
+        if (!Array.isArray(nextBucket.fv_only)) nextBucket.fv_only = []
+        out.releases[name] = nextBucket
+      }
+    }
+  }
+
+  // Component breakdown rows
+  if (Array.isArray(data.component_breakdown)) {
+    var comps = data.component_breakdown
+    var needsComps = false
+    for (var ci = 0; ci < comps.length; ci++) {
+      var comp = comps[ci]
+      if (!comp || typeof comp !== 'object') continue
+      if (comp.aligned_on_time == null && comp.aligned != null) { needsComps = true; break }
+      if (comp.misaligned == null && comp.mismatched != null) { needsComps = true; break }
+    }
+    if (needsComps) {
+      ensureClone()
+      migrated = true
+      out.component_breakdown = comps.map(function (comp) {
+        if (!comp || typeof comp !== 'object') return comp
+        var next = Object.assign({}, comp)
+        if (next.aligned_on_time == null && next.aligned != null) next.aligned_on_time = next.aligned
+        if (next.aligned_late == null) next.aligned_late = 0
+        if (next.misaligned == null && next.mismatched != null) next.misaligned = next.mismatched
+        var cTotal = next.total || 0
+        next.alignment_pct = cTotal > 0
+          ? Math.round(1000 * ((next.aligned_on_time || 0) + (next.aligned_late || 0)) / cTotal) / 10
+          : 0
+        return next
+      })
+    }
+  }
+
+  if (migrated) {
+    ensureClone()
+    out.metadata = Object.assign({}, out.metadata || {}, { schema: 'tv-fv-5cat', legacy_migrated: true })
+  }
+
+  return out
+}
+
+// ---------------------------------------------------------------------------
 // Route registration
 // ---------------------------------------------------------------------------
 
@@ -771,6 +915,7 @@ module.exports.isReleaseFrozen = isReleaseFrozen
 module.exports.normalizeIssue = normalizeIssue
 module.exports.classifyFeatures = classifyFeatures
 module.exports.buildExport = buildExport
+module.exports.normalizeLegacyTvFvCache = normalizeLegacyTvFvCache
 module.exports.DEFAULT_RELEASES = DEFAULT_RELEASES
 module.exports.DEFAULT_JIRA_PROJECT = DEFAULT_JIRA_PROJECT
 module.exports.jqlSafePattern = jqlSafePattern
@@ -844,18 +989,30 @@ async function registerRoutes(router, context) {
     const data = await storage.readFromStorage(CACHE_KEY)
 
     if (data) {
+      // Bridge pre-5-category caches so the UI never sees blank aligned/misaligned cells
+      const normalized = normalizeLegacyTvFvCache(data)
+      const healed = normalized !== data
+
       // Check staleness
-      const cachedAt = data.metadata && data.metadata.generated_at
+      const cachedAt = normalized.metadata && normalized.metadata.generated_at
       if (cachedAt) {
         const age = Date.now() - new Date(cachedAt).getTime()
         if (age >= CACHE_MAX_AGE_MS) {
-          const cachedReleases = (data.metadata.releases || DEFAULT_RELEASES)
+          const cachedReleases = (normalized.metadata.releases || DEFAULT_RELEASES)
             .filter(function(r) { return typeof r === 'string' && jqlSafePattern.test(r) })
           triggerBackgroundRefresh(cachedReleases.length ? cachedReleases : DEFAULT_RELEASES)
         }
       }
+
+      // Persist healed schema so subsequent reads don't re-migrate (best-effort)
+      if (healed) {
+        storage.writeToStorage(CACHE_KEY, normalized).catch(function (err) {
+          console.warn('[releases/tv-fv-delta] Failed to persist legacy cache migration:', err.message)
+        })
+      }
+
       return res.json({
-        ...data,
+        ...normalized,
         _refreshing: refreshState.running
       })
     }


### PR DESCRIPTION
## Summary
- After #1285, production still served pre-migration TV/FV cache (`aligned` / `mismatched`) while the UI reads `aligned_on_time` / `misaligned`, leaving those columns blank and rollups at 0% while Alignment % stayed non-zero.
- Normalize legacy cache on API read (and persist healed payload), with client fallbacks for summary/detail merge.
- Prefer this forward-fix over revert #1304.

## Test plan
- [x] Unit tests for `normalizeLegacyTvFvCache` + legacy merge fallback
- [ ] Deploy and load Reports → TV/FV Delta without refresh — Aligned On Time / Misaligned should show counts
- [ ] Confirm cycle/milestone rollups no longer show 0% when product rows have alignment
- [ ] Trigger Refresh from Jira to rewrite cache in native 5-category shape
- [ ] Confirm GA / Planning Freeze columns after refresh (separate PP date indexing from #1285)


Made with [Cursor](https://cursor.com)