### PR TITLE
feat(releases): CVE report filtering, drill-down modal, and report rename

### DIFF
--- a/fixtures/releases/cve-sustaining/latest.json
+++ b/fixtures/releases/cve-sustaining/latest.json
@@ -1,0 +1,130 @@
+{
+  "lastRefreshed": "2026-07-15T12:00:00.000Z",
+  "totalOpen": 8,
+  "totalOpen_jql": "https://redhat.atlassian.net/issues/?jql=project%20in%20(RHAIENG)%20AND%20issuetype%20in%20(vulnerability)%20AND%20status%20not%20in%20(Closed%2C%20Resolved)",
+  "totalAll": 25,
+  "totalAll_jql": "https://redhat.atlassian.net/issues/?jql=project%20in%20(RHAIENG)%20AND%20issuetype%20in%20(vulnerability)",
+  "openCvesByComponent": [
+    { "component": "Model Serving", "count": 3, "pct": 37.5, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "component": "Dashboard", "count": 2, "pct": 25.0, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "component": "Pipelines", "count": 2, "pct": 25.0, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "component": "None", "count": 1, "pct": 12.5, "jql": "https://redhat.atlassian.net/issues/?jql=test" }
+  ],
+  "cvesByDueDate": {
+    "passed": { "count": 2, "pct": 25, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    "lessThan30": { "count": 1, "pct": 13, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    "between30And90": { "count": 2, "pct": 25, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    "moreThan90": { "count": 1, "pct": 13, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    "none": { "count": 2, "pct": 25, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    "total": 8,
+    "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+  },
+  "cvesAcrossVersions": {
+    "versions": ["rhoai-2.16", "rhoai-2.17", "None"],
+    "rows": [
+      {
+        "component": "Dashboard",
+        "cells": { "rhoai-2.16": 1, "rhoai-2.17": 1, "None": 0 },
+        "cellJqls": { "rhoai-2.16": "https://redhat.atlassian.net/issues/?jql=test", "rhoai-2.17": "https://redhat.atlassian.net/issues/?jql=test" },
+        "total": 2,
+        "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+      },
+      {
+        "component": "Model Serving",
+        "cells": { "rhoai-2.16": 1, "rhoai-2.17": 2, "None": 0 },
+        "cellJqls": { "rhoai-2.16": "https://redhat.atlassian.net/issues/?jql=test", "rhoai-2.17": "https://redhat.atlassian.net/issues/?jql=test" },
+        "total": 3,
+        "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+      },
+      {
+        "component": "Pipelines",
+        "cells": { "rhoai-2.16": 0, "rhoai-2.17": 1, "None": 1 },
+        "cellJqls": { "rhoai-2.17": "https://redhat.atlassian.net/issues/?jql=test", "None": "https://redhat.atlassian.net/issues/?jql=test" },
+        "total": 2,
+        "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+      }
+    ],
+    "columnTotals": { "rhoai-2.16": 2, "rhoai-2.17": 4, "None": 1 },
+    "columnJqls": { "rhoai-2.16": "https://redhat.atlassian.net/issues/?jql=test", "rhoai-2.17": "https://redhat.atlassian.net/issues/?jql=test", "None": "https://redhat.atlassian.net/issues/?jql=test" },
+    "grandTotal": 7,
+    "grandTotal_jql": "https://redhat.atlassian.net/issues/?jql=test"
+  },
+  "openCvesByVersion": [
+    { "version": "rhoai-2.17", "count": 4, "pct": 57.14, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "version": "rhoai-2.16", "count": 2, "pct": 28.57, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "version": "None", "count": 1, "pct": 14.29, "jql": "https://redhat.atlassian.net/issues/?jql=test" }
+  ],
+  "cvesByAssigneeStatus": {
+    "assignees": ["Alice", "Bob", "Unassigned"],
+    "rows": [
+      {
+        "status": "New",
+        "cells": { "Alice": 1, "Bob": 0, "Unassigned": 2 },
+        "cellJqls": { "Alice": "https://redhat.atlassian.net/issues/?jql=test", "Unassigned": "https://redhat.atlassian.net/issues/?jql=test" },
+        "total": 3,
+        "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+      },
+      {
+        "status": "In Progress",
+        "cells": { "Alice": 2, "Bob": 1, "Unassigned": 0 },
+        "cellJqls": { "Alice": "https://redhat.atlassian.net/issues/?jql=test", "Bob": "https://redhat.atlassian.net/issues/?jql=test" },
+        "total": 3,
+        "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+      },
+      {
+        "status": "Review",
+        "cells": { "Alice": 0, "Bob": 2, "Unassigned": 0 },
+        "cellJqls": { "Bob": "https://redhat.atlassian.net/issues/?jql=test" },
+        "total": 2,
+        "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+      }
+    ],
+    "columnTotals": { "Alice": 3, "Bob": 3, "Unassigned": 2 },
+    "columnJqls": { "Alice": "https://redhat.atlassian.net/issues/?jql=test", "Bob": "https://redhat.atlassian.net/issues/?jql=test", "Unassigned": "https://redhat.atlassian.net/issues/?jql=test" },
+    "grandTotal": 8,
+    "grandTotal_jql": "https://redhat.atlassian.net/issues/?jql=test"
+  },
+  "falsePositivesByVex": {
+    "items": [
+      { "justification": "inline_mitigations_already_exist", "count": 5, "pct": 50.0, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+      { "justification": "vulnerable_code_not_in_execute_path", "count": 3, "pct": 30.0, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+      { "justification": "None", "count": 2, "pct": 20.0, "jql": "https://redhat.atlassian.net/issues/?jql=test" }
+    ],
+    "total": 10,
+    "total_jql": "https://redhat.atlassian.net/issues/?jql=test"
+  },
+  "createdVsResolved": [
+    { "label": "W25, Jun 16", "weekStart": "2026-06-16", "created": 3, "created_jql": "https://redhat.atlassian.net/issues/?jql=test", "resolved": 1, "resolved_jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "label": "W26, Jun 23", "weekStart": "2026-06-23", "created": 2, "created_jql": "https://redhat.atlassian.net/issues/?jql=test", "resolved": 4, "resolved_jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "label": "W27, Jun 30", "weekStart": "2026-06-30", "created": 1, "created_jql": "https://redhat.atlassian.net/issues/?jql=test", "resolved": 2, "resolved_jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "label": "W28, Jul 7", "weekStart": "2026-07-07", "created": 4, "created_jql": "https://redhat.atlassian.net/issues/?jql=test", "resolved": 3, "resolved_jql": "https://redhat.atlassian.net/issues/?jql=test" }
+  ],
+  "unresolved": [
+    { "label": "W25, Jun 16", "weekStart": "2026-06-16", "unresolved": 20, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "label": "W26, Jun 23", "weekStart": "2026-06-23", "unresolved": 18, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "label": "W27, Jun 30", "weekStart": "2026-06-30", "unresolved": 17, "jql": "https://redhat.atlassian.net/issues/?jql=test" },
+    { "label": "W28, Jul 7", "weekStart": "2026-07-07", "unresolved": 18, "jql": "https://redhat.atlassian.net/issues/?jql=test" }
+  ],
+  "falsePositivesTrend": {
+    "resolutionTypes": ["Not a bug", "Duplicate", "Won't Do", "Obsolete", "Can't Do"],
+    "months": [
+      { "label": "Feb 2026", "monthStart": "2026-02-01", "series": { "Not a bug": 2, "Duplicate": 1 } },
+      { "label": "Mar 2026", "monthStart": "2026-03-01", "series": { "Not a bug": 1, "Won't Do": 1, "Obsolete": 1 } },
+      { "label": "Apr 2026", "monthStart": "2026-04-01", "series": { "Duplicate": 2, "Can't Do": 1 } },
+      { "label": "May 2026", "monthStart": "2026-05-01", "series": { "Not a bug": 3, "Duplicate": 1 } },
+      { "label": "Jun 2026", "monthStart": "2026-06-01", "series": { "Not a bug": 1, "Won't Do": 2 } },
+      { "label": "Jul 2026", "monthStart": "2026-07-01", "series": { "Obsolete": 1, "Can't Do": 1 } }
+    ]
+  },
+  "openIssueRecords": [
+    { "key": "RHAIENG-1001", "summary": "CVE-2026-0001 in golang stdlib", "component": "Model Serving", "components": ["Model Serving"], "versions": ["rhoai-2.17"], "status": "New", "assignee": "Alice", "duedate": "2026-06-01" },
+    { "key": "RHAIENG-1002", "summary": "CVE-2026-0002 in openssl", "component": "Model Serving", "components": ["Model Serving"], "versions": ["rhoai-2.16", "rhoai-2.17"], "status": "In Progress", "assignee": "Alice", "duedate": "2026-09-15" },
+    { "key": "RHAIENG-1003", "summary": "CVE-2026-0003 in python requests library", "component": "Model Serving", "components": ["Model Serving"], "versions": ["rhoai-2.17"], "status": "In Progress", "assignee": "Alice", "duedate": "2026-10-01" },
+    { "key": "RHAIENG-1004", "summary": "CVE-2026-0004 in react-dom", "component": "Dashboard", "components": ["Dashboard"], "versions": ["rhoai-2.16"], "status": "New", "assignee": "Unassigned", "duedate": null },
+    { "key": "RHAIENG-1005", "summary": "CVE-2026-0005 in patternfly", "component": "Dashboard", "components": ["Dashboard"], "versions": ["rhoai-2.17"], "status": "In Progress", "assignee": "Bob", "duedate": "2026-08-20" },
+    { "key": "RHAIENG-1006", "summary": "CVE-2026-0006 in tekton pipelines", "component": "Pipelines", "components": ["Pipelines"], "versions": ["rhoai-2.17"], "status": "Review", "assignee": "Bob", "duedate": "2026-08-01" },
+    { "key": "RHAIENG-1007", "summary": "CVE-2026-0007 in argo workflows", "component": "Pipelines", "components": ["Pipelines"], "versions": ["None"], "status": "Review", "assignee": "Bob", "duedate": null },
+    { "key": "RHAIENG-1008", "summary": "CVE-2026-0008 in kubernetes client-go", "component": "None", "components": ["None"], "versions": ["None"], "status": "New", "assignee": "Unassigned", "duedate": null }
+  ],
+  "jiraSearchBase": "https://redhat.atlassian.net/issues/?jql="
+}

--- a/modules/releases/client/reports/CapacityCommitmentReport.vue
+++ b/modules/releases/client/reports/CapacityCommitmentReport.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Header -->
     <div class="mb-6">
-      <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Release Capacity &amp; Commitment</h2>
+      <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">Program Level Release Report</h2>
       <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Key deadlines and capacity overview for a selected release</p>
     </div>
 
@@ -39,58 +39,12 @@
           </div>
 
           <!-- Filter line -->
-          <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700/50 flex items-start justify-between gap-4">
-            <div class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
-              <!-- No filters active -->
-              <template v-if="!hasActiveFilters">
-                Showing all features and initiatives.
-                <button @click="openFilterModal" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">Manage filters</button>
-                or apply a
-                <button @click="openFilterModalToPresets" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">saved preset</button>.
-              </template>
-
-              <!-- Preset applied -->
-              <template v-else-if="appliedPreset">
-                Showing features filtered by
-                <span class="font-semibold text-gray-900 dark:text-gray-100 inline-flex items-baseline gap-1">
-                  {{ appliedPreset.name }}
-                  <span v-if="appliedPreset.description" class="relative group inline-flex">
-                    <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 cursor-help self-center" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
-                    </svg>
-                    <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2.5 py-1.5 text-xs font-normal text-white bg-gray-900 dark:bg-gray-700 rounded-md shadow-lg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10">{{ appliedPreset.description }}</span>
-                  </span>
-                </span>.
-              </template>
-
-              <!-- Ad-hoc filters -->
-              <template v-else>
-                Showing features filtered by
-                <template v-for="(part, idx) in filterNarrativeParts" :key="part.field">
-                  <template v-if="idx > 0 && idx === filterNarrativeParts.length - 1"> {{ crossFieldMode }} </template>
-                  <template v-else-if="idx > 0">, </template>
-                  <span class="font-semibold text-gray-900 dark:text-gray-100">{{ part.label }}: {{ part.values }}</span>
-                </template>.
-              </template>
-
-              <!-- Editing indicator (inline) -->
-              <span v-if="editingFilterId" class="ml-1 text-xs text-amber-600 dark:text-amber-400">
-                (editing preset · <button @click="cancelEditFilter" class="hover:underline">cancel</button>)
-              </span>
-            </div>
-
-            <!-- Filter action buttons -->
-            <div class="flex items-center gap-2 shrink-0">
-              <button
-                @click="openFilterModal"
-                class="px-3 py-1.5 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 transition-colors"
-              >{{ hasActiveFilters ? 'Edit' : 'Manage Filters' }}</button>
-              <button
-                v-if="hasActiveFilters"
-                @click="clearAllFilters"
-                class="px-3 py-1.5 text-sm font-medium rounded-md text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-              >Clear</button>
-            </div>
+          <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700/50">
+            <ReportFilterNarrative
+              :filters="filters"
+              no-filter-text="Showing all features and initiatives."
+              filter-prefix="Showing features filtered by"
+            />
           </div>
         </template>
         <template v-else>
@@ -809,262 +763,7 @@
     </Teleport>
 
     <!-- Filter modal -->
-    <Teleport to="body">
-      <div v-if="filterModalOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div class="absolute inset-0 bg-black/40 dark:bg-black/60" @click="closeFilterModal"></div>
-        <div class="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-xl max-h-[80vh] flex flex-col">
-          <!-- Header with tabs -->
-          <div class="shrink-0">
-            <div class="flex items-center justify-between px-6 pt-4 pb-0">
-              <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Filters</h3>
-              <button @click="closeFilterModal" class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
-                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div class="flex gap-6 px-6 mt-3 border-b border-gray-200 dark:border-gray-700">
-              <button
-                @click="filterModalTab = 'fields'"
-                class="pb-2.5 text-sm font-medium transition-colors whitespace-nowrap border-b-2"
-                :class="filterModalTab === 'fields'
-                  ? 'border-primary-600 text-primary-600 dark:text-primary-400 dark:border-primary-400'
-                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
-              >Filter Fields</button>
-              <button
-                @click="filterModalTab = 'presets'"
-                class="pb-2.5 text-sm font-medium transition-colors whitespace-nowrap border-b-2 inline-flex items-center gap-1.5"
-                :class="filterModalTab === 'presets'
-                  ? 'border-primary-600 text-primary-600 dark:text-primary-400 dark:border-primary-400'
-                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
-              >
-                Saved Presets
-                <span
-                  v-if="savedFilters.length > 0"
-                  class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
-                  :class="filterModalTab === 'presets'
-                    ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-600 dark:text-primary-400'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'"
-                >{{ savedFilters.length }}</span>
-              </button>
-            </div>
-          </div>
-
-          <!-- Tab: Filter Fields -->
-          <div v-if="filterModalTab === 'fields'" class="flex flex-1 min-h-0" style="min-height: 320px">
-            <!-- Field list (left) -->
-            <div class="w-44 shrink-0 border-r border-gray-200 dark:border-gray-700 flex flex-col bg-gray-50/50 dark:bg-gray-900/20">
-              <div class="flex-1 overflow-y-auto">
-                <button
-                  v-for="f in FILTER_FIELDS"
-                  :key="f.key"
-                  @click="selectFilterField(f.key)"
-                  class="w-full px-4 py-2.5 text-sm text-left transition-colors"
-                  :class="filterModalField === f.key
-                    ? 'bg-white dark:bg-gray-800 text-primary-700 dark:text-primary-300 font-medium border-r-2 border-primary-600 dark:border-primary-400'
-                    : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50'"
-                >
-                  <div class="flex items-center justify-between gap-2">
-                    <span class="truncate">{{ f.label }}</span>
-                    <span
-                      v-if="activeFilters[f.key]?.length"
-                      class="text-[10px] font-semibold text-primary-600 dark:text-primary-400 bg-primary-100 dark:bg-primary-900/40 px-1.5 py-0.5 rounded-full shrink-0"
-                    >{{ activeFilters[f.key].length }}</span>
-                  </div>
-                </button>
-              </div>
-              <!-- Cross-field mode -->
-              <div v-if="activeFieldCount > 1" class="border-t border-gray-200 dark:border-gray-700 px-3 py-2.5">
-                <div class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1.5">Across fields</div>
-                <button
-                  @click="crossFieldMode = crossFieldMode === 'and' ? 'or' : 'and'; persistActiveFilters()"
-                  class="w-full px-2 py-1 rounded text-[11px] font-medium text-center transition-colors"
-                  :class="crossFieldMode === 'and'
-                    ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
-                    : 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'"
-                >{{ crossFieldMode === 'and' ? 'ALL fields (AND)' : 'ANY field (OR)' }}</button>
-              </div>
-            </div>
-
-            <!-- Value list (right) -->
-            <div class="flex-1 flex flex-col min-w-0">
-              <div v-if="!filterModalField" class="flex-1 flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
-                Select a field to filter by
-              </div>
-              <template v-else>
-                <!-- Search + match mode -->
-                <div class="px-4 pt-3 pb-2 shrink-0 space-y-2">
-                  <input
-                    v-model="filterModalSearch"
-                    type="text"
-                    :placeholder="'Search ' + filterFieldLabel(filterModalField).toLowerCase() + 's...'"
-                    class="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
-                  />
-                  <div v-if="activeFilters[filterModalField]?.length > 1" class="flex items-center gap-2">
-                    <span class="text-[11px] text-gray-500 dark:text-gray-400">Match:</span>
-                    <button
-                      @click="toggleFilterMode(filterModalField)"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium transition-colors"
-                      :class="(filterModes[filterModalField] || 'or') === 'and'
-                        ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
-                        : 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'"
-                    >
-                      {{ (filterModes[filterModalField] || 'or') === 'and' ? 'ALL (AND)' : 'ANY (OR)' }}
-                    </button>
-                  </div>
-                </div>
-
-                <!-- Values -->
-                <div class="flex-1 overflow-y-auto px-4 pb-3">
-                  <div v-if="filterModalValues.selected.length === 0 && filterModalValues.unselected.length === 0" class="text-sm text-gray-400 dark:text-gray-500 text-center py-8">
-                    {{ filterModalSearch ? 'No matching values' : 'No values available' }}
-                  </div>
-                  <template v-else>
-                    <!-- Selected values -->
-                    <div v-if="filterModalValues.selected.length > 0" class="space-y-0.5">
-                      <label
-                        v-for="val in filterModalValues.selected"
-                        :key="val"
-                        class="flex items-center gap-2.5 px-3 py-1.5 text-sm rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
-                      >
-                        <input
-                          type="checkbox"
-                          checked
-                          @change="toggleFilterValue(filterModalField, val)"
-                          class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
-                        />
-                        <span class="text-gray-700 dark:text-gray-300 truncate">{{ val }}</span>
-                      </label>
-                    </div>
-                    <!-- Separator -->
-                    <div v-if="filterModalValues.selected.length > 0 && filterModalValues.unselected.length > 0" class="my-2 border-t border-gray-200 dark:border-gray-700"></div>
-                    <!-- Unselected values -->
-                    <div v-if="filterModalValues.unselected.length > 0" class="space-y-0.5">
-                      <label
-                        v-for="val in filterModalValues.unselected"
-                        :key="val"
-                        class="flex items-center gap-2.5 px-3 py-1.5 text-sm rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
-                      >
-                        <input
-                          type="checkbox"
-                          @change="toggleFilterValue(filterModalField, val)"
-                          class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
-                        />
-                        <span class="text-gray-700 dark:text-gray-300 truncate">{{ val }}</span>
-                      </label>
-                    </div>
-                  </template>
-                </div>
-              </template>
-            </div>
-          </div>
-
-          <!-- Tab: Saved Presets -->
-          <div v-if="filterModalTab === 'presets'" class="flex-1 flex flex-col min-h-0" style="min-height: 320px">
-            <!-- Saved filter list -->
-            <div class="flex-1 overflow-y-auto">
-              <div v-if="savedFilters.length === 0" class="px-6 py-8 text-center text-sm text-gray-400 dark:text-gray-500">
-                No saved presets yet.
-              </div>
-              <div v-else class="divide-y divide-gray-200 dark:divide-gray-700">
-                <div
-                  v-for="preset in savedFilters"
-                  :key="preset.id"
-                  class="px-6 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-                >
-                  <div class="flex items-start justify-between gap-3">
-                    <div class="flex-1 min-w-0">
-                      <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ preset.name }}</div>
-                      <div v-if="preset.description" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ preset.description }}</div>
-                      <div class="flex flex-wrap gap-1 mt-1.5">
-                        <span
-                          v-for="(values, field) in preset.filters"
-                          :key="field"
-                          class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400"
-                        >{{ filterFieldLabel(field) }}: {{ formatFilterValues(values) }}</span>
-                      </div>
-                    </div>
-                    <div class="flex items-center gap-1 shrink-0">
-                      <button @click="applySavedFilter(preset)" class="p-1 text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded transition-colors" title="Apply">
-                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-                        </svg>
-                      </button>
-                      <button @click="editSavedFilter(preset)" class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors" title="Edit">
-                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-                        </svg>
-                      </button>
-                      <button @click="deleteSavedFilter(preset.id)" class="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors" title="Delete">
-                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Footer -->
-          <div class="border-t border-gray-200 dark:border-gray-700 shrink-0">
-            <!-- Save form (expandable) -->
-            <div v-if="showSaveForm && hasActiveFilters" class="px-6 py-3 bg-gray-50/50 dark:bg-gray-900/30 border-b border-gray-200 dark:border-gray-700">
-              <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
-                {{ editingFilterId ? 'Update Preset' : 'Save as Preset' }}
-              </div>
-              <div class="space-y-2">
-                <input
-                  v-model="savedFilterName"
-                  type="text"
-                  placeholder="Name (required)"
-                  class="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
-                />
-                <input
-                  v-model="savedFilterDescription"
-                  type="text"
-                  placeholder="Description (optional)"
-                  class="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
-                />
-                <div class="flex items-center gap-2">
-                  <button
-                    @click="saveCurrentFilters"
-                    :disabled="!savedFilterName.trim()"
-                    class="px-3 py-1.5 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >{{ editingFilterId ? 'Update' : 'Save' }}</button>
-                  <button
-                    @click="cancelSaveForm"
-                    class="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                  >Cancel</button>
-                </div>
-              </div>
-            </div>
-
-            <!-- Button bar -->
-            <div class="flex items-center justify-between px-6 py-3">
-              <button
-                v-if="hasActiveFilters"
-                @click="clearAllFilters"
-                class="text-sm text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
-              >Clear All Filters</button>
-              <span v-else></span>
-              <div class="flex items-center gap-2">
-                <button
-                  v-if="hasActiveFilters && !showSaveForm"
-                  @click="showSaveForm = true"
-                  class="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                >Save as Preset</button>
-                <button
-                  @click="closeFilterModal"
-                  class="px-4 py-2 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 transition-colors"
-                >Done</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <ReportFilterModal :filters="filters" :available-filter-values="availableFilterValues" />
 
     <!-- Feature list modal -->
     <Teleport to="body">
@@ -1216,6 +915,9 @@ import { ref, reactive, computed, watch, onMounted, onUnmounted, inject } from '
 import { apiRequest } from '@shared/client/services/api.js'
 import { Doughnut } from 'vue-chartjs'
 import { Chart as ChartJS, ArcElement, Tooltip } from 'chart.js'
+import { useReportFilters } from './composables/useReportFilters.js'
+import ReportFilterModal from './components/ReportFilterModal.vue'
+import ReportFilterNarrative from './components/ReportFilterNarrative.vue'
 
 ChartJS.register(ArcElement, Tooltip)
 
@@ -1246,8 +948,11 @@ const FILTER_FIELDS = [
   { key: 'issueType', label: 'Type' },
   { key: 'priority', label: 'Priority' }
 ]
-const FILTERS_STORAGE_KEY = 'tt_cache:capacity-report-active-filters'
-const SAVED_FILTERS_STORAGE_KEY = 'tt_cache:capacity-report-saved-filters'
+
+const filters = useReportFilters({
+  storageKeyPrefix: 'capacity-report',
+  filterFields: FILTER_FIELDS
+})
 
 const RISK_COLORS = {
   'Green': '#22c55e',
@@ -1277,21 +982,6 @@ const riskOpen = ref(true)
 
 const selection = reactive({ version: '', families: new Set(), phases: new Set() })
 const draft = reactive({ version: '', families: new Set(), phases: new Set() })
-
-// ── Filter state ──
-const activeFilters = reactive({})
-const filterModes = reactive({}) // per-field: 'or' (default) or 'and'
-const crossFieldMode = ref('and') // across fields: 'and' (default) or 'or'
-const filterModalOpen = ref(false)
-const filterModalField = ref(null)
-const filterModalSearch = ref('')
-const filterModalTab = ref('fields')
-const showSaveForm = ref(false)
-const savedFilters = ref([])
-const savedFilterName = ref('')
-const savedFilterDescription = ref('')
-const editingFilterId = ref(null)
-const appliedPresetId = ref(null)
 
 // ── Registry parsing ──
 
@@ -1535,7 +1225,7 @@ function reconcileDraftPhases() {
 // Close modal on Escape
 function handleEscape(e) {
   if (e.key !== 'Escape') return
-  if (filterModalOpen.value) { closeFilterModal(); return }
+  if (filters.filterModalOpen.value) { filters.closeFilterModal(); return }
   if (columnSettingsOpen.value) { columnSettingsOpen.value = false; return }
   if (riskColumnSettingsOpen.value) { riskColumnSettingsOpen.value = false; return }
   if (featureListStatus.value) { closeFeatureList(); return }
@@ -1672,60 +1362,7 @@ onMounted(fetchFieldOptions)
 
 // ── Feature filtering ──
 
-function matchesFieldFilter(feature, field, values) {
-  const valSet = new Set(values)
-  const mode = filterModes[field] || 'or'
-  const val = feature[field]
-  if (mode === 'and') {
-    if (Array.isArray(val)) return [...valSet].every(v => val.includes(v))
-    return valSet.size === 1 && valSet.has(val || '')
-  }
-  if (Array.isArray(val)) return val.some(v => valSet.has(v))
-  return valSet.has(val || '')
-}
-
-const filteredAllFeatures = computed(() => {
-  const activeEntries = Object.entries(activeFilters).filter(([, v]) => v && v.length > 0)
-  if (activeEntries.length === 0) return allFeatures.value
-
-  if (crossFieldMode.value === 'or') {
-    return allFeatures.value.filter(f =>
-      activeEntries.some(([field, values]) => matchesFieldFilter(f, field, values))
-    )
-  }
-  return allFeatures.value.filter(f =>
-    activeEntries.every(([field, values]) => matchesFieldFilter(f, field, values))
-  )
-})
-
-const hasActiveFilters = computed(() => {
-  return Object.values(activeFilters).some(v => v && v.length > 0)
-})
-
-const activeFieldCount = computed(() => {
-  return Object.values(activeFilters).filter(v => v && v.length > 0).length
-})
-
-const activeFilterDisplay = computed(() => {
-  const result = {}
-  for (const [field, values] of Object.entries(activeFilters)) {
-    if (values && values.length > 0) result[field] = values
-  }
-  return result
-})
-
-const appliedPreset = computed(() => {
-  if (!appliedPresetId.value) return null
-  return savedFilters.value.find(f => f.id === appliedPresetId.value) || null
-})
-
-const filterNarrativeParts = computed(() => {
-  return Object.entries(activeFilterDisplay.value).map(([field, values]) => ({
-    field,
-    label: filterFieldLabel(field),
-    values: formatFilterValues(values)
-  }))
-})
+const filteredAllFeatures = computed(() => filters.filterItems(allFeatures.value))
 
 const availableFilterValues = computed(() => {
   if (!hasSelection.value) return {}
@@ -1753,219 +1390,6 @@ const availableFilterValues = computed(() => {
   }
   return result
 })
-
-const filterModalValues = computed(() => {
-  if (!filterModalField.value) return { selected: [], unselected: [] }
-  const all = availableFilterValues.value[filterModalField.value] || []
-  const q = filterModalSearch.value.toLowerCase().trim()
-  const filtered = q ? all.filter(v => v.toLowerCase().includes(q)) : all
-  const active = activeFilters[filterModalField.value] || []
-  const activeSet = new Set(active)
-  const selected = filtered.filter(v => activeSet.has(v))
-  const unselected = filtered.filter(v => !activeSet.has(v))
-  return { selected, unselected }
-})
-
-function filterFieldLabel(key) {
-  const field = FILTER_FIELDS.find(f => f.key === key)
-  return field ? field.label : key
-}
-
-function formatFilterValues(values) {
-  if (values.length <= 2) return values.join(', ')
-  return values.slice(0, 2).join(', ') + ' +' + (values.length - 2)
-}
-
-function toggleFilterValue(field, value) {
-  if (!activeFilters[field]) activeFilters[field] = []
-  const idx = activeFilters[field].indexOf(value)
-  if (idx >= 0) {
-    activeFilters[field].splice(idx, 1)
-    if (activeFilters[field].length === 0) delete activeFilters[field]
-  } else {
-    activeFilters[field].push(value)
-  }
-  appliedPresetId.value = null
-  persistActiveFilters()
-}
-
-function toggleFilterMode(field) {
-  filterModes[field] = (filterModes[field] || 'or') === 'or' ? 'and' : 'or'
-  persistActiveFilters()
-}
-
-function clearAllFilters() {
-  for (const key of Object.keys(activeFilters)) delete activeFilters[key]
-  for (const key of Object.keys(filterModes)) delete filterModes[key]
-  crossFieldMode.value = 'and'
-  appliedPresetId.value = null
-  editingFilterId.value = null
-  persistActiveFilters()
-}
-
-function openFilterModal() {
-  filterModalField.value = FILTER_FIELDS[0]?.key || null
-  filterModalSearch.value = ''
-  filterModalTab.value = 'fields'
-  filterModalOpen.value = true
-}
-
-function openFilterModalToPresets() {
-  filterModalTab.value = 'presets'
-  filterModalOpen.value = true
-}
-
-function closeFilterModal() {
-  filterModalOpen.value = false
-  filterModalSearch.value = ''
-  showSaveForm.value = false
-}
-
-function selectFilterField(key) {
-  filterModalField.value = key
-  filterModalSearch.value = ''
-}
-
-function persistActiveFilters() {
-  const data = {}
-  for (const [k, v] of Object.entries(activeFilters)) {
-    if (v && v.length > 0) data[k] = v
-  }
-  const modes = {}
-  for (const [k, v] of Object.entries(filterModes)) {
-    if (v === 'and') modes[k] = v
-  }
-  const cross = crossFieldMode.value !== 'and' ? crossFieldMode.value : undefined
-  if (Object.keys(data).length > 0 || Object.keys(modes).length > 0) {
-    localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify({ filters: data, modes, crossFieldMode: cross }))
-  } else {
-    localStorage.removeItem(FILTERS_STORAGE_KEY)
-  }
-}
-
-function loadActiveFilters() {
-  try {
-    const stored = localStorage.getItem(FILTERS_STORAGE_KEY)
-    if (!stored) return
-    const parsed = JSON.parse(stored)
-    // Support both old format (flat object) and new format ({ filters, modes })
-    const filters = parsed.filters || (Array.isArray(parsed) ? {} : (!parsed.modes ? parsed : {}))
-    const modes = parsed.modes || {}
-    for (const [k, v] of Object.entries(filters)) {
-      if (Array.isArray(v) && v.length > 0) activeFilters[k] = v
-    }
-    for (const [k, v] of Object.entries(modes)) {
-      if (v === 'and') filterModes[k] = v
-    }
-    if (parsed.crossFieldMode) crossFieldMode.value = parsed.crossFieldMode
-  } catch { /* ignore */ }
-}
-
-function loadSavedFilters() {
-  try {
-    const stored = localStorage.getItem(SAVED_FILTERS_STORAGE_KEY)
-    if (stored) savedFilters.value = JSON.parse(stored)
-  } catch { /* ignore */ }
-}
-
-function persistSavedFilters() {
-  localStorage.setItem(SAVED_FILTERS_STORAGE_KEY, JSON.stringify(savedFilters.value))
-}
-
-function saveCurrentFilters() {
-  const name = savedFilterName.value.trim()
-  if (!name) return
-
-  const filterData = {}
-  for (const [k, v] of Object.entries(activeFilters)) {
-    if (v && v.length > 0) filterData[k] = [...v]
-  }
-  const modesData = {}
-  for (const [k, v] of Object.entries(filterModes)) {
-    if (v === 'and') modesData[k] = v
-  }
-
-  if (editingFilterId.value) {
-    const idx = savedFilters.value.findIndex(f => f.id === editingFilterId.value)
-    if (idx >= 0) {
-      savedFilters.value[idx] = {
-        ...savedFilters.value[idx],
-        name,
-        description: savedFilterDescription.value.trim(),
-        filters: filterData,
-        modes: modesData,
-        crossFieldMode: crossFieldMode.value
-      }
-    }
-    editingFilterId.value = null
-  } else {
-    savedFilters.value.push({
-      id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
-      name,
-      description: savedFilterDescription.value.trim(),
-      filters: filterData,
-      modes: modesData,
-      crossFieldMode: crossFieldMode.value
-    })
-  }
-
-  persistSavedFilters()
-  savedFilterName.value = ''
-  savedFilterDescription.value = ''
-  showSaveForm.value = false
-}
-
-function cancelSaveForm() {
-  showSaveForm.value = false
-  editingFilterId.value = null
-  savedFilterName.value = ''
-  savedFilterDescription.value = ''
-}
-
-function restorePresetState(preset) {
-  for (const key of Object.keys(activeFilters)) delete activeFilters[key]
-  for (const key of Object.keys(filterModes)) delete filterModes[key]
-  for (const [k, v] of Object.entries(preset.filters)) {
-    if (Array.isArray(v) && v.length > 0) activeFilters[k] = [...v]
-  }
-  if (preset.modes) {
-    for (const [k, v] of Object.entries(preset.modes)) filterModes[k] = v
-  }
-  crossFieldMode.value = preset.crossFieldMode || 'and'
-}
-
-function applySavedFilter(preset) {
-  restorePresetState(preset)
-  appliedPresetId.value = preset.id
-  persistActiveFilters()
-  editingFilterId.value = null
-  closeFilterModal()
-}
-
-function editSavedFilter(preset) {
-  restorePresetState(preset)
-  persistActiveFilters()
-  editingFilterId.value = preset.id
-  savedFilterName.value = preset.name
-  savedFilterDescription.value = preset.description || ''
-  showSaveForm.value = true
-  filterModalTab.value = 'fields'
-}
-
-function cancelEditFilter() {
-  editingFilterId.value = null
-  savedFilterName.value = ''
-  savedFilterDescription.value = ''
-}
-
-function deleteSavedFilter(id) {
-  savedFilters.value = savedFilters.value.filter(f => f.id !== id)
-  persistSavedFilters()
-  if (editingFilterId.value === id) cancelEditFilter()
-}
-
-loadActiveFilters()
-loadSavedFilters()
 
 // Restore modal state when returning from feature detail
 watch(featuresLoading, (loading) => {

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -57,15 +57,24 @@
 
     <!-- Data -->
     <div v-else class="space-y-6">
+      <!-- Filter bar -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-5 py-3">
+        <ReportFilterNarrative
+          :filters="filters"
+          no-filter-text="Showing all open CVEs."
+          filter-prefix="Showing open CVEs filtered by"
+        />
+      </div>
+
       <!-- Total count banner -->
       <div class="bg-gradient-to-r from-red-600 to-orange-600 dark:from-red-700 dark:to-orange-700 rounded-lg px-6 py-4 text-white shadow">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-xs font-semibold uppercase tracking-widest text-red-200">Open CVEs</p>
-            <a :href="data.totalOpen_jql" target="_blank" rel="noopener noreferrer"
+            <p class="text-xs font-semibold uppercase tracking-widest text-red-200">Open CVEs{{ filters.hasActiveFilters.value ? ' (filtered)' : '' }}</p>
+            <a :href="agg.totalOpen_jql.value" target="_blank" rel="noopener noreferrer"
               class="text-3xl font-extrabold hover:underline decoration-dotted cursor-pointer inline-flex items-center gap-1.5"
               title="View open CVEs in Jira">
-              {{ data.totalOpen.toLocaleString() }}
+              {{ agg.totalOpen.value.toLocaleString() }}
               <svg class="w-4 h-4 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
             </a>
           </div>
@@ -94,7 +103,7 @@
           </a>
         </div>
         <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
-          {{ data.cvesByDueDate.total.toLocaleString() }} issues
+          {{ agg.cvesByDueDate.value.total.toLocaleString() }} issues
         </p>
       </section>
 
@@ -105,7 +114,7 @@
           <Bar :data="openCvesChartData" :options="openCvesChartOptions" />
         </div>
         <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
-          Issues by Components &middot; {{ (data.openCvesByComponent || []).length }}
+          Issues by Components &middot; {{ agg.openCvesByComponent.value.length }}
         </p>
       </section>
 
@@ -117,12 +126,15 @@
             <Pie :data="versionPieData" :options="versionPieOptions" />
           </div>
           <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
-            {{ data.totalOpen.toLocaleString() }} issues &middot; Issues by Target Version
+            {{ agg.totalOpen.value.toLocaleString() }} issues &middot; Issues by Target Version
           </p>
         </section>
 
         <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">False Positive by VEX Justification</h3>
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            False Positive by VEX Justification
+            <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
+          </h3>
           <div style="height: 300px;">
             <Doughnut :data="vexDoughnutData" :options="vexPieOptions" />
           </div>
@@ -139,14 +151,14 @@
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-700">
               <th class="text-left py-2 pr-3 font-semibold text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800 z-10">Components</th>
-              <th v-for="ver in data.cvesAcrossVersions.versions" :key="ver" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ ver }}</th>
+              <th v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ ver }}</th>
               <th class="text-right py-2 pl-3 font-bold text-gray-900 dark:text-gray-100">Total</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="row in data.cvesAcrossVersions.rows" :key="row.component" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+            <tr v-for="row in agg.cvesAcrossVersions.value.rows" :key="row.component" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
               <td class="py-1.5 pr-3 text-gray-800 dark:text-gray-200 sticky left-0 bg-white dark:bg-gray-800 z-10">{{ row.component }}</td>
-              <td v-for="ver in data.cvesAcrossVersions.versions" :key="ver" class="text-right py-1.5 px-2 tabular-nums">
+              <td v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-1.5 px-2 tabular-nums">
                 <ClickableCount v-if="row.cells[ver]" :count="row.cells[ver]" :jql="row.cellJqls[ver] || ''" />
                 <span v-else class="text-gray-400 dark:text-gray-500">0</span>
               </td>
@@ -158,17 +170,17 @@
           <tfoot>
             <tr class="border-t-2 border-gray-300 dark:border-gray-600">
               <td class="py-2 pr-3 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10">Total</td>
-              <td v-for="ver in data.cvesAcrossVersions.versions" :key="ver" class="text-right py-2 px-2 font-bold tabular-nums">
-                <ClickableCount :count="data.cvesAcrossVersions.columnTotals[ver] || 0" :jql="data.cvesAcrossVersions.columnJqls[ver] || ''" />
+              <td v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-2 px-2 font-bold tabular-nums">
+                <ClickableCount :count="agg.cvesAcrossVersions.value.columnTotals[ver] || 0" :jql="agg.cvesAcrossVersions.value.columnJqls[ver] || ''" />
               </td>
               <td class="text-right py-2 pl-3 font-bold tabular-nums">
-                <ClickableCount :count="data.cvesAcrossVersions.grandTotal" :jql="data.cvesAcrossVersions.grandTotal_jql || ''" />
+                <ClickableCount :count="agg.cvesAcrossVersions.value.grandTotal" :jql="agg.cvesAcrossVersions.value.grandTotal_jql || ''" />
               </td>
             </tr>
           </tfoot>
         </table>
         <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
-          Issues by Target Version &middot; {{ data.cvesAcrossVersions.versions.length }} versions &middot; Components {{ data.cvesAcrossVersions.rows.length }}
+          Issues by Target Version &middot; {{ agg.cvesAcrossVersions.value.versions.length }} versions &middot; Components {{ agg.cvesAcrossVersions.value.rows.length }}
         </p>
       </section>
 
@@ -179,18 +191,18 @@
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-700">
               <th class="text-left py-2 pr-3 font-semibold text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800 z-10">Status</th>
-              <th v-for="a in data.cvesByAssigneeStatus.assignees" :key="a" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ a }}</th>
+              <th v-for="a in agg.cvesByAssigneeStatus.value.assignees" :key="a" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ a }}</th>
               <th class="text-right py-2 pl-3 font-bold text-gray-900 dark:text-gray-100">Total</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="row in data.cvesByAssigneeStatus.rows" :key="row.status" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+            <tr v-for="row in agg.cvesByAssigneeStatus.value.rows" :key="row.status" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
               <td class="py-1.5 pr-3 sticky left-0 bg-white dark:bg-gray-800 z-10">
                 <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide" :class="statusBadgeClass(row.status)">
                   {{ row.status }}
                 </span>
               </td>
-              <td v-for="a in data.cvesByAssigneeStatus.assignees" :key="a" class="text-right py-1.5 px-2 tabular-nums">
+              <td v-for="a in agg.cvesByAssigneeStatus.value.assignees" :key="a" class="text-right py-1.5 px-2 tabular-nums">
                 <ClickableCount v-if="row.cells[a]" :count="row.cells[a]" :jql="row.cellJqls[a] || ''" />
                 <span v-else class="text-gray-400 dark:text-gray-500">0</span>
               </td>
@@ -202,23 +214,26 @@
           <tfoot>
             <tr class="border-t-2 border-gray-300 dark:border-gray-600">
               <td class="py-2 pr-3 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10">Total</td>
-              <td v-for="a in data.cvesByAssigneeStatus.assignees" :key="a" class="text-right py-2 px-2 font-bold tabular-nums">
-                <ClickableCount :count="data.cvesByAssigneeStatus.columnTotals[a] || 0" :jql="data.cvesByAssigneeStatus.columnJqls[a] || ''" />
+              <td v-for="a in agg.cvesByAssigneeStatus.value.assignees" :key="a" class="text-right py-2 px-2 font-bold tabular-nums">
+                <ClickableCount :count="agg.cvesByAssigneeStatus.value.columnTotals[a] || 0" :jql="agg.cvesByAssigneeStatus.value.columnJqls[a] || ''" />
               </td>
               <td class="text-right py-2 pl-3 font-bold tabular-nums">
-                <ClickableCount :count="data.cvesByAssigneeStatus.grandTotal" :jql="data.cvesByAssigneeStatus.grandTotal_jql || ''" />
+                <ClickableCount :count="agg.cvesByAssigneeStatus.value.grandTotal" :jql="agg.cvesByAssigneeStatus.value.grandTotal_jql || ''" />
               </td>
             </tr>
           </tfoot>
         </table>
         <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
-          {{ data.cvesByAssigneeStatus.grandTotal }} issues &middot; Issues by Assignee + Status
+          {{ agg.cvesByAssigneeStatus.value.grandTotal }} issues &middot; Issues by Assignee + Status
         </p>
       </section>
 
       <!-- 7. Created vs Resolved (line chart) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Created vs Resolved Chart around CVEs</h3>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Created vs Resolved Chart around CVEs
+          <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
+        </h3>
         <div style="height: 300px;">
           <Line :data="createdVsResolvedData" :options="createdResolvedOptions" />
         </div>
@@ -229,7 +244,10 @@
 
       <!-- 8. Unresolved (line chart) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Unresolved</h3>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Unresolved
+          <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
+        </h3>
         <div style="height: 300px;">
           <Line :data="unresolvedData" :options="unresolvedOptions" />
         </div>
@@ -240,7 +258,10 @@
 
       <!-- 9. RHOAI False Positives (multi-series line) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">RHOAI False Positives</h3>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          RHOAI False Positives
+          <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
+        </h3>
         <div style="height: 300px;">
           <Line :data="falsePositivesTrendData" :options="falsePositivesOptions" />
         </div>
@@ -249,6 +270,9 @@
         </p>
       </section>
     </div>
+
+    <!-- Filter modal -->
+    <ReportFilterModal :filters="filters" :available-filter-values="availableFilterValues" />
   </div>
 </template>
 
@@ -269,12 +293,50 @@ import {
   Legend
 } from 'chart.js'
 import { useCveSustaining } from './composables/useCveSustaining'
+import { useReportFilters } from './composables/useReportFilters.js'
+import { useCveAggregation } from './composables/useCveAggregation.js'
+import ReportFilterModal from './components/ReportFilterModal.vue'
+import ReportFilterNarrative from './components/ReportFilterNarrative.vue'
 import ClickableCount from '../components/ClickableCount.vue'
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Filler, Tooltip, Legend)
 
 const nav = inject('moduleNav')
 const { data, loading, error, refreshing, loadData, refresh } = useCveSustaining()
+
+// ─── Filters ──────────────────────────────────────────────────────────────────
+
+const CVE_FILTER_FIELDS = [
+  { key: 'component', label: 'Component' },
+  { key: 'versions', label: 'Target Version' },
+  { key: 'assignee', label: 'Assignee' },
+  { key: 'status', label: 'Status' }
+]
+
+const filters = useReportFilters({
+  storageKeyPrefix: 'cve-sustaining',
+  filterFields: CVE_FILTER_FIELDS
+})
+
+const openIssueRecords = computed(() => data.value?.openIssueRecords || [])
+const jiraSearchBase = computed(() => data.value?.jiraSearchBase || '')
+
+const filteredIssues = computed(() => filters.filterItems(openIssueRecords.value))
+
+const agg = useCveAggregation(filteredIssues, jiraSearchBase, filters.activeFilterDisplay)
+
+const availableFilterValues = computed(() => {
+  const issues = openIssueRecords.value
+  if (issues.length === 0) return {}
+  return {
+    component: [...new Set(issues.map(i => i.component))].sort(),
+    versions: [...new Set(issues.flatMap(i => i.versions))].sort(),
+    assignee: [...new Set(issues.map(i => i.assignee))].sort(),
+    status: [...new Set(issues.map(i => i.status))].sort()
+  }
+})
+
+// ─── Navigation & data ────────────────────────────────────────────────────────
 
 function goBack() {
   nav.navigateTo('reports')
@@ -299,7 +361,7 @@ function formatDate(iso) {
 // ─── Due Date Buckets ────────────────────────────────────────────────────────
 
 const dueDateBuckets = computed(() => {
-  const dd = data.value?.cvesByDueDate
+  const dd = agg.cvesByDueDate.value
   if (!dd) return []
   return [
     { key: 'passed', label: 'Due Date Passed', pct: dd.passed.pct, count: dd.passed.count, jql: dd.passed.jql, classes: 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800' },
@@ -338,7 +400,7 @@ const CHART_COLORS = [
 // ─── 1. Open CVEs Bar Chart ─────────────────────────────────────────────────
 
 const openCvesChartData = computed(() => {
-  const items = data.value?.openCvesByComponent || []
+  const items = agg.openCvesByComponent.value
   const top = items.slice(0, 20)
   return {
     labels: top.map(i => truncateLabel(i.component, 18)),
@@ -359,7 +421,7 @@ const openCvesChartOptions = computed(() => ({
   onClick: (_event, elements) => {
     if (elements.length > 0) {
       const idx = elements[0].index
-      const items = data.value?.openCvesByComponent || []
+      const items = agg.openCvesByComponent.value
       const item = items[idx]
       if (item?.jql) window.open(item.jql, '_blank', 'noopener,noreferrer')
     }
@@ -372,7 +434,7 @@ const openCvesChartOptions = computed(() => ({
     tooltip: {
       callbacks: {
         label: (ctx) => {
-          const items = data.value?.openCvesByComponent || []
+          const items = agg.openCvesByComponent.value
           const item = items[ctx.dataIndex]
           return item ? `${ctx.raw} issues (${item.pct}%) — click to view in Jira` : `${ctx.raw} issues`
         }
@@ -396,7 +458,7 @@ const openCvesChartOptions = computed(() => ({
 // ─── 4. Version Pie Chart ────────────────────────────────────────────────────
 
 const versionPieData = computed(() => {
-  const items = data.value?.openCvesByVersion || []
+  const items = agg.openCvesByVersion.value
   return {
     labels: items.map(i => `${i.version} (${i.count} / ${i.pct}%)`),
     datasets: [{
@@ -408,7 +470,7 @@ const versionPieData = computed(() => {
   }
 })
 
-// ─── 6. VEX Justification Doughnut ──────────────────────────────────────────
+// ─── 6. VEX Justification Doughnut (unfiltered — uses allIssues data) ──────
 
 const vexDoughnutData = computed(() => {
   const items = data.value?.falsePositivesByVex?.items || []
@@ -423,7 +485,7 @@ const vexDoughnutData = computed(() => {
   }
 })
 
-function makePieOptions(dataKey, itemJqlAccessor) {
+function makePieOptions(itemJqlAccessor) {
   return computed(() => ({
     responsive: true,
     maintainAspectRatio: false,
@@ -460,10 +522,10 @@ function makePieOptions(dataKey, itemJqlAccessor) {
   }))
 }
 
-const versionPieOptions = makePieOptions('openCvesByVersion', () => data.value?.openCvesByVersion || [])
-const vexPieOptions = makePieOptions('falsePositivesByVex', () => data.value?.falsePositivesByVex?.items || [])
+const versionPieOptions = makePieOptions(() => agg.openCvesByVersion.value)
+const vexPieOptions = makePieOptions(() => data.value?.falsePositivesByVex?.items || [])
 
-// ─── 7. Created vs Resolved Line Chart ──────────────────────────────────────
+// ─── 7. Created vs Resolved Line Chart (unfiltered) ─────────────────────────
 
 const createdVsResolvedData = computed(() => {
   const series = data.value?.createdVsResolved || []
@@ -494,7 +556,7 @@ const createdVsResolvedData = computed(() => {
   }
 })
 
-// ─── 8. Unresolved Line Chart ───────────────────────────────────────────────
+// ─── 8. Unresolved Line Chart (unfiltered) ───────────────────────────────────
 
 const unresolvedData = computed(() => {
   const series = data.value?.unresolved || []
@@ -513,7 +575,7 @@ const unresolvedData = computed(() => {
   }
 })
 
-// ─── 9. False Positives Trend (Multi-Series) ────────────────────────────────
+// ─── 9. False Positives Trend (unfiltered) ────────────────────────────────────
 
 const FP_COLORS = {
   'Not a bug': 'rgba(239, 68, 68, 1)',

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -94,13 +94,14 @@
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
         <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by Due Date</h3>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-          <a v-for="bucket in dueDateBuckets" :key="bucket.key" :href="bucket.jql" target="_blank" rel="noopener noreferrer"
-            class="rounded-lg border p-4 text-center hover:shadow-md transition-shadow cursor-pointer block" :class="bucket.classes"
-            :title="`${bucket.label}: ${bucket.count} issues — click to view in Jira`">
+          <button v-for="bucket in dueDateBuckets" :key="bucket.key"
+            class="rounded-lg border p-4 text-center hover:shadow-md transition-shadow cursor-pointer block w-full" :class="bucket.classes"
+            :title="`${bucket.label}: ${bucket.count} issues — click to view list`"
+            @click="drillDownByDueDate(bucket.key, bucket.label, bucket.jql)">
             <p class="text-3xl font-extrabold">{{ bucket.pct }}%</p>
             <p class="text-[10px] font-semibold uppercase tracking-wide mt-1 opacity-80">{{ bucket.label }}</p>
             <p class="text-xs mt-1 opacity-60">{{ bucket.count }} issues</p>
-          </a>
+          </button>
         </div>
         <p class="text-xs text-gray-400 dark:text-gray-500 mt-3 text-right">
           {{ agg.cvesByDueDate.value.total.toLocaleString() }} issues
@@ -159,11 +160,12 @@
             <tr v-for="row in agg.cvesAcrossVersions.value.rows" :key="row.component" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
               <td class="py-1.5 pr-3 text-gray-800 dark:text-gray-200 sticky left-0 bg-white dark:bg-gray-800 z-10">{{ row.component }}</td>
               <td v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-1.5 px-2 tabular-nums">
-                <ClickableCount v-if="row.cells[ver]" :count="row.cells[ver]" :jql="row.cellJqls[ver] || ''" />
+                <button v-if="row.cells[ver]" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByMatrixCell(row.component, ver, row.cellJqls[ver])">{{ row.cells[ver] }}</button>
                 <span v-else class="text-gray-400 dark:text-gray-500">0</span>
               </td>
               <td class="text-right py-1.5 pl-3 font-bold tabular-nums">
-                <ClickableCount :count="row.total" :jql="row.total_jql || ''" />
+                <button v-if="row.total" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByMatrixRow(row.component, row.total_jql)">{{ row.total }}</button>
+                <span v-else class="font-semibold text-gray-600 dark:text-gray-400">0</span>
               </td>
             </tr>
           </tbody>
@@ -171,10 +173,12 @@
             <tr class="border-t-2 border-gray-300 dark:border-gray-600">
               <td class="py-2 pr-3 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10">Total</td>
               <td v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-2 px-2 font-bold tabular-nums">
-                <ClickableCount :count="agg.cvesAcrossVersions.value.columnTotals[ver] || 0" :jql="agg.cvesAcrossVersions.value.columnJqls[ver] || ''" />
+                <button v-if="agg.cvesAcrossVersions.value.columnTotals[ver]" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByMatrixColumn(ver, agg.cvesAcrossVersions.value.columnJqls[ver])">{{ agg.cvesAcrossVersions.value.columnTotals[ver] }}</button>
+                <span v-else class="font-semibold text-gray-600 dark:text-gray-400">0</span>
               </td>
               <td class="text-right py-2 pl-3 font-bold tabular-nums">
-                <ClickableCount :count="agg.cvesAcrossVersions.value.grandTotal" :jql="agg.cvesAcrossVersions.value.grandTotal_jql || ''" />
+                <button v-if="agg.cvesAcrossVersions.value.grandTotal" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="openDrillDown('All CVEs', filteredIssues, agg.cvesAcrossVersions.value.grandTotal_jql)">{{ agg.cvesAcrossVersions.value.grandTotal }}</button>
+                <span v-else class="font-semibold text-gray-600 dark:text-gray-400">0</span>
               </td>
             </tr>
           </tfoot>
@@ -186,7 +190,7 @@
 
       <!-- 5. CVEs by RHOAI Sustaining (assignee x status table) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5 overflow-x-auto">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by RHOAI Sustaining</h3>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by Assignee</h3>
         <table class="w-full text-xs">
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-700">
@@ -203,11 +207,12 @@
                 </span>
               </td>
               <td v-for="a in agg.cvesByAssigneeStatus.value.assignees" :key="a" class="text-right py-1.5 px-2 tabular-nums">
-                <ClickableCount v-if="row.cells[a]" :count="row.cells[a]" :jql="row.cellJqls[a] || ''" />
+                <button v-if="row.cells[a]" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByAssigneeStatus(row.status, a, row.cellJqls[a])">{{ row.cells[a] }}</button>
                 <span v-else class="text-gray-400 dark:text-gray-500">0</span>
               </td>
               <td class="text-right py-1.5 pl-3 font-bold tabular-nums">
-                <ClickableCount :count="row.total" :jql="row.total_jql || ''" />
+                <button v-if="row.total" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByStatus(row.status, row.total_jql)">{{ row.total }}</button>
+                <span v-else class="font-semibold text-gray-600 dark:text-gray-400">0</span>
               </td>
             </tr>
           </tbody>
@@ -215,10 +220,12 @@
             <tr class="border-t-2 border-gray-300 dark:border-gray-600">
               <td class="py-2 pr-3 font-bold text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10">Total</td>
               <td v-for="a in agg.cvesByAssigneeStatus.value.assignees" :key="a" class="text-right py-2 px-2 font-bold tabular-nums">
-                <ClickableCount :count="agg.cvesByAssigneeStatus.value.columnTotals[a] || 0" :jql="agg.cvesByAssigneeStatus.value.columnJqls[a] || ''" />
+                <button v-if="agg.cvesByAssigneeStatus.value.columnTotals[a]" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByAssignee(a, agg.cvesByAssigneeStatus.value.columnJqls[a])">{{ agg.cvesByAssigneeStatus.value.columnTotals[a] }}</button>
+                <span v-else class="font-semibold text-gray-600 dark:text-gray-400">0</span>
               </td>
               <td class="text-right py-2 pl-3 font-bold tabular-nums">
-                <ClickableCount :count="agg.cvesByAssigneeStatus.value.grandTotal" :jql="agg.cvesByAssigneeStatus.value.grandTotal_jql || ''" />
+                <button v-if="agg.cvesByAssigneeStatus.value.grandTotal" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="openDrillDown('All CVEs', filteredIssues, agg.cvesByAssigneeStatus.value.grandTotal_jql)">{{ agg.cvesByAssigneeStatus.value.grandTotal }}</button>
+                <span v-else class="font-semibold text-gray-600 dark:text-gray-400">0</span>
               </td>
             </tr>
           </tfoot>
@@ -273,11 +280,21 @@
 
     <!-- Filter modal -->
     <ReportFilterModal :filters="filters" :available-filter-values="availableFilterValues" />
+
+    <!-- Issue list drill-down modal -->
+    <CveIssueListModal
+      :visible="drillDown.visible"
+      :title="drillDown.title"
+      :issues="drillDown.issues"
+      :jql="drillDown.jql"
+      :dot-color="drillDown.dotColor"
+      @close="closeDrillDown"
+    />
   </div>
 </template>
 
 <script setup>
-import { computed, onMounted, inject } from 'vue'
+import { ref, computed, onMounted, onUnmounted, inject } from 'vue'
 import { ArrowLeft, RefreshCw, Shield } from 'lucide-vue-next'
 import { Bar, Pie, Doughnut, Line } from 'vue-chartjs'
 import {
@@ -297,7 +314,7 @@ import { useReportFilters } from './composables/useReportFilters.js'
 import { useCveAggregation } from './composables/useCveAggregation.js'
 import ReportFilterModal from './components/ReportFilterModal.vue'
 import ReportFilterNarrative from './components/ReportFilterNarrative.vue'
-import ClickableCount from '../components/ClickableCount.vue'
+import CveIssueListModal from './components/CveIssueListModal.vue'
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Filler, Tooltip, Legend)
 
@@ -335,6 +352,84 @@ const availableFilterValues = computed(() => {
     status: [...new Set(issues.map(i => i.status))].sort()
   }
 })
+
+// ─── Drill-down modal ─────────────────────────────────────────────────────────
+
+const drillDown = ref({ visible: false, title: '', issues: [], jql: '', dotColor: '' })
+
+function openDrillDown(title, issues, jql, dotColor) {
+  drillDown.value = { visible: true, title, issues, jql: jql || '', dotColor: dotColor || '' }
+}
+
+function closeDrillDown() {
+  drillDown.value = { visible: false, title: '', issues: [], jql: '', dotColor: '' }
+}
+
+function drillDownByComponent(componentName) {
+  const issues = filteredIssues.value.filter(i => i.component === componentName || (componentName === 'None' && i.component === 'None'))
+  const item = agg.openCvesByComponent.value.find(c => c.component === componentName)
+  openDrillDown(componentName, issues, item?.jql)
+}
+
+function drillDownByVersion(versionName) {
+  const issues = filteredIssues.value.filter(i => i.versions.includes(versionName) || (versionName === 'None' && i.versions.includes('None')))
+  const item = agg.openCvesByVersion.value.find(v => v.version === versionName)
+  openDrillDown(versionName, issues, item?.jql)
+}
+
+function drillDownByDueDate(bucketKey, label, jql) {
+  const now = new Date()
+  const issues = filteredIssues.value.filter(i => {
+    if (!i.duedate) return bucketKey === 'none'
+    const due = new Date(i.duedate)
+    const diffDays = Math.floor((due - now) / (1000 * 60 * 60 * 24))
+    if (bucketKey === 'passed') return diffDays < 0
+    if (bucketKey === 'lt30') return diffDays >= 0 && diffDays < 30
+    if (bucketKey === '30-90') return diffDays >= 30 && diffDays <= 90
+    if (bucketKey === 'gt90') return diffDays > 90
+    return false
+  })
+  openDrillDown(label, issues, jql)
+}
+
+function drillDownByMatrixCell(componentName, versionName, jql) {
+  const issues = filteredIssues.value.filter(i =>
+    i.components.includes(componentName) && i.versions.includes(versionName)
+  )
+  openDrillDown(`${componentName} / ${versionName}`, issues, jql)
+}
+
+function drillDownByMatrixRow(componentName, jql) {
+  const issues = filteredIssues.value.filter(i => i.components.includes(componentName))
+  openDrillDown(componentName, issues, jql)
+}
+
+function drillDownByMatrixColumn(versionName, jql) {
+  const issues = filteredIssues.value.filter(i => i.versions.includes(versionName))
+  openDrillDown(versionName, issues, jql)
+}
+
+function drillDownByAssigneeStatus(status, assignee, jql) {
+  const issues = filteredIssues.value.filter(i => i.status === status && i.assignee === assignee)
+  openDrillDown(`${status} / ${assignee}`, issues, jql)
+}
+
+function drillDownByStatus(status, jql) {
+  const issues = filteredIssues.value.filter(i => i.status === status)
+  openDrillDown(status, issues, jql)
+}
+
+function drillDownByAssignee(assignee, jql) {
+  const issues = filteredIssues.value.filter(i => i.assignee === assignee)
+  openDrillDown(assignee, issues, jql)
+}
+
+function handleEscape(e) {
+  if (e.key === 'Escape' && drillDown.value.visible) closeDrillDown()
+}
+
+onMounted(() => document.addEventListener('keydown', handleEscape))
+onUnmounted(() => document.removeEventListener('keydown', handleEscape))
 
 // ─── Navigation & data ────────────────────────────────────────────────────────
 
@@ -423,7 +518,7 @@ const openCvesChartOptions = computed(() => ({
       const idx = elements[0].index
       const items = agg.openCvesByComponent.value
       const item = items[idx]
-      if (item?.jql) window.open(item.jql, '_blank', 'noopener,noreferrer')
+      if (item) drillDownByComponent(item.component)
     }
   },
   onHover: (event, elements) => {
@@ -436,7 +531,7 @@ const openCvesChartOptions = computed(() => ({
         label: (ctx) => {
           const items = agg.openCvesByComponent.value
           const item = items[ctx.dataIndex]
-          return item ? `${ctx.raw} issues (${item.pct}%) — click to view in Jira` : `${ctx.raw} issues`
+          return item ? `${ctx.raw} issues (${item.pct}%) — click to view list` : `${ctx.raw} issues`
         }
       }
     }
@@ -485,45 +580,44 @@ const vexDoughnutData = computed(() => {
   }
 })
 
-function makePieOptions(itemJqlAccessor) {
-  return computed(() => ({
-    responsive: true,
-    maintainAspectRatio: false,
-    onClick: (_event, elements) => {
-      if (elements.length > 0) {
-        const idx = elements[0].index
-        const items = itemJqlAccessor()
-        const item = items[idx]
-        if (item?.jql) window.open(item.jql, '_blank', 'noopener,noreferrer')
-      }
-    },
-    onHover: (event, elements) => {
-      event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default'
-    },
-    plugins: {
-      legend: {
-        display: true,
-        position: 'right',
-        labels: {
-          padding: 8,
-          font: { size: 10 },
-          color: '#6b7280',
-          usePointStyle: true,
-          pointStyle: 'circle',
-          boxWidth: 8
-        }
-      },
-      tooltip: {
-        callbacks: {
-          label: (ctx) => `${ctx.raw} issues — click to view in Jira`
-        }
-      }
-    }
-  }))
+const PIE_LEGEND = {
+  display: true,
+  position: 'right',
+  labels: { padding: 8, font: { size: 10 }, color: '#6b7280', usePointStyle: true, pointStyle: 'circle', boxWidth: 8 }
 }
 
-const versionPieOptions = makePieOptions(() => agg.openCvesByVersion.value)
-const vexPieOptions = makePieOptions(() => data.value?.falsePositivesByVex?.items || [])
+const versionPieOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  onClick: (_event, elements) => {
+    if (elements.length > 0) {
+      const item = agg.openCvesByVersion.value[elements[0].index]
+      if (item) drillDownByVersion(item.version)
+    }
+  },
+  onHover: (event, elements) => { event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default' },
+  plugins: {
+    legend: PIE_LEGEND,
+    tooltip: { callbacks: { label: (ctx) => `${ctx.raw} issues — click to view list` } }
+  }
+}))
+
+const vexPieOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  onClick: (_event, elements) => {
+    if (elements.length > 0) {
+      const items = data.value?.falsePositivesByVex?.items || []
+      const item = items[elements[0].index]
+      if (item?.jql) window.open(item.jql, '_blank', 'noopener,noreferrer')
+    }
+  },
+  onHover: (event, elements) => { event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default' },
+  plugins: {
+    legend: PIE_LEGEND,
+    tooltip: { callbacks: { label: (ctx) => `${ctx.raw} issues — click to view in Jira` } }
+  }
+}))
 
 // ─── 7. Created vs Resolved Line Chart (unfiltered) ─────────────────────────
 

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -425,7 +425,9 @@ function drillDownByAssignee(assignee, jql) {
 }
 
 function handleEscape(e) {
-  if (e.key === 'Escape' && drillDown.value.visible) closeDrillDown()
+  if (e.key !== 'Escape') return
+  if (filters.filterModalOpen.value) { filters.closeFilterModal(); return }
+  if (drillDown.value.visible) closeDrillDown()
 }
 
 onMounted(() => document.addEventListener('keydown', handleEscape))

--- a/modules/releases/client/reports/components/CveIssueListModal.vue
+++ b/modules/releases/client/reports/components/CveIssueListModal.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script setup>
-defineProps({
+const props = defineProps({
   visible: { type: Boolean, default: false },
   title: { type: String, default: '' },
   issues: { type: Array, default: () => [] },
@@ -109,7 +109,8 @@ defineProps({
 defineEmits(['close'])
 
 function jiraIssueUrl(key) {
-  return `https://issues.redhat.com/browse/${key}`
+  const host = props.jiraHost || 'https://issues.redhat.com'
+  return `${host}/browse/${key}`
 }
 
 function statusBadgeClass(status) {

--- a/modules/releases/client/reports/components/CveIssueListModal.vue
+++ b/modules/releases/client/reports/components/CveIssueListModal.vue
@@ -1,0 +1,129 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40 dark:bg-black/60" @click="$emit('close')"></div>
+      <div class="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-7xl max-h-[80vh] flex flex-col">
+        <!-- Header -->
+        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
+          <div class="flex items-center gap-3 min-w-0">
+            <span v-if="dotColor" class="w-3 h-3 rounded-full shrink-0" :style="{ backgroundColor: dotColor }"></span>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{{ title }}</h3>
+            <span class="text-sm text-gray-500 dark:text-gray-400 shrink-0">({{ issues.length }})</span>
+          </div>
+          <div class="flex items-center gap-2 shrink-0">
+            <a
+              v-if="jql"
+              :href="jql"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              title="View these issues in Jira"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+              </svg>
+              View in Jira
+            </a>
+            <button
+              @click="$emit('close')"
+              class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            >
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Table -->
+        <div class="overflow-auto flex-1">
+          <table class="w-full text-sm">
+            <thead class="sticky top-0 bg-gray-50 dark:bg-gray-800/90">
+              <tr class="border-b border-gray-200 dark:border-gray-700">
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32">Key</th>
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Summary</th>
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider whitespace-nowrap">Component</th>
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider whitespace-nowrap">Target Version</th>
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Assignee</th>
+                <th class="text-left py-2.5 px-4 text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider whitespace-nowrap">Due Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="issue in issues"
+                :key="issue.key"
+                class="border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+              >
+                <td class="py-2 px-4">
+                  <span class="inline-flex items-center gap-1.5">
+                    <a
+                      :href="jiraIssueUrl(issue.key)"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
+                    >{{ issue.key }}</a>
+                    <a
+                      :href="jiraIssueUrl(issue.key)"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 shrink-0"
+                      title="Open in Jira"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                      </svg>
+                    </a>
+                  </span>
+                </td>
+                <td class="py-2 px-4 text-gray-900 dark:text-gray-100">{{ issue.summary || '—' }}</td>
+                <td class="py-2 px-4 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.component || '—' }}</td>
+                <td class="py-2 px-4 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ (issue.versions || []).join(', ') || '—' }}</td>
+                <td class="py-2 px-4">
+                  <span
+                    class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide"
+                    :class="statusBadgeClass(issue.status)"
+                  >{{ issue.status }}</span>
+                </td>
+                <td class="py-2 px-4 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ issue.assignee || '—' }}</td>
+                <td class="py-2 px-4 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ formatDueDate(issue.duedate) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+defineProps({
+  visible: { type: Boolean, default: false },
+  title: { type: String, default: '' },
+  issues: { type: Array, default: () => [] },
+  jql: { type: String, default: '' },
+  dotColor: { type: String, default: '' },
+  jiraHost: { type: String, default: 'https://issues.redhat.com' }
+})
+
+defineEmits(['close'])
+
+function jiraIssueUrl(key) {
+  return `https://issues.redhat.com/browse/${key}`
+}
+
+function statusBadgeClass(status) {
+  const s = (status || '').toUpperCase()
+  if (s === 'NEW') return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300'
+  if (s === 'IN PROGRESS') return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
+  if (s === 'REVIEW') return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300'
+  if (s === 'RESOLVED') return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300'
+  if (s === 'CLOSED') return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+}
+
+function formatDueDate(duedate) {
+  if (!duedate) return '—'
+  return new Date(duedate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+</script>

--- a/modules/releases/client/reports/components/ReportFilterModal.vue
+++ b/modules/releases/client/reports/components/ReportFilterModal.vue
@@ -1,0 +1,279 @@
+<template>
+  <Teleport to="body">
+    <div v-if="filters.filterModalOpen.value" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40 dark:bg-black/60" @click="filters.closeFilterModal()"></div>
+      <div class="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-xl max-h-[80vh] flex flex-col">
+        <!-- Header with tabs -->
+        <div class="shrink-0">
+          <div class="flex items-center justify-between px-6 pt-4 pb-0">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Filters</h3>
+            <button @click="filters.closeFilterModal()" class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <div class="flex gap-6 px-6 mt-3 border-b border-gray-200 dark:border-gray-700">
+            <button
+              @click="filters.setFilterModalTab('fields')"
+              class="pb-2.5 text-sm font-medium transition-colors whitespace-nowrap border-b-2"
+              :class="filters.filterModalTab.value === 'fields'
+                ? 'border-primary-600 text-primary-600 dark:text-primary-400 dark:border-primary-400'
+                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
+            >Filter Fields</button>
+            <button
+              @click="filters.setFilterModalTab('presets')"
+              class="pb-2.5 text-sm font-medium transition-colors whitespace-nowrap border-b-2 inline-flex items-center gap-1.5"
+              :class="filters.filterModalTab.value === 'presets'
+                ? 'border-primary-600 text-primary-600 dark:text-primary-400 dark:border-primary-400'
+                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
+            >
+              Saved Presets
+              <span
+                v-if="filters.savedFilters.value.length > 0"
+                class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
+                :class="filters.filterModalTab.value === 'presets'
+                  ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-600 dark:text-primary-400'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'"
+              >{{ filters.savedFilters.value.length }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Tab: Filter Fields -->
+        <div v-if="filters.filterModalTab.value === 'fields'" class="flex flex-1 min-h-0" style="min-height: 320px">
+          <!-- Field list (left) -->
+          <div class="w-44 shrink-0 border-r border-gray-200 dark:border-gray-700 flex flex-col bg-gray-50/50 dark:bg-gray-900/20">
+            <div class="flex-1 overflow-y-auto">
+              <button
+                v-for="f in filters.filterFields"
+                :key="f.key"
+                @click="filters.selectFilterField(f.key)"
+                class="w-full px-4 py-2.5 text-sm text-left transition-colors"
+                :class="filters.filterModalField.value === f.key
+                  ? 'bg-white dark:bg-gray-800 text-primary-700 dark:text-primary-300 font-medium border-r-2 border-primary-600 dark:border-primary-400'
+                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50'"
+              >
+                <div class="flex items-center justify-between gap-2">
+                  <span class="truncate">{{ f.label }}</span>
+                  <span
+                    v-if="filters.activeFilters[f.key]?.length"
+                    class="text-[10px] font-semibold text-primary-600 dark:text-primary-400 bg-primary-100 dark:bg-primary-900/40 px-1.5 py-0.5 rounded-full shrink-0"
+                  >{{ filters.activeFilters[f.key].length }}</span>
+                </div>
+              </button>
+            </div>
+            <!-- Cross-field mode -->
+            <div v-if="filters.activeFieldCount.value > 1" class="border-t border-gray-200 dark:border-gray-700 px-3 py-2.5">
+              <div class="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1.5">Across fields</div>
+              <button
+                @click="filters.setCrossFieldMode(filters.crossFieldMode.value === 'and' ? 'or' : 'and')"
+                class="w-full px-2 py-1 rounded text-[11px] font-medium text-center transition-colors"
+                :class="filters.crossFieldMode.value === 'and'
+                  ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+                  : 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'"
+              >{{ filters.crossFieldMode.value === 'and' ? 'ALL fields (AND)' : 'ANY field (OR)' }}</button>
+            </div>
+          </div>
+
+          <!-- Value list (right) -->
+          <div class="flex-1 flex flex-col min-w-0">
+            <div v-if="!filters.filterModalField.value" class="flex-1 flex items-center justify-center text-sm text-gray-400 dark:text-gray-500">
+              Select a field to filter by
+            </div>
+            <template v-else>
+              <!-- Search + match mode -->
+              <div class="px-4 pt-3 pb-2 shrink-0 space-y-2">
+                <input
+                  :value="filters.filterModalSearch.value"
+                  @input="filters.setFilterModalSearch($event.target.value)"
+                  type="text"
+                  :placeholder="'Search ' + filters.filterFieldLabel(filters.filterModalField.value).toLowerCase() + 's...'"
+                  class="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+                />
+                <div v-if="filters.activeFilters[filters.filterModalField.value]?.length > 1" class="flex items-center gap-2">
+                  <span class="text-[11px] text-gray-500 dark:text-gray-400">Match:</span>
+                  <button
+                    @click="filters.toggleFilterMode(filters.filterModalField.value)"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium transition-colors"
+                    :class="(filters.filterModes[filters.filterModalField.value] || 'or') === 'and'
+                      ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+                      : 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'"
+                  >
+                    {{ (filters.filterModes[filters.filterModalField.value] || 'or') === 'and' ? 'ALL (AND)' : 'ANY (OR)' }}
+                  </button>
+                </div>
+              </div>
+
+              <!-- Values -->
+              <div class="flex-1 overflow-y-auto px-4 pb-3">
+                <div v-if="modalValues.selected.length === 0 && modalValues.unselected.length === 0" class="text-sm text-gray-400 dark:text-gray-500 text-center py-8">
+                  {{ filters.filterModalSearch.value ? 'No matching values' : 'No values available' }}
+                </div>
+                <template v-else>
+                  <!-- Selected values -->
+                  <div v-if="modalValues.selected.length > 0" class="space-y-0.5">
+                    <label
+                      v-for="val in modalValues.selected"
+                      :key="val"
+                      class="flex items-center gap-2.5 px-3 py-1.5 text-sm rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked
+                        @change="filters.toggleFilterValue(filters.filterModalField.value, val)"
+                        class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+                      />
+                      <span class="text-gray-700 dark:text-gray-300 truncate">{{ val }}</span>
+                    </label>
+                  </div>
+                  <!-- Separator -->
+                  <div v-if="modalValues.selected.length > 0 && modalValues.unselected.length > 0" class="my-2 border-t border-gray-200 dark:border-gray-700"></div>
+                  <!-- Unselected values -->
+                  <div v-if="modalValues.unselected.length > 0" class="space-y-0.5">
+                    <label
+                      v-for="val in modalValues.unselected"
+                      :key="val"
+                      class="flex items-center gap-2.5 px-3 py-1.5 text-sm rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        @change="filters.toggleFilterValue(filters.filterModalField.value, val)"
+                        class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+                      />
+                      <span class="text-gray-700 dark:text-gray-300 truncate">{{ val }}</span>
+                    </label>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <!-- Tab: Saved Presets -->
+        <div v-if="filters.filterModalTab.value === 'presets'" class="flex-1 flex flex-col min-h-0" style="min-height: 320px">
+          <div class="flex-1 overflow-y-auto">
+            <div v-if="filters.savedFilters.value.length === 0" class="px-6 py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+              No saved presets yet.
+            </div>
+            <div v-else class="divide-y divide-gray-200 dark:divide-gray-700">
+              <div
+                v-for="preset in filters.savedFilters.value"
+                :key="preset.id"
+                class="px-6 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+              >
+                <div class="flex items-start justify-between gap-3">
+                  <div class="flex-1 min-w-0">
+                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ preset.name }}</div>
+                    <div v-if="preset.description" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ preset.description }}</div>
+                    <div class="flex flex-wrap gap-1 mt-1.5">
+                      <span
+                        v-for="(values, field) in preset.filters"
+                        :key="field"
+                        class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400"
+                      >{{ filters.filterFieldLabel(field) }}: {{ filters.formatFilterValues(values) }}</span>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-1 shrink-0">
+                    <button @click="filters.applySavedFilter(preset)" class="p-1 text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded transition-colors" title="Apply">
+                      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                      </svg>
+                    </button>
+                    <button @click="filters.editSavedFilter(preset)" class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors" title="Edit">
+                      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+                      </svg>
+                    </button>
+                    <button @click="filters.deleteSavedFilter(preset.id)" class="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors" title="Delete">
+                      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="border-t border-gray-200 dark:border-gray-700 shrink-0">
+          <!-- Save form (expandable) -->
+          <div v-if="filters.showSaveForm.value && filters.hasActiveFilters.value" class="px-6 py-3 bg-gray-50/50 dark:bg-gray-900/30 border-b border-gray-200 dark:border-gray-700">
+            <div class="text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+              {{ filters.editingFilterId.value ? 'Update Preset' : 'Save as Preset' }}
+            </div>
+            <div class="space-y-2">
+              <input
+                :value="filters.savedFilterName.value"
+                @input="filters.setSavedFilterName($event.target.value)"
+                type="text"
+                placeholder="Name (required)"
+                class="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+              />
+              <input
+                :value="filters.savedFilterDescription.value"
+                @input="filters.setSavedFilterDescription($event.target.value)"
+                type="text"
+                placeholder="Description (optional)"
+                class="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+              />
+              <div class="flex items-center gap-2">
+                <button
+                  @click="filters.saveCurrentFilters()"
+                  :disabled="!filters.savedFilterName.value.trim()"
+                  class="px-3 py-1.5 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >{{ filters.editingFilterId.value ? 'Update' : 'Save' }}</button>
+                <button
+                  @click="filters.cancelSaveForm()"
+                  class="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                >Cancel</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Button bar -->
+          <div class="flex items-center justify-between px-6 py-3">
+            <button
+              v-if="filters.hasActiveFilters.value"
+              @click="filters.clearAllFilters()"
+              class="text-sm text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+            >Clear All Filters</button>
+            <span v-else></span>
+            <div class="flex items-center gap-2">
+              <button
+                v-if="filters.hasActiveFilters.value && !filters.showSaveForm.value"
+                @click="filters.setShowSaveForm(true)"
+                class="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              >Save as Preset</button>
+              <button
+                @click="filters.closeFilterModal()"
+                class="px-4 py-2 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+              >Done</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  filters: {
+    type: Object,
+    required: true
+  },
+  availableFilterValues: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const modalValues = computed(() => {
+  return props.filters.getFilterModalValues(props.availableFilterValues)
+})
+</script>

--- a/modules/releases/client/reports/components/ReportFilterNarrative.vue
+++ b/modules/releases/client/reports/components/ReportFilterNarrative.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="flex items-start justify-between gap-4">
+    <div class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+      <!-- No filters active -->
+      <template v-if="!filters.hasActiveFilters.value">
+        {{ noFilterText }}
+        <button @click="filters.openFilterModal()" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">Manage filters</button>
+        or apply a
+        <button @click="filters.openFilterModalToPresets()" class="text-primary-600 dark:text-primary-400 hover:underline font-medium">saved preset</button>.
+      </template>
+
+      <!-- Preset applied -->
+      <template v-else-if="filters.appliedPreset.value">
+        {{ filterPrefix }}
+        <span class="font-semibold text-gray-900 dark:text-gray-100 inline-flex items-baseline gap-1">
+          {{ filters.appliedPreset.value.name }}
+          <span v-if="filters.appliedPreset.value.description" class="relative group inline-flex">
+            <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 cursor-help self-center" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+            </svg>
+            <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2.5 py-1.5 text-xs font-normal text-white bg-gray-900 dark:bg-gray-700 rounded-md shadow-lg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10">{{ filters.appliedPreset.value.description }}</span>
+          </span>
+        </span>.
+      </template>
+
+      <!-- Ad-hoc filters -->
+      <template v-else>
+        {{ filterPrefix }}
+        <template v-for="(part, idx) in filters.filterNarrativeParts.value" :key="part.field">
+          <template v-if="idx > 0 && idx === filters.filterNarrativeParts.value.length - 1"> {{ filters.crossFieldMode.value }} </template>
+          <template v-else-if="idx > 0">, </template>
+          <span class="font-semibold text-gray-900 dark:text-gray-100">{{ part.label }}: {{ part.values }}</span>
+        </template>.
+      </template>
+
+      <!-- Editing indicator -->
+      <span v-if="filters.editingFilterId.value" class="ml-1 text-xs text-amber-600 dark:text-amber-400">
+        (editing preset · <button @click="filters.cancelEditFilter()" class="hover:underline">cancel</button>)
+      </span>
+    </div>
+
+    <!-- Filter action buttons -->
+    <div class="flex items-center gap-2 shrink-0">
+      <button
+        @click="filters.openFilterModal()"
+        class="px-3 py-1.5 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+      >{{ filters.hasActiveFilters.value ? 'Edit' : 'Manage Filters' }}</button>
+      <button
+        v-if="filters.hasActiveFilters.value"
+        @click="filters.clearAllFilters()"
+        class="px-3 py-1.5 text-sm font-medium rounded-md text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+      >Clear</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  filters: {
+    type: Object,
+    required: true
+  },
+  noFilterText: {
+    type: String,
+    default: 'Showing all items.'
+  },
+  filterPrefix: {
+    type: String,
+    default: 'Showing items filtered by'
+  }
+})
+</script>

--- a/modules/releases/client/reports/composables/useCveAggregation.js
+++ b/modules/releases/client/reports/composables/useCveAggregation.js
@@ -1,0 +1,303 @@
+import { computed } from 'vue'
+
+// ─── JQL constants (mirrored from server) ───────────────────────────────────
+
+const BASE_JQL = [
+  'project in (RHAIENG, RHOAIENG)',
+  '(labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is EMPTY)',
+  'component not in (Documentation, PXE, Devops, testops)',
+  'issuetype in (vulnerability)',
+  'status not in (Closed, Resolved)'
+].join(' AND ')
+
+// ─── JQL helpers ─────────────────────────────────────────────────────────────
+
+function jqlUrl(searchBase, jql) {
+  return searchBase + encodeURIComponent(jql)
+}
+
+function quoteComponent(name) {
+  return name === 'None' ? ' AND component is EMPTY' : ` AND component = "${name}"`
+}
+
+function quoteVersion(name) {
+  return name === 'None' ? ' AND "Target Version" is EMPTY' : ` AND "Target Version" = "${name}"`
+}
+
+function quoteAssignee(name) {
+  return name === 'Unassigned' ? ' AND assignee is EMPTY' : ` AND assignee = "${name}"`
+}
+
+function quoteStatus(name) {
+  return ` AND status = "${name}"`
+}
+
+/**
+ * Build a JQL fragment from active filters to append to drill-down URLs.
+ * Each active filter field adds an AND clause.
+ */
+function buildFilterJql(activeFilters) {
+  const parts = []
+  for (const [field, values] of Object.entries(activeFilters)) {
+    if (!values || values.length === 0) continue
+    if (field === 'component') {
+      if (values.length === 1) {
+        parts.push(quoteComponent(values[0]))
+      } else {
+        const clauses = values.map(v => v === 'None' ? 'component is EMPTY' : `component = "${v}"`)
+        parts.push(` AND (${clauses.join(' OR ')})`)
+      }
+    } else if (field === 'versions') {
+      if (values.length === 1) {
+        parts.push(quoteVersion(values[0]))
+      } else {
+        const clauses = values.map(v => v === 'None' ? '"Target Version" is EMPTY' : `"Target Version" = "${v}"`)
+        parts.push(` AND (${clauses.join(' OR ')})`)
+      }
+    } else if (field === 'assignee') {
+      if (values.length === 1) {
+        parts.push(quoteAssignee(values[0]))
+      } else {
+        const clauses = values.map(v => v === 'Unassigned' ? 'assignee is EMPTY' : `assignee = "${v}"`)
+        parts.push(` AND (${clauses.join(' OR ')})`)
+      }
+    } else if (field === 'status') {
+      if (values.length === 1) {
+        parts.push(quoteStatus(values[0]))
+      } else {
+        parts.push(` AND status in (${values.map(v => `"${v}"`).join(', ')})`)
+      }
+    }
+  }
+  return parts.join('')
+}
+
+// ─── Aggregation functions ───────────────────────────────────────────────────
+// These mirror the server-side aggregation but operate on projected issue
+// records (flat fields: component, components, versions, status, assignee, duedate).
+
+function buildComponentCounts(issues, searchBase, filterJql) {
+  const counts = {}
+  for (const issue of issues) {
+    const comp = issue.component
+    counts[comp] = (counts[comp] || 0) + 1
+  }
+  const total = issues.length || 1
+  return Object.entries(counts)
+    .map(([component, count]) => ({
+      component,
+      count,
+      pct: parseFloat(((count / total) * 100).toFixed(2)),
+      jql: jqlUrl(searchBase, BASE_JQL + filterJql + quoteComponent(component))
+    }))
+    .sort((a, b) => b.count - a.count)
+}
+
+function buildDueDateBuckets(issues, searchBase, filterJql) {
+  const now = new Date()
+  const buckets = { passed: 0, lessThan30: 0, between30And90: 0, moreThan90: 0, none: 0 }
+  const total = issues.length || 1
+
+  for (const issue of issues) {
+    if (!issue.duedate) {
+      buckets.none++
+      continue
+    }
+    const due = new Date(issue.duedate)
+    const diffDays = Math.floor((due - now) / (1000 * 60 * 60 * 24))
+    if (diffDays < 0) buckets.passed++
+    else if (diffDays < 30) buckets.lessThan30++
+    else if (diffDays <= 90) buckets.between30And90++
+    else buckets.moreThan90++
+  }
+
+  const today = now.toISOString().slice(0, 10)
+  const in30 = new Date(now.getTime() + 30 * 86400000).toISOString().slice(0, 10)
+  const in90 = new Date(now.getTime() + 90 * 86400000).toISOString().slice(0, 10)
+  const base = BASE_JQL + filterJql
+
+  return {
+    passed: { count: buckets.passed, pct: Math.round((buckets.passed / total) * 100), jql: jqlUrl(searchBase, base + ` AND duedate < "${today}"`) },
+    lessThan30: { count: buckets.lessThan30, pct: Math.round((buckets.lessThan30 / total) * 100), jql: jqlUrl(searchBase, base + ` AND duedate >= "${today}" AND duedate < "${in30}"`) },
+    between30And90: { count: buckets.between30And90, pct: Math.round((buckets.between30And90 / total) * 100), jql: jqlUrl(searchBase, base + ` AND duedate >= "${in30}" AND duedate <= "${in90}"`) },
+    moreThan90: { count: buckets.moreThan90, pct: Math.round((buckets.moreThan90 / total) * 100), jql: jqlUrl(searchBase, base + ` AND duedate > "${in90}"`) },
+    none: { count: buckets.none, pct: Math.round((buckets.none / total) * 100), jql: jqlUrl(searchBase, base + ' AND duedate is EMPTY') },
+    total: issues.length,
+    total_jql: jqlUrl(searchBase, base)
+  }
+}
+
+function buildVersionComponentMatrix(issues, searchBase, filterJql) {
+  const components = new Set()
+  const versions = new Set()
+  const matrix = {}
+
+  for (const issue of issues) {
+    for (const comp of issue.components) {
+      components.add(comp)
+      for (const ver of issue.versions) {
+        versions.add(ver)
+        const key = `${comp}||${ver}`
+        matrix[key] = (matrix[key] || 0) + 1
+      }
+    }
+  }
+
+  const sortedComponents = [...components].sort()
+  const sortedVersions = [...versions].sort()
+  const base = BASE_JQL + filterJql
+
+  const rows = sortedComponents.map(comp => {
+    const cells = {}
+    const cellJqls = {}
+    let rowTotal = 0
+    for (const ver of sortedVersions) {
+      const val = matrix[`${comp}||${ver}`] || 0
+      cells[ver] = val
+      if (val > 0) cellJqls[ver] = jqlUrl(searchBase, base + quoteComponent(comp) + quoteVersion(ver))
+      rowTotal += val
+    }
+    return {
+      component: comp,
+      cells,
+      cellJqls,
+      total: rowTotal,
+      total_jql: rowTotal > 0 ? jqlUrl(searchBase, base + quoteComponent(comp)) : null
+    }
+  })
+
+  const columnTotals = {}
+  const columnJqls = {}
+  let grandTotal = 0
+  for (const ver of sortedVersions) {
+    const sum = rows.reduce((acc, r) => acc + (r.cells[ver] || 0), 0)
+    columnTotals[ver] = sum
+    if (sum > 0) columnJqls[ver] = jqlUrl(searchBase, base + quoteVersion(ver))
+    grandTotal += sum
+  }
+
+  return { versions: sortedVersions, rows, columnTotals, columnJqls, grandTotal, grandTotal_jql: jqlUrl(searchBase, base) }
+}
+
+function buildVersionCounts(issues, searchBase, filterJql) {
+  const counts = {}
+  for (const issue of issues) {
+    for (const ver of issue.versions) {
+      counts[ver] = (counts[ver] || 0) + 1
+    }
+  }
+  const total = Object.values(counts).reduce((a, b) => a + b, 0) || 1
+  const base = BASE_JQL + filterJql
+  return Object.entries(counts)
+    .map(([version, count]) => ({
+      version,
+      count,
+      pct: parseFloat(((count / total) * 100).toFixed(2)),
+      jql: jqlUrl(searchBase, base + quoteVersion(version))
+    }))
+    .sort((a, b) => b.count - a.count)
+}
+
+function buildAssigneeStatusMatrix(issues, searchBase, filterJql) {
+  const assignees = new Set()
+  const statuses = new Set()
+  const matrix = {}
+
+  for (const issue of issues) {
+    assignees.add(issue.assignee)
+    statuses.add(issue.status)
+    const key = `${issue.status}||${issue.assignee}`
+    matrix[key] = (matrix[key] || 0) + 1
+  }
+
+  const statusOrder = ['NEW', 'IN PROGRESS', 'REVIEW', 'RESOLVED', 'CLOSED']
+  const sortedStatuses = [...statuses].sort((a, b) => {
+    const ai = statusOrder.indexOf(a.toUpperCase())
+    const bi = statusOrder.indexOf(b.toUpperCase())
+    if (ai === -1 && bi === -1) return a.localeCompare(b)
+    if (ai === -1) return 1
+    if (bi === -1) return -1
+    return ai - bi
+  })
+  const sortedAssignees = [...assignees].sort()
+  const base = BASE_JQL + filterJql
+
+  const rows = sortedStatuses.map(status => {
+    const cells = {}
+    const cellJqls = {}
+    let rowTotal = 0
+    for (const assignee of sortedAssignees) {
+      const val = matrix[`${status}||${assignee}`] || 0
+      cells[assignee] = val
+      if (val > 0) cellJqls[assignee] = jqlUrl(searchBase, base + quoteStatus(status) + quoteAssignee(assignee))
+      rowTotal += val
+    }
+    return {
+      status,
+      cells,
+      cellJqls,
+      total: rowTotal,
+      total_jql: rowTotal > 0 ? jqlUrl(searchBase, base + quoteStatus(status)) : null
+    }
+  })
+
+  const columnTotals = {}
+  const columnJqls = {}
+  let grandTotal = 0
+  for (const assignee of sortedAssignees) {
+    const sum = rows.reduce((acc, r) => acc + (r.cells[assignee] || 0), 0)
+    columnTotals[assignee] = sum
+    if (sum > 0) columnJqls[assignee] = jqlUrl(searchBase, base + quoteAssignee(assignee))
+    grandTotal += sum
+  }
+
+  return { assignees: sortedAssignees, rows, columnTotals, columnJqls, grandTotal, grandTotal_jql: jqlUrl(searchBase, base) }
+}
+
+// ─── Composable ──────────────────────────────────────────────────────────────
+
+/**
+ * Reactive CVE aggregation from filtered issue records.
+ *
+ * @param {import('vue').Ref<Array>} filteredIssues - Filtered projected issue records
+ * @param {import('vue').Ref<string>} jiraSearchBase - Jira search URL prefix
+ * @param {import('vue').Ref<Object>} activeFilterDisplay - Current active filters (for JQL)
+ */
+export function useCveAggregation(filteredIssues, jiraSearchBase, activeFilterDisplay) {
+  const filterJql = computed(() => buildFilterJql(activeFilterDisplay.value))
+
+  const totalOpen = computed(() => filteredIssues.value.length)
+  const totalOpen_jql = computed(() =>
+    jqlUrl(jiraSearchBase.value, BASE_JQL + filterJql.value)
+  )
+
+  const openCvesByComponent = computed(() =>
+    buildComponentCounts(filteredIssues.value, jiraSearchBase.value, filterJql.value)
+  )
+
+  const cvesByDueDate = computed(() =>
+    buildDueDateBuckets(filteredIssues.value, jiraSearchBase.value, filterJql.value)
+  )
+
+  const cvesAcrossVersions = computed(() =>
+    buildVersionComponentMatrix(filteredIssues.value, jiraSearchBase.value, filterJql.value)
+  )
+
+  const openCvesByVersion = computed(() =>
+    buildVersionCounts(filteredIssues.value, jiraSearchBase.value, filterJql.value)
+  )
+
+  const cvesByAssigneeStatus = computed(() =>
+    buildAssigneeStatusMatrix(filteredIssues.value, jiraSearchBase.value, filterJql.value)
+  )
+
+  return {
+    totalOpen,
+    totalOpen_jql,
+    openCvesByComponent,
+    cvesByDueDate,
+    cvesAcrossVersions,
+    openCvesByVersion,
+    cvesByAssigneeStatus
+  }
+}

--- a/modules/releases/client/reports/composables/useReportFilters.js
+++ b/modules/releases/client/reports/composables/useReportFilters.js
@@ -1,0 +1,383 @@
+import { ref, reactive, computed } from 'vue'
+
+/**
+ * Reusable report filter composable.
+ *
+ * Provides multi-field filtering with AND/OR modes, localStorage persistence,
+ * and named preset management. Extracted from CapacityCommitmentReport.
+ *
+ * @param {Object} options
+ * @param {string} options.storageKeyPrefix - Prefix for localStorage keys (e.g. 'capacity-report')
+ * @param {Array<{key: string, label: string}>} options.filterFields - Available filter field definitions
+ */
+export function useReportFilters({ storageKeyPrefix, filterFields }) {
+  const FILTERS_STORAGE_KEY = `tt_cache:${storageKeyPrefix}-active-filters`
+  const SAVED_FILTERS_STORAGE_KEY = `tt_cache:${storageKeyPrefix}-saved-filters`
+
+  // ── Filter state ──
+  const activeFilters = reactive({})
+  const filterModes = reactive({}) // per-field: 'or' (default) or 'and'
+  const crossFieldMode = ref('and') // across fields: 'and' (default) or 'or'
+  const filterModalOpen = ref(false)
+  const filterModalField = ref(null)
+  const filterModalSearch = ref('')
+  const filterModalTab = ref('fields')
+  const showSaveForm = ref(false)
+  const savedFilters = ref([])
+  const savedFilterName = ref('')
+  const savedFilterDescription = ref('')
+  const editingFilterId = ref(null)
+  const appliedPresetId = ref(null)
+
+  // ── Computeds ──
+
+  const hasActiveFilters = computed(() => {
+    return Object.values(activeFilters).some(v => v && v.length > 0)
+  })
+
+  const activeFieldCount = computed(() => {
+    return Object.values(activeFilters).filter(v => v && v.length > 0).length
+  })
+
+  const activeFilterDisplay = computed(() => {
+    const result = {}
+    for (const [field, values] of Object.entries(activeFilters)) {
+      if (values && values.length > 0) result[field] = values
+    }
+    return result
+  })
+
+  const appliedPreset = computed(() => {
+    if (!appliedPresetId.value) return null
+    return savedFilters.value.find(f => f.id === appliedPresetId.value) || null
+  })
+
+  const filterNarrativeParts = computed(() => {
+    return Object.entries(activeFilterDisplay.value).map(([field, values]) => ({
+      field,
+      label: filterFieldLabel(field),
+      values: formatFilterValues(values)
+    }))
+  })
+
+  /**
+   * Compute modal values for the currently selected field, given available values.
+   * @param {Object} availableValues - { [fieldKey]: string[] }
+   */
+  function getFilterModalValues(availableValues) {
+    if (!filterModalField.value) return { selected: [], unselected: [] }
+    const all = (availableValues || {})[filterModalField.value] || []
+    const q = filterModalSearch.value.toLowerCase().trim()
+    const filtered = q ? all.filter(v => v.toLowerCase().includes(q)) : all
+    const active = activeFilters[filterModalField.value] || []
+    const activeSet = new Set(active)
+    const selected = filtered.filter(v => activeSet.has(v))
+    const unselected = filtered.filter(v => !activeSet.has(v))
+    return { selected, unselected }
+  }
+
+  // ── Helpers ──
+
+  function filterFieldLabel(key) {
+    const field = filterFields.find(f => f.key === key)
+    return field ? field.label : key
+  }
+
+  function formatFilterValues(values) {
+    if (values.length <= 2) return values.join(', ')
+    return values.slice(0, 2).join(', ') + ' +' + (values.length - 2)
+  }
+
+  // ── Filter matching ──
+
+  function matchesFieldFilter(item, field, values) {
+    const valSet = new Set(values)
+    const mode = filterModes[field] || 'or'
+    const val = item[field]
+    if (mode === 'and') {
+      if (Array.isArray(val)) return [...valSet].every(v => val.includes(v))
+      return valSet.size === 1 && valSet.has(val || '')
+    }
+    if (Array.isArray(val)) return val.some(v => valSet.has(v))
+    return valSet.has(val || '')
+  }
+
+  function filterItems(items) {
+    const activeEntries = Object.entries(activeFilters).filter(([, v]) => v && v.length > 0)
+    if (activeEntries.length === 0) return items
+
+    if (crossFieldMode.value === 'or') {
+      return items.filter(item =>
+        activeEntries.some(([field, values]) => matchesFieldFilter(item, field, values))
+      )
+    }
+    return items.filter(item =>
+      activeEntries.every(([field, values]) => matchesFieldFilter(item, field, values))
+    )
+  }
+
+  // ── Filter actions ──
+
+  function toggleFilterValue(field, value) {
+    if (!activeFilters[field]) activeFilters[field] = []
+    const idx = activeFilters[field].indexOf(value)
+    if (idx >= 0) {
+      activeFilters[field].splice(idx, 1)
+      if (activeFilters[field].length === 0) delete activeFilters[field]
+    } else {
+      activeFilters[field].push(value)
+    }
+    appliedPresetId.value = null
+    persistActiveFilters()
+  }
+
+  function toggleFilterMode(field) {
+    filterModes[field] = (filterModes[field] || 'or') === 'or' ? 'and' : 'or'
+    persistActiveFilters()
+  }
+
+  function clearAllFilters() {
+    for (const key of Object.keys(activeFilters)) delete activeFilters[key]
+    for (const key of Object.keys(filterModes)) delete filterModes[key]
+    crossFieldMode.value = 'and'
+    appliedPresetId.value = null
+    editingFilterId.value = null
+    persistActiveFilters()
+  }
+
+  // ── Modal control ──
+
+  function openFilterModal() {
+    filterModalField.value = filterFields[0]?.key || null
+    filterModalSearch.value = ''
+    filterModalTab.value = 'fields'
+    filterModalOpen.value = true
+  }
+
+  function openFilterModalToPresets() {
+    filterModalTab.value = 'presets'
+    filterModalOpen.value = true
+  }
+
+  function closeFilterModal() {
+    filterModalOpen.value = false
+    filterModalSearch.value = ''
+    showSaveForm.value = false
+  }
+
+  function selectFilterField(key) {
+    filterModalField.value = key
+    filterModalSearch.value = ''
+  }
+
+  // ── Persistence ──
+
+  function persistActiveFilters() {
+    const data = {}
+    for (const [k, v] of Object.entries(activeFilters)) {
+      if (v && v.length > 0) data[k] = v
+    }
+    const modes = {}
+    for (const [k, v] of Object.entries(filterModes)) {
+      if (v === 'and') modes[k] = v
+    }
+    const cross = crossFieldMode.value !== 'and' ? crossFieldMode.value : undefined
+    if (Object.keys(data).length > 0 || Object.keys(modes).length > 0) {
+      localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify({ filters: data, modes, crossFieldMode: cross }))
+    } else {
+      localStorage.removeItem(FILTERS_STORAGE_KEY)
+    }
+  }
+
+  function loadActiveFilters() {
+    try {
+      const stored = localStorage.getItem(FILTERS_STORAGE_KEY)
+      if (!stored) return
+      const parsed = JSON.parse(stored)
+      // Support both old format (flat object) and new format ({ filters, modes })
+      const filters = parsed.filters || (Array.isArray(parsed) ? {} : (!parsed.modes ? parsed : {}))
+      const modes = parsed.modes || {}
+      for (const [k, v] of Object.entries(filters)) {
+        if (Array.isArray(v) && v.length > 0) activeFilters[k] = v
+      }
+      for (const [k, v] of Object.entries(modes)) {
+        if (v === 'and') filterModes[k] = v
+      }
+      if (parsed.crossFieldMode) crossFieldMode.value = parsed.crossFieldMode
+    } catch { /* ignore */ }
+  }
+
+  function persistSavedFilters() {
+    localStorage.setItem(SAVED_FILTERS_STORAGE_KEY, JSON.stringify(savedFilters.value))
+  }
+
+  function loadSavedFilters() {
+    try {
+      const stored = localStorage.getItem(SAVED_FILTERS_STORAGE_KEY)
+      if (stored) savedFilters.value = JSON.parse(stored)
+    } catch { /* ignore */ }
+  }
+
+  // ── Preset management ──
+
+  function restorePresetState(preset) {
+    for (const key of Object.keys(activeFilters)) delete activeFilters[key]
+    for (const key of Object.keys(filterModes)) delete filterModes[key]
+    for (const [k, v] of Object.entries(preset.filters)) {
+      if (Array.isArray(v) && v.length > 0) activeFilters[k] = [...v]
+    }
+    if (preset.modes) {
+      for (const [k, v] of Object.entries(preset.modes)) filterModes[k] = v
+    }
+    crossFieldMode.value = preset.crossFieldMode || 'and'
+  }
+
+  function saveCurrentFilters() {
+    const name = savedFilterName.value.trim()
+    if (!name) return
+
+    const filterData = {}
+    for (const [k, v] of Object.entries(activeFilters)) {
+      if (v && v.length > 0) filterData[k] = [...v]
+    }
+    const modesData = {}
+    for (const [k, v] of Object.entries(filterModes)) {
+      if (v === 'and') modesData[k] = v
+    }
+
+    if (editingFilterId.value) {
+      const idx = savedFilters.value.findIndex(f => f.id === editingFilterId.value)
+      if (idx >= 0) {
+        savedFilters.value[idx] = {
+          ...savedFilters.value[idx],
+          name,
+          description: savedFilterDescription.value.trim(),
+          filters: filterData,
+          modes: modesData,
+          crossFieldMode: crossFieldMode.value
+        }
+      }
+      editingFilterId.value = null
+    } else {
+      savedFilters.value.push({
+        id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
+        name,
+        description: savedFilterDescription.value.trim(),
+        filters: filterData,
+        modes: modesData,
+        crossFieldMode: crossFieldMode.value
+      })
+    }
+
+    persistSavedFilters()
+    savedFilterName.value = ''
+    savedFilterDescription.value = ''
+    showSaveForm.value = false
+  }
+
+  function applySavedFilter(preset) {
+    restorePresetState(preset)
+    appliedPresetId.value = preset.id
+    persistActiveFilters()
+    editingFilterId.value = null
+    closeFilterModal()
+  }
+
+  function editSavedFilter(preset) {
+    restorePresetState(preset)
+    persistActiveFilters()
+    editingFilterId.value = preset.id
+    savedFilterName.value = preset.name
+    savedFilterDescription.value = preset.description || ''
+    showSaveForm.value = true
+    filterModalTab.value = 'fields'
+  }
+
+  function cancelSaveForm() {
+    showSaveForm.value = false
+    editingFilterId.value = null
+    savedFilterName.value = ''
+    savedFilterDescription.value = ''
+  }
+
+  function cancelEditFilter() {
+    editingFilterId.value = null
+    savedFilterName.value = ''
+    savedFilterDescription.value = ''
+  }
+
+  function deleteSavedFilter(id) {
+    savedFilters.value = savedFilters.value.filter(f => f.id !== id)
+    persistSavedFilters()
+    if (editingFilterId.value === id) cancelEditFilter()
+  }
+
+  // ── Initialize ──
+  loadActiveFilters()
+  loadSavedFilters()
+
+  return {
+    // State
+    activeFilters,
+    filterModes,
+    crossFieldMode,
+    filterModalOpen,
+    filterModalField,
+    filterModalSearch,
+    filterModalTab,
+    showSaveForm,
+    savedFilters,
+    savedFilterName,
+    savedFilterDescription,
+    editingFilterId,
+    appliedPresetId,
+
+    // Computeds
+    hasActiveFilters,
+    activeFieldCount,
+    activeFilterDisplay,
+    appliedPreset,
+    filterNarrativeParts,
+
+    // Functions
+    filterFields,
+    filterFieldLabel,
+    formatFilterValues,
+    getFilterModalValues,
+    matchesFieldFilter,
+    filterItems,
+    toggleFilterValue,
+    toggleFilterMode,
+    clearAllFilters,
+    openFilterModal,
+    openFilterModalToPresets,
+    closeFilterModal,
+    selectFilterField,
+    persistActiveFilters,
+    setCrossFieldMode(mode) {
+      crossFieldMode.value = mode
+      persistActiveFilters()
+    },
+    setFilterModalTab(tab) {
+      filterModalTab.value = tab
+    },
+    setFilterModalSearch(query) {
+      filterModalSearch.value = query
+    },
+    setSavedFilterName(name) {
+      savedFilterName.value = name
+    },
+    setSavedFilterDescription(desc) {
+      savedFilterDescription.value = desc
+    },
+    setShowSaveForm(show) {
+      showSaveForm.value = show
+    },
+    saveCurrentFilters,
+    applySavedFilter,
+    editSavedFilter,
+    cancelSaveForm,
+    cancelEditFilter,
+    deleteSavedFilter
+  }
+}

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -47,7 +47,7 @@ export const reports = [
   },
   {
     id: 'capacity-commitment',
-    label: 'Release Capacity & Commitment',
+    label: 'Program Level Release Report',
     description: 'Key deadlines, team capacity, and commitment overview for a selected release.',
     component: defineAsyncComponent(() => import('./CapacityCommitmentReport.vue'))
   },

--- a/modules/releases/client/views/FeatureDetailView.vue
+++ b/modules/releases/client/views/FeatureDetailView.vue
@@ -394,7 +394,7 @@ onMounted(() => {
       class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white flex items-center gap-1"
       @click="goBack"
     >
-      &larr; {{ fromForYou ? 'Back to State of the Union' : fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : fromPlanFeatures ? 'Back to Features List' : fromPlan ? 'Back to Plan' : fromHygieneReport ? 'Back to Hygiene Report' : fromCapacityReport ? 'Back to Capacity & Commitment' : fromFeatureStatus ? 'Back to Feature Status' : 'Back to Execute' }}
+      &larr; {{ fromForYou ? 'Back to State of the Union' : fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : fromPlanFeatures ? 'Back to Features List' : fromPlan ? 'Back to Plan' : fromHygieneReport ? 'Back to Hygiene Report' : fromCapacityReport ? 'Back to Program Level Release Report' : fromFeatureStatus ? 'Back to Feature Status' : 'Back to Execute' }}
     </button>
 
     <!-- Loading -->

--- a/modules/releases/client/views/ReportsView.vue
+++ b/modules/releases/client/views/ReportsView.vue
@@ -42,7 +42,7 @@ function clearReport() {
   }
 }
 
-// Restore report from URL params (e.g. returning from feature detail)
+// Sync report selection with URL params
 watch(() => nav.params.value, (params) => {
   const reportId = params?.report
   if (reportId && !selectedReport.value) {
@@ -54,6 +54,12 @@ watch(() => nav.params.value, (params) => {
       selectedReport.value = report
       nextTick(() => { updatingFromUrl = false })
     }
+  } else if (!reportId && selectedReport.value) {
+    updatingFromUrl = true
+    selectedReport.value = null
+    initialProduct.value = null
+    initialVersion.value = null
+    nextTick(() => { updatingFromUrl = false })
   }
 }, { immediate: true })
 </script>

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -128,7 +128,22 @@ function aggregateMetrics(openIssues, allIssues) {
     falsePositivesByVex: buildVexJustification(allIssues),
     createdVsResolved: buildCreatedVsResolved(allIssues, now),
     unresolved: buildUnresolvedTimeSeries(allIssues, now),
-    falsePositivesTrend: buildFalsePositivesTrend(allIssues, now)
+    falsePositivesTrend: buildFalsePositivesTrend(allIssues, now),
+    // Lightweight issue projections for client-side filtering
+    openIssueRecords: openIssues.map(projectIssue),
+    jiraSearchBase: JIRA_SEARCH
+  };
+}
+
+function projectIssue(issue) {
+  return {
+    key: issue.key,
+    component: getComponentName(issue),
+    components: getAllComponentNames(issue),
+    versions: getTargetVersions(issue),
+    status: getStatus(issue),
+    assignee: getAssignee(issue),
+    duedate: issue.fields?.duedate || null
   };
 }
 

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -27,7 +27,7 @@ const ALL_STATUSES_JQL = [
 ].join(' AND ');
 
 const TARGET_VERSION_FIELD = 'customfield_10855';
-const JIRA_FIELDS = `status,components,fixVersions,${TARGET_VERSION_FIELD},duedate,assignee,resolution,created,resolutiondate,labels,customfield_10873`;
+const JIRA_FIELDS = `summary,status,components,fixVersions,${TARGET_VERSION_FIELD},duedate,assignee,resolution,created,resolutiondate,labels,customfield_10873`;
 
 const VEX_FIELD = 'customfield_10873';
 
@@ -138,6 +138,7 @@ function aggregateMetrics(openIssues, allIssues) {
 function projectIssue(issue) {
   return {
     key: issue.key,
+    summary: issue.fields?.summary || '',
     component: getComponentName(issue),
     components: getAllComponentNames(issue),
     versions: getTargetVersions(issue),

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1029,3 +1029,232 @@ test.describe('Releases Big Rocks hybrid candidates @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 });
+
+/**
+ * CVE Sustaining Report
+ *
+ * Verify the CVE sustaining report renders from fixture data, displays
+ * charts/tables, supports client-side filtering, and opens drill-down
+ * modals on click.
+ */
+test.describe('Releases CVE Sustaining Report @releases', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('CVE sustaining report card is visible in Reports hub', async ({ page }) => {
+    await page.goto('/#/releases/reports');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    var card = page.locator('text=RHOAI Sustaining (CVEs)');
+    await expect(card.first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('CVE sustaining report loads with charts and tables', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Report heading
+    await expect(page.locator('text=RHOAI Sustaining (CVEs)').first()).toBeVisible();
+
+    // Open CVEs banner
+    await expect(page.locator('text=Open CVEs').first()).toBeVisible();
+
+    // Due date section
+    await expect(page.locator('text=CVEs by Due Date').first()).toBeVisible();
+    await expect(page.locator('text=Due Date Passed').first()).toBeVisible();
+
+    // Bar chart section
+    await expect(page.locator('text=RHOAI Open CVEs').first()).toBeVisible();
+
+    // Version matrix table
+    await expect(page.locator('text=CVEs across all versions').first()).toBeVisible();
+
+    // Assignee table
+    await expect(page.locator('text=CVEs by Assignee').first()).toBeVisible();
+
+    // Time series charts
+    await expect(page.locator('text=Created vs Resolved').first()).toBeVisible();
+    await expect(page.locator('text=Unresolved').first()).toBeVisible();
+    await expect(page.locator('text=RHOAI False Positives').first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('CVE sustaining API returns cached fixture data', async ({ request }) => {
+    var res = await request.get('/api/modules/releases/cve-sustaining');
+    expect(res.ok()).toBe(true);
+    var body = await res.json();
+
+    expect(body).toHaveProperty('lastRefreshed');
+    expect(body).toHaveProperty('totalOpen');
+    expect(body).toHaveProperty('totalAll');
+    expect(body).toHaveProperty('openCvesByComponent');
+    expect(body).toHaveProperty('cvesByDueDate');
+    expect(body).toHaveProperty('cvesAcrossVersions');
+    expect(body).toHaveProperty('openCvesByVersion');
+    expect(body).toHaveProperty('cvesByAssigneeStatus');
+    expect(body).toHaveProperty('falsePositivesByVex');
+    expect(body).toHaveProperty('createdVsResolved');
+    expect(body).toHaveProperty('unresolved');
+    expect(body).toHaveProperty('falsePositivesTrend');
+    expect(body).toHaveProperty('openIssueRecords');
+    expect(body).toHaveProperty('jiraSearchBase');
+
+    expect(Array.isArray(body.openIssueRecords)).toBe(true);
+    expect(body.openIssueRecords.length).toBeGreaterThan(0);
+
+    var record = body.openIssueRecords[0];
+    expect(record).toHaveProperty('key');
+    expect(record).toHaveProperty('summary');
+    expect(record).toHaveProperty('component');
+    expect(record).toHaveProperty('components');
+    expect(record).toHaveProperty('versions');
+    expect(record).toHaveProperty('status');
+    expect(record).toHaveProperty('assignee');
+  });
+
+  test('filter bar is visible and shows default state', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Default no-filter text
+    await expect(page.locator('text=Showing all open CVEs').first()).toBeVisible();
+
+    // Edit Filters button should be present
+    var editBtn = page.locator('button', { hasText: 'Manage Filters' }).first();
+    await expect(editBtn).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('filter modal opens and shows filter fields', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Open filter modal
+    var editBtn = page.locator('button', { hasText: 'Manage Filters' }).first();
+    await editBtn.click();
+    await page.waitForTimeout(500);
+
+    // Modal should be visible with filter fields
+    await expect(page.locator('text=Filters').first()).toBeVisible();
+    await expect(page.locator('text=Component').first()).toBeVisible();
+    await expect(page.locator('text=Target Version').first()).toBeVisible();
+    await expect(page.locator('text=Assignee').first()).toBeVisible();
+    await expect(page.locator('text=Status').first()).toBeVisible();
+
+    // Close modal
+    var doneBtn = page.locator('button', { hasText: 'Done' });
+    await doneBtn.click();
+    await page.waitForTimeout(500);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('applying a filter updates the report', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Open filter modal
+    await page.locator('button', { hasText: 'Manage Filters' }).first().click();
+    await page.waitForTimeout(500);
+
+    // Click Component field
+    await page.locator('button', { hasText: 'Component' }).first().click();
+    await page.waitForTimeout(300);
+
+    // Select "Model Serving" checkbox
+    var checkbox = page.locator('label').filter({ hasText: 'Model Serving' }).locator('input[type="checkbox"]');
+    await checkbox.click();
+    await page.waitForTimeout(300);
+
+    // Close modal
+    await page.locator('button', { hasText: 'Done' }).click();
+    await page.waitForTimeout(500);
+
+    // Filter narrative should update
+    await expect(page.locator('text=Showing all open CVEs').first()).not.toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('due date card click opens drill-down modal', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Click on a due date card
+    var dueDateCard = page.locator('button', { hasText: 'Due Date Passed' });
+    await expect(dueDateCard).toBeVisible();
+    await dueDateCard.click();
+    await page.waitForTimeout(500);
+
+    // Drill-down modal should appear with issue table
+    await expect(page.locator('text=Due Date Passed').nth(1)).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Key' }).first()).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Summary' }).first()).toBeVisible();
+
+    // "View in Jira" button should be present
+    await expect(page.locator('a', { hasText: 'View in Jira' }).first()).toBeVisible();
+
+    // Issue keys should be clickable links
+    var issueLink = page.locator('a[href*="/browse/"]').first();
+    await expect(issueLink).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('version matrix cell click opens drill-down modal', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Find a clickable cell in the version matrix table
+    var matrixSection = page.locator('section').filter({ hasText: 'CVEs across all versions' });
+    var cellButton = matrixSection.locator('button').first();
+    await expect(cellButton).toBeVisible();
+    await cellButton.click();
+    await page.waitForTimeout(500);
+
+    // Drill-down modal should appear
+    await expect(page.locator('th', { hasText: 'Key' }).first()).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Summary' }).first()).toBeVisible();
+
+    // Close via Escape
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('assignee table cell click opens drill-down modal', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=cve-sustaining');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Find a clickable cell in the assignee status table
+    var assigneeSection = page.locator('section').filter({ hasText: 'CVEs by Assignee' });
+    var cellButton = assigneeSection.locator('button').first();
+    await expect(cellButton).toBeVisible();
+    await cellButton.click();
+    await page.waitForTimeout(500);
+
+    // Drill-down modal should appear with issue links
+    await expect(page.locator('a[href*="/browse/"]').first()).toBeVisible();
+    await expect(page.locator('a', { hasText: 'View in Jira' }).first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Client-side filtering for CVE sustaining report**: Filter open CVEs by component, target version, assignee, and status with AND/OR modes, saved presets, and localStorage persistence. Extracted reusable `useReportFilters` composable and `ReportFilterModal`/`ReportFilterNarrative` components from the capacity report (~550 lines removed from `CapacityCommitmentReport.vue`).
- **Drill-down issue list modal**: Click any chart bar, pie slice, due date card, or table cell to open a modal showing matching CVE issues with key, summary, component, target version, status, assignee, and due date. Each issue links to Jira, and a "View in Jira" button preserves the JQL filter.
- **Report rename**: "Release Capacity & Commitment" → "Program Level Release Report"
- **Sidebar nav fix**: Clicking "Reports" in the left nav while viewing a report now navigates back to the reports hub.

## Test plan

- [ ] Open the CVE sustaining report and verify filter bar appears
- [ ] Filter by component, target version, assignee, and status — verify charts/tables update
- [ ] Save a filter preset, reload the page, verify it persists
- [ ] Click a bar in the Open CVEs chart — verify drill-down modal opens with matching issues
- [ ] Click a due date card — verify drill-down modal opens with correct issues
- [ ] Click cells/totals in the version matrix and assignee tables — verify drill-down
- [ ] Click a version pie slice — verify drill-down modal
- [ ] In the drill-down modal, click an issue key — verify it opens in Jira
- [ ] In the drill-down modal, click "View in Jira" — verify JQL filter opens
- [ ] Verify VEX doughnut and time-series charts still link directly to Jira (no drill-down)
- [ ] Verify the capacity report still works with the extracted filter components
- [ ] Verify "Program Level Release Report" label appears in reports hub and back navigation
- [ ] Click "Reports" in sidebar while viewing a report — verify it returns to reports hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)