### PR TITLE
feat: add Labels column to feature readiness CSV export

### DIFF
--- a/modules/releases/client/plan/utils/feature-readiness-export.js
+++ b/modules/releases/client/plan/utils/feature-readiness-export.js
@@ -76,7 +76,8 @@ function exportFeatureReadinessCsv(features) {
     { label: 'Team', getter: function(f) { return f.team || '' } },
     { label: 'Status', getter: function(f) { return f.status || '' } },
     { label: 'Priority', getter: function(f) { return f.priority || '' } },
-    { label: 'Confidence', getter: function(f) { return f.confidence || '' } }
+    { label: 'Confidence', getter: function(f) { return f.confidence || '' } },
+    { label: 'Labels', getter: function(f) { return Array.isArray(f.labels) ? f.labels.join('; ') : (f.labels || '') } }
   ]
 
   var header = columns.map(function(c) { return escapeCsv(c.label) }).join(',')


### PR DESCRIPTION
## Problem

The feature readiness CSV export (`exportFeatureReadinessCsv`) does not include the Jira **Labels** column.

Labels are already fetched from Jira and present on the feature object (populated by `jira-transform.js` and `jira-enrich.js`), but were never added to the export column list.

This creates a gap for any tooling that consumes the CSV: pipeline labels like `rp-qg1-pass`, `strat-creator-rubric-pass`, `strat-creator-human-sign-off`, and `epic-creator-auto-decomposed` are invisible in the export, even though they exist on the Jira issue.

**Concrete example:** RHAISTRAT-1473 has `rp-qg1-pass` in Jira (meaning it passed QG1 — planning gate cleared, all mandatory FPDoR fields confirmed). The current CSV export has no Labels column, so any downstream tool reading the CSV cannot detect this and must fall back to a heuristic that is often wrong.

## Fix

Add `Labels` as a column in `exportFeatureReadinessCsv`. Multiple labels are joined with `'; '` to match the existing serialization pattern used for `Components` and `Target Versions` in the same file.

```js
{ label: 'Labels', getter: function(f) { return Array.isArray(f.labels) ? f.labels.join('; ') : (f.labels || '') } }
```

## Why this matters

The AI-First Release Planner (currently in POC) uses this CSV to classify features. The `rp-qg1-pass` label is a strong planning signal:
- It confirms the feature passed QG1 (TV, Release Type, Components, Priority, RICE, Docs all set)
- It bypasses the manual FPDoR gate entirely for that feature
- It boosts placement confidence by +10%

Without the Labels column in the export, all features appear as "Legacy / assumed" regardless of their actual pipeline status.

## Change

One line added to `modules/releases/client/plan/utils/feature-readiness-export.js`. No logic changes, no new data fetches — the labels are already on the feature object.

Signed-off-by: yluria@redhat.com