### PR TITLE
fix(releases): extract product name from any position in release id

### DIFF
--- a/modules/releases/__tests__/client/useScheduleHelpers.test.js
+++ b/modules/releases/__tests__/client/useScheduleHelpers.test.js
@@ -119,6 +119,11 @@ describe('getProduct', () => {
     expect(getProduct({ productPagesShortname: '3.6-rhoai', id: 'rhoai-3.6.EA1' })).toBe('rhoai')
   })
 
+  it('extracts product from reversed id format (version-product)', () => {
+    expect(getProduct({ productPagesShortname: '3.5', id: '3.5rhoai' })).toBe('rhoai')
+    expect(getProduct({ productPagesShortname: '3.6-rhoai', id: '3.6-rhoai' })).toBe('rhoai')
+  })
+
   it('falls back to regex extraction from id', () => {
     expect(getProduct({ id: 'rhoai-3.5' })).toBe('rhoai')
   })
@@ -127,8 +132,8 @@ describe('getProduct', () => {
     expect(getProduct({ id: 'RHOAI-3.5' })).toBe('rhoai')
   })
 
-  it('returns full id when regex does not match', () => {
-    expect(getProduct({ id: 'standalone' })).toBe('standalone')
+  it('returns full id when no 4+ letter sequence found', () => {
+    expect(getProduct({ id: 'ab-1' })).toBe('ab-1')
   })
 })
 

--- a/modules/releases/client/composables/useScheduleHelpers.js
+++ b/modules/releases/client/composables/useScheduleHelpers.js
@@ -33,7 +33,7 @@ export function getProduct(release) {
   var sources = [release.id, release.displayName]
   for (var i = 0; i < sources.length; i++) {
     if (!sources[i]) continue
-    var match = sources[i].match(/^([a-z]+)-/i)
+    var match = sources[i].match(/([a-z]{4,})/i)
     if (match) return match[1].toLowerCase()
   }
   return release.id

--- a/modules/releases/client/views/RegistryView.vue
+++ b/modules/releases/client/views/RegistryView.vue
@@ -539,6 +539,7 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUpdate, nextTick, watch, inject } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
+import { getProduct } from '../composables/useScheduleHelpers.js'
 import { useAuth } from '@shared/client/composables/useAuth.js'
 import HygieneConfigView from '../components/HygieneConfigView.vue'
 
@@ -623,11 +624,6 @@ const editForm = ref({
 
 const KNOWN_MILESTONES = ['codeFreeze', 'ea1', 'ga']
 
-function getProduct(release) {
-  if (release.productPagesShortname) return release.productPagesShortname
-  const match = release.id.match(/^([a-z]+)-/)
-  return match ? match[1] : release.id
-}
 
 const products = computed(() => {
   const set = new Set(releases.value.map(getProduct))


### PR DESCRIPTION
## Summary

Fix broken product filter pills showing "3.5rhoai" and "3.6-rhoai" on the Release Schedule page.

## Problem

PR #1316 fixed entries where `productPagesShortname` had digits, but the fallback regex `^([a-z]+)-` only matches product names at the START of the id. Some production registry entries have reversed formats where the version comes first (e.g., id: `"3.5rhoai"`, `"3.6-rhoai"`). The regex fails and returns the raw id as the product name.

## Fix

Changed `getProduct()` fallback from `^([a-z]+)-` (anchored to start) to `([a-z]{4,})` (finds 4+ letter sequence anywhere). All known product names (rhai, rhaii, rhoai, rhelai, rhaiis) are 4+ letters, so this skips short tokens like "EA" or "GA".

Examples:
- `"3.5rhoai"` → `"rhoai"` (was: `"3.5rhoai"`)
- `"3.6-rhoai"` → `"rhoai"` (was: `"3.6-rhoai"`)
- `"rhoai-3.5.EA1"` → `"rhoai"` (unchanged)

## Test plan

- [ ] Verify product filter pills show clean names (rhaii / rhelai / rhoai) — no version prefixes
- [ ] Unit tests cover reversed id formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)