### PR TITLE
fix(releases): unique-key TV/FV rollups and section Jira links

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/jiraKeysJql.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/jiraKeysJql.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { buildKeysJqlUrl } from '../../../client/composables/jiraKeysJql'
+
+describe('buildKeysJqlUrl', function () {
+  it('returns empty string for empty input', function () {
+    expect(buildKeysJqlUrl(null)).toBe('')
+    expect(buildKeysJqlUrl([])).toBe('')
+  })
+
+  it('builds a key-in JQL URL and dedupes keys', function () {
+    var url = buildKeysJqlUrl([
+      { key: 'RHAISTRAT-1' },
+      { key: 'RHAISTRAT-2' },
+      { key: 'RHAISTRAT-1' },
+    ])
+    expect(url).toContain('https://redhat.atlassian.net/issues/?jql=')
+    var jql = decodeURIComponent(url.split('jql=')[1])
+    expect(jql).toBe('key in (RHAISTRAT-1, RHAISTRAT-2)')
+  })
+})

--- a/modules/releases/__tests__/client/tv-fv-delta/mergeReleaseDetails.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/mergeReleaseDetails.test.js
@@ -2,7 +2,7 @@
  * Unit tests for merging multi-product release detail buckets.
  */
 import { describe, it, expect } from 'vitest'
