### PR TITLE
feat(releases): add Hide Closed filter to PM Hub

### DIFF
--- a/modules/releases/__tests__/client/plan/pm-hub-filter-persistence.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-filter-persistence.test.js
@@ -24,6 +24,7 @@ function saveFilters(state) {
       releaseType: state.releaseType || [],
       status: state.status || [],
       blocked: state.blocked !== undefined ? state.blocked : null,
+      hideClosed: state.hideClosed || false,
       delOwner: state.delOwner || [],
       pmOwner: state.pmOwner || [],
       sort: state.sort || { column: null, direction: 'asc' }
@@ -47,6 +48,7 @@ function restoreFilters() {
     if (state.releaseType && Array.isArray(state.releaseType)) result.releaseType = state.releaseType
     if (state.status && Array.isArray(state.status)) result.status = state.status
     if (state.blocked !== undefined) result.blocked = state.blocked
+    if (state.hideClosed !== undefined) result.hideClosed = !!state.hideClosed
     if (state.delOwner && Array.isArray(state.delOwner)) result.delOwner = state.delOwner
     if (state.pmOwner && Array.isArray(state.pmOwner)) result.pmOwner = state.pmOwner
     if (state.sort && typeof state.sort === 'object') result.sort = state.sort
@@ -88,6 +90,7 @@ describe('saveFilters', function () {
       releaseType: ['Feature'],
       status: ['Green'],
       blocked: true,
+      hideClosed: true,
       delOwner: ['Alice'],
       pmOwner: ['Bob'],
       sort: { column: 'key', direction: 'asc' }
@@ -104,6 +107,7 @@ describe('saveFilters', function () {
     expect(parsed.releaseType).toEqual(['Feature'])
     expect(parsed.status).toEqual(['Green'])
     expect(parsed.blocked).toBe(true)
+    expect(parsed.hideClosed).toBe(true)
     expect(parsed.delOwner).toEqual(['Alice'])
     expect(parsed.pmOwner).toEqual(['Bob'])
     expect(parsed.sort).toEqual({ column: 'key', direction: 'asc' })
@@ -115,7 +119,20 @@ describe('saveFilters', function () {
     expect(parsed.pillars).toEqual([])
     expect(parsed.components).toEqual([])
     expect(parsed.blocked).toBeNull()
+    expect(parsed.hideClosed).toBe(false)
     expect(parsed.sort).toEqual({ column: null, direction: 'asc' })
+  })
+
+  it('saves hideClosed=true correctly', function () {
+    saveFilters({ hideClosed: true })
+    var parsed = JSON.parse(store[STORAGE_KEY])
+    expect(parsed.hideClosed).toBe(true)
+  })
+
+  it('saves hideClosed=false correctly', function () {
+    saveFilters({ hideClosed: false })
+    var parsed = JSON.parse(store[STORAGE_KEY])
+    expect(parsed.hideClosed).toBe(false)
   })
 
   it('saves blocked=false correctly', function () {
@@ -178,6 +195,7 @@ describe('restoreFilters', function () {
       releaseType: ['Feature'],
       status: ['Green'],
       blocked: true,
+      hideClosed: true,
       delOwner: ['Alice'],
       pmOwner: ['Bob'],
       sort: { column: 'priority', direction: 'desc' }
@@ -192,9 +210,22 @@ describe('restoreFilters', function () {
     expect(restored.releaseType).toEqual(['Feature'])
     expect(restored.status).toEqual(['Green'])
     expect(restored.blocked).toBe(true)
+    expect(restored.hideClosed).toBe(true)
     expect(restored.delOwner).toEqual(['Alice'])
     expect(restored.pmOwner).toEqual(['Bob'])
     expect(restored.sort).toEqual({ column: 'priority', direction: 'desc' })
+  })
+
+  it('restores hideClosed=true correctly', function () {
+    saveFilters({ hideClosed: true })
+    var restored = restoreFilters()
+    expect(restored.hideClosed).toBe(true)
+  })
+
+  it('restores hideClosed=false as false', function () {
+    saveFilters({ hideClosed: false })
+    var restored = restoreFilters()
+    expect(restored.hideClosed).toBe(false)
   })
 
   it('restores blocked=false correctly', function () {
@@ -284,6 +315,7 @@ describe('save/restore round-trip', function () {
       releaseType: ['Feature', 'Enhancement'],
       status: ['Green', 'Yellow', 'Red'],
       blocked: true,
+      hideClosed: true,
       delOwner: ['Alice', 'Bob'],
       pmOwner: ['Charlie', 'Diana'],
       sort: { column: 'priority', direction: 'desc' }
@@ -298,6 +330,7 @@ describe('save/restore round-trip', function () {
     expect(restored.releaseType).toEqual(original.releaseType)
     expect(restored.status).toEqual(original.status)
     expect(restored.blocked).toEqual(original.blocked)
+    expect(restored.hideClosed).toEqual(original.hideClosed)
     expect(restored.delOwner).toEqual(original.delOwner)
     expect(restored.pmOwner).toEqual(original.pmOwner)
     expect(restored.sort).toEqual(original.sort)

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -224,6 +224,16 @@
           {{ filterBlocked === true ? 'Blocked' : filterBlocked === false ? 'Not Blocked' : 'Blocked' }}
         </button>
 
+        <!-- Hide Closed -->
+        <button
+          type="button"
+          @click="hideClosed = !hideClosed; saveFilters()"
+          class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+          :class="hideClosed ? 'bg-gray-700 dark:bg-gray-200 border-gray-700 dark:border-gray-200 text-white dark:text-gray-800' : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'"
+        >
+          Hide Closed
+        </button>
+
         <!-- Docs Required -->
         <div class="inline-flex items-center rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 overflow-hidden">
           <button
@@ -439,6 +449,7 @@ var filterType = ref([])
 var filterReleaseType = ref([])
 var filterStatus = ref([])
 var filterBlocked = ref(null)
+var hideClosed = ref(false)
 var filterDelOwner = ref([])
 var filterPmOwner = ref([])
 var filterDocs = ref([])
@@ -471,6 +482,7 @@ function saveFilters() {
       releaseType: filterReleaseType.value,
       status: filterStatus.value,
       blocked: filterBlocked.value,
+      hideClosed: hideClosed.value,
       delOwner: filterDelOwner.value,
       pmOwner: filterPmOwner.value,
       docs: filterDocs.value,
@@ -493,6 +505,7 @@ function restoreFilters() {
     if (state.releaseType && Array.isArray(state.releaseType)) filterReleaseType.value = state.releaseType
     if (state.status && Array.isArray(state.status)) filterStatus.value = state.status
     if (state.blocked !== undefined) filterBlocked.value = state.blocked
+    if (state.hideClosed !== undefined) hideClosed.value = !!state.hideClosed
     if (state.delOwner && Array.isArray(state.delOwner)) filterDelOwner.value = state.delOwner
     if (state.pmOwner && Array.isArray(state.pmOwner)) filterPmOwner.value = state.pmOwner
     if (state.docs && Array.isArray(state.docs)) filterDocs.value = state.docs
@@ -542,6 +555,7 @@ var activeFilterCount = computed(function() {
   count += filterProduct.value.length + filterType.value.length + filterReleaseType.value.length
   count += filterStatus.value.length + filterDelOwner.value.length + filterPmOwner.value.length + filterDocs.value.length
   if (filterBlocked.value !== null) count++
+  if (hideClosed.value) count++
   return count
 })
 
@@ -557,6 +571,7 @@ function clearAllFilters() {
   filterReleaseType.value = []
   filterStatus.value = []
   filterBlocked.value = null
+  hideClosed.value = false
   filterDelOwner.value = []
   filterPmOwner.value = []
   filterDocs.value = []
@@ -641,7 +656,7 @@ var filteredPmOwners = computed(function() {
 })
 
 var hasClientFilters = computed(function() {
-  return filterProduct.value.length > 0 || filterType.value.length > 0 || filterReleaseType.value.length > 0 || filterStatus.value.length > 0 || filterBlocked.value !== null || filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0 || filterDocs.value.length > 0
+  return filterProduct.value.length > 0 || filterType.value.length > 0 || filterReleaseType.value.length > 0 || filterStatus.value.length > 0 || filterBlocked.value !== null || hideClosed.value || filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0 || filterDocs.value.length > 0
 })
 
 var clientFilteredGroups = computed(function() {
@@ -697,6 +712,7 @@ var clientFilteredGroups = computed(function() {
         }
         if (filterBlocked.value === true && !f.isBlocked) return false
         if (filterBlocked.value === false && f.isBlocked) return false
+        if (hideClosed.value && f.statusCategory === 'Done') return false
         if (filterDelOwner.value.length > 0 && filterDelOwner.value.indexOf(f.assignee || '') === -1) return false
         if (filterPmOwner.value.length > 0 && filterPmOwner.value.indexOf(f.pmOwner || '') === -1) return false
         if (filterDocs.value.length > 0) {
@@ -1096,7 +1112,7 @@ watch([selectedComponents, selectedVersions, selectedPillars], function() {
 
 // Save filters to localStorage on any filter change
 watch(
-  [selectedPillars, selectedComponents, selectedVersions, filterProduct, filterType, filterReleaseType, filterStatus, filterBlocked, filterDelOwner, filterPmOwner, filterDocs],
+  [selectedPillars, selectedComponents, selectedVersions, filterProduct, filterType, filterReleaseType, filterStatus, filterBlocked, hideClosed, filterDelOwner, filterPmOwner, filterDocs],
   saveFilters,
   { deep: true }
 )


### PR DESCRIPTION
## Summary

- Add a "Hide Closed" toggle button to PM Hub's Component Release Load report that excludes features with `statusCategory = Done` from the table view
- Filter is client-side only since `statusCategory` is already returned by the API
- Persists to localStorage alongside existing filters, included in active filter count and Clear All

Closes #1311

## Test plan

- [x] Unit tests for filter persistence round-trip (save/restore/clear) pass
- [x] ESLint passes clean
- [x] Manual: Load PM Hub > Component Release Load, toggle "Hide Closed", verify closed features disappear
- [x] Manual: Refresh page, verify filter state persists
- [x] Manual: Click "Clear All", verify toggle resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)