### PR TITLE
feat(releases): link Component Breakdown counts to Jira

### DIFF
--- a/modules/releases/__tests__/client/tv-fv-delta/jiraKeysJql.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/jiraKeysJql.test.js
@@ -17,4 +17,11 @@ describe('buildKeysJqlUrl', function () {
     var jql = decodeURIComponent(url.split('jql=')[1])
     expect(jql).toBe('key in (RHAISTRAT-1, RHAISTRAT-2)')
   })
+
+  it('falls back to /browse/ KEY from url when key is missing', function () {
+    var url = buildKeysJqlUrl([
+      { url: 'https://redhat.atlassian.net/browse/RHAISTRAT-2196' },
+    ])
+    expect(decodeURIComponent(url.split('jql=')[1])).toBe('key in (RHAISTRAT-2196)')
+  })
 })

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -363,6 +363,49 @@ describe('TvFvDeltaView milestone vs product selection', function () {
   })
 })
 
+describe('TvFvDeltaView category section Jira links', function () {
+  beforeEach(function () {
+    mockApiRequest.mockReset()
+  })
+
+  it('shows View in Jira on Misaligned when the section has features', async function () {
+    var wrapper = await mountView({
+      releases: {
+        '3.6 GA RHOAI RELEASE': {
+          aligned_on_time: [],
+          aligned_late: [],
+          tv_only: [],
+          fv_only: [],
+          misaligned: [
+            {
+              key: 'RHAISTRAT-2196',
+              url: 'https://redhat.atlassian.net/browse/RHAISTRAT-2196',
+              summary: 'Misaligned A',
+            },
+            {
+              key: 'RHAISTRAT-2013',
+              url: 'https://redhat.atlassian.net/browse/RHAISTRAT-2013',
+              summary: 'Misaligned B',
+            },
+          ],
+        },
+      },
+    })
+
+    var misaligned = wrapper.findAll('details').find(function (d) {
+      return d.text().includes('Misaligned —')
+    })
+    expect(misaligned).toBeTruthy()
+    var jiraLink = misaligned.findAll('a').find(function (a) {
+      return a.text().includes('View in Jira')
+    })
+    expect(jiraLink).toBeTruthy()
+    expect(jiraLink.attributes('href')).toContain('key')
+    expect(jiraLink.attributes('href')).toContain('RHAISTRAT-2196')
+    expect(jiraLink.attributes('href')).toContain('RHAISTRAT-2013')
+  })
+})
+
 describe('TvFvDeltaView component breakdown PM/ENG columns', function () {
   beforeEach(function () {
     mockApiRequest.mockReset()

--- a/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/tv-fv-delta-view.test.js
@@ -87,7 +87,7 @@ async function mountView(extraData) {
     global: {
       stubs: {
         ClickableCount: {
-          template: '<span class="clickable-count">{{ count }}</span>',
+          template: '<a v-if="jql" class="clickable-count" :href="jql">{{ count }}</a><span v-else class="clickable-count">{{ count }}</span>',
           props: ['count', 'jql', 'color', 'label'],
         },
       },
@@ -406,6 +406,13 @@ describe('TvFvDeltaView component breakdown PM/ENG columns', function () {
     })
     expect(servingRow.text()).toContain('PM Lead Serving')
     expect(servingRow.text()).toContain('Eng Lead Serving')
+
+    // Non-zero counts link to key-in Jira lists for that component
+    var totalLink = servingRow.findAll('a').find(function (a) {
+      return a.attributes('href') && a.attributes('href').includes('key') && a.text().trim() === '1'
+    })
+    expect(totalLink).toBeTruthy()
+    expect(totalLink.attributes('href')).toContain('RHAISTRAT-1')
 
     var unknownRow = table.findAll('tbody tr').find(function (r) {
       return r.text().includes('Unknown Comp')

--- a/modules/releases/__tests__/client/tv-fv-delta/useComponentBreakdown.test.js
+++ b/modules/releases/__tests__/client/tv-fv-delta/useComponentBreakdown.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useComponentBreakdown } from '../../../client/composables/useComponentBreakdown'
+
+function setup(releaseData, metadata) {
+  var data = ref({
+    metadata: metadata || { all_components: [] },
+    releases: {},
+  })
+  var rd = ref(releaseData)
+  return useComponentBreakdown(data, rd).releaseComponentBreakdown
+}
+
+describe('useComponentBreakdown Jira links', function () {
+  it('builds key-in JQL URLs for every non-zero category count', function () {
+    var breakdown = setup({
+      aligned_on_time: [
+        { key: 'RHAISTRAT-1', component: 'Serving' },
+        { key: 'RHAISTRAT-2', component: 'Serving' },
+      ],
+      aligned_late: [
+        { key: 'RHAISTRAT-3', component: 'Serving' },
+      ],
+      tv_only: [
+        { key: 'RHAISTRAT-4', component: 'Serving' },
+      ],
+      fv_only: [
+        { key: 'RHAISTRAT-5', component: 'Serving' },
+      ],
+      misaligned: [
+        { key: 'RHAISTRAT-6', component: 'Serving' },
+      ],
+    })
+
+    var serving = breakdown.value.find(function (c) { return c.component === 'Serving' })
+    expect(serving.total).toBe(6)
+    expect(serving.aligned_on_time).toBe(2)
+    expect(serving.total_jql).toMatch(/key%20in%20\(/)
+    expect(serving.total_jql).toContain('RHAISTRAT-1')
+    expect(serving.total_jql).toContain('RHAISTRAT-6')
+    expect(serving.aligned_on_time_jql).toContain('RHAISTRAT-1')
+    expect(serving.aligned_on_time_jql).toContain('RHAISTRAT-2')
+    expect(serving.aligned_on_time_jql).not.toContain('RHAISTRAT-3')
+    expect(serving.aligned_late_jql).toContain('RHAISTRAT-3')
+    expect(serving.tv_only_jql).toContain('RHAISTRAT-4')
+    expect(serving.fv_only_jql).toContain('RHAISTRAT-5')
+    expect(serving.misaligned_jql).toContain('RHAISTRAT-6')
+  })
+
+  it('leaves JQL empty when a category count is zero', function () {
+    var breakdown = setup({
+      aligned_on_time: [{ key: 'RHAISTRAT-1', component: 'Training' }],
+      aligned_late: [],
+      tv_only: [],
+      fv_only: [],
+      misaligned: [],
+    }, { all_components: ['Training', 'EmptyComp'] })
+
+    var training = breakdown.value.find(function (c) { return c.component === 'Training' })
+    expect(training.total_jql).toContain('RHAISTRAT-1')
+    expect(training.aligned_late_jql).toBe('')
+    expect(training.tv_only_jql).toBe('')
+
+    var empty = breakdown.value.find(function (c) { return c.component === 'EmptyComp' })
+    expect(empty.total).toBe(0)
+    expect(empty.total_jql).toBe('')
+  })
+
+  it('dedupes multi-component features and still links total keys', function () {
+    var breakdown = setup({
+      aligned_on_time: [
+        { key: 'RHAISTRAT-10', component: 'Serving, Training' },
+      ],
+      aligned_late: [],
+      tv_only: [],
+      fv_only: [],
+      misaligned: [],
+    })
+
+    var serving = breakdown.value.find(function (c) { return c.component === 'Serving' })
+    var training = breakdown.value.find(function (c) { return c.component === 'Training' })
+    expect(serving.total).toBe(1)
+    expect(training.total).toBe(1)
+    expect(serving.total_jql).toContain('RHAISTRAT-10')
+    expect(training.total_jql).toContain('RHAISTRAT-10')
+  })
+})

--- a/modules/releases/client/components/ClickableCount.vue
+++ b/modules/releases/client/components/ClickableCount.vue
@@ -20,6 +20,7 @@ const emit = defineEmits(['drill-down'])
     :class="{
       'text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300': color === 'red',
       'text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300': color === 'yellow',
+      'text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300': color === 'amber',
       'text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300': color === 'green',
       'text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300': !color || color === 'default',
       'text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300': color === 'muted',
@@ -37,6 +38,7 @@ const emit = defineEmits(['drill-down'])
     :class="{
       'text-red-600 dark:text-red-400': color === 'red',
       'text-yellow-600 dark:text-yellow-400': color === 'yellow',
+      'text-amber-600 dark:text-amber-400': color === 'amber',
       'text-green-600 dark:text-green-400': color === 'green',
       'text-blue-600 dark:text-blue-400': !color || color === 'default',
     }"

--- a/modules/releases/client/composables/jiraKeysJql.js
+++ b/modules/releases/client/composables/jiraKeysJql.js
@@ -13,13 +13,22 @@ var MAX_KEYS = 400
  * @param {Array<{ key?: string }>|null|undefined} features
  * @returns {string} Jira URL, or '' when there are no keys
  */
+function featureKey(feat) {
+  if (!feat) return ''
+  if (feat.key) return feat.key
+  // Fallback: /browse/RHAISTRAT-123
+  var url = feat.url || ''
+  var match = url.match(/\/browse\/([A-Z][A-Z0-9]+-\d+)/i)
+  return match ? match[1] : ''
+}
+
 export function buildKeysJqlUrl(features) {
   if (!features || !features.length) return ''
 
   var keys = []
   var seen = {}
   for (var i = 0; i < features.length; i++) {
-    var key = features[i] && features[i].key
+    var key = featureKey(features[i])
     if (!key || seen[key]) continue
     seen[key] = true
     keys.push(key)

--- a/modules/releases/client/composables/useComponentBreakdown.js
+++ b/modules/releases/client/composables/useComponentBreakdown.js
@@ -1,4 +1,62 @@
 import { computed } from 'vue'
+import { buildKeysJqlUrl } from './jiraKeysJql'
+
+var CATEGORIES = ['aligned_on_time', 'aligned_late', 'tv_only', 'fv_only', 'misaligned']
+
+function emptyBucket() {
+  return {
+    component: '',
+    total: 0,
+    aligned_on_time: 0,
+    aligned_late: 0,
+    tv_only: 0,
+    fv_only: 0,
+    misaligned: 0,
+    alignment_pct: 0,
+    total_jql: '',
+    aligned_on_time_jql: '',
+    aligned_late_jql: '',
+    tv_only_jql: '',
+    fv_only_jql: '',
+    misaligned_jql: '',
+  }
+}
+
+function featuresForKeys(keySet, byKey) {
+  var out = []
+  keySet.forEach(function (key) {
+    if (byKey[key]) out.push(byKey[key])
+  })
+  return out
+}
+
+function toRow(compName, bucket, byKey) {
+  if (!bucket) {
+    var empty = emptyBucket()
+    empty.component = compName
+    return empty
+  }
+
+  var totalFeatures = featuresForKeys(bucket.keys, byKey)
+  return {
+    component: compName,
+    total: bucket.total,
+    aligned_on_time: bucket.aligned_on_time,
+    aligned_late: bucket.aligned_late,
+    tv_only: bucket.tv_only,
+    fv_only: bucket.fv_only,
+    misaligned: bucket.misaligned,
+    alignment_pct: bucket.total
+      ? Math.round(1000 * (bucket.aligned_on_time + bucket.aligned_late) / bucket.total) / 10
+      : 0,
+    total_jql: buildKeysJqlUrl(totalFeatures),
+    aligned_on_time_jql: buildKeysJqlUrl(featuresForKeys(bucket.byCategory.aligned_on_time, byKey)),
+    aligned_late_jql: buildKeysJqlUrl(featuresForKeys(bucket.byCategory.aligned_late, byKey)),
+    tv_only_jql: buildKeysJqlUrl(featuresForKeys(bucket.byCategory.tv_only, byKey)),
+    fv_only_jql: buildKeysJqlUrl(featuresForKeys(bucket.byCategory.fv_only, byKey)),
+    misaligned_jql: buildKeysJqlUrl(featuresForKeys(bucket.byCategory.misaligned, byKey)),
+  }
+}
 
 /** Per-release component breakdown computation. */
 export function useComponentBreakdown(data, releaseData) {
@@ -13,22 +71,36 @@ export function useComponentBreakdown(data, releaseData) {
       ...releaseData.value.misaligned.map(f => ({ ...f, category: 'misaligned' })),
     ]
 
+    const byKey = {}
     const compMap = {}
     for (const feat of allFeatures) {
+      if (feat.key) byKey[feat.key] = feat
       const comps = Array.isArray(feat.components)
         ? feat.components
         : (feat.component ? feat.component.split(', ').map(c => c.trim()).filter(Boolean) : [])
       for (const comp of comps) {
         if (!compMap[comp]) {
+          var byCategory = {}
+          for (var ci = 0; ci < CATEGORIES.length; ci++) {
+            byCategory[CATEGORIES[ci]] = new Set()
+          }
           compMap[comp] = {
-            component: comp, total: 0, aligned_on_time: 0, aligned_late: 0,
-            tv_only: 0, fv_only: 0, misaligned: 0, keys: new Set(),
+            component: comp,
+            total: 0,
+            aligned_on_time: 0,
+            aligned_late: 0,
+            tv_only: 0,
+            fv_only: 0,
+            misaligned: 0,
+            keys: new Set(),
+            byCategory: byCategory,
           }
         }
         if (!compMap[comp].keys.has(feat.key)) {
           compMap[comp].keys.add(feat.key)
           compMap[comp].total++
           compMap[comp][feat.category]++
+          if (feat.key) compMap[comp].byCategory[feat.category].add(feat.key)
         }
       }
     }
@@ -37,22 +109,9 @@ export function useComponentBreakdown(data, releaseData) {
 
     let compList
     if (allComponentNames.length > 0) {
-      compList = allComponentNames.map(compName => {
-        const c = compMap[compName]
-        if (!c) {
-          return { component: compName, total: 0, aligned_on_time: 0, aligned_late: 0, tv_only: 0, fv_only: 0, misaligned: 0, alignment_pct: 0 }
-        }
-        return {
-          component: compName, total: c.total, aligned_on_time: c.aligned_on_time, aligned_late: c.aligned_late,
-          tv_only: c.tv_only, fv_only: c.fv_only, misaligned: c.misaligned,
-          alignment_pct: c.total ? Math.round(1000 * (c.aligned_on_time + c.aligned_late) / c.total) / 10 : 0,
-        }
-      })
+      compList = allComponentNames.map(compName => toRow(compName, compMap[compName], byKey))
     } else {
-      compList = Object.values(compMap).map(c => ({
-        component: c.component, total: c.total, aligned_on_time: c.aligned_on_time, aligned_late: c.aligned_late, tv_only: c.tv_only, fv_only: c.fv_only, misaligned: c.misaligned,
-        alignment_pct: c.total ? Math.round(1000 * (c.aligned_on_time + c.aligned_late) / c.total) / 10 : 0,
-      }))
+      compList = Object.keys(compMap).map(compName => toRow(compName, compMap[compName], byKey))
     }
 
     return compList.sort((a, b) => b.total - a.total || a.component.localeCompare(b.component))

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -840,12 +840,24 @@ onBeforeUnmount(() => {
                 <td class="px-4 py-2 text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
                   {{ leadsFor(comp.component)?.engLead || '—' }}
                 </td>
-                <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">{{ comp.total }}</td>
-                <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">{{ comp.aligned_on_time }}</td>
-                <td class="px-4 py-2 text-right text-amber-600 dark:text-amber-400">{{ comp.aligned_late }}</td>
-                <td class="px-4 py-2 text-right text-yellow-600 dark:text-yellow-400">{{ comp.tv_only }}</td>
-                <td class="px-4 py-2 text-right text-gray-500 dark:text-gray-400">{{ comp.fv_only }}</td>
-                <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">{{ comp.misaligned }}</td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount :count="comp.total" :jql="comp.total_jql" label="Total features" />
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount :count="comp.aligned_on_time" :jql="comp.aligned_on_time_jql" color="green" label="Aligned on time" />
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount :count="comp.aligned_late" :jql="comp.aligned_late_jql" color="amber" label="Aligned late" />
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount :count="comp.tv_only" :jql="comp.tv_only_jql" color="yellow" label="TV-only" />
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount :count="comp.fv_only" :jql="comp.fv_only_jql" color="muted" label="FV-only" />
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <ClickableCount :count="comp.misaligned" :jql="comp.misaligned_jql" color="red" label="Misaligned" />
+                </td>
                 <td class="px-4 py-2 text-right">
                   <span
                     class="font-semibold"

--- a/modules/releases/client/views/TvFvDeltaView.vue
+++ b/modules/releases/client/views/TvFvDeltaView.vue
@@ -672,10 +672,10 @@ onBeforeUnmount(() => {
         </p>
         <!-- TV-Only -->
         <details class="group bg-white dark:bg-gray-800 rounded-lg border border-yellow-200 dark:border-yellow-800 overflow-hidden mb-4">
-          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-yellow-50 dark:hover:bg-yellow-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-            <span class="flex items-center gap-2">
-              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-yellow-700 dark:text-yellow-400">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-yellow-50 dark:hover:bg-yellow-900/10 flex items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2 min-w-0">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform shrink-0">&#9654;</span>
+              <span class="text-sm font-semibold text-yellow-700 dark:text-yellow-400 truncate">
                 TV-Only — Target Version set, no Fix Version ({{ releaseData.tv_only.length }})
               </span>
             </span>
@@ -684,7 +684,7 @@ onBeforeUnmount(() => {
               :href="sectionJiraLinks.tv_only"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              class="shrink-0 whitespace-nowrap text-xs text-blue-600 dark:text-blue-400 hover:underline"
               @click.stop
             >
               View in Jira &rarr;
@@ -699,10 +699,10 @@ onBeforeUnmount(() => {
 
         <!-- FV-Only -->
         <details class="group bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden mb-4">
-          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-            <span class="flex items-center gap-2">
-              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-gray-600 dark:text-gray-400" :title="COLUMN_HELP.fv_only">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 flex items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2 min-w-0">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform shrink-0">&#9654;</span>
+              <span class="text-sm font-semibold text-gray-600 dark:text-gray-400 truncate" :title="COLUMN_HELP.fv_only">
                 FV-Only — Fix Version set, no Target Version ({{ releaseData.fv_only.length }})
               </span>
             </span>
@@ -711,7 +711,7 @@ onBeforeUnmount(() => {
               :href="sectionJiraLinks.fv_only"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              class="shrink-0 whitespace-nowrap text-xs text-blue-600 dark:text-blue-400 hover:underline"
               @click.stop
             >
               View in Jira &rarr;
@@ -726,10 +726,10 @@ onBeforeUnmount(() => {
 
         <!-- Aligned (on time) -->
         <details class="group bg-white dark:bg-gray-800 rounded-lg border border-green-200 dark:border-green-800 overflow-hidden mb-4">
-          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-            <span class="flex items-center gap-2">
-              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-green-700 dark:text-green-400" :title="COLUMN_HELP.aligned_on_time">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-green-50 dark:hover:bg-green-900/10 flex items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2 min-w-0">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform shrink-0">&#9654;</span>
+              <span class="text-sm font-semibold text-green-700 dark:text-green-400 truncate" :title="COLUMN_HELP.aligned_on_time">
                 Aligned On Time — shipping on or ahead of plan ({{ releaseData.aligned_on_time.length }})
               </span>
             </span>
@@ -738,7 +738,7 @@ onBeforeUnmount(() => {
               :href="sectionJiraLinks.aligned_on_time"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              class="shrink-0 whitespace-nowrap text-xs text-blue-600 dark:text-blue-400 hover:underline"
               @click.stop
             >
               View in Jira &rarr;
@@ -753,10 +753,10 @@ onBeforeUnmount(() => {
 
         <!-- Aligned (late) -->
         <details v-if="releaseData.aligned_late.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-amber-200 dark:border-amber-800 overflow-hidden mb-4">
-          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-            <span class="flex items-center gap-2">
-              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-amber-600 dark:text-amber-400" :title="COLUMN_HELP.aligned_late">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-900/10 flex items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2 min-w-0">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform shrink-0">&#9654;</span>
+              <span class="text-sm font-semibold text-amber-600 dark:text-amber-400 truncate" :title="COLUMN_HELP.aligned_late">
                 Aligned Late — slipped after planning freeze ({{ releaseData.aligned_late.length }})
               </span>
             </span>
@@ -765,7 +765,7 @@ onBeforeUnmount(() => {
               :href="sectionJiraLinks.aligned_late"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              class="shrink-0 whitespace-nowrap text-xs text-blue-600 dark:text-blue-400 hover:underline"
               @click.stop
             >
               View in Jira &rarr;
@@ -779,10 +779,10 @@ onBeforeUnmount(() => {
 
         <!-- Misaligned -->
         <details v-if="releaseData.misaligned.length" class="group bg-white dark:bg-gray-800 rounded-lg border border-red-200 dark:border-red-800 overflow-hidden mb-4">
-          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-            <span class="flex items-center gap-2">
-              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform">&#9654;</span>
-              <span class="text-sm font-semibold text-red-700 dark:text-red-400" :title="COLUMN_HELP.misaligned">
+          <summary class="list-none px-4 py-3 cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+            <span class="flex items-center gap-2 min-w-0">
+              <span class="text-xs text-gray-400 group-open:rotate-90 transition-transform shrink-0">&#9654;</span>
+              <span class="text-sm font-semibold text-red-700 dark:text-red-400 truncate" :title="COLUMN_HELP.misaligned">
                 Misaligned — slip before freeze, or different products ({{ releaseData.misaligned.length }})
               </span>
             </span>
@@ -791,7 +791,7 @@ onBeforeUnmount(() => {
               :href="sectionJiraLinks.misaligned"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              class="shrink-0 whitespace-nowrap text-xs text-blue-600 dark:text-blue-400 hover:underline"
               @click.stop
             >
               View in Jira &rarr;

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1349,18 +1349,18 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     await expect(servingRow).toBeVisible();
 
     // Total (3) and Aligned On Time (2) should be key-in Jira links
-    const totalLink = servingRow.locator('a[href*="key"]').filter({ hasText: /^3$/ });
+    const totalLink = servingRow.getByRole('link', { name: '3', exact: true });
     await expect(totalLink).toBeVisible();
     await expect(totalLink).toHaveAttribute('href', /key%20in|key\+in|key in/);
     await expect(totalLink).toHaveAttribute('href', /RHAISTRAT-100/);
 
-    const alignedLink = servingRow.locator('a[href*="key"]').filter({ hasText: /^2$/ });
+    const alignedLink = servingRow.getByRole('link', { name: '2', exact: true });
     await expect(alignedLink).toBeVisible();
     await expect(alignedLink).toHaveAttribute('href', /RHAISTRAT-100/);
     await expect(alignedLink).toHaveAttribute('href', /RHAISTRAT-102/);
 
     // Zero cells stay plain text (no Jira link)
-    await expect(servingRow.locator('a[href*="key"]').filter({ hasText: /^0$/ })).toHaveCount(0);
+    await expect(servingRow.getByRole('link', { name: '0', exact: true })).toHaveCount(0);
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
@@ -1447,7 +1447,8 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     await page.waitForTimeout(300);
 
     const compSection = page.locator('details:has(summary:has-text("Component Breakdown"))');
-    const pctSpans = compSection.locator('tbody span.font-semibold');
+    // Alignment % is the last column — avoid matching ClickableCount zero spans
+    const pctSpans = compSection.locator('tbody td:last-child span.font-semibold');
     const count = await pctSpans.count();
     expect(count).toBeGreaterThan(0);
 

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -1321,6 +1321,7 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     await page.goto('/#/releases/reports?report=tv-fv-delta');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
 
     // Expand Component Breakdown
     await page.locator('summary:has-text("Component Breakdown")').click();
@@ -1330,6 +1331,36 @@ test.describe('TV/FV Delta — Component Breakdown @tv-fv-delta', () => {
     // EA1: Serving appears in RHAISTRAT-100, 102, 300 = 3 features (meets >= 2 threshold)
     const servingRow = compSection.locator('tbody tr', { hasText: 'Serving' });
     await expect(servingRow).toBeVisible();
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
+
+  test('should link non-zero component counts to Jira key-in lists', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+    await selectVersion(page, '3.5 EA1 RHOAI RELEASE');
+
+    await page.locator('summary:has-text("Component Breakdown")').click();
+    await page.waitForTimeout(300);
+
+    const servingRow = page.locator('details:has(summary:has-text("Component Breakdown"))')
+      .locator('tbody tr', { hasText: 'Serving' });
+    await expect(servingRow).toBeVisible();
+
+    // Total (3) and Aligned On Time (2) should be key-in Jira links
+    const totalLink = servingRow.locator('a[href*="key"]').filter({ hasText: /^3$/ });
+    await expect(totalLink).toBeVisible();
+    await expect(totalLink).toHaveAttribute('href', /key%20in|key\+in|key in/);
+    await expect(totalLink).toHaveAttribute('href', /RHAISTRAT-100/);
+
+    const alignedLink = servingRow.locator('a[href*="key"]').filter({ hasText: /^2$/ });
+    await expect(alignedLink).toBeVisible();
+    await expect(alignedLink).toHaveAttribute('href', /RHAISTRAT-100/);
+    await expect(alignedLink).toHaveAttribute('href', /RHAISTRAT-102/);
+
+    // Zero cells stay plain text (no Jira link)
+    await expect(servingRow.locator('a[href*="key"]').filter({ hasText: /^0$/ })).toHaveCount(0);
 
     expect(relevantErrors(page)).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- Component Breakdown count cells (Total, Aligned On Time/Late, TV-Only, FV-Only, Misaligned) with values **> 0** now link to a Jira `key in (...)` search for the issues in that cell.
- Zero counts stay plain text; Alignment % stays a percentage (not a key list).
- Reuses the existing `ClickableCount` + `buildKeysJqlUrl` helpers.

## Test plan
- [x] Unit tests for per-category / total key-in URLs and empty categories
- [x] View test asserts Serving total links include the feature key
- [ ] Open TV/FV Delta → pick a release with component data → expand Component Breakdown
- [ ] Click a non-zero Total / TV-Only / Misaligned cell → Jira opens with those keys
- [ ] Zero cells are not links


Made with [Cursor](https://cursor.com)