### PR TITLE
fix(releases): await async loadAllBugs() to prevent 'not iterable' error

### DIFF
--- a/modules/releases/server/delivery/routes.js
+++ b/modules/releases/server/delivery/routes.js
@@ -1814,7 +1814,7 @@ module.exports = async function registerRoutes(router, context) {
         return res.json({ labels: [], datasets: [] })
       }
 
-      const allBugs = loadAllBugs(config.projectKeys)
+      const allBugs = await loadAllBugs(config.projectKeys)
 
       const versionSet = new Set(versions)
       let filteredBugs = allBugs.filter(bug =>
@@ -1851,7 +1851,7 @@ module.exports = async function registerRoutes(router, context) {
   router.get('/quality/components', requireAuth, requireScope('releases:read'), async function(req, res) {
     try {
       const config = await getConfig(readFromStorage)
-      const allBugs = loadAllBugs(config.projectKeys)
+      const allBugs = await loadAllBugs(config.projectKeys)
 
       const componentCounts = {}
       for (const bug of allBugs) {
@@ -1933,7 +1933,7 @@ module.exports = async function registerRoutes(router, context) {
         cacheAge: bugsCache.timestamp ? Date.now() - bugsCache.timestamp : null
       }
 
-      const allBugs = loadAllBugs(config.projectKeys)
+      const allBugs = await loadAllBugs(config.projectKeys)
 
       const bugsByProject = {}
       for (const project of config.projectKeys) {
@@ -2125,7 +2125,7 @@ module.exports = async function registerRoutes(router, context) {
     try {
       const config = await getConfig(readFromStorage)
       const versions = await readFromStorage('releases/delivery/quality/versions.json') || []
-      const allBugs = loadAllBugs(config.projectKeys)
+      const allBugs = await loadAllBugs(config.projectKeys)
       const releases = compute90DaySummary(null, allBugs, versions)
       res.json({ releases: releases })
     } catch (error) {
@@ -2153,7 +2153,7 @@ module.exports = async function registerRoutes(router, context) {
     try {
       const config = await getConfig(readFromStorage)
       const versions = await readFromStorage('releases/delivery/quality/versions.json') || []
-      const allBugs = loadAllBugs(config.projectKeys)
+      const allBugs = await loadAllBugs(config.projectKeys)
       const configReleases = req.body && req.body.releases ? req.body.releases : null
       const releases = compute90DaySummary(configReleases, allBugs, versions)
       res.json({ releases: releases })


### PR DESCRIPTION
## Summary
- Fixes "allBugs is not iterable" error on the OKR Hub Reports page (90-Day Post-Release Bug Tracking)
- `loadAllBugs()` is an `async` function but was called without `await` at all 5 call sites in the quality routes, causing the variable to hold a Promise instead of an array
- Added `await` to all 5 `loadAllBugs()` calls in `modules/releases/server/delivery/routes.js`

Fixes red-hat-data-services/org-pulse-core#66

## Test plan
- [ ] Navigate to OKR Hub > Reports and verify the 90-Day Post-Release Bug Tracking section loads without error
- [ ] Verify the quality/bugs, quality/components, and quality/debug endpoints return data
- [ ] Verify the 90day-summary GET and POST endpoints return data

🤖 Generated with [Claude Code](https://claude.com/claude-code)