### PR TITLE
feat(product-builds): add cross-entity search

### DIFF
--- a/modules/product-builds/__tests__/client/SearchResultsView.test.js
+++ b/modules/product-builds/__tests__/client/SearchResultsView.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import SearchResultsView from '../../client/views/SearchResultsView.vue'
+import { SEARCH_LIMIT } from '../../client/composables/useSearch'
+
+vi.mock('@shared/client/services/api', () => ({
+  apiRequest: vi.fn(),
+}))
+
+const { apiRequest } = await import('@shared/client/services/api')
+
+const SAMPLE_RESULTS = {
+  query: 'vllm',
+  drops: [
+    { key: 'rhaiis-3.2.3', name: '3.2.3', product_key: 'rhaiis', created_at: '2026-06-07T00:00:00Z' }
+  ],
+  artifacts: {
+    containers: [
+      {
+        key: 'registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.3',
+        commit: 'abc123def456',
+        variant: 'cuda-ubi9',
+        environments: ['production'],
+        product_key: 'rhaiis',
+        created_at: '2026-06-07T00:00:00Z'
+      }
+    ]
+  },
+  total_results: 2,
+  page: 1,
+  page_size: 200,
+  total_pages: 1
+}
+
+function createNav(params = {}) {
+  return {
+    params: ref(params),
+    navigateTo: vi.fn(),
+    updateParams: vi.fn(),
+    goBack: vi.fn()
+  }
+}
+
+function mountView(navParams = {}) {
+  const nav = createNav(navParams)
+  const wrapper = mount(SearchResultsView, {
+    global: { provide: { moduleNav: nav } }
+  })
+  return { wrapper, nav }
+}
+
+describe('SearchResultsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiRequest.mockImplementation((path) => {
+      if (path.includes('/search/filters')) {
+        return Promise.resolve({ artifact_types: ['containers'], environments: ['production'], architectures: ['x86_64'], accelerators: ['cuda'] })
+      }
+      if (path.includes('/search?')) {
+        return Promise.resolve(SAMPLE_RESULTS)
+      }
+      return Promise.resolve({})
+    })
+  })
+
+  it('shows empty state when no query is present', async () => {
+    const { wrapper } = mountView({})
+    await flushPromises()
+    expect(wrapper.text()).toContain('Enter a search query')
+    expect(apiRequest).not.toHaveBeenCalledWith(expect.stringContaining('/search?'))
+  })
+
+  it('reads q param from URL on mount and runs the search', async () => {
+    const { wrapper } = mountView({ q: 'vllm' })
+    await flushPromises()
+
+    const input = wrapper.find('input[type="text"]')
+    expect(input.element.value).toBe('vllm')
+    expect(apiRequest).toHaveBeenCalledWith(expect.stringContaining('q=vllm'))
+    expect(wrapper.text()).toContain('Found 2 results')
+  })
+
+  it('groups results into drops and artifact-type sections', async () => {
+    const { wrapper } = mountView({ q: 'vllm' })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Drops (1)')
+    expect(wrapper.text()).toContain('Containers (1)')
+    expect(wrapper.text()).toContain('rhaiis-3.2.3')
+    expect(wrapper.text()).toContain('registry.redhat.io/rhaiis/vllm-cuda-rhel9:3.2.3')
+  })
+
+  it('re-runs the search when the q param changes externally', async () => {
+    const { wrapper, nav } = mountView({})
+    await flushPromises()
+
+    nav.params.value = { q: 'torch' }
+    await nextTick()
+    await nextTick()
+    await flushPromises()
+
+    const input = wrapper.find('input[type="text"]')
+    expect(input.element.value).toBe('torch')
+    expect(apiRequest).toHaveBeenCalledWith(expect.stringContaining('q=torch'))
+  })
+
+  it('navigates to drop-detail when a drop row is clicked', async () => {
+    const { wrapper, nav } = mountView({ q: 'vllm' })
+    await flushPromises()
+
+    await wrapper.find('tbody tr').trigger('click')
+    expect(nav.navigateTo).toHaveBeenCalledWith('drop-detail', { key: 'rhaiis-3.2.3', product: 'rhaiis' })
+  })
+
+  it('shows a truncation notice when the API caps results, using the actual body count over the unreliable total_results', async () => {
+    const cappedDrops = Array.from({ length: SEARCH_LIMIT }, (_, i) => ({
+      key: `rhaiis-${i}`, name: `${i}`, product_key: 'rhaiis', created_at: '2026-06-07T00:00:00Z'
+    }))
+    apiRequest.mockImplementation((path) => {
+      if (path.includes('/search/filters')) return Promise.resolve({})
+      if (path.includes('/search?')) {
+        return Promise.resolve({ query: 'rhel', drops: cappedDrops, artifacts: {}, total_results: 400 })
+      }
+      return Promise.resolve({})
+    })
+    const { wrapper } = mountView({ q: 'rhel' })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(`Showing the first ${SEARCH_LIMIT} results`)
+    expect(wrapper.text()).not.toContain('Found 400 results')
+    expect(wrapper.text()).not.toContain(`Found ${SEARCH_LIMIT} results`)
+  })
+
+  it('shows a no-results message when the search returns nothing', async () => {
+    apiRequest.mockImplementation((path) => {
+      if (path.includes('/search/filters')) return Promise.resolve({})
+      if (path.includes('/search?')) return Promise.resolve({ query: 'zzz', drops: [], artifacts: {}, total_results: 0 })
+      return Promise.resolve({})
+    })
+    const { wrapper } = mountView({ q: 'zzz' })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No drops or artifacts match')
+  })
+})

