### PR TITLE
fix(releases): expand TV/FV delta JQL to cover all aligned_on_time cases

### DIFF
--- a/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
+++ b/modules/releases/__tests__/server/tv-fv-delta/pipeline.test.js
@@ -1225,6 +1225,58 @@ describe('buildExport', () => {
     expect(result.executive_summary[0].alignment_pct).toBe(0);
     expect(result.releases['rhoai-3.5']).toBeDefined();
   });
+
+  it('aligned_on_time_jql includes earlier same-product releases in fixVersion clause (Case 2: ahead of schedule)', () => {
+    const releases = ['3.6 EA1 RHOAI RELEASE', '3.5 GA RHOAI RELEASE', '3.5 EA2 RHOAI RELEASE'];
+    const classifications = [
+      { release: '3.6 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
+    // Must include the earlier RHOAI releases as valid fix versions
+    expect(jql).toContain('"3.5 GA RHOAI RELEASE"');
+    expect(jql).toContain('"3.5 EA2 RHOAI RELEASE"');
+    // Must still require TV = the target release
+    expect(jql).toContain('"Target Version" in ("3.6 EA1 RHOAI RELEASE")');
+  });
+
+  it('aligned_on_time_jql includes later same-product releases in Target Version clause (Case 3: FV ahead)', () => {
+    const releases = ['3.6 EA1 RHOAI RELEASE', '3.6 EA2 RHOAI RELEASE', '3.6 GA RHOAI RELEASE'];
+    const classifications = [
+      { release: '3.6 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
+    // Case 3 clause: FV = EA1, TV = later release
+    expect(jql).toContain('fixVersion in ("3.6 EA1 RHOAI RELEASE")');
+    expect(jql).toContain('"3.6 EA2 RHOAI RELEASE"');
+    expect(jql).toContain('"3.6 GA RHOAI RELEASE"');
+  });
+
+  it('aligned_on_time_jql does not bleed cross-product releases into fixVersion or Target Version clauses', () => {
+    const releases = ['3.6 EA1 RHOAI RELEASE', '3.6 EA1 RHAII RELEASE', '3.5 GA RHOAI RELEASE'];
+    const classifications = [
+      { release: '3.6 EA1 RHOAI RELEASE', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
+    // RHAII release must not appear — different product
+    expect(jql).not.toContain('RHAII');
+    // Earlier RHOAI release must appear
+    expect(jql).toContain('"3.5 GA RHOAI RELEASE"');
+  });
+
+  it('aligned_on_time_jql falls back to exact-match when release is unparseable (no earlier/later computed)', () => {
+    const releases = ['unparseable-version', 'rhoai-3.5'];
+    const classifications = [
+      { release: 'unparseable-version', category: 'aligned_on_time', key: 'X-1', url: '', summary: '', status: '', color_status: '', product_manager: '', assignee: '', team: '', components: [], component: '', target_version: '', fix_versions: '' },
+    ];
+    const result = buildExport(classifications, releases, '2026-01-01T00:00:00Z', [], 'RHAISTRAT');
+    const jql = decodeURIComponent(result.executive_summary[0].aligned_on_time_jql);
+    // Just the release itself, no compound OR clause (compound uses ') OR (' pattern)
+    expect(jql).toContain('"unparseable-version"');
+    expect(jql).not.toContain(') OR (');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/modules/releases/server/tv-fv-delta/routes.js
+++ b/modules/releases/server/tv-fv-delta/routes.js
@@ -592,12 +592,39 @@ function buildExport(classifications, releases, fetchTimestamp, allComponents, j
       dates = releaseDates[release] || releaseDates[normVer(release)] || {}
     }
 
+    // Build compound aligned_on_time JQL covering all three cases:
+    //   Case 1: TV = R, FV = R (exact match)
+    //   Case 2: TV = R, FV = earlier same-product release (ahead of schedule)
+    //   Case 3: FV = R, TV = later same-product release (also ahead of schedule)
+    // Note: features with FV pointing outside the tracked releases array won't appear
+    // in this JQL — we can only enumerate releases known to the pipeline.
+    var rParsed = parseReleaseName(release)
+    var sameProduct = releases.filter(function(r) {
+      if (r === release) return false
+      var p = parseReleaseName(r)
+      return p && rParsed && p.product === rParsed.product
+    })
+    var earlierReleases = sameProduct.filter(function(r) {
+      var cmp = compareReleasesTemporally(r, release)
+      return cmp !== null && cmp < 0
+    })
+    var laterReleases = sameProduct.filter(function(r) {
+      var cmp = compareReleasesTemporally(r, release)
+      return cmp !== null && cmp > 0
+    })
+    var allFvForAligned = [release].concat(earlierReleases)
+    var case12 = '"Target Version" in (' + quoteRelease(release) + ') AND fixVersion in (' + allFvForAligned.map(quoteRelease).join(', ') + ')'
+    var case3 = laterReleases.length > 0
+      ? 'fixVersion in (' + quoteRelease(release) + ') AND "Target Version" in (' + laterReleases.map(quoteRelease).join(', ') + ')'
+      : null
+    var alignedOnTimeJql = case3 ? '(' + case12 + ') OR (' + case3 + ')' : case12
+
     executiveSummary.push({
       release: release,
       total: nTotal,
       total_jql: jqlUrl(baseJql + ' AND ("Target Version" in (' + quoteRelease(release) + ') OR fixVersion in (' + quoteRelease(release) + '))'),
       aligned_on_time: cats.aligned_on_time,
-      aligned_on_time_jql: jqlUrl(baseJql + ' AND "Target Version" in (' + quoteRelease(release) + ') AND fixVersion in (' + quoteRelease(release) + ')'),
+      aligned_on_time_jql: jqlUrl(baseJql + ' AND (' + alignedOnTimeJql + ')'),
       aligned_late: cats.aligned_late,
       aligned_late_jql: null, // Cannot express temporal + freeze logic in JQL
       misaligned: cats.misaligned,

--- a/tests/integration/tv-fv-delta.spec.js
+++ b/tests/integration/tv-fv-delta.spec.js
@@ -681,6 +681,48 @@ test.describe('TV/FV Delta — Executive Summary @tv-fv-delta', () => {
 
     expect(relevantErrors(page)).toHaveLength(0);
   });
+
+  test('should render compound aligned_on_time JQL link when fixture contains OR clause (Cases 1-3)', async ({ page }) => {
+    // Fixture where 3.5 GA has compound JQL: Case 1+2 (earlier FV) OR Case 3 (later TV)
+    const compoundJql = encodeURIComponent(
+      'project = RHAISTRAT AND (("Target Version" in ("3.5 GA RHOAI RELEASE") AND fixVersion in ("3.5 GA RHOAI RELEASE", "3.5 EA2 RHOAI RELEASE", "3.5 EA1 RHOAI RELEASE")) OR (fixVersion in ("3.5 GA RHOAI RELEASE") AND "Target Version" in ("3.6 EA1 RHOAI RELEASE")))'
+    );
+    const compoundFixture = {
+      ...FIXTURE_DATA,
+      executive_summary: FIXTURE_DATA.executive_summary.map(row =>
+        row.release === '3.5 GA RHOAI RELEASE'
+          ? { ...row, aligned_on_time_jql: 'https://redhat.atlassian.net/issues/?jql=' + compoundJql }
+          : row
+      )
+    };
+
+    await page.unroute('**/api/modules/releases/tv-fv-delta');
+    await page.route('**/api/modules/releases/tv-fv-delta', route => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+      } else {
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(compoundFixture) });
+      }
+    });
+
+    await page.goto('/#/releases/reports?report=tv-fv-delta');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const summarySection = page.locator('div:has(> div > h2:has-text("Executive Summary"))').first();
+    const gaRow = summarySection.locator('tbody tr', { hasText: '3.5 GA RHOAI RELEASE' });
+
+    // Aligned On Time is the second Jira link in the row (after Total)
+    const alignedLink = gaRow.locator('a[href*="atlassian.net"]').nth(1);
+    await expect(alignedLink).toBeVisible();
+
+    const href = await alignedLink.getAttribute('href');
+    expect(href).toContain('3.5%20EA2%20RHOAI%20RELEASE');
+    expect(href).toContain('3.5%20EA1%20RHOAI%20RELEASE');
+    expect(href).toContain('3.6%20EA1%20RHOAI%20RELEASE');
+
+    expect(relevantErrors(page)).toHaveLength(0);
+  });
 });
 
 


### PR DESCRIPTION
## Summary

The `aligned_on_time` classification in `classifyFeatures` covers three scenarios:

- **Case 1:** TV = R, FV = R — exact match, shipped as planned
- **Case 2:** TV = R, FV = earlier same-product release — shipped early (ahead of schedule)
- **Case 3:** FV = R, TV = later same-product release — also counted as on-time from R's perspective

The previous `aligned_on_time_jql` link only matched Case 1 (TV = R AND FV = R), so the Jira live count diverged from the table count whenever Case 2 or Case 3 features were present.

This PR builds a compound JQL covering all three cases:
- **Case 1+2:** "Target Version" in (R) AND fixVersion in (R, ...earlierSameProductReleases)
- **Case 3:** fixVersion in (R) AND "Target Version" in (...laterSameProductReleases)

Same-product filtering uses `parseReleaseName` and `compareReleasesTemporally`, the same functions the classification logic already uses. Releases with unparseable names fall back to the original exact-match JQL.

**Known limitation:** JQL cannot express the freeze-date and worst-category constraints from `classifyFeatures`, so counts may still differ slightly for features with multiple TVs spanning categories. This is the same reason `aligned_late_jql` is null.

## Test plan
- [x] Unit tests for Case 2 (earlier FV), Case 3 (later TV), cross-product bleed, and unparseable fallback
- [x] Open TV/FV Delta for a release with early-shipped features - aligned_on_time Jira link count matches table
