### PR TITLE
fix: override js-yaml to 4.3.1 for CVE-2026-59870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
   "overrides": {
     "swagger-jsdoc": {
       "brace-expansion": "5.0.9"
+    },
+    "@apidevtools/json-schema-ref-parser": {
+      "js-yaml": "4.3.1"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Override `js-yaml` to `4.3.1` inside `@apidevtools/json-schema-ref-parser` to fix CVE-2026-59870 (quadratic CPU on `!!omap` resolution)
- The upstream `swagger-parser` still pins `json-schema-ref-parser@14.0.1` which bundles vulnerable `js-yaml 4.0.0-4.3.0`
- This unblocks CI for all PRs — `npm audit --audit-level=high` now passes

## Test plan

- [x] `npm audit --omit=dev --audit-level=high` passes (only moderate mermaid advisory remains)
- [ ] CI "Test & Build" passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)