### PR TITLE
feat(releases): use registry-based release selector in program hygiene report

### DIFF
--- a/modules/releases/client/composables/useReleaseSelector.js
+++ b/modules/releases/client/composables/useReleaseSelector.js
@@ -1,0 +1,299 @@
+import { ref, reactive, computed, onMounted, onUnmounted, inject } from 'vue'
+import { apiRequest } from '@shared/client/services/api.js'
+
+const PHASE_ORDER = ['EA1', 'EA2', 'GA']
+
+// Z-stream releases (e.g. rhoai-3.6.z) are intentionally excluded — they are
+// separate registry entries with distinct schedules and should not appear in the
+// family/version/phase selector alongside standard milestones.
+function parseReleaseId(id) {
+  const match = id.match(/^([a-z]+)-(\d+\.\d+)(?:\.(ea\d?))?$/i)
+  if (!match) return null
+  return { family: match[1].toLowerCase(), version: match[2], phase: match[3] ? match[3].toUpperCase() : 'GA' }
+}
+
+/**
+ * Shared composable for the registry-based release selector modal used by
+ * program-level reports (Capacity Commitment, Program Hygiene, etc.).
+ *
+ * Manages: registry fetch, release parsing, draft/apply modal state, family/
+ * version/phase selection, URL param + localStorage persistence, narrative
+ * text, and escape-key handling.
+ *
+ * @param {object} options
+ * @param {string} options.storageKey  localStorage key for persisting selection
+ */
+export function useReleaseSelector({ storageKey }) {
+  const nav = inject('moduleNav')
+
+  const releases = ref([])
+  const modalOpen = ref(false)
+  const selection = reactive({ version: '', families: new Set(), phases: new Set() })
+  const draft = reactive({ version: '', families: new Set(), phases: new Set() })
+
+  // ── Registry parsing ──
+
+  const parsedReleases = computed(() => {
+    return releases.value
+      .filter(r => r.state === 'active')
+      .map(r => ({ ...r, ...parseReleaseId(r.id) }))
+      .filter(r => r.family)
+  })
+
+  const availableFamilies = computed(() => {
+    return [...new Set(parsedReleases.value.map(r => r.family))].sort()
+  })
+
+  const draftVersions = computed(() => {
+    if (draft.families.size === 0) return []
+    const filtered = parsedReleases.value.filter(r => draft.families.has(r.family))
+    return [...new Set(filtered.map(r => r.version))].sort()
+  })
+
+  const draftPhases = computed(() => {
+    if (!draft.version || draft.families.size === 0) return []
+    const filtered = parsedReleases.value.filter(r =>
+      r.version === draft.version && draft.families.has(r.family)
+    )
+    return [...new Set(filtered.map(r => r.phase))].sort((a, b) => PHASE_ORDER.indexOf(a) - PHASE_ORDER.indexOf(b))
+  })
+
+  const isAllFamiliesDraft = computed(() =>
+    availableFamilies.value.length > 0 && draft.families.size === availableFamilies.value.length
+  )
+
+  const hasSelection = computed(() =>
+    selection.version && selection.families.size > 0 && selection.phases.size > 0
+  )
+
+  const canApply = computed(() =>
+    draft.version && draft.families.size > 0 && draft.phases.size > 0
+  )
+
+  // ── Data loading ──
+
+  async function fetchRegistry() {
+    const data = await apiRequest('/modules/releases/registry')
+    releases.value = data.releases || []
+  }
+
+  // ── Selection management ──
+
+  function restoreSelection() {
+    const params = nav?.params?.value || {}
+    if (params.version) {
+      const families = params.families
+        ? params.families.split(',').filter(f => availableFamilies.value.includes(f))
+        : [...availableFamilies.value]
+      const phases = params.phases
+        ? params.phases.split(',').filter(p => PHASE_ORDER.includes(p.toUpperCase())).map(p => p.toUpperCase())
+        : ['GA']
+
+      if (families.length > 0 && phases.length > 0) {
+        applySelection(params.version, new Set(families), new Set(phases))
+        return
+      }
+    }
+
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored) {
+        const parsed = JSON.parse(stored)
+        if (parsed.version && parsed.families?.length && parsed.phases?.length) {
+          const validFamilies = parsed.families.filter(f => availableFamilies.value.includes(f))
+          const validPhases = parsed.phases.filter(p => PHASE_ORDER.includes(p))
+          if (validFamilies.length > 0 && validPhases.length > 0) {
+            applySelection(parsed.version, new Set(validFamilies), new Set(validPhases))
+            return
+          }
+        }
+      }
+    } catch { /* ignore */ }
+
+    if (availableFamilies.value.length > 0) {
+      const allVersions = [...new Set(parsedReleases.value.map(r => r.version))].sort()
+      const latestVersion = pickDefaultVersion(allVersions)
+      if (latestVersion) {
+        applySelection(latestVersion, new Set(availableFamilies.value), new Set(['GA']))
+      }
+    }
+  }
+
+  function pickDefaultVersion(versions) {
+    const now = Date.now()
+    let best = null
+    let bestDelta = Infinity
+
+    for (const v of versions) {
+      const gaReleases = parsedReleases.value.filter(r => r.version === v && r.phase === 'GA' && r.milestones?.ga)
+      for (const r of gaReleases) {
+        const ts = new Date(r.milestones.ga).getTime()
+        const delta = ts - now
+        if (delta >= 0 && delta < bestDelta) {
+          bestDelta = delta
+          best = v
+        }
+      }
+    }
+
+    return best || versions[versions.length - 1] || null
+  }
+
+  function applySelection(version, families, phases) {
+    selection.version = version
+    selection.families = families
+    selection.phases = phases
+    persistSelection()
+  }
+
+  function persistSelection() {
+    const data = {
+      version: selection.version,
+      families: [...selection.families],
+      phases: [...selection.phases]
+    }
+    localStorage.setItem(storageKey, JSON.stringify(data))
+    nav.updateParams({
+      version: selection.version,
+      families: [...selection.families].join(','),
+      phases: [...selection.phases].map(p => p.toLowerCase()).join(',')
+    })
+  }
+
+  // ── Modal logic ──
+
+  function openModal() {
+    draft.version = selection.version
+    draft.families = new Set(selection.families.size > 0 ? selection.families : availableFamilies.value)
+    draft.phases = new Set(selection.phases.size > 0 ? selection.phases : ['GA'])
+    modalOpen.value = true
+  }
+
+  function cancelModal() {
+    modalOpen.value = false
+  }
+
+  function applyModal() {
+    if (!canApply.value) return
+    applySelection(draft.version, new Set(draft.families), new Set(draft.phases))
+    modalOpen.value = false
+  }
+
+  function toggleAllFamilies() {
+    draft.families = new Set(availableFamilies.value)
+    reconcileDraftVersion()
+  }
+
+  function toggleFamily(family) {
+    const next = new Set(draft.families)
+    if (isAllFamiliesDraft.value) {
+      next.clear()
+      next.add(family)
+    } else if (next.has(family) && next.size > 1) {
+      next.delete(family)
+    } else {
+      next.add(family)
+    }
+    draft.families = next
+    reconcileDraftVersion()
+  }
+
+  function selectVersionDraft(version) {
+    draft.version = version
+    reconcileDraftPhases()
+  }
+
+  function togglePhase(phase) {
+    const next = new Set(draft.phases)
+    if (next.has(phase) && next.size > 1) {
+      next.delete(phase)
+    } else {
+      next.add(phase)
+    }
+    draft.phases = next
+  }
+
+  function reconcileDraftVersion() {
+    if (draft.version && !draftVersions.value.includes(draft.version)) {
+      draft.version = ''
+      draft.phases = new Set()
+    } else {
+      reconcileDraftPhases()
+    }
+  }
+
+  function reconcileDraftPhases() {
+    const available = draftPhases.value
+    const next = new Set([...draft.phases].filter(p => available.includes(p)))
+    if (next.size === 0 && available.includes('GA')) next.add('GA')
+    else if (next.size === 0 && available.length > 0) next.add(available[0])
+    draft.phases = next
+  }
+
+  // ── Narrative ──
+
+  const familyNarrative = computed(() => {
+    if (selection.families.size === availableFamilies.value.length) return 'all product families'
+    const names = [...selection.families].sort().map(f => f.toUpperCase())
+    if (names.length === 1) return names[0]
+    if (names.length === 2) return names[0] + ' and ' + names[1]
+    return names.slice(0, -1).join(', ') + ', and ' + names[names.length - 1]
+  })
+
+  const phaseNarrative = computed(() => {
+    const sorted = [...selection.phases].sort((a, b) => PHASE_ORDER.indexOf(a) - PHASE_ORDER.indexOf(b))
+    if (sorted.length === PHASE_ORDER.length) return 'EA1, EA2, and GA'
+    if (sorted.length === 1) return sorted[0]
+    if (sorted.length === 2) return sorted[0] + ' and ' + sorted[1]
+    return sorted.slice(0, -1).join(', ') + ', and ' + sorted[sorted.length - 1]
+  })
+
+  // ── Escape handler ──
+
+  function handleEscape(e) {
+    if (e.key === 'Escape' && modalOpen.value) cancelModal()
+  }
+  onMounted(() => document.addEventListener('keydown', handleEscape))
+  onUnmounted(() => document.removeEventListener('keydown', handleEscape))
+
+  // ── Registry ID matching ──
+
+  function selectedRegistryIdSet() {
+    if (!hasSelection.value) return new Set()
+    return new Set(
+      parsedReleases.value
+        .filter(r => selection.families.has(r.family) &&
+          r.version === selection.version &&
+          selection.phases.has(r.phase))
+        .map(r => r.id)
+    )
+  }
+
+  return {
+    releases,
+    modalOpen,
+    selection,
+    draft,
+    parsedReleases,
+    availableFamilies,
+    draftVersions,
+    draftPhases,
+    isAllFamiliesDraft,
+    hasSelection,
+    canApply,
+    fetchRegistry,
+    restoreSelection,
+    applySelection,
+    openModal,
+    cancelModal,
+    applyModal,
+    toggleAllFamilies,
+    toggleFamily,
+    selectVersionDraft,
+    togglePhase,
+    familyNarrative,
+    phaseNarrative,
+    selectedRegistryIdSet,
+    PHASE_ORDER
+  }
+}

