### PR TITLE
feat(ai-impact): pipeline lineage traceability across delivery phases

### DIFF
--- a/modules/ai-impact/__tests__/server/pipeline-signals-resolve.test.js
+++ b/modules/ai-impact/__tests__/server/pipeline-signals-resolve.test.js
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../server/component-onboarding/storage', () => ({
+  readComponentOnboarding: vi.fn(),
+  projectComponent: vi.fn((entry) => ({
+    ...entry.latest,
+    completionStatus: entry.latest.completionStatus || 'in-progress'
+  }))
+}));
+
+vi.mock('../../server/features/storage', () => ({
+  readFeatures: vi.fn()
+}));
+
+vi.mock('../../server/test-plans/storage', () => ({
+  readTestPlans: vi.fn()
+}));
+
+vi.mock('../../server/decomposer/storage', () => ({
+  readDecomposer: vi.fn()
+}));
+
+import {
+  resolveRfeSignal,
+  resolveFeatureSignal,
+  resolveDecomposerSignal,
+  resolveTestPlanSignal,
+  resolveDocSignal,
+  resolveBuildReleaseSignal
+} from '../../server/pipeline-signals/resolve.js';
+
+// --- Fixtures ---
+
+function makeRfeData(issueOverrides = {}) {
+  return {
+    issues: [
+      {
+        key: 'RHAIRFE-100',
+        aiInvolvement: 'both',
+        linkedFeature: { key: 'RHAISTRAT-1', status: 'In Progress', fixVersions: ['1.2'] },
+        ...issueOverrides
+      }
+    ]
+  };
+}
+
+function makeFeaturesData(latestOverrides = {}) {
+  return {
+    features: {
+      'RHAISTRAT-1': {
+        latest: {
+          key: 'RHAISTRAT-1',
+          recommendation: 'approve',
+          humanReviewStatus: 'approved',
+          labels: ['strat-creator-auto-created'],
+          scores: { total: 7, feasibility: 2, testability: 2, scope: 2, architecture: 1 },
+          ...latestOverrides
+        },
+        history: []
+      }
+    }
+  };
+}
+
+function makeDecomposerData(stratOverrides = {}) {
+  return {
+    strategies: [
+      {
+        strat_id: 'RHAISTRAT-1',
+        title: 'Test Strategy',
+        epic_count: 5,
+        critical_path_length: 3,
+        review: { score: 85, pass: true, recommendation: 'accept' },
+        epics: [],
+        ...stratOverrides
+      }
+    ]
+  };
+}
+
+function makeTestPlansData(planOverrides = {}) {
+  return {
+    testPlans: {
+      tp1: {
+        latest: {
+          key: 'tp1',
+          sourceKey: 'RHAISTRAT-1',
+          verdict: 'Ready',
+          score: 9,
+          humanReviewStatus: 'approved',
+          labels: ['test-plan-auto-created'],
+          ...planOverrides
+        },
+        history: []
+      }
+    }
+  };
+}
+
+function makeDocData(issueOverrides = {}) {
+  return {
+    issues: [
+      {
+        key: 'RHAISTRAT-1',
+        hasDocContributed: true,
+        docContributedDate: '2026-06-01',
+        ...issueOverrides
+      }
+    ]
+  };
+}
+
+function makeCoData(latestOverrides = {}) {
+  return {
+    components: {
+      comp1: {
+        latest: {
+          key: 'comp1',
+          summary: 'Component One',
+          status: 'Resolved',
+          linkedFeatures: ['RHAISTRAT-1'],
+          completionStatus: 'completed',
+          targetVersion: '1.2',
+          onboardingSteps: { step1: true, step2: true, step3: false },
+          ...latestOverrides
+        },
+        history: []
+      }
+    }
+  };
+}
+
+// --- RFE ---
+
+describe('resolveRfeSignal', () => {
+  it('returns completed with linkedKey for matched RFE', () => {
+    const result = resolveRfeSignal(makeRfeData(), 'RHAISTRAT-1');
+    expect(result.completed).toBe(true);
+    expect(result.current).toBe(false);
+    expect(result.aiUsed).toBe(true);
+    expect(result.linkedKey).toBe('RHAIRFE-100');
+    expect(result.detail).toBe('AI created & revised');
+  });
+
+  it('returns no linked RFE for unknown feature key', () => {
+    const result = resolveRfeSignal(makeRfeData(), 'RHAISTRAT-999');
+    expect(result.completed).toBe(false);
+    expect(result.aiUsed).toBeNull();
+    expect(result.detail).toBe('No linked RFE');
+    expect(result).not.toHaveProperty('linkedKey');
+  });
+
+  it('handles null rfeData', () => {
+    const result = resolveRfeSignal(null, 'RHAISTRAT-1');
+    expect(result.completed).toBe(false);
+    expect(result.detail).toBe('No data');
+  });
+
+  it('handles missing issues array', () => {
+    const result = resolveRfeSignal({ issues: 'not-array' }, 'RHAISTRAT-1');
+    expect(result.detail).toBe('No data');
+  });
+
+  it('detects AI created involvement', () => {
+    const result = resolveRfeSignal(makeRfeData({ aiInvolvement: 'created' }), 'RHAISTRAT-1');
+    expect(result.aiUsed).toBe(true);
+    expect(result.detail).toBe('AI created');
+  });
+
+  it('detects AI revised involvement', () => {
+    const result = resolveRfeSignal(makeRfeData({ aiInvolvement: 'revised' }), 'RHAISTRAT-1');
+    expect(result.aiUsed).toBe(true);
+    expect(result.detail).toBe('AI revised');
+  });
+
+  it('detects no AI involvement', () => {
+    const result = resolveRfeSignal(makeRfeData({ aiInvolvement: 'none' }), 'RHAISTRAT-1');
+    expect(result.aiUsed).toBe(false);
+    expect(result.detail).toBe('No AI involvement');
+  });
+});
+
+// --- Feature Review ---
+
+describe('resolveFeatureSignal', () => {
+  it('returns completed when approved', () => {
+    const result = resolveFeatureSignal(makeFeaturesData(), 'RHAISTRAT-1');
+    expect(result.completed).toBe(true);
+    expect(result.current).toBe(false);
+    expect(result.aiUsed).toBe(true);
+    expect(result.linkedKey).toBe('RHAISTRAT-1');
+    expect(result.detail).toBe('approve — 7/8');
+    expect(result.scores).toEqual({ total: 7, feasibility: 2, testability: 2, scope: 2, architecture: 1 });
+    expect(result.recommendation).toBe('approve');
+  });
+
+  it('returns current when not approved', () => {
+    const result = resolveFeatureSignal(
+      makeFeaturesData({ humanReviewStatus: 'needs-review' }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(true);
+  });
+
+  it('returns aiUsed false when no AI labels', () => {
+    const result = resolveFeatureSignal(
+      makeFeaturesData({ labels: [] }),
+      'RHAISTRAT-1'
+    );
+    expect(result.aiUsed).toBe(false);
+  });
+
+  it('returns no data for unknown feature', () => {
+    const result = resolveFeatureSignal(makeFeaturesData(), 'RHAISTRAT-999');
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(false);
+    expect(result.aiUsed).toBeNull();
+    expect(result.detail).toBe('No feature data');
+  });
+
+  it('handles missing scores gracefully', () => {
+    const result = resolveFeatureSignal(
+      makeFeaturesData({ scores: null }),
+      'RHAISTRAT-1'
+    );
+    expect(result.detail).toBe('approve — 0/8');
+  });
+});
+
+// --- Decomposer ---
+
+describe('resolveDecomposerSignal', () => {
+  it('returns completed when review passes', () => {
+    const result = resolveDecomposerSignal(makeDecomposerData(), 'RHAISTRAT-1');
+    expect(result.completed).toBe(true);
+    expect(result.current).toBe(false);
+    expect(result.aiUsed).toBe(true);
+    expect(result.linkedKey).toBe('RHAISTRAT-1');
+    expect(result.detail).toBe('5 epics · pass (85)');
+    expect(result.epicCount).toBe(5);
+    expect(result.score).toBe(85);
+    expect(result.pass).toBe(true);
+  });
+
+  it('returns current when review fails', () => {
+    const result = resolveDecomposerSignal(
+      makeDecomposerData({ review: { score: 40, pass: false, recommendation: 'revise' } }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(true);
+    expect(result.detail).toBe('5 epics · fail (40)');
+    expect(result.pass).toBe(false);
+  });
+
+  it('handles null decomposer data', () => {
+    const result = resolveDecomposerSignal(null, 'RHAISTRAT-1');
+    expect(result.completed).toBe(false);
+    expect(result.detail).toBe('No data');
+  });
+
+  it('handles non-array strategies', () => {
+    const result = resolveDecomposerSignal({ strategies: 'nope' }, 'RHAISTRAT-1');
+    expect(result.detail).toBe('No data');
+  });
+
+  it('handles missing strategy', () => {
+    const result = resolveDecomposerSignal(makeDecomposerData(), 'RHAISTRAT-999');
+    expect(result.completed).toBe(false);
+    expect(result.detail).toBe('Not decomposed');
+  });
+
+  it('handles strategy with no review', () => {
+    const result = resolveDecomposerSignal(
+      makeDecomposerData({ review: undefined }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.pass).toBe(false);
+  });
+});
+
+// --- Test Plan ---
+
+describe('resolveTestPlanSignal', () => {
+  it('returns completed when approved', () => {
+    const result = resolveTestPlanSignal(makeTestPlansData(), 'RHAISTRAT-1');
+    expect(result.completed).toBe(true);
+    expect(result.current).toBe(false);
+    expect(result.aiUsed).toBe(true);
+    expect(result.detail).toBe('Ready — 9/10');
+    expect(result.linkedKey).toBe('RHAISTRAT-1');
+  });
+
+  it('returns current when not approved but has verdict', () => {
+    const result = resolveTestPlanSignal(
+      makeTestPlansData({ humanReviewStatus: 'needs-review' }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(true);
+  });
+
+  it('returns aiUsed false when no AI labels', () => {
+    const result = resolveTestPlanSignal(
+      makeTestPlansData({ labels: ['manual'] }),
+      'RHAISTRAT-1'
+    );
+    expect(result.aiUsed).toBe(false);
+  });
+
+  it('handles missing test plan for feature', () => {
+    const result = resolveTestPlanSignal(makeTestPlansData(), 'RHAISTRAT-999');
+    expect(result.completed).toBe(false);
+    expect(result.detail).toBe('No test plan');
+  });
+
+  it('handles null test plan data', () => {
+    const result = resolveTestPlanSignal(null, 'RHAISTRAT-1');
+    expect(result.detail).toBe('No data');
+  });
+});
+
+// --- Documentation ---
+
+describe('resolveDocSignal', () => {
+  it('returns completed when docs contributed', () => {
+    const result = resolveDocSignal(makeDocData(), 'RHAISTRAT-1');
+    expect(result.completed).toBe(true);
+    expect(result.aiUsed).toBe(true);
+    expect(result.detail).toBe('Docs contributed');
+    expect(result.hasDocContributed).toBe(true);
+    expect(result.docContributedDate).toBe('2026-06-01');
+    expect(result.linkedKey).toBe('RHAISTRAT-1');
+  });
+
+  it('returns completed when docs skipped', () => {
+    const result = resolveDocSignal(
+      makeDocData({ hasDocContributed: false, hasDocSkipped: true }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(true);
+    expect(result.aiUsed).toBe(false);
+    expect(result.detail).toBe('Docs skipped');
+    expect(result.hasDocSkipped).toBe(true);
+  });
+
+  it('returns current when doc tool invoked but not contributed', () => {
+    const result = resolveDocSignal(
+      makeDocData({ hasDocContributed: false, hasDocInvoked: true }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(true);
+    expect(result.aiUsed).toBe(true);
+    expect(result.detail).toBe('Doc tool invoked');
+  });
+
+  it('returns not started when no doc flags', () => {
+    const result = resolveDocSignal(
+      makeDocData({ hasDocContributed: false }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(false);
+    expect(result.aiUsed).toBeNull();
+    expect(result.detail).toBe('Docs not started');
+  });
+
+  it('handles missing doc issue', () => {
+    const result = resolveDocSignal(makeDocData(), 'RHAISTRAT-999');
+    expect(result.detail).toBe('No doc issue');
+  });
+
+  it('handles null doc data', () => {
+    const result = resolveDocSignal(null, 'RHAISTRAT-1');
+    expect(result.detail).toBe('No data');
+  });
+
+  it('handles non-array issues', () => {
+    const result = resolveDocSignal({ issues: {} }, 'RHAISTRAT-1');
+    expect(result.detail).toBe('No data');
+  });
+});
+
+// --- Build & Release ---
+
+describe('resolveBuildReleaseSignal', () => {
+  it('returns completed for completed components', () => {
+    const result = resolveBuildReleaseSignal(makeCoData(), 'RHAISTRAT-1');
+    expect(result.completed).toBe(true);
+    expect(result.detail).toContain('2/3 steps');
+    expect(result.detail).toContain('1.2');
+    expect(result.linkedKey).toBe('comp1');
+  });
+
+  it('returns current for in-progress components', () => {
+    const result = resolveBuildReleaseSignal(
+      makeCoData({ completionStatus: 'in-progress', status: 'In Progress' }),
+      'RHAISTRAT-1'
+    );
+    expect(result.completed).toBe(false);
+    expect(result.current).toBe(true);
+  });
+
+  it('handles missing component for feature', () => {
+    const result = resolveBuildReleaseSignal(makeCoData(), 'RHAISTRAT-999');
+    expect(result.completed).toBe(false);
+    expect(result.detail).toBe('No onboarding data');
+  });
+
+  it('handles null coData', () => {
+    const result = resolveBuildReleaseSignal(null, 'RHAISTRAT-1');
+    expect(result.completed).toBe(false);
+    expect(result.detail).toBe('No data');
+  });
+
+  it('handles missing components property', () => {
+    const result = resolveBuildReleaseSignal({}, 'RHAISTRAT-1');
+    expect(result.detail).toBe('No data');
+  });
+
+  it('omits version from detail when no targetVersion', () => {
+    const result = resolveBuildReleaseSignal(
+      makeCoData({ targetVersion: null }),
+      'RHAISTRAT-1'
+    );
+    expect(result.detail).toBe('2/3 steps');
+    expect(result.detail).not.toContain('·');
+  });
+});

--- a/modules/ai-impact/__tests__/server/pipeline-signals-routes.test.js
+++ b/modules/ai-impact/__tests__/server/pipeline-signals-routes.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../server/features/storage', () => ({
+  readFeatures: vi.fn().mockResolvedValue({ features: {} })
+}));
+
+vi.mock('../../server/test-plans/storage', () => ({
+  readTestPlans: vi.fn().mockResolvedValue({ testPlans: {} })
+}));
+
+vi.mock('../../server/decomposer/storage', () => ({
+  readDecomposer: vi.fn().mockResolvedValue({ strategies: [] })
+}));
+
+vi.mock('../../server/component-onboarding/storage', () => ({
+  readComponentOnboarding: vi.fn().mockResolvedValue({ components: {} }),
+  projectComponent: vi.fn((entry) => entry.latest)
+}));
+
+import registerPipelineSignalRoutes from '../../server/pipeline-signals/routes.js';
+
+function makeContext(storageOverrides = {}) {
+  const defaultData = {
+    'ai-impact/rfe-data.json': {
+      issues: [
+        {
+          key: 'RHAIRFE-100',
+          aiInvolvement: 'both',
+          linkedFeature: { key: 'RHAISTRAT-123', status: 'In Progress' }
+        }
+      ]
+    },
+    'ai-impact/doc-data.json': { issues: [] }
+  };
+  const data = { ...defaultData, ...storageOverrides };
+
+  return {
+    storage: {
+      readFromStorage: vi.fn((key) => Promise.resolve(data[key] || null))
+    },
+    requireScope: () => (req, res, next) => next()
+  };
+}
+
+function createRouter() {
+  const routes = {};
+  const router = {
+    get: vi.fn((path, ...h) => { routes[`GET ${path}`] = h; }),
+    post: vi.fn((path, ...h) => { routes[`POST ${path}`] = h; }),
+    put: vi.fn((path, ...h) => { routes[`PUT ${path}`] = h; }),
+    delete: vi.fn((path, ...h) => { routes[`DELETE ${path}`] = h; })
+  };
+  return { router, routes };
+}
+
+async function callHandler(routes, method, path, { params = {}, query = {} } = {}) {
+  const handlers = routes[`${method} ${path}`];
+  if (!handlers) throw new Error(`No route for ${method} ${path}. Have: ${Object.keys(routes).join(', ')}`);
+  const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+  const req = { params, query, body: {} };
+  await handlers[handlers.length - 1](req, res);
+  return { req, res };
+}
+
+describe('pipeline-signals routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers GET /pipeline-signals/:featureKey', () => {
+    const { router } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext());
+    expect(router.get).toHaveBeenCalledWith(
+      '/pipeline-signals/:featureKey',
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it('returns resolved signals for a valid feature key', async () => {
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext());
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: 'RHAISTRAT-123' }
+    });
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.featureKey).toBe('RHAISTRAT-123');
+    expect(payload.phases).toBeDefined();
+    expect(payload.phases['rfe-review']).toBeDefined();
+    expect(payload.phases['rfe-review'].completed).toBe(true);
+    expect(payload.phases['rfe-review'].linkedKey).toBe('RHAIRFE-100');
+    expect(payload.phases['feature-review']).toBeDefined();
+    expect(payload.phases['decomposer']).toBeDefined();
+    expect(payload.phases['test-plan-review']).toBeDefined();
+    expect(payload.phases['documentation']).toBeDefined();
+    expect(payload.phases['build-release']).toBeDefined();
+    expect(payload.jiraHost).toBeTruthy();
+    expect(payload.rfeKey).toBe('RHAIRFE-100');
+  });
+
+  it('returns 400 for invalid feature key format', async () => {
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext());
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: 'invalid-key' }
+    });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid feature key format' });
+  });
+
+  it('returns 400 for empty feature key', async () => {
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext());
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: '' }
+    });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 for lowercase key', async () => {
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext());
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: 'rhaistrat-123' }
+    });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('accepts RHOAIENG-style keys', async () => {
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext());
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: 'RHOAIENG-567' }
+    });
+
+    expect(res.json).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.featureKey).toBe('RHOAIENG-567');
+  });
+
+  it('returns 500 when storage throws', async () => {
+    const ctx = makeContext();
+    ctx.storage.readFromStorage = vi.fn().mockRejectedValue(new Error('storage failure'));
+
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, ctx);
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: 'RHAISTRAT-123' }
+    });
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to resolve pipeline signals' });
+  });
+
+  it('returns all phases even when feature has no matching data', async () => {
+    const { router, routes } = createRouter();
+    registerPipelineSignalRoutes(router, makeContext({
+      'ai-impact/rfe-data.json': { issues: [] },
+      'ai-impact/doc-data.json': { issues: [] }
+    }));
+
+    const { res } = await callHandler(routes, 'GET', '/pipeline-signals/:featureKey', {
+      params: { featureKey: 'RHAISTRAT-999' }
+    });
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.featureKey).toBe('RHAISTRAT-999');
+    expect(payload.rfeKey).toBeNull();
+    expect(Object.keys(payload.phases)).toHaveLength(6);
+    expect(payload.phases['rfe-review'].completed).toBe(false);
+    expect(payload.phases['feature-review'].completed).toBe(false);
+  });
+
+  it('uses requireScope middleware', () => {
+    const ctx = makeContext();
+    ctx.requireScope = vi.fn(() => (req, res, next) => next());
+
+    const { router } = createRouter();
+    registerPipelineSignalRoutes(router, ctx);
+
+    expect(ctx.requireScope).toHaveBeenCalledWith('ai-impact:read');
+  });
+});

