### PR TITLE
fix(releases): PM Hub display-only tiles and TV-aware Committed

### DIFF
--- a/modules/releases/__tests__/client/plan/pm-hub-summary-card-clicks.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-summary-card-clicks.test.js
@@ -1,32 +1,13 @@
 /**
- * Tests for PM Hub summary card click-to-filter and blocked percentage.
+ * Tests for PM Hub summary card display-only KPIs, blocked percentage,
+ * and filter-chip persistence (REQ/COM / Blocked chips — not tile clicks).
  *
- * Exercises the toggle logic, ring-class bindings, blocked percentage
- * computation, and filter persistence for the click-to-filter feature
- * added to the Requested, Committed, and Blocked summary cards.
+ * Summary tiles no longer toggle filters; click-to-filter was removed so
+ * independent Requested (TV) / Committed (FV) counts are not correlated via UI.
  *
  * Same inlined-function pattern as the other PM Hub test files.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-
-// ---------------------------------------------------------------------------
-// Inline toggle helpers from ComponentReleaseLoadReport.vue
-// ---------------------------------------------------------------------------
-
-function toggleInArray(arr, value) {
-  var idx = arr.indexOf(value)
-  if (idx >= 0) {
-    arr.splice(idx, 1)
-  } else {
-    arr.push(value)
-  }
-  return arr
-}
-
-function toggleFilter(filterRefs, filterName, value) {
-  var arr = filterRefs[filterName]
-  if (arr) toggleInArray(arr, value)
-}
 
 // ---------------------------------------------------------------------------
 // Inline totalFeatures + blockedPercent from ComponentReleaseLoadReport.vue
@@ -59,25 +40,22 @@ function computeBlockedPercent(totalBlocked, totalFeatures) {
 }
 
 // ---------------------------------------------------------------------------
-// Ring class helpers — mirrors the :class bindings on the cards
+// Chip toggle helpers (filter bar — not summary tiles)
 // ---------------------------------------------------------------------------
 
-function requestedCardRingClass(filterType) {
-  return filterType.indexOf('requested') >= 0
-    ? 'ring-2 ring-blue-300 dark:ring-blue-700'
-    : 'hover:shadow-md'
+function toggleInArray(arr, value) {
+  var idx = arr.indexOf(value)
+  if (idx >= 0) {
+    arr.splice(idx, 1)
+  } else {
+    arr.push(value)
+  }
+  return arr
 }
 
-function committedCardRingClass(filterType) {
-  return filterType.indexOf('committed') >= 0
-    ? 'ring-2 ring-emerald-300 dark:ring-emerald-700'
-    : 'hover:shadow-md'
-}
-
-function blockedCardRingClass(filterBlocked) {
-  return filterBlocked === true
-    ? 'ring-2 ring-red-300 dark:ring-red-700'
-    : 'hover:shadow-md'
+function toggleFilter(filterRefs, filterName, value) {
+  var arr = filterRefs[filterName]
+  if (arr) toggleInArray(arr, value)
 }
 
 // ---------------------------------------------------------------------------
@@ -184,108 +162,25 @@ beforeEach(function () {
 })
 
 // ---------------------------------------------------------------------------
-// Requested card click-to-filter
+// Summary tiles are display-only (no click-to-filter / selection rings)
 // ---------------------------------------------------------------------------
 
-describe('Requested card click-to-filter', function () {
-  it('clicking adds requested to filterType', function () {
-    var filterType = []
-    toggleInArray(filterType, 'requested')
-    expect(filterType).toEqual(['requested'])
-  })
-
-  it('clicking again removes requested from filterType', function () {
-    var filterType = ['requested']
-    toggleInArray(filterType, 'requested')
-    expect(filterType).toEqual([])
-  })
-
-  it('shows blue ring when requested filter is active', function () {
-    expect(requestedCardRingClass(['requested'])).toBe('ring-2 ring-blue-300 dark:ring-blue-700')
-  })
-
-  it('shows hover shadow when requested filter is inactive', function () {
-    expect(requestedCardRingClass([])).toBe('hover:shadow-md')
-  })
-
-  it('ring persists when both requested and committed are active', function () {
-    expect(requestedCardRingClass(['requested', 'committed'])).toBe('ring-2 ring-blue-300 dark:ring-blue-700')
+describe('summary tiles are display-only', function () {
+  it('does not apply selection ring classes for filterType', function () {
+    // Tiles no longer bind ring/hover-as-button classes to filterType
+    var tileClass = 'relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5'
+    expect(tileClass.indexOf('cursor-pointer')).toBe(-1)
+    expect(tileClass.indexOf('ring-2')).toBe(-1)
+    expect(tileClass.indexOf('hover:shadow-md')).toBe(-1)
   })
 })
 
 // ---------------------------------------------------------------------------
-// Committed card click-to-filter
+// Filter bar chips still toggle type / blocked
 // ---------------------------------------------------------------------------
 
-describe('Committed card click-to-filter', function () {
-  it('clicking adds committed to filterType', function () {
-    var filterType = []
-    toggleInArray(filterType, 'committed')
-    expect(filterType).toEqual(['committed'])
-  })
-
-  it('clicking again removes committed from filterType', function () {
-    var filterType = ['committed']
-    toggleInArray(filterType, 'committed')
-    expect(filterType).toEqual([])
-  })
-
-  it('shows emerald ring when committed filter is active', function () {
-    expect(committedCardRingClass(['committed'])).toBe('ring-2 ring-emerald-300 dark:ring-emerald-700')
-  })
-
-  it('shows hover shadow when committed filter is inactive', function () {
-    expect(committedCardRingClass([])).toBe('hover:shadow-md')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Blocked card click-to-filter
-// ---------------------------------------------------------------------------
-
-describe('Blocked card click-to-filter', function () {
-  it('clicking when null sets filterBlocked to true', function () {
-    var filterBlocked = null
-    filterBlocked = filterBlocked === true ? null : true
-    expect(filterBlocked).toBe(true)
-  })
-
-  it('clicking when true sets filterBlocked to null', function () {
-    var filterBlocked = true
-    filterBlocked = filterBlocked === true ? null : true
-    expect(filterBlocked).toBeNull()
-  })
-
-  it('never cycles through false — null toggles straight to true', function () {
-    var filterBlocked = null
-    var states = []
-    for (var i = 0; i < 6; i++) {
-      filterBlocked = filterBlocked === true ? null : true
-      states.push(filterBlocked)
-    }
-    expect(states).toEqual([true, null, true, null, true, null])
-    expect(states.indexOf(false)).toBe(-1)
-  })
-
-  it('shows red ring when blocked filter is active', function () {
-    expect(blockedCardRingClass(true)).toBe('ring-2 ring-red-300 dark:ring-red-700')
-  })
-
-  it('shows hover shadow when blocked filter is null', function () {
-    expect(blockedCardRingClass(null)).toBe('hover:shadow-md')
-  })
-
-  it('shows hover shadow when blocked filter is false', function () {
-    expect(blockedCardRingClass(false)).toBe('hover:shadow-md')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// toggleFilter via filterRefs (simulates card @click through toggleFilter)
-// ---------------------------------------------------------------------------
-
-describe('toggleFilter via filterRefs', function () {
-  it('Requested card click path toggles filterType correctly', function () {
+describe('filter bar chips toggle filters', function () {
+  it('REQ chip toggles filterType requested', function () {
     var filterRefs = { filterType: [] }
     toggleFilter(filterRefs, 'filterType', 'requested')
     expect(filterRefs.filterType).toEqual(['requested'])
@@ -293,7 +188,7 @@ describe('toggleFilter via filterRefs', function () {
     expect(filterRefs.filterType).toEqual([])
   })
 
-  it('Committed card click path toggles filterType correctly', function () {
+  it('COM chip toggles filterType committed', function () {
     var filterRefs = { filterType: [] }
     toggleFilter(filterRefs, 'filterType', 'committed')
     expect(filterRefs.filterType).toEqual(['committed'])
@@ -301,17 +196,21 @@ describe('toggleFilter via filterRefs', function () {
     expect(filterRefs.filterType).toEqual([])
   })
 
-  it('clicking both cards adds both values', function () {
+  it('both chips can be active together', function () {
     var filterRefs = { filterType: [] }
     toggleFilter(filterRefs, 'filterType', 'requested')
     toggleFilter(filterRefs, 'filterType', 'committed')
     expect(filterRefs.filterType).toEqual(['requested', 'committed'])
   })
 
-  it('ignores unknown filter names', function () {
-    var filterRefs = { filterType: [] }
-    toggleFilter(filterRefs, 'unknownFilter', 'value')
-    expect(filterRefs.filterType).toEqual([])
+  it('Blocked chip cycles null → true → false → null', function () {
+    var filterBlocked = null
+    filterBlocked = filterBlocked === null ? true : filterBlocked === true ? false : null
+    expect(filterBlocked).toBe(true)
+    filterBlocked = filterBlocked === null ? true : filterBlocked === true ? false : null
+    expect(filterBlocked).toBe(false)
+    filterBlocked = filterBlocked === null ? true : filterBlocked === true ? false : null
+    expect(filterBlocked).toBeNull()
   })
 })
 
@@ -463,41 +362,41 @@ describe('blocked percentage from group data', function () {
 })
 
 // ---------------------------------------------------------------------------
-// Filter persistence for card-click state
+// Filter persistence for chip state (not tile clicks)
 // ---------------------------------------------------------------------------
 
-describe('filter persistence for card-click state', function () {
-  it('saves and restores filterType set by Requested card click', function () {
+describe('filter persistence for chip state', function () {
+  it('saves and restores filterType from REQ chip', function () {
     saveFilters({ type: ['requested'] })
     var restored = restoreFilters()
     expect(restored.type).toEqual(['requested'])
   })
 
-  it('saves and restores filterType set by Committed card click', function () {
+  it('saves and restores filterType from COM chip', function () {
     saveFilters({ type: ['committed'] })
     var restored = restoreFilters()
     expect(restored.type).toEqual(['committed'])
   })
 
-  it('saves and restores both Requested and Committed active', function () {
+  it('saves and restores both REQ and COM active', function () {
     saveFilters({ type: ['requested', 'committed'] })
     var restored = restoreFilters()
     expect(restored.type).toEqual(['requested', 'committed'])
   })
 
-  it('saves and restores filterBlocked=true set by Blocked card click', function () {
+  it('saves and restores filterBlocked=true from Blocked chip', function () {
     saveFilters({ blocked: true })
     var restored = restoreFilters()
     expect(restored.blocked).toBe(true)
   })
 
-  it('saves and restores filterBlocked=null after Blocked card toggle off', function () {
+  it('saves and restores filterBlocked=null after Blocked chip clear', function () {
     saveFilters({ blocked: null })
     var restored = restoreFilters()
     expect(restored.blocked).toBeNull()
   })
 
-  it('round-trips a full card-click scenario', function () {
+  it('round-trips a full chip filter scenario', function () {
     saveFilters({ type: ['requested'], blocked: true })
     var restored = restoreFilters()
     expect(restored.type).toEqual(['requested'])

--- a/modules/releases/__tests__/client/plan/pm-hub-summary-totals.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-summary-totals.test.js
@@ -1,10 +1,8 @@
 /**
  * Tests for PM Hub summary card totals.
  *
- * Exercises the logic that computes totalRequested, totalCommitted, and
- * totalBlocked from client-filtered groups — verifying that the summary
- * cards update when client-side filters (product, type, status, blocked,
- * delivery owner, PM owner) are applied.
+ * Exercises totalRequested / totalCommitted / totalBlocked from summaryFilteredGroups
+ * (ignores REQ/COM type) vs clientFilteredGroups (table, applies type chips).
  *
  * Same inlined-function pattern as the other PM Hub test files.
  */