--- a/modules/releases/client/reports/CapacityCommitmentReport.vue
+++ b/modules/releases/client/reports/CapacityCommitmentReport.vue
@@ -916,6 +916,7 @@ import { apiRequest } from '@shared/client/services/api.js'
 import { Doughnut } from 'vue-chartjs'
 import { Chart as ChartJS, ArcElement, Tooltip } from 'chart.js'
 import { useReportFilters } from './composables/useReportFilters.js'
+import { useReleaseSelector } from '../composables/useReleaseSelector.js'
 import ReportFilterModal from './components/ReportFilterModal.vue'
 import ReportFilterNarrative from './components/ReportFilterNarrative.vue'
 
@@ -923,13 +924,11 @@ ChartJS.register(ArcElement, Tooltip)
 
 // ── Constants ──
 
-const STORAGE_KEY = 'tt_cache:capacity-report-selection'
 const MILESTONES = [
   { key: 'featureFreeze', label: 'Feature Freeze' },
   { key: 'codeFreeze', label: 'Code Freeze' },
   { key: 'ga', label: 'Release Date' }
 ]
-const PHASE_ORDER = ['EA1', 'EA2', 'GA']
 const analysisTabs = [
   { id: 'status-charts', label: 'Features & Initiatives by Status' },
   { id: 'color-status', label: 'Features & Initiatives by Color Status' }
@@ -967,95 +966,51 @@ const FLAG_LABELS = {
   'PLANNING_INCOMPLETE': 'Planning Incomplete'
 }
 
+// ── Release selector (shared composable) ──
+
+const {
+  modalOpen,
+  selection,
+  draft,
+  parsedReleases,
+  availableFamilies,
+  draftVersions,
+  draftPhases,
+  isAllFamiliesDraft,
+  hasSelection,
+  canApply,
+  fetchRegistry,
+  restoreSelection,
+  openModal,
+  cancelModal,
+  applyModal,
+  toggleAllFamilies,
+  toggleFamily,
+  selectVersionDraft: selectVersion,
+  togglePhase,
+  familyNarrative,
+  phaseNarrative,
+  PHASE_ORDER
+} = useReleaseSelector({ storageKey: 'tt_cache:capacity-report-selection' })
+
 // ── Core state ──
 
 const nav = inject('moduleNav')
-const releases = ref([])
 const loading = ref(true)
 const error = ref(null)
-const modalOpen = ref(false)
 const activeAnalysisTab = ref('status-charts')
 
 const milestonesOpen = ref(true)
 const chartsOpen = ref(true)
 const riskOpen = ref(true)
 
-const selection = reactive({ version: '', families: new Set(), phases: new Set() })
-const draft = reactive({ version: '', families: new Set(), phases: new Set() })
-
-// ── Registry parsing ──
-
-function parseReleaseId(id) {
-  const match = id.match(/^([a-z]+)-(\d+\.\d+)(?:\.z)?(?:\.(ea\d?))?$/i)
-  if (!match) return null
-  return { family: match[1].toLowerCase(), version: match[2], phase: match[3] ? match[3].toUpperCase() : 'GA' }
-}
-
-const parsedReleases = computed(() => {
-  return releases.value
-    .filter(r => r.state === 'active')
-    .map(r => ({ ...r, ...parseReleaseId(r.id) }))
-    .filter(r => r.family)
-})
-
-const availableFamilies = computed(() => {
-  return [...new Set(parsedReleases.value.map(r => r.family))].sort()
-})
-
-// Versions available for the draft's selected families
-const draftVersions = computed(() => {
-  if (draft.families.size === 0) return []
-  const filtered = parsedReleases.value.filter(r => draft.families.has(r.family))
-  return [...new Set(filtered.map(r => r.version))].sort()
-})
-
-// Phases available for the draft's selected version + families
-const draftPhases = computed(() => {
-  if (!draft.version || draft.families.size === 0) return []
-  const filtered = parsedReleases.value.filter(r =>
-    r.version === draft.version && draft.families.has(r.family)
-  )
-  return [...new Set(filtered.map(r => r.phase))].sort((a, b) => PHASE_ORDER.indexOf(a) - PHASE_ORDER.indexOf(b))
-})
-
-const isAllFamiliesDraft = computed(() =>
-  availableFamilies.value.length > 0 && draft.families.size === availableFamilies.value.length
-)
-
-const hasSelection = computed(() =>
-  selection.version && selection.families.size > 0 && selection.phases.size > 0
-)
-
-const canApply = computed(() =>
-  draft.version && draft.families.size > 0 && draft.phases.size > 0
-)
-
-// ── Summary display ──
-
-const familyNarrative = computed(() => {
-  if (selection.families.size === availableFamilies.value.length) return 'all product families'
-  const names = [...selection.families].sort().map(f => f.toUpperCase())
-  if (names.length === 1) return names[0]
-  if (names.length === 2) return names[0] + ' and ' + names[1]
-  return names.slice(0, -1).join(', ') + ', and ' + names[names.length - 1]
-})
-
-const phaseNarrative = computed(() => {
-  const sorted = [...selection.phases].sort((a, b) => PHASE_ORDER.indexOf(a) - PHASE_ORDER.indexOf(b))
-  if (sorted.length === PHASE_ORDER.length) return 'EA1, EA2, and GA'
-  if (sorted.length === 1) return sorted[0]
-  if (sorted.length === 2) return sorted[0] + ' and ' + sorted[1]
-  return sorted.slice(0, -1).join(', ') + ', and ' + sorted[sorted.length - 1]
-})
-
 // ── Data loading ──
 
-async function fetchRegistry() {
+async function loadData() {
   loading.value = true
   error.value = null
   try {
-    const data = await apiRequest('/modules/releases/registry')
-    releases.value = data.releases || []
+    await fetchRegistry()
     restoreSelection()
   } catch (e) {
     error.value = e.message || 'Failed to load releases'
@@ -1064,165 +1019,10 @@ async function fetchRegistry() {
   }
 }
 
-onMounted(fetchRegistry)
+onMounted(loadData)
 
-function restoreSelection() {
-  // Try URL params first
-  const params = nav?.params?.value || {}
-  if (params.version) {
-    const families = params.families
-      ? params.families.split(',').filter(f => availableFamilies.value.includes(f))
-      : [...availableFamilies.value]
-    const phases = params.phases
-      ? params.phases.split(',').filter(p => PHASE_ORDER.includes(p.toUpperCase())).map(p => p.toUpperCase())
-      : ['GA']
+// ── Escape / click-outside ──
 
-    if (families.length > 0 && phases.length > 0) {
-      applySelection(params.version, new Set(families), new Set(phases))
-      return
-    }
-  }
-
-  // Try localStorage
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) {
-      const parsed = JSON.parse(stored)
-      if (parsed.version && parsed.families?.length && parsed.phases?.length) {
-        const validFamilies = parsed.families.filter(f => availableFamilies.value.includes(f))
-        const validPhases = parsed.phases.filter(p => PHASE_ORDER.includes(p))
-        if (validFamilies.length > 0 && validPhases.length > 0) {
-          applySelection(parsed.version, new Set(validFamilies), new Set(validPhases))
-          return
-        }
-      }
-    }
-  } catch { /* ignore */ }
-
-  // Smart default: latest version, all families, GA
-  if (availableFamilies.value.length > 0) {
-    const allVersions = [...new Set(parsedReleases.value.map(r => r.version))].sort()
-    const latestVersion = pickDefaultVersion(allVersions)
-    if (latestVersion) {
-      applySelection(latestVersion, new Set(availableFamilies.value), new Set(['GA']))
-    }
-  }
-}
-
-function pickDefaultVersion(versions) {
-  const now = Date.now()
-  let best = null
-  let bestDelta = Infinity
-
-  for (const v of versions) {
-    const gaReleases = parsedReleases.value.filter(r => r.version === v && r.phase === 'GA' && r.milestones?.ga)
-    for (const r of gaReleases) {
-      const ts = new Date(r.milestones.ga).getTime()
-      const delta = ts - now
-      if (delta >= 0 && delta < bestDelta) {
-        bestDelta = delta
-        best = v
-      }
-    }
-  }
-
-  return best || versions[versions.length - 1] || null
-}
-
-function applySelection(version, families, phases) {
-  selection.version = version
-  selection.families = families
-  selection.phases = phases
-  persistSelection()
-}
-
-function persistSelection() {
-  const data = {
-    version: selection.version,
-    families: [...selection.families],
-    phases: [...selection.phases]
-  }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-  nav.updateParams({
-    version: selection.version,
-    families: [...selection.families].join(','),
-    phases: [...selection.phases].map(p => p.toLowerCase()).join(',')
-  })
-}
-
-// ── Modal logic ──
-
-function openModal() {
-  draft.version = selection.version
-  draft.families = new Set(selection.families.size > 0 ? selection.families : availableFamilies.value)
-  draft.phases = new Set(selection.phases.size > 0 ? selection.phases : ['GA'])
-  modalOpen.value = true
-}
-
-function cancelModal() {
-  modalOpen.value = false
-}
-
-function applyModal() {
-  if (!canApply.value) return
-  applySelection(draft.version, new Set(draft.families), new Set(draft.phases))
-  modalOpen.value = false
-}
-
-function toggleAllFamilies() {
-  draft.families = new Set(availableFamilies.value)
-  reconcileDraftVersion()
-}
-
-function toggleFamily(family) {
-  const next = new Set(draft.families)
-  if (isAllFamiliesDraft.value) {
-    // Was "all" — switch to just this one
-    next.clear()
-    next.add(family)
-  } else if (next.has(family) && next.size > 1) {
-    next.delete(family)
-  } else {
-    next.add(family)
-  }
-  draft.families = next
-  reconcileDraftVersion()
-}
-
-function selectVersion(version) {
-  draft.version = version
-  reconcileDraftPhases()
-}
-
-function togglePhase(phase) {
-  const next = new Set(draft.phases)
-  if (next.has(phase) && next.size > 1) {
-    next.delete(phase)
-  } else {
-    next.add(phase)
-  }
-  draft.phases = next
-}
-
-// Keep version/phase valid when families change
-function reconcileDraftVersion() {
-  if (draft.version && !draftVersions.value.includes(draft.version)) {
-    draft.version = ''
-    draft.phases = new Set()
-  } else {
-    reconcileDraftPhases()
-  }
-}
-
-function reconcileDraftPhases() {
-  const available = draftPhases.value
-  const next = new Set([...draft.phases].filter(p => available.includes(p)))
-  if (next.size === 0 && available.includes('GA')) next.add('GA')
-  else if (next.size === 0 && available.length > 0) next.add(available[0])
-  draft.phases = next
-}
-
-// Close modal on Escape
 function handleEscape(e) {
   if (e.key !== 'Escape') return
   if (filters.filterModalOpen.value) { filters.closeFilterModal(); return }

--- a/modules/releases/client/reports/ProgramHygieneReport.vue
+++ b/modules/releases/client/reports/ProgramHygieneReport.vue
@@ -1,29 +1,53 @@
 <script setup>
 import { ref, computed, onMounted, inject } from 'vue'
 import { apiRequest } from '@shared/client/services/api.js'
-import { extractProduct } from '../deliver/composables/release-utils.js'
+import { useReleaseSelector } from '../composables/useReleaseSelector.js'
 
 const nav = inject('moduleNav')
 
-const props = defineProps({
-  initialProduct: { type: String, default: null },
-  initialVersion: { type: String, default: null }
-})
+const {
+  modalOpen,
+  selection,
+  draft,
+  availableFamilies,
+  draftVersions,
+  draftPhases,
+  isAllFamiliesDraft,
+  hasSelection,
+  canApply,
+  fetchRegistry,
+  restoreSelection,
+  openModal,
+  cancelModal,
+  applyModal,
+  toggleAllFamilies,
+  toggleFamily,
+  selectVersionDraft,
+  togglePhase,
+  familyNarrative,
+  phaseNarrative,
+  selectedRegistryIdSet
+} = useReleaseSelector({ storageKey: 'tt_cache:hygiene-report-selection' })
+
+// ── State ──
 
 const loading = ref(true)
 const error = ref(null)
 const reportData = ref(null)
-
-// Selectors — initialized from props (restored URL params)
-const selectedProduct = ref(props.initialProduct)
-const selectedVersion = ref(props.initialVersion)
 const activeTab = ref('features')
 
-async function loadReport() {
+// ── Data loading ──
+
+async function loadData() {
   loading.value = true
   error.value = null
   try {
-    reportData.value = await apiRequest('/modules/releases/hygiene/program-report')
+    const [hygieneData] = await Promise.all([
+      apiRequest('/modules/releases/hygiene/program-report'),
+      fetchRegistry()
+    ])
+    reportData.value = hygieneData
+    restoreSelection()
   } catch (err) {
     error.value = err.message
   } finally {
@@ -31,55 +55,23 @@ async function loadReport() {
   }
 }
 
-onMounted(loadReport)
+onMounted(loadData)
+
+// ── Hygiene data ──
 
 const allVersions = computed(() => reportData.value?.versions || [])
 const ruleDefinitions = computed(() => reportData.value?.ruleDefinitions || {})
 
-// Products derived from version IDs
-const products = computed(() => {
-  const set = new Set()
-  for (const v of allVersions.value) {
-    const p = extractProduct(v.versionId)
-    if (p) set.add(p)
-  }
-  return [...set].sort()
-})
+const selectedRegistryIds = computed(() => selectedRegistryIdSet())
 
-// Versions filtered by product
-const filteredVersions = computed(() => {
-  if (!selectedProduct.value) return allVersions.value
-  return allVersions.value.filter(v => extractProduct(v.versionId) === selectedProduct.value)
-})
-
-function selectProduct(product) {
-  if (selectedProduct.value === product) {
-    selectedProduct.value = null
-  } else {
-    selectedProduct.value = product
-  }
-  // Reset version if it's no longer visible
-  if (selectedVersion.value) {
-    const visible = filteredVersions.value.map(v => v.versionId)
-    if (!visible.includes(selectedVersion.value)) {
-      selectedVersion.value = null
-    }
-  }
-}
-
-function selectVersion(versionId) {
-  selectedVersion.value = selectedVersion.value === versionId ? null : versionId
-}
-
-// Currently displayed versions (either filtered by product or single selected)
 const activeVersions = computed(() => {
-  if (selectedVersion.value) {
-    return filteredVersions.value.filter(v => v.versionId === selectedVersion.value)
-  }
-  return filteredVersions.value
+  if (!hasSelection.value) return []
+  const ids = selectedRegistryIds.value
+  return allVersions.value.filter(v => v.registryId && ids.has(v.registryId))
 })
 
-// Aggregated totals for active versions
+// ── Aggregated totals ──
+
 const totals = computed(() => {
   let totalFeatures = 0
   let featuresWithViolations = 0
@@ -102,7 +94,6 @@ const totals = computed(() => {
   return { totalFeatures, featuresWithViolations, totalViolations, violationsByRule, violationsByTeam }
 })
 
-// Sorted rule violations for bar chart
 const sortedRuleViolations = computed(() => {
   const byRule = totals.value.violationsByRule
   return Object.keys(byRule)
@@ -117,7 +108,6 @@ const sortedRuleViolations = computed(() => {
 
 const maxRuleCount = computed(() => sortedRuleViolations.value[0]?.count || 1)
 
-// Sorted team violations for bar chart
 const sortedTeamViolations = computed(() => {
   const byTeam = totals.value.violationsByTeam
   return Object.keys(byTeam)
@@ -139,7 +129,6 @@ const allFeatures = computed(() => {
   return features
 })
 
-// Violation popover
 const popoverFeature = ref(null)
 const popoverStyle = ref({})
 
@@ -187,7 +176,7 @@ function toggleFeatureSort(key) {
 
 function sortIcon(key) {
   if (featureSortKey.value !== key) return ''
-  return featureSortAsc.value ? ' \u25B2' : ' \u25BC'
+  return featureSortAsc.value ? ' ▲' : ' ▼'
 }
 
 // ── Tab B: Team accountability ──
@@ -221,14 +210,6 @@ const categoryColors = {
   lifecycle: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400'
 }
 
-const activeChipClass = 'px-2.5 py-1 text-xs font-medium rounded-full border ' +
-  'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 ' +
-  'border-primary-300 dark:border-primary-600'
-
-const inactiveChipClass = 'px-2.5 py-1 text-xs font-medium rounded-full border ' +
-  'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 ' +
-  'border-gray-200 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700'
-
 const tabs = [
   { id: 'features', label: 'Features' },
   { id: 'teams', label: 'Team Accountability' }
@@ -255,312 +236,404 @@ const tabs = [
     </div>
 
     <template v-else>
-      <!-- Product / Version selector -->
-      <div class="space-y-2 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3 mb-6">
-        <div class="flex items-center gap-2">
-          <span class="text-xs font-medium text-gray-500 dark:text-gray-400 w-16 shrink-0">Product</span>
-          <div class="flex flex-wrap gap-1.5">
-            <button
-              @click="selectedProduct = null; selectedVersion = null"
-              :class="!selectedProduct ? activeChipClass : inactiveChipClass"
-            >All</button>
-            <button
-              v-for="product in products"
-              :key="product"
-              @click="selectProduct(product)"
-              :class="selectedProduct === product ? activeChipClass : inactiveChipClass"
-            >{{ product.toUpperCase() }}</button>
+      <!-- Selection bar -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 mb-6 px-5 py-4">
+        <template v-if="hasSelection">
+          <div class="flex items-start justify-between gap-4">
+            <div class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+              Showing hygiene data for
+              <span class="font-semibold text-gray-900 dark:text-gray-100">{{ familyNarrative }}</span>,
+              <span class="font-semibold text-gray-900 dark:text-gray-100">version {{ selection.version }}</span>,
+              covering the
+              <span class="font-semibold text-gray-900 dark:text-gray-100">{{ phaseNarrative }}</span>
+              {{ selection.phases.size === 1 ? 'phase' : 'phases' }}
+              of the release lifecycle.
+            </div>
+            <div class="flex items-center gap-2 shrink-0">
+              <button
+                @click="openModal"
+                class="px-3 py-1.5 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+              >Select Release</button>
+            </div>
           </div>
-        </div>
-        <div class="flex items-center gap-2">
-          <span class="text-xs font-medium text-gray-500 dark:text-gray-400 w-16 shrink-0">Version</span>
-          <div class="flex flex-wrap gap-1.5">
+        </template>
+        <template v-else>
+          <div class="text-center py-6">
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
+              Select a release version and product family to view hygiene data across the release lifecycle.
+            </p>
             <button
-              @click="selectedVersion = null"
-              :class="!selectedVersion ? activeChipClass : inactiveChipClass"
-            >All</button>
-            <button
-              v-for="ver in filteredVersions"
-              :key="ver.versionId"
-              @click="selectVersion(ver.versionId)"
-              :class="selectedVersion === ver.versionId ? activeChipClass : inactiveChipClass"
-            >{{ ver.displayName }}</button>
+              @click="openModal"
+              class="px-4 py-2 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+            >Select Release</button>
           </div>
-        </div>
+        </template>
       </div>
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-          <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Versions</div>
-          <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ activeVersions.length }}</div>
-        </div>
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-          <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Features</div>
-          <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ totals.totalFeatures }}</div>
-        </div>
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-          <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Features with Violations</div>
-          <div class="text-2xl font-bold" :class="totals.featuresWithViolations > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">
-            {{ totals.featuresWithViolations }}
+      <template v-if="hasSelection">
+        <!-- Summary cards -->
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Versions</div>
+            <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ activeVersions.length }}</div>
           </div>
-        </div>
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-          <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Violations</div>
-          <div class="text-2xl font-bold" :class="totals.totalViolations > 0 ? 'text-orange-600 dark:text-orange-400' : 'text-green-600 dark:text-green-400'">
-            {{ totals.totalViolations }}
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Features</div>
+            <div class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ totals.totalFeatures }}</div>
           </div>
-        </div>
-      </div>
-
-      <!-- Two-column layout: by rule + by team bar charts -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-        <!-- Violations by rule -->
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Violations by Rule</h3>
-          <div v-if="sortedRuleViolations.length === 0" class="text-sm text-gray-400">No violations found.</div>
-          <div v-else class="space-y-2.5">
-            <div v-for="rule in sortedRuleViolations" :key="rule.id" class="flex items-center gap-3">
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 mb-0.5">
-                  <span class="text-xs font-medium text-gray-700 dark:text-gray-300 truncate">{{ rule.name }}</span>
-                  <span class="px-1.5 py-0.5 text-[9px] font-medium rounded" :class="categoryColors[rule.category] || 'bg-gray-100 text-gray-600'">
-                    {{ rule.category }}
-                  </span>
-                </div>
-                <div class="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
-                  <div
-                    class="h-full bg-red-500 dark:bg-red-400 rounded-full transition-all"
-                    :style="{ width: (rule.count / maxRuleCount * 100) + '%' }"
-                  />
-                </div>
-              </div>
-              <span class="text-sm font-semibold text-gray-900 dark:text-gray-100 w-10 text-right shrink-0">{{ rule.count }}</span>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Features with Violations</div>
+            <div class="text-2xl font-bold" :class="totals.featuresWithViolations > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">
+              {{ totals.featuresWithViolations }}
+            </div>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Violations</div>
+            <div class="text-2xl font-bold" :class="totals.totalViolations > 0 ? 'text-orange-600 dark:text-orange-400' : 'text-green-600 dark:text-green-400'">
+              {{ totals.totalViolations }}
             </div>
           </div>
         </div>
 
-        <!-- Violations by team -->
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Violations by Team</h3>
-          <div v-if="sortedTeamViolations.length === 0" class="text-sm text-gray-400">No violations found.</div>
-          <div v-else class="space-y-2.5">
-            <div v-for="team in sortedTeamViolations" :key="team.team" class="flex items-center gap-3">
-              <div class="flex-1 min-w-0">
-                <div class="text-xs font-medium text-gray-700 dark:text-gray-300 truncate mb-0.5">{{ team.team }}</div>
-                <div class="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
-                  <div
-                    class="h-full bg-orange-500 dark:bg-orange-400 rounded-full transition-all"
-                    :style="{ width: (team.count / maxTeamCount * 100) + '%' }"
-                  />
+        <!-- Two-column layout: by rule + by team bar charts -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+          <!-- Violations by rule -->
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Violations by Rule</h3>
+            <div v-if="sortedRuleViolations.length === 0" class="text-sm text-gray-400">No violations found.</div>
+            <div v-else class="space-y-2.5">
+              <div v-for="rule in sortedRuleViolations" :key="rule.id" class="flex items-center gap-3">
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 mb-0.5">
+                    <span class="text-xs font-medium text-gray-700 dark:text-gray-300 truncate">{{ rule.name }}</span>
+                    <span class="px-1.5 py-0.5 text-[9px] font-medium rounded" :class="categoryColors[rule.category] || 'bg-gray-100 text-gray-600'">
+                      {{ rule.category }}
+                    </span>
+                  </div>
+                  <div class="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                    <div
+                      class="h-full bg-red-500 dark:bg-red-400 rounded-full transition-all"
+                      :style="{ width: (rule.count / maxRuleCount * 100) + '%' }"
+                    />
+                  </div>
                 </div>
+                <span class="text-sm font-semibold text-gray-900 dark:text-gray-100 w-10 text-right shrink-0">{{ rule.count }}</span>
               </div>
-              <span class="text-sm font-semibold text-gray-900 dark:text-gray-100 w-10 text-right shrink-0">{{ team.count }}</span>
+            </div>
+          </div>
+
+          <!-- Violations by team -->
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Violations by Team</h3>
+            <div v-if="sortedTeamViolations.length === 0" class="text-sm text-gray-400">No violations found.</div>
+            <div v-else class="space-y-2.5">
+              <div v-for="team in sortedTeamViolations" :key="team.team" class="flex items-center gap-3">
+                <div class="flex-1 min-w-0">
+                  <div class="text-xs font-medium text-gray-700 dark:text-gray-300 truncate mb-0.5">{{ team.team }}</div>
+                  <div class="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                    <div
+                      class="h-full bg-orange-500 dark:bg-orange-400 rounded-full transition-all"
+                      :style="{ width: (team.count / maxTeamCount * 100) + '%' }"
+                    />
+                  </div>
+                </div>
+                <span class="text-sm font-semibold text-gray-900 dark:text-gray-100 w-10 text-right shrink-0">{{ team.count }}</span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Tabbed detail section -->
-      <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <!-- Tab bar -->
-        <div class="border-b border-gray-200 dark:border-gray-700 px-4">
-          <div class="flex gap-4">
-            <button
-              v-for="tab in tabs"
-              :key="tab.id"
-              @click="activeTab = tab.id"
-              class="py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors"
-              :class="activeTab === tab.id
-                ? 'border-primary-500 text-primary-600 dark:text-primary-400'
-                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
-            >{{ tab.label }}</button>
+        <!-- Tabbed detail section -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <!-- Tab bar -->
+          <div class="border-b border-gray-200 dark:border-gray-700 px-4">
+            <div class="flex gap-4">
+              <button
+                v-for="tab in tabs"
+                :key="tab.id"
+                @click="activeTab = tab.id"
+                class="py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors"
+                :class="activeTab === tab.id
+                  ? 'border-primary-500 text-primary-600 dark:text-primary-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+              >{{ tab.label }}</button>
+            </div>
           </div>
-        </div>
 
-        <!-- Tab: Features -->
-        <div v-if="activeTab === 'features'">
-          <div v-if="sortedFeatures.length === 0" class="p-6 text-center text-sm text-gray-400">
-            No features in selected scope.
-          </div>
-          <div v-else class="overflow-x-auto">
-            <table class="w-full text-sm">
-              <thead>
-                <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                  <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('key')">
-                    Key{{ sortIcon('key') }}
-                  </th>
-                  <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('summary')">
-                    Summary{{ sortIcon('summary') }}
-                  </th>
-                  <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('assignee')">
-                    Assignee{{ sortIcon('assignee') }}
-                  </th>
-                  <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('team')">
-                    Team{{ sortIcon('team') }}
-                  </th>
-                  <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('status')">
-                    Status{{ sortIcon('status') }}
-                  </th>
-                  <th v-if="!selectedVersion" class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('version')">
-                    Version{{ sortIcon('version') }}
-                  </th>
-                  <th class="px-4 py-2 font-medium text-right cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('violationCount')">
-                    Violations{{ sortIcon('violationCount') }}
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
-                <tr v-for="f in sortedFeatures" :key="f.key + f.version" class="hover:bg-gray-50 dark:hover:bg-gray-700/30">
-                  <td class="px-4 py-2 whitespace-nowrap">
-                    <div class="flex items-center gap-1.5">
+          <!-- Tab: Features -->
+          <div v-if="activeTab === 'features'">
+            <div v-if="sortedFeatures.length === 0" class="p-6 text-center text-sm text-gray-400">
+              No features in selected scope.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                    <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('key')">
+                      Key{{ sortIcon('key') }}
+                    </th>
+                    <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('summary')">
+                      Summary{{ sortIcon('summary') }}
+                    </th>
+                    <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('assignee')">
+                      Assignee{{ sortIcon('assignee') }}
+                    </th>
+                    <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('team')">
+                      Team{{ sortIcon('team') }}
+                    </th>
+                    <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('status')">
+                      Status{{ sortIcon('status') }}
+                    </th>
+                    <th class="px-4 py-2 font-medium cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('version')">
+                      Version{{ sortIcon('version') }}
+                    </th>
+                    <th class="px-4 py-2 font-medium text-right cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" @click="toggleFeatureSort('violationCount')">
+                      Violations{{ sortIcon('violationCount') }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+                  <tr v-for="f in sortedFeatures" :key="f.key + f.version" class="hover:bg-gray-50 dark:hover:bg-gray-700/30">
+                    <td class="px-4 py-2 whitespace-nowrap">
+                      <div class="flex items-center gap-1.5">
+                        <button
+                          class="font-mono text-xs text-primary-600 dark:text-primary-400 hover:underline"
+                          @click="nav.navigateTo('feature-detail', {
+                            key: f.key,
+                            from: 'hygiene-report'
+                          })"
+                        >{{ f.key }}</button>
+                        <a
+                          :href="'https://redhat.atlassian.net/browse/' + f.key"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                          title="Open in Jira"
+                          @click.stop
+                        >
+                          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                          </svg>
+                        </a>
+                      </div>
+                    </td>
+                    <td class="px-4 py-2 text-gray-900 dark:text-gray-100 max-w-md truncate">{{ f.summary }}</td>
+                    <td class="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ f.assignee }}</td>
+                    <td class="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ f.team }}</td>
+                    <td class="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ f.status || '—' }}</td>
+                    <td class="px-4 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap text-xs">{{ f.version }}</td>
+                    <td class="px-4 py-2 text-right">
                       <button
-                        class="font-mono text-xs text-primary-600 dark:text-primary-400 hover:underline"
-                        @click="nav.navigateTo('feature-detail', {
-                          key: f.key,
-                          from: 'hygiene-report',
-                          ...(selectedProduct ? { product: selectedProduct } : {}),
-                          ...(selectedVersion ? { version: selectedVersion } : {})
-                        })"
-                      >{{ f.key }}</button>
-                      <a
-                        :href="'https://redhat.atlassian.net/browse/' + f.key"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                        title="Open in Jira"
-                        @click.stop
+                        v-if="f.violationCount > 0"
+                        class="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 text-xs font-semibold rounded-full bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-800/40 cursor-pointer transition-colors"
+                        @click="showViolations(f, $event)"
                       >
-                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                        </svg>
-                      </a>
-                    </div>
-                  </td>
-                  <td class="px-4 py-2 text-gray-900 dark:text-gray-100 max-w-md truncate">{{ f.summary }}</td>
-                  <td class="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ f.assignee }}</td>
-                  <td class="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ f.team }}</td>
-                  <td class="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ f.status || '—' }}</td>
-                  <td v-if="!selectedVersion" class="px-4 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap text-xs">{{ f.version }}</td>
-                  <td class="px-4 py-2 text-right">
-                    <button
-                      v-if="f.violationCount > 0"
-                      class="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 text-xs font-semibold rounded-full bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-800/40 cursor-pointer transition-colors"
-                      @click="showViolations(f, $event)"
-                    >
-                      {{ f.violationCount }}
-                    </button>
-                    <span v-else class="text-gray-300 dark:text-gray-600">0</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div v-if="sortedFeatures.length > 0" class="px-4 py-2 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400">
-            {{ sortedFeatures.length }} feature{{ sortedFeatures.length !== 1 ? 's' : '' }}
-          </div>
-
-          <!-- Violations popover -->
-          <teleport to="body">
-            <div v-if="popoverFeature" class="fixed inset-0 z-40" @click="closePopover" />
-            <div
-              v-if="popoverFeature"
-              :style="popoverStyle"
-              class="z-50 w-80 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-xl"
-            >
-              <div class="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
-                <div class="min-w-0">
-                  <button
-                    class="text-xs font-mono text-primary-600 dark:text-primary-400 hover:underline"
-                    @click="nav.navigateTo('feature-detail', {
-                      key: popoverFeature.key,
-                      from: 'hygiene-report',
-                      ...(selectedProduct ? { product: selectedProduct } : {}),
-                      ...(selectedVersion ? { version: selectedVersion } : {})
-                    })"
-                  >{{ popoverFeature.key }}</button>
-                  <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ popoverFeature.summary }}</div>
-                </div>
-                <button class="ml-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0" @click="closePopover">
-                  <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-              <ul class="px-4 py-3 space-y-2">
-                <li v-for="vid in popoverFeature.violations" :key="vid" class="flex items-start gap-2">
-                  <span class="mt-0.5 px-1.5 py-0.5 text-[9px] font-medium rounded shrink-0" :class="categoryColors[ruleDefinitions[vid]?.category] || 'bg-gray-100 text-gray-600'">
-                    {{ ruleDefinitions[vid]?.category || 'unknown' }}
-                  </span>
-                  <span class="text-sm text-gray-700 dark:text-gray-300">{{ ruleDefinitions[vid]?.name || vid }}</span>
-                </li>
-              </ul>
+                        {{ f.violationCount }}
+                      </button>
+                      <span v-else class="text-gray-300 dark:text-gray-600">0</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
-          </teleport>
-        </div>
+            <div v-if="sortedFeatures.length > 0" class="px-4 py-2 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400">
+              {{ sortedFeatures.length }} feature{{ sortedFeatures.length !== 1 ? 's' : '' }}
+            </div>
 
