### PR TITLE
AIPCC-27608: Add Test Sign-Off Risk Assessment to Release Blockers tab

### DIFF
--- a/fixtures/releases/delivery/tfa-risk-3.5.json
+++ b/fixtures/releases/delivery/tfa-risk-3.5.json
@@ -1,0 +1,110 @@
+{
+  "releaseNumber": "rhoai-3.5",
+  "fetchedAt": "2026-08-04T10:00:00Z",
+  "overall": {
+    "signoffDone": 14,
+    "signoffTotal": 22,
+    "signoffPct": 64,
+    "failedOpen": 8
+  },
+  "components": [
+    {
+      "name": "Model Serving",
+      "signoffs": { "done": 4, "inProgress": 1, "todo": 0, "total": 5, "pct": 80 },
+      "failedOpen": 1,
+      "riskLevel": "green",
+      "issues": [
+        { "key": "RHOAIENG-68001", "summary": "TFA Sign-Off: Model Serving Nightly", "status": "Closed", "statusCategory": "done", "assignee": "Aarav Patel", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68001" },
+        { "key": "RHOAIENG-68002", "summary": "TFA Sign-Off: Model Serving RC1", "status": "Closed", "statusCategory": "done", "assignee": "Aarav Patel", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68002" },
+        { "key": "RHOAIENG-68003", "summary": "TFA Sign-Off: Model Serving RC2", "status": "Closed", "statusCategory": "done", "assignee": "Mei Chen", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68003" },
+        { "key": "RHOAIENG-68004", "summary": "TFA Sign-Off: Model Serving RC3", "status": "Closed", "statusCategory": "done", "assignee": "Mei Chen", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68004" },
+        { "key": "RHOAIENG-68005", "summary": "TFA Sign-Off: Model Serving GA", "status": "In Progress", "statusCategory": "inProgress", "assignee": "Aarav Patel", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68005" }
+      ],
+      "failedIssues": [
+        { "key": "RHOAIENG-69001", "summary": "vLLM inference latency regression on GPU nodes", "status": "In Progress", "assignee": "Aarav Patel", "link": "https://redhat.atlassian.net/browse/RHOAIENG-69001" }
+      ]
+    },
+    {
+      "name": "KubeRay",
+      "signoffs": { "done": 2, "inProgress": 1, "todo": 0, "total": 3, "pct": 67 },
+      "failedOpen": 0,
+      "riskLevel": "yellow",
+      "issues": [
+        { "key": "RHOAIENG-68010", "summary": "TFA Sign-Off: KubeRay Nightly", "status": "Closed", "statusCategory": "done", "assignee": "Liam O'Brien", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68010" },
+        { "key": "RHOAIENG-68011", "summary": "TFA Sign-Off: KubeRay RC1", "status": "Closed", "statusCategory": "done", "assignee": "Liam O'Brien", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68011" },
+        { "key": "RHOAIENG-68012", "summary": "TFA Sign-Off: KubeRay RC2", "status": "In Progress", "statusCategory": "inProgress", "assignee": "Liam O'Brien", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68012" }
+      ],
+      "failedIssues": []
+    },
+    {
+      "name": "AI Core Dashboard",
+      "signoffs": { "done": 2, "inProgress": 0, "todo": 2, "total": 4, "pct": 50 },
+      "failedOpen": 3,
+      "riskLevel": "yellow",
+      "issues": [
+        { "key": "RHOAIENG-68020", "summary": "TFA Sign-Off: Dashboard Nightly", "status": "Closed", "statusCategory": "done", "assignee": "Priya Sharma", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68020" },
+        { "key": "RHOAIENG-68021", "summary": "TFA Sign-Off: Dashboard RC1", "status": "Closed", "statusCategory": "done", "assignee": "Priya Sharma", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68021" },
+        { "key": "RHOAIENG-68022", "summary": "TFA Sign-Off: Dashboard RC2", "status": "New", "statusCategory": "todo", "assignee": null, "link": "https://redhat.atlassian.net/browse/RHOAIENG-68022" },
+        { "key": "RHOAIENG-68023", "summary": "TFA Sign-Off: Dashboard RC3", "status": "New", "statusCategory": "todo", "assignee": null, "link": "https://redhat.atlassian.net/browse/RHOAIENG-68023" }
+      ],
+      "failedIssues": [
+        { "key": "RHOAIENG-69010", "summary": "Dashboard login redirect fails on RHEL 9", "status": "Open", "assignee": "Priya Sharma", "link": "https://redhat.atlassian.net/browse/RHOAIENG-69010" },
+        { "key": "RHOAIENG-69011", "summary": "Settings page crashes with empty config", "status": "Open", "assignee": null, "link": "https://redhat.atlassian.net/browse/RHOAIENG-69011" },
+        { "key": "RHOAIENG-69012", "summary": "RBAC integration test flaky on parallel runs", "status": "In Progress", "assignee": "Priya Sharma", "link": "https://redhat.atlassian.net/browse/RHOAIENG-69012" }
+      ]
+    },
+    {
+      "name": "Notebooks",
+      "signoffs": { "done": 3, "inProgress": 0, "todo": 0, "total": 3, "pct": 100 },
+      "failedOpen": 0,
+      "riskLevel": "green",
+      "issues": [
+        { "key": "RHOAIENG-68030", "summary": "TFA Sign-Off: Notebooks Nightly", "status": "Closed", "statusCategory": "done", "assignee": "Carlos Rivera", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68030" },
+        { "key": "RHOAIENG-68031", "summary": "TFA Sign-Off: Notebooks RC1", "status": "Closed", "statusCategory": "done", "assignee": "Carlos Rivera", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68031" },
+        { "key": "RHOAIENG-68032", "summary": "TFA Sign-Off: Notebooks RC2", "status": "Closed", "statusCategory": "done", "assignee": "Carlos Rivera", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68032" }
+      ],
+      "failedIssues": []
+    },
+    {
+      "name": "AI Pipelines",
+      "signoffs": { "done": 1, "inProgress": 1, "todo": 1, "total": 3, "pct": 33 },
+      "failedOpen": 2,
+      "riskLevel": "red",
+      "issues": [
+        { "key": "RHOAIENG-68040", "summary": "TFA Sign-Off: Pipelines Nightly", "status": "Closed", "statusCategory": "done", "assignee": "Elena Volkov", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68040" },
+        { "key": "RHOAIENG-68041", "summary": "TFA Sign-Off: Pipelines RC1", "status": "In Progress", "statusCategory": "inProgress", "assignee": "Elena Volkov", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68041" },
+        { "key": "RHOAIENG-68042", "summary": "TFA Sign-Off: Pipelines RC2", "status": "New", "statusCategory": "todo", "assignee": null, "link": "https://redhat.atlassian.net/browse/RHOAIENG-68042" }
+      ],
+      "failedIssues": [
+        { "key": "RHOAIENG-69020", "summary": "Pipeline execution timeout on large DAGs", "status": "Open", "assignee": "Elena Volkov", "link": "https://redhat.atlassian.net/browse/RHOAIENG-69020" },
+        { "key": "RHOAIENG-69021", "summary": "S3 artifact upload fails with special chars", "status": "Open", "assignee": null, "link": "https://redhat.atlassian.net/browse/RHOAIENG-69021" }
+      ]
+    },
+    {
+      "name": "Training Kubeflow",
+      "signoffs": { "done": 0, "inProgress": 1, "todo": 1, "total": 2, "pct": 0 },
+      "failedOpen": 1,
+      "riskLevel": "red",
+      "issues": [
+        { "key": "RHOAIENG-68050", "summary": "TFA Sign-Off: Training Nightly", "status": "In Progress", "statusCategory": "inProgress", "assignee": "James Kim", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68050" },
+        { "key": "RHOAIENG-68051", "summary": "TFA Sign-Off: Training RC1", "status": "New", "statusCategory": "todo", "assignee": null, "link": "https://redhat.atlassian.net/browse/RHOAIENG-68051" }
+      ],
+      "failedIssues": [
+        { "key": "RHOAIENG-69030", "summary": "Distributed training job hangs on multi-node setup", "status": "In Progress", "assignee": "James Kim", "link": "https://redhat.atlassian.net/browse/RHOAIENG-69030" }
+      ]
+    },
+    {
+      "name": "MLflow",
+      "signoffs": { "done": 2, "inProgress": 0, "todo": 0, "total": 2, "pct": 100 },
+      "failedOpen": 1,
+      "riskLevel": "green",
+      "issues": [
+        { "key": "RHOAIENG-68060", "summary": "TFA Sign-Off: MLflow Nightly", "status": "Closed", "statusCategory": "done", "assignee": "Sofia Andersson", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68060" },
+        { "key": "RHOAIENG-68061", "summary": "TFA Sign-Off: MLflow RC1", "status": "Closed", "statusCategory": "done", "assignee": "Sofia Andersson", "link": "https://redhat.atlassian.net/browse/RHOAIENG-68061" }
+      ],
+      "failedIssues": [
+        { "key": "RHOAIENG-69040", "summary": "MLflow model registry sync timeout", "status": "Open", "assignee": "Sofia Andersson", "link": "https://redhat.atlassian.net/browse/RHOAIENG-69040" }
+      ]
+    }
+  ]
+}

--- a/modules/releases/client/deliver/components/TfaOutcomeChart.vue
+++ b/modules/releases/client/deliver/components/TfaOutcomeChart.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="relative mx-auto" style="width: 180px; height: 180px;">
+    <Doughnut v-if="hasData" :data="chartData" :options="chartOptions" />
+    <div v-if="hasData" class="absolute inset-0 flex items-center justify-center pointer-events-none" style="z-index: 1;">
+      <div class="text-center">
+        <p class="text-base font-bold text-gray-900 dark:text-gray-100">{{ resolvedPct }}%</p>
+        <p class="text-xs text-gray-500 dark:text-gray-400">Resolved</p>
+      </div>
+    </div>
+    <!-- External HTML tooltip -->
+    <div v-if="tooltip.visible" class="absolute bg-gray-900 text-white rounded-lg shadow-xl pointer-events-none" style="z-index: 10; min-width: 170px;" :style="tooltipStyle">
+      <div class="px-3 py-2 border-b border-gray-700">
+        <p class="font-bold text-sm">{{ tooltip.title }}</p>
+      </div>
+      <div class="px-3 py-2 space-y-1.5 text-xs">
+        <div v-for="row in tooltip.rows" :key="row.key" class="flex justify-between gap-4">
+          <span class="text-gray-400">{{ row.key }}</span>
+          <span class="font-medium" :class="row.cls || ''">{{ row.value }}</span>
+        </div>
+      </div>
+      <div class="px-3 py-1.5 border-t border-gray-700 text-center text-gray-500 text-xs">Click to filter pillars</div>
+    </div>
+    <div v-if="!hasData" class="flex items-center justify-center h-full">
+      <p class="text-xs text-gray-400 dark:text-gray-500">No outcome data</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, reactive } from 'vue'
+import { Doughnut } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip
+} from 'chart.js'
+
+ChartJS.register(ArcElement, Tooltip)
+
+var props = defineProps({
+  signoffDone: { type: Number, default: 0 },
+  failedOpen: { type: Number, default: 0 }
+})
+
+var emit = defineEmits(['select-outcome'])
+
+var tooltip = reactive({ visible: false, title: '', rows: [], x: 0, y: 0 })
+
+var tooltipStyle = computed(function () {
+  return {
+    left: tooltip.x + 'px',
+    top: Math.max(0, tooltip.y - 12) + 'px',
+    transform: 'translate(-50%, -100%)'
+  }
+})
+
+var total = computed(function () {
+  return props.signoffDone + props.failedOpen
+})
+
+var resolvedPct = computed(function () {
+  if (total.value === 0) return 0
+  return Math.round((props.signoffDone / total.value) * 100)
+})
+
+var hasData = computed(function () {
+  return total.value > 0
+})
+
+var chartData = computed(function () {
+  return {
+    labels: ['Sign-offs Done', 'Failed Open'],
+    datasets: [{
+      data: [props.signoffDone, props.failedOpen],
+      backgroundColor: ['rgba(16, 185, 129, 0.8)', 'rgba(239, 68, 68, 0.7)'],
+      hoverBackgroundColor: ['rgb(16, 185, 129)', 'rgb(239, 68, 68)'],
+      borderWidth: 2,
+      borderColor: 'rgba(255,255,255,0.9)',
+      hoverOffset: 6
+    }]
+  }
+})
+
+var chartOptions = computed(function () {
+  return {
+    responsive: true,
+    maintainAspectRatio: true,
+    cutout: '58%',
+    onHover: function (event, elements) {
+      var canvas = event.native && event.native.target
+      if (canvas) canvas.style.cursor = elements.length > 0 ? 'pointer' : 'default'
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        enabled: false,
+        external: function (context) {
+          var model = context.tooltip
+          if (model.opacity === 0) {
+            tooltip.visible = false
+            return
+          }
+          var dp = model.dataPoints && model.dataPoints[0]
+          if (!dp) { tooltip.visible = false; return }
+
+          var idx = dp.dataIndex
+          var isDone = idx === 0
+          var count = isDone ? props.signoffDone : props.failedOpen
+          var pct = total.value > 0 ? Math.round((count / total.value) * 100) : 0
+
+          tooltip.title = isDone ? 'Sign-offs Done' : 'Failed Tests Open'
+          tooltip.rows = [
+            { key: 'Count', value: String(count) },
+            { key: 'Of total', value: String(total.value) },
+            { key: 'Share', value: pct + '%', cls: isDone ? 'text-emerald-400' : 'text-red-400' }
+          ]
+          tooltip.x = model.caretX
+          tooltip.y = model.caretY
+          tooltip.visible = true
+        }
+      }
+    },
+    onClick: function (event, elements) {
+      if (!elements || !elements.length) return
+      var idx = elements[0].index
+      emit('select-outcome', idx === 0 ? 'done' : 'failed')
+    }
+  }
+})
+</script>

--- a/modules/releases/client/deliver/components/TfaRiskChart.vue
+++ b/modules/releases/client/deliver/components/TfaRiskChart.vue
@@ -2,32 +2,20 @@
   <div class="relative" style="height: 240px;">
     <Doughnut v-if="hasData" :data="chartData" :options="chartOptions" ref="chartRef" />
     <div v-if="hasData" class="absolute inset-0 flex items-center justify-center pointer-events-none" style="z-index: 1;">
-      <div class="text-center bg-white dark:bg-gray-800 rounded-full px-4 py-2 shadow-sm">
+      <div class="text-center">
         <p class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ overallPct }}%</p>
         <p class="text-xs text-gray-500 dark:text-gray-400">TFA Complete</p>
       </div>
     </div>
     <!-- External HTML tooltip -->
-    <div v-if="tooltip.visible" class="absolute bg-gray-900 text-white rounded-lg shadow-xl pointer-events-none" style="z-index: 10; min-width: 200px;" :style="tooltipStyle">
+    <div v-if="tooltip.visible" class="absolute bg-gray-900 text-white rounded-lg shadow-xl pointer-events-none" style="z-index: 10; min-width: 180px;" :style="tooltipStyle">
       <div class="px-3 py-2 border-b border-gray-700">
         <p class="font-bold text-sm">{{ tooltip.title }}</p>
       </div>
       <div class="px-3 py-2 space-y-1.5 text-xs">
-        <div class="flex justify-between gap-4">
-          <span class="text-gray-400">Sign-offs</span>
-          <span class="font-medium">{{ tooltip.signoffs }}</span>
-        </div>
-        <div class="flex justify-between gap-4">
-          <span class="text-gray-400">Completion</span>
-          <span class="font-medium">{{ tooltip.pct }}%</span>
-        </div>
-        <div class="flex justify-between gap-4">
-          <span class="text-gray-400">Failed open</span>
-          <span class="font-medium" :class="tooltip.failedOpen > 0 ? 'text-red-400' : ''">{{ tooltip.failedOpen }}</span>
-        </div>
-        <div class="flex justify-between gap-4">
-          <span class="text-gray-400">Risk</span>
-          <span class="font-medium" :class="tooltip.riskColor">{{ tooltip.riskLabel }}</span>
+        <div v-for="row in tooltip.rows" :key="row.key" class="flex justify-between gap-4">
+          <span class="text-gray-400">{{ row.key }}</span>
+          <span class="font-medium" :class="row.cls || ''">{{ row.value }}</span>
         </div>
       </div>
       <div class="px-3 py-1.5 border-t border-gray-700 text-center text-gray-500 text-xs">Click to expand</div>
@@ -46,46 +34,28 @@ import {
   ArcElement,
   Tooltip
 } from 'chart.js'
+import { getPillarColor } from '../composables/pillarColors.js'
 
 ChartJS.register(ArcElement, Tooltip)
 
-var PILLAR_PALETTE = [
-  { bg: 'rgba(59, 130, 246, 0.75)', border: 'rgb(59, 130, 246)' },
-  { bg: 'rgba(139, 92, 246, 0.75)', border: 'rgb(139, 92, 246)' },
-  { bg: 'rgba(20, 184, 166, 0.75)', border: 'rgb(20, 184, 166)' },
-  { bg: 'rgba(245, 158, 11, 0.75)', border: 'rgb(245, 158, 11)' },
-  { bg: 'rgba(236, 72, 153, 0.75)', border: 'rgb(236, 72, 153)' },
-  { bg: 'rgba(16, 185, 129, 0.75)', border: 'rgb(16, 185, 129)' },
-  { bg: 'rgba(239, 68, 68, 0.75)', border: 'rgb(239, 68, 68)' },
-  { bg: 'rgba(107, 114, 128, 0.75)', border: 'rgb(107, 114, 128)' }
-]
+var DONE_COLOR = { bg: 'rgba(16, 185, 129, 0.8)', border: 'rgb(16, 185, 129)' }
+var REMAINING_COLOR = { bg: 'rgba(239, 68, 68, 0.7)', border: 'rgb(239, 68, 68)' }
 
-var RISK_LABELS = {
-  green: 'On Track',
-  yellow: 'At Risk',
-  red: 'Likely Blocker'
-}
-
-var RISK_COLORS = {
-  green: 'text-emerald-400',
-  yellow: 'text-amber-400',
-  red: 'text-red-400'
-}
+var RISK_LABELS = { green: 'On Track', yellow: 'At Risk', red: 'Likely Blocker' }
+var RISK_COLORS = { green: 'text-emerald-400', yellow: 'text-amber-400', red: 'text-red-400' }
 
 var props = defineProps({
   pillarData: { type: Array, required: true },
   overallPct: { type: Number, required: true },
-  selectedPillar: { type: String, default: null },
-  thresholds: { type: Object, default: function () { return { green: 80, yellow: 50 } } }
+  overallDone: { type: Number, default: 0 },
+  overallTotal: { type: Number, default: 0 },
+  selectedPillar: { type: String, default: null }
 })
 
-var emit = defineEmits(['select-pillar'])
+var emit = defineEmits(['select-pillar', 'select-status'])
 
 var chartRef = ref(null)
-var tooltip = reactive({
-  visible: false, title: '', signoffs: '', pct: 0,
-  failedOpen: 0, riskLabel: '', riskColor: '', x: 0, y: 0
-})
+var tooltip = reactive({ visible: false, title: '', rows: [], x: 0, y: 0 })
 
 var tooltipStyle = computed(function () {
   return {
@@ -99,34 +69,50 @@ var hasData = computed(function () {
   return props.pillarData && props.pillarData.length > 0
 })
 
+var overallRemaining = computed(function () {
+  return Math.max(0, props.overallTotal - props.overallDone)
+})
+
 var chartData = computed(function () {
-  var labels = []
-  var data = []
-  var bgColors = []
-  var borderColors = []
-  var hoverBgColors = []
+  var outerLabels = []
+  var outerData = []
+  var outerBg = []
+  var outerHover = []
 
   for (var i = 0; i < props.pillarData.length; i++) {
     var p = props.pillarData[i]
-    labels.push(p.pillarName)
-    data.push(p.total || 1)
-    var palette = PILLAR_PALETTE[i % PILLAR_PALETTE.length]
+    outerLabels.push(p.pillarName)
+    outerData.push(p.total || 1)
+    var color = getPillarColor(p.pillarName)
     var isSelected = props.selectedPillar === p.pillarName
-    bgColors.push(isSelected ? palette.border : palette.bg)
-    borderColors.push(palette.border)
-    hoverBgColors.push(palette.border)
+    outerBg.push(isSelected ? color.border : color.bg)
+    outerHover.push(color.border)
   }
 
   return {
-    labels: labels,
-    datasets: [{
-      data: data,
-      backgroundColor: bgColors,
-      borderColor: borderColors,
-      hoverBackgroundColor: hoverBgColors,
-      borderWidth: 2,
-      hoverOffset: 8
-    }]
+    labels: outerLabels.concat(['Done', 'Remaining']),
+    datasets: [
+      {
+        label: 'Pillars',
+        data: outerData,
+        backgroundColor: outerBg,
+        hoverBackgroundColor: outerHover,
+        borderWidth: 2,
+        borderColor: 'rgba(255,255,255,0.9)',
+        hoverOffset: 6,
+        weight: 3
+      },
+      {
+        label: 'Completion',
+        data: [props.overallDone, overallRemaining.value],
+        backgroundColor: [DONE_COLOR.bg, REMAINING_COLOR.bg],
+        hoverBackgroundColor: [DONE_COLOR.border, REMAINING_COLOR.border],
+        borderWidth: 2,
+        borderColor: 'rgba(255,255,255,0.9)',
+        hoverOffset: 4,
+        weight: 1.5
+      }
+    ]
   }
 })
 
@@ -134,7 +120,8 @@ var chartOptions = computed(function () {
   return {
     responsive: true,
     maintainAspectRatio: false,
-    cutout: '65%',
+    cutout: '50%',
+    spacing: 4,
     onHover: function (event, elements) {
       var canvas = event.native && event.native.target
       if (canvas) canvas.style.cursor = elements.length > 0 ? 'pointer' : 'default'
@@ -149,18 +136,33 @@ var chartOptions = computed(function () {
             tooltip.visible = false
             return
           }
-          var idx = model.dataPoints && model.dataPoints[0] ? model.dataPoints[0].dataIndex : -1
-          var p = props.pillarData[idx]
-          if (!p) {
-            tooltip.visible = false
-            return
+          var dp = model.dataPoints && model.dataPoints[0]
+          if (!dp) { tooltip.visible = false; return }
+
+          var dsIdx = dp.datasetIndex
+          var idx = dp.dataIndex
+
+          if (dsIdx === 0) {
+            var p = props.pillarData[idx]
+            if (!p) { tooltip.visible = false; return }
+            tooltip.title = p.pillarName
+            tooltip.rows = [
+              { key: 'Sign-offs', value: p.done + ' / ' + p.total },
+              { key: 'Completion', value: p.pct + '%' },
+              { key: 'Failed open', value: String(p.failedOpen), cls: p.failedOpen > 0 ? 'text-red-400' : '' },
+              { key: 'Risk', value: RISK_LABELS[p.riskLevel] || 'Unknown', cls: RISK_COLORS[p.riskLevel] || '' }
+            ]
+          } else {
+            var label = idx === 0 ? 'Done' : 'Remaining'
+            var count = idx === 0 ? props.overallDone : overallRemaining.value
+            tooltip.title = 'TFA Sign-offs — ' + label
+            tooltip.rows = [
+              { key: 'Count', value: String(count) },
+              { key: 'Of total', value: String(props.overallTotal) },
+              { key: 'Percentage', value: (idx === 0 ? props.overallPct : (100 - props.overallPct)) + '%' }
+            ]
           }
-          tooltip.title = p.pillarName
-          tooltip.signoffs = p.done + ' / ' + p.total
-          tooltip.pct = p.pct
-          tooltip.failedOpen = p.failedOpen
-          tooltip.riskLabel = RISK_LABELS[p.riskLevel] || 'Unknown'
-          tooltip.riskColor = RISK_COLORS[p.riskLevel] || ''
+
           tooltip.x = model.caretX
           tooltip.y = model.caretY
           tooltip.visible = true
@@ -168,14 +170,16 @@ var chartOptions = computed(function () {
       }
     },
     onClick: function (event, elements) {
-      if (elements && elements.length > 0) {
-        var idx = elements[0].index
+      if (!elements || !elements.length) return
+      var el = elements[0]
+      var dsIdx = el.datasetIndex
+      var idx = el.index
+
+      if (dsIdx === 0) {
         var pillarName = props.pillarData[idx] ? props.pillarData[idx].pillarName : null
-        if (pillarName === props.selectedPillar) {
-          emit('select-pillar', null)
-        } else {
-          emit('select-pillar', pillarName)
-        }
+        if (pillarName) emit('select-pillar', pillarName)
+      } else {
+        emit('select-status', idx === 0 ? 'done' : 'remaining')
       }
     }
   }

--- a/modules/releases/client/deliver/components/TfaRiskChart.vue
+++ b/modules/releases/client/deliver/components/TfaRiskChart.vue
@@ -1,0 +1,183 @@
+<template>
+  <div class="relative" style="height: 240px;">
+    <Doughnut v-if="hasData" :data="chartData" :options="chartOptions" ref="chartRef" />
+    <div v-if="hasData" class="absolute inset-0 flex items-center justify-center pointer-events-none" style="z-index: 1;">
+      <div class="text-center bg-white dark:bg-gray-800 rounded-full px-4 py-2 shadow-sm">
+        <p class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ overallPct }}%</p>
+        <p class="text-xs text-gray-500 dark:text-gray-400">TFA Complete</p>
+      </div>
+    </div>
+    <!-- External HTML tooltip -->
+    <div v-if="tooltip.visible" class="absolute bg-gray-900 text-white rounded-lg shadow-xl pointer-events-none" style="z-index: 10; min-width: 200px;" :style="tooltipStyle">
+      <div class="px-3 py-2 border-b border-gray-700">
+        <p class="font-bold text-sm">{{ tooltip.title }}</p>
+      </div>
+      <div class="px-3 py-2 space-y-1.5 text-xs">
+        <div class="flex justify-between gap-4">
+          <span class="text-gray-400">Sign-offs</span>
+          <span class="font-medium">{{ tooltip.signoffs }}</span>
+        </div>
+        <div class="flex justify-between gap-4">
+          <span class="text-gray-400">Completion</span>
+          <span class="font-medium">{{ tooltip.pct }}%</span>
+        </div>
+        <div class="flex justify-between gap-4">
+          <span class="text-gray-400">Failed open</span>
+          <span class="font-medium" :class="tooltip.failedOpen > 0 ? 'text-red-400' : ''">{{ tooltip.failedOpen }}</span>
+        </div>
+        <div class="flex justify-between gap-4">
+          <span class="text-gray-400">Risk</span>
+          <span class="font-medium" :class="tooltip.riskColor">{{ tooltip.riskLabel }}</span>
+        </div>
+      </div>
+      <div class="px-3 py-1.5 border-t border-gray-700 text-center text-gray-500 text-xs">Click to expand</div>
+    </div>
+    <div v-if="!hasData" class="flex items-center justify-center h-full">
+      <p class="text-sm text-gray-400 dark:text-gray-500">No TFA data</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, reactive } from 'vue'
+import { Doughnut } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip
+} from 'chart.js'
+
+ChartJS.register(ArcElement, Tooltip)
+
+var PILLAR_PALETTE = [
+  { bg: 'rgba(59, 130, 246, 0.75)', border: 'rgb(59, 130, 246)' },
+  { bg: 'rgba(139, 92, 246, 0.75)', border: 'rgb(139, 92, 246)' },
+  { bg: 'rgba(20, 184, 166, 0.75)', border: 'rgb(20, 184, 166)' },
+  { bg: 'rgba(245, 158, 11, 0.75)', border: 'rgb(245, 158, 11)' },
+  { bg: 'rgba(236, 72, 153, 0.75)', border: 'rgb(236, 72, 153)' },
+  { bg: 'rgba(16, 185, 129, 0.75)', border: 'rgb(16, 185, 129)' },
+  { bg: 'rgba(239, 68, 68, 0.75)', border: 'rgb(239, 68, 68)' },
+  { bg: 'rgba(107, 114, 128, 0.75)', border: 'rgb(107, 114, 128)' }
+]
+
+var RISK_LABELS = {
+  green: 'On Track',
+  yellow: 'At Risk',
+  red: 'Likely Blocker'
+}
+
+var RISK_COLORS = {
+  green: 'text-emerald-400',
+  yellow: 'text-amber-400',
+  red: 'text-red-400'
+}
+
+var props = defineProps({
+  pillarData: { type: Array, required: true },
+  overallPct: { type: Number, required: true },
+  selectedPillar: { type: String, default: null },
+  thresholds: { type: Object, default: function () { return { green: 80, yellow: 50 } } }
+})
+
+var emit = defineEmits(['select-pillar'])
+
+var chartRef = ref(null)
+var tooltip = reactive({
+  visible: false, title: '', signoffs: '', pct: 0,
+  failedOpen: 0, riskLabel: '', riskColor: '', x: 0, y: 0
+})
+
+var tooltipStyle = computed(function () {
+  return {
+    left: tooltip.x + 'px',
+    top: Math.max(0, tooltip.y - 12) + 'px',
+    transform: 'translate(-50%, -100%)'
+  }
+})
+
+var hasData = computed(function () {
+  return props.pillarData && props.pillarData.length > 0
+})
+
+var chartData = computed(function () {
+  var labels = []
+  var data = []
+  var bgColors = []
+  var borderColors = []
+  var hoverBgColors = []
+
+  for (var i = 0; i < props.pillarData.length; i++) {
+    var p = props.pillarData[i]
+    labels.push(p.pillarName)
+    data.push(p.total || 1)
+    var palette = PILLAR_PALETTE[i % PILLAR_PALETTE.length]
+    var isSelected = props.selectedPillar === p.pillarName
+    bgColors.push(isSelected ? palette.border : palette.bg)
+    borderColors.push(palette.border)
+    hoverBgColors.push(palette.border)
+  }
+
+  return {
+    labels: labels,
+    datasets: [{
+      data: data,
+      backgroundColor: bgColors,
+      borderColor: borderColors,
+      hoverBackgroundColor: hoverBgColors,
+      borderWidth: 2,
+      hoverOffset: 8
+    }]
+  }
+})
+
+var chartOptions = computed(function () {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    cutout: '65%',
+    onHover: function (event, elements) {
+      var canvas = event.native && event.native.target
+      if (canvas) canvas.style.cursor = elements.length > 0 ? 'pointer' : 'default'
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        enabled: false,
+        external: function (context) {
+          var model = context.tooltip
+          if (model.opacity === 0) {
+            tooltip.visible = false
+            return
+          }
+          var idx = model.dataPoints && model.dataPoints[0] ? model.dataPoints[0].dataIndex : -1
+          var p = props.pillarData[idx]
+          if (!p) {
+            tooltip.visible = false
+            return
+          }
+          tooltip.title = p.pillarName
+          tooltip.signoffs = p.done + ' / ' + p.total
+          tooltip.pct = p.pct
+          tooltip.failedOpen = p.failedOpen
+          tooltip.riskLabel = RISK_LABELS[p.riskLevel] || 'Unknown'
+          tooltip.riskColor = RISK_COLORS[p.riskLevel] || ''
+          tooltip.x = model.caretX
+          tooltip.y = model.caretY
+          tooltip.visible = true
+        }
+      }
+    },
+    onClick: function (event, elements) {
+      if (elements && elements.length > 0) {
+        var idx = elements[0].index
+        var pillarName = props.pillarData[idx] ? props.pillarData[idx].pillarName : null
+        if (pillarName === props.selectedPillar) {
+          emit('select-pillar', null)
+        } else {
+          emit('select-pillar', pillarName)
+        }
+      }
+    }
+  }
+})
+</script>

--- a/modules/releases/client/deliver/components/TfaRiskSection.vue
+++ b/modules/releases/client/deliver/components/TfaRiskSection.vue
@@ -1,0 +1,362 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 mb-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-1">
+      <div>
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Test Sign-Off Risk Assessment</h3>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Grouped by product pillar. Click a segment or row to view component details.</p>
+      </div>
+      <div v-if="overallStats.signoffTotal > 0" class="flex items-center gap-2">
+        <span class="text-xs text-gray-400 dark:text-gray-500">
+          {{ overallStats.signoffDone }}/{{ overallStats.signoffTotal }} sign-offs
+        </span>
+        <span v-if="overallStats.failedOpen > 0" class="text-xs text-red-500 dark:text-red-400 font-medium">
+          {{ overallStats.failedOpen }} failed open
+        </span>
+      </div>
+    </div>
+
+    <!-- Threshold config tile -->
+    <div class="mb-4 mt-2 px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900/50 border border-gray-100 dark:border-gray-700">
+      <div class="flex items-center gap-4 flex-wrap">
+        <span class="relative group flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 cursor-help">
+          Risk Thresholds
+          <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke-width="2"/><path stroke-width="2" stroke-linecap="round" d="M12 16v-4m0-4h.01"/></svg>
+          <span class="hidden group-hover:block absolute left-0 top-full mt-1 w-64 p-2 rounded-md bg-gray-900 text-white text-xs z-20 shadow-lg leading-relaxed">
+            Pillars with TFA completion below the Blocker value are flagged as likely release blockers. Those at or above On Track are considered safe. The gap between the two is the At Risk warning zone. On Track must be strictly greater than Blocker.
+          </span>
+        </span>
+        <div class="flex items-center gap-1">
+          <span class="w-2 h-2 rounded-full bg-red-500 flex-shrink-0"></span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">Blocker &lt;</span>
+          <input
+            v-model.number="inputBlocker"
+            type="number" min="0" max="100" step="5"
+            class="w-12 px-1.5 py-0.5 text-xs text-center rounded border bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1"
+            :class="thresholdError ? 'border-red-300 dark:border-red-600 focus:border-red-400 focus:ring-red-300' : 'border-gray-300 dark:border-gray-600 focus:border-blue-400 focus:ring-blue-300'"
+            @keydown.enter="applyThresholds"
+          />
+          <span class="text-xs text-gray-500 dark:text-gray-400">%</span>
+        </div>
+        <div class="flex items-center gap-1">
+          <span class="w-2 h-2 rounded-full bg-emerald-500 flex-shrink-0"></span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">On Track &ge;</span>
+          <input
+            v-model.number="inputOnTrack"
+            type="number" min="0" max="100" step="5"
+            class="w-12 px-1.5 py-0.5 text-xs text-center rounded border bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1"
+            :class="thresholdError ? 'border-red-300 dark:border-red-600 focus:border-red-400 focus:ring-red-300' : 'border-gray-300 dark:border-gray-600 focus:border-blue-400 focus:ring-blue-300'"
+            @keydown.enter="applyThresholds"
+          />
+          <span class="text-xs text-gray-500 dark:text-gray-400">%</span>
+        </div>
+        <div class="flex items-center gap-1">
+          <span class="w-2 h-2 rounded-full bg-amber-500 flex-shrink-0"></span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">At Risk</span>
+          <span class="text-xs font-medium text-amber-600 dark:text-amber-400">{{ atRiskRange }}</span>
+        </div>
+        <button
+          @click="applyThresholds"
+          class="px-3 py-1 text-xs font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+        >Apply</button>
+      </div>
+      <p v-if="thresholdError" class="mt-1.5 text-xs text-red-500 dark:text-red-400">{{ thresholdError }}</p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-8">
+      <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="py-4">
+      <p class="text-xs text-red-500 dark:text-red-400">{{ error }}</p>
+    </div>
+
+    <!-- No data -->
+    <div v-else-if="!pillarRiskData.length" class="py-4 text-center">
+      <p class="text-xs text-gray-400 dark:text-gray-500">No TFA sign-off data available for this version.</p>
+    </div>
+
+    <!-- Content -->
+    <template v-else>
+      <div class="grid grid-cols-1 lg:grid-cols-5 gap-4">
+        <!-- Chart (left, col-span-2) -->
+        <div class="lg:col-span-2">
+          <TfaRiskChart
+            :pillar-data="pillarRiskData"
+            :overall-pct="overallStats.signoffPct"
+            :selected-pillar="lastClickedPillar"
+            :thresholds="{ green: effectiveGreenThreshold, yellow: effectiveRedThreshold }"
+            @select-pillar="handleChartClick"
+          />
+        </div>
+
+        <!-- Pillar summary table (right, col-span-3) -->
+        <div class="lg:col-span-3 overflow-y-auto" style="max-height: 240px;">
+          <div class="space-y-1">
+            <div v-for="(pillar, idx) in pillarRiskData" :key="pillar.pillarName">
+              <!-- Pillar row -->
+              <button
+                @click="togglePillar(pillar.pillarName)"
+                class="w-full flex items-center gap-3 rounded-md px-3 py-2 text-left transition-colors group cursor-pointer"
+                :class="isExpanded(pillar.pillarName)
+                  ? 'bg-blue-50 dark:bg-blue-900/20'
+                  : 'hover:bg-gray-50 dark:hover:bg-gray-750'"
+              >
+                <!-- Risk badge -->
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap"
+                  :class="riskBadgeClass(pillar.riskLevel)"
+                >{{ riskLabel(pillar.riskLevel) }}</span>
+
+                <!-- Color dot -->
+                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ backgroundColor: pillarColor(idx) }"></span>
+
+                <!-- Pillar name -->
+                <span class="text-sm font-medium text-gray-800 dark:text-gray-200 min-w-0 truncate">{{ pillar.pillarName }}</span>
+
+                <!-- Progress bar -->
+                <div class="flex-1 min-w-0">
+                  <div class="h-1.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                    <div
+                      class="h-full rounded-full transition-all"
+                      :class="riskBarClass(pillar.riskLevel)"
+                      :style="{ width: pillar.pct + '%' }"
+                    ></div>
+                  </div>
+                </div>
+
+                <!-- Stats -->
+                <span class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap tabular-nums">
+                  {{ pillar.done }}/{{ pillar.total }} ({{ pillar.pct }}%)
+                </span>
+                <span v-if="pillar.failedOpen > 0" class="text-xs text-red-500 dark:text-red-400 font-medium whitespace-nowrap">
+                  {{ pillar.failedOpen }} failed
+                </span>
+
+                <!-- Expand indicator -->
+                <span class="flex items-center gap-1 text-xs transition-colors flex-shrink-0" :class="isExpanded(pillar.pillarName) ? 'text-blue-500 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'">
+                  <span>{{ pillar.componentCount }}</span>
+                  <span>{{ isExpanded(pillar.pillarName) ? '▾' : '▸' }}</span>
+                </span>
+              </button>
+
+              <!-- Expanded component sub-list -->
+              <div v-if="isExpanded(pillar.pillarName)" class="ml-4 pl-3 border-l-2 border-blue-200 dark:border-blue-800 space-y-1 pb-1">
+                <div
+                  v-for="comp in pillar.components"
+                  :key="comp.name"
+                  class="flex items-center gap-2 px-2 py-1.5 rounded text-xs"
+                >
+                  <a v-if="comp.signoffJqlUrl" :href="comp.signoffJqlUrl" target="_blank" rel="noopener"
+                    class="text-blue-600 dark:text-blue-400 font-medium hover:underline min-w-0 truncate" style="max-width: 160px;">
+                    {{ comp.name }}
+                  </a>
+                  <span v-else class="text-gray-700 dark:text-gray-300 font-medium min-w-0 truncate" style="max-width: 160px;">{{ comp.name }}</span>
+                  <span :class="riskTextClass(comp.riskLevel)" class="whitespace-nowrap tabular-nums">
+                    {{ comp.signoffs.done }}/{{ comp.signoffs.total }}
+                  </span>
+                  <span v-if="uniqueAssignees(comp).length" class="text-gray-400 dark:text-gray-500 truncate" style="max-width: 140px;">
+                    {{ uniqueAssignees(comp).join(', ') }}
+                  </span>
+                  <a v-if="comp.failedOpen > 0 && comp.failedJqlUrl" :href="comp.failedJqlUrl" target="_blank" rel="noopener"
+                    class="ml-auto text-red-500 dark:text-red-400 font-medium whitespace-nowrap hover:underline">
+                    {{ comp.failedOpen }} failed
+                  </a>
+                  <span v-else-if="comp.failedOpen > 0" class="ml-auto text-red-500 dark:text-red-400 font-medium whitespace-nowrap">
+                    {{ comp.failedOpen }} failed
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Risk verdict banner -->
+      <button
+        v-if="pillarsAtRisk > 0"
+        @click="expandAtRiskPillars"
+        class="mt-3 w-full px-3 py-2 rounded-md text-xs font-medium text-left cursor-pointer transition-opacity hover:opacity-80"
+        :class="verdictClass"
+      >{{ verdictText }}</button>
+      <div
+        v-else-if="pillarRiskData.length"
+        class="mt-3 px-3 py-2 rounded-md text-xs font-medium"
+        :class="verdictClass"
+      >{{ verdictText }}</div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, toRef } from 'vue'
+import TfaRiskChart from './TfaRiskChart.vue'
+import { useTfaRiskAssessment } from '../composables/useTfaRiskAssessment.js'
+
+var PILLAR_COLORS = [
+  'rgb(59, 130, 246)', 'rgb(139, 92, 246)', 'rgb(20, 184, 166)',
+  'rgb(245, 158, 11)', 'rgb(236, 72, 153)', 'rgb(16, 185, 129)',
+  'rgb(239, 68, 68)', 'rgb(107, 114, 128)'
+]
+
+var props = defineProps({
+  version: { type: String, required: true }
+})
+
+var inputBlocker = ref(50)
+var inputOnTrack = ref(80)
+var appliedBlocker = ref(50)
+var appliedOnTrack = ref(80)
+var thresholdError = ref('')
+
+function validateThresholds() {
+  var b = parseInt(inputBlocker.value, 10)
+  var g = parseInt(inputOnTrack.value, 10)
+  if (isNaN(b) || isNaN(g)) return 'Values must be numbers 0–100'
+  if (b < 0 || b > 100 || g < 0 || g > 100) return 'Values must be between 0 and 100'
+  if (g < b) return 'On Track must be greater than or equal to Blocker'
+  if (g === b) return 'On Track must be greater than Blocker to have an At Risk zone'
+  return ''
+}
+
+function applyThresholds() {
+  var err = validateThresholds()
+  thresholdError.value = err
+  if (err) return
+  appliedBlocker.value = parseInt(inputBlocker.value, 10)
+  appliedOnTrack.value = parseInt(inputOnTrack.value, 10)
+}
+
+var atRiskRange = computed(function () {
+  return appliedBlocker.value + '–' + (appliedOnTrack.value - 1) + '%'
+})
+
+var thresholdsRef = computed(function () {
+  return { green: appliedOnTrack.value, yellow: appliedBlocker.value }
+})
+
+var {
+  pillarRiskData,
+  overallStats,
+  pillarsAtRisk,
+  expandedPillars,
+  loading,
+  error
+} = useTfaRiskAssessment(toRef(props, 'version'), thresholdsRef)
+
+var lastClickedPillar = ref(null)
+
+function isExpanded(name) {
+  return !!expandedPillars.value[name]
+}
+
+function togglePillar(name) {
+  var copy = Object.assign({}, expandedPillars.value)
+  if (copy[name]) {
+    delete copy[name]
+    lastClickedPillar.value = null
+  } else {
+    copy[name] = true
+    lastClickedPillar.value = name
+  }
+  expandedPillars.value = copy
+}
+
+function handleChartClick(name) {
+  if (name) {
+    togglePillar(name)
+  } else {
+    lastClickedPillar.value = null
+  }
+}
+
+function expandAtRiskPillars() {
+  var copy = Object.assign({}, expandedPillars.value)
+  var data = pillarRiskData.value
+  for (var i = 0; i < data.length; i++) {
+    if (data[i].riskLevel === 'red' || data[i].riskLevel === 'yellow') {
+      copy[data[i].pillarName] = true
+    }
+  }
+  expandedPillars.value = copy
+}
+
+function pillarColor(idx) {
+  return PILLAR_COLORS[idx % PILLAR_COLORS.length]
+}
+
+function uniqueAssignees(comp) {
+  var seen = {}
+  var result = []
+  var issues = comp.issues || []
+  for (var i = 0; i < issues.length; i++) {
+    var a = issues[i].assignee
+    if (a && !seen[a]) {
+      seen[a] = true
+      result.push(a)
+    }
+  }
+  return result
+}
+
+function riskBadgeClass(level) {
+  if (level === 'red') return 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+  if (level === 'yellow') return 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+  return 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+}
+
+function riskBarClass(level) {
+  if (level === 'red') return 'bg-red-500'
+  if (level === 'yellow') return 'bg-amber-500'
+  return 'bg-emerald-500'
+}
+
+function riskTextClass(level) {
+  if (level === 'red') return 'text-red-600 dark:text-red-400 font-medium'
+  if (level === 'yellow') return 'text-amber-600 dark:text-amber-400 font-medium'
+  return 'text-emerald-600 dark:text-emerald-400'
+}
+
+function riskLabel(level) {
+  if (level === 'red') return 'Likely Blocker'
+  if (level === 'yellow') return 'At Risk'
+  return 'On Track'
+}
+
+var hasRedPillars = computed(function () {
+  return pillarRiskData.value.some(function (p) { return p.riskLevel === 'red' })
+})
+
+var verdictClass = computed(function () {
+  if (hasRedPillars.value) {
+    return 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800'
+  }
+  if (pillarsAtRisk.value > 0) {
+    return 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800'
+  }
+  return 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800'
+})
+
+var verdictText = computed(function () {
+  var redCount = 0
+  var yellowCount = 0
+  var names = []
+  for (var i = 0; i < pillarRiskData.value.length; i++) {
+    var p = pillarRiskData.value[i]
+    if (p.riskLevel === 'red') { redCount++; names.push(p.pillarName) }
+    else if (p.riskLevel === 'yellow') { yellowCount++; names.push(p.pillarName) }
+  }
+  var total = redCount + yellowCount
+  if (total > 0) {
+    var summary = names.join(', ')
+    if (redCount > 0 && yellowCount > 0) {
+      return total + ' pillar(s) at risk: ' + summary + ' — click to expand all'
+    }
+    if (redCount > 0) return total + ' pillar(s) likely to block release: ' + summary + ' — click to expand'
+    return total + ' pillar(s) at risk: ' + summary + ' — click to expand'
+  }
+  return 'All pillars on track for release'
+})
+</script>

--- a/modules/releases/client/deliver/components/TfaRiskSection.vue
+++ b/modules/releases/client/deliver/components/TfaRiskSection.vue
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between mb-1">
       <div>
         <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Test Sign-Off Risk Assessment</h3>
-        <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Grouped by product pillar. Click a segment or row to view component details.</p>
+        <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Click any segment or row to expand details.</p>
       </div>
       <div v-if="overallStats.signoffTotal > 0" class="flex items-center gap-2">
         <span class="text-xs text-gray-400 dark:text-gray-500">
@@ -81,21 +81,33 @@
     <!-- Content -->
     <template v-else>
       <div class="grid grid-cols-1 lg:grid-cols-5 gap-4">
-        <!-- Chart (left, col-span-2) -->
-        <div class="lg:col-span-2">
+        <!-- Charts (left, col-span-2) -->
+        <div class="lg:col-span-2 space-y-3">
+          <p class="text-xs font-medium text-gray-500 dark:text-gray-400 px-1">TFA Completion by Pillar</p>
+          <p class="text-xs text-gray-400 dark:text-gray-500 px-1">Grouped by product pillar. Outer ring = pillars, inner ring = done vs remaining.</p>
           <TfaRiskChart
             :pillar-data="pillarRiskData"
             :overall-pct="overallStats.signoffPct"
+            :overall-done="overallStats.signoffDone"
+            :overall-total="overallStats.signoffTotal"
             :selected-pillar="lastClickedPillar"
-            :thresholds="{ green: effectiveGreenThreshold, yellow: effectiveRedThreshold }"
             @select-pillar="handleChartClick"
+            @select-status="handleStatusClick"
           />
+          <div>
+            <p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">Sign-offs vs Failed Tests</p>
+            <TfaOutcomeChart
+              :signoff-done="overallStats.signoffDone"
+              :failed-open="overallStats.failedOpen"
+              @select-outcome="handleOutcomeClick"
+            />
+          </div>
         </div>
 
         <!-- Pillar summary table (right, col-span-3) -->
-        <div class="lg:col-span-3 overflow-y-auto" style="max-height: 240px;">
+        <div class="lg:col-span-3 overflow-y-auto scrollable-table" style="max-height: 520px;">
           <div class="space-y-1">
-            <div v-for="(pillar, idx) in pillarRiskData" :key="pillar.pillarName">
+            <div v-for="pillar in pillarRiskData" :key="pillar.pillarName">
               <!-- Pillar row -->
               <button
                 @click="togglePillar(pillar.pillarName)"
@@ -110,14 +122,14 @@
                   :class="riskBadgeClass(pillar.riskLevel)"
                 >{{ riskLabel(pillar.riskLevel) }}</span>
 
-                <!-- Color dot -->
-                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ backgroundColor: pillarColor(idx) }"></span>
+                <!-- Color dot (matches chart segment) -->
+                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ backgroundColor: pillarColorBorder(pillar.pillarName) }"></span>
 
                 <!-- Pillar name -->
-                <span class="text-sm font-medium text-gray-800 dark:text-gray-200 min-w-0 truncate">{{ pillar.pillarName }}</span>
+                <span class="text-sm font-medium text-gray-800 dark:text-gray-200 truncate" style="width: 130px; flex-shrink: 0;">{{ pillar.pillarName }}</span>
 
                 <!-- Progress bar -->
-                <div class="flex-1 min-w-0">
+                <div class="flex-1 min-w-0" style="min-width: 80px;">
                   <div class="h-1.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
                     <div
                       class="h-full rounded-full transition-all"
@@ -193,13 +205,9 @@
 <script setup>
 import { computed, ref, toRef } from 'vue'
 import TfaRiskChart from './TfaRiskChart.vue'
+import TfaOutcomeChart from './TfaOutcomeChart.vue'
 import { useTfaRiskAssessment } from '../composables/useTfaRiskAssessment.js'
-
-var PILLAR_COLORS = [
-  'rgb(59, 130, 246)', 'rgb(139, 92, 246)', 'rgb(20, 184, 166)',
-  'rgb(245, 158, 11)', 'rgb(236, 72, 153)', 'rgb(16, 185, 129)',
-  'rgb(239, 68, 68)', 'rgb(107, 114, 128)'
-]
+import { getPillarColor } from '../composables/pillarColors.js'
 
 var props = defineProps({
   version: { type: String, required: true }
@@ -265,26 +273,49 @@ function togglePillar(name) {
 }
 
 function handleChartClick(name) {
-  if (name) {
-    togglePillar(name)
-  } else {
-    lastClickedPillar.value = null
-  }
+  togglePillar(name)
 }
 
-function expandAtRiskPillars() {
-  var copy = Object.assign({}, expandedPillars.value)
+function toggleGroup(matchFn) {
   var data = pillarRiskData.value
+  var targets = []
   for (var i = 0; i < data.length; i++) {
-    if (data[i].riskLevel === 'red' || data[i].riskLevel === 'yellow') {
-      copy[data[i].pillarName] = true
+    if (matchFn(data[i])) targets.push(data[i].pillarName)
+  }
+  var allOpen = targets.every(function (n) { return expandedPillars.value[n] })
+  var copy = Object.assign({}, expandedPillars.value)
+  for (var j = 0; j < targets.length; j++) {
+    if (allOpen) {
+      delete copy[targets[j]]
+    } else {
+      copy[targets[j]] = true
     }
   }
   expandedPillars.value = copy
 }
 
-function pillarColor(idx) {
-  return PILLAR_COLORS[idx % PILLAR_COLORS.length]
+function handleStatusClick(status) {
+  toggleGroup(function (p) {
+    if (status === 'done') return p.done > 0 && p.done === p.total
+    return p.total > p.done || p.failedOpen > 0
+  })
+}
+
+function handleOutcomeClick(outcome) {
+  toggleGroup(function (p) {
+    if (outcome === 'done') return p.done > 0
+    return p.failedOpen > 0
+  })
+}
+
+function expandAtRiskPillars() {
+  toggleGroup(function (p) {
+    return p.riskLevel === 'red' || p.riskLevel === 'yellow'
+  })
+}
+
+function pillarColorBorder(name) {
+  return getPillarColor(name).border
 }
 
 function uniqueAssignees(comp) {
@@ -360,3 +391,22 @@ var verdictText = computed(function () {
   return 'All pillars on track for release'
 })
 </script>
+
+<style scoped>
+.scrollable-table {
+  scrollbar-width: thin;
+}
+.scrollable-table::-webkit-scrollbar {
+  width: 6px;
+}
+.scrollable-table::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollable-table::-webkit-scrollbar-thumb {
+  background-color: rgba(156, 163, 175, 0.4);
+  border-radius: 3px;
+}
+.scrollable-table::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(156, 163, 175, 0.6);
+}
+</style>

--- a/modules/releases/client/deliver/composables/pillarColors.js
+++ b/modules/releases/client/deliver/composables/pillarColors.js
@@ -1,0 +1,29 @@
+var PILLAR_COLOR_MAP = {
+  'agents': { bg: 'rgba(59, 130, 246, 0.75)', border: 'rgb(59, 130, 246)' },
+  'data': { bg: 'rgba(168, 85, 247, 0.75)', border: 'rgb(168, 85, 247)' },
+  'inference': { bg: 'rgba(251, 146, 60, 0.75)', border: 'rgb(251, 146, 60)' },
+  'platform': { bg: 'rgba(244, 114, 182, 0.75)', border: 'rgb(244, 114, 182)' },
+  'other components': { bg: 'rgba(100, 116, 139, 0.75)', border: 'rgb(100, 116, 139)' }
+}
+
+var FALLBACK_COLORS = [
+  { bg: 'rgba(59, 130, 246, 0.75)', border: 'rgb(59, 130, 246)' },
+  { bg: 'rgba(139, 92, 246, 0.75)', border: 'rgb(139, 92, 246)' },
+  { bg: 'rgba(14, 165, 233, 0.75)', border: 'rgb(14, 165, 233)' },
+  { bg: 'rgba(234, 179, 8, 0.75)', border: 'rgb(234, 179, 8)' },
+  { bg: 'rgba(56, 189, 248, 0.75)', border: 'rgb(56, 189, 248)' },
+  { bg: 'rgba(236, 72, 153, 0.75)', border: 'rgb(236, 72, 153)' }
+]
+
+var dynamicAssignments = {}
+var nextFallback = 0
+
+export function getPillarColor(name) {
+  var key = String(name || '').toLowerCase()
+  if (PILLAR_COLOR_MAP[key]) return PILLAR_COLOR_MAP[key]
+  if (dynamicAssignments[key]) return dynamicAssignments[key]
+  var color = FALLBACK_COLORS[nextFallback % FALLBACK_COLORS.length]
+  nextFallback++
+  dynamicAssignments[key] = color
+  return color
+}

--- a/modules/releases/client/deliver/composables/useTfaRiskAssessment.js
+++ b/modules/releases/client/deliver/composables/useTfaRiskAssessment.js
@@ -1,0 +1,178 @@
+import { ref, computed, watch } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+var OTHER_PILLAR = 'Other Components'
+
+function normalizeComponentName(name) {
+  return String(name || '').toLowerCase().replace(/[-_\s]+/g, '')
+}
+
+function computeRiskLevel(pct, total, failedOpen, thresholds) {
+  var redBelow = (thresholds && thresholds.yellow) || 50
+  var greenAt = (thresholds && thresholds.green) || 80
+  if (total === 0 && failedOpen > 0) return 'red'
+  if (total === 0) return 'green'
+  if (pct < redBelow) return 'red'
+  if (pct < greenAt) return 'yellow'
+  return 'green'
+}
+
+function matchComponentToPillar(componentName, pillarMap) {
+  var lower = normalizeComponentName(componentName)
+  if (!lower) return null
+  if (pillarMap[lower]) return pillarMap[lower]
+  var keys = Object.keys(pillarMap)
+  for (var i = 0; i < keys.length; i++) {
+    if (lower.includes(keys[i]) || keys[i].includes(lower)) return pillarMap[keys[i]]
+  }
+  return null
+}
+
+function resolvePillarName(raw) {
+  if (!raw || raw === 'Undefined' || raw === 'Unassigned') return OTHER_PILLAR
+  return raw
+}
+
+export function useTfaRiskAssessment(versionRef, thresholdsRef) {
+  var tfaData = ref(null)
+  var pillarConfig = ref({ pillars: [] })
+  var loading = ref(false)
+  var error = ref(null)
+  var expandedPillars = ref({})
+
+  var pillarRiskData = computed(function () {
+    if (!tfaData.value || !tfaData.value.components || !tfaData.value.components.length) return []
+
+    var pillarMap = {}
+    var pillars = (pillarConfig.value && pillarConfig.value.pillars) || []
+    for (var pi = 0; pi < pillars.length; pi++) {
+      var mappedName = resolvePillarName(pillars[pi].name)
+      var comps = pillars[pi].components || []
+      for (var ci = 0; ci < comps.length; ci++) {
+        var c = comps[ci]
+        var name = typeof c === 'object' && c !== null ? c.name : c
+        if (name) {
+          pillarMap[normalizeComponentName(name)] = mappedName
+        }
+      }
+    }
+
+    var pillarAgg = {}
+    var components = tfaData.value.components
+
+    for (var i = 0; i < components.length; i++) {
+      var comp = components[i]
+      var rawPillar = comp.name === '(No component)'
+        ? null
+        : matchComponentToPillar(comp.name, pillarMap)
+      var pillarName = resolvePillarName(rawPillar)
+
+      if (!pillarAgg[pillarName]) {
+        pillarAgg[pillarName] = {
+          pillarName: pillarName,
+          done: 0,
+          total: 0,
+          pct: 0,
+          failedOpen: 0,
+          riskLevel: 'green',
+          componentCount: 0,
+          components: []
+        }
+      }
+
+      var p = pillarAgg[pillarName]
+      p.done += comp.signoffs.done
+      p.total += comp.signoffs.total
+      p.failedOpen += comp.failedOpen
+      p.componentCount++
+      p.components.push(comp)
+    }
+
+    var result = []
+    var names = Object.keys(pillarAgg)
+    for (var j = 0; j < names.length; j++) {
+      var pillar = pillarAgg[names[j]]
+      pillar.pct = pillar.total > 0 ? Math.round((pillar.done / pillar.total) * 100) : 0
+      var t = thresholdsRef ? thresholdsRef.value : null
+      pillar.riskLevel = computeRiskLevel(pillar.pct, pillar.total, pillar.failedOpen, t)
+      result.push(pillar)
+    }
+
+    result.sort(function (a, b) {
+      if (a.pillarName === OTHER_PILLAR) return 1
+      if (b.pillarName === OTHER_PILLAR) return -1
+      var riskOrder = { red: 0, yellow: 1, green: 2 }
+      var diff = (riskOrder[a.riskLevel] || 2) - (riskOrder[b.riskLevel] || 2)
+      if (diff !== 0) return diff
+      return a.pillarName.localeCompare(b.pillarName)
+    })
+
+    return result
+  })
+
+  var overallStats = computed(function () {
+    if (!tfaData.value || !tfaData.value.overall) {
+      return { signoffDone: 0, signoffTotal: 0, signoffPct: 0, failedOpen: 0, riskLevel: 'green' }
+    }
+    var o = tfaData.value.overall
+    return {
+      signoffDone: o.signoffDone,
+      signoffTotal: o.signoffTotal,
+      signoffPct: o.signoffPct,
+      failedOpen: o.failedOpen,
+      riskLevel: computeRiskLevel(o.signoffPct, o.signoffTotal, o.failedOpen, thresholdsRef ? thresholdsRef.value : null)
+    }
+  })
+
+  var pillarsAtRisk = computed(function () {
+    var count = 0
+    var data = pillarRiskData.value
+    for (var i = 0; i < data.length; i++) {
+      if (data[i].riskLevel === 'red' || data[i].riskLevel === 'yellow') count++
+    }
+    return count
+  })
+
+  async function fetchData(version) {
+    if (!version) {
+      tfaData.value = null
+      return
+    }
+    loading.value = true
+    error.value = null
+    expandedPillars.value = {}
+    try {
+      var results = await Promise.all([
+        apiRequest('/modules/releases/delivery/tfa-risk/' + encodeURIComponent(version)),
+        apiRequest('/modules/releases/pm-hub/pillar-config')
+      ])
+      tfaData.value = results[0]
+      if (results[1] && Array.isArray(results[1].pillars)) {
+        pillarConfig.value = results[1]
+      }
+    } catch (err) {
+      if (err && err.status === 404) {
+        error.value = null
+        tfaData.value = null
+      } else {
+        error.value = (err && err.message) || 'Failed to load TFA risk data'
+        tfaData.value = null
+      }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  watch(versionRef, function (v) { fetchData(v) }, { immediate: true })
+
+  return {
+    tfaData: tfaData,
+    pillarRiskData: pillarRiskData,
+    overallStats: overallStats,
+    pillarsAtRisk: pillarsAtRisk,
+    expandedPillars: expandedPillars,
+    loading: loading,
+    error: error,
+    refresh: function () { fetchData(versionRef.value) }
+  }
+}

--- a/modules/releases/client/deliver/views/ReleaseBlockersView.vue
+++ b/modules/releases/client/deliver/views/ReleaseBlockersView.vue
@@ -98,6 +98,9 @@
         </button>
       </div>
 
+      <!-- Test Sign-Off Risk Assessment -->
+      <TfaRiskSection v-if="effectiveReleaseNumber" :version="effectiveReleaseNumber" />
+
       <!-- Timing Breakdown + Aging Metrics row -->
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
         <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
@@ -329,6 +332,7 @@
 <script setup>
 import { ref, computed, inject, watch } from 'vue'
 import { useReleaseBlockers } from '../composables/useReleaseBlockers.js'
+import TfaRiskSection from '../components/TfaRiskSection.vue'
 
 const filter = inject('releaseFilter')
 const moduleNav = inject('moduleNav', null)

--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -7,6 +7,7 @@ const { getRegistryReleasesFlat, readRegistry, writeRegistry, normalizeRelease }
 const registerConformaRoutes = require('./conforma')
 const { registerConformaFetcher } = require('./conforma-fetcher')
 const registerBlockerRoutes = require('./blockers')
+const registerTfaRiskRoutes = require('./tfa-risk')
 const { logAudit } = require('../planning/audit-log')
 const { stripZStream: sharedStripZStream, normalizeVersionName, extractProduct: sharedExtractProduct } = require('../version-utils')
 
@@ -1005,6 +1006,7 @@ module.exports = async function registerRoutes(router, context) {
   registerConformaRoutes(router, context)
   registerConformaFetcher(router, context)
   registerBlockerRoutes(router, context)
+  registerTfaRiskRoutes(router, context)
 
   const { storage, requireAuth, requireAdmin, requireScope } = context
   const { readFromStorage, writeToStorage } = storage

--- a/modules/releases/server/delivery/tfa-risk.js
+++ b/modules/releases/server/delivery/tfa-risk.js
@@ -1,0 +1,286 @@
+'use strict'
+
+var sharedJira = require('../../../../shared/server/jira')
+
+var DEMO_MODE = process.env.DEMO_MODE === 'true'
+
+var TFA_FIELDS = [
+  'summary', 'status', 'components', 'assignee',
+  'labels', 'created', 'updated'
+].join(',')
+
+var CACHE_TTL_MS = 5 * 60 * 1000
+var CACHE_MAX_ENTRIES = 50
+var tfaRiskCache = new Map()
+
+var RELEASE_NUMBER_RE = /^[a-zA-Z0-9._\- ]+$/
+
+function sanitizeForJql(value) {
+  return value.replace(/'/g, "\\'")
+}
+
+function buildVersionClause(safe) {
+  return (
+    "(fixVersion IN ('" + safe + "') " +
+    "OR affectedVersion IN ('" + safe + "') " +
+    "OR cf[10855] IN ('" + safe + "'))"
+  )
+}
+
+function buildTfaSignoffJql(version) {
+  var safe = sanitizeForJql(version)
+  return (
+    'project in (RHAIENG, RHOAIENG) ' +
+    'AND ' + buildVersionClause(safe) + ' ' +
+    'AND summary ~ "TFA Sign-Off" ' +
+    'AND issuetype NOT IN (Epic, Initiative)'
+  )
+}
+
+function buildFailedTestJql(version) {
+  var safe = sanitizeForJql(version)
+  return (
+    'project in (RHAIENG, RHOAIENG) ' +
+    'AND ' + buildVersionClause(safe) + ' ' +
+    'AND labels = "test-failed" ' +
+    'AND status not in (Closed, Resolved) ' +
+    'AND issuetype NOT IN (Epic, Initiative)'
+  )
+}
+
+function statusCategoryKey(status) {
+  var cat = (status && status.statusCategory) || {}
+  var key = String(cat.key || '').toLowerCase()
+  if (key === 'done') return 'done'
+  if (key === 'indeterminate') return 'inProgress'
+  return 'todo'
+}
+
+function computeRiskLevel(pct, total, failedOpen) {
+  if (total === 0 && failedOpen > 0) return 'red'
+  if (total === 0) return 'green'
+  if (pct < 50) return 'red'
+  if (pct < 80) return 'yellow'
+  return 'green'
+}
+
+function buildComponentSignoffJqlUrl(jiraHost, version, componentName) {
+  var safe = sanitizeForJql(version)
+  var safeComp = sanitizeForJql(componentName)
+  var jql = 'project in (RHAIENG, RHOAIENG) AND ' + buildVersionClause(safe) +
+    ' AND summary ~ "TFA Sign-Off" AND component = "' + safeComp + '" AND issuetype NOT IN (Epic, Initiative)'
+  return jiraHost + '/issues/?jql=' + encodeURIComponent(jql)
+}
+
+function buildComponentFailedJqlUrl(jiraHost, version, componentName) {
+  var safe = sanitizeForJql(version)
+  var safeComp = sanitizeForJql(componentName)
+  var jql = 'project in (RHAIENG, RHOAIENG) AND ' + buildVersionClause(safe) +
+    ' AND labels = "test-failed" AND component = "' + safeComp + '" AND status not in (Closed, Resolved) AND issuetype NOT IN (Epic, Initiative)'
+  return jiraHost + '/issues/?jql=' + encodeURIComponent(jql)
+}
+
+function buildTfaRiskResponse(releaseNumber, signoffIssues, failedIssues, jiraHost) {
+  var componentMap = {}
+
+  for (var i = 0; i < signoffIssues.length; i++) {
+    var issue = signoffIssues[i]
+    var components = ((issue.fields && issue.fields.components) || [])
+      .map(function (c) { return (c.name || '').trim() })
+      .filter(Boolean)
+
+    if (components.length === 0) components = ['(No component)']
+
+    var catKey = statusCategoryKey(issue.fields && issue.fields.status)
+    var assigneeObj = issue.fields && issue.fields.assignee
+    var assignee = assigneeObj ? (assigneeObj.displayName || null) : null
+
+    var issueRecord = {
+      key: issue.key,
+      summary: (issue.fields && issue.fields.summary) || '',
+      status: (issue.fields && issue.fields.status && issue.fields.status.name) || 'Unknown',
+      statusCategory: catKey,
+      assignee: assignee,
+      link: jiraHost + '/browse/' + encodeURIComponent(issue.key)
+    }
+
+    for (var ci = 0; ci < components.length; ci++) {
+      var compName = components[ci]
+      if (!componentMap[compName]) {
+        componentMap[compName] = {
+          name: compName,
+          signoffs: { done: 0, inProgress: 0, todo: 0, total: 0, pct: 0 },
+          failedOpen: 0,
+          riskLevel: 'green',
+          issues: [],
+          failedIssues: []
+        }
+      }
+      componentMap[compName].signoffs[catKey]++
+      componentMap[compName].signoffs.total++
+      componentMap[compName].issues.push(issueRecord)
+    }
+  }
+
+  for (var j = 0; j < failedIssues.length; j++) {
+    var fi = failedIssues[j]
+    var fComponents = ((fi.fields && fi.fields.components) || [])
+      .map(function (c) { return (c.name || '').trim() })
+      .filter(Boolean)
+
+    if (fComponents.length === 0) fComponents = ['(No component)']
+
+    var fAssigneeObj = fi.fields && fi.fields.assignee
+    var fAssignee = fAssigneeObj ? (fAssigneeObj.displayName || null) : null
+
+    var failedRecord = {
+      key: fi.key,
+      summary: (fi.fields && fi.fields.summary) || '',
+      status: (fi.fields && fi.fields.status && fi.fields.status.name) || 'Unknown',
+      assignee: fAssignee,
+      link: jiraHost + '/browse/' + encodeURIComponent(fi.key)
+    }
+
+    for (var fci = 0; fci < fComponents.length; fci++) {
+      var fCompName = fComponents[fci]
+      if (!componentMap[fCompName]) {
+        componentMap[fCompName] = {
+          name: fCompName,
+          signoffs: { done: 0, inProgress: 0, todo: 0, total: 0, pct: 0 },
+          failedOpen: 0,
+          riskLevel: 'green',
+          issues: [],
+          failedIssues: []
+        }
+      }
+      componentMap[fCompName].failedOpen++
+      componentMap[fCompName].failedIssues.push(failedRecord)
+    }
+  }
+
+  var overallDone = 0
+  var overallTotal = 0
+  var overallFailedOpen = 0
+  var componentList = []
+
+  var names = Object.keys(componentMap)
+  for (var k = 0; k < names.length; k++) {
+    var comp = componentMap[names[k]]
+    var s = comp.signoffs
+    s.pct = s.total > 0 ? Math.round((s.done / s.total) * 100) : 0
+    comp.riskLevel = computeRiskLevel(s.pct, s.total, comp.failedOpen)
+    if (comp.name !== '(No component)') {
+      comp.signoffJqlUrl = buildComponentSignoffJqlUrl(jiraHost, releaseNumber, comp.name)
+      comp.failedJqlUrl = buildComponentFailedJqlUrl(jiraHost, releaseNumber, comp.name)
+    }
+    overallDone += s.done
+    overallTotal += s.total
+    overallFailedOpen += comp.failedOpen
+    componentList.push(comp)
+  }
+
+  componentList.sort(function (a, b) { return a.name.localeCompare(b.name) })
+
+  var overallPct = overallTotal > 0 ? Math.round((overallDone / overallTotal) * 100) : 0
+
+  return {
+    releaseNumber: releaseNumber,
+    fetchedAt: new Date().toISOString(),
+    overall: {
+      signoffDone: overallDone,
+      signoffTotal: overallTotal,
+      signoffPct: overallPct,
+      failedOpen: overallFailedOpen
+    },
+    components: componentList
+  }
+}
+
+module.exports = async function registerTfaRiskRoutes(router, context) {
+  var storage = context.storage
+  var requireAuth = context.requireAuth
+  var requireScope = context.requireScope
+  var readFromStorage = storage.readFromStorage
+
+  var jiraHost = sharedJira.JIRA_HOST
+  var fetchJql
+  if (context.jira) {
+    jiraHost = context.jira.JIRA_HOST
+    fetchJql = function (jql, fields, opts) {
+      return context.jira.fetchAllJqlResults(jql, fields, opts)
+    }
+  } else {
+    fetchJql = function (jql, fields, opts) {
+      return sharedJira.fetchAllJqlResults(sharedJira.jiraRequest, jql, fields, opts)
+    }
+  }
+
+  /**
+   * @openapi
+   * /api/modules/releases/delivery/tfa-risk/{releaseNumber}:
+   *   get:
+   *     tags: ['Releases: Delivery']
+   *     summary: Get TFA sign-off risk assessment data for a specific release
+   *     description: Queries Jira for TFA sign-off issues and failed test issues, aggregated by component with assignee info
+   *     parameters:
+   *       - in: path
+   *         name: releaseNumber
+   *         required: true
+   *         schema: { type: string }
+   *         description: Release version identifier (e.g., "rhoai-3.5.EA1")
+   *     responses:
+   *       200:
+   *         description: TFA risk assessment data with component breakdowns
+   *       400:
+   *         description: Invalid release number format
+   */
+  router.get('/tfa-risk/:releaseNumber', requireAuth, requireScope('releases:read'), async function (req, res) {
+    var releaseNumber = req.params.releaseNumber
+
+    if (!releaseNumber || !RELEASE_NUMBER_RE.test(releaseNumber)) {
+      return res.status(400).json({ error: 'Invalid release number format' })
+    }
+
+    if (DEMO_MODE) {
+      var fixture = await readFromStorage('releases/delivery/tfa-risk-' + releaseNumber + '.json')
+      if (fixture) return res.json(fixture)
+      return res.json({
+        releaseNumber: releaseNumber,
+        fetchedAt: new Date().toISOString(),
+        overall: { signoffDone: 0, signoffTotal: 0, signoffPct: 0, failedOpen: 0 },
+        components: []
+      })
+    }
+
+    var cached = tfaRiskCache.get(releaseNumber)
+    if (cached && (Date.now() - cached.timestamp) < CACHE_TTL_MS) {
+      return res.json(cached.data)
+    }
+
+    try {
+      var signoffJql = buildTfaSignoffJql(releaseNumber)
+      var failedJql = buildFailedTestJql(releaseNumber)
+
+      var results = await Promise.all([
+        fetchJql(signoffJql, TFA_FIELDS, { maxResults: 100 }),
+        fetchJql(failedJql, TFA_FIELDS, { maxResults: 100 })
+      ])
+
+      var signoffIssues = results[0] || []
+      var failedIssues = results[1] || []
+
+      var response = buildTfaRiskResponse(releaseNumber, signoffIssues, failedIssues, jiraHost)
+
+      tfaRiskCache.set(releaseNumber, { data: response, timestamp: Date.now() })
+      if (tfaRiskCache.size > CACHE_MAX_ENTRIES) {
+        var oldest = tfaRiskCache.keys().next().value
+        tfaRiskCache.delete(oldest)
+      }
+
+      res.json(response)
+    } catch (err) {
+      console.error('[releases/delivery] tfa-risk fetch error:', err)
+      res.status(500).json({ error: 'Failed to fetch TFA risk data: ' + err.message })
+    }
+  })
+}


### PR DESCRIPTION
## Summary
Adds a TFA risk assessment section to the Release Blockers tab that queries Jira live for TFA sign-off and failed test issues, groups them by product pillar, and visualizes risk through interactive concentric doughnut charts with configurable thresholds.

Server endpoint queries Jira for TFA sign-offs and failed tests, aggregated by component with assignee info
Client groups components into pillars via PM Hub pillar config, renders concentric doughnut (pillars + done/remaining) and outcome pie (sign-offs vs failures)
Expandable pillar rows with Jira-linked component details, configurable risk thresholds with validation
