### PR TITLE
fix(releases): count unique feature keys in PM Hub summary cards

### DIFF
--- a/modules/releases/__tests__/client/plan/pm-hub-summary-totals.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-summary-totals.test.js
@@ -121,19 +121,45 @@ function applyClientFilters(groups, filters) {
 }
 
 /**
- * Compute summary totals from (filtered) groups — mirrors the fix where
- * totalRequested/totalCommitted/totalBlocked read from clientFilteredGroups.
+ * Compute summary totals from (filtered) groups — mirrors ComponentReleaseLoadReport
+ * unique-key counting for Requested / Committed / Blocked cards.
  */
 function computeTotals(groups) {
+  var reqSeen = {}
+  var comSeen = {}
+  var blockedSeen = {}
   var requested = 0
   var committed = 0
   var blocked = 0
   for (var i = 0; i < groups.length; i++) {
     var comps = groups[i].components || []
     for (var ci = 0; ci < comps.length; ci++) {
-      requested += comps[ci].requestedCount || 0
-      committed += comps[ci].committedCount || 0
-      blocked += comps[ci].blockedCount || 0
+      var reqList = comps[ci].requestedFeatures || []
+      var comList = comps[ci].committedFeatures || []
+      for (var ri = 0; ri < reqList.length; ri++) {
+        var rk = reqList[ri] && reqList[ri].key
+        if (rk && !reqSeen[rk]) {
+          reqSeen[rk] = true
+          requested++
+        }
+      }
+      for (var cmi = 0; cmi < comList.length; cmi++) {
+        var ck = comList[cmi] && comList[cmi].key
+        if (ck && !comSeen[ck]) {
+          comSeen[ck] = true
+          committed++
+        }
+      }
+      var lists = [reqList, comList]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (f && f.key && f.isBlocked && !blockedSeen[f.key]) {
+            blockedSeen[f.key] = true
+            blocked++
+          }
+        }
+      }
     }
   }
   return { requested: requested, committed: committed, blocked: blocked }
@@ -443,6 +469,39 @@ describe('edge cases', function () {
     var totals = computeTotals(filtered)
     // Only X-1 matches both blocked=true AND status=Red
     expect(totals.requested).toBe(1)
+    expect(totals.blocked).toBe(1)
+  })
+
+  it('dedupes the same feature key across multiple components', function () {
+    var shared = makeFeature({ key: 'X-SHARED', isBlocked: true })
+    var groups = [{
+      version: 'rhoai-3.5',
+      components: [
+        {
+          component: 'Dashboard',
+          requestedFeatures: [shared],
+          committedFeatures: [shared],
+          requestedCount: 1,
+          committedCount: 1,
+          blockedCount: 1
+        },
+        {
+          component: 'Inference',
+          requestedFeatures: [shared],
+          committedFeatures: [shared],
+          requestedCount: 1,
+          committedCount: 1,
+          blockedCount: 1
+        }
+      ],
+      requestedCount: 2,
+      committedCount: 2,
+      blockedCount: 2
+    }]
+
+    var totals = computeTotals(groups)
+    expect(totals.requested).toBe(1)
+    expect(totals.committed).toBe(1)
     expect(totals.blocked).toBe(1)
   })
 

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -855,32 +855,51 @@ var filteredVersions = computed(function() {
   return portfolioVersionLabels.filter(function(name) { return name.toLowerCase().includes(q) })
 })
 
-var totalRequested = computed(function() {
-  var source = clientFilteredGroups.value
+/** Count unique feature keys across component groups (multi-component features must not inflate summary cards). */
+function countUniqueFeatureKeys(groups, listName) {
+  var seen = {}
   var count = 0
-  for (var i = 0; i < source.length; i++) {
-    var comps = source[i].components || []
-    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].requestedCount || 0
+  for (var gi = 0; gi < groups.length; gi++) {
+    var comps = groups[gi].components || []
+    for (var ci = 0; ci < comps.length; ci++) {
+      var list = comps[ci][listName] || []
+      for (var fi = 0; fi < list.length; fi++) {
+        var f = list[fi]
+        if (!f || !f.key || seen[f.key]) continue
+        seen[f.key] = true
+        count++
+      }
+    }
   }
   return count
+}
+
+var totalRequested = computed(function() {
+  return countUniqueFeatureKeys(clientFilteredGroups.value, 'requestedFeatures')
 })
 
 var totalCommitted = computed(function() {
-  var source = clientFilteredGroups.value
-  var count = 0
-  for (var i = 0; i < source.length; i++) {
-    var comps = source[i].components || []
-    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].committedCount || 0
-  }
-  return count
+  return countUniqueFeatureKeys(clientFilteredGroups.value, 'committedFeatures')
 })
 
 var totalBlocked = computed(function() {
+  // Unique blocked keys across either bucket (same feature under multiple components counts once)
   var source = clientFilteredGroups.value
+  var seen = {}
   var count = 0
-  for (var i = 0; i < source.length; i++) {
-    var comps = source[i].components || []
-    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].blockedCount || 0
+  for (var gi = 0; gi < source.length; gi++) {
+    var comps = source[gi].components || []
+    for (var ci = 0; ci < comps.length; ci++) {
+      var lists = [comps[ci].requestedFeatures || [], comps[ci].committedFeatures || []]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!f || !f.key || seen[f.key] || !f.isBlocked) continue
+          seen[f.key] = true
+          count++
+        }
+      }
+    }
   }
   return count
 })


### PR DESCRIPTION
## Summary
- PM Hub (Component Release Load Tracking) Requested / Committed / Blocked summary cards now count **unique feature keys** across components instead of summing per-component counts, so multi-component features are not double-counted.
- Mirrors the unique-key approach already used elsewhere in the report.

## Test plan
- [x] Automated: `npx vitest run modules/releases/__tests__/client/plan/pm-hub-summary-totals.test.js` (22 passed), including new coverage that the same feature key across multiple components contributes once to each summary total
- [ ] Optional manual: open Component Release Load Tracking, pick a release with multi-component features, confirm summary card totals match unique feature counts (not inflated by component duplication)


Made with [Cursor](https://cursor.com)