### PR TITLE
feat(releases): Jira-first feature registry (Phases 1-2)

### DIFF
--- a/modules/releases/__tests__/server/execution/jira-sync.test.js
+++ b/modules/releases/__tests__/server/execution/jira-sync.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 
 const {
+  fullJiraSync,
+  detectStaleFeatures,
   syncAllFeatures,
   discoverFromJira,
   reconcileTrackingData
@@ -22,7 +24,243 @@ function makeStorage(initialFiles = {}) {
   }
 }
 
-describe('syncAllFeatures', () => {
+// Minimal Jira issue fixture for discoverFeatures/transformForEnrichment
+function makeJiraIssue(key, overrides = {}) {
+  return {
+    key,
+    fields: {
+      summary: overrides.summary || 'Feature ' + key,
+      status: { name: overrides.status || 'New', statusCategory: { name: overrides.statusCategory || 'To Do' } },
+      issuetype: { name: 'Feature' },
+      assignee: overrides.assignee || null,
+      fixVersions: (overrides.fixVersions || []).map(v => ({ name: v })),
+      components: [], labels: overrides.labels || [],
+      priority: { name: 'Normal' },
+      issuelinks: [], created: null, updated: overrides.updated || '2026-07-01T00:00:00Z',
+      parent: null,
+      customfield_10001: null, customfield_10851: null, customfield_10814: null,
+      customfield_10712: null, customfield_10665: null, customfield_10023: null,
+      customfield_10469: null, customfield_10855: null,
+      customfield_10862: null, customfield_10836: null,
+      customfield_10838: null, customfield_10637: null, customfield_10864: null,
+      ...overrides.fields
+    },
+    renderedFields: {}
+  }
+}
+
+describe('fullJiraSync', () => {
+  it('creates new features for unknown keys', async () => {
+    const storage = makeStorage({})
+
+    const mockFetchAll = vi.fn()
+    // discoverFeatures call
+    mockFetchAll.mockResolvedValueOnce([
+      makeJiraIssue('RHAISTRAT-1'),
+      makeJiraIssue('RHAISTRAT-2')
+    ])
+    // fetchEpicsForFeatures call
+    mockFetchAll.mockResolvedValueOnce([])
+
+    const result = await fullJiraSync(storage, vi.fn(), mockFetchAll)
+
+    expect(result.status).toBe('success')
+    expect(result.featureCount).toBe(2)
+    expect(result.newCount).toBe(2)
+    expect(result.updatedCount).toBe(0)
+    expect(result.jiraKeys).toBeInstanceOf(Set)
+    expect(result.jiraKeys.has('RHAISTRAT-1')).toBe(true)
+
+    // Verify features were written
+    expect(storage._files['releases/execution/features/RHAISTRAT-1.json']).toBeDefined()
+    expect(storage._files['releases/execution/features/RHAISTRAT-2.json']).toBeDefined()
+    expect(storage._files['releases/execution/features/RHAISTRAT-1.json']._sources.jira).toBeDefined()
+  })
+
+  it('updates existing features while preserving pipeline + AI review fields', async () => {
+    const storage = makeStorage({
+      'releases/execution/features/RHAISTRAT-1.json': {
+        key: 'RHAISTRAT-1',
+        summary: 'Old summary',
+        status: 'New',
+        metrics: { health: 'YELLOW', completionPct: 42 },
+        aiReview: { recommendation: 'approve', scores: { quality: 8 } },
+        _sources: { pipeline: '2026-06-01T00:00:00Z', jira: '2026-06-01T00:00:00Z' }
+      }
+    })
+
+    const mockFetchAll = vi.fn()
+    mockFetchAll.mockResolvedValueOnce([
+      makeJiraIssue('RHAISTRAT-1', { summary: 'Updated summary', status: 'In Progress', statusCategory: 'In Progress' })
+    ])
+    mockFetchAll.mockResolvedValueOnce([]) // epics
+
+    const result = await fullJiraSync(storage, vi.fn(), mockFetchAll)
+
+    expect(result.status).toBe('success')
+    expect(result.newCount).toBe(0)
+    expect(result.updatedCount).toBe(1)
+
+    const feature = storage._files['releases/execution/features/RHAISTRAT-1.json']
+    expect(feature.summary).toBe('Updated summary')
+    expect(feature.status).toBe('In Progress')
+    // Pipeline fields preserved
+    expect(feature.metrics).toEqual({ health: 'YELLOW', completionPct: 42 })
+    // AI review preserved (existing aiReview + jira-derived humanReviewStatus merged)
+    expect(feature.aiReview.recommendation).toBe('approve')
+    expect(feature.aiReview.scores).toEqual({ quality: 8 })
+    // Sources updated
+    expect(feature._sources.pipeline).toBe('2026-06-01T00:00:00Z')
+    expect(feature._sources.jira).toBeDefined()
+  })
+
+  it('handles empty Jira results gracefully (no store wipe)', async () => {
+    const storage = makeStorage({
+      'releases/execution/features/RHAISTRAT-1.json': {
+        key: 'RHAISTRAT-1', summary: 'Existing',
+        _sources: { jira: '2026-06-01T00:00:00Z' }
+      }
+    })
+
+    const mockFetchAll = vi.fn().mockResolvedValueOnce([])
+
+    const result = await fullJiraSync(storage, vi.fn(), mockFetchAll)
+
+    expect(result.status).toBe('skipped')
+    // Existing feature should NOT be deleted
+    expect(storage._files['releases/execution/features/RHAISTRAT-1.json']).toBeDefined()
+  })
+
+  it('writes last-enrichment.json metadata', async () => {
+    const storage = makeStorage({})
+
+    const mockFetchAll = vi.fn()
+    mockFetchAll.mockResolvedValueOnce([makeJiraIssue('RHAISTRAT-1')])
+    mockFetchAll.mockResolvedValueOnce([])
+
+    await fullJiraSync(storage, vi.fn(), mockFetchAll)
+
+    const meta = storage._files['releases/execution/last-enrichment.json']
+    expect(meta).toBeDefined()
+    expect(meta.status).toBe('success')
+    expect(meta.featureCount).toBe(1)
+  })
+
+  it('attaches epics from fetchEpicsForFeatures', async () => {
+    const storage = makeStorage({})
+
+    const mockFetchAll = vi.fn()
+    mockFetchAll.mockResolvedValueOnce([makeJiraIssue('RHAISTRAT-1')])
+    // Epic discovery returns a child epic
+    mockFetchAll.mockResolvedValueOnce([{
+      key: 'RHAISTRAT-100',
+      fields: {
+        summary: 'Child Epic',
+        status: { name: 'In Progress' },
+        parent: { key: 'RHAISTRAT-1' },
+        customfield_10014: null
+      }
+    }])
+
+    await fullJiraSync(storage, vi.fn(), mockFetchAll)
+
+    const feature = storage._files['releases/execution/features/RHAISTRAT-1.json']
+    expect(feature.epics).toHaveLength(1)
+    expect(feature.epics[0].key).toBe('RHAISTRAT-100')
+  })
+})
+
+describe('detectStaleFeatures', () => {
+  it('flags features not returned by Jira that have _sources.jira', async () => {
+    const storage = makeStorage({
+      'releases/execution/features/RHAISTRAT-1.json': {
+        key: 'RHAISTRAT-1', summary: 'Still in Jira',
+        _sources: { jira: '2026-06-01T00:00:00Z' }
+      },
+      'releases/execution/features/RHAISTRAT-2.json': {
+        key: 'RHAISTRAT-2', summary: 'Gone from Jira',
+        _sources: { jira: '2026-06-01T00:00:00Z' }
+      }
+    })
+
+    const jiraKeys = new Set(['RHAISTRAT-1'])
+    const result = await detectStaleFeatures(storage, jiraKeys)
+
+    expect(result.staleCount).toBe(1)
+    expect(result.recoveredCount).toBe(0)
+
+    const staleFeature = storage._files['releases/execution/features/RHAISTRAT-2.json']
+    expect(staleFeature._stale).toBeDefined()
+    expect(staleFeature._stale.detectedAt).toBeDefined()
+
+    // Non-stale feature should NOT have the flag
+    const activeFeature = storage._files['releases/execution/features/RHAISTRAT-1.json']
+    expect(activeFeature._stale).toBeUndefined()
+  })
+
+  it('clears _stale on features that reappear in Jira', async () => {
+    const storage = makeStorage({
+      'releases/execution/features/RHAISTRAT-1.json': {
+        key: 'RHAISTRAT-1', summary: 'Was stale, now back',
+        _stale: { detectedAt: '2026-06-01T00:00:00Z' },
+        _sources: { jira: '2026-06-01T00:00:00Z' }
+      }
+    })
+
+    const jiraKeys = new Set(['RHAISTRAT-1'])
+    const result = await detectStaleFeatures(storage, jiraKeys)
+
+    expect(result.staleCount).toBe(0)
+    expect(result.recoveredCount).toBe(1)
+
+    const feature = storage._files['releases/execution/features/RHAISTRAT-1.json']
+    expect(feature._stale).toBeUndefined()
+  })
+
+  it('does not flag pipeline-only features (no _sources.jira)', async () => {
+    const storage = makeStorage({
+      'releases/execution/features/RHAISTRAT-1.json': {
+        key: 'RHAISTRAT-1', summary: 'Pipeline only',
+        _sources: { pipeline: '2026-06-01T00:00:00Z' }
+      }
+    })
+
+    const jiraKeys = new Set() // Not in Jira at all
+    const result = await detectStaleFeatures(storage, jiraKeys)
+
+    expect(result.staleCount).toBe(0)
+    const feature = storage._files['releases/execution/features/RHAISTRAT-1.json']
+    expect(feature._stale).toBeUndefined()
+  })
+
+  it('does not double-flag already stale features', async () => {
+    const originalTimestamp = '2026-06-01T00:00:00Z'
+    const storage = makeStorage({
+      'releases/execution/features/RHAISTRAT-1.json': {
+        key: 'RHAISTRAT-1', summary: 'Already stale',
+        _stale: { detectedAt: originalTimestamp },
+        _sources: { jira: '2026-05-01T00:00:00Z' }
+      }
+    })
+
+    const jiraKeys = new Set()
+    const result = await detectStaleFeatures(storage, jiraKeys)
+
+    expect(result.staleCount).toBe(0) // Already stale, not newly stale
+    const feature = storage._files['releases/execution/features/RHAISTRAT-1.json']
+    expect(feature._stale.detectedAt).toBe(originalTimestamp) // Original timestamp preserved
+  })
+
+  it('handles empty store', async () => {
+    const storage = makeStorage({})
+    const result = await detectStaleFeatures(storage, new Set(['RHAISTRAT-1']))
+    expect(result.staleCount).toBe(0)
+    expect(result.recoveredCount).toBe(0)
+  })
+})
+
+// Legacy function tests (kept until Phase 3 removal)
+describe('syncAllFeatures (deprecated)', () => {
   it('enriches existing features and writes merged results', async () => {
     const storage = makeStorage({
       'releases/execution/features/X-1.json': {
@@ -71,7 +309,7 @@ describe('syncAllFeatures', () => {
   })
 })
 
-describe('discoverFromJira', () => {
+describe('discoverFromJira (deprecated)', () => {
   it('creates new feature entries for undiscovered keys', async () => {
     const storage = makeStorage({
       'releases/execution/features/X-1.json': { key: 'X-1' }
@@ -115,7 +353,7 @@ describe('discoverFromJira', () => {
   })
 })
 
-describe('reconcileTrackingData', () => {
+describe('reconcileTrackingData (deprecated)', () => {
   it('creates stubs for tracking keys not in store', async () => {
     const storage = makeStorage({
       'releases/execution/features/X-1.json': { key: 'X-1' },

--- a/modules/releases/client/execute/components/ExecutionSettings.vue
+++ b/modules/releases/client/execute/components/ExecutionSettings.vue
@@ -70,17 +70,17 @@ function formatAge(timestamp) {
   return days === 1 ? '1 day ago' : days + ' days ago'
 }
 
-const jiraEnrichmentStatusClass = computed(() => {
-  const je = statusData.value?.jiraEnrichment
-  if (!je) return ''
-  if (!je.jiraConfigured || je.stale || je.warning) return 'bg-yellow-50 dark:bg-yellow-900/20'
+const jiraSyncStatusClass = computed(() => {
+  const js = statusData.value?.jiraSync
+  if (!js) return ''
+  if (!js.jiraConfigured || js.stale || js.warning) return 'bg-yellow-50 dark:bg-yellow-900/20'
   return 'bg-green-50 dark:bg-green-900/20'
 })
 
-const jiraEnrichmentTextClass = computed(() => {
-  const je = statusData.value?.jiraEnrichment
-  if (!je) return ''
-  if (!je.jiraConfigured || je.stale || je.warning) return 'text-yellow-700 dark:text-yellow-300'
+const jiraSyncTextClass = computed(() => {
+  const js = statusData.value?.jiraSync
+  if (!js) return ''
+  if (!js.jiraConfigured || js.stale || js.warning) return 'text-yellow-700 dark:text-yellow-300'
   return 'text-green-700 dark:text-green-300'
 })
 
@@ -114,20 +114,21 @@ onMounted(() => {
         </p>
       </div>
 
-      <!-- Jira Enrichment Status -->
-      <div v-if="statusData?.jiraEnrichment" class="rounded-md p-3" :class="jiraEnrichmentStatusClass">
-        <p class="text-sm font-medium" :class="jiraEnrichmentTextClass">Jira Enrichment</p>
-        <p class="text-sm mt-1" :class="jiraEnrichmentTextClass">
-          <template v-if="!statusData.jiraEnrichment.jiraConfigured">
+      <!-- Jira Sync Status -->
+      <div v-if="statusData?.jiraSync" class="rounded-md p-3" :class="jiraSyncStatusClass">
+        <p class="text-sm font-medium" :class="jiraSyncTextClass">Jira Sync</p>
+        <p class="text-sm mt-1" :class="jiraSyncTextClass">
+          <template v-if="!statusData.jiraSync.jiraConfigured">
             Jira client not configured — feature status, assignees, and fields cannot be synced from Jira.
           </template>
-          <template v-else-if="statusData.jiraEnrichment.warning">
-            {{ statusData.jiraEnrichment.warning }}.
+          <template v-else-if="statusData.jiraSync.warning">
+            {{ statusData.jiraSync.warning }}.
             Feature statuses may be outdated.
           </template>
-          <template v-else-if="statusData.jiraEnrichment.lastSync">
-            Last synced {{ formatAge(statusData.jiraEnrichment.lastSync.timestamp) }},
-            {{ statusData.jiraEnrichment.lastSync.enrichedCount }} features updated.
+          <template v-else-if="statusData.jiraSync.lastSync">
+            Last synced {{ formatAge(statusData.jiraSync.lastSync.timestamp) }},
+            {{ statusData.jiraSync.lastSync.featureCount }} features synced
+            ({{ statusData.jiraSync.lastSync.newCount }} new, {{ statusData.jiraSync.lastSync.updatedCount }} updated).
           </template>
           <template v-else>
             Enabled but has not run yet.

--- a/modules/releases/server/execution/feature-store.js
+++ b/modules/releases/server/execution/feature-store.js
@@ -180,6 +180,9 @@ async function rebuildIndex(storage) {
     const feature = await storage.readFromStorage(DATA_PREFIX + '/features/' + fileName);
     if (!feature || !feature.key) continue;
 
+    // Skip stale features (no longer in Jira) from the index
+    if (feature._stale) continue;
+
     // Map detail fields to index summary fields
     const indexEntry = {
       key: feature.key,

--- a/modules/releases/server/execution/jira-sync.js
+++ b/modules/releases/server/execution/jira-sync.js
@@ -1,24 +1,193 @@
 /**
  * Periodic Jira sync and feature discovery.
  *
- * Re-enriches all features from Jira on a configurable cadence,
- * discovers new features via JQL, and reconciles tracking data.
+ * fullJiraSync is the primary entry point — it fetches all RHAISTRAT features
+ * from Jira, merges with existing store data (preserving pipeline + AI review
+ * fields), and writes in a single pass.
+ *
+ * Legacy functions (syncAllFeatures, discoverFromJira, reconcileTrackingData)
+ * are deprecated and will be removed in a future release.
  */
 
-const { enrichFeatures, discoverFeatures, fetchSignOffDetails } = require('./jira-enrich');
+const { discoverFeatures, fetchEpicsForFeatures, fetchSignOffDetails } = require('./jira-enrich');
 const { mergeFeatureData, writeFeatures } = require('./feature-store');
 
 const DATA_PREFIX = 'releases/execution';
 
+const FULL_SYNC_JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative)';
+
 /**
- * Sync all existing features with fresh Jira data.
+ * Full Jira sync — fetches all RHAISTRAT features and merges into the store.
+ *
+ * 1. Bulk JQL fetch of all features (no `created` filter)
+ * 2. Epic discovery for returned keys
+ * 3. Sign-off detection merged into main pass
+ * 4. Single writeFeatures call (single index rebuild)
  *
  * @param {object} storage - Storage abstraction
  * @param {Function} jiraRequestFn - Bound jiraRequest
  * @param {Function} fetchAllJqlResultsFn - Bound fetchAllJqlResults
  * @returns {Promise<object>} Sync result metadata
  */
+async function fullJiraSync(storage, jiraRequestFn, fetchAllJqlResultsFn) {
+  const startTime = Date.now();
+
+  console.log('[jira-sync] Starting full Jira sync: ' + FULL_SYNC_JQL);
+
+  // Step 1: Bulk fetch all features from Jira
+  const discovered = await discoverFeatures(FULL_SYNC_JQL, jiraRequestFn, fetchAllJqlResultsFn);
+
+  // Guard: if Jira returns 0 results, something is wrong — do NOT wipe the store
+  if (!discovered || discovered.length === 0) {
+    console.warn('[jira-sync] Jira returned 0 results — skipping sync to avoid wiping store');
+    return {
+      status: 'skipped',
+      message: 'Jira returned 0 results',
+      timestamp: new Date().toISOString(),
+      duration: Date.now() - startTime
+    };
+  }
+
+  console.log('[jira-sync] Fetched ' + discovered.length + ' features from Jira');
+
+  // Step 2: Fetch epics for all discovered keys
+  const keys = [];
+  for (let i = 0; i < discovered.length; i++) {
+    keys.push(discovered[i].key);
+  }
+
+  const epicMap = await fetchEpicsForFeatures(keys, jiraRequestFn, fetchAllJqlResultsFn);
+
+  // Attach epics to discovered features
+  for (let i = 0; i < discovered.length; i++) {
+    const feature = discovered[i];
+    feature.epics = epicMap.get(feature.key) || [];
+  }
+
+  // Step 3: Fetch sign-off details BEFORE main write
+  let signOffMap = new Map();
+  try {
+    signOffMap = await fetchSignOffDetails(keys, storage, jiraRequestFn, fetchAllJqlResultsFn);
+    if (signOffMap.size > 0) {
+      console.log('[jira-sync] Found sign-off details for ' + signOffMap.size + ' features');
+    }
+  } catch (err) {
+    console.warn('[jira-sync] Sign-off detection pass failed:', err.message);
+  }
+
+  // Step 4: Merge with existing store data
+  let newCount = 0;
+  let updatedCount = 0;
+  const mergedFeatures = [];
+
+  for (let i = 0; i < discovered.length; i++) {
+    const jiraData = discovered[i];
+    const existing = await storage.readFromStorage(DATA_PREFIX + '/features/' + jiraData.key + '.json');
+
+    if (!existing) {
+      newCount++;
+    } else {
+      updatedCount++;
+    }
+
+    // Merge sign-off data into aiReview if present
+    const signOff = signOffMap.get(jiraData.key);
+    if (signOff && existing && existing.aiReview) {
+      // Will be merged via the existing aiReview on base
+      existing.aiReview.approvedBy = signOff.approvedBy;
+      existing.aiReview.approvedAt = signOff.approvedAt;
+    }
+
+    const merged = mergeFeatureData(existing, null, jiraData);
+    mergedFeatures.push(merged);
+  }
+
+  // Step 5: Single write + single index rebuild
+  await writeFeatures(storage, mergedFeatures);
+
+  const duration = Date.now() - startTime;
+  const jiraKeys = new Set(keys);
+
+  const result = {
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    featureCount: discovered.length,
+    newCount,
+    updatedCount,
+    duration
+  };
+
+  // Write sync metadata
+  await storage.writeToStorage(DATA_PREFIX + '/last-enrichment.json', result);
+
+  console.log('[jira-sync] Full sync complete: ' + discovered.length + ' features (' + newCount + ' new, ' + updatedCount + ' updated) in ' + duration + 'ms');
+
+  return { ...result, jiraKeys };
+}
+
+/**
+ * Detect features in the store that are no longer in Jira.
+ *
+ * Only flags features that have `_sources.jira` (i.e., were previously synced
+ * from Jira). Pipeline-only features are left alone.
+ *
+ * Features that reappear in Jira have their `_stale` flag removed.
+ *
+ * @param {object} storage - Storage abstraction
+ * @param {Set<string>} jiraKeys - Set of keys returned by the latest Jira sync
+ * @returns {Promise<object>} { staleCount, recoveredCount }
+ */
+async function detectStaleFeatures(storage, jiraKeys) {
+  const fileNames = await storage.listStorageFiles(DATA_PREFIX + '/features');
+  if (!fileNames || fileNames.length === 0) {
+    return { staleCount: 0, recoveredCount: 0 };
+  }
+
+  let staleCount = 0;
+  let recoveredCount = 0;
+  const toWrite = [];
+
+  for (let i = 0; i < fileNames.length; i++) {
+    if (!fileNames[i].endsWith('.json')) continue;
+
+    const key = fileNames[i].replace('.json', '');
+    const feature = await storage.readFromStorage(DATA_PREFIX + '/features/' + fileNames[i]);
+    if (!feature) continue;
+
+    const inJira = jiraKeys.has(key);
+    const wasJiraSourced = feature._sources && feature._sources.jira;
+
+    if (!inJira && wasJiraSourced && !feature._stale) {
+      // Mark as stale
+      feature._stale = { detectedAt: new Date().toISOString() };
+      toWrite.push(feature);
+      staleCount++;
+    } else if (inJira && feature._stale) {
+      // Recovered — remove stale flag
+      delete feature._stale;
+      toWrite.push(feature);
+      recoveredCount++;
+    }
+  }
+
+  if (toWrite.length > 0) {
+    await writeFeatures(storage, toWrite);
+  }
+
+  if (staleCount > 0 || recoveredCount > 0) {
+    console.log('[jira-sync] Stale detection: ' + staleCount + ' newly stale, ' + recoveredCount + ' recovered');
+  }
+
+  return { staleCount, recoveredCount };
+}
+
+/**
+ * @deprecated Use fullJiraSync instead. Will be removed in a future release.
+ *
+ * Sync all existing features with fresh Jira data.
+ */
 async function syncAllFeatures(storage, jiraRequestFn, fetchAllJqlResultsFn) {
+  const { enrichFeatures } = require('./jira-enrich');
   const startTime = Date.now();
 
   // List all feature files
@@ -99,13 +268,9 @@ async function syncAllFeatures(storage, jiraRequestFn, fetchAllJqlResultsFn) {
 }
 
 /**
- * Discover new features from Jira via configurable JQL.
+ * @deprecated Use fullJiraSync instead. Will be removed in a future release.
  *
- * @param {object} storage - Storage abstraction
- * @param {Function} jiraRequestFn
- * @param {Function} fetchAllJqlResultsFn
- * @param {object} config - { discoveryJql: string }
- * @returns {Promise<object>} Discovery result
+ * Discover new features from Jira via configurable JQL.
  */
 async function discoverFromJira(storage, jiraRequestFn, fetchAllJqlResultsFn, config) {
   const jql = config.discoveryJql ||
@@ -140,10 +305,9 @@ async function discoverFromJira(storage, jiraRequestFn, fetchAllJqlResultsFn, co
 }
 
 /**
- * Reconcile tracking data files — create stub entries for keys not in the store.
+ * @deprecated Use fullJiraSync instead. Will be removed in a future release.
  *
- * @param {object} storage - Storage abstraction
- * @returns {Promise<object>} Reconciliation result
+ * Reconcile tracking data files — create stub entries for keys not in the store.
  */
 async function reconcileTrackingData(storage) {
   // Find all tracking-data-*.json files
@@ -198,8 +362,11 @@ async function reconcileTrackingData(storage) {
 }
 
 module.exports = {
+  fullJiraSync,
+  detectStaleFeatures,
   syncAllFeatures,
   discoverFromJira,
   reconcileTrackingData,
-  DATA_PREFIX
+  DATA_PREFIX,
+  FULL_SYNC_JQL
 };

--- a/modules/releases/server/execution/routes.js
+++ b/modules/releases/server/execution/routes.js
@@ -317,31 +317,33 @@ module.exports = async function registerExecutionRoutes(router, context) {
       result.nextScheduledFetch = nextFetch.toISOString();
     }
 
-    // Jira enrichment status
+    // Jira sync status
     const jiraEnrichConfig = config.jiraEnrichment || {};
     const lastEnrichment = await readDataFile('last-enrichment.json');
-    result.jiraEnrichment = {
+    const jiraSyncStatus = {
       enabled: jiraEnrichConfig.enabled !== false,
       jiraConfigured: !!jira,
       lastSync: lastEnrichment || null
     };
-    // Warn if Jira enrichment hasn't run in >24h (2x the default 6h cadence)
-    if (result.jiraEnrichment.enabled && jira) {
+    // Warn if Jira sync hasn't run in >24h
+    if (jiraSyncStatus.enabled && jira) {
       const enrichTs = lastEnrichment?.timestamp ? new Date(lastEnrichment.timestamp).getTime() : 0;
       const enrichAgeMs = enrichTs ? Date.now() - enrichTs : Infinity;
       const enrichAgeHours = enrichAgeMs / (1000 * 60 * 60);
       if (enrichAgeHours > 24) {
-        result.jiraEnrichment.stale = true;
+        jiraSyncStatus.stale = true;
         if (enrichTs === 0) {
-          result.jiraEnrichment.warning = 'Jira enrichment has never run';
+          jiraSyncStatus.warning = 'Jira sync has never run';
         } else {
           const ageDays = Math.floor(enrichAgeHours / 24);
-          result.jiraEnrichment.warning = 'Last Jira sync was ' + (ageDays === 1 ? '1 day' : ageDays + ' days') + ' ago';
+          jiraSyncStatus.warning = 'Last Jira sync was ' + (ageDays === 1 ? '1 day' : ageDays + ' days') + ' ago';
         }
       }
     } else if (!jira) {
-      result.jiraEnrichment.warning = 'Jira client not configured — enrichment cannot run';
+      jiraSyncStatus.warning = 'Jira client not configured — sync cannot run';
     }
+    result.jiraSync = jiraSyncStatus;
+    result.jiraEnrichment = jiraSyncStatus; // backward-compat alias
 
     res.json(result);
   });
@@ -552,12 +554,14 @@ module.exports = async function registerExecutionRoutes(router, context) {
         schemaVersion: index?.schemaVersion || null,
         lastFetchStatus: lastFetch?.status || null,
         configured: config.enabled && !!getToken(),
-        jiraEnrichment: {
+        jiraSync: {
           enabled: jiraEnrichConfig.enabled !== false,
           jiraConfigured: !!jira,
           lastSyncStatus: lastEnrichment?.status || null,
           lastSyncTimestamp: lastEnrichment?.timestamp || null,
-          enrichedCount: lastEnrichment?.enrichedCount || 0
+          featureCount: lastEnrichment?.featureCount || 0,
+          newCount: lastEnrichment?.newCount || 0,
+          updatedCount: lastEnrichment?.updatedCount || 0
         }
       };
     });
@@ -593,52 +597,39 @@ module.exports = async function registerExecutionRoutes(router, context) {
       });
     });
 
-    // Register Jira enrichment periodic sync (Phase 3)
+    // Register Jira sync handler — full Jira fetch as authoritative source
     if (jira) {
-      const { syncAllFeatures, discoverFromJira, reconcileTrackingData } = require('./jira-sync');
+      const { fullJiraSync, detectStaleFeatures } = require('./jira-sync');
 
-      const enrichmentConfig = initialConfig.jiraEnrichment || {};
-      const syncIntervalHours = enrichmentConfig.syncIntervalHours || 6;
-
-      const enrichmentHandler = async function() {
+      const jiraSyncHandler = async function() {
         const config = await loadConfig(storage);
         const jiraEnrichConfig = config.jiraEnrichment || {};
-        // Default to enabled — Jira enrichment should run unless explicitly disabled
+        // Default to enabled — Jira sync should run unless explicitly disabled
         if (jiraEnrichConfig.enabled === false) {
-          return { status: 'skipped', message: 'Jira enrichment disabled in config (jiraEnrichment.enabled = false)' };
+          return { status: 'skipped', message: 'Jira sync disabled in config (jiraEnrichment.enabled = false)' };
         }
 
-        const result = await syncAllFeatures(storage, jira.jiraRequest, jira.fetchAllJqlResults);
+        const result = await fullJiraSync(storage, jira.jiraRequest, jira.fetchAllJqlResults);
 
-        // Feature discovery (Phase 4)
-        if (jiraEnrichConfig.discoveryEnabled) {
+        // Detect stale features (in store but no longer in Jira)
+        if (result.jiraKeys) {
           try {
-            const discovery = await discoverFromJira(
-              storage, jira.jiraRequest, jira.fetchAllJqlResults, jiraEnrichConfig
-            );
-            result.discovery = discovery;
+            const staleResult = await detectStaleFeatures(storage, result.jiraKeys);
+            result.stale = staleResult;
           } catch (err) {
-            console.warn('[execution] Feature discovery failed:', err.message);
+            console.warn('[execution] Stale feature detection failed:', err.message);
           }
-        }
-
-        // Tracking data reconciliation
-        try {
-          const reconciliation = await reconcileTrackingData(storage);
-          result.reconciliation = reconciliation;
-        } catch (err) {
-          console.warn('[execution] Tracking reconciliation failed:', err.message);
         }
 
         return result;
       };
 
-      context.registerRefresh('jira-enrichment', {
+      context.registerRefresh('jira-sync', {
         order: 75,
-        cadence: syncIntervalHours + 'h',
-        timeout: 120000,
-        description: 'Enriches execution data with Jira issue details, status transitions, and tracking reconciliation.',
-        handler: enrichmentHandler
+        cadence: '12h',
+        timeout: 600000,
+        description: 'Full Jira sync — fetches all RHAISTRAT features, creates/updates store entries, detects stale features.',
+        handler: jiraSyncHandler
       });
     }
   }


### PR DESCRIPTION
## Summary

- Makes Jira the authoritative source for which features exist in the execution store
- New `fullJiraSync` replaces `syncAllFeatures` + `discoverFromJira` + `reconcileTrackingData` with a single bulk fetch of all `project = RHAISTRAT AND issuetype IN (Feature, Initiative)` issues (no `created` filter)
- `detectStaleFeatures` flags store entries no longer in Jira (only if previously Jira-sourced; pipeline-only features are left alone)
- `rebuildIndex` excludes `_stale` features from API responses and reports
- Refresh handler renamed `jira-enrichment` → `jira-sync` (order 75, cadence 12h, timeout 600s)
- Settings UI updated: label "Jira Sync", shows feature counts (new/updated)
- Old functions marked `@deprecated` — removal in Phase 3 follow-on PR

## Key design decisions

- **Empty result guard**: If Jira returns 0 results, sync is skipped entirely to prevent wiping the store
- **Single write pass**: Sign-off data is fetched and merged before `writeFeatures`, avoiding double index rebuild
- **Handler ordering**: Kept at order 75 (after GitLab pipeline at 70) since pipeline fetch already handles missing features via inline enrichment
- **Stale detection**: Only flags features with `_sources.jira` to avoid false positives on pipeline-only entries

## Test plan

- [x] 16 unit tests pass (5 fullJiraSync, 5 detectStaleFeatures, 6 legacy)
- [x] Full test suite passes (6801 tests)
- [x] Lint clean
- [ ] Local dev: trigger manual refresh, verify feature count matches Jira
- [ ] Verify Settings UI shows "Jira Sync" with correct counts
- [ ] After deploy: compare feature count against live Jira JQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)