### PR TITLE
fix(ai-impact): pipeline signals lost when test-plan fetch returns 404

### DIFF
--- a/modules/ai-impact/client/components/FeatureDetailPanel.vue
+++ b/modules/ai-impact/client/components/FeatureDetailPanel.vue
@@ -35,14 +35,14 @@ watch(
     if (!props.show || !key || !props.loadFeatureDetail) return
     detailLoading.value = true
     try {
-      const [detail, tp, signals] = await Promise.all([
+      const [detail, tp, signals] = await Promise.allSettled([
         props.loadFeatureDetail(key),
         loadTestPlanDetail(key),
         loadPipelineSignals(key)
       ])
-      featureDetail.value = detail
-      testPlanData.value = tp
-      pipelineSignals.value = signals
+      featureDetail.value = detail.status === 'fulfilled' ? detail.value : null
+      testPlanData.value = tp.status === 'fulfilled' ? tp.value : null
+      pipelineSignals.value = signals.status === 'fulfilled' ? signals.value : null
     } catch {
       // Silently fail - slim data still shows
     } finally {

--- a/modules/ai-impact/client/components/RFEDetailModal.vue
+++ b/modules/ai-impact/client/components/RFEDetailModal.vue
@@ -39,12 +39,13 @@ watch(
     try {
       assessmentDetail.value = await props.loadAssessmentDetail(key)
       if (props.rfe?.linkedFeature?.key) {
-        const [tp, signals] = await Promise.all([
-          loadTestPlanDetail(props.rfe.linkedFeature.key),
-          loadPipelineSignals(props.rfe.linkedFeature.key)
+        const featureKey = props.rfe.linkedFeature.key
+        const [tp, signals] = await Promise.allSettled([
+          loadTestPlanDetail(featureKey),
+          loadPipelineSignals(featureKey)
         ])
-        testPlanData.value = tp
-        pipelineSignals.value = signals
+        testPlanData.value = tp.status === 'fulfilled' ? tp.value : null
+        pipelineSignals.value = signals.status === 'fulfilled' ? signals.value : null
       }
     } catch {
       // Silently fail - slim data still shows

--- a/modules/ai-impact/client/composables/useTestPlans.js
+++ b/modules/ai-impact/client/composables/useTestPlans.js
@@ -46,7 +46,7 @@ async function loadTestPlanDetail(key) {
     detailCache.value[key] = data
     return data
   } catch (e) {
-    if (e.message && e.message.includes('404')) {
+    if (e.status === 404) {
       return null
     }
     throw e


### PR DESCRIPTION
## Summary

- **Root cause**: `loadTestPlanDetail` checked `e.message.includes('404')` to detect 404 errors, but the server returns `{"error":"Not found"}` — the error message is `"Not found"`, not `"HTTP 404"`. The check failed, the error was re-thrown, `Promise.all` rejected, the outer catch silently swallowed it, and `pipelineSignals` stayed null.
- **Impact**: Any RFE whose linked feature has no test plan (404 response) shows a blue circle instead of a green check for the RFE Review phase, even though the server correctly reports `completed: true`.
- **Fix 1**: Check `e.status === 404` (set by `apiRequest`) instead of string-matching the error message.
- **Fix 2**: Switch `RFEDetailModal` from `Promise.all` to `Promise.allSettled` so a test-plan failure can never block pipeline signals.

## Test plan

- [x] All 724 AI Impact tests pass
- [x] Lint clean
- [ ] Verify RHAIRFE-1644 shows green check after deploy
- [ ] Verify RHAIRFE-644 still shows green check (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)