### PR TITLE
feat(releases): hide empty Big Rocks by default

### DIFF
--- a/modules/releases/__tests__/client/plan/components.test.js
+++ b/modules/releases/__tests__/client/plan/components.test.js
@@ -413,4 +413,36 @@ describe('FilterBar', () => {
     })
     expect(wrapper.text()).not.toContain('Clear Filters')
   })
+
+  it('shows empty-rocks toggle on big-rocks tab with hidden count', () => {
+    const wrapper = mount(FilterBar, {
+      props: {
+        filterOptions,
+        activeTab: 'big-rocks',
+        showEmptyRocks: false,
+        emptyRockCount: 3
+      }
+    })
+    expect(wrapper.text()).toContain('Show empty rocks')
+    expect(wrapper.text()).toContain('(3 hidden)')
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.exists()).toBe(true)
+    expect(checkbox.element.checked).toBe(false)
+  })
+
+  it('hides empty-rocks toggle on features tab', () => {
+    const wrapper = mount(FilterBar, {
+      props: { filterOptions, activeTab: 'features', emptyRockCount: 3 }
+    })
+    expect(wrapper.text()).not.toContain('Show empty rocks')
+  })
+
+  it('emits update:showEmptyRocks when toggle changes', async () => {
+    const wrapper = mount(FilterBar, {
+      props: { filterOptions, activeTab: 'big-rocks', showEmptyRocks: false, emptyRockCount: 1 }
+    })
+    await wrapper.find('input[type="checkbox"]').setValue(true)
+    expect(wrapper.emitted('update:showEmptyRocks')).toBeTruthy()
+    expect(wrapper.emitted('update:showEmptyRocks')[0]).toEqual([true])
+  })
 })