-        <!-- Tab: Team Accountability -->
-        <div v-if="activeTab === 'teams'">
-          <div v-if="teamAccountability.length === 0" class="p-6 text-center text-sm text-gray-400">
-            No features in selected scope.
+            <!-- Violations popover -->
+            <teleport to="body">
+              <div v-if="popoverFeature" class="fixed inset-0 z-40" @click="closePopover" />
+              <div
+                v-if="popoverFeature"
+                :style="popoverStyle"
+                class="z-50 w-80 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-xl"
+              >
+                <div class="px-4 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+                  <div class="min-w-0">
+                    <button
+                      class="text-xs font-mono text-primary-600 dark:text-primary-400 hover:underline"
+                      @click="nav.navigateTo('feature-detail', {
+                        key: popoverFeature.key,
+                        from: 'hygiene-report'
+                      })"
+                    >{{ popoverFeature.key }}</button>
+                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ popoverFeature.summary }}</div>
+                  </div>
+                  <button class="ml-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0" @click="closePopover">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                <ul class="px-4 py-3 space-y-2">
+                  <li v-for="vid in popoverFeature.violations" :key="vid" class="flex items-start gap-2">
+                    <span class="mt-0.5 px-1.5 py-0.5 text-[9px] font-medium rounded shrink-0" :class="categoryColors[ruleDefinitions[vid]?.category] || 'bg-gray-100 text-gray-600'">
+                      {{ ruleDefinitions[vid]?.category || 'unknown' }}
+                    </span>
+                    <span class="text-sm text-gray-700 dark:text-gray-300">{{ ruleDefinitions[vid]?.name || vid }}</span>
+                  </li>
+                </ul>
+              </div>
+            </teleport>
           </div>
