### PR TITLE
fix(ai-impact): resolve RFE-to-feature links in both clone directions

### DIFF
--- a/modules/ai-impact/__tests__/server/link-resolver.test.js
+++ b/modules/ai-impact/__tests__/server/link-resolver.test.js
@@ -21,9 +21,23 @@ describe('extractLinkedKey', () => {
     expect(extractLinkedKey(links, CONFIG)).toBeNull();
   });
 
-  it('returns null when no outward issue exists', () => {
+  it('returns key from inwardIssue when outwardIssue is absent', () => {
     const links = [
       { type: { name: 'Cloners' }, inwardIssue: { key: 'RHAISTRAT-123' } }
+    ];
+    expect(extractLinkedKey(links, CONFIG)).toBe('RHAISTRAT-123');
+  });
+
+  it('prefers outwardIssue over inwardIssue when both are present', () => {
+    const links = [
+      { type: { name: 'Cloners' }, outwardIssue: { key: 'RHAISTRAT-100' }, inwardIssue: { key: 'RHAISTRAT-200' } }
+    ];
+    expect(extractLinkedKey(links, CONFIG)).toBe('RHAISTRAT-100');
+  });
+
+  it('returns null when inwardIssue is a different project', () => {
+    const links = [
+      { type: { name: 'Cloners' }, inwardIssue: { key: 'OTHER-123' } }
     ];
     expect(extractLinkedKey(links, CONFIG)).toBeNull();
   });

--- a/modules/ai-impact/server/jira/link-resolver.js
+++ b/modules/ai-impact/server/jira/link-resolver.js
@@ -2,7 +2,7 @@ const { fetchAllJqlResults } = require('../../../../shared/server/jira');
 
 /**
  * Extract linked feature key from an RFE's issuelinks.
- * Returns the first matching outward link key, or null.
+ * Returns the first matching link key (outward preferred), or null.
  */
 function extractLinkedKey(issueLinks, config) {
   const { linkTypeName, linkedProject } = config;

--- a/modules/ai-impact/server/jira/link-resolver.js
+++ b/modules/ai-impact/server/jira/link-resolver.js
@@ -8,8 +8,8 @@ function extractLinkedKey(issueLinks, config) {
   const { linkTypeName, linkedProject } = config;
   for (const link of issueLinks) {
     if (link.type.name !== linkTypeName) continue;
-    // "is cloned by" from RFE perspective = outwardIssue points to RHAISTRAT
-    const linked = link.outwardIssue;
+    // Check both directions: outwardIssue ("clones") and inwardIssue ("is cloned by")
+    const linked = link.outwardIssue || link.inwardIssue;
     if (!linked || !linked.key.startsWith(linkedProject)) continue;
     return linked.key;
   }


### PR DESCRIPTION
## Summary
- `extractLinkedKey` in the RFE link resolver only checked `outwardIssue` ("clones" direction), missing the `inwardIssue` ("is cloned by" direction)
- This caused ~98% of RFEs (1666 of 1700) to show "No linked RFE" in pipeline progress despite having valid Cloners links to RHAISTRAT features in Jira
- Example: RHAIRFE-644 → RHAISTRAT-1047 link exists in Jira but was invisible to pipeline signals

## Test plan
- [x] Updated `extractLinkedKey` unit tests: inward-only match, outward preference when both present, non-matching inward project
- [x] All 14 link-resolver tests pass
- [x] All 36 pipeline-signals-resolve tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)