### PR TITLE
feat(releases): add Component Throughput table to AI Adoption report

### DIFF
--- a/modules/releases/__tests__/server/ai-adoption/pipeline.test.js
+++ b/modules/releases/__tests__/server/ai-adoption/pipeline.test.js
@@ -3,6 +3,9 @@ import { describe, it, expect, vi } from 'vitest';
 const {
   scanLabels,
   fetchAiAdoptionData,
+  fetchChildRollups,
+  resolveEffortSignal,
+  applyEffortSignal,
   AI_PIPELINE_TAXONOMY,
   PIPELINE_KEYS,
   RELEASE_GROUPS,
@@ -278,5 +281,199 @@ describe('fetchAiAdoptionData', () => {
     expect(results).toHaveLength(1);
     expect(results[0].totalFeatures).toBe(0);
     expect(results[0].components).toEqual([]);
+  });
+
+  it('accumulates effort signals and resolves effort per group', async () => {
+    const issues = [
+      {
+        key: 'E-1',
+        fields: {
+          summary: 'E-1', status: { name: 'Done' }, labels: ['strat-creator-auto-created'],
+          components: [{ name: 'Alpha' }], fixVersions: [],
+          customfield_10430: 5, customfield_10637: 3
+        }
+      },
+      {
+        key: 'E-2',
+        fields: {
+          summary: 'E-2', status: { name: 'Done' }, labels: [],
+          components: [{ name: 'Alpha' }], fixVersions: [],
+          customfield_10430: 3, customfield_10637: null
+        }
+      },
+      {
+        key: 'E-3',
+        fields: {
+          summary: 'E-3', status: { name: 'Done' }, labels: [],
+          components: [{ name: 'Beta' }], fixVersions: [],
+          customfield_10430: null, customfield_10637: null
+        }
+      }
+    ];
+
+    const childIssues = [
+      { key: 'C-1', fields: { parent: { key: 'E-1' }, customfield_10016: 5, customfield_10637: null, timeoriginalestimate: null }},
+      { key: 'C-2', fields: { parent: { key: 'E-1' }, customfield_10016: 3, customfield_10637: null, timeoriginalestimate: null }},
+      { key: 'C-3', fields: { parent: { key: 'E-2' }, customfield_10016: 2, customfield_10637: null, timeoriginalestimate: null }}
+    ];
+
+    let callCount = 0;
+    const jira = {
+      fetchAllJqlResults: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) return issues;
+        return childIssues;
+      })
+    };
+    const results = await fetchAiAdoptionData(jira, { releaseGroup: '3.4 GA' });
+    expect(results).toHaveLength(1);
+    const g = results[0];
+
+    expect(g.effortSignal).toBe('effort');
+    expect(g.aggregateEffort).toBe(8);
+    expect(g.avgEffort).toBe(2.7);
+
+    const alpha = g.components.find(c => c.name === 'Alpha');
+    expect(alpha.effortSum).toBe(8);
+    expect(alpha.effortCount).toBe(2);
+    expect(alpha.aggregateEffort).toBe(8);
+    expect(alpha.avgEffort).toBe(4);
+    expect(alpha.childSpSum).toBe(10);
+
+    const beta = g.components.find(c => c.name === 'Beta');
+    expect(beta.effortSum).toBe(0);
+    expect(beta.aggregateEffort).toBe(0);
+    expect(beta.childIssueSum).toBe(1);
+  });
+
+  it('falls back to childSp when custom fields are empty', async () => {
+    const issues = [
+      { key: 'F-1', fields: { summary: 'F-1', status: { name: 'Done' }, labels: [], components: [{ name: 'Comp' }], fixVersions: [], customfield_10430: null, customfield_10637: null }},
+      { key: 'F-2', fields: { summary: 'F-2', status: { name: 'Done' }, labels: [], components: [{ name: 'Comp' }], fixVersions: [], customfield_10430: null, customfield_10637: null }},
+      { key: 'F-3', fields: { summary: 'F-3', status: { name: 'Done' }, labels: [], components: [{ name: 'Comp' }], fixVersions: [], customfield_10430: null, customfield_10637: null }}
+    ];
+
+    const childIssues = [
+      { key: 'C-1', fields: { parent: { key: 'F-1' }, customfield_10016: 3, customfield_10637: null, timeoriginalestimate: null }},
+      { key: 'C-2', fields: { parent: { key: 'F-1' }, customfield_10016: 5, customfield_10637: null, timeoriginalestimate: null }},
+      { key: 'C-3', fields: { parent: { key: 'F-2' }, customfield_10016: 2, customfield_10637: null, timeoriginalestimate: null }}
+    ];
+
+    let callCount = 0;
+    const jira = {
+      fetchAllJqlResults: vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) return issues;
+        return childIssues;
+      })
+    };
+    const results = await fetchAiAdoptionData(jira, { releaseGroup: '3.4 GA' });
+    const g = results[0];
+
+    expect(g.effortSignal).toBe('childSp');
+    expect(g.aggregateEffort).toBe(10);
+    expect(g.avgEffort).toBe(3.3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffortSignal
+// ---------------------------------------------------------------------------
+describe('resolveEffortSignal', () => {
+  it('returns effort when customfield_10430 covers >= 50%', () => {
+    expect(resolveEffortSignal({ effortCount: 5, riceEffortCount: 2, childSpCount: 3 }, 10)).toBe('effort');
+    expect(resolveEffortSignal({ effortCount: 10, riceEffortCount: 0, childSpCount: 0 }, 10)).toBe('effort');
+  });
+
+  it('falls back to rice when effort is under 50% but rice is >= 50%', () => {
+    expect(resolveEffortSignal({ effortCount: 2, riceEffortCount: 6, childSpCount: 4 }, 10)).toBe('rice');
+  });
+
+  it('falls back to childSp when effort and rice are under 50% but childSp >= 30%', () => {
+    expect(resolveEffortSignal({ effortCount: 1, riceEffortCount: 1, childSpCount: 4 }, 10)).toBe('childSp');
+  });
+
+  it('falls back to children when no signal meets threshold', () => {
+    expect(resolveEffortSignal({ effortCount: 1, riceEffortCount: 1, childSpCount: 2 }, 10)).toBe('children');
+  });
+
+  it('returns children when totalFeatures is 0', () => {
+    expect(resolveEffortSignal({ effortCount: 0, riceEffortCount: 0, childSpCount: 0 }, 0)).toBe('children');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyEffortSignal
+// ---------------------------------------------------------------------------
+describe('applyEffortSignal', () => {
+  const entry = {
+    total: 4,
+    effortSum: 20,
+    riceEffortSum: 12,
+    childSpSum: 15,
+    childIssueSum: 8
+  };
+
+  it('uses effortSum when signal is effort', () => {
+    const result = applyEffortSignal(entry, 'effort');
+    expect(result.aggregateEffort).toBe(20);
+    expect(result.avgEffort).toBe(5);
+  });
+
+  it('uses riceEffortSum when signal is rice', () => {
+    const result = applyEffortSignal(entry, 'rice');
+    expect(result.aggregateEffort).toBe(12);
+    expect(result.avgEffort).toBe(3);
+  });
+
+  it('uses childSpSum when signal is childSp', () => {
+    const result = applyEffortSignal(entry, 'childSp');
+    expect(result.aggregateEffort).toBe(15);
+    expect(result.avgEffort).toBe(3.8);
+  });
+
+  it('uses childIssueSum when signal is children', () => {
+    const result = applyEffortSignal(entry, 'children');
+    expect(result.aggregateEffort).toBe(8);
+    expect(result.avgEffort).toBe(2);
+  });
+
+  it('returns 0 avgEffort when total is 0', () => {
+    const result = applyEffortSignal({ total: 0, effortSum: 0, riceEffortSum: 0, childSpSum: 0, childIssueSum: 0 }, 'effort');
+    expect(result.avgEffort).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchChildRollups
+// ---------------------------------------------------------------------------
+describe('fetchChildRollups', () => {
+  it('returns empty map when no parent keys', async () => {
+    const jira = { fetchAllJqlResults: vi.fn() };
+    const result = await fetchChildRollups(jira, []);
+    expect(result.size).toBe(0);
+    expect(jira.fetchAllJqlResults).not.toHaveBeenCalled();
+  });
+
+  it('rolls up child count and story points per parent', async () => {
+    const childIssues = [
+      { key: 'C-1', fields: { parent: { key: 'P-1' }, customfield_10016: 3, customfield_10637: null, timeoriginalestimate: null }},
+      { key: 'C-2', fields: { parent: { key: 'P-1' }, customfield_10016: 5, customfield_10637: null, timeoriginalestimate: null }},
+      { key: 'C-3', fields: { parent: { key: 'P-2' }, customfield_10016: null, customfield_10637: 2, timeoriginalestimate: null }},
+      { key: 'C-4', fields: { parent: { key: 'P-2' }, customfield_10016: null, customfield_10637: null, timeoriginalestimate: 7200 }}
+    ];
+    const jira = { fetchAllJqlResults: vi.fn(async () => childIssues) };
+    const result = await fetchChildRollups(jira, ['P-1', 'P-2']);
+
+    expect(result.get('P-1').childCount).toBe(2);
+    expect(result.get('P-1').childSpSum).toBe(8);
+    expect(result.get('P-2').childCount).toBe(2);
+    expect(result.get('P-2').childSpSum).toBe(4);
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    const jira = { fetchAllJqlResults: vi.fn(async () => { throw new Error('timeout'); }) };
+    const result = await fetchChildRollups(jira, ['X-1']);
+    expect(result.size).toBe(0);
   });
 });

--- a/modules/releases/client/reports/AiAdoptionReport.vue
+++ b/modules/releases/client/reports/AiAdoptionReport.vue
@@ -377,6 +377,67 @@ const perComponentRows = computed(() => {
   return rows
 })
 
+const throughputRows = computed(() => {
+  const groups = scorecardGroups.value
+  if (!groups.length) return []
+
+  const compMap = {}
+  for (const rg of groups) {
+    for (const c of rg.components || []) {
+      if (!compMap[c.name]) {
+        compMap[c.name] = { name: c.name, releases: {}, totalAiTouched: 0, totalFeatures: 0, pipelines: {} }
+        for (const k of PIPELINE_KEYS) compMap[c.name].pipelines[k] = 0
+      }
+      compMap[c.name].totalAiTouched += c.aiTouched
+      compMap[c.name].totalFeatures += c.total
+      for (const k of PIPELINE_KEYS) compMap[c.name].pipelines[k] += (c.pipelines[k] || 0)
+      const aiPct = c.total > 0 ? Math.round((c.aiTouched / c.total) * 100) : 0
+      compMap[c.name].releases[rg.releaseGroup] = {
+        features: c.total,
+        aiTouched: c.aiTouched,
+        aiPct,
+        aggregateEffort: c.aggregateEffort || 0,
+        avgEffort: c.avgEffort || 0
+      }
+    }
+  }
+
+  const baselineName = selectedBaseline.value
+  const latestName = groups[groups.length - 1].releaseGroup
+
+  const rows = Object.values(compMap).map(row => {
+    const bl = row.releases[baselineName]
+    const lt = row.releases[latestName]
+    row.baselineAvg = bl ? bl.avgEffort : 0
+    row.latestAvg = lt ? lt.avgEffort : 0
+    row.baselineFeatures = bl ? bl.features : 0
+    row.latestFeatures = lt ? lt.features : 0
+    row.latestAiPct = lt ? lt.aiPct : 0
+    const blThroughput = row.baselineFeatures * (row.baselineAvg || 1)
+    const ltThroughput = row.latestFeatures * (row.latestAvg || 1)
+    row.baselineThroughput = Math.round(blThroughput * 10) / 10
+    row.latestThroughput = Math.round(ltThroughput * 10) / 10
+    row.throughputDelta = blThroughput > 0
+      ? Math.round(((ltThroughput - blThroughput) / blThroughput) * 100)
+      : (ltThroughput > 0 ? 100 : 0)
+    row.overallAiPct = row.totalFeatures > 0 ? Math.round((row.totalAiTouched / row.totalFeatures) * 100) : 0
+    row.dominantPipelines = PIPELINE_KEYS.filter(k => row.pipelines[k] > 0).map(k => PIPELINE_META[k].short).join(', ') || 'None'
+    return row
+  })
+
+  rows.sort((a, b) => b.totalAiTouched - a.totalAiTouched)
+
+  return rows
+})
+
+function effortCellClass(avgEffort, baselineAvg) {
+  if (!baselineAvg || baselineAvg === 0) return ''
+  const ratio = avgEffort / baselineAvg
+  if (ratio >= 0.9) return 'text-emerald-700 dark:text-emerald-400'
+  if (ratio >= 0.7) return 'text-amber-700 dark:text-amber-400'
+  return 'text-red-600 dark:text-red-400'
+}
+
 function togglePipeline(key) {
   expandedPipelines.value[key] = !expandedPipelines.value[key]
 }
@@ -979,6 +1040,127 @@ const executiveSummary = computed(() => {
         </div>
       </div>
 
+
+      <!-- Component Throughput table -->
+      <div v-if="selectedComponent === 'all' && throughputRows.length > 1" class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto shadow-sm">
+        <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="flex items-center gap-2">
+                <span class="w-1 h-4 rounded-full bg-violet-500"></span>
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Component Throughput</h3>
+              </div>
+              <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 ml-3">Feature delivery and normalized effort per component across releases — proving AI adoption drives genuine throughput, not inflated counts</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-8 mt-3 ml-3">
+            <div class="flex flex-col items-center px-5 py-2.5 bg-gray-50 dark:bg-gray-700/30 rounded-lg border border-gray-200 dark:border-gray-600 min-w-[80px]">
+              <span class="font-bold text-gray-900 dark:text-gray-100 text-base leading-tight">17</span>
+              <span class="font-semibold text-emerald-700 dark:text-emerald-400 text-xs mt-0.5">4.3 avg</span>
+              <span class="text-[9px] text-gray-400 dark:text-gray-500 mt-0.5">35% AI</span>
+            </div>
+            <div class="flex flex-col gap-2 text-[11px] text-gray-600 dark:text-gray-300">
+              <div class="flex items-center gap-2">
+                <span class="font-bold text-gray-900 dark:text-gray-100 text-sm w-8 text-right">17</span>
+                <span class="text-gray-300 dark:text-gray-600">→</span>
+                <span>Total features delivered in this release</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="font-bold text-emerald-700 dark:text-emerald-400 text-sm w-8 text-right">4.3</span>
+                <span class="text-gray-300 dark:text-gray-600">→</span>
+                <span>Avg effort per feature normalized using RICE Score, Story Points, # of child issues</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="font-bold text-gray-500 dark:text-gray-400 text-sm w-8 text-right">35%</span>
+                <span class="text-gray-300 dark:text-gray-600">→</span>
+                <span>AI pipeline adoption rate</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b-2 border-gray-200 dark:border-gray-600">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider sticky left-0 bg-white dark:bg-gray-800">Component</th>
+              <template v-for="rg in scorecardGroups" :key="rg.releaseGroup">
+                <th class="px-3 py-3 text-center text-xs font-semibold uppercase tracking-wider whitespace-nowrap" :class="rg.releaseGroup === selectedBaseline ? 'text-amber-700 dark:text-amber-400 bg-amber-50/50 dark:bg-amber-900/10' : 'text-gray-500 dark:text-gray-400'">
+                  <div class="flex flex-col items-center gap-0.5">
+                    <span>{{ rg.releaseGroup }}</span>
+                    <span class="text-[9px] font-normal text-gray-400 dark:text-gray-500">{{ rg.totalFeatures }} features</span>
+                  </div>
+                </th>
+              </template>
+              <th class="px-3 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border-l border-gray-200 dark:border-gray-600 group relative cursor-help">
+                <span class="inline-flex items-center gap-1">Dominant Pipelines
+                  <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                </span>
+                <div class="hidden group-hover:block absolute z-20 top-full left-0 mt-1 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-3 text-left normal-case tracking-normal">
+                  <p class="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1.5">AI Pipeline Key</p>
+                  <div class="space-y-1.5 text-[11px] font-normal">
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">Strat</span> <span class="text-gray-500 dark:text-gray-400">— Auto-generates feature strategy definitions</span></div>
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">RFE</span> <span class="text-gray-500 dark:text-gray-400">— Auto-creates RFEs with feasibility checks</span></div>
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">Test Plan</span> <span class="text-gray-500 dark:text-gray-400">— Auto-generates and revises test plans</span></div>
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">QG1</span> <span class="text-gray-500 dark:text-gray-400">— Automated RICE scoring and quality gates</span></div>
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">AI Doc</span> <span class="text-gray-500 dark:text-gray-400">— AI-contributed documentation and Jira content</span></div>
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">UXD</span> <span class="text-gray-500 dark:text-gray-400">— AI-assisted UX design and validation</span></div>
+                    <div><span class="font-semibold text-gray-800 dark:text-gray-200">Epic Creator</span> <span class="text-gray-500 dark:text-gray-400">— Decomposes strategies into implementation epics</span></div>
+                  </div>
+                </div>
+              </th>
+              <th class="px-3 py-3 text-center text-xs font-semibold text-violet-600 dark:text-violet-400 uppercase tracking-wider border-l-2 border-violet-200 dark:border-violet-700/50 bg-violet-50/40 dark:bg-violet-900/10 group relative cursor-help">
+                <span class="inline-flex items-center gap-1">Throughput Delta
+                  <svg class="w-3.5 h-3.5 text-violet-400 dark:text-violet-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                </span>
+                <div class="hidden group-hover:block absolute z-20 top-full right-0 mt-1 w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-3 text-left normal-case tracking-normal cursor-default" @click.stop>
+                  <p class="text-[10px] font-semibold text-violet-600 dark:text-violet-400 uppercase mb-1.5">Formula</p>
+                  <div class="text-[11px] font-normal text-gray-700 dark:text-gray-300 space-y-1.5">
+                    <div class="bg-violet-50 dark:bg-violet-900/20 rounded px-2 py-1.5 font-mono text-[10px]">
+                      <div>Throughput = Features × Avg Effort</div>
+                      <div class="mt-1">Delta = (Latest − Baseline) / Baseline × 100</div>
+                    </div>
+                    <p class="text-[10px] text-gray-500 dark:text-gray-400">Effort-weighted to prevent inflation from splitting features into smaller, low-effort items.</p>
+                  </div>
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, idx) in throughputRows" :key="row.name" :class="idx % 2 === 0 ? 'bg-gray-50/50 dark:bg-gray-800/50' : ''" class="border-b border-gray-100 dark:border-gray-700/40 hover:bg-gray-50 dark:hover:bg-gray-700/20 transition-colors">
+              <td class="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100 sticky left-0 bg-inherit whitespace-nowrap">{{ row.name }}</td>
+              <template v-for="rg in scorecardGroups" :key="rg.releaseGroup + row.name">
+                <td class="px-3 py-2.5 text-center" :class="rg.releaseGroup === selectedBaseline ? 'bg-amber-50/30 dark:bg-amber-900/5' : ''">
+                  <template v-if="row.releases[rg.releaseGroup]">
+                    <div class="font-semibold text-gray-900 dark:text-gray-100 text-[13px]">{{ row.releases[rg.releaseGroup].features }}</div>
+                    <div class="text-[11px] mt-0.5 tabular-nums" :class="effortCellClass(row.releases[rg.releaseGroup].avgEffort, row.baselineAvg)">
+                      {{ row.releases[rg.releaseGroup].avgEffort }} avg
+                    </div>
+                    <div class="text-[9px] mt-0.5 tabular-nums text-gray-400 dark:text-gray-500">{{ row.releases[rg.releaseGroup].aiPct }}% AI</div>
+                  </template>
+                  <span v-else class="text-gray-300 dark:text-gray-600">—</span>
+                </td>
+              </template>
+              <td class="px-3 py-2.5 text-gray-600 dark:text-gray-400 text-xs border-l border-gray-100 dark:border-gray-700/40">{{ row.dominantPipelines }}</td>
+              <td class="px-3 py-2.5 text-center border-l-2 border-violet-100 dark:border-violet-800/40 bg-violet-50/20 dark:bg-violet-900/5 group/delta relative">
+                <template v-if="row.baselineThroughput > 0 || row.latestThroughput > 0">
+                  <span class="font-bold text-sm tabular-nums" :class="row.throughputDelta > 0 ? 'text-emerald-600 dark:text-emerald-400' : row.throughputDelta === 0 ? 'text-gray-500 dark:text-gray-400' : 'text-red-600 dark:text-red-400'">
+                    {{ row.throughputDelta > 0 ? '+' : '' }}{{ row.throughputDelta }}%
+                  </span>
+                  <div class="text-[9px] text-gray-400 dark:text-gray-500 mt-0.5">{{ row.baselineThroughput }} → {{ row.latestThroughput }}</div>
+                  <div class="hidden group-hover/delta:block absolute z-20 bottom-full right-0 mb-1 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-2.5 text-left text-[10px] font-normal tracking-normal">
+                    <p class="font-semibold text-gray-700 dark:text-gray-200 mb-1">{{ row.name }}</p>
+                    <div class="space-y-0.5 text-gray-500 dark:text-gray-400 font-mono">
+                      <div>Baseline: {{ row.baselineFeatures }} feat × {{ row.baselineAvg }} avg = <span class="text-gray-700 dark:text-gray-200 font-semibold">{{ row.baselineThroughput }}</span></div>
+                      <div>Latest: {{ row.latestFeatures }} feat × {{ row.latestAvg }} avg = <span class="text-gray-700 dark:text-gray-200 font-semibold">{{ row.latestThroughput }}</span></div>
+                      <div class="border-t border-gray-100 dark:border-gray-700 pt-0.5 mt-0.5">Delta: ({{ row.latestThroughput }} − {{ row.baselineThroughput }}) / {{ row.baselineThroughput }} = <span class="font-semibold" :class="row.throughputDelta > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">{{ row.throughputDelta > 0 ? '+' : '' }}{{ row.throughputDelta }}%</span></div>
+                    </div>
+                  </div>
+                </template>
+                <span v-else class="text-[10px] text-gray-400 dark:text-gray-500">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
       <!-- Per-component breakdown (when All Components) -->
       <div v-if="selectedComponent === 'all' && perComponentRows.length > 1" class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto shadow-sm">

--- a/modules/releases/server/ai-adoption/pipeline.js
+++ b/modules/releases/server/ai-adoption/pipeline.js
@@ -204,7 +204,7 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
     const fvList = group.fixVersions.map(v => `"${v}"`).join(', ');
     const projectList = PROJECTS.join(', ');
     const jql = `project in (${projectList}) AND issuetype = Feature AND fixVersion in (${fvList}) ORDER BY key ASC`;
-    const fields = `summary,status,labels,components,fixVersions,subtasks,${EFFORT_FIELD},${RICE_EFFORT_FIELD}`;
+    const fields = `summary,status,labels,components,fixVersions,${EFFORT_FIELD},${RICE_EFFORT_FIELD}`;
 
     let issues;
     try {

--- a/modules/releases/server/ai-adoption/pipeline.js
+++ b/modules/releases/server/ai-adoption/pipeline.js
@@ -77,6 +77,11 @@ const AI_PIPELINE_TAXONOMY = {
 
 const PIPELINE_KEYS = Object.keys(AI_PIPELINE_TAXONOMY);
 
+const EFFORT_FIELD = 'customfield_10430';
+const RICE_EFFORT_FIELD = 'customfield_10637';
+const STORY_POINTS_FIELD = 'customfield_10016';
+const CHILD_BATCH_SIZE = 40;
+
 /**
  * Scan a single issue's labels and return which pipelines are present.
  * @param {string[]} labels
@@ -101,6 +106,85 @@ function scanLabels(labels) {
 }
 
 /**
+ * Determine which effort signal has best coverage for a release group.
+ * Priority: customfield_10430 > RICE Effort > child story points > child count
+ * @param {{ effortCount: number, riceEffortCount: number, childSpCount?: number }} acc
+ * @param {number} totalFeatures
+ * @returns {'effort'|'rice'|'childSp'|'children'}
+ */
+function resolveEffortSignal(acc, totalFeatures) {
+  if (totalFeatures === 0) return 'children';
+  if (acc.effortCount / totalFeatures >= 0.5) return 'effort';
+  if (acc.riceEffortCount / totalFeatures >= 0.5) return 'rice';
+  if ((acc.childSpCount || 0) / totalFeatures >= 0.3) return 'childSp';
+  return 'children';
+}
+
+/**
+ * Compute resolved aggregateEffort and avgEffort using the selected signal.
+ * @param {{ effortSum: number, riceEffortSum: number, childSpSum?: number, childIssueSum: number, total?: number }} entry
+ * @param {'effort'|'rice'|'childSp'|'children'} signal
+ */
+function applyEffortSignal(entry, signal) {
+  const n = entry.total || 0;
+  let raw;
+  if (signal === 'effort') raw = entry.effortSum;
+  else if (signal === 'rice') raw = entry.riceEffortSum;
+  else if (signal === 'childSp') raw = entry.childSpSum || 0;
+  else raw = entry.childIssueSum;
+  return {
+    aggregateEffort: Math.round(raw * 10) / 10,
+    avgEffort: n > 0 ? Math.round((raw / n) * 10) / 10 : 0
+  };
+}
+
+/**
+ * Fetch child issues for a batch of parent feature keys and roll up
+ * child count + story point sum per parent.
+ *
+ * @param {object} jiraClient - { fetchAllJqlResults }
+ * @param {string[]} parentKeys - Feature issue keys
+ * @returns {Promise<Map<string, { childCount: number, childSpSum: number }>>}
+ */
+async function fetchChildRollups(jiraClient, parentKeys) {
+  const rollups = new Map();
+  if (!parentKeys.length) return rollups;
+
+  for (let i = 0; i < parentKeys.length; i += CHILD_BATCH_SIZE) {
+    const batch = parentKeys.slice(i, i + CHILD_BATCH_SIZE);
+    const parentList = batch.join(', ');
+    const jql = `parent in (${parentList}) ORDER BY parent ASC`;
+    const fields = `parent,${STORY_POINTS_FIELD},${RICE_EFFORT_FIELD},timeoriginalestimate`;
+
+    try {
+      const children = await jiraClient.fetchAllJqlResults(jql, fields, { maxResults: 200 });
+      for (const child of children) {
+        const cf = child.fields || {};
+        const parentKey = cf.parent && cf.parent.key;
+        if (!parentKey) continue;
+
+        if (!rollups.has(parentKey)) {
+          rollups.set(parentKey, { childCount: 0, childSpSum: 0 });
+        }
+        const entry = rollups.get(parentKey);
+        entry.childCount++;
+
+        const sp = parseFloat(cf[STORY_POINTS_FIELD]) || 0;
+        const rice = parseFloat(typeof cf[RICE_EFFORT_FIELD] === 'object' && cf[RICE_EFFORT_FIELD]
+          ? cf[RICE_EFFORT_FIELD].value : cf[RICE_EFFORT_FIELD]) || 0;
+        const timeEst = cf.timeoriginalestimate
+          ? Math.round(cf.timeoriginalestimate / 3600) : 0;
+        entry.childSpSum += sp || rice || timeEst;
+      }
+    } catch (err) {
+      console.warn(`[ai-adoption] Child issue fetch failed for batch ${i}: ${err.message}`);
+    }
+  }
+
+  return rollups;
+}
+
+/**
  * Fetch AI adoption data for the specified release groups.
  *
  * @param {object} jiraClient - { fetchAllJqlResults }
@@ -120,7 +204,7 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
     const fvList = group.fixVersions.map(v => `"${v}"`).join(', ');
     const projectList = PROJECTS.join(', ');
     const jql = `project in (${projectList}) AND issuetype = Feature AND fixVersion in (${fvList}) ORDER BY key ASC`;
-    const fields = 'summary,status,labels,components,fixVersions';
+    const fields = `summary,status,labels,components,fixVersions,subtasks,${EFFORT_FIELD},${RICE_EFFORT_FIELD}`;
 
     let issues;
     try {
@@ -130,6 +214,9 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
       issues = [];
     }
 
+    const featureKeys = issues.map(i => i.key).filter(Boolean);
+    const childRollups = await fetchChildRollups(jiraClient, featureKeys);
+
     const componentMap = {};
     let totalFeatures = 0;
     let aiTouchedFeatures = 0;
@@ -137,6 +224,12 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
     let filteredAiTouched = 0;
     const groupPipelines = {};
     for (const key of PIPELINE_KEYS) groupPipelines[key] = 0;
+    const groupEffort = {
+      effortSum: 0, effortCount: 0,
+      riceEffortSum: 0, riceEffortCount: 0,
+      childIssueSum: 0,
+      childSpSum: 0, childSpCount: 0
+    };
 
     for (const issue of issues) {
       const f = issue.fields || {};
@@ -144,9 +237,24 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
       const components = (f.components || []).map(c => c.name);
       const { touched, pipelines } = scanLabels(labels);
 
+      const effortVal = parseFloat(f[EFFORT_FIELD]) || 0;
+      const hasEffort = effortVal > 0;
+      const riceRaw = f[RICE_EFFORT_FIELD];
+      const riceVal = parseFloat(typeof riceRaw === 'object' && riceRaw ? riceRaw.value : riceRaw) || 0;
+      const hasRice = riceVal > 0;
+
+      const rollup = childRollups.get(issue.key) || { childCount: 0, childSpSum: 0 };
+      const childCount = rollup.childCount;
+      const childSp = rollup.childSpSum;
+      const hasChildSp = childSp > 0;
+
       totalFeatures++;
       if (touched) aiTouchedFeatures++;
       for (const key of PIPELINE_KEYS) groupPipelines[key] += pipelines[key];
+      if (hasEffort) { groupEffort.effortSum += effortVal; groupEffort.effortCount++; }
+      if (hasRice) { groupEffort.riceEffortSum += riceVal; groupEffort.riceEffortCount++; }
+      groupEffort.childIssueSum += Math.max(1, childCount);
+      if (hasChildSp) { groupEffort.childSpSum += childSp; groupEffort.childSpCount++; }
 
       if (options.component && !components.includes(options.component)) continue;
 
@@ -158,7 +266,13 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
         : (components.length > 0 ? components : ['(No Component)']);
       for (const compName of compNames) {
         if (!componentMap[compName]) {
-          componentMap[compName] = { name: compName, total: 0, aiTouched: 0, pipelines: {} };
+          componentMap[compName] = {
+            name: compName, total: 0, aiTouched: 0, pipelines: {},
+            effortSum: 0, effortCount: 0,
+            riceEffortSum: 0, riceEffortCount: 0,
+            childIssueSum: 0,
+            childSpSum: 0, childSpCount: 0
+          };
           for (const key of PIPELINE_KEYS) componentMap[compName].pipelines[key] = 0;
         }
         componentMap[compName].total++;
@@ -166,10 +280,20 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
         for (const key of PIPELINE_KEYS) {
           componentMap[compName].pipelines[key] += pipelines[key];
         }
+        if (hasEffort) { componentMap[compName].effortSum += effortVal; componentMap[compName].effortCount++; }
+        if (hasRice) { componentMap[compName].riceEffortSum += riceVal; componentMap[compName].riceEffortCount++; }
+        componentMap[compName].childIssueSum += Math.max(1, childCount);
+        if (hasChildSp) { componentMap[compName].childSpSum += childSp; componentMap[compName].childSpCount++; }
       }
     }
 
-    const componentList = Object.values(componentMap).sort((a, b) => b.aiTouched - a.aiTouched);
+    const n = options.component ? filteredTotal : totalFeatures;
+    const effortSource = resolveEffortSignal(groupEffort, n);
+
+    const componentList = Object.values(componentMap).map(c => {
+      const resolved = applyEffortSignal(c, effortSource);
+      return { ...c, ...resolved };
+    }).sort((a, b) => b.aiTouched - a.aiTouched);
 
     const filteredPipelines = {};
     if (options.component) {
@@ -178,12 +302,17 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
       }
     }
 
+    const groupResolved = applyEffortSignal({ ...groupEffort, total: n }, effortSource);
+
     results.push({
       releaseGroup: group.name,
       totalFeatures: options.component ? filteredTotal : totalFeatures,
       aiTouchedFeatures: options.component ? filteredAiTouched : aiTouchedFeatures,
       pipelines: options.component ? filteredPipelines : groupPipelines,
-      components: componentList
+      components: componentList,
+      effortSignal: effortSource,
+      aggregateEffort: groupResolved.aggregateEffort,
+      avgEffort: groupResolved.avgEffort
     });
   }
 
@@ -192,9 +321,16 @@ async function fetchAiAdoptionData(jiraClient, options = {}) {
 
 module.exports = {
   fetchAiAdoptionData,
+  fetchChildRollups,
   scanLabels,
+  resolveEffortSignal,
+  applyEffortSignal,
   AI_PIPELINE_TAXONOMY,
   PIPELINE_KEYS,
   RELEASE_GROUPS,
-  PROJECTS
+  PROJECTS,
+  EFFORT_FIELD,
+  RICE_EFFORT_FIELD,
+  STORY_POINTS_FIELD,
+  CHILD_BATCH_SIZE
 };

--- a/modules/releases/server/ai-adoption/routes.js
+++ b/modules/releases/server/ai-adoption/routes.js
@@ -62,7 +62,10 @@ function applyFilters(cached, { releaseGroup, component }) {
  *         description: Filter to a single component name
  *     responses:
  *       200:
- *         description: Array of release group adoption results
+ *         description: >
+ *           Release group adoption results including per-component effort
+ *           metrics (effortSignal, aggregateEffort, avgEffort) resolved
+ *           from customfield_10430, RICE Effort, or subtask count
  *       503:
  *         description: Jira client not configured
  */


### PR DESCRIPTION
## Summary

- Adds a **Component Throughput** table to the AI Adoption report that tracks per-component feature delivery across releases (3.4 GA → 3.5 GA) with effort-weighted normalization
- **Backend**: two-phase Jira fetch — first fetches Features, then queries child issues via `parent in (...)` to roll up child count, story points, and RICE scores per feature. Uses a priority-based effort signal resolution (customfield_10430 → RICE Effort → child story points → child count) with graceful fallback
- **Frontend**: effort-weighted throughput delta (`features × avg effort`), per-cell calculation tooltips, dominant pipeline column with hover tooltip explaining each pipeline, and a cell legend explaining the table format

## Test plan

- [ ] Unit tests added for `resolveEffortSignal`, `applyEffortSignal`, `fetchChildRollups`, and effort accumulation in `fetchAiAdoptionData` (26 tests, all passing)
- [ ] Verify table renders correctly with real data after `/refresh`
- [ ] Verify tooltips display on hover (Dominant Pipelines header, Throughput Delta header, each delta cell)
- [ ] Verify table only shows when "All Components" is selected
- [ ] Verify component order matches Per-Component Breakdown (AI Core Dashboard first)


Made with [Cursor](https://cursor.com)