-          <div v-else class="overflow-x-auto">
-            <table class="w-full text-sm">
-              <thead>
-                <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                  <th class="px-4 py-2 font-medium">Team</th>
-                  <th class="px-4 py-2 font-medium text-right">Features</th>
-                  <th class="px-4 py-2 font-medium text-right">With Violations</th>
-                  <th class="px-4 py-2 font-medium text-right">Total Violations</th>
-                  <th class="px-4 py-2 font-medium text-right">Ownership</th>
-                  <th class="px-4 py-2 font-medium text-right">Timeliness</th>
-                  <th class="px-4 py-2 font-medium text-right">Metadata</th>
-                  <th class="px-4 py-2 font-medium text-right">Lifecycle</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
-                <tr v-for="team in teamAccountability" :key="team.team" class="hover:bg-gray-50 dark:hover:bg-gray-700/30">
-                  <td class="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ team.team }}</td>
-                  <td class="px-4 py-2.5 text-right text-gray-700 dark:text-gray-300">{{ team.totalFeatures }}</td>
-                  <td class="px-4 py-2.5 text-right">
-                    <span :class="team.featuresWithViolations > 0 ? 'text-red-600 dark:text-red-400 font-semibold' : 'text-gray-400'">
-                      {{ team.featuresWithViolations }}
-                    </span>
-                  </td>
-                  <td class="px-4 py-2.5 text-right">
-                    <span :class="team.totalViolations > 0 ? 'text-orange-600 dark:text-orange-400 font-semibold' : 'text-gray-400'">
-                      {{ team.totalViolations }}
-                    </span>
-                  </td>
-                  <td class="px-4 py-2.5 text-right">
-                    <span :class="(team.byCategory.ownership || 0) > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-300 dark:text-gray-600'">
-                      {{ team.byCategory.ownership || 0 }}
-                    </span>
-                  </td>
-                  <td class="px-4 py-2.5 text-right">
-                    <span :class="(team.byCategory.timeliness || 0) > 0 ? 'text-orange-600 dark:text-orange-400' : 'text-gray-300 dark:text-gray-600'">
-                      {{ team.byCategory.timeliness || 0 }}
-                    </span>
-                  </td>
-                  <td class="px-4 py-2.5 text-right">
-                    <span :class="(team.byCategory.metadata || 0) > 0 ? 'text-purple-600 dark:text-purple-400' : 'text-gray-300 dark:text-gray-600'">
-                      {{ team.byCategory.metadata || 0 }}
-                    </span>
-                  </td>
-                  <td class="px-4 py-2.5 text-right">
-                    <span :class="(team.byCategory.lifecycle || 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-300 dark:text-gray-600'">
-                      {{ team.byCategory.lifecycle || 0 }}
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+
+          <!-- Tab: Team Accountability -->
+          <div v-if="activeTab === 'teams'">
+            <div v-if="teamAccountability.length === 0" class="p-6 text-center text-sm text-gray-400">
+              No features in selected scope.
+            </div>
+            <div v-else class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                    <th class="px-4 py-2 font-medium">Team</th>
+                    <th class="px-4 py-2 font-medium text-right">Features</th>
+                    <th class="px-4 py-2 font-medium text-right">With Violations</th>
+                    <th class="px-4 py-2 font-medium text-right">Total Violations</th>
+                    <th class="px-4 py-2 font-medium text-right">Ownership</th>
+                    <th class="px-4 py-2 font-medium text-right">Timeliness</th>
+                    <th class="px-4 py-2 font-medium text-right">Metadata</th>
+                    <th class="px-4 py-2 font-medium text-right">Lifecycle</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+                  <tr v-for="team in teamAccountability" :key="team.team" class="hover:bg-gray-50 dark:hover:bg-gray-700/30">
+                    <td class="px-4 py-2.5 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{{ team.team }}</td>
+                    <td class="px-4 py-2.5 text-right text-gray-700 dark:text-gray-300">{{ team.totalFeatures }}</td>
+                    <td class="px-4 py-2.5 text-right">
+                      <span :class="team.featuresWithViolations > 0 ? 'text-red-600 dark:text-red-400 font-semibold' : 'text-gray-400'">
+                        {{ team.featuresWithViolations }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-right">
+                      <span :class="team.totalViolations > 0 ? 'text-orange-600 dark:text-orange-400 font-semibold' : 'text-gray-400'">
+                        {{ team.totalViolations }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-right">
+                      <span :class="(team.byCategory.ownership || 0) > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-gray-300 dark:text-gray-600'">
+                        {{ team.byCategory.ownership || 0 }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-right">
+                      <span :class="(team.byCategory.timeliness || 0) > 0 ? 'text-orange-600 dark:text-orange-400' : 'text-gray-300 dark:text-gray-600'">
+                        {{ team.byCategory.timeliness || 0 }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-right">
+                      <span :class="(team.byCategory.metadata || 0) > 0 ? 'text-purple-600 dark:text-purple-400' : 'text-gray-300 dark:text-gray-600'">
+                        {{ team.byCategory.metadata || 0 }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2.5 text-right">
+                      <span :class="(team.byCategory.lifecycle || 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-300 dark:text-gray-600'">
+                        {{ team.byCategory.lifecycle || 0 }}
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div v-if="teamAccountability.length > 0" class="px-4 py-2 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400">
+              {{ teamAccountability.length }} team{{ teamAccountability.length !== 1 ? 's' : '' }}
+            </div>
           </div>
-          <div v-if="teamAccountability.length > 0" class="px-4 py-2 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-400">
-            {{ teamAccountability.length }} team{{ teamAccountability.length !== 1 ? 's' : '' }}
+        </div>
+      </template>
+    </template>
+
+    <!-- Release selection modal -->
+    <Teleport to="body">
+      <div v-if="modalOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-black/40 dark:bg-black/60" @click="cancelModal"></div>
+        <div
+          class="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full p-6"
+          @keydown.escape="cancelModal"
+        >
+          <!-- Modal header -->
+          <div class="flex items-center justify-between mb-6">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Select Release</h3>
+            <button
+              @click="cancelModal"
+              class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            >
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Product Family -->
+          <div class="mb-5">
+            <label class="block text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Product Family</label>
+            <div class="flex flex-wrap gap-2">
+              <button
+                @click="toggleAllFamilies"
+                class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+                :class="isAllFamiliesDraft
+                  ? 'bg-primary-600 text-white border-primary-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+              >All</button>
+              <button
+                v-for="f in availableFamilies"
+                :key="f"
+                @click="toggleFamily(f)"
+                class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+                :class="draft.families.has(f)
+                  ? 'bg-primary-600 text-white border-primary-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+              >{{ f.toUpperCase() }}</button>
+            </div>
+          </div>
+
+          <!-- Version -->
+          <div class="mb-5">
+            <label class="block text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Version</label>
+            <div v-if="draftVersions.length > 0" class="flex flex-wrap gap-2">
+              <button
+                v-for="v in draftVersions"
+                :key="v"
+                @click="selectVersionDraft(v)"
+                class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+                :class="draft.version === v
+                  ? 'bg-primary-600 text-white border-primary-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+              >{{ v }}</button>
+            </div>
+            <p v-else class="text-xs text-gray-400 dark:text-gray-500">Select a product family first.</p>
+          </div>
+
+          <!-- Phase -->
+          <div class="mb-6">
+            <label class="block text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Phase</label>
+            <div v-if="draftPhases.length > 0" class="flex flex-wrap gap-2">
+              <button
+                v-for="p in draftPhases"
+                :key="p"
+                @click="togglePhase(p)"
+                class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border"
+                :class="draft.phases.has(p)
+                  ? 'bg-primary-600 text-white border-primary-600'
+                  : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-300 dark:hover:border-primary-600'"
+              >{{ p }}</button>
+            </div>
+            <p v-else class="text-xs text-gray-400 dark:text-gray-500">Select a version first.</p>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex justify-end gap-3 pt-2 border-t border-gray-200 dark:border-gray-700">
+            <button
+              @click="cancelModal"
+              class="px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            >Cancel</button>
+            <button
+              @click="applyModal"
+              :disabled="!canApply"
+              class="px-4 py-2 text-sm font-medium rounded-md bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >Apply</button>
           </div>
         </div>
       </div>
-    </template>
+    </Teleport>
   </div>
 </template>

--- a/modules/releases/server/hygiene/routes.js
+++ b/modules/releases/server/hygiene/routes.js
@@ -669,6 +669,7 @@ module.exports = async function registerHygieneRoutes(router, context) {
 
       versions.push({
         versionId: versionId,
+        registryId: rel ? rel.id : null,
         displayName: (rel && rel.displayName) || data.version || versionId,
         gaDate: gaDate || null,
         isReleased: !!isReleased,

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -1258,3 +1258,115 @@ test.describe('Releases CVE Sustaining Report @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 });
+
+/**
+ * Program Hygiene Report
+ *
+ * Verify the Program Hygiene Report loads, renders the release selector,
+ * summary cards, violation charts, feature table, and team accountability
+ * table. Also tests the hygiene program-report API endpoint.
+ */
+test.describe('Program Hygiene Report @releases', () => {
+  test.beforeEach(async ({ page }) => {
+    setupErrorTracking(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    logCapturedErrors(page, testInfo);
+  });
+
+  test('program hygiene report loads with heading and selector', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=program-hygiene');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    await expect(page.locator('text=Program Hygiene Report').first()).toBeVisible();
+
+    // Should show the release selector button (either in empty state or selection bar)
+    await expect(page.locator('button', { hasText: 'Select Release' }).first()).toBeVisible();
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('program hygiene API returns expected shape', async ({ request }) => {
+    const res = await request.get('/api/modules/releases/hygiene/program-report');
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body).toHaveProperty('versions');
+    expect(Array.isArray(body.versions)).toBe(true);
+    expect(body).toHaveProperty('ruleDefinitions');
+    expect(typeof body.ruleDefinitions).toBe('object');
+  });
+
+  test('release selector modal opens and has expected fields', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=program-hygiene');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Open the selector modal
+    await page.locator('button', { hasText: 'Select Release' }).first().click();
+    await page.waitForTimeout(300);
+
+    // Modal should show family, version, and phase sections
+    await expect(page.locator('text=Product Family').first()).toBeVisible();
+    await expect(page.locator('text=Version').first()).toBeVisible();
+    await expect(page.locator('text=Phase').first()).toBeVisible();
+
+    // Cancel and Apply buttons
+    await expect(page.locator('button', { hasText: 'Cancel' }).first()).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Apply' }).first()).toBeVisible();
+
+    // Close via Escape
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('shows summary cards and violation charts when data is available', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=program-hygiene');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // If data loaded and a selection was auto-applied, we should see summary cards
+    const versionsCard = page.locator('text=Versions').first();
+    const hasData = await versionsCard.isVisible().catch(() => false);
+
+    if (hasData) {
+      await expect(page.locator('text=Total Features').first()).toBeVisible();
+      await expect(page.locator('text=Features with Violations').first()).toBeVisible();
+      await expect(page.locator('text=Total Violations').first()).toBeVisible();
+
+      // Violation charts
+      await expect(page.locator('text=Violations by Rule').first()).toBeVisible();
+      await expect(page.locator('text=Violations by Team').first()).toBeVisible();
+
+      // Feature table tab
+      await expect(page.locator('button', { hasText: 'Features' }).first()).toBeVisible();
+      await expect(page.locator('button', { hasText: 'Team Accountability' }).first()).toBeVisible();
+    }
+
+    expect(page.errors).toHaveLength(0);
+  });
+
+  test('team accountability tab renders table', async ({ page }) => {
+    await page.goto('/#/releases/reports?report=program-hygiene');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
+
+    // Switch to Team Accountability tab if visible
+    const teamTab = page.locator('button', { hasText: 'Team Accountability' }).first();
+    const tabVisible = await teamTab.isVisible().catch(() => false);
+
+    if (tabVisible) {
+      await teamTab.click();
+      await page.waitForTimeout(300);
+
+      // Team table headers
+      await expect(page.locator('th', { hasText: 'Team' }).first()).toBeVisible();
+      await expect(page.locator('th', { hasText: 'With Violations' }).first()).toBeVisible();
+    }
+
+    expect(page.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Modal-based release selector**: Replaces inline chip-bar filters with the same draft/apply modal UX used by the Program Level Release Report — multi-select product families, single-select version, multi-select phases, with selection persistence (URL params + localStorage)
- **Registry integration**: Server now passes `registryId` through the program-report API so the client matches hygiene versions against the releases registry directly, instead of inferring family/version/phase from `versionId` strings
- **Z-stream handling**: Z-stream releases (`.z` suffix) are correctly excluded from the release selector since they don't parse as standard registry entries

## Test plan

- [ ] Open Program Hygiene Report — verify modal opens with product families, version, and phases
- [ ] Select a family + version + phases, apply — verify report filters correctly
- [ ] Verify version count card shows correct number (e.g., "3.6 GA" = 1 version, not 2)
- [ ] Refresh page — verify selection restores from URL params
- [ ] Navigate away and back — verify selection restores from localStorage
- [ ] Compare filter behavior with Program Level Release Report for consistency
- [ ] Verify narrative summary bar matches selected filters
- [ ] Click a feature row to open detail view, then navigate back — verify selection persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)