### PR TITLE
ci: use pull_request_target for dependabot lockfile workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,7 +1,7 @@
 name: Dependabot Lockfile Fix
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize]
 
@@ -33,7 +33,7 @@ jobs:
           node-version: '22'
 
       - name: Regenerate lockfile
-        run: npm install --package-lock-only
+        run: npm install --package-lock-only --ignore-scripts
 
       - name: Commit updated lockfile
         run: |


### PR DESCRIPTION
## Summary
- Fixes #1362's workflow which fails because GitHub restricts secret access on `pull_request` events from dependabot
- Switches from `pull_request` to `pull_request_target`, which runs in the base branch context and has access to secrets (`APP_ID` / `APP_PRIVATE_KEY`)

## Security
This is safe because:
- `if: github.actor == 'dependabot[bot]'` limits execution to dependabot PRs only
- The only operation is `npm install --package-lock-only` — no untrusted PR code is executed
- Checkout uses `github.head_ref` to get the dependabot branch's `package.json`

## Test plan
- [ ] Merge this, then `@dependabot rebase` on one open dependabot PR
- [ ] Confirm the lockfile fixup workflow succeeds
- [ ] Confirm CI passes after the fixup commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)