-import { mergeReleaseDetails } from '../../../client/composables/mergeReleaseDetails'
+import { mergeReleaseDetails, countUniqueCategoryTotals } from '../../../client/composables/mergeReleaseDetails'
 
 describe('mergeReleaseDetails', function () {
   it('returns null when no names or missing map', function () {
@@ -72,5 +72,46 @@ describe('mergeReleaseDetails', function () {
     expect(merged.aligned_on_time.map(function (f) { return f.key })).toEqual(['LEGACY-A'])
     expect(merged.misaligned.map(function (f) { return f.key })).toEqual(['LEGACY-M'])
     expect(merged.aligned_late).toEqual([])
+  })
+})
+
+describe('countUniqueCategoryTotals', function () {
+  it('dedupes the same key across products in every category', function () {
+    var releases = {
+      '3.6 EA1 RHOAI RELEASE': {
+        aligned_on_time: [{ key: 'A-SHARED' }, { key: 'A-RHOAI' }],
+        aligned_late: [{ key: 'L-SHARED' }],
+        tv_only: [{ key: 'T-SHARED' }, { key: 'T-RHOAI' }],
+        fv_only: [{ key: 'F-RHOAI' }],
+        misaligned: [{ key: 'M-SHARED' }, { key: 'M-RHOAI' }],
+      },
+      '3.6 EA1 RHAII RELEASE': {
+        aligned_on_time: [{ key: 'A-SHARED' }, { key: 'A-RHAII' }],
+        aligned_late: [{ key: 'L-SHARED' }],
+        tv_only: [{ key: 'T-SHARED' }, { key: 'T-RHAII' }],
+        fv_only: [],
+        misaligned: [{ key: 'M-SHARED' }],
+      },
+    }
+
+    // Naive sum would be on_time 4, late 2, tv 4, fv 1, mis 3, total 14
+    var totals = countUniqueCategoryTotals(releases, [
+      '3.6 EA1 RHOAI RELEASE',
+      '3.6 EA1 RHAII RELEASE',
+    ])
+    expect(totals.aligned_on_time).toBe(3) // A-SHARED, A-RHOAI, A-RHAII
+    expect(totals.aligned_late).toBe(1) // L-SHARED
+    expect(totals.tv_only).toBe(3) // T-SHARED, T-RHOAI, T-RHAII
+    expect(totals.fv_only).toBe(1)
+    expect(totals.misaligned).toBe(2) // M-SHARED, M-RHOAI
+    expect(totals.total).toBe(10)
+    expect(totals.alignment_pct).toBe(40) // (3+1)/10
+  })
+
+  it('returns null when any product is missing detail data', function () {
+    expect(countUniqueCategoryTotals(
+      { '3.6 EA1 RHOAI RELEASE': { aligned_on_time: [], aligned_late: [], tv_only: [], fv_only: [], misaligned: [] } },
+      ['3.6 EA1 RHOAI RELEASE', '3.6 EA1 RHAII RELEASE'],
+    )).toBeNull()
   })
 })

--- a/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useReleaseFamily.test.js
@@ -342,6 +342,42 @@ describe('useReleaseFamily composable', function () {
       // 10+5+1 + 4 + 7 = 27
       expect(cycle36.totals.total).toBe(27)
     })
+
+    it('dedupes multi-product keys in milestone rollups for every category', function () {
+      var rows = [
+        { release: '3.6 EA1 RHOAI RELEASE', total: 5, aligned_on_time: 2, aligned_late: 1, tv_only: 1, fv_only: 0, misaligned: 1, alignment_pct: 60 },
+        { release: '3.6 EA1 RHAII RELEASE', total: 5, aligned_on_time: 2, aligned_late: 1, tv_only: 1, fv_only: 0, misaligned: 1, alignment_pct: 60 },
+      ]
+      var dataRef = ref({
+        executive_summary: rows,
+        releases: {
+          '3.6 EA1 RHOAI RELEASE': {
+            aligned_on_time: [{ key: 'A-SHARED' }, { key: 'A-RHOAI' }],
+            aligned_late: [{ key: 'L-SHARED' }],
+            tv_only: [{ key: 'T-SHARED' }],
+            fv_only: [],
+            misaligned: [{ key: 'M-SHARED' }],
+          },
+          '3.6 EA1 RHAII RELEASE': {
+            aligned_on_time: [{ key: 'A-SHARED' }, { key: 'A-RHAII' }],
+            aligned_late: [{ key: 'L-SHARED' }],
+            tv_only: [{ key: 'T-SHARED' }],
+            fv_only: [],
+            misaligned: [{ key: 'M-SHARED' }],
+          },
+        },
+      })
+      var rf = useReleaseFamily(ref(rows), dataRef)
+      var ea1 = rf.summaryRollup.value[0].milestones.find(function (m) { return m.key === '3.6-EA1' })
+      // Naive sum would be 4/2/2/0/2 total 10 — unique is half the shared keys
+      expect(ea1.totals.aligned_on_time).toBe(3)
+      expect(ea1.totals.aligned_late).toBe(1)
+      expect(ea1.totals.tv_only).toBe(1)
+      expect(ea1.totals.fv_only).toBe(0)
+      expect(ea1.totals.misaligned).toBe(1)
+      expect(ea1.totals.total).toBe(6)
+      expect(ea1.totals.alignment_pct).toBe(66.7)
+    })
   })
 
   describe('sorting', function () {

--- a/modules/releases/client/composables/jiraKeysJql.js
+++ b/modules/releases/client/composables/jiraKeysJql.js
@@ -1,0 +1,31 @@
+/**
+ * Build a Jira issue-search URL for the exact keys shown in a TV/FV section.
+ * Used when category logic cannot be expressed in JQL (aligned late / misaligned)
+ * or when multiple products are merged into one view.
+ */
+
+var JIRA_ISSUES = 'https://redhat.atlassian.net/issues/?jql='
+
+/** Soft cap — keeps URLs under common browser/proxy limits while covering typical sections */
+var MAX_KEYS = 400
+
+/**
+ * @param {Array<{ key?: string }>|null|undefined} features
+ * @returns {string} Jira URL, or '' when there are no keys
+ */
+export function buildKeysJqlUrl(features) {
+  if (!features || !features.length) return ''
+
+  var keys = []
+  var seen = {}
+  for (var i = 0; i < features.length; i++) {
+    var key = features[i] && features[i].key
+    if (!key || seen[key]) continue
+    seen[key] = true
+    keys.push(key)
+    if (keys.length >= MAX_KEYS) break
+  }
+  if (!keys.length) return ''
+
+  return JIRA_ISSUES + encodeURIComponent('key in (' + keys.join(', ') + ')')
+}

--- a/modules/releases/client/composables/mergeReleaseDetails.js
+++ b/modules/releases/client/composables/mergeReleaseDetails.js
@@ -60,3 +60,65 @@ export function mergeReleaseDetails(releasesMap, names) {
 
   return any ? out : null
 }
+
+/**
+ * Count unique issue keys per category (and overall) for a multi-product scope.
+ * Prefer this over summing per-product executive_summary counts — the same
+ * feature can appear under more than one product version.
+ *
+ * @param {Record<string, object>|null|undefined} releasesMap
+ * @param {string[]} names
+ * @returns {{
+ *   total: number,
+ *   aligned_on_time: number,
+ *   aligned_late: number,
+ *   tv_only: number,
+ *   fv_only: number,
+ *   misaligned: number,
+ *   alignment_pct: number,
+ * }|null}
+ */
+export function countUniqueCategoryTotals(releasesMap, names) {
+  if (!releasesMap || !names || !names.length) return null
+
+  // Require detail buckets for every product so we never under-count vs summary
+  for (var ni = 0; ni < names.length; ni++) {
+    if (!releasesMap[names[ni]]) return null
+  }
+
+  var merged = mergeReleaseDetails(releasesMap, names)
+  if (!merged) return null
+
+  var cats = ['aligned_on_time', 'aligned_late', 'tv_only', 'fv_only', 'misaligned']
+  var allKeys = {}
+  var counts = {
+    aligned_on_time: 0,
+    aligned_late: 0,
+    tv_only: 0,
+    fv_only: 0,
+    misaligned: 0,
+  }
+
+  for (var ci = 0; ci < cats.length; ci++) {
+    var cat = cats[ci]
+    var list = merged[cat] || []
+    counts[cat] = list.length
+    for (var fi = 0; fi < list.length; fi++) {
+      var key = list[fi] && list[fi].key
+      if (key) allKeys[key] = true
+    }
+  }
+
+  var total = Object.keys(allKeys).length
+  return {
+    total: total,
+    aligned_on_time: counts.aligned_on_time,
+    aligned_late: counts.aligned_late,
+    tv_only: counts.tv_only,
+    fv_only: counts.fv_only,
+    misaligned: counts.misaligned,
+    alignment_pct: total > 0
+      ? Math.round(1000 * (counts.aligned_on_time + counts.aligned_late) / total) / 10
+      : 0,
+  }
+}

--- a/modules/releases/client/composables/useReleaseFamily.js
+++ b/modules/releases/client/composables/useReleaseFamily.js
@@ -1,4 +1,5 @@
 import { ref, computed } from 'vue'
+import { countUniqueCategoryTotals } from './mergeReleaseDetails'
 
 // ═══ RELEASE NAME PARSING ═══
 
@@ -427,9 +428,15 @@ export function useReleaseFamily(filteredSummary, data) {
         return compareMilestoneKeys(a, b)
       })
 
+      var releasesMap = data && data.value && data.value.releases
+
       var milestones = c.milestoneOrder.map(function (mk) {
         var ms = c.milestones[mk]
-        var totals = sumRows(ms.rows)
+        var names = ms.rows.map(function (r) { return r.release })
+        // Prefer unique-key totals from detail buckets so multi-product features
+        // are not double-counted (matches all-products section counts).
+        var uniqueTotals = countUniqueCategoryTotals(releasesMap, names)
+        var totals = uniqueTotals || sumRows(ms.rows)
         return {
           key: ms.key,
           label: ms.label,
@@ -439,15 +446,20 @@ export function useReleaseFamily(filteredSummary, data) {
       })
 
       var allRows = []
+      var allNames = []
       for (var mi = 0; mi < milestones.length; mi++) {
         allRows = allRows.concat(milestones[mi].rows)
+        for (var ri = 0; ri < milestones[mi].rows.length; ri++) {
+          allNames.push(milestones[mi].rows[ri].release)
+        }
       }
 
+      var cycleUnique = countUniqueCategoryTotals(releasesMap, allNames)
       return {
         key: c.key,
         label: c.label,
         milestones: milestones,
-        totals: sumRows(allRows),
+        totals: cycleUnique || sumRows(allRows),
       }
     })
   })

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -8,6 +8,7 @@ import { useComponentLeads } from '../composables/useComponentLeads'
 import { useTvFvData } from '../composables/useTvFvData'
 import { useReleaseFamily, getAlignmentTarget, buildNameRollup } from '../composables/useReleaseFamily'
 import { mergeReleaseDetails } from '../composables/mergeReleaseDetails'
