### PR TITLE
chore(ci): switch Vertex AI to rhai-org-pulse global region

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -212,8 +212,8 @@ jobs:
             - **PR branch naming:** `fix/issue-<number>-<short-desc>` for bugs,
               `feat/issue-<number>-<short-desc>` for features.
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
-          CLOUD_ML_REGION: "us-east5"
+          ANTHROPIC_VERTEX_PROJECT_ID: "rhai-org-pulse"
+          CLOUD_ML_REGION: "global"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_PROMPT_CACHING: "1"
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -290,8 +290,8 @@ jobs:
               fix an issue (e.g., a missing import in another file).
 
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
-          CLOUD_ML_REGION: "us-east5"
+          ANTHROPIC_VERTEX_PROJECT_ID: "rhai-org-pulse"
+          CLOUD_ML_REGION: "global"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_PROMPT_CACHING: "1"
 
@@ -341,8 +341,8 @@ jobs:
             - Use `gh pr diff` and `Read` to understand the changes.
             - Be concise. Focus on actionable feedback.
         env:
-          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
-          CLOUD_ML_REGION: "us-east5"
+          ANTHROPIC_VERTEX_PROJECT_ID: "rhai-org-pulse"
+          CLOUD_ML_REGION: "global"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_PROMPT_CACHING: "1"
 


### PR DESCRIPTION
## Summary
- Migrate Claude Code GitHub Actions (`claude-issues.yml`, `claude-review.yml`) from `itpc-gcp-ai-eng-claude` / `us-east5` to `rhai-org-pulse` / `global`
- Matches the change made in org-pulse-core ([red-hat-data-services/org-pulse-core#73](https://github.com/red-hat-data-services/org-pulse-core/pull/73))

## Test plan
- [ ] Verify Claude issue workflow triggers correctly on a test issue
- [ ] Verify Claude review workflow triggers correctly on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)