### PR TITLE
fix(releases): update version naming in hygiene program report

### DIFF
--- a/modules/releases/__tests__/client/deliver/release-utils.test.js
+++ b/modules/releases/__tests__/client/deliver/release-utils.test.js
@@ -11,6 +11,8 @@ describe('KNOWN_PRODUCTS', () => {
     expect(KNOWN_PRODUCTS).toContain('rhoai')
     expect(KNOWN_PRODUCTS).toContain('rhel-ai')
     expect(KNOWN_PRODUCTS).toContain('rhaii')
+    expect(KNOWN_PRODUCTS).toContain('rhelai')
+    expect(KNOWN_PRODUCTS).toContain('rhaiis')
     expect(KNOWN_PRODUCTS).toContain('base-images')
   })
 })
@@ -51,6 +53,23 @@ describe('extractProduct', () => {
   it('returns empty for bare versions', () => {
     expect(extractProduct('3.4')).toBe('')
     expect(extractProduct('1.0')).toBe('')
+  })
+
+  it('extracts product from new RHAISTRAT naming convention', () => {
+    expect(extractProduct('3.5 GA RHOAI RELEASE')).toBe('rhoai')
+    expect(extractProduct('3.5 EA1 RHOAI RELEASE')).toBe('rhoai')
+    expect(extractProduct('3.6 EA2 RHOAI RELEASE')).toBe('rhoai')
+    expect(extractProduct('3.5 GA RHAII RELEASE')).toBe('rhaii')
+    expect(extractProduct('3.6 EA1 RHAII RELEASE')).toBe('rhaii')
+    expect(extractProduct('3.5 GA RHELAI RELEASE')).toBe('rhelai')
+    expect(extractProduct('3.6 EA1 RHELAI RELEASE')).toBe('rhelai')
+    expect(extractProduct('3.5 GA RHAIIS RELEASE')).toBe('rhaiis')
+  })
+
+  it('extracts rhelai and rhaiis from prefix-style names', () => {
+    expect(extractProduct('rhelai-3.5')).toBe('rhelai')
+    expect(extractProduct('rhaiis-3.5')).toBe('rhaiis')
+    expect(extractProduct('RHELAI-3.5.EA1')).toBe('rhelai')
   })
 })
 