+import { buildKeysJqlUrl } from '../composables/jiraKeysJql'
 import { DEFAULT_SELECTED_VERSIONS } from '../composables/tvFvDeltaDefaults'
 
 const FEATURE_COLS = [
@@ -18,7 +19,7 @@ const FEATURE_COLS = [
 /** Plain-English explanations for executive summary / component table headers */
 const COLUMN_HELP = {
   release: 'Jira Target Version / Fix Version name for this product release.',
-  total: 'All features that have this release on Target Version (TV) or Fix Version (FV).',
+  total: 'All features that have this release on Target Version (TV) or Fix Version (FV). Cycle/milestone rollups count each issue once across products.',
   aligned_on_time: 'Aligned on time: Fix Version matches Target Version, or ships earlier than planned.',
   aligned_late: 'Aligned late: Fix Version is later than Target Version, but planning freeze for that Target Version has already passed — accepted slip.',
   tv_only: 'TV-only: Target Version is set for this release, but Fix Version is empty.',
@@ -128,10 +129,17 @@ const releaseData = computed(() => {
   return mergeReleaseDetails(data.value.releases, activeReleaseNames.value)
 })
 
-/** Per-product Jira deep-links only apply in single-product mode */
-const releaseSummary = computed(() => {
-  if (!data.value || selectedMilestoneKey.value || !selectedRelease.value) return null
-  return data.value.executive_summary.find(s => s.release === selectedRelease.value)
+/** Section "View in Jira" links — exact keys shown in the table (works for all-products + late/misaligned) */
+const sectionJiraLinks = computed(() => {
+  const rd = releaseData.value
+  if (!rd) return {}
+  return {
+    tv_only: buildKeysJqlUrl(rd.tv_only),
+    fv_only: buildKeysJqlUrl(rd.fv_only),
+    aligned_on_time: buildKeysJqlUrl(rd.aligned_on_time),
+    aligned_late: buildKeysJqlUrl(rd.aligned_late),
+    misaligned: buildKeysJqlUrl(rd.misaligned),
+  }
 })
 
 const filteredSummary = computed(() => {
@@ -672,8 +680,8 @@ onBeforeUnmount(() => {
               </span>
             </span>
             <a
-              v-if="releaseSummary"
-              :href="releaseSummary.tv_only_jql"
+              v-if="sectionJiraLinks.tv_only"
+              :href="sectionJiraLinks.tv_only"
               target="_blank"
               rel="noopener noreferrer"
               class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
@@ -699,8 +707,8 @@ onBeforeUnmount(() => {
               </span>
             </span>
             <a
-              v-if="releaseSummary"
-              :href="releaseSummary.fv_only_jql"
+              v-if="sectionJiraLinks.fv_only"
+              :href="sectionJiraLinks.fv_only"
               target="_blank"
               rel="noopener noreferrer"
               class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
@@ -726,8 +734,8 @@ onBeforeUnmount(() => {
               </span>
             </span>
             <a
-              v-if="releaseSummary && releaseSummary.aligned_on_time_jql"
-              :href="releaseSummary.aligned_on_time_jql"
+              v-if="sectionJiraLinks.aligned_on_time"
+              :href="sectionJiraLinks.aligned_on_time"
               target="_blank"
               rel="noopener noreferrer"
               class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
@@ -752,6 +760,16 @@ onBeforeUnmount(() => {
                 Aligned Late — slipped after planning freeze ({{ releaseData.aligned_late.length }})
               </span>
             </span>
+            <a
+              v-if="sectionJiraLinks.aligned_late"
+              :href="sectionJiraLinks.aligned_late"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              @click.stop
+            >
+              View in Jira &rarr;
+            </a>
           </summary>
           <FeatureTable
             :features="releaseData.aligned_late"
@@ -768,6 +786,16 @@ onBeforeUnmount(() => {
                 Misaligned — slip before freeze, or different products ({{ releaseData.misaligned.length }})
               </span>
             </span>
+            <a
+              v-if="sectionJiraLinks.misaligned"
+              :href="sectionJiraLinks.misaligned"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              @click.stop
+            >
+              View in Jira &rarr;
+            </a>
           </summary>
           <FeatureTable
             :features="releaseData.misaligned"

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -932,6 +932,14 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     const count = await jiraLinks.count();
     // Should have "View in Jira" on each visible category section
     expect(count).toBeGreaterThanOrEqual(3);
+    // Links use exact key-in JQL for the rows shown in the section
+    await expect(jiraLinks.first()).toHaveAttribute('href', /key\+in|key%20in|key in/);
+
+    // Also available in all-products (milestone) scope
+    const selector = page.locator('div.mb-6.space-y-4');
+    await selector.getByRole('button', { name: /3\.5 EA1 Release\s+all products/ }).click();
+    await page.waitForTimeout(300);
+    expect(await page.locator('summary a:has-text("View in Jira")').count()).toBeGreaterThanOrEqual(3);
 
     expect(relevantErrors(page)).toHaveLength(0);
   });

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -928,9 +928,12 @@ test.describe('TV/FV Delta — Category Sections @tv-fv-delta', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
 
+    // Default GA fixture only has aligned_on_time; pick EA1 (aligned + TV-only + misaligned)
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
+
     const jiraLinks = page.locator('summary a:has-text("View in Jira")');
     const count = await jiraLinks.count();
-    // Should have "View in Jira" on each visible category section
+    // Should have "View in Jira" on each non-empty category section
     expect(count).toBeGreaterThanOrEqual(3);
     // Links use exact key-in JQL for the rows shown in the section
     await expect(jiraLinks.first()).toHaveAttribute('href', /key\+in|key%20in|key in/);
@@ -1102,7 +1105,8 @@ test.describe('TV/FV Delta — Feature Tables @tv-fv-delta', () => {
     await page.waitForTimeout(300);
 
     const tvOnlyDetails = page.locator('details:has(summary:has-text("TV-Only"))');
-    const keyLink = tvOnlyDetails.locator('a[href*="RHAISTRAT-200"]');
+    // Prefer /browse/ so the section "View in Jira" key-in link does not also match
+    const keyLink = tvOnlyDetails.locator('a[href*="/browse/RHAISTRAT-200"]');
     await expect(keyLink).toBeVisible();
     const href = await keyLink.getAttribute('href');
     expect(href).toContain('redhat.atlassian.net/browse/RHAISTRAT-200');


### PR DESCRIPTION
## Summary
- **84 vs 83 (and similar gaps):** milestone/cycle rollups summed per-product category counts, while the all-products detail view dedupes by issue key. One feature on both RHOAI + RHAII was counted twice in the rollup.
- Fix rollups to count **unique keys for every category** (and overall total) when detail buckets are available.
- Add **View in Jira →** on every category section (including all-products, Aligned Late, Misaligned) via `key in (...)` for the exact rows shown.

## Test plan
- [x] Unit tests for unique-key totals across all categories + key-in JQL helper
- [ ] Open 3.6 EA1 **All products** — milestone TV-Only (and other columns) should match section header counts
- [ ] Each section shows **View in Jira →** and opens the keys listed in that table
- [ ] Single-product rows still show their own (non-deduped) product counts


Made with [Cursor](https://cursor.com)