--- a/modules/product-builds/__tests__/server/routes.test.js
+++ b/modules/product-builds/__tests__/server/routes.test.js
@@ -76,6 +76,8 @@ describe('product-builds routes', () => {
       expect(paths).toContain('/artifacts/:key')
       expect(paths).toContain('/artifacts/:key/wheels')
       expect(paths).toContain('/artifacts/:key/containers')
+      expect(paths).toContain('/search')
+      expect(paths).toContain('/search/filters')
       expect(paths).toContain('/package-reports')
       expect(paths).toContain('/package-reports/latest')
       expect(paths).toContain('/package-reports/onboarded')

--- a/modules/product-builds/client/components/PersistentSearchBar.vue
+++ b/modules/product-builds/client/components/PersistentSearchBar.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { ref, inject } from 'vue'
+import { Search } from 'lucide-vue-next'
+
+const nav = inject('moduleNav')
+const query = ref('')
+
+function submit() {
+  const q = query.value.trim()
+  if (!q) return
+  nav.navigateTo('search', { q })
+}
+</script>
+
+<template>
+  <div class="relative w-full max-w-sm flex-shrink-0">
+    <Search :size="16" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 pointer-events-none" />
+    <input
+      v-model="query"
+      type="text"
+      placeholder="Search drops, artifacts, commits..."
+      class="w-full pl-9 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+      @keyup.enter="submit"
+    />
+  </div>
+</template>

--- a/modules/product-builds/client/composables/useSearch.js
+++ b/modules/product-builds/client/composables/useSearch.js
@@ -1,0 +1,64 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api'
+
+const BASE = '/modules/product-builds'
+export const SEARCH_LIMIT = 200
+
+export function useSearch() {
+  const results = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function search(query, filters = {}) {
+    if (!query) {
+      results.value = null
+      return
+    }
+
+    loading.value = true
+    error.value = null
+
+    const params = new URLSearchParams({ q: query, limit: String(SEARCH_LIMIT) })
+    if (filters.types) params.set('types', filters.types)
+    if (filters.products) params.set('products', filters.products)
+    if (filters.envs) params.set('envs', filters.envs)
+    if (filters.archs) params.set('archs', filters.archs)
+    if (filters.date) params.set('date', filters.date)
+    if (filters.accel) params.set('accel', filters.accel)
+
+    try {
+      results.value = await apiRequest(`${BASE}/search?${params}`)
+    } catch (err) {
+      error.value = err.message
+      results.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { results, loading, error, search }
+}
+
+export function useSearchFilters() {
+  const artifactTypes = ref([])
+  const environments = ref([])
+  const architectures = ref([])
+  const accelerators = ref([])
+  const loaded = ref(false)
+
+  async function loadFilterOptions() {
+    if (loaded.value) return
+    try {
+      const data = await apiRequest(`${BASE}/search/filters`)
+      artifactTypes.value = data.artifact_types || []
+      environments.value = data.environments || []
+      architectures.value = data.architectures || []
+      accelerators.value = data.accelerators || []
+      loaded.value = true
+    } catch {
+      // Filter dropdowns simply stay empty/hidden on failure
+    }
+  }
+
+  return { artifactTypes, environments, architectures, accelerators, loadFilterOptions }
+}

--- a/modules/product-builds/client/index.js
+++ b/modules/product-builds/client/index.js
@@ -4,6 +4,7 @@ const ProductView = defineAsyncComponent(() => import('./views/ProductView.vue')
 
 export const routes = {
   'overview': defineAsyncComponent(() => import('./views/OverviewView.vue')),
+  'search': defineAsyncComponent(() => import('./views/SearchResultsView.vue')),
   'rhaiis': ProductView,
   'rhel-ai': ProductView,
   'base-images': ProductView,

--- a/modules/product-builds/client/views/ArtifactDetailView.vue
+++ b/modules/product-builds/client/views/ArtifactDetailView.vue
@@ -3,6 +3,7 @@ import { ref, reactive, computed, watch, onMounted, inject, defineAsyncComponent
 import { useArtifactDetail } from '../composables/useArtifacts'
 import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getAcceleratorInfo, getCommitUrl, getRegistryUrl, getDigestUrl } from '../utils/formatting'
 import ChiBadge from '../components/ChiBadge.vue'
+import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const DependencyGraph = defineAsyncComponent(() => import('../components/DependencyGraph.vue'))
 
@@ -308,18 +309,21 @@ const otherLabels = computed(() => {
 
     <template v-if="artifact">
       <!-- Header -->
-      <div>
-        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100 break-all">{{ prodKey || artifact.key }}</h1>
-        <div v-if="prodKey" class="flex items-center gap-2 mt-1">
-          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">Production</span>
-          <a v-if="getRegistryUrl(prodKey)" :href="getRegistryUrl(prodKey)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline text-sm inline-flex items-center gap-1">
-            View in Red Hat Catalog
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
-          </a>
+      <div class="flex items-start justify-between gap-4">
+        <div class="min-w-0">
+          <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100 break-all">{{ prodKey || artifact.key }}</h1>
+          <div v-if="prodKey" class="flex items-center gap-2 mt-1">
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">Production</span>
+            <a v-if="getRegistryUrl(prodKey)" :href="getRegistryUrl(prodKey)" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-blue-400 hover:underline text-sm inline-flex items-center gap-1">
+              View in Red Hat Catalog
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+            </a>
+          </div>
+          <div v-if="artifact.series" class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400">
+            <span>Series: <span class="text-gray-900 dark:text-gray-100">{{ artifact.series }}</span></span>
+          </div>
         </div>
-        <div v-if="artifact.series" class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400">
-          <span>Series: <span class="text-gray-900 dark:text-gray-100">{{ artifact.series }}</span></span>
-        </div>
+        <PersistentSearchBar />
       </div>
 
       <!-- Details grid -->

--- a/modules/product-builds/client/views/DropDetailView.vue
+++ b/modules/product-builds/client/views/DropDetailView.vue
@@ -6,6 +6,7 @@ import { apiRequest } from '@shared/client/services/api'
 import { formatDate, envBadgeClass, archBadgeClass, konfluxStateBadgeClass, testStatusBadgeClass, testStatusLabel, formatDuration, getCommitUrl, getRegistryUrl, getQuayDirectTagUrl, getQuayAllTagsUrl, getDigestUrl } from '../utils/formatting'
 import ChiBadge from '../components/ChiBadge.vue'
 import DropTimeline from '../components/DropTimeline.vue'
+import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const BASE = '/modules/product-builds'
 const nav = inject('moduleNav')
@@ -224,30 +225,33 @@ const totalColumns = 7
 
     <template v-if="drop">
       <!-- Header -->
-      <div>
-        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Drop: {{ drop.name }}</h1>
-        <div class="flex items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
-          <span>Version: <span class="text-gray-900 dark:text-gray-100">{{ drop.product_version }}</span></span>
-          <span v-if="drop.git_branch">&middot; Branch: <span class="text-gray-900 dark:text-gray-100">{{ drop.git_branch }}</span></span>
-          <span v-if="dropCommit">&middot; Commit:
-            <a
-              v-if="getCommitUrl(dropCommit)"
-              :href="getCommitUrl(dropCommit)"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="font-mono text-primary-600 dark:text-blue-400 hover:underline"
-            >{{ dropCommit.commit.slice(0, 8) }}</a>
-            <span v-else class="font-mono text-gray-900 dark:text-gray-100">{{ dropCommit.commit.slice(0, 8) }}</span>
-          </span>
+      <div class="flex items-start justify-between gap-4">
+        <div class="min-w-0">
+          <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Drop: {{ drop.name }}</h1>
+          <div class="flex items-center gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
+            <span>Version: <span class="text-gray-900 dark:text-gray-100">{{ drop.product_version }}</span></span>
+            <span v-if="drop.git_branch">&middot; Branch: <span class="text-gray-900 dark:text-gray-100">{{ drop.git_branch }}</span></span>
+            <span v-if="dropCommit">&middot; Commit:
+              <a
+                v-if="getCommitUrl(dropCommit)"
+                :href="getCommitUrl(dropCommit)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="font-mono text-primary-600 dark:text-blue-400 hover:underline"
+              >{{ dropCommit.commit.slice(0, 8) }}</a>
+              <span v-else class="font-mono text-gray-900 dark:text-gray-100">{{ dropCommit.commit.slice(0, 8) }}</span>
+            </span>
+          </div>
+          <div v-if="drop.environments?.length" class="flex gap-1 mt-2">
+            <span
+              v-for="env in drop.environments"
+              :key="env"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+              :class="envBadgeClass(env)"
+            >{{ env }}</span>
+          </div>
         </div>
-        <div v-if="drop.environments?.length" class="flex gap-1 mt-2">
-          <span
-            v-for="env in drop.environments"
-            :key="env"
-            class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-            :class="envBadgeClass(env)"
-          >{{ env }}</span>
-        </div>
+        <PersistentSearchBar />
       </div>
 
       <!-- Release timing -->

--- a/modules/product-builds/client/views/OverviewView.vue
+++ b/modules/product-builds/client/views/OverviewView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, inject, defineAsyncComponent } from 'vue'
 import { useOverviewData } from '../composables/useOverviewData'
 import { formatDate } from '../utils/formatting'
 import DropTimeline from '../components/DropTimeline.vue'
+import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const ImageDependencyGraph = defineAsyncComponent(() => import('../components/ImageDependencyGraph.vue'))
 const ProductionTimelineChart = defineAsyncComponent(() => import('../components/ProductionTimelineChart.vue'))
@@ -51,11 +52,14 @@ function shortDate(iso) {
 <template>
   <div class="space-y-6">
     <!-- Header -->
-    <div>
-      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Product Builds Overview</h1>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-        Cross-product build and release dashboard
-      </p>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Product Builds Overview</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Cross-product build and release dashboard
+        </p>
+      </div>
+      <PersistentSearchBar />
     </div>
 
     <!-- Loading -->

--- a/modules/product-builds/client/views/ProductView.vue
+++ b/modules/product-builds/client/views/ProductView.vue
@@ -5,6 +5,7 @@ import { useProduct, useDrops, useSeries } from '../composables/useDrops'
 import { useArtifacts } from '../composables/useArtifacts'
 import { formatDate, envBadgeClass } from '../utils/formatting'
 import ChiBadge from '../components/ChiBadge.vue'
+import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const PRODUCT_CONFIGS = {
   'rhaiis':            { key: 'rhaiis',        artifactType: 'containers' },
@@ -132,13 +133,16 @@ const groupedDrops = computed(() => {
 <template>
   <div class="space-y-6">
     <!-- Header -->
-    <div>
-      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-        {{ productConfig.label || product?.product_name || product?.short_name || productKey }}
-      </h1>
-      <p v-if="product" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-        Overview of {{ product.short_name || productKey }} product series and their available drops
-      </p>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+          {{ productConfig.label || product?.product_name || product?.short_name || productKey }}
+        </h1>
+        <p v-if="product" class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Overview of {{ product.short_name || productKey }} product series and their available drops
+        </p>
+      </div>
+      <PersistentSearchBar />
     </div>
 
     <!-- Loading / Error -->

--- a/modules/product-builds/client/views/SearchResultsView.vue
+++ b/modules/product-builds/client/views/SearchResultsView.vue
@@ -1,0 +1,378 @@
+<script setup>
+import { ref, computed, reactive, onMounted, watch, inject } from 'vue'
+import { useSearch, useSearchFilters, SEARCH_LIMIT } from '../composables/useSearch'
+import { formatDate, envBadgeClass, getCommitUrl } from '../utils/formatting'
+
+const nav = inject('moduleNav')
+const { results, loading, error, search } = useSearch()
+const { artifactTypes, environments, architectures, accelerators, loadFilterOptions } = useSearchFilters()
+
+const ARTIFACT_TYPE_LABELS = {
+  'base-images': 'Base Images',
+  'cloud-containers': 'Cloud Containers',
+  'cloud-disk-images': 'Cloud Disk Images',
+  'containers': 'Containers',
+  'disk-image-containers': 'Disk Image Containers',
+  'disk-images': 'Disk Images',
+  'instructlab': 'InstructLab',
+  'models': 'Models',
+  'model-cars': 'Model Cars',
+  'unknown': 'Unknown',
+  'wheels-collections': 'Wheels Collections'
+}
+
+const DATE_RANGES = [
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: '90d', label: 'Last 90 days' }
+]
+
+const ITEMS_PER_PAGE = 10
+
+const queryInput = ref('')
+const filters = reactive({
+  types: '',
+  products: '',
+  envs: '',
+  archs: '',
+  date: '',
+  accel: ''
+})
+
+const dropsPage = ref(1)
+const artifactSectionPages = reactive({})
+
+function paginate(items, page) {
+  const start = (page - 1) * ITEMS_PER_PAGE
+  return items.slice(start, start + ITEMS_PER_PAGE)
+}
+
+const paginatedDrops = computed(() => results.value?.drops ? paginate(results.value.drops, dropsPage.value) : [])
+
+function artifactPage(artifactType) {
+  return artifactSectionPages[artifactType] || 1
+}
+
+function paginatedArtifacts(artifactType, artifacts) {
+  return paginate(artifacts, artifactPage(artifactType))
+}
+
+function setArtifactPage(artifactType, page) {
+  artifactSectionPages[artifactType] = page
+}
+
+const hasActiveFilters = computed(() =>
+  !!(filters.types || filters.products || filters.envs || filters.archs || filters.date || filters.accel)
+)
+
+// The API's total_results is computed before its own per-type limit is applied to the
+// response body, so it can report more than what's actually returned and pageable here.
+// Count what we actually got instead, so the header always matches what you can page through.
+const shownCount = computed(() => {
+  if (!results.value) return 0
+  const artifactCount = Object.values(results.value.artifacts || {}).reduce((sum, arr) => sum + arr.length, 0)
+  return (results.value.drops?.length || 0) + artifactCount
+})
+const isTruncated = computed(() => shownCount.value >= SEARCH_LIMIT)
+
+function syncFromParams() {
+  const p = nav.params.value || {}
+  queryInput.value = p.q || ''
+  filters.types = p.types || ''
+  filters.products = p.products || ''
+  filters.envs = p.envs || ''
+  filters.archs = p.archs || ''
+  filters.date = p.date || ''
+  filters.accel = p.accel || ''
+}
+
+function runSearch() {
+  dropsPage.value = 1
+  Object.keys(artifactSectionPages).forEach((key) => delete artifactSectionPages[key])
+  search(queryInput.value.trim(), { ...filters })
+}
+
+function submitSearch() {
+  nav.updateParams({
+    q: queryInput.value.trim() || undefined,
+    types: filters.types || undefined,
+    products: filters.products || undefined,
+    envs: filters.envs || undefined,
+    archs: filters.archs || undefined,
+    date: filters.date || undefined,
+    accel: filters.accel || undefined
+  }, { push: true })
+  runSearch()
+}
+
+function onFilterChange() {
+  nav.updateParams({
+    types: filters.types || undefined,
+    products: filters.products || undefined,
+    envs: filters.envs || undefined,
+    archs: filters.archs || undefined,
+    date: filters.date || undefined,
+    accel: filters.accel || undefined
+  }, { push: false })
+  runSearch()
+}
+
+function clearFilters() {
+  filters.types = ''
+  filters.products = ''
+  filters.envs = ''
+  filters.archs = ''
+  filters.date = ''
+  filters.accel = ''
+  onFilterChange()
+}
+
+function goToDrop(drop) {
+  nav.navigateTo('drop-detail', { key: drop.key, product: drop.product_key })
+}
+
+function goToArtifact(artifact) {
+  nav.navigateTo('artifact-detail', { key: artifact.key, product: artifact.product_key })
+}
+
+watch(() => nav.params.value?.q, (val) => {
+  if ((val || '') !== queryInput.value) {
+    syncFromParams()
+    runSearch()
+  }
+})
+
+onMounted(() => {
+  syncFromParams()
+  loadFilterOptions()
+  if (queryInput.value) runSearch()
+})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div>
+      <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Search</h1>
+      <p class="text-sm text-gray-500 dark:text-gray-400">Search across products, drops, and artifacts.</p>
+    </div>
+
+    <!-- Search input -->
+    <div class="flex gap-2">
+      <input
+        v-model="queryInput"
+        type="text"
+        placeholder="Search by key, name, commit, or alternative name..."
+        class="flex-1 px-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        @keyup.enter="submitSearch"
+      />
+      <button
+        @click="submitSearch"
+        class="px-5 py-2.5 rounded-lg text-sm font-semibold text-white bg-primary-600 hover:bg-primary-700 transition-colors"
+      >Search</button>
+    </div>
+
+    <!-- Filters -->
+    <div v-if="queryInput" class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-3">
+      <div class="flex flex-wrap gap-4 items-end">
+        <div style="min-width: 160px">
+          <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Type</label>
+          <select v-model="filters.types" @change="onFilterChange" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <option value="">All</option>
+            <option value="drops">Drops</option>
+            <option v-for="t in artifactTypes" :key="t" :value="t">{{ ARTIFACT_TYPE_LABELS[t] || t }}</option>
+          </select>
+        </div>
+
+        <div style="min-width: 150px">
+          <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Product</label>
+          <select v-model="filters.products" @change="onFilterChange" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <option value="">All</option>
+            <option value="rhaiis">RHAIIS</option>
+            <option value="rhel-ai">RHEL AI</option>
+            <option value="base-images">Base Images</option>
+            <option value="builder-images">Builder Images</option>
+          </select>
+        </div>
+
+        <div v-if="environments.length" style="min-width: 150px">
+          <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Environment</label>
+          <select v-model="filters.envs" @change="onFilterChange" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <option value="">All</option>
+            <option v-for="e in environments" :key="e" :value="e">{{ e }}</option>
+          </select>
+        </div>
+
+        <div v-if="architectures.length" style="min-width: 150px">
+          <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Architecture</label>
+          <select v-model="filters.archs" @change="onFilterChange" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <option value="">All</option>
+            <option v-for="a in architectures" :key="a" :value="a">{{ a }}</option>
+          </select>
+        </div>
+
+        <div style="min-width: 150px">
+          <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Date Range</label>
+          <select v-model="filters.date" @change="onFilterChange" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <option value="">All time</option>
+            <option v-for="d in DATE_RANGES" :key="d.value" :value="d.value">{{ d.label }}</option>
+          </select>
+        </div>
+
+        <div v-if="accelerators.length" style="min-width: 150px">
+          <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Accelerator</label>
+          <select v-model="filters.accel" @change="onFilterChange" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <option value="">All</option>
+            <option v-for="a in accelerators" :key="a" :value="a">{{ a.toUpperCase() }}</option>
+          </select>
+        </div>
+
+        <button
+          v-if="hasActiveFilters"
+          @click="clearFilters"
+          class="ml-auto px-4 py-1.5 rounded-lg text-sm font-semibold text-white bg-red-600 hover:bg-red-700 transition-colors"
+        >Clear all filters</button>
+      </div>
+    </div>
+
+    <!-- Empty query state -->
+    <div v-if="!queryInput" class="text-sm text-gray-500 dark:text-gray-400 text-center py-12">
+      Enter a search query above to find drops and artifacts.
+    </div>
+
+    <!-- Loading -->
+    <div v-else-if="loading && !results" class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">Searching…</div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3 text-sm text-red-700 dark:text-red-400">{{ error }}</div>
+
+    <template v-else-if="results">
+      <p class="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
+        <span v-if="isTruncated">Showing the first {{ SEARCH_LIMIT }} results for "{{ results.query }}" — narrow your search or add filters to see more precise results</span>
+        <span v-else>Found {{ shownCount }} result{{ shownCount !== 1 ? 's' : '' }} for "{{ results.query }}"</span>
+        <span v-if="loading" class="text-xs text-gray-400 dark:text-gray-500">Searching…</span>
+      </p>
+
+      <div v-if="shownCount === 0" class="text-sm text-gray-500 dark:text-gray-400 text-center py-8">
+        No drops or artifacts match your search query. Try a different search term or adjust your filters.
+      </div>
+
+      <!-- Drops -->
+      <div
+        v-if="results.drops && results.drops.length"
+        class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden transition-opacity"
+        :class="{ 'opacity-60 pointer-events-none': loading }"
+      >
+        <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700 font-semibold text-gray-900 dark:text-gray-100">
+          Drops ({{ results.drops.length }})
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Key</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Product</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
+              <tr
+                v-for="drop in paginatedDrops"
+                :key="drop.key"
+                class="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                @click="goToDrop(drop)"
+              >
+                <td class="px-4 py-2 text-sm text-primary-600 dark:text-blue-400">{{ drop.key }}</td>
+                <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-300">{{ drop.name }}</td>
+                <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-300">{{ drop.product_key }}</td>
+                <td class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">{{ formatDate(drop.created_at) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="results.drops.length > ITEMS_PER_PAGE" class="flex items-center justify-between px-4 py-2 border-t border-gray-200 dark:border-gray-700 text-sm">
+          <button
+            :disabled="dropsPage <= 1"
+            @click="dropsPage--"
+            class="px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700/50"
+          >Previous</button>
+          <span class="text-gray-500 dark:text-gray-400">Page {{ dropsPage }} of {{ Math.ceil(results.drops.length / ITEMS_PER_PAGE) }}</span>
+          <button
+            :disabled="dropsPage >= Math.ceil(results.drops.length / ITEMS_PER_PAGE)"
+            @click="dropsPage++"
+            class="px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700/50"
+          >Next</button>
+        </div>
+      </div>
+
+      <!-- Artifacts, grouped by type -->
+      <div
+        v-for="(artifacts, artifactType) in results.artifacts"
+        :key="artifactType"
+        class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden transition-opacity"
+        :class="{ 'opacity-60 pointer-events-none': loading }"
+      >
+        <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700 font-semibold text-gray-900 dark:text-gray-100">
+          {{ ARTIFACT_TYPE_LABELS[artifactType] || artifactType }} ({{ artifacts.length }})
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/50">
+              <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Key</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Commit</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Variant</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Environments</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-700/50">
+              <tr
+                v-for="artifact in paginatedArtifacts(artifactType, artifacts)"
+                :key="artifact.key"
+                class="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                @click="goToArtifact(artifact)"
+              >
+                <td class="px-4 py-2 text-sm text-primary-600 dark:text-blue-400 max-w-md break-all">{{ artifact.key }}</td>
+                <td class="px-4 py-2 text-sm">
+                  <a
+                    v-if="getCommitUrl(artifact)"
+                    :href="getCommitUrl(artifact)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary-600 dark:text-blue-400 hover:underline"
+                    @click.stop
+                  ><code>{{ (artifact.commit || '').substring(0, 8) }}</code></a>
+                  <code v-else>{{ (artifact.commit || 'N/A').substring(0, 8) }}</code>
+                </td>
+                <td class="px-4 py-2 text-sm text-gray-700 dark:text-gray-300">{{ artifact.variant }}</td>
+                <td class="px-4 py-2 text-sm">
+                  <span
+                    v-for="env in artifact.environments"
+                    :key="env"
+                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium mr-1"
+                    :class="envBadgeClass(env)"
+                  >{{ env }}</span>
+                </td>
+                <td class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">{{ formatDate(artifact.created_at) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="artifacts.length > ITEMS_PER_PAGE" class="flex items-center justify-between px-4 py-2 border-t border-gray-200 dark:border-gray-700 text-sm">
+          <button
+            :disabled="artifactPage(artifactType) <= 1"
+            @click="setArtifactPage(artifactType, artifactPage(artifactType) - 1)"
+            class="px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700/50"
+          >Previous</button>
+          <span class="text-gray-500 dark:text-gray-400">Page {{ artifactPage(artifactType) }} of {{ Math.ceil(artifacts.length / ITEMS_PER_PAGE) }}</span>
+          <button
+            :disabled="artifactPage(artifactType) >= Math.ceil(artifacts.length / ITEMS_PER_PAGE)"
+            @click="setArtifactPage(artifactType, artifactPage(artifactType) + 1)"
+            class="px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700/50"
+          >Next</button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/modules/product-builds/client/views/SeriesDetailView.vue
+++ b/modules/product-builds/client/views/SeriesDetailView.vue
@@ -4,6 +4,7 @@ import { useDrops } from '../composables/useDrops'
 import { apiRequest } from '@shared/client/services/api'
 import { formatDate, envBadgeClass } from '../utils/formatting'
 import SeriesTimeline from '../components/SeriesTimeline.vue'
+import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const BASE = '/modules/product-builds'
 const nav = inject('moduleNav')
@@ -54,7 +55,10 @@ const hasMetrics = computed(() => Object.keys(metricsMap).length > 0)
     >&larr; Back</button>
 
     <!-- Title -->
-    <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Series: {{ seriesName }}</h1>
+    <div class="flex items-start justify-between gap-4">
+      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100 min-w-0 break-all">Series: {{ seriesName }}</h1>
+      <PersistentSearchBar />
+    </div>
 
     <!-- Loading / Error -->
     <div v-if="dropsLoading && drops.length === 0" class="text-sm text-gray-500 dark:text-gray-400">Loading drops…</div>

--- a/modules/product-builds/client/views/WheelCollectionsView.vue
+++ b/modules/product-builds/client/views/WheelCollectionsView.vue
@@ -4,6 +4,7 @@ import { useWheelBrowse, useWheelPackageSearch, useWheelFilters } from '../compo
 import { formatDate, envBadgeClass, archBadgeClass, getCommitUrl } from '../utils/formatting'
 import { apiRequest, getApiBase } from '@shared/client/services/api'
 import { impersonatingUid } from '@shared/client/state/impersonation'
+import PersistentSearchBar from '../components/PersistentSearchBar.vue'
 
 const nav = inject('moduleNav')
 
@@ -328,11 +329,14 @@ onUnmounted(() => { clearTimeout(searchTimeout); clearTimeout(containerHoverTime
 <template>
   <div class="space-y-6">
     <!-- Header -->
-    <div>
-      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Wheel Collections</h1>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-        Browse wheel collection releases or search for specific packages across releases
-      </p>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">Wheel Collections</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Browse wheel collection releases or search for specific packages across releases
+        </p>
+      </div>
+      <PersistentSearchBar />
     </div>
 
     <!-- Tabs -->

--- a/modules/product-builds/module.json
+++ b/modules/product-builds/module.json
@@ -20,12 +20,20 @@
     "hiddenRoutes": {
       "series-detail": "$product",
       "drop-detail": "$product",
-      "artifact-detail": "$product"
+      "artifact-detail": "$product",
+      "search": null
     },
     "settingsComponent": "./client/components/ProductBuildsSettings.vue"
   },
   "server": {
     "entry": "./server/index.js"
+  },
+  "search": {
+    "enabled": true,
+    "keywords": ["build", "release", "drop", "artifact", "container", "pullspec", "wheel", "package", "image"],
+    "views": [
+      { "viewId": "search", "paramName": "q", "placeholder": "Search drops, artifacts, commits..." }
+    ]
   },
   "secrets": {
     "platform": ["jira", "gitlab", "google"],

--- a/modules/product-builds/server/index.js
+++ b/modules/product-builds/server/index.js
@@ -535,6 +535,82 @@ module.exports = function registerRoutes(router, context) {
     await upstream(`/artifacts/${encodeURIComponent(req.params.key)}/containers`, req, res);
   });
 
+  /**
+   * @openapi
+   * /api/modules/product-builds/search:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Cross-entity search across drops and artifacts
+   *     description: Searches drop keys/names and artifact keys/commits/alternative_names, grouped by entity type. Backed by the AIPCC Dashboard's search endpoint.
+   *     parameters:
+   *       - name: q
+   *         in: query
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Search query string
+   *       - name: types
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by artifact type, or "drops" to show only drops
+   *       - name: products
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter by product key (e.g. rhaiis, rhel-ai)
+   *       - name: envs
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter artifacts by environment (e.g. production, stage)
+   *       - name: archs
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter artifacts by architecture (e.g. x86_64, aarch64)
+   *       - name: date
+   *         in: query
+   *         schema:
+   *           type: string
+   *           enum: [7d, 30d, 90d]
+   *         description: Filter artifacts by creation date range
+   *       - name: accel
+   *         in: query
+   *         schema:
+   *           type: string
+   *         description: Filter artifacts by accelerator (e.g. cuda, rocm, cpu)
+   *       - name: limit
+   *         in: query
+   *         schema:
+   *           type: integer
+   *           default: 200
+   *         description: Maximum total results to return. The client always sends 200 explicitly rather than relying on the upstream default.
+   *     responses:
+   *       200:
+   *         description: Search results grouped by type (drops array, artifacts object keyed by type)
+   *       503:
+   *         description: AIPCC Dashboard API not configured
+   */
+  router.get('/search', async function(req, res) {
+    await upstream('/search', req, res);
+  });
+
+  /**
+   * @openapi
+   * /api/modules/product-builds/search/filters:
+   *   get:
+   *     tags: [Product Builds]
+   *     summary: Get available search filter values
+   *     description: Returns distinct artifact types, environments, architectures, and accelerators present in the data, used to populate search filter dropdowns.
+   *     responses:
+   *       200:
+   *         description: Object with artifact_types, environments, architectures, accelerators arrays
+   */
+  router.get('/search/filters', async function(req, res) {
+    await upstream('/search/filters', req, res);
+  });
+
   // --- Package Analysis ---
 
   let _jira;

--- a/platform/view-owners/owners.js
+++ b/platform/view-owners/owners.js
@@ -56,6 +56,7 @@ export const viewOwners = {
   'product-builds/package-analysis':               'Einat Pacifici',
   'product-builds/rhaiis':                         'Pavol Pitonak',
   'product-builds/rhel-ai':                        'Pavol Pitonak',
+  'product-builds/search':                         'Rishabh Kothari',
   'product-builds/series-detail':                  'Giulia Naponiello',
   'product-builds/wheel-collections':              'Pavol Pitonak',
 

--- a/tests/integration/product-builds.spec.js
+++ b/tests/integration/product-builds.spec.js
@@ -101,4 +101,35 @@ test.describe('Product Builds Module @product-builds', () => {
     const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
     expect(appErrors).toHaveLength(0);
   });
+
+  test('should navigate to Search view and show empty state', async ({ page }) => {
+    await page.goto('/#/product-builds/search');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    expect(page.url()).toMatch(/product-builds\/search/);
+
+    const searchInput = page.locator('input[type="text"]');
+    await expect(searchInput).toBeVisible();
+    await expect(page.locator('text=Enter a search query')).toBeVisible();
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
+    expect(appErrors).toHaveLength(0);
+  });
+
+  test('should run a search and update the URL query param', async ({ page }) => {
+    await page.goto('/#/product-builds/search');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    const searchInput = page.locator('input[type="text"]');
+    await searchInput.fill('rhaiis');
+    await searchInput.press('Enter');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    expect(page.url()).toMatch(/[?&]q=rhaiis/);
+
+    const appErrors = page.errors.filter(e => !/status of (429|404|503)/.test(e.message));
+    expect(appErrors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds search to the Product Builds module, backed by the AIPCC Dashboard's existing `/search` API. You can search drops and artifacts by key, name, commit, or alternative name, with filters for type, product, environment, architecture, date, and accelerator, plus pagination.
- Adds a persistent search bar inline with each page's title (Overview, product pages, Wheel Collections, and the drop/artifact/series detail views). Also registers the view with core's global command palette so it's reachable via `/`.
- Shows a result count based on what's actually returned rather than the API's `total_results`, which is computed before its own per-type cap is applied and can overstate what's actually pageable (see review discussion below); shows a truncation notice when the cap is hit.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 178/178 product-builds unit tests pass
- [x] Verified manually against live dashboard API + MongoDB (this module has no demo fixtures): pagination works, filters work, the bar renders correctly on every embedded view, stays out of the way on Package Analysis and the Search Results view itself, and the truncation notice shows correctly on broad queries that exceed the 200-result cap

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>