### PR TITLE
fix(releases): reject invalid productPagesShortname in product filter

### DIFF
--- a/modules/releases/__tests__/client/useScheduleHelpers.test.js
+++ b/modules/releases/__tests__/client/useScheduleHelpers.test.js
@@ -110,16 +110,21 @@ describe('formatShort', () => {
 })
 
 describe('getProduct', () => {
-  it('returns productPagesShortname when present', () => {
+  it('returns productPagesShortname when valid', () => {
     expect(getProduct({ productPagesShortname: 'rhoai', id: 'rhoai-3.5' })).toBe('rhoai')
+  })
+
+  it('rejects shortname with digits and falls back to id', () => {
+    expect(getProduct({ productPagesShortname: '3.5rhoai', id: 'rhoai-3.5' })).toBe('rhoai')
+    expect(getProduct({ productPagesShortname: '3.6-rhoai', id: 'rhoai-3.6.EA1' })).toBe('rhoai')
   })
 
   it('falls back to regex extraction from id', () => {
     expect(getProduct({ id: 'rhoai-3.5' })).toBe('rhoai')
   })
 
-  it('regex is case-insensitive', () => {
-    expect(getProduct({ id: 'RHOAI-3.5' })).toBe('RHOAI')
+  it('normalizes to lowercase', () => {
+    expect(getProduct({ id: 'RHOAI-3.5' })).toBe('rhoai')
   })
 
   it('returns full id when regex does not match', () => {

--- a/modules/releases/client/composables/useScheduleHelpers.js
+++ b/modules/releases/client/composables/useScheduleHelpers.js
@@ -28,9 +28,15 @@ export function formatShort(dateStr, opts) {
 }
 
 export function getProduct(release) {
-  if (release.productPagesShortname) return release.productPagesShortname
-  const match = release.id.match(/^([a-z]+)-/i)
-  return match ? match[1] : release.id
+  var shortname = release.productPagesShortname
+  if (shortname && /^[a-z]+$/i.test(shortname)) return shortname
+  var sources = [release.id, release.displayName]
+  for (var i = 0; i < sources.length; i++) {
+    if (!sources[i]) continue
+    var match = sources[i].match(/^([a-z]+)-/i)
+    if (match) return match[1].toLowerCase()
+  }
+  return release.id
 }
 
 export function releasePhase(release) {


### PR DESCRIPTION
## Summary

Fix broken product filter pills showing "3.5rhoai" and "3.6-rhoai" instead of clean product names.

## Problem

The registry sync sets `productPagesShortname` to `releaseNumber.split('-')[0]`, which produces values like "3.5rhoai" when the release number format is "3.5-rhoai". `getProduct()` returns these verbatim, creating broken filter pills.

## Fix

`getProduct()` now validates that `productPagesShortname` contains only letters (`/^[a-z]+$/i`). Values with digits (like "3.5rhoai") are rejected and the function falls back to extracting the product name from the release id via regex. Results are lowercased for consistency.

## Test plan

- [ ] Verify product filter pills show clean names (rhaii / rhelai / rhoai) — no version prefixes
- [ ] Verify filtering by product works correctly
- [ ] Unit tests pass for `getProduct()` with both valid and invalid shortnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)