### PR TITLE
fix: Feature Pressure counts align with JQL verification links

### DIFF
--- a/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
+++ b/modules/releases/__tests__/server/feature-pressure/pipeline.test.js
@@ -8,6 +8,10 @@ const {
   nextMonth,
   generateMonthRange,
   lookbackDate,
+  lookbackCutoff,
+  onOrAfter,
+  jiraOffset,
+  offsetMin,
   classifyByMonth,
   computeComponentPressure,
   computeRfePipeline,
@@ -145,6 +149,133 @@ describe('lookbackDate', function () {
   it('returns a date string in YYYY-MM-DD format', function () {
     var result = lookbackDate(12)
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Timezone-aware window helpers (fix for JQL count mismatch)
+// ---------------------------------------------------------------------------
+
+/** Format a ms instant as an ISO string carrying a numeric "+HHMM"/"-HHMM" offset */
+function toOffsetIso(ms, offset) {
+  var offMin = offsetMin(offset)
+  var d = new Date(ms + offMin * 60000)
+  var p = function (n) { return (n < 10 ? '0' : '') + n }
+  return d.getUTCFullYear() + '-' + p(d.getUTCMonth() + 1) + '-' + p(d.getUTCDate()) +
+    'T' + p(d.getUTCHours()) + ':' + p(d.getUTCMinutes()) + ':00.000' +
+    offset.slice(0, 3) + ':' + offset.slice(3)
+}
+
+describe('offsetMin', function () {
+  it('parses positive offsets to minutes east of UTC', function () {
+    expect(offsetMin('+0530')).toBe(330)
+    expect(offsetMin('+0000')).toBe(0)
+  })
+
+  it('parses negative offsets', function () {
+    expect(offsetMin('-0400')).toBe(-240)
+  })
+})
+
+describe('jiraOffset', function () {
+  it('extracts the numeric offset carried by Jira timestamps', function () {
+    var issues = [{ created: '2026-03-15T10:00:00.000-0400', resolved: null }]
+    expect(jiraOffset(issues)).toBe('-0400')
+  })
+
+  it('prefers resolved when created is null', function () {
+    var issues = [{ created: null, resolved: '2026-03-15T10:00:00.000+0530' }]
+    expect(jiraOffset(issues)).toBe('+0530')
+  })
+
+  it('falls back to a valid offset string when only "...Z" data is present', function () {
+    var issues = [{ created: '2026-03-15T10:00:00.000Z', resolved: null }]
+    expect(jiraOffset(issues)).toMatch(/^[+-]\d{4}$/)
+  })
+
+  it('falls back to a valid offset string for empty input', function () {
+    expect(jiraOffset([])).toMatch(/^[+-]\d{4}$/)
+  })
+})
+
+describe('lookbackCutoff', function () {
+  it('returns a YYYY-MM-DD dateStr and a numeric ms instant', function () {
+    var c = lookbackCutoff(12, '+0000')
+    expect(c.dateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(typeof c.ms).toBe('number')
+  })
+
+  it('ms equals midnight of dateStr in the given offset', function () {
+    var utc = lookbackCutoff(12, '+0000')
+    // Midnight UTC of the same calendar date
+    expect(utc.ms).toBe(Date.parse(utc.dateStr + 'T00:00:00.000Z'))
+  })
+
+  it('shifts the instant by the offset (west of UTC is later in absolute time)', function () {
+    var utc = lookbackCutoff(12, '+0000')
+    var west = lookbackCutoff(12, '-0400')
+    // Same calendar date, but -0400 midnight happens 4h after UTC midnight
+    expect(west.dateStr).toBe(utc.dateStr)
+    expect(west.ms - utc.ms).toBe(4 * 60 * 60 * 1000)
+  })
+
+  it('derives dateStr from today in the account timezone, not server-local', function () {
+    // +1400 is far enough east that its calendar day can differ from a UTC/most-server
+    // day. dateStr must reflect the account-TZ day so it matches Jira's JQL evaluation.
+    var offset = '+1400'
+    var acct = new Date(Date.now() + offsetMin(offset) * 60000)
+    var pad = function (n) { return (n < 10 ? '0' : '') + n }
+    var expected = acct.getUTCFullYear() + '-' + pad(acct.getUTCMonth() + 1) + '-' + pad(acct.getUTCDate())
+    expect(lookbackCutoff(0, offset).dateStr).toBe(expected)
+  })
+})
+
+describe('onOrAfter', function () {
+  it('is inclusive of the cutoff instant', function () {
+    var cutoffMs = Date.parse('2026-01-01T00:00:00.000Z')
+    expect(onOrAfter('2026-01-01T00:00:00.000Z', cutoffMs)).toBe(true)
+  })
+
+  it('excludes instants one millisecond before the cutoff', function () {
+    var cutoffMs = Date.parse('2026-01-01T00:00:00.000Z')
+    expect(onOrAfter(new Date(cutoffMs - 1).toISOString(), cutoffMs)).toBe(false)
+  })
+
+  it('compares by instant across timezones, not by raw string prefix', function () {
+    // Cutoff midnight in -0400 happens 4h AFTER UTC midnight of the same date.
+    // onOrAfter must judge by absolute time, not the shared "YYYY-MM-DD" prefix.
+    var cutoff = lookbackCutoff(12, '-0400')
+    // Exactly at the cutoff instant, expressed in -0400 -> included.
+    expect(onOrAfter(toOffsetIso(cutoff.ms, '-0400'), cutoff.ms)).toBe(true)
+    // Same calendar date at UTC midnight is 4h earlier in absolute time -> before cutoff,
+    // even though the raw string prefix "YYYY-MM-DD" is identical (the old lexicographic bug).
+    var sameDateUtc = cutoff.dateStr + 'T00:00:00.000Z'
+    expect(Date.parse(sameDateUtc) < cutoff.ms).toBe(true)
+    expect(onOrAfter(sameDateUtc, cutoff.ms)).toBe(false)
+  })
+
+  it('returns false for null/invalid dates', function () {
+    expect(onOrAfter(null, 0)).toBe(false)
+    expect(onOrAfter('not-a-date', 0)).toBe(false)
+  })
+})
+
+describe('computeComponentPressure — timezone window boundary', function () {
+  it('derives the account offset from data and counts by that offset boundary', function () {
+    var offset = '-0400'
+    var cutoff = lookbackCutoff(12, offset)
+    var features = [
+      // 1 day inside the window (created), carries the account offset
+      makeFeature('F-in', 'Boundary', toOffsetIso(cutoff.ms + 24 * 3600000, offset), null),
+      // 1 day before the window — must be excluded
+      makeFeature('F-out', 'Boundary', toOffsetIso(cutoff.ms - 24 * 3600000, offset), null)
+    ]
+    var result = computeComponentPressure(features, 12)
+    var b = result.find(function (r) { return r.component === 'Boundary' })
+    expect(b).toBeDefined()
+    expect(b.created).toBe(1) // only F-in
+    // JQL date clause uses the same account-tz calendar date as the count boundary
+    expect(b.created_jql).toContain(encodeURIComponent('created >= "' + cutoff.dateStr + '"'))
   })
 })
 

--- a/modules/releases/client/views/FeaturePressureView.vue
+++ b/modules/releases/client/views/FeaturePressureView.vue
@@ -71,6 +71,13 @@ function formatMonths(val) {
   return val
 }
 
+function formatTimestamp(iso) {
+  if (!iso) return 'unknown'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return 'unknown'
+  return d.toLocaleString()
+}
+
 function riskColor(level) {
   const colors = {
     critical: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
@@ -221,6 +228,10 @@ onBeforeUnmount(() => { cleanup() })
             'text-gray-600 dark:text-gray-400': summary.backlog_trend === 'stable',
           }">{{ summary.backlog_trend }}</strong></span>
         </div>
+
+        <p v-if="metadata && metadata.data_timestamp" class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+          Data as of {{ formatTimestamp(metadata.data_timestamp) }} · counts are a snapshot; JQL links query Jira live, so live totals may differ by a few.
+        </p>
 
         <!-- Executive Summary — RFEs (RHAIRFE) -->
         <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-5 mb-2">Feature Requests (RHAIRFE)</h3>

--- a/modules/releases/server/feature-pressure/routes.js
+++ b/modules/releases/server/feature-pressure/routes.js
@@ -120,13 +120,53 @@ var normalizeRfe = normalizeIssue
 // Date helpers
 // ---------------------------------------------------------------------------
 
-/** Parse ISO date string to YYYY-MM month key */
-function toMonth(dateStr) {
+/** Zero-pad a number to 2 digits */
+function pad2(n) {
+  return (n < 10 ? '0' : '') + n
+}
+
+/** Parse a "+HHMM"/"-HHMM" offset string to minutes east of UTC */
+function offsetMin(offset) {
+  if (!offset) return 0
+  var sign = offset.charAt(0) === '-' ? -1 : 1
+  var h = parseInt(offset.slice(1, 3), 10) || 0
+  var mm = parseInt(offset.slice(3, 5), 10) || 0
+  return sign * (h * 60 + mm)
+}
+
+/** Server-local UTC offset as "+HHMM"/"-HHMM" (fallback when Jira data carries no numeric offset) */
+function localOffset() {
+  var off = -new Date().getTimezoneOffset() // minutes east of UTC
+  var sign = off >= 0 ? '+' : '-'
+  var a = Math.abs(off)
+  return sign + pad2(Math.floor(a / 60)) + pad2(a % 60)
+}
+
+/**
+ * Derive the Jira account's UTC offset from the data itself.  Jira Cloud returns
+ * all timestamps in the requesting account's timezone (numeric offset), and JQL
+ * evaluates dates in that same timezone — so counts computed with this offset match
+ * their JQL verification links exactly.  Falls back to server-local when no numeric
+ * offset is present (e.g. synthetic "...Z" test fixtures).
+ */
+function jiraOffset(issues) {
+  for (var i = 0; i < issues.length; i++) {
+    var s = issues[i] && (issues[i].created || issues[i].resolved)
+    var m = s && s.match(/([+-]\d{4})$/)
+    if (m) return m[1]
+  }
+  return localOffset()
+}
+
+/** Parse ISO date string to YYYY-MM month key, bucketed in `offset` (default server-local) */
+function toMonth(dateStr, offset) {
   if (!dateStr) return null
-  var d = new Date(dateStr)
-  if (isNaN(d.getTime())) return null
-  var m = d.getMonth() + 1
-  return d.getFullYear() + '-' + (m < 10 ? '0' : '') + m
+  var t = Date.parse(dateStr)
+  if (isNaN(t)) return null
+  var off = offset === undefined ? -new Date().getTimezoneOffset() : offsetMin(offset)
+  var d = new Date(t + off * 60000)
+  var m = d.getUTCMonth() + 1
+  return d.getUTCFullYear() + '-' + (m < 10 ? '0' : '') + m
 }
 
 /** Generate array of YYYY-MM strings for the lookback window */
@@ -148,6 +188,30 @@ function lookbackDate(months) {
   return d.toISOString().slice(0, 10)
 }
 
+/**
+ * Cutoff for "last N months" as both a calendar date (for JQL, which Jira evaluates
+ * in the account timezone) and an absolute instant in ms (for in-memory filtering).
+ * The instant is midnight of that date in `offset`, so onOrAfter() matches a JQL
+ * `created >= "<dateStr>"` clause exactly.
+ */
+function lookbackCutoff(months, offset) {
+  var offMin = offsetMin(offset)
+  // Read "today" in the account timezone, not server-local, so the calendar date
+  // matches what Jira considers the current day when it evaluates the JQL clause.
+  var acct = new Date(Date.now() + offMin * 60000)
+  var d = new Date(Date.UTC(acct.getUTCFullYear(), acct.getUTCMonth() - months, acct.getUTCDate()))
+  var dateStr = d.getUTCFullYear() + '-' + pad2(d.getUTCMonth() + 1) + '-' + pad2(d.getUTCDate())
+  var ms = Date.parse(dateStr + 'T00:00:00.000Z') - offMin * 60000
+  return { dateStr: dateStr, ms: ms }
+}
+
+/** True if a Jira timestamp string is on or after the cutoff instant (ms epoch) */
+function onOrAfter(dateStr, cutoffMs) {
+  if (!dateStr) return false
+  var t = Date.parse(dateStr)
+  return !isNaN(t) && t >= cutoffMs
+}
+
 // ---------------------------------------------------------------------------
 // Analysis functions (exported for testing)
 // ---------------------------------------------------------------------------
@@ -158,7 +222,8 @@ function lookbackDate(months) {
  */
 function classifyByMonth(features, lookbackMonths) {
   var monthRange = generateMonthRange(lookbackMonths)
-  var cutoff = lookbackDate(lookbackMonths)
+  var offset = jiraOffset(features)
+  var cutoff = lookbackCutoff(lookbackMonths, offset)
 
   var createdMap = {}
   var resolvedMap = {}
@@ -169,12 +234,12 @@ function classifyByMonth(features, lookbackMonths) {
 
   for (var fi = 0; fi < features.length; fi++) {
     var feat = features[fi]
-    if (feat.created && feat.created >= cutoff) {
-      var cm = toMonth(feat.created)
+    if (onOrAfter(feat.created, cutoff.ms)) {
+      var cm = toMonth(feat.created, offset)
       if (cm && createdMap[cm] !== undefined) createdMap[cm]++
     }
-    if (feat.resolved && feat.resolved >= cutoff) {
-      var rm = toMonth(feat.resolved)
+    if (onOrAfter(feat.resolved, cutoff.ms)) {
+      var rm = toMonth(feat.resolved, offset)
       if (rm && resolvedMap[rm] !== undefined) resolvedMap[rm]++
     }
   }
@@ -216,7 +281,8 @@ function nextMonth(ym) {
  * Returns sorted array of { component, created, resolved, open, net, pressure_ratio, ..._jql }
  */
 function computeComponentPressure(features, lookbackMonths) {
-  var cutoff = lookbackDate(lookbackMonths)
+  var offset = jiraOffset(features)
+  var cutoff = lookbackCutoff(lookbackMonths, offset)
   var compMap = {} // component -> { created, resolved, open }
 
   for (var fi = 0; fi < features.length; fi++) {
@@ -229,10 +295,10 @@ function computeComponentPressure(features, lookbackMonths) {
         compMap[comp] = { created: 0, resolved: 0, open: 0 }
       }
 
-      if (feat.created && feat.created >= cutoff) {
+      if (onOrAfter(feat.created, cutoff.ms)) {
         compMap[comp].created++
       }
-      if (feat.resolved && feat.resolved >= cutoff) {
+      if (onOrAfter(feat.resolved, cutoff.ms)) {
         compMap[comp].resolved++
       }
       if (feat.statusCategory !== 'Done') {
@@ -255,9 +321,9 @@ function computeComponentPressure(features, lookbackMonths) {
     result.push({
       component: name,
       created: data.created,
-      created_jql: jqlUrl(baseJql + compQ + ' AND created >= "' + cutoff + '"'),
+      created_jql: jqlUrl(baseJql + compQ + ' AND created >= "' + cutoff.dateStr + '"'),
       resolved: data.resolved,
-      resolved_jql: jqlUrl(baseJql + compQ + ' AND resolved >= "' + cutoff + '"'),
+      resolved_jql: jqlUrl(baseJql + compQ + ' AND resolved >= "' + cutoff.dateStr + '"'),
       open: data.open,
       open_jql: jqlUrl(baseJql + compQ + ' AND statusCategory != Done'),
       net: net,
@@ -277,7 +343,8 @@ function computeComponentPressure(features, lookbackMonths) {
  * Returns { status_breakdown, monthly_arrivals, per_component_pending }
  */
 function computeRfePipeline(rfes, lookbackMonths) {
-  var cutoff = lookbackDate(lookbackMonths)
+  var offset = jiraOffset(rfes)
+  var cutoff = lookbackCutoff(lookbackMonths, offset)
   var monthRange = generateMonthRange(lookbackMonths)
 
   // Status breakdown
@@ -307,8 +374,8 @@ function computeRfePipeline(rfes, lookbackMonths) {
   for (var mi = 0; mi < monthRange.length; mi++) arrivalMap[monthRange[mi]] = 0
 
   for (var ai = 0; ai < rfes.length; ai++) {
-    if (rfes[ai].created && rfes[ai].created >= cutoff) {
-      var m = toMonth(rfes[ai].created)
+    if (onOrAfter(rfes[ai].created, cutoff.ms)) {
+      var m = toMonth(rfes[ai].created, offset)
       if (m && arrivalMap[m] !== undefined) arrivalMap[m]++
     }
   }
@@ -389,7 +456,8 @@ function computeBacklogHalfLife(componentPressure, lookbackMonths) {
  */
 function buildHeatmapMatrix(features, lookbackMonths) {
   var monthRange = generateMonthRange(lookbackMonths)
-  var cutoff = lookbackDate(lookbackMonths)
+  var offset = jiraOffset(features)
+  var cutoff = lookbackCutoff(lookbackMonths, offset)
 
   // Count created and resolved per component per month
   var compMonthCreated = {} // comp -> { month -> count }
@@ -407,15 +475,15 @@ function buildHeatmapMatrix(features, lookbackMonths) {
       var comp = comps[ci]
       activeComps[comp] = true
 
-      if (feat.created && feat.created >= cutoff) {
-        var cm = toMonth(feat.created)
+      if (onOrAfter(feat.created, cutoff.ms)) {
+        var cm = toMonth(feat.created, offset)
         if (cm) {
           if (!compMonthCreated[comp]) compMonthCreated[comp] = {}
           compMonthCreated[comp][cm] = (compMonthCreated[comp][cm] || 0) + 1
         }
       }
-      if (feat.resolved && feat.resolved >= cutoff) {
-        var rm = toMonth(feat.resolved)
+      if (onOrAfter(feat.resolved, cutoff.ms)) {
+        var rm = toMonth(feat.resolved, offset)
         if (rm) {
           if (!compMonthResolved[comp]) compMonthResolved[comp] = {}
           compMonthResolved[comp][rm] = (compMonthResolved[comp][rm] || 0) + 1
@@ -475,7 +543,8 @@ function buildHeatmapMatrix(features, lookbackMonths) {
  */
 function computeTrend(features, lookbackMonths) {
   var monthRange = generateMonthRange(lookbackMonths)
-  var cutoff = lookbackDate(lookbackMonths)
+  var offset = jiraOffset(features)
+  var cutoff = lookbackCutoff(lookbackMonths, offset)
   var midIdx = Math.floor(monthRange.length / 2)
   var firstHalfMonths = monthRange.slice(0, midIdx)
   var secondHalfMonths = monthRange.slice(midIdx)
@@ -501,16 +570,16 @@ function computeTrend(features, lookbackMonths) {
         compData[comp] = { h1_created: 0, h1_resolved: 0, h2_created: 0, h2_resolved: 0 }
       }
 
-      if (feat.created && feat.created >= cutoff) {
-        var cm = toMonth(feat.created)
+      if (onOrAfter(feat.created, cutoff.ms)) {
+        var cm = toMonth(feat.created, offset)
         if (cm) {
           activeComps[comp] = true
           if (firstHalfSet[cm]) compData[comp].h1_created++
           else if (secondHalfSet[cm]) compData[comp].h2_created++
         }
       }
-      if (feat.resolved && feat.resolved >= cutoff) {
-        var rm = toMonth(feat.resolved)
+      if (onOrAfter(feat.resolved, cutoff.ms)) {
+        var rm = toMonth(feat.resolved, offset)
         if (rm) {
           activeComps[comp] = true
           if (firstHalfSet[rm]) compData[comp].h1_resolved++
@@ -659,15 +728,16 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
   var scorecard = computeScorecard(componentPressure, rfePipeline, backlogHalfLife, trend)
 
   // Executive summary
-  var cutoff = lookbackDate(lookbackMonths)
+  var offset = jiraOffset(features.length ? features : rfes)
+  var cutoff = lookbackCutoff(lookbackMonths, offset)
   var baseJql = 'project = ' + FEATURE_PROJECT + ' AND issuetype = Feature'
   var rfeBaseJql = 'project = ' + RFE_PROJECT + ' AND issuetype = "Feature Request"'
   var pendingStatusJql = 'status in (New, Draft, "Stakeholder review", "Stakeholder Feedback", "Pending Approval")'
   var acceptedStatusJql = 'status in (Approved, "In Progress", Refinement, Planning, Review, Resolved)'
 
   var totalOpen = features.filter(function (f) { return f.statusCategory !== 'Done' }).length
-  var totalCreated = features.filter(function (f) { return f.created && f.created >= cutoff }).length
-  var totalResolved = features.filter(function (f) { return f.resolved && f.resolved >= cutoff }).length
+  var totalCreated = features.filter(function (f) { return onOrAfter(f.created, cutoff.ms) }).length
+  var totalResolved = features.filter(function (f) { return onOrAfter(f.resolved, cutoff.ms) }).length
   var burnRate = Math.round(100 * totalResolved / lookbackMonths) / 100
   var monthsToClear = burnRate > 0 ? Math.round(10 * totalOpen / burnRate) / 10 : Infinity
 
@@ -690,9 +760,9 @@ async function fetchAndAnalyze(lookbackMonths, storage) {
       open_features: totalOpen,
       open_features_jql: jqlUrl(baseJql + ' AND statusCategory != Done'),
       created_in_window: totalCreated,
-      created_in_window_jql: jqlUrl(baseJql + ' AND created >= "' + cutoff + '"'),
+      created_in_window_jql: jqlUrl(baseJql + ' AND created >= "' + cutoff.dateStr + '"'),
       resolved_in_window: totalResolved,
-      resolved_in_window_jql: jqlUrl(baseJql + ' AND resolved >= "' + cutoff + '"'),
+      resolved_in_window_jql: jqlUrl(baseJql + ' AND resolved >= "' + cutoff.dateStr + '"'),
       net_in_window: totalCreated - totalResolved,
       monthly_burn_rate: burnRate,
       months_to_clear: monthsToClear,
@@ -895,6 +965,10 @@ module.exports.toMonth = toMonth
 module.exports.nextMonth = nextMonth
 module.exports.generateMonthRange = generateMonthRange
 module.exports.lookbackDate = lookbackDate
+module.exports.lookbackCutoff = lookbackCutoff
+module.exports.onOrAfter = onOrAfter
+module.exports.jiraOffset = jiraOffset
+module.exports.offsetMin = offsetMin
 module.exports.classifyByMonth = classifyByMonth
 module.exports.computeComponentPressure = computeComponentPressure
 module.exports.computeRfePipeline = computeRfePipeline

--- a/tests/integration/feature-pressure.spec.js
+++ b/tests/integration/feature-pressure.spec.js
@@ -289,6 +289,16 @@ test.describe('Feature Pressure - Executive Summary @feature-pressure', () => {
     await expect(page.locator('text=growing').first()).toBeVisible();
     expect(relevantErrors(page)).toHaveLength(0);
   });
+
+  test('should show the snapshot freshness label', async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto('/#/releases/reports?report=feature-pressure');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('text=counts are a snapshot').first()).toBeVisible();
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
 });
 
 test.describe('Feature Pressure - Component Table @feature-pressure', () => {


### PR DESCRIPTION
## Problem

The Feature Pressure report advertises that every count is backed by a clickable JQL verification link. But the Executive Summary numbers for RHAISTRAT (Total, Open, Created 6mo, Resolved 6mo, Net) drifted 1–5 units from the counts returned by their own JQL links. Same drift in the component/RFE/heatmap/trend tables.

### Two independent causes:

1. Timezone-broken date compare (the real bug, deterministic). Window filtering compared a full Jira ISO timestamp against a date-only cutoff as raw strings:
```js
  var cutoff = lookbackDate(months)        // "2026-01-31" — built in UTC
  features.filter(f => f.created >= cutoff) // lexicographic string compare
```
Jira Cloud returns created/resolutiondate in the account's timezone (e.g. -0400) and JQL evaluates dates in that same timezone. The cutoff was built in UTC. Issues near the midnight boundary landed on the opposite side of the cutoff vs Jira's own JQL → the 1–5 mismatch.

2. Cached snapshot vs live JQL (inherent). The page serves a stale-while-revalidate cache up to 1h old; JQL links query Jira live. For an active project this alone drifts Total/Open by a few. No code change makes cached == live.

## Solution
**Cause 1** — compare by instant, not string. All timestamps in a fetch share the account's UTC offset. Derive it from the data itself (jiraOffset), build the cutoff as an instant at midnight in that offset (lookbackCutoff), and compare by instant (onOrAfter). JQL clauses keep the account-TZ calendar date (cutoff.dateStr) so displayed counts match their links exactly. toMonth() now buckets by the account offset so monthly flow / heatmap / trend align on the same boundaries. Applied to all 6 analyses + the Executive Summary.

**Cause 2** — surface it. Added a freshness label under the Executive Summary: "Data as of … · counts are a snapshot; JQL links query Jira live, so live totals may differ by a few." The residual drift is now expected and explained, not a bug.

## Testing
- Unit tests: 93 pass (npm test), including a new cross-timezone boundary test (-0400 midnight) that the old string compare failed, plus direct unit tests for jiraOffset / lookbackCutoff / onOrAfter / offsetMin.
- Lint clean (npm run lint).
- End-to-end against real Jira (npm run dev:full): refresh completes successfully — "1992 features, 2591 RFEs analysed" — with the fix code running the full pipeline. Cache file confirmed wired correctly (JQL cutoff "2026-01-31" matches the instant filter). Any remaining drift is bounded by the ≤1h cache age (Cause 2), now labeled.