@@ -24,10 +22,11 @@ function extractProduct(versionName) {
 }
 
 /**
- * Client-side filtering logic from clientFilteredGroups computed property.
- * Applies client-side filters to server-returned groups and recomputes counts.
+ * Client-side filtering from filterGroups().
+ * @param {object} filters
+ * @param {boolean} [includeTypeFilter=false] - KPI path omits type; table path passes true
  */
-function applyClientFilters(groups, filters) {
+function applyClientFilters(groups, filters, includeTypeFilter) {
   var filterProduct = filters.product || []
   var filterType = filters.type || []
   var filterReleaseType = filters.releaseType || []
@@ -36,11 +35,12 @@ function applyClientFilters(groups, filters) {
   var filterDelOwner = filters.delOwner || []
   var filterPmOwner = filters.pmOwner || []
 
-  var hasFilters = filterProduct.length > 0 || filterType.length > 0 ||
-    filterReleaseType.length > 0 || filterStatus.length > 0 ||
-    filterBlocked !== null || filterDelOwner.length > 0 || filterPmOwner.length > 0
+  var applyType = !!includeTypeFilter && filterType.length > 0
+  var hasOther = filterProduct.length > 0 || filterReleaseType.length > 0 ||
+    filterStatus.length > 0 || filterBlocked !== null ||
+    filterDelOwner.length > 0 || filterPmOwner.length > 0
 
-  if (!hasFilters) return groups
+  if (!applyType && !hasOther) return groups
 
   return groups.map(function (g) {
     var version = g.version
@@ -75,7 +75,7 @@ function applyClientFilters(groups, filters) {
         var isReq = !!reqKeys[f.key]
         var isCom = !!comKeys[f.key]
 
-        if (filterType.length > 0) {
+        if (applyType) {
           var matches = false
           if (filterType.indexOf('requested') >= 0 && isReq) matches = true
           if (filterType.indexOf('committed') >= 0 && isCom) matches = true
@@ -356,75 +356,69 @@ describe('summary totals reflect client-side filters', function () {
 })
 
 // ---------------------------------------------------------------------------
-// Type filter (REQ / COM toggle)
+// Type filter (REQ / COM) — KPIs ignore type; table applies it
 // ---------------------------------------------------------------------------
 
-describe('type filter affects totals', function () {
+describe('type filter: KPI totals stay independent; table filters', function () {
   var feat1 = makeFeature({ key: 'X-1', isBlocked: true })
   var feat2 = makeFeature({ key: 'X-2', isBlocked: false })
 
-  it('type=requested shows only requested features', function () {
-    // feat1 is requested-only, feat2 is committed-only
-    var groups = [{
-      version: 'rhoai-3.5',
-      components: [{
-        component: 'Dashboard',
-        requestedFeatures: [feat1],
-        committedFeatures: [feat2],
-        requestedCount: 1,
-        committedCount: 1,
-        blockedCount: 0
-      }],
+  var splitGroups = [{
+    version: 'rhoai-3.5',
+    components: [{
+      component: 'Dashboard',
+      requestedFeatures: [feat1],
+      committedFeatures: [feat2],
       requestedCount: 1,
       committedCount: 1,
       blockedCount: 0
-    }]
-    var filtered = applyClientFilters(groups, { type: ['requested'] })
-    var totals = computeTotals(filtered)
+    }],
+    requestedCount: 1,
+    committedCount: 1,
+    blockedCount: 0
+  }]
+
+  it('with type=requested only, Committed KPI still includes committed-only features', function () {
+    var summary = applyClientFilters(splitGroups, { type: ['requested'] }, false)
+    var totals = computeTotals(summary)
+    expect(totals.requested).toBe(1)
+    expect(totals.committed).toBe(1)
+    expect(totals.blocked).toBe(1)
+  })
+
+  it('with type=requested only, Requested KPI is unchanged', function () {
+    var baseline = computeTotals(applyClientFilters(splitGroups, {}, false))
+    var withType = computeTotals(applyClientFilters(splitGroups, { type: ['requested'] }, false))
+    expect(withType.requested).toBe(baseline.requested)
+    expect(withType.committed).toBe(baseline.committed)
+  })
+
+  it('with type=committed only, Requested KPI still includes requested-only features', function () {
+    var summary = applyClientFilters(splitGroups, { type: ['committed'] }, false)
+    var totals = computeTotals(summary)
+    expect(totals.requested).toBe(1)
+    expect(totals.committed).toBe(1)
+  })
+
+  it('REQ chip still filters table data (includeTypeFilter=true)', function () {
+    var table = applyClientFilters(splitGroups, { type: ['requested'] }, true)
+    var totals = computeTotals(table)
     expect(totals.requested).toBe(1)
     expect(totals.committed).toBe(0)
     expect(totals.blocked).toBe(1)
   })
 
-  it('type=committed shows only committed features', function () {
-    var groups = [{
-      version: 'rhoai-3.5',
-      components: [{
-        component: 'Dashboard',
-        requestedFeatures: [feat1],
-        committedFeatures: [feat2],
-        requestedCount: 1,
-        committedCount: 1,
-        blockedCount: 0
-      }],
-      requestedCount: 1,
-      committedCount: 1,
-      blockedCount: 0
-    }]
-    var filtered = applyClientFilters(groups, { type: ['committed'] })
-    var totals = computeTotals(filtered)
+  it('COM chip still filters table data (includeTypeFilter=true)', function () {
+    var table = applyClientFilters(splitGroups, { type: ['committed'] }, true)
+    var totals = computeTotals(table)
     expect(totals.requested).toBe(0)
     expect(totals.committed).toBe(1)
     expect(totals.blocked).toBe(0)
   })
 
-  it('type=[requested,committed] shows features in either bucket', function () {
-    var groups = [{
-      version: 'rhoai-3.5',
-      components: [{
-        component: 'Dashboard',
-        requestedFeatures: [feat1],
-        committedFeatures: [feat2],
-        requestedCount: 1,
-        committedCount: 1,
-        blockedCount: 0
-      }],
-      requestedCount: 1,
-      committedCount: 1,
-      blockedCount: 0
-    }]
-    var filtered = applyClientFilters(groups, { type: ['requested', 'committed'] })
-    var totals = computeTotals(filtered)
+  it('type=[requested,committed] table shows features in either bucket', function () {
+    var table = applyClientFilters(splitGroups, { type: ['requested', 'committed'] }, true)
+    var totals = computeTotals(table)
     expect(totals.requested).toBe(1)
     expect(totals.committed).toBe(1)
     expect(totals.blocked).toBe(1)

--- a/modules/releases/__tests__/server/pm-hub/committed-definition.test.js
+++ b/modules/releases/__tests__/server/pm-hub/committed-definition.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+
+const {
+  sameReleaseCycle,
+  tvSupportsCommittedFixVersion,
+  filterCommittedFixVersions
+} = require('../../../server/pm-hub/committed-definition')
+
+describe('sameReleaseCycle', function () {
+  it('true for same product + major.minor across naming styles', function () {
+    expect(sameReleaseCycle('rhoai-3.6.EA1', '3.6 EA2 RHOAI RELEASE')).toBe(true)
+    expect(sameReleaseCycle('rhoai-3.6.EA1', 'rhoai-3.6')).toBe(true)
+  })
+
+  it('false for different minor, product, or unparseable', function () {
+    expect(sameReleaseCycle('rhoai-3.6.EA1', 'rhoai-3.5.EA1')).toBe(false)
+    expect(sameReleaseCycle('rhoai-3.6.EA1', 'rhelai-3.6.EA1')).toBe(false)
+    expect(sameReleaseCycle('rhoai-3.6.EA1', 'not-a-version')).toBe(false)
+  })
+})
+
+describe('tvSupportsCommittedFixVersion / filterCommittedFixVersions', function () {
+  it('exact TV=FV match → committed', function () {
+    expect(tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhoai-3.6.EA1'])).toBe(true)
+    expect(filterCommittedFixVersions(['rhoai-3.6.EA1'], ['rhoai-3.6.EA1'])).toEqual(['rhoai-3.6.EA1'])
+  })
+
+  it('semantic TV=FV match across naming styles → committed', function () {
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['3.6 EA1 RHOAI RELEASE'])
+    ).toBe(true)
+  })
+
+  it('early delivery (FV EA1, TV EA2 same cycle) → committed', function () {
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhoai-3.6.EA2'])
+    ).toBe(true)
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['3.6 EA2 RHOAI RELEASE'])
+    ).toBe(true)
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA2', ['rhoai-3.6'])
+    ).toBe(true)
+  })
+
+  it('FV-only (no TV) → not committed', function () {
+    expect(tvSupportsCommittedFixVersion('rhoai-3.6.EA1', [])).toBe(false)
+    expect(tvSupportsCommittedFixVersion('rhoai-3.6.EA1', null)).toBe(false)
+    expect(filterCommittedFixVersions(['rhoai-3.6.EA1'], [])).toEqual([])
+  })
+
+  it('late (FV EA2, TV EA1 same cycle) → not committed', function () {
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA2', ['rhoai-3.6.EA1'])
+    ).toBe(false)
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6', ['rhoai-3.6.EA1'])
+    ).toBe(false)
+  })
+
+  it('cross-cycle / cross-product → not committed', function () {
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhoai-3.5.EA2'])
+    ).toBe(false)
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['rhelai-3.6.EA2'])
+    ).toBe(false)
+  })
+
+  it('unparseable TV that cannot establish same-cycle → not committed', function () {
+    expect(
+      tvSupportsCommittedFixVersion('rhoai-3.6.EA1', ['Totally Unknown Version'])
+    ).toBe(false)
+  })
+
+  it('identical unparseable TV and FV strings → committed (exact match)', function () {
+    expect(
+      tvSupportsCommittedFixVersion('Custom Label X', ['Custom Label X'])
+    ).toBe(true)
+  })
+
+  it('filters matching FVs to only those supported by TV', function () {
+    var matchingFv = ['rhoai-3.6.EA1', 'rhoai-3.6.EA2']
+    // TV EA1 supports EA1 match, but not EA2 (late)
+    expect(filterCommittedFixVersions(matchingFv, ['rhoai-3.6.EA1'])).toEqual([
+      'rhoai-3.6.EA1'
+    ])
+    // TV EA2 supports EA1 (early) and EA2 (match)
+    expect(filterCommittedFixVersions(matchingFv, ['rhoai-3.6.EA2'])).toEqual([
+      'rhoai-3.6.EA1',
+      'rhoai-3.6.EA2'
+    ])
+  })
+})
+
+describe('Requested unchanged (caller contract)', function () {
+  // Requested is TV ∩ selected scope — not altered by committed helpers.
+  // Document the independence: FV-only helpers never consume matchingTv.
+  it('committed helpers ignore selected-scope TV list; use all issue TVs', function () {
+    // Selected scope is EA1 only; TV is EA2 (not in scope) but still qualifies early delivery
+    var matchingFv = ['rhoai-3.6.EA1']
+    var allTvOnIssue = ['rhoai-3.6.EA2']
+    expect(filterCommittedFixVersions(matchingFv, allTvOnIssue)).toEqual([
+      'rhoai-3.6.EA1'
+    ])
+  })
+
+  it('TV-only (no matching FV) yields empty committed list', function () {
+    expect(filterCommittedFixVersions([], ['rhoai-3.6.EA1'])).toEqual([])
+  })
+})

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -290,9 +290,15 @@
       </div>
     </div>
 
-    <!-- Summary cards -->
+    <!--
+      Summary cards are display-only KPIs. Click-to-filter was removed because
+      toggling Requested/Committed via tiles made independent Requested (TV in
+      scope) and Committed (FV in scope + TV match/early delivery) counts appear
+      correlated. Use REQ/COM (and other) filter chips in the bar above to filter
+      the table.
+    -->
     <div v-if="groups.length > 0 && !loadingData" class="grid grid-cols-2 sm:grid-cols-6 gap-3">
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5 cursor-pointer transition-all" :class="filterType.includes('requested') ? 'ring-2 ring-blue-300 dark:ring-blue-700' : 'hover:shadow-md'" @click="toggleFilter('filterType', 'requested')" title="Filter by Requested">
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-blue-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-blue-100 dark:bg-blue-900/40">
@@ -302,7 +308,7 @@
         </div>
         <div class="text-2xl font-bold text-blue-600 dark:text-blue-400 ml-7">{{ totalRequested }}</div>
       </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5 cursor-pointer transition-all" :class="filterType.includes('committed') ? 'ring-2 ring-emerald-300 dark:ring-emerald-700' : 'hover:shadow-md'" @click="toggleFilter('filterType', 'committed')" title="Filter by Committed">
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-emerald-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-emerald-100 dark:bg-emerald-900/40">
@@ -312,7 +318,7 @@
         </div>
         <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400 ml-7">{{ totalCommitted }}</div>
       </div>
-      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5 cursor-pointer transition-all" :class="filterBlocked === true ? 'ring-2 ring-red-300 dark:ring-red-700' : 'hover:shadow-md'" @click="filterBlocked = filterBlocked === true ? null : true" title="Filter by Blocked">
+      <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-red-500 rounded-l-xl" />
         <div class="flex items-center gap-2 mb-1.5">
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-red-100 dark:bg-red-900/40">
@@ -655,12 +661,20 @@ var filteredPmOwners = computed(function() {
   return availablePmOwners.value.filter(function(o) { return o.toLowerCase().includes(q) })
 })
 
-var hasClientFilters = computed(function() {
-  return filterProduct.value.length > 0 || filterType.value.length > 0 || filterReleaseType.value.length > 0 || filterStatus.value.length > 0 || filterBlocked.value !== null || hideClosed.value || filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0 || filterDocs.value.length > 0
-})
+/**
+ * Apply client-side filters to groups.
+ * @param {boolean} includeTypeFilter - when true, apply REQ/COM (filterType) for the table.
+ *   KPI summary tiles intentionally omit type filter so Requested (TV in scope)
+ *   and Committed (FV in scope + TV match/early delivery) remain independent
+ *   headline counts.
+ */
+function filterGroups(includeTypeFilter) {
+  var applyType = includeTypeFilter && filterType.value.length > 0
+  var hasOther = filterProduct.value.length > 0 || filterReleaseType.value.length > 0 ||
+    filterStatus.value.length > 0 || filterBlocked.value !== null || hideClosed.value ||
+    filterDelOwner.value.length > 0 || filterPmOwner.value.length > 0 || filterDocs.value.length > 0
 
-var clientFilteredGroups = computed(function() {
-  if (!hasClientFilters.value) return groups.value
+  if (!applyType && !hasOther) return groups.value
 
   return groups.value.map(function(g) {
     var version = g.version
@@ -695,7 +709,7 @@ var clientFilteredGroups = computed(function() {
         var isReq = !!reqKeys[f.key]
         var isCom = !!comKeys[f.key]
 
-        if (filterType.value.length > 0) {
+        if (applyType) {
           var matches = false
           if (filterType.value.indexOf('requested') >= 0 && isReq) matches = true
           if (filterType.value.indexOf('committed') >= 0 && isCom) matches = true
@@ -750,6 +764,16 @@ var clientFilteredGroups = computed(function() {
 
     return Object.assign({}, g, { components: filteredComps })
   }).filter(function(g) { return g.components.length > 0 })
+}
+
+/** Table/groups view — includes REQ/COM type chips. */
+var clientFilteredGroups = computed(function() {
+  return filterGroups(true)
+})
+
+/** KPI tiles — ignore filterType so Requested and Committed stay independent. */
+var summaryFilteredGroups = computed(function() {
+  return filterGroups(false)
 })
 
 var HIDDEN_COMPONENTS = ['lllm-d']
@@ -875,16 +899,16 @@ function countUniqueFeatureKeys(groups, listName) {
 }
 
 var totalRequested = computed(function() {
-  return countUniqueFeatureKeys(clientFilteredGroups.value, 'requestedFeatures')
+  return countUniqueFeatureKeys(summaryFilteredGroups.value, 'requestedFeatures')
 })
 
 var totalCommitted = computed(function() {
-  return countUniqueFeatureKeys(clientFilteredGroups.value, 'committedFeatures')
+  return countUniqueFeatureKeys(summaryFilteredGroups.value, 'committedFeatures')
 })
 
 var totalBlocked = computed(function() {
   // Unique blocked keys across either bucket (same feature under multiple components counts once)
-  var source = clientFilteredGroups.value
+  var source = summaryFilteredGroups.value
   var seen = {}
   var count = 0
   for (var gi = 0; gi < source.length; gi++) {
@@ -905,7 +929,7 @@ var totalBlocked = computed(function() {
 })
 
 var totalFeatures = computed(function() {
-  var source = clientFilteredGroups.value
+  var source = summaryFilteredGroups.value
   var seen = {}
   var count = 0
   for (var gi = 0; gi < source.length; gi++) {
@@ -933,7 +957,7 @@ var blockedPercent = computed(function() {
 })
 
 var totalAtRisk = computed(function() {
-  var source = clientFilteredGroups.value
+  var source = summaryFilteredGroups.value
   var seen = {}
   var count = 0
   for (var gi = 0; gi < source.length; gi++) {

--- a/modules/releases/server/pm-hub/committed-definition.js
+++ b/modules/releases/server/pm-hub/committed-definition.js
@@ -1,0 +1,75 @@
+/**
+ * PM Hub "Committed" classification.
+ *
+ * Requested = Target Version intersects selected release scope (handled by caller).
+ * Committed = Fix Version intersects selected release scope AND some Target Version
+ *   either matches that Fix Version, or is later in the same release cycle
+ *   (early delivery). Same cycle = same product + major.minor; milestone order
+ *   EA1 < EA2 < GA via tv-fv-delta parse/compare helpers.
+ */
+
+const {
+  parseReleaseName,
+  compareReleasesTemporally
+} = require('../tv-fv-delta/routes')
+
+/**
+ * True when both names parse to the same product + major.minor.
+ */
+function sameReleaseCycle(a, b) {
+  var pa = parseReleaseName(a)
+  var pb = parseReleaseName(b)
+  if (!pa || !pb) return false
+  return pa.product === pb.product && pa.major === pb.major && pa.minor === pb.minor
+}
+
+/**
+ * Whether a Target Version supports treating `fv` as Committed.
+ * Match (same version) or early delivery (TV later in same cycle).
+ */
+function tvSupportsCommittedFixVersion(fv, tvNames) {
+  if (!fv || !Array.isArray(tvNames) || tvNames.length === 0) return false
+
+  for (var i = 0; i < tvNames.length; i++) {
+    var tv = tvNames[i]
+    if (!tv) continue
+
+    // Exact string match (covers unparseable but identical labels)
+    if (tv === fv) return true
+
+    if (!sameReleaseCycle(fv, tv)) continue
+
+    // compareReleasesTemporally: negative = FV earlier than TV, 0 = same
+    var cmp = compareReleasesTemporally(fv, tv)
+    if (cmp !== null && cmp <= 0) return true
+  }
+
+  return false
+}
+
+/**
+ * Filter selected-scope Fix Versions down to those that qualify as Committed
+ * given the issue's Target Versions.
+ *
+ * @param {string[]} matchingFv - Fix Versions that intersect the selected scope
+ * @param {string[]} tvNames - All Target Versions on the issue
+ * @returns {string[]} subset of matchingFv that are Committed
+ */
+function filterCommittedFixVersions(matchingFv, tvNames) {
+  if (!Array.isArray(matchingFv) || matchingFv.length === 0) return []
+  var out = []
+  for (var i = 0; i < matchingFv.length; i++) {
+    if (tvSupportsCommittedFixVersion(matchingFv[i], tvNames)) {
+      out.push(matchingFv[i])
+    }
+  }
+  return out
+}
+
+module.exports = {
+  sameReleaseCycle,
+  tvSupportsCommittedFixVersion,
+  filterCommittedFixVersions,
+  parseReleaseName,
+  compareReleasesTemporally
+}

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -9,6 +9,7 @@
 const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
 const { blockDuringImpersonation } = require('../../../../shared/server/auth')
 const { JIRA_HOST } = require('../../../../shared/server/jira')
+const { filterCommittedFixVersions } = require('./committed-definition')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 const PM_HUB_PROJECTS = ['RHAIENG', 'RHOAIENG', 'INFERENG', 'AIPCC', 'RHAISTRAT', 'RHAIRFE']
@@ -525,7 +526,9 @@ module.exports = async function registerPmHubRoutes(router, context) {
    *     description: >
    *       Queries Jira for Features/Initiatives grouped by version then component.
    *       F Requested = issues where Target Version (cf[10855]) matches a selected version.
-   *       F Committed = issues where fixVersion matches a selected version.
+   *       F Committed = issues where fixVersion matches a selected version AND a Target
+   *       Version either matches that fixVersion or is later in the same release cycle
+   *       (early delivery; same product + major.minor, EA1 < EA2 < GA).
    *     parameters:
    *       - in: query
    *         name: components
@@ -657,7 +660,8 @@ module.exports = async function registerPmHubRoutes(router, context) {
         requestedIssues = await jiraClient.fetchAllJqlResults(tvJql, fieldsWithTv, { expand: 'renderedFields' })
       }
 
-      // Query 2: F Committed — fixVersion matches selected versions
+      // Query 2: FV candidates — fixVersion matches selected versions.
+      // Committed bucketing applies a stricter TV/FV rule after fetch.
       var committedIssues = []
       if (versionNames.length > 0) {
         var fvJqlParts = baseParts.slice()
@@ -693,8 +697,8 @@ module.exports = async function registerPmHubRoutes(router, context) {
 
       // Process all issues with OR display logic:
       // Show issue if selected release matches fixVersion OR targetVersion.
-      // committedFeatures/Count = fixVersion matches only.
-      // requestedFeatures/Count = targetVersion matches only.
+      // committedFeatures/Count = FV in scope + TV match or early delivery (same cycle).
+      // requestedFeatures/Count = targetVersion matches selected scope only.
       var allIssues = {}
 
       for (var ri = 0; ri < requestedIssues.length; ri++) {
@@ -716,13 +720,14 @@ module.exports = async function registerPmHubRoutes(router, context) {
         var compList = f.components && f.components.length > 0 ? f.components : ['No Component']
 
         if (versionNames.length === 0) {
-          // Component-only mode: group by fixVersion, all go into committed
-          var groupFvList = fvList.length > 0 ? fvList : ['Unversioned']
-          for (var ufi = 0; ufi < groupFvList.length; ufi++) {
+          // Component-only mode: group by fixVersion; Committed still requires TV support
+          var committedFvOnly = filterCommittedFixVersions(fvList, tvNames)
+          if (committedFvOnly.length === 0) continue
+          for (var ufi = 0; ufi < committedFvOnly.length; ufi++) {
             for (var uci = 0; uci < compList.length; uci++) {
               var ucName = compList[uci]
               if (componentNames.length > 0 && componentNames.indexOf(ucName) === -1) continue
-              var uGroup = ensureGroup(groupFvList[ufi], ucName)
+              var uGroup = ensureGroup(committedFvOnly[ufi], ucName)
               if (!uGroup.committedFeatures.some(function(e) { return e.key === f.key })) {
                 uGroup.committedFeatures.push(buildFeatureObj(f, tvNames))
                 uGroup.committedCount++
@@ -746,13 +751,17 @@ module.exports = async function registerPmHubRoutes(router, context) {
         // OR logic: skip if neither field matches any selected version
         if (matchingFv.length === 0 && matchingTv.length === 0) continue
 
-        // Determine group version keys — use all unique matching versions from either field
+        // Committed = selected FV + TV match or early delivery in same cycle
+        var committedFv = filterCommittedFixVersions(matchingFv, tvNames)
+
+        // Group only under versions that will receive this feature (avoid empty groups
+        // when FV is in scope but fails the Committed TV rule).
         var groupVersions = {}
-        for (var mf = 0; mf < matchingFv.length; mf++) groupVersions[matchingFv[mf]] = true
+        for (var mf = 0; mf < committedFv.length; mf++) groupVersions[committedFv[mf]] = true
         for (var mt = 0; mt < matchingTv.length; mt++) groupVersions[matchingTv[mt]] = true
         var groupVersionKeys = Object.keys(groupVersions)
+        if (groupVersionKeys.length === 0) continue
 
-        var isCommitted = matchingFv.length > 0
         var isRequested = matchingTv.length > 0
         var featureObj = buildFeatureObj(f, tvNames)
 
@@ -763,7 +772,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
             if (componentNames.length > 0 && componentNames.indexOf(cName) === -1) continue
             var group = ensureGroup(vKey, cName)
 
-            if (isCommitted && matchingFv.indexOf(vKey) !== -1) {
+            if (committedFv.indexOf(vKey) !== -1) {
               if (!group.committedFeatures.some(function(e) { return e.key === f.key })) {
                 group.committedFeatures.push(featureObj)
                 group.committedCount++
@@ -836,3 +845,4 @@ module.exports.backfillLeads = backfillLeads
 module.exports.computeVelocity = computeVelocity
 module.exports.buildFeatureObj = buildFeatureObj
 module.exports.extractTargetVersions = extractTargetVersions
+module.exports.filterCommittedFixVersions = filterCommittedFixVersions


### PR DESCRIPTION
## Summary
- Make PM Hub summary tiles display-only so clicking Requested/Committed/Blocked no longer toggles filters or rewrites KPI totals; REQ/COM chips still filter the table.
- Compute summary KPIs without the REQ/COM type filter so Requested (Target Version) and Committed stay independent headline counts.
- Redefine **Committed** as Fix Version in the selected scope plus a Target Version that matches that FV or is later in the same release cycle (early delivery). FV-only, late, and cross-cycle issues drop out of Committed; Requested is unchanged.

## Test plan
- [ ] Open PM Hub → Component Release Load Tracking for **3.6 EA1**; confirm Requested ~147 and Committed is lower than the old FV-only count (~91 expected under the new rule)
- [ ] Confirm summary tiles are not clickable (no cursor/ring); REQ/COM chips still filter the table without changing tile totals
- [ ] Spot-check an early-delivery case (FV EA1, TV EA2 same cycle) still counts as Committed
- [ ] Spot-check an FV-only issue no longer counts as Committed
- [ ] `npm test -- modules/releases/__tests__/server/pm-hub/committed-definition.test.js modules/releases/__tests__/client/plan/pm-hub-summary`


Made with [Cursor](https://cursor.com)