### PR TITLE
feat(ai-impact): add 6-month and all-time autofix time windows

### DIFF
--- a/modules/ai-impact/client/components/AutofixContent.vue
+++ b/modules/ai-impact/client/components/AutofixContent.vue
@@ -98,6 +98,10 @@ function getWindowBounds(timeWindow) {
       return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
     case 'last90':
       return { start: Date.now() - 90 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
+    case 'last180':
+      return { start: Date.now() - 180 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
+    case 'all':
+      return { start: 0, end: Date.now(), useTerminalDate: false }
     default:
       return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false }
   }
@@ -116,6 +120,7 @@ function formatUTCShortDate(d) {
 }
 
 const windowDateRange = computed(() => {
+  if (props.timeWindow === 'all') return 'All Time'
   const { start, end } = getWindowBounds(props.timeWindow)
   if (props.timeWindow === 'lastWeek') {
     const s = new Date(start)
@@ -311,7 +316,7 @@ const trendData = computed(() => {
   const issues = projectFilteredIssues.value
   const { useTerminalDate } = getWindowBounds(props.timeWindow)
   const tw = props.timeWindow
-  const weekCounts = (tw === 'week' || tw === 'lastWeek' || tw === 'last7') ? 4 : (tw === 'month' || tw === 'lastMonth' || tw === 'last30') ? 8 : 13
+  const weekCounts = (tw === 'week' || tw === 'lastWeek' || tw === 'last7') ? 4 : (tw === 'month' || tw === 'lastMonth' || tw === 'last30') ? 8 : tw === 'last180' ? 26 : tw === 'all' ? 52 : 13
   const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
   let anchor
   if (tw === 'lastWeek') {
@@ -755,6 +760,8 @@ function buildJiraLabelUrl(jiraLabels, excludeLabels) {
           <option value="lastMonth">Last Month</option>
           <option value="last30">Last 30 Days</option>
           <option value="last90">Last 90 Days</option>
+          <option value="last180">Last 6 Months</option>
+          <option value="all">All Time</option>
         </select>
       </div>
     </header>

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -117,7 +117,7 @@ module.exports = function registerRoutes(router, context) {
 
   // ─── Autofix data ───
 
-  const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'lastWeek', 'last7', 'month', 'lastMonth', 'last30', 'last90'];
+  const VALID_AUTOFIX_TIME_WINDOWS = ['week', 'lastWeek', 'last7', 'month', 'lastMonth', 'last30', 'last90', 'last180', 'all'];
 
   let autofixDataCache = null;
 

--- a/modules/ai-impact/server/jira/autofix-fetcher.js
+++ b/modules/ai-impact/server/jira/autofix-fetcher.js
@@ -218,6 +218,10 @@ function getWindowBounds(timeWindow) {
       return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
     case 'last90':
       return { start: Date.now() - 90 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
+    case 'last180':
+      return { start: Date.now() - 180 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
+    case 'all':
+      return { start: 0, end: Date.now(), useTerminalDate: false };
     default:
       return { start: Date.now() - 30 * 24 * 60 * 60 * 1000, end: Date.now(), useTerminalDate: false };
   }
@@ -323,6 +327,8 @@ function computeAutofixMetrics(issues, timeWindow) {
 function getTrendWeekCount(timeWindow) {
   if (timeWindow === 'week' || timeWindow === 'lastWeek' || timeWindow === 'last7') return 4;
   if (timeWindow === 'month' || timeWindow === 'lastMonth' || timeWindow === 'last30') return 8;
+  if (timeWindow === 'last180') return 26;
+  if (timeWindow === 'all') return 52;
   return 13;
 }
 


### PR DESCRIPTION
## Summary
- Adds "Last 6 Months" (`last180`) and "All Time" (`all`) options to the AI Impact autofix dashboard time window selector
- Server-side validation, window bounds, and trend week counts updated (26 weeks for 6 months, 52 for all time)
- Client-side filtering, trend recomputation, and date-range banner updated to match
- Date-range banner shows "All Time" text instead of epoch date for the all-time window

## Note
The team-tracker autofix tab (`/#/team-tracker/team-detail?tab=autofix`) has the same time window limitation but lives in `@org-pulse/core`. A companion PR will be opened in the core repo.

## Test plan
- [ ] Select "Last 6 Months" in AI Impact autofix — verify metrics and trend chart cover ~6 months
- [ ] Select "All Time" — verify metrics show all data, trend chart shows ~1 year of weekly buckets
- [ ] Verify date-range banner shows "All Time" (not "Jan 1 1970")
- [ ] Verify existing time windows (week, month, last 30/90 days) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)