--- a/modules/ai-impact/client/components/DecomposerContent.vue
+++ b/modules/ai-impact/client/components/DecomposerContent.vue
@@ -2,7 +2,6 @@
 import { ref, computed, watch } from 'vue'
 import DecomposerMetricsRow from './DecomposerMetricsRow.vue'
 import DecomposerCharts from './DecomposerCharts.vue'
-import MermaidDiagram from './MermaidDiagram.vue'
 
 const props = defineProps({
   snapshot: { type: Object, default: null },
@@ -10,14 +9,13 @@ const props = defineProps({
   error: { type: String, default: null }
 })
 
-defineEmits(['retry'])
+defineEmits(['retry', 'selectStrategy'])
 
 const PAGE_SIZE = 10
 
 const searchQuery = ref('')
 const timeWindow = ref('month') // all | week | month | 3months
 const currentPage = ref(1)
-const expandedId = ref(null)
 
 const WINDOW_DAYS = { week: 7, month: 30, '3months': 90 }
 
@@ -96,15 +94,10 @@ const pagedStrategies = computed(() => {
   return filteredStrategies.value.slice(start, start + PAGE_SIZE)
 })
 
-watch([searchQuery, timeWindow], () => { currentPage.value = 1; expandedId.value = null })
+watch([searchQuery, timeWindow], () => { currentPage.value = 1 })
 
 function goToPage(p) {
   currentPage.value = Math.min(Math.max(1, p), totalPages.value)
-  expandedId.value = null
-}
-
-function toggleExpand(id) {
-  expandedId.value = expandedId.value === id ? null : id
 }
 
 function recClass(rec) {
@@ -198,9 +191,9 @@ function recClass(rec) {
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
               <template v-for="s in pagedStrategies" :key="s.strat_id">
-                <tr class="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer" @click="toggleExpand(s.strat_id)">
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer" @click="$emit('selectStrategy', s)">
                   <td class="px-2 py-2 text-gray-400">
-                    <svg class="h-4 w-4 transition-transform" :class="{ 'rotate-90': expandedId === s.strat_id }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                   </td>
@@ -221,41 +214,6 @@ function recClass(rec) {
                     <span class="px-2 py-0.5 rounded text-xs font-medium" :class="recClass(s.review?.recommendation)">
                       {{ s.review?.pass ? 'pass' : 'fail' }} · {{ s.review?.recommendation || '—' }}
                     </span>
-                  </td>
-                </tr>
-                <!-- Expanded detail: DAG + epics -->
-                <tr v-if="expandedId === s.strat_id" class="bg-gray-50 dark:bg-gray-800/40">
-                  <td colspan="7" class="px-6 py-4">
-                    <div class="grid gap-6 lg:grid-cols-2">
-                      <div>
-                        <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">Decomposition DAG</h4>
-                        <div v-if="s.mermaid_dag" class="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
-                          <MermaidDiagram :chart="s.mermaid_dag" />
-                        </div>
-                        <p v-else class="text-xs text-gray-400">No DAG available.</p>
-                      </div>
-                      <div>
-                        <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">Epics ({{ s.epics?.length || 0 }})</h4>
-                        <ul class="space-y-1">
-                          <li v-for="e in s.epics" :key="e.epic_id" class="text-xs flex items-start gap-2">
-                            <span class="font-mono text-gray-400 shrink-0">{{ e.epic_id?.split('-').pop() }}</span>
-                            <span class="dark:text-gray-200">
-                              {{ e.title }}
-                              <span class="text-gray-400">· {{ e.type }} · {{ e.priority }} · {{ e.component }}</span>
-                              <span v-if="e.ai_implementability" class="ml-1 px-1 rounded bg-gray-200 dark:bg-gray-700">AI: {{ e.ai_implementability }}</span>
-                              <a
-                                v-if="e.jira_key"
-                                :href="browseUrl(e.jira_key)"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="ml-1 text-blue-600 dark:text-blue-400 hover:underline"
-                                @click.stop
-                              >{{ e.jira_key }}</a>
-                            </span>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
                   </td>
                 </tr>
               </template>

--- a/modules/ai-impact/client/components/DecomposerDetailPanel.vue
+++ b/modules/ai-impact/client/components/DecomposerDetailPanel.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import PipelineTimeline from './PipelineTimeline.vue'
+import MermaidDiagram from './MermaidDiagram.vue'
+import { usePipelineSignals } from '../composables/usePipelineSignals.js'
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+  strategy: { type: Object, default: null },
+  phases: { type: Array, required: true },
+  jiraHost: { type: String, default: null }
+})
+
+const emit = defineEmits([
+  'close',
+  'navigateToRFE',
+  'navigateToFeature',
+  'navigateToTestPlan',
+  'navigateToDocumentation',
+  'navigateToBuildRelease'
+])
+
+const { loadPipelineSignals } = usePipelineSignals()
+const pipelineSignals = ref(null)
+const modalRef = ref(null)
+let previousActiveElement = null
+
+watch(
+  () => props.strategy?.strat_id,
+  async (key) => {
+    pipelineSignals.value = null
+    if (!props.show || !key) return
+    pipelineSignals.value = await loadPipelineSignals(key)
+  },
+  { immediate: true }
+)
+
+watch(() => props.show, (visible) => {
+  if (visible) {
+    previousActiveElement = document.activeElement
+    document.body.style.overflow = 'hidden'
+    nextTick(() => {
+      const focusable = modalRef.value?.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+      focusable?.focus()
+    })
+  } else {
+    document.body.style.overflow = ''
+    previousActiveElement?.focus()
+    previousActiveElement = null
+  }
+})
+
+onBeforeUnmount(() => {
+  document.body.style.overflow = ''
+})
+
+function handleKeydown(e) {
+  if (e.key === 'Escape') {
+    emit('close')
+    return
+  }
+  if (e.key === 'Tab' && modalRef.value) {
+    const focusables = modalRef.value.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+}
+
+function recClass(rec) {
+  if (rec === 'accept') return 'text-green-700 bg-green-100 dark:text-green-300 dark:bg-green-900/40'
+  if (rec === 'reject') return 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/40'
+  return 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40'
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="show && strategy" class="fixed inset-0 z-50 flex items-center justify-center p-4" @keydown="handleKeydown">
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/50" @click="emit('close')" />
+
+        <!-- Modal -->
+        <div ref="modalRef" role="dialog" aria-modal="true" class="relative bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-4xl w-full max-h-[90vh] flex flex-col">
+          <!-- Header -->
+          <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <div class="flex items-center gap-3 min-w-0">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Decomposer Details</h2>
+              <a
+                v-if="jiraHost"
+                :href="`${jiraHost}/browse/${strategy.strat_id}`"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline shrink-0"
+              >
+                {{ strategy.strat_id }}
+              </a>
+              <span v-else class="font-mono text-xs text-gray-500 dark:text-gray-400 shrink-0">{{ strategy.strat_id }}</span>
+            </div>
+            <button
+              @click="emit('close')"
+              aria-label="Close"
+              class="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Content (scrollable) -->
+          <div class="flex-1 overflow-auto px-6 py-5">
+            <h3 class="font-medium text-gray-900 dark:text-gray-200 mb-4">{{ strategy.title }}</h3>
+
+            <!-- Metadata grid -->
+            <div class="grid grid-cols-4 gap-4 mb-6 text-sm">
+              <div>
+                <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Epics</p>
+                <p class="text-lg font-bold dark:text-gray-200">{{ strategy.epic_count }}</p>
+              </div>
+              <div>
+                <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Critical Path</p>
+                <p class="text-lg font-bold dark:text-gray-200">{{ strategy.critical_path_length }}</p>
+              </div>
+              <div>
+                <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Score</p>
+                <p class="text-lg font-bold dark:text-gray-200">{{ strategy.review?.score ?? '—' }}</p>
+              </div>
+              <div>
+                <p class="text-gray-500 dark:text-gray-400 text-xs mb-1">Review</p>
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                  :class="recClass(strategy.review?.recommendation)"
+                >
+                  {{ strategy.review?.pass ? 'Pass' : 'Fail' }} · {{ strategy.review?.recommendation || '—' }}
+                </span>
+              </div>
+            </div>
+
+            <!-- DAG -->
+            <div class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
+              <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">Decomposition DAG</h4>
+              <div v-if="strategy.mermaid_dag" class="bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 p-3">
+                <MermaidDiagram :chart="strategy.mermaid_dag" />
+              </div>
+              <p v-else class="text-sm text-gray-400 dark:text-gray-500">No DAG available.</p>
+            </div>
+
+            <!-- Epics list -->
+            <div class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
+              <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Epics ({{ strategy.epics?.length || 0 }})
+              </h4>
+              <div v-if="strategy.epics?.length" class="space-y-2">
+                <div
+                  v-for="epic in strategy.epics"
+                  :key="epic.epic_id"
+                  class="flex items-start gap-3 p-2.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm"
+                >
+                  <span class="font-mono text-xs text-gray-400 shrink-0 pt-0.5">{{ epic.epic_id?.split('-').pop() }}</span>
+                  <div class="flex-1 min-w-0">
+                    <p class="dark:text-gray-200">{{ epic.title }}</p>
+                    <div class="flex items-center gap-2 mt-1 text-xs text-gray-400 dark:text-gray-500">
+                      <span>{{ epic.type }}</span>
+                      <span>·</span>
+                      <span>{{ epic.priority }}</span>
+                      <span>·</span>
+                      <span>{{ epic.component }}</span>
+                      <span v-if="epic.ai_implementability" class="px-1 rounded bg-gray-200 dark:bg-gray-700">
+                        AI: {{ epic.ai_implementability }}
+                      </span>
+                      <a
+                        v-if="epic.jira_key && jiraHost"
+                        :href="`${jiraHost}/browse/${epic.jira_key}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-blue-600 dark:text-blue-400 hover:underline"
+                      >{{ epic.jira_key }}</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p v-else class="text-sm text-gray-400 dark:text-gray-500">No epics in this strategy.</p>
+            </div>
+
+            <!-- Pipeline Progress -->
+            <PipelineTimeline
+              :phases="phases"
+              :jiraHost="jiraHost"
+              :signals="pipelineSignals"
+              @navigateToRFE="emit('navigateToRFE', $event)"
+              @navigateToFeature="emit('navigateToFeature', $event)"
+              @navigateToTestPlan="emit('navigateToTestPlan', $event)"
+              @navigateToDocumentation="emit('navigateToDocumentation', $event)"
+              @navigateToBuildRelease="emit('navigateToBuildRelease', $event)"
+            />
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+.modal-enter-active .relative,
+.modal-leave-active .relative {
+  transition: transform 0.2s ease;
+}
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+.modal-enter-from .relative {
+  transform: scale(0.95);
+}
+</style>

--- a/modules/ai-impact/client/components/FeatureDetailPanel.vue
+++ b/modules/ai-impact/client/components/FeatureDetailPanel.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onBeforeUnmount, nextTick } from 'vue'
 import PipelineTimeline from './PipelineTimeline.vue'
 import { getRecommendationClass, getRecommendationLabel, getRecommendationTooltip, getScoreClass, getReviewStatusClass, getReviewStatusLabel, getReviewStatusTooltip } from '../utils/feature-helpers.js'
 import { useTestPlans } from '../composables/useTestPlans.js'
+import { usePipelineSignals } from '../composables/usePipelineSignals.js'
 import InfoBubble from './InfoBubble.vue'
 
 const props = defineProps({
@@ -13,7 +14,7 @@ const props = defineProps({
   loadFeatureDetail: { type: Function, default: null }
 })
 
-const emit = defineEmits(['close', 'navigateToRFE', 'navigateToTestPlan'])
+const emit = defineEmits(['close', 'navigateToRFE', 'navigateToTestPlan', 'navigateToDecomposer', 'navigateToDocumentation', 'navigateToBuildRelease', 'viewInReleases'])
 
 const featureDetail = ref(null)
 const detailLoading = ref(false)
@@ -21,19 +22,27 @@ const modalRef = ref(null)
 let previousActiveElement = null
 
 const { loadTestPlanDetail } = useTestPlans()
+const { loadPipelineSignals } = usePipelineSignals()
 const testPlanData = ref(null)
+const pipelineSignals = ref(null)
 
 watch(
   () => props.feature?.key,
   async (key) => {
     featureDetail.value = null
     testPlanData.value = null
+    pipelineSignals.value = null
     if (!props.show || !key || !props.loadFeatureDetail) return
     detailLoading.value = true
     try {
-      featureDetail.value = await props.loadFeatureDetail(key)
-      // Load test plan data for this feature (sourceKey matches feature.key)
-      testPlanData.value = await loadTestPlanDetail(key)
+      const [detail, tp, signals] = await Promise.all([
+        props.loadFeatureDetail(key),
+        loadTestPlanDetail(key),
+        loadPipelineSignals(key)
+      ])
+      featureDetail.value = detail
+      testPlanData.value = tp
+      pipelineSignals.value = signals
     } catch {
       // Silently fail - slim data still shows
     } finally {
@@ -110,6 +119,15 @@ const history = computed(() => featureDetail.value?.history || [])
                 {{ feature.key }}
               </a>
               <span v-else class="font-mono text-xs text-gray-500 dark:text-gray-400 shrink-0">{{ feature.key }}</span>
+              <button
+                @click="emit('viewInReleases', feature.key)"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors shrink-0"
+              >
+                <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+                Releases
+              </button>
             </div>
             <button
               @click="emit('close')"
@@ -271,7 +289,18 @@ const history = computed(() => featureDetail.value?.history || [])
             <div v-if="detailLoading" class="text-xs text-gray-400 dark:text-gray-500 mb-4">Loading details...</div>
 
             <!-- Pipeline Progress -->
-            <PipelineTimeline :feature="featureDetail?.latest || feature" :testPlan="testPlanData?.latest" :phases="phases" :jiraHost="jiraHost" @navigateToRFE="emit('navigateToRFE', $event)" @navigateToTestPlan="emit('navigateToTestPlan', $event)" />
+            <PipelineTimeline
+              :feature="featureDetail?.latest || feature"
+              :testPlan="testPlanData?.latest"
+              :phases="phases"
+              :jiraHost="jiraHost"
+              :signals="pipelineSignals"
+              @navigateToRFE="emit('navigateToRFE', $event)"
+              @navigateToTestPlan="emit('navigateToTestPlan', $event)"
+              @navigateToDecomposer="emit('navigateToDecomposer', $event)"
+              @navigateToDocumentation="emit('navigateToDocumentation', $event)"
+              @navigateToBuildRelease="emit('navigateToBuildRelease', $event)"
+            />
           </div>
         </div>
       </div>

--- a/modules/ai-impact/client/components/PipelineTimeline.vue
+++ b/modules/ai-impact/client/components/PipelineTimeline.vue
@@ -1,15 +1,31 @@
 <script setup>
+import { computed } from 'vue'
+
 const props = defineProps({
   rfe: { type: Object, default: null },
   feature: { type: Object, default: null },
   testPlan: { type: Object, default: null },
   phases: { type: Array, required: true },
-  jiraHost: { type: String, default: null }
+  jiraHost: { type: String, default: null },
+  signals: { type: Object, default: null }
 })
 
-const emit = defineEmits(['navigateToRFE', 'navigateToFeature', 'navigateToTestPlan'])
+const emit = defineEmits([
+  'navigateToRFE',
+  'navigateToFeature',
+  'navigateToTestPlan',
+  'navigateToDecomposer',
+  'navigateToDocumentation',
+  'navigateToBuildRelease'
+])
 
 function getPhaseSignal(phaseId) {
+  // Server-resolved signals take precedence
+  if (props.signals && props.signals.phases && props.signals.phases[phaseId]) {
+    return props.signals.phases[phaseId]
+  }
+
+  // Legacy inline computation fallback
   if (props.testPlan && !props.rfe && !props.feature) {
     return getTestPlanContextSignal(phaseId)
   }
@@ -129,6 +145,47 @@ function getFeaturePhaseSignal(phaseId) {
       return { completed: false, current: false, aiUsed: null, detail: 'No signals yet' }
   }
 }
+
+const signalMap = computed(() => {
+  const map = {}
+  for (const phase of props.phases) {
+    map[phase.id] = getPhaseSignal(phase.id)
+  }
+  return map
+})
+
+function isClickable(phaseId, signal) {
+  if (!signal.linkedKey) return false
+  const clickablePhases = [
+    'rfe-review', 'feature-review', 'decomposer',
+    'test-plan-review', 'documentation', 'build-release'
+  ]
+  return clickablePhases.includes(phaseId)
+}
+
+function handlePhaseClick(phaseId, signal) {
+  if (!signal.linkedKey) return
+  switch (phaseId) {
+    case 'rfe-review':
+      emit('navigateToRFE', signal.linkedKey)
+      break
+    case 'feature-review':
+      emit('navigateToFeature', signal.linkedKey)
+      break
+    case 'decomposer':
+      emit('navigateToDecomposer', signal.linkedKey)
+      break
+    case 'test-plan-review':
+      emit('navigateToTestPlan', signal.linkedKey)
+      break
+    case 'documentation':
+      emit('navigateToDocumentation', signal.linkedKey)
+      break
+    case 'build-release':
+      emit('navigateToBuildRelease', signal.linkedKey)
+      break
+  }
+}
 </script>
 
 <template>
@@ -147,17 +204,17 @@ function getFeaturePhaseSignal(phaseId) {
           <div
             class="w-8 h-8 rounded-full flex items-center justify-center z-10"
             :class="{
-              'bg-green-500 text-white': getPhaseSignal(phase.id).completed,
-              'bg-blue-500 text-white': getPhaseSignal(phase.id).current && !getPhaseSignal(phase.id).completed,
-              'bg-gray-100 dark:bg-gray-700 text-gray-300 dark:text-gray-600': !getPhaseSignal(phase.id).completed && !getPhaseSignal(phase.id).current
+              'bg-green-500 text-white': signalMap[phase.id].completed,
+              'bg-blue-500 text-white': signalMap[phase.id].current && !signalMap[phase.id].completed,
+              'bg-gray-100 dark:bg-gray-700 text-gray-300 dark:text-gray-600': !signalMap[phase.id].completed && !signalMap[phase.id].current
             }"
           >
             <!-- Checkmark for completed -->
-            <svg v-if="getPhaseSignal(phase.id).completed" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg v-if="signalMap[phase.id].completed" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
             <!-- Circle for current phase -->
-            <svg v-else-if="getPhaseSignal(phase.id).current" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg v-else-if="signalMap[phase.id].current" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <circle cx="12" cy="12" r="10" stroke-width="2" />
             </svg>
             <!-- Lock for coming-soon -->
@@ -175,12 +232,12 @@ function getFeaturePhaseSignal(phaseId) {
             <div class="flex items-center gap-2">
               <span
                 class="text-sm font-medium dark:text-gray-200"
-                :class="{ 'text-gray-300 dark:text-gray-600': phase.status === 'coming-soon' && phase.id !== 'build-release' }"
+                :class="{ 'text-gray-300 dark:text-gray-600': phase.status === 'coming-soon' }"
               >
                 {{ phase.name }}
               </span>
               <svg
-                v-if="getPhaseSignal(phase.id).aiUsed"
+                v-if="signalMap[phase.id].aiUsed"
                 class="h-3 w-3 text-blue-500 dark:text-blue-400"
                 fill="none" stroke="currentColor" viewBox="0 0 24 24"
               >
@@ -190,78 +247,53 @@ function getFeaturePhaseSignal(phaseId) {
             </div>
 
             <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              <!-- Source RFE link (feature context) -->
-              <template v-if="getPhaseSignal(phase.id).isSourceRfe && getPhaseSignal(phase.id).linkedKey">
+              <!-- Clickable linked key (for any phase with a linkedKey) -->
+              <template v-if="isClickable(phase.id, signalMap[phase.id])">
                 <button
                   class="text-blue-600 dark:text-blue-400 hover:underline"
-                  @click="emit('navigateToRFE', getPhaseSignal(phase.id).linkedKey)"
+                  @click="handlePhaseClick(phase.id, signalMap[phase.id])"
                 >
-                  {{ getPhaseSignal(phase.id).linkedKey }}
+                  <template v-if="phase.id === 'feature-review' && !signalMap[phase.id].isSourceRfe">
+                    {{ signalMap[phase.id].linkedKey }}
+                  </template>
+                  <template v-else>
+                    {{ signalMap[phase.id].linkedKey }}
+                  </template>
                 </button>
                 <a
-                  v-if="jiraHost"
-                  :href="`${jiraHost}/browse/${getPhaseSignal(phase.id).linkedKey}`"
+                  v-if="jiraHost && !['documentation', 'build-release', 'decomposer'].includes(phase.id)"
+                  :href="`${jiraHost}/browse/${signalMap[phase.id].linkedKey}`"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="ml-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
                   title="View in Jira"
+                  @click.stop
                 >
                   <svg class="inline h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                   </svg>
                 </a>
+                <!-- Detail text after the key for feature-review -->
+                <template v-if="phase.id === 'feature-review' && signalMap[phase.id].detail && !signalMap[phase.id].isSourceRfe">
+                  <span class="ml-1">
+                    - {{ signalMap[phase.id].detail.split(' - ').slice(1).join(' - ') }}
+                  </span>
+                  <span v-if="signalMap[phase.id].fixVersions?.length > 0" class="ml-1">
+                    ({{ signalMap[phase.id].fixVersions.join(', ') }})
+                  </span>
+                </template>
+                <!-- Detail text for other clickable phases -->
+                <template v-else-if="phase.id !== 'rfe-review' && phase.id !== 'feature-review'">
+                  <span class="ml-1">— {{ signalMap[phase.id].detail }}</span>
+                </template>
               </template>
-              <!-- Linked feature link (RFE context) -->
-              <template v-else-if="phase.id === 'feature-review' && getPhaseSignal(phase.id).linkedKey">
-                <button
-                  class="text-blue-600 dark:text-blue-400 hover:underline"
-                  @click="emit('navigateToFeature', getPhaseSignal(phase.id).linkedKey)"
-                >
-                  {{ getPhaseSignal(phase.id).linkedKey }}
-                </button>
-                <a
-                  v-if="jiraHost"
-                  :href="`${jiraHost}/browse/${getPhaseSignal(phase.id).linkedKey}`"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="ml-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
-                  title="View in Jira"
-                >
-                  <svg class="inline h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                  </svg>
-                </a>
-                - {{ getPhaseSignal(phase.id).detail.split(' - ')[1] }}
-                <span v-if="getPhaseSignal(phase.id).fixVersions?.length > 0" class="ml-1">
-                  ({{ getPhaseSignal(phase.id).fixVersions.join(', ') }})
-                </span>
-              </template>
-              <!-- Test plan link (test-plan-review phase) -->
-              <template v-else-if="phase.id === 'test-plan-review' && getPhaseSignal(phase.id).linkedKey && testPlan">
-                <button
-                  class="text-blue-600 dark:text-blue-400 hover:underline"
-                  @click="emit('navigateToTestPlan', getPhaseSignal(phase.id).linkedKey)"
-                >
-                  {{ getPhaseSignal(phase.id).detail }}
-                </button>
-                <a
-                  v-if="testPlan.gitlabPath"
-                  :href="`https://gitlab.com/redhat/rhel-ai/agentic-ci/test-plans-data/-/tree/main/${testPlan.gitlabPath}`"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="ml-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
-                  title="View test plan in GitLab"
-                >
-                  <svg class="inline h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51A.42.42 0 0 1 18.6 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51L23 13.45a.84.84 0 0 1-.35.94z"/>
-                  </svg>
-                </a>
-              </template>
-              <template v-else-if="phase.status === 'coming-soon' && phase.id !== 'feature-review' && phase.id !== 'build-release'">
+              <!-- Coming-soon phases -->
+              <template v-else-if="phase.status === 'coming-soon'">
                 <span class="text-gray-300 dark:text-gray-600">No signals yet</span>
               </template>
+              <!-- Non-clickable phases with detail text -->
               <template v-else>
-                {{ getPhaseSignal(phase.id).detail }}
+                {{ signalMap[phase.id].detail }}
               </template>
             </div>
           </div>

--- a/modules/ai-impact/client/components/RFEDetailModal.vue
+++ b/modules/ai-impact/client/components/RFEDetailModal.vue
@@ -5,6 +5,7 @@ import AssessmentBreakdown from './AssessmentBreakdown.vue'
 import AssessmentHistory from './AssessmentHistory.vue'
 import FeedbackText from './FeedbackText.vue'
 import { useTestPlans } from '../composables/useTestPlans.js'
+import { usePipelineSignals } from '../composables/usePipelineSignals.js'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -15,7 +16,7 @@ const props = defineProps({
   loadAssessmentDetail: { type: Function, default: null }
 })
 
-const emit = defineEmits(['close', 'navigateToFeature', 'navigateToTestPlan'])
+const emit = defineEmits(['close', 'navigateToFeature', 'navigateToTestPlan', 'navigateToDecomposer', 'navigateToDocumentation', 'navigateToBuildRelease'])
 
 const assessmentDetail = ref(null)
 const detailLoading = ref(false)
@@ -23,20 +24,27 @@ const modalRef = ref(null)
 let previousActiveElement = null
 
 const { loadTestPlanDetail } = useTestPlans()
+const { loadPipelineSignals } = usePipelineSignals()
 const testPlanData = ref(null)
+const pipelineSignals = ref(null)
 
 watch(
   () => props.rfe?.key,
   async (key) => {
     assessmentDetail.value = null
     testPlanData.value = null
+    pipelineSignals.value = null
     if (!props.show || !key || !props.assessment || !props.loadAssessmentDetail) return
     detailLoading.value = true
     try {
       assessmentDetail.value = await props.loadAssessmentDetail(key)
-      // Load test plan for the linked feature (if exists)
       if (props.rfe?.linkedFeature?.key) {
-        testPlanData.value = await loadTestPlanDetail(props.rfe.linkedFeature.key)
+        const [tp, signals] = await Promise.all([
+          loadTestPlanDetail(props.rfe.linkedFeature.key),
+          loadPipelineSignals(props.rfe.linkedFeature.key)
+        ])
+        testPlanData.value = tp
+        pipelineSignals.value = signals
       }
     } catch {
       // Silently fail - slim data still shows
@@ -218,7 +226,18 @@ function getInvolvementClass(involvement) {
               </div>
             </div>
 
-            <PipelineTimeline :rfe="rfe" :testPlan="testPlanData?.latest" :phases="phases" :jiraHost="jiraHost" @navigateToFeature="emit('navigateToFeature', $event)" @navigateToTestPlan="emit('navigateToTestPlan', $event)" />
+            <PipelineTimeline
+              :rfe="rfe"
+              :testPlan="testPlanData?.latest"
+              :phases="phases"
+              :jiraHost="jiraHost"
+              :signals="pipelineSignals"
+              @navigateToFeature="emit('navigateToFeature', $event)"
+              @navigateToTestPlan="emit('navigateToTestPlan', $event)"
+              @navigateToDecomposer="emit('navigateToDecomposer', $event)"
+              @navigateToDocumentation="emit('navigateToDocumentation', $event)"
+              @navigateToBuildRelease="emit('navigateToBuildRelease', $event)"
+            />
           </div>
         </div>
       </div>

--- a/modules/ai-impact/client/components/TestPlanDetailPanel.vue
+++ b/modules/ai-impact/client/components/TestPlanDetailPanel.vue
@@ -6,6 +6,7 @@ import GapAnalysisText from './GapAnalysisText.vue'
 import InfoBubble from './InfoBubble.vue'
 import { getVerdictBgClass, getVerdictLabel, getCriterionLabel, getCriterionScoreClass, getCriterionScoreBgClass, getCriterionScoreLabel, getScoreColorClass, CRITERIA } from '../utils/test-plan-helpers.js'
 import { getReviewStatusClass } from '../utils/feature-helpers.js'
+import { usePipelineSignals } from '../composables/usePipelineSignals.js'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -15,12 +16,15 @@ const props = defineProps({
   loadTestPlanDetail: { type: Function, default: null }
 })
 
-const emit = defineEmits(['close', 'navigateToFeature', 'navigateToRFE'])
+const emit = defineEmits(['close', 'navigateToFeature', 'navigateToRFE', 'navigateToDecomposer', 'navigateToDocumentation', 'navigateToBuildRelease'])
+
+const { loadPipelineSignals } = usePipelineSignals()
 
 const planDetail = ref(null)
 const detailLoading = ref(false)
 const modalRef = ref(null)
 const expandedCriteria = ref({})
+const pipelineSignals = ref(null)
 let previousActiveElement = null
 
 watch(
@@ -28,10 +32,16 @@ watch(
   async (key) => {
     planDetail.value = null
     expandedCriteria.value = {}
+    pipelineSignals.value = null
     if (!props.show || !key || !props.loadTestPlanDetail) return
     detailLoading.value = true
     try {
-      planDetail.value = await props.loadTestPlanDetail(key)
+      const [detail, signals] = await Promise.all([
+        props.loadTestPlanDetail(key),
+        loadPipelineSignals(key)
+      ])
+      planDetail.value = detail
+      pipelineSignals.value = signals
     } catch {
       // Silently fail - slim data still shows
     } finally {
@@ -379,7 +389,17 @@ const allHistoryEntries = computed(() => {
             <div v-if="detailLoading" class="text-xs text-gray-400 dark:text-gray-500 mb-4">Loading details...</div>
 
             <!-- Pipeline Progress -->
-            <PipelineTimeline :testPlan="currentPlan" :phases="phases" :jiraHost="jiraHost" @navigateToFeature="emit('navigateToFeature', $event)" @navigateToRFE="emit('navigateToRFE', $event)" />
+            <PipelineTimeline
+              :testPlan="currentPlan"
+              :phases="phases"
+              :jiraHost="jiraHost"
+              :signals="pipelineSignals"
+              @navigateToFeature="emit('navigateToFeature', $event)"
+              @navigateToRFE="emit('navigateToRFE', $event)"
+              @navigateToDecomposer="emit('navigateToDecomposer', $event)"
+              @navigateToDocumentation="emit('navigateToDocumentation', $event)"
+              @navigateToBuildRelease="emit('navigateToBuildRelease', $event)"
+            />
           </div>
         </div>
       </div>

--- a/modules/ai-impact/client/composables/usePipelineSignals.js
+++ b/modules/ai-impact/client/composables/usePipelineSignals.js
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const cache = ref({})
+
+/**
+ * Load pipeline signals for a feature key. Results are cached per key
+ * for the lifetime of the session.
+ *
+ * @param {string} featureKey - RHAISTRAT-xxx or RHOAIENG-xxx
+ * @returns {Promise<object|null>} Resolved pipeline signals or null on error
+ */
+async function loadPipelineSignals(featureKey) {
+  if (!featureKey) return null
+  if (cache.value[featureKey]) return cache.value[featureKey]
+
+  try {
+    const data = await apiRequest(`/modules/ai-impact/pipeline-signals/${encodeURIComponent(featureKey)}`)
+    cache.value[featureKey] = data
+    return data
+  } catch {
+    return null
+  }
+}
+
+export function usePipelineSignals() {
+  return { loadPipelineSignals, cache }
+}

--- a/modules/ai-impact/client/constants.js
+++ b/modules/ai-impact/client/constants.js
@@ -4,10 +4,10 @@
 export const PHASES = [
   { id: 'rfe-review', name: 'RFE Review', order: 1, status: 'active' },
   { id: 'feature-review', name: 'Feature Review', order: 2, status: 'active' },
-  { id: 'test-plan-review', name: 'Test Plan Review', order: 3, status: 'active' },
-  { id: 'implementation', name: 'Implementation', order: 4, status: 'coming-soon' },
-  { id: 'security', name: 'Security Review', order: 5, status: 'coming-soon' },
-  { id: 'documentation', name: 'Documentation', order: 6, status: 'active' },
-  { id: 'build-release', name: 'Build & Release', order: 7, status: 'active' },
-  { id: 'jira-autofix', name: 'Jira Autofix', order: 8, status: 'active' },
+  { id: 'decomposer', name: 'Feature Decomposer', order: 3, status: 'active' },
+  { id: 'test-plan-review', name: 'Test Plan Review', order: 4, status: 'active' },
+  { id: 'implementation', name: 'Implementation', order: 5, status: 'coming-soon' },
+  { id: 'security', name: 'Security Review', order: 6, status: 'coming-soon' },
+  { id: 'documentation', name: 'Documentation', order: 7, status: 'active' },
+  { id: 'build-release', name: 'Build & Release', order: 8, status: 'active' },
 ]

--- a/modules/ai-impact/client/views/FeatureDecomposerView.vue
+++ b/modules/ai-impact/client/views/FeatureDecomposerView.vue
@@ -1,8 +1,64 @@
 <script setup>
+import { ref, watch, inject } from 'vue'
 import { useDecomposer } from '../composables/useDecomposer.js'
+import { useModuleLink } from '@shared/client/composables/useModuleLink.js'
+import { PHASES } from '../constants.js'
 import DecomposerContent from '../components/DecomposerContent.vue'
+import DecomposerDetailPanel from '../components/DecomposerDetailPanel.vue'
+
+const moduleNav = inject('moduleNav')
+const { navigateTo: crossNavigate } = useModuleLink()
 
 const { snapshot, loading, error, load } = useDecomposer()
+
+const selectedStrategy = ref(null)
+
+function handleSelectStrategy(strategy) {
+  selectedStrategy.value = strategy
+  if (strategy) {
+    moduleNav.navigateTo('feature-decomposer', { select: strategy.strat_id })
+  }
+}
+
+function handleCloseModal() {
+  selectedStrategy.value = null
+  moduleNav.navigateTo('feature-decomposer')
+}
+
+function handleNavigateToRFE(rfeKey) {
+  moduleNav.navigateTo('rfe-review', { select: rfeKey })
+}
+
+function handleNavigateToFeature(featureKey) {
+  crossNavigate('releases', 'feature-detail', {
+    key: featureKey,
+    fromDecomposer: '1'
+  })
+}
+
+function handleNavigateToTestPlan(sourceKey) {
+  moduleNav.navigateTo('test-plan-review', { select: sourceKey })
+}
+
+function handleNavigateToDocumentation(featureKey) {
+  moduleNav.navigateTo('documentation', { highlight: featureKey })
+}
+
+function handleNavigateToBuildRelease(featureKey) {
+  moduleNav.navigateTo('build-release', { highlight: featureKey })
+}
+
+const jiraHost = () => (snapshot.value?.jiraHost || 'https://redhat.atlassian.net').replace(/\/$/, '')
+
+// Handle incoming select param (cross-link from other views)
+watch([() => moduleNav.params.value, snapshot], ([params]) => {
+  if (params?.select && snapshot.value?.strategies?.length > 0) {
+    const strategy = snapshot.value.strategies.find(s => s.strat_id === params.select)
+    if (strategy && selectedStrategy.value?.strat_id !== strategy.strat_id) {
+      selectedStrategy.value = strategy
+    }
+  }
+}, { immediate: true })
 </script>
 
 <template>
@@ -12,6 +68,20 @@ const { snapshot, loading, error, load } = useDecomposer()
       :loading="loading"
       :error="error"
       @retry="load"
+      @selectStrategy="handleSelectStrategy"
+    />
+
+    <DecomposerDetailPanel
+      :show="!!selectedStrategy"
+      :strategy="selectedStrategy"
+      :phases="PHASES"
+      :jiraHost="jiraHost()"
+      @close="handleCloseModal"
+      @navigateToRFE="handleNavigateToRFE"
+      @navigateToFeature="handleNavigateToFeature"
+      @navigateToTestPlan="handleNavigateToTestPlan"
+      @navigateToDocumentation="handleNavigateToDocumentation"
+      @navigateToBuildRelease="handleNavigateToBuildRelease"
     />
   </div>
 </template>

--- a/modules/ai-impact/client/views/FeatureReviewView.vue
+++ b/modules/ai-impact/client/views/FeatureReviewView.vue
@@ -35,10 +35,8 @@ function handleRetry() {
 
 function handleSelectFeature(feature) {
   if (feature) {
-    crossNavigate('releases', 'feature-detail', {
-      key: feature.key,
-      fromFeatureReview: '1'
-    })
+    selectedFeature.value = feature
+    moduleNav.navigateTo('feature-review', { select: feature.key })
   }
 }
 
@@ -53,6 +51,25 @@ function handleNavigateToRFE(rfeKey) {
 
 function handleNavigateToTestPlan(sourceKey) {
   moduleNav.navigateTo('test-plan-review', { select: sourceKey })
+}
+
+function handleNavigateToDecomposer(featureKey) {
+  moduleNav.navigateTo('feature-decomposer', { select: featureKey })
+}
+
+function handleNavigateToDocumentation(featureKey) {
+  moduleNav.navigateTo('documentation', { highlight: featureKey })
+}
+
+function handleNavigateToBuildRelease(featureKey) {
+  moduleNav.navigateTo('build-release', { highlight: featureKey })
+}
+
+function handleViewInReleases(featureKey) {
+  crossNavigate('releases', 'feature-detail', {
+    key: featureKey,
+    fromFeatureReview: '1'
+  })
 }
 
 // Handle incoming select param (cross-link from RFE Review)
@@ -121,6 +138,10 @@ watch(() => Object.keys(features.value).length, () => {
       @close="handleCloseModal"
       @navigateToRFE="handleNavigateToRFE"
       @navigateToTestPlan="handleNavigateToTestPlan"
+      @navigateToDecomposer="handleNavigateToDecomposer"
+      @navigateToDocumentation="handleNavigateToDocumentation"
+      @navigateToBuildRelease="handleNavigateToBuildRelease"
+      @viewInReleases="handleViewInReleases"
     />
 
     <AIImpactGuide />

--- a/modules/ai-impact/client/views/RFEReviewView.vue
+++ b/modules/ai-impact/client/views/RFEReviewView.vue
@@ -117,6 +117,18 @@ function handleNavigateToTestPlan(sourceKey) {
   moduleNav.navigateTo('test-plan-review', { select: sourceKey })
 }
 
+function handleNavigateToDecomposer(featureKey) {
+  moduleNav.navigateTo('feature-decomposer', { select: featureKey })
+}
+
+function handleNavigateToDocumentation(featureKey) {
+  moduleNav.navigateTo('documentation', { highlight: featureKey })
+}
+
+function handleNavigateToBuildRelease(featureKey) {
+  moduleNav.navigateTo('build-release', { highlight: featureKey })
+}
+
 const fromForYou = computed(() => moduleNav.params.value?.from === 'sotu' || moduleNav.params.value?.from === 'state-of-the-union')
 
 function goBackToForYou() {
@@ -238,6 +250,9 @@ watch([() => moduleNav.params.value, rfeData], ([params]) => {
       @close="handleCloseModal"
       @navigateToFeature="handleNavigateToFeature"
       @navigateToTestPlan="handleNavigateToTestPlan"
+      @navigateToDecomposer="handleNavigateToDecomposer"
+      @navigateToDocumentation="handleNavigateToDocumentation"
+      @navigateToBuildRelease="handleNavigateToBuildRelease"
     />
 
     <AIImpactGuide />

--- a/modules/ai-impact/client/views/TestPlanView.vue
+++ b/modules/ai-impact/client/views/TestPlanView.vue
@@ -49,6 +49,18 @@ function handleNavigateToRFE(rfeKey) {
   moduleNav.navigateTo('rfe-review', { select: rfeKey })
 }
 
+function handleNavigateToDecomposer(featureKey) {
+  moduleNav.navigateTo('feature-decomposer', { select: featureKey })
+}
+
+function handleNavigateToDocumentation(featureKey) {
+  moduleNav.navigateTo('documentation', { highlight: featureKey })
+}
+
+function handleNavigateToBuildRelease(featureKey) {
+  moduleNav.navigateTo('build-release', { highlight: featureKey })
+}
+
 // Handle incoming select param (cross-link from other views)
 watch(() => moduleNav.params.value, (params) => {
   if (params?.select && Object.keys(testPlans.value).length > 0) {
@@ -109,6 +121,9 @@ watch(() => Object.keys(testPlans.value).length, () => {
       @close="handleCloseModal"
       @navigateToFeature="handleNavigateToFeature"
       @navigateToRFE="handleNavigateToRFE"
+      @navigateToDecomposer="handleNavigateToDecomposer"
+      @navigateToDocumentation="handleNavigateToDocumentation"
+      @navigateToBuildRelease="handleNavigateToBuildRelease"
     />
 
     <AIImpactGuide defaultTab="testplans" />

--- a/modules/ai-impact/server/index.js
+++ b/modules/ai-impact/server/index.js
@@ -52,6 +52,10 @@ module.exports = function registerRoutes(router, context) {
   const registerDecomposerRoutes = require('./decomposer/routes');
   registerDecomposerRoutes(router, context);
 
+  // Pipeline signals routes (cross-store lineage resolution)
+  const registerPipelineSignalRoutes = require('./pipeline-signals/routes');
+  registerPipelineSignalRoutes(router, context);
+
   // ─── Refresh state (in-memory) ───
 
   const refreshState = {

--- a/modules/ai-impact/server/pipeline-signals/resolve.js
+++ b/modules/ai-impact/server/pipeline-signals/resolve.js
@@ -1,0 +1,276 @@
+const { readFeatures } = require('../features/storage');
+const { readTestPlans } = require('../test-plans/storage');
+const { readDecomposer } = require('../decomposer/storage');
+const { readComponentOnboarding, projectComponent } = require('../component-onboarding/storage');
+
+/**
+ * Resolve pipeline signals for a given feature key by joining across all
+ * AI Impact data stores.
+ *
+ * @param {string} featureKey - RHAISTRAT-xxx or RHOAIENG-xxx
+ * @param {Function} readFromStorage - storage read function
+ * @param {object} [options]
+ * @param {string} [options.jiraHost] - Jira base URL
+ * @returns {Promise<object|null>} Resolved signals or null if feature not found
+ */
+async function resolvePipelineSignals(featureKey, readFromStorage, options = {}) {
+  const [rfeData, featuresData, testPlansData, decomposerData, docData, coData] = await Promise.all([
+    readFromStorage('ai-impact/rfe-data.json'),
+    readFeatures(readFromStorage),
+    readTestPlans(readFromStorage),
+    readDecomposer(readFromStorage),
+    readFromStorage('ai-impact/doc-data.json'),
+    readComponentOnboarding(readFromStorage)
+  ]);
+
+  const phases = {};
+
+  // --- RFE Review ---
+  const rfeSignal = resolveRfeSignal(rfeData, featureKey);
+  phases['rfe-review'] = rfeSignal;
+
+  // --- Feature Review ---
+  phases['feature-review'] = resolveFeatureSignal(featuresData, featureKey);
+
+  // --- Feature Decomposer ---
+  phases['decomposer'] = resolveDecomposerSignal(decomposerData, featureKey);
+
+  // --- Test Plan Review ---
+  phases['test-plan-review'] = resolveTestPlanSignal(testPlansData, featureKey);
+
+  // --- Documentation ---
+  phases['documentation'] = resolveDocSignal(docData, featureKey);
+
+  // --- Build & Release ---
+  phases['build-release'] = resolveBuildReleaseSignal(coData, featureKey);
+
+  return {
+    featureKey,
+    rfeKey: rfeSignal.linkedKey || null,
+    jiraHost: options.jiraHost || null,
+    phases
+  };
+}
+
+function resolveRfeSignal(rfeData, featureKey) {
+  if (!rfeData || !Array.isArray(rfeData.issues)) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No data' };
+  }
+
+  const rfe = rfeData.issues.find(function(issue) {
+    return issue.linkedFeature && issue.linkedFeature.key === featureKey;
+  });
+
+  if (!rfe) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No linked RFE' };
+  }
+
+  const aiUsed = rfe.aiInvolvement !== 'none';
+  let detail = 'No AI involvement';
+  if (rfe.aiInvolvement === 'both') detail = 'AI created & revised';
+  else if (rfe.aiInvolvement === 'created') detail = 'AI created';
+  else if (rfe.aiInvolvement === 'revised') detail = 'AI revised';
+
+  return {
+    completed: true,
+    current: false,
+    aiUsed,
+    detail,
+    linkedKey: rfe.key
+  };
+}
+
+function resolveFeatureSignal(featuresData, featureKey) {
+  const entry = featuresData.features[featureKey];
+  if (!entry) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No feature data' };
+  }
+
+  const latest = entry.latest;
+  const labels = latest.labels || [];
+  const aiUsed = labels.some(function(l) {
+    return l === 'strat-creator-auto-created' || l === 'strat-creator-auto-refined';
+  });
+
+  const approved = latest.humanReviewStatus === 'approved';
+  const total = latest.scores && latest.scores.total != null ? latest.scores.total : 0;
+
+  return {
+    completed: approved,
+    current: !approved,
+    aiUsed,
+    detail: (latest.recommendation || 'pending') + ' — ' + total + '/8',
+    linkedKey: featureKey,
+    scores: latest.scores || null,
+    recommendation: latest.recommendation || null,
+    humanReviewStatus: latest.humanReviewStatus || null
+  };
+}
+
+function resolveDecomposerSignal(decomposerData, featureKey) {
+  if (!decomposerData || !Array.isArray(decomposerData.strategies)) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No data' };
+  }
+
+  const strategy = decomposerData.strategies.find(function(s) {
+    return s.strat_id === featureKey;
+  });
+
+  if (!strategy) {
+    return { completed: false, current: false, aiUsed: null, detail: 'Not decomposed' };
+  }
+
+  const review = strategy.review || {};
+  const score = review.score != null ? review.score : null;
+  const pass = review.pass || false;
+
+  return {
+    completed: pass,
+    current: !pass && score != null,
+    aiUsed: true,
+    detail: strategy.epic_count + ' epics · ' + (pass ? 'pass' : 'fail') + (score != null ? ' (' + score + ')' : ''),
+    linkedKey: featureKey,
+    epicCount: strategy.epic_count,
+    score,
+    pass
+  };
+}
+
+function resolveTestPlanSignal(testPlansData, featureKey) {
+  if (!testPlansData || !testPlansData.testPlans) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No data' };
+  }
+
+  // Test plans use sourceKey to link back to the feature
+  let testPlan = null;
+  for (const entry of Object.values(testPlansData.testPlans)) {
+    if (entry.latest && entry.latest.sourceKey === featureKey) {
+      testPlan = entry.latest;
+      break;
+    }
+  }
+
+  if (!testPlan) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No test plan' };
+  }
+
+  const aiUsed = (testPlan.labels || []).some(function(l) {
+    return l === 'test-plan-auto-created';
+  });
+  const approved = testPlan.humanReviewStatus === 'approved';
+
+  return {
+    completed: approved,
+    current: !approved && testPlan.verdict !== undefined,
+    aiUsed,
+    detail: (testPlan.verdict || 'pending') + ' — ' + (testPlan.score || 0) + '/10',
+    linkedKey: testPlan.sourceKey || testPlan.key
+  };
+}
+
+function resolveDocSignal(docData, featureKey) {
+  if (!docData || !Array.isArray(docData.issues)) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No data' };
+  }
+
+  const issue = docData.issues.find(function(i) {
+    return i.key === featureKey;
+  });
+
+  if (!issue) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No doc issue' };
+  }
+
+  if (issue.hasDocContributed) {
+    return {
+      completed: true,
+      current: false,
+      aiUsed: true,
+      detail: 'Docs contributed',
+      linkedKey: featureKey,
+      hasDocContributed: true,
+      docContributedDate: issue.docContributedDate || null
+    };
+  }
+
+  if (issue.hasDocSkipped) {
+    return {
+      completed: true,
+      current: false,
+      aiUsed: false,
+      detail: 'Docs skipped',
+      linkedKey: featureKey,
+      hasDocSkipped: true
+    };
+  }
+
+  if (issue.hasDocInvoked) {
+    return {
+      completed: false,
+      current: true,
+      aiUsed: true,
+      detail: 'Doc tool invoked',
+      linkedKey: featureKey,
+      hasDocInvoked: true
+    };
+  }
+
+  return {
+    completed: false,
+    current: false,
+    aiUsed: null,
+    detail: 'Docs not started',
+    linkedKey: featureKey
+  };
+}
+
+function resolveBuildReleaseSignal(coData, featureKey) {
+  if (!coData || !coData.components) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No data' };
+  }
+
+  // Scan components for any whose linkedFeatures contains the feature key
+  let match = null;
+  for (const entry of Object.values(coData.components)) {
+    const latest = entry.latest;
+    if (latest && Array.isArray(latest.linkedFeatures) && latest.linkedFeatures.includes(featureKey)) {
+      match = projectComponent(entry);
+      break;
+    }
+  }
+
+  if (!match) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No onboarding data' };
+  }
+
+  const steps = match.onboardingSteps || {};
+  const stepKeys = Object.keys(steps);
+  const completedSteps = stepKeys.filter(function(k) { return steps[k]; }).length;
+  const totalSteps = stepKeys.length;
+
+  const completed = match.completionStatus === 'completed';
+  const current = match.completionStatus === 'in-progress';
+
+  let detail = completedSteps + '/' + totalSteps + ' steps';
+  if (match.targetVersion) detail += ' · ' + match.targetVersion;
+
+  return {
+    completed,
+    current,
+    aiUsed: null,
+    detail,
+    linkedKey: match.key,
+    completionStatus: match.completionStatus,
+    targetVersion: match.targetVersion
+  };
+}
+
+module.exports = {
+  resolvePipelineSignals,
+  resolveRfeSignal,
+  resolveFeatureSignal,
+  resolveDecomposerSignal,
+  resolveTestPlanSignal,
+  resolveDocSignal,
+  resolveBuildReleaseSignal
+};

--- a/modules/ai-impact/server/pipeline-signals/resolve.js
+++ b/modules/ai-impact/server/pipeline-signals/resolve.js
@@ -81,6 +81,10 @@ function resolveRfeSignal(rfeData, featureKey) {
 }
 
 function resolveFeatureSignal(featuresData, featureKey) {
+  if (!featuresData || !featuresData.features) {
+    return { completed: false, current: false, aiUsed: null, detail: 'No data' };
+  }
+
   const entry = featuresData.features[featureKey];
   if (!entry) {
     return { completed: false, current: false, aiUsed: null, detail: 'No feature data' };

--- a/modules/ai-impact/server/pipeline-signals/routes.js
+++ b/modules/ai-impact/server/pipeline-signals/routes.js
@@ -1,0 +1,54 @@
+const { resolvePipelineSignals } = require('./resolve');
+
+/**
+ * Register pipeline-signals routes on the module router.
+ *
+ * @param {import('express').Router} router
+ * @param {object} context - Module context with storage and auth middleware
+ */
+module.exports = function registerPipelineSignalRoutes(router, context) {
+  const { storage, requireScope } = context;
+  const { readFromStorage } = storage;
+
+  const JIRA_HOST = process.env.JIRA_HOST || 'https://redhat.atlassian.net';
+
+  /**
+   * @openapi
+   * /api/modules/ai-impact/pipeline-signals/{featureKey}:
+   *   get:
+   *     summary: Resolve pipeline lineage signals for a feature key
+   *     description: >
+   *       Joins across all AI Impact data stores (RFE, feature review,
+   *       decomposer, test plans, documentation, component onboarding)
+   *       to return the full pipeline status for a given feature.
+   *     tags: [AI Impact - Pipeline]
+   *     parameters:
+   *       - in: path
+   *         name: featureKey
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Feature Jira key (e.g. RHAISTRAT-1234 or RHOAIENG-567)
+   *     responses:
+   *       200:
+   *         description: Pipeline signals for all phases
+   *       400:
+   *         description: Missing or invalid feature key
+   */
+  router.get('/pipeline-signals/:featureKey', requireScope('ai-impact:read'), async function(req, res) {
+    const featureKey = req.params.featureKey;
+    if (!featureKey || !/^[A-Z][A-Z0-9]+-\d+$/.test(featureKey)) {
+      return res.status(400).json({ error: 'Invalid feature key format' });
+    }
+
+    try {
+      const result = await resolvePipelineSignals(featureKey, readFromStorage, {
+        jiraHost: JIRA_HOST
+      });
+      res.json(result);
+    } catch (err) {
+      console.error('[ai-impact] Pipeline signals resolve error:', err);
+      res.status(500).json({ error: 'Failed to resolve pipeline signals' });
+    }
+  });
+};

--- a/modules/releases/client/components/PipelineTimelineLite.vue
+++ b/modules/releases/client/components/PipelineTimelineLite.vue
@@ -1,0 +1,133 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const props = defineProps({
+  featureKey: { type: String, default: null }
+})
+
+const emit = defineEmits(['navigate'])
+
+const signals = ref(null)
+const loading = ref(false)
+const error = ref(false)
+
+const PHASES = [
+  { id: 'rfe-review', name: 'RFE Review' },
+  { id: 'feature-review', name: 'Feature Review' },
+  { id: 'decomposer', name: 'Feature Decomposer' },
+  { id: 'test-plan-review', name: 'Test Plan Review' },
+  { id: 'implementation', name: 'Implementation', comingSoon: true },
+  { id: 'security', name: 'Security Review', comingSoon: true },
+  { id: 'documentation', name: 'Documentation' },
+  { id: 'build-release', name: 'Build & Release' },
+]
+
+const cache = {}
+
+watch(() => props.featureKey, async (key) => {
+  signals.value = null
+  error.value = false
+  if (!key) return
+
+  if (cache[key]) {
+    signals.value = cache[key]
+    return
+  }
+
+  loading.value = true
+  try {
+    const data = await apiRequest(`/modules/ai-impact/pipeline-signals/${encodeURIComponent(key)}`)
+    cache[key] = data
+    signals.value = data
+  } catch {
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+}, { immediate: true })
+
+function getPhase(phaseId) {
+  if (!signals.value?.phases?.[phaseId]) {
+    return { completed: false, current: false, aiUsed: null, detail: null }
+  }
+  return signals.value.phases[phaseId]
+}
+
+function handleClick(phaseId, signal) {
+  if (!signal.linkedKey) return
+  emit('navigate', { phase: phaseId, key: signal.linkedKey })
+}
+
+const hasAnySignal = () => {
+  if (!signals.value?.phases) return false
+  return Object.values(signals.value.phases).some(p => p.completed || p.current || p.detail)
+}
+</script>
+
+<template>
+  <div v-if="loading" class="text-xs text-gray-400 dark:text-gray-500 py-2">
+    Loading pipeline signals...
+  </div>
+  <div v-else-if="error" class="text-xs text-gray-400 dark:text-gray-500 py-2">
+    Pipeline signals unavailable
+  </div>
+  <div v-else-if="signals && hasAnySignal()">
+    <div class="relative">
+      <div class="absolute left-3 top-4 bottom-4 w-px bg-gray-200 dark:bg-gray-700" />
+      <div class="space-y-2.5">
+        <div
+          v-for="phase in PHASES"
+          :key="phase.id"
+          class="flex items-center gap-3 relative"
+        >
+          <div
+            class="w-6 h-6 rounded-full flex items-center justify-center z-10 shrink-0"
+            :class="{
+              'bg-green-500 text-white': getPhase(phase.id).completed,
+              'bg-blue-500 text-white': getPhase(phase.id).current && !getPhase(phase.id).completed,
+              'bg-gray-100 dark:bg-gray-700 text-gray-300 dark:text-gray-600': !getPhase(phase.id).completed && !getPhase(phase.id).current
+            }"
+          >
+            <svg v-if="getPhase(phase.id).completed" class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg v-else-if="getPhase(phase.id).current" class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="10" stroke-width="2" />
+            </svg>
+            <svg v-else-if="phase.comingSoon" class="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            <svg v-else class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="4" stroke-width="2" />
+            </svg>
+          </div>
+
+          <div class="flex items-center gap-2 min-w-0">
+            <span
+              class="text-xs font-medium dark:text-gray-200"
+              :class="{ 'text-gray-300 dark:text-gray-600': phase.comingSoon }"
+            >{{ phase.name }}</span>
+            <svg
+              v-if="getPhase(phase.id).aiUsed"
+              class="h-3 w-3 text-blue-500 dark:text-blue-400 shrink-0"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+            </svg>
+            <button
+              v-if="getPhase(phase.id).linkedKey && !phase.comingSoon"
+              class="text-[11px] text-blue-600 dark:text-blue-400 hover:underline truncate"
+              @click="handleClick(phase.id, getPhase(phase.id))"
+            >{{ getPhase(phase.id).linkedKey }}</button>
+            <span v-else-if="getPhase(phase.id).detail && !phase.comingSoon" class="text-[11px] text-gray-400 dark:text-gray-500 truncate">
+              {{ getPhase(phase.id).detail }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/modules/releases/client/views/FeatureDetailView.vue
+++ b/modules/releases/client/views/FeatureDetailView.vue
@@ -10,6 +10,7 @@ import EpicBreakdown from '../execute/components/EpicBreakdown.vue'
 import SignoffSection from '../execute/components/SignoffSection.vue'
 import AIReviewSection from '../execute/components/AIReviewSection.vue'
 import HygieneViolations from '@shared/client/components/HygieneViolations.vue'
+import PipelineTimelineLite from '../components/PipelineTimelineLite.vue'
 
 const nav = inject('moduleNav')
 const { feature, loading, error, loadFeature } = useFeatureDetail()
@@ -21,6 +22,7 @@ const hygieneLoading = ref(false)
 const hygieneViolations = ref([])
 const hygieneAvailable = ref(true)
 const hygieneExpanded = ref(false)
+const pipelineExpanded = ref(false)
 
 // --- FPDoR Readiness ---
 const fpdorData = ref(null)
@@ -167,6 +169,7 @@ const hasDeliveryInsight = computed(() => {
 
 const fromRfe = computed(() => nav.params.value.fromRfe)
 const fromFeatureReview = computed(() => nav.params.value.fromFeatureReview)
+const fromDecomposer = computed(() => nav.params.value.fromDecomposer)
 const fromPlan = computed(() => nav.params.value.from === 'plan')
 const fromPlanFeatures = computed(() => nav.params.value.from === 'plan-features')
 const fromFeatureStatus = computed(() => nav.params.value.from === 'feature-status')
@@ -181,6 +184,8 @@ function goBack() {
     crossNavigate('ai-impact', 'rfe-review', { select: fromRfe.value })
   } else if (fromFeatureReview.value) {
     crossNavigate('ai-impact', 'feature-review')
+  } else if (fromDecomposer.value) {
+    crossNavigate('ai-impact', 'feature-decomposer')
   } else if (fromPlanFeatures.value) {
     nav.navigateTo('plan', { tab: 'feature-readiness' })
   } else if (fromPlan.value) {
@@ -203,6 +208,21 @@ function goBack() {
     nav.navigateTo('execute', params)
   } else {
     nav.navigateTo('execute')
+  }
+}
+
+function handlePipelineNavigate({ phase, key }) {
+  const viewMap = {
+    'rfe-review': 'rfe-review',
+    'feature-review': 'feature-review',
+    'decomposer': 'feature-decomposer',
+    'test-plan-review': 'test-plan-review',
+    'documentation': 'documentation',
+    'build-release': 'build-release'
+  }
+  const viewId = viewMap[phase]
+  if (viewId) {
+    crossNavigate('ai-impact', viewId, { select: key })
   }
 }
 
@@ -394,7 +414,7 @@ onMounted(() => {
       class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white flex items-center gap-1"
       @click="goBack"
     >
-      &larr; {{ fromForYou ? 'Back to State of the Union' : fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : fromPlanFeatures ? 'Back to Features List' : fromPlan ? 'Back to Plan' : fromHygieneReport ? 'Back to Hygiene Report' : fromCapacityReport ? 'Back to Program Level Release Report' : fromFeatureStatus ? 'Back to Feature Status' : 'Back to Execute' }}
+      &larr; {{ fromForYou ? 'Back to State of the Union' : fromRfe ? 'Back to RFE Review' : fromFeatureReview ? 'Back to Feature Review' : fromDecomposer ? 'Back to Feature Decomposer' : fromPlanFeatures ? 'Back to Features List' : fromPlan ? 'Back to Plan' : fromHygieneReport ? 'Back to Hygiene Report' : fromCapacityReport ? 'Back to Program Level Release Report' : fromFeatureStatus ? 'Back to Feature Status' : 'Back to Execute' }}
     </button>
 
     <!-- Loading -->
@@ -543,6 +563,31 @@ onMounted(() => {
         class="text-xs text-gray-400 dark:text-gray-500 italic px-1"
       >
         No hygiene data available
+      </div>
+
+      <!-- AI Pipeline Progress (collapsible) -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+        <button
+          class="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+          @click="pipelineExpanded = !pipelineExpanded"
+        >
+          <div class="flex items-center gap-2">
+            <svg
+              class="h-4 w-4 text-gray-400 dark:text-gray-500 transition-transform"
+              :class="{ 'rotate-90': pipelineExpanded }"
+              xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">AI Pipeline</span>
+          </div>
+        </button>
+        <div v-if="pipelineExpanded" class="px-5 pb-4">
+          <PipelineTimelineLite
+            :featureKey="featureKey"
+            @navigate="handlePipelineNavigate"
+          />
+        </div>
       </div>
 
       <!-- Progress Summary (always visible above tabs) -->


### PR DESCRIPTION
## Summary

- **Pipeline signals API** (`GET /pipeline-signals/:featureKey`) — server-side join across all 6 AI Impact data stores (RFE, Feature Review, Decomposer, Test Plan, Documentation, Build & Release) returning per-phase completion status, AI involvement, and linked keys
- **Interactive pipeline timeline** shown in detail panels across all AI Impact views (RFE Review, Feature Review, Feature Decomposer, Test Plan Review) and in the releases FeatureDetailView — clicking a phase opens the corresponding detail modal in-context
- **45 unit/integration tests** covering all 6 per-phase resolvers and the route handler

### New files
| File | Purpose |
|------|---------|
| `server/pipeline-signals/resolve.js` | 6 pure resolver functions + orchestrator |
| `server/pipeline-signals/routes.js` | Express route with key validation |
| `client/composables/usePipelineSignals.js` | Client-side fetch composable |
| `client/components/DecomposerDetailPanel.vue` | Strategy drill-down panel |
| `releases/client/components/PipelineTimelineLite.vue` | Cross-module timeline (no module imports) |
| `__tests__/server/pipeline-signals-resolve.test.js` | 36 resolver unit tests |
| `__tests__/server/pipeline-signals-routes.test.js` | 9 route integration tests |

### How it works
Each pipeline phase has a resolver that reads from its respective data store and returns `{ completed, current, aiUsed, detail, linkedKey }`. The orchestrator runs all 6 in parallel via `Promise.all`. The client composable fetches signals when a feature key is provided and feeds them to the `PipelineTimeline` component, which renders phase dots with status colors and clickable linked keys that open detail modals in-context.

## Test plan
- [x] `npm test` — 45 new tests pass (resolver + routes)
- [x] Verified full pipeline flow in browser with synthetic data for RHAISTRAT-133 (all 6 phases lit green)
- [x] Timeline renders correctly in Feature Review, RFE Review, Test Plan, Decomposer, and Releases views
- [x] Clicking timeline phase keys opens correct detail modals
- [x] Invalid/empty/lowercase keys return 400
- [x] Storage failures return 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)