--- a/modules/releases/__tests__/client/plan/use-filters-big-rocks.test.js
+++ b/modules/releases/__tests__/client/plan/use-filters-big-rocks.test.js
@@ -3,21 +3,50 @@ import { ref } from 'vue'
 import { useFilters } from '../../../client/plan/composables/useFilters'
 
 var sampleBigRocks = [
-  { name: 'MaaS', pillar: 'Inference', owner: 'Pat Johnson', architect: 'Alex', notes: '', fullName: 'Model as a Service' },
-  { name: 'Gen AI Studio', pillar: 'Agents', owner: 'Morgan Lee', architect: 'Sam', notes: 'Priority', fullName: '' },
-  { name: 'Eval Hub', pillar: 'Inference', owner: 'Taylor', architect: '', notes: '', fullName: 'Evaluation Hub' }
+  { name: 'MaaS', pillar: 'Inference', owner: 'Pat Johnson', architect: 'Alex', notes: '', fullName: 'Model as a Service', featureCount: 3, rfeCount: 1 },
+  { name: 'Gen AI Studio', pillar: 'Agents', owner: 'Morgan Lee', architect: 'Sam', notes: 'Priority', fullName: '', featureCount: 2, rfeCount: 0 },
+  { name: 'Eval Hub', pillar: 'Inference', owner: 'Taylor', architect: '', notes: '', fullName: 'Evaluation Hub', featureCount: 1, rfeCount: 0 },
+  { name: 'Empty Rock', pillar: 'Inference', owner: 'Pat', architect: '', notes: 'wiring', fullName: '', featureCount: 0, rfeCount: 0 }
 ]
 
 describe('filteredBigRocks', function() {
-  it('returns all big rocks when no filters active', function() {
+  it('hides empty rocks by default', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref(sampleBigRocks)
     var result = useFilters(features, rfes, bigRocks)
-    expect(result.filteredBigRocks.value).toEqual(sampleBigRocks)
+    expect(result.showEmptyRocks.value).toBe(false)
+    expect(result.emptyRockCount.value).toBe(1)
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual([
+      'MaaS', 'Gen AI Studio', 'Eval Hub'
+    ])
   })
 
-  it('filters by pillar', function() {
+  it('shows empty rocks when toggle is on', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.showEmptyRocks.value = true
+    expect(result.filteredBigRocks.value).toHaveLength(4)
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toContain('Empty Rock')
+  })
+
+  it('treats missing feature/rfe counts as empty', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref([
+      { name: 'No Counts', pillar: 'Agents' },
+      { name: 'Has Work', pillar: 'Agents', featureCount: 1, rfeCount: 0 }
+    ])
+    var result = useFilters(features, rfes, bigRocks)
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['Has Work'])
+    result.showEmptyRocks.value = true
+    expect(result.filteredBigRocks.value).toHaveLength(2)
+  })
+
+  it('filters by pillar (still hides empty by default)', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref(sampleBigRocks)
@@ -26,6 +55,19 @@ describe('filteredBigRocks', function() {
     result.selectedPillar.value = 'Inference'
     expect(result.filteredBigRocks.value).toHaveLength(2)
     expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['MaaS', 'Eval Hub'])
+  })
+
+  it('filters by pillar and can include empty rocks', function() {
+    var features = ref([])
+    var rfes = ref([])
+    var bigRocks = ref(sampleBigRocks)
+    var result = useFilters(features, rfes, bigRocks)
+
+    result.selectedPillar.value = 'Inference'
+    result.showEmptyRocks.value = true
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual([
+      'MaaS', 'Eval Hub', 'Empty Rock'
+    ])
   })
 
   it('filters by search query (name)', function() {
@@ -100,18 +142,21 @@ describe('filteredBigRocks', function() {
     var bigRocks = ref(null)
     var result = useFilters(features, rfes, bigRocks)
     expect(result.filteredBigRocks.value).toEqual([])
+    expect(result.emptyRockCount.value).toBe(0)
   })
 
-  it('clearFilters resets pillar and shows all rocks', function() {
+  it('clearFilters resets pillar but keeps empty-rock preference', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref(sampleBigRocks)
     var result = useFilters(features, rfes, bigRocks)
 
     result.selectedPillar.value = 'Inference'
-    expect(result.filteredBigRocks.value).toHaveLength(2)
+    result.showEmptyRocks.value = true
+    expect(result.filteredBigRocks.value).toHaveLength(3)
 
     result.clearFilters()
-    expect(result.filteredBigRocks.value).toEqual(sampleBigRocks)
+    expect(result.showEmptyRocks.value).toBe(true)
+    expect(result.filteredBigRocks.value).toHaveLength(4)
   })
 })

--- a/modules/releases/client/plan/components/FilterBar.vue
+++ b/modules/releases/client/plan/components/FilterBar.vue
@@ -11,6 +11,8 @@ const props = defineProps({
   selectedPriority: { type: String, default: '' },
   selectedTeams: { type: Array, default: () => [] },
   searchQuery: { type: String, default: '' },
+  showEmptyRocks: { type: Boolean, default: false },
+  emptyRockCount: { type: Number, default: 0 },
   hasActiveFilters: { type: Boolean, default: false }
 })
 
@@ -21,6 +23,7 @@ const emit = defineEmits([
   'update:selectedPriority',
   'update:selectedTeams',
   'update:searchQuery',
+  'update:showEmptyRocks',
   'clearFilters'
 ])
 
@@ -148,6 +151,26 @@ useClickOutside(teamsDropdownRef, function() {
         </label>
       </div>
     </div>
+
+    <label
+      v-if="activeTab === 'big-rocks'"
+      class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none"
+      title="Rocks with 0 Features and 0 RFEs for this release are hidden by default"
+    >
+      <input
+        type="checkbox"
+        :checked="showEmptyRocks"
+        @change="$emit('update:showEmptyRocks', $event.target.checked)"
+        class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+      />
+      <span>Show empty rocks</span>
+      <span
+        v-if="!showEmptyRocks && emptyRockCount > 0"
+        class="text-xs text-gray-500 dark:text-gray-400"
+      >
+        ({{ emptyRockCount }} hidden)
+      </span>
+    </label>
 
     <button
       v-if="hasActiveFilters"

--- a/modules/releases/client/plan/composables/useFilters.js
+++ b/modules/releases/client/plan/composables/useFilters.js
@@ -1,5 +1,13 @@
 import { ref, computed } from 'vue'
 
+function rockChildCount(rock) {
+  return (rock.featureCount || 0) + (rock.rfeCount || 0)
+}
+
+function isEmptyRock(rock) {
+  return rockChildCount(rock) === 0
+}
+
 export function useFilters(features, rfes, bigRocks) {
   const selectedPillar = ref('')
   const selectedRock = ref('')
@@ -7,6 +15,8 @@ export function useFilters(features, rfes, bigRocks) {
   const selectedPriority = ref('')
   const selectedTeams = ref([])
   const searchQuery = ref('')
+  /** When false (default), rocks with 0 Features and 0 RFEs for this release are hidden. */
+  const showEmptyRocks = ref(false)
 
   function matchesFilters(item) {
     if (searchQuery.value) {
@@ -63,10 +73,15 @@ export function useFilters(features, rfes, bigRocks) {
     return rfes.value.filter(matchesFilters)
   })
 
+  const emptyRockCount = computed(() => {
+    if (!bigRocks.value) return 0
+    return bigRocks.value.filter(isEmptyRock).length
+  })
+
   const filteredBigRocks = computed(() => {
     if (!bigRocks.value) return []
-    if (!selectedPillar.value && !searchQuery.value) return bigRocks.value
     return bigRocks.value.filter(function(rock) {
+      if (!showEmptyRocks.value && isEmptyRock(rock)) return false
       if (selectedPillar.value && rock.pillar !== selectedPillar.value) return false
       if (searchQuery.value) {
         const q = searchQuery.value.toLowerCase()
@@ -104,6 +119,8 @@ export function useFilters(features, rfes, bigRocks) {
     selectedPriority,
     selectedTeams,
     searchQuery,
+    showEmptyRocks,
+    emptyRockCount,
     filteredFeatures,
     filteredRfes,
     filteredBigRocks,

--- a/modules/releases/client/plan/views/DashboardView.vue
+++ b/modules/releases/client/plan/views/DashboardView.vue
@@ -90,6 +90,8 @@ const {
   selectedPriority,
   selectedTeams,
   searchQuery,
+  showEmptyRocks,
+  emptyRockCount,
   filteredFeatures,
   filteredRfes,
   filteredBigRocks,
@@ -379,6 +381,8 @@ onMounted(async function() {
         v-model:selectedPriority="selectedPriority"
         v-model:selectedTeams="selectedTeams"
         v-model:searchQuery="searchQuery"
+        v-model:showEmptyRocks="showEmptyRocks"
+        :emptyRockCount="emptyRockCount"
         :hasActiveFilters="hasActiveFilters"
         @clearFilters="clearFilters"
       />

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -75,7 +75,17 @@ export const viewOwners = {
   'system-health/quality-analysis':                'Dana Gutride',
 
   // team-tracker
+  'team-tracker/home':                             'Dipanshu Gupta',
   'team-tracker/jira-taxonomy':                    'Alex Corvin',
+  'team-tracker/manage':                           'Alex Corvin',
+  'team-tracker/manager-dashboard':                'Alex Corvin',
+  'team-tracker/org-dashboard':                    'Alex Corvin',
+  'team-tracker/org-explorer':                     'Dipanshu Gupta',
+  'team-tracker/people':                           'Dipanshu Gupta',
+  'team-tracker/person-detail':                    'Dipanshu Gupta',
+  'team-tracker/reports':                          'Alex Corvin',
+  'team-tracker/team-detail':                      'Alex Corvin',
+  'team-tracker/unassigned':                       'Alex Corvin',
 
   // upstream-pulse
   'upstream-pulse/dashboard':                      'Dipanshu Gupta',
@@ -103,6 +113,12 @@ export const viewOwners = {
   // system-health > component-maturity
   'system-health/component-maturity/disconnected': 'Ajay Jaganathan',
 
+  // team-tracker > manage
+  'team-tracker/manage/data-quality':              'Alex Corvin',
+  'team-tracker/manage/field-options':             'Alex Corvin',
+  'team-tracker/manage/fields':                    'Alex Corvin',
+  'team-tracker/manage/teams':                     'Alex Corvin',
+
   // ── Report owners (module/view/reportId) ──
   // These override the view-level owner when a specific report is selected.
 
@@ -113,6 +129,11 @@ export const viewOwners = {
   'releases/reports/program-hygiene':              'Alex Corvin',
   'releases/reports/release-readiness':            'Arthy Loganathan',
   'releases/reports/tv-fv-delta':                  'Dimitri Saridakis',
+
+  // team-tracker > reports
+  'team-tracker/reports/allocation':               'Alex Corvin',
+  'team-tracker/reports/team-comparison':          'Alex Corvin',
+  'team-tracker/reports/trends':                   'Alex Corvin',
 }
 
 /**

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -533,6 +533,21 @@ test.describe('Releases Planning Health @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 
+  test('Big Rocks tab has Show empty rocks toggle (off by default)', async ({ page }) => {
+    await page.goto('/#/releases/plan');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const toggle = page.getByRole('checkbox', { name: /Show empty rocks/ });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
   // Health tab is temporarily hidden from PlanView — skip until re-enabled
   test.skip('Health tab loads and shows planning mode banner when applicable', async ({ page }) => {
     await page.goto('/#/releases/plan?tab=health');


### PR DESCRIPTION
## Summary
- Big Rocks with **0 Features and 0 RFEs** for the selected release are hidden by default (e.g. 3.5-complete outcomes that should not appear on 3.6).
- New **Show empty rocks** toggle on the Big Rocks filter bar for people still wiring outcomes; shows how many are hidden when off.

## Test plan
- [x] Unit tests for empty-rock filter + FilterBar toggle
- [ ] Open Plan → Big Rocks for 3.6 — rocks with no qualifying children are hidden
- [ ] Enable **Show empty rocks** — empty rocks reappear (with “N hidden” count when off)
- [ ] Pillar / search filters still work with the toggle


Made with [Cursor](https://cursor.com)