--- a/modules/releases/client/deliver/composables/release-utils.js
+++ b/modules/releases/client/deliver/composables/release-utils.js
@@ -1,4 +1,6 @@
-export const KNOWN_PRODUCTS = ['base-images', 'rhel-ai-container-disk-images', 'rhel-ai-disk-images', 'rhel-ai', 'rhoai', 'rhaii']
+export const KNOWN_PRODUCTS = ['base-images', 'rhel-ai-container-disk-images', 'rhel-ai-disk-images', 'rhel-ai', 'rhaiis', 'rhoai', 'rhelai', 'rhaii']
+
+const PRODUCT_TOKENS = ['rhaiis', 'rhoai', 'rhelai', 'rhaii']
 
 export function extractProduct(releaseNumber) {
   const s = (releaseNumber || '').toLowerCase()
@@ -7,7 +9,13 @@ export function extractProduct(releaseNumber) {
     if (s.startsWith(p + '-') && /\d/.test(s[p.length + 1])) return p
   }
   const m = s.match(/^(.+?)-(\d.*)$/)
-  return m ? m[1] : ''
+  if (m) return m[1]
+  // New convention: product name as a word within the string
+  // e.g. "3.5 GA RHOAI RELEASE" → "rhoai"
+  for (const p of PRODUCT_TOKENS) {
+    if (new RegExp('\\b' + p + '\\b').test(s)) return p
+  }
+  return ''
 }
 
 export function extractVersion(releaseNumber) {

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -10,6 +10,7 @@ const { evaluateHygiene, hygieneRules, RULE_CATEGORIES } = require('./hygiene-ru
 const { fetchHygieneFeatures } = require('./jira-fetch');
 const { logAudit } = require('../planning/audit-log');
 const { readRegistry } = require('../registry');
+const { normalizeVersionName } = require('../version-utils');
 
 const DATA_PREFIX = 'releases/hygiene';
 const COOLDOWN_MS = 5 * 60 * 1000;
@@ -667,9 +668,20 @@ module.exports = async function registerHygieneRoutes(router, context) {
         }
       }
 
+      // Prefer fixVersion matching current RHAISTRAT convention (e.g. "3.5 GA RHOAI RELEASE")
+      var displayName = (rel && rel.displayName) || data.version || versionId;
+      if (rel && rel.fixVersions) {
+        for (var fvi = 0; fvi < rel.fixVersions.length; fvi++) {
+          if (/^\d+\.\d+\s+(GA|EA\d+)\s+\w+\s+RELEASE$/i.test(rel.fixVersions[fvi])) {
+            displayName = rel.fixVersions[fvi];
+            break;
+          }
+        }
+      }
+
       versions.push({
         versionId: versionId,
-        displayName: (rel && rel.displayName) || data.version || versionId,
+        displayName: displayName,
         gaDate: gaDate || null,
         isReleased: !!isReleased,
         fetchedAt: data.fetchedAt || null,
@@ -682,6 +694,32 @@ module.exports = async function registerHygieneRoutes(router, context) {
         features: featureList
       });
     }
+
+    // Deduplicate versions that normalize to the same logical release
+    // (e.g. "rhoai-3.5", "3.5 GA RHOAI RELEASE", and "rhoai-3.5.z" all map to the same release)
+    var dedupMap = {};
+    for (var di = 0; di < versions.length; di++) {
+      var dv = versions[di];
+      var normKey = normalizeVersionName(dv.versionId) || dv.versionId;
+      if (!dedupMap[normKey]) {
+        dedupMap[normKey] = dv;
+      } else {
+        var existing = dedupMap[normKey];
+        var existingTime = existing.fetchedAt ? new Date(existing.fetchedAt).getTime() : 0;
+        var newTime = dv.fetchedAt ? new Date(dv.fetchedAt).getTime() : 0;
+        if (newTime > existingTime) {
+          var prevName = existing.displayName;
+          dedupMap[normKey] = dv;
+          // Preserve the more descriptive display name
+          if (/RELEASE$/i.test(prevName) && !/RELEASE$/i.test(dv.displayName)) {
+            dedupMap[normKey].displayName = prevName;
+          }
+        } else if (/RELEASE$/i.test(dv.displayName) && !/RELEASE$/i.test(existing.displayName)) {
+          existing.displayName = dv.displayName;
+        }
+      }
+    }
+    versions = Object.values(dedupMap);
 
     // Build cross-version aggregates
     var totalViolationsByRule = {};


### PR DESCRIPTION
## Summary

Fixes #1259 — The Program Hygiene Report filter panel showed outdated version names (e.g. `rhoai-3.5`) instead of the current RHAISTRAT convention (e.g. `3.5 GA RHOAI RELEASE`).

Three fixes:

- **Frontend `extractProduct`**: Added word-boundary matching for product names within version strings, handling the new `3.5 GA RHOAI RELEASE` format where the product appears mid-string. Also added `rhelai` and `rhaiis` to `KNOWN_PRODUCTS`
- **Program-report display names**: When a registry entry has fixVersions matching the RHAISTRAT pattern, prefer that as the display name instead of the Product Pages-style name
- **Program-report deduplication**: Group versions by `normalizeVersionName()` to merge old-style (`rhoai-3.5`), new-style (`3.5 GA RHOAI RELEASE`), and stale `.z` variants (`rhoai-3.5.z`) of the same logical release, keeping the most recently fetched data

## Test plan

- [x] All existing tests pass (5625 tests)
- [x] New test cases for `extractProduct` with RHAISTRAT naming convention
- [x] Verified `extractProduct` handles all production version names correctly
- [x] Verified `normalizeVersionName` correctly groups duplicate versions
- [ ] Deploy and verify the program hygiene report filter panel shows current naming convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)