### PR TITLE
fix(releases): make TV/FV All products control a clear chip button

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -303,12 +303,16 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     })
 
     var msBtn = wrapper.findAll('button').find(function (b) {
-      return b.text().includes('3.6 GA Release') && b.text().includes('all products')
+      return (b.attributes('aria-label') || '').includes('3.6 GA Release')
+        && (b.attributes('aria-label') || '').includes('all products')
     })
     expect(msBtn).toBeTruthy()
+    expect(msBtn.attributes('aria-pressed')).toBe('false')
+    expect(msBtn.text()).toMatch(/All products/)
     await msBtn.trigger('click')
     await flushPromises()
 
+    expect(msBtn.attributes('aria-pressed')).toBe('true')
     expect(wrapper.text()).toContain('Showing features for')
     expect(wrapper.text()).toContain('3.6 GA Release')
     expect(wrapper.text()).toMatch(/all products \(2\)/)
@@ -338,7 +342,8 @@ describe('TvFvDeltaView milestone vs product selection', function () {
     })
 
     var msBtn = wrapper.findAll('button').find(function (b) {
-      return b.text().includes('3.6 GA Release') && b.text().includes('all products')
+      return (b.attributes('aria-label') || '').includes('3.6 GA Release')
+        && (b.attributes('aria-label') || '').includes('all products')
     })
     await msBtn.trigger('click')
     await flushPromises()

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -538,18 +538,33 @@ onBeforeUnmount(() => {
             class="px-3 py-2.5 border-t border-gray-100 dark:border-gray-700/80"
             :class="{ 'bg-blue-50/40 dark:bg-blue-900/15': isMilestoneSelected(ms.key) }"
           >
-            <button
-              type="button"
-              class="text-[11px] font-medium mb-1.5 inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 -ml-1.5 transition-colors"
-              :class="isMilestoneSelected(ms.key)
-                ? 'text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40'
-                : 'text-gray-600 dark:text-gray-300 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-gray-100 dark:hover:bg-gray-800'"
-              :title="'View all products for ' + ms.label"
-              @click="selectMilestoneGroup(ms)"
-            >
-              {{ ms.label }}
-              <span class="text-[10px] font-normal opacity-70">all products</span>
-            </button>
+            <div class="flex items-center gap-2 mb-1.5 flex-wrap">
+              <span
+                class="text-[11px] font-semibold"
+                :class="isMilestoneSelected(ms.key)
+                  ? 'text-blue-800 dark:text-blue-200'
+                  : 'text-gray-700 dark:text-gray-200'"
+              >{{ ms.label }}</span>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-md border shadow-sm transition-colors"
+                :class="isMilestoneSelected(ms.key)
+                  ? 'bg-blue-600 text-white border-blue-600 dark:border-blue-500'
+                  : 'bg-white dark:bg-gray-900 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30'"
+                :aria-pressed="isMilestoneSelected(ms.key) ? 'true' : 'false'"
+                :aria-label="ms.label + ' all products'"
+                :title="'Select all products for ' + ms.label"
+                @click="selectMilestoneGroup(ms)"
+              >
+                All products
+                <span
+                  class="inline-flex items-center justify-center min-w-[1.25rem] px-1 rounded text-[10px] font-bold"
+                  :class="isMilestoneSelected(ms.key)
+                    ? 'bg-blue-500/80 text-white'
+                    : 'bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200'"
+                >{{ ms.names.length }}</span>
+              </button>
+            </div>
             <div class="flex items-center gap-1.5 flex-wrap">
               <button
                 v-for="name in ms.names"

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -720,14 +720,20 @@ test.describe('TV/FV Delta — Release Tabs @tv-fv-delta', () => {
     await expect(cycleHeaders.nth(1)).toHaveText(/3\.5 Release Cycle/i);
 
     const cycle36 = selector.locator('div.rounded-lg.border').filter({ hasText: '3.6 Release Cycle' }).first();
-    // Milestone headers are buttons: "3.6 EA1 Release all products"
-    const milestoneLabels = (await cycle36.getByRole('button', { name: /all products/ }).allTextContents())
-      .map(t => t.replace(/\s+/g, ' ').trim().replace(/\s+all products$/i, ''));
+    // Milestone "All products" chips expose accessible names like "3.6 EA1 Release all products"
+    const milestoneButtons = cycle36.getByRole('button', { name: /all products/i });
+    const milestoneCount = await milestoneButtons.count();
+    const milestoneLabels = [];
+    for (let i = 0; i < milestoneCount; i++) {
+      const label = await milestoneButtons.nth(i).getAttribute('aria-label');
+      milestoneLabels.push(String(label || '').replace(/\s+all products$/i, '').trim());
+    }
     expect(milestoneLabels).toEqual([
       '3.6 EA1 Release',
       '3.6 EA2 Release',
       '3.6 GA Release',
     ]);
+    await expect(milestoneButtons.first()).toHaveAttribute('aria-pressed', /.+/);
 
     // Product chips under the first milestone (EA1), in product order
     const ea1Group = cycle36.locator('div.border-t').first();


### PR DESCRIPTION
## Summary
- The milestone “all products” control still looked like faint helper text, so it was not obvious you could click it.
- Restyle it as a real chip button (border, count badge, solid blue when selected, `aria-pressed`), with the milestone name kept as a label beside it.

## Test plan
- [x] Unit tests for milestone chip selection / aria-pressed
- [ ] Open Reports → TV/FV Delta and confirm each milestone shows an **All products (N)** chip
- [ ] Selected chip is solid blue; unselected chips look clickable (blue border)
- [ ] Clicking it still scopes the detail view to all products in that milestone


Made with [Cursor](https://cursor.com)