### PR TITLE
fix(releases): remove "Show empty rocks" toggle and show all big rocks by default

### DIFF
--- a/modules/releases/__tests__/client/plan/components.test.js
+++ b/modules/releases/__tests__/client/plan/components.test.js
@@ -263,35 +263,4 @@ describe('FilterBar', () => {
     expect(wrapper.text()).not.toContain('Clear Filters')
   })
 
-  it('shows empty-rocks toggle on big-rocks tab with hidden count', () => {
-    const wrapper = mount(FilterBar, {
-      props: {
-        filterOptions,
-        activeTab: 'big-rocks',
-        showEmptyRocks: false,
-        emptyRockCount: 3
-      }
-    })
-    expect(wrapper.text()).toContain('Show empty rocks')
-    expect(wrapper.text()).toContain('(3 hidden)')
-    const checkbox = wrapper.find('input[type="checkbox"]')
-    expect(checkbox.exists()).toBe(true)
-    expect(checkbox.element.checked).toBe(false)
-  })
-
-  it('hides empty-rocks toggle on features tab', () => {
-    const wrapper = mount(FilterBar, {
-      props: { filterOptions, activeTab: 'features', emptyRockCount: 3 }
-    })
-    expect(wrapper.text()).not.toContain('Show empty rocks')
-  })
-
-  it('emits update:showEmptyRocks when toggle changes', async () => {
-    const wrapper = mount(FilterBar, {
-      props: { filterOptions, activeTab: 'big-rocks', showEmptyRocks: false, emptyRockCount: 1 }
-    })
-    await wrapper.find('input[type="checkbox"]').setValue(true)
-    expect(wrapper.emitted('update:showEmptyRocks')).toBeTruthy()
-    expect(wrapper.emitted('update:showEmptyRocks')[0]).toEqual([true])
-  })
 })

--- a/modules/releases/__tests__/client/plan/use-filters-big-rocks.test.js
+++ b/modules/releases/__tests__/client/plan/use-filters-big-rocks.test.js
@@ -10,30 +10,18 @@ var sampleBigRocks = [
 ]
 
 describe('filteredBigRocks', function() {
-  it('hides empty rocks by default', function() {
+  it('returns all rocks including empty ones', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref(sampleBigRocks)
     var result = useFilters(features, rfes, bigRocks)
-    expect(result.showEmptyRocks.value).toBe(false)
-    expect(result.emptyRockCount.value).toBe(1)
+    expect(result.filteredBigRocks.value).toHaveLength(4)
     expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual([
-      'MaaS', 'Gen AI Studio', 'Eval Hub'
+      'MaaS', 'Gen AI Studio', 'Eval Hub', 'Empty Rock'
     ])
   })
 
-  it('shows empty rocks when toggle is on', function() {
-    var features = ref([])
-    var rfes = ref([])
-    var bigRocks = ref(sampleBigRocks)
-    var result = useFilters(features, rfes, bigRocks)
-
-    result.showEmptyRocks.value = true
-    expect(result.filteredBigRocks.value).toHaveLength(4)
-    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toContain('Empty Rock')
-  })
-
-  it('treats missing feature/rfe counts as empty', function() {
+  it('returns rocks regardless of feature/rfe counts', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref([
@@ -41,33 +29,19 @@ describe('filteredBigRocks', function() {
       { name: 'Has Work', pillar: 'Agents', featureCount: 1, rfeCount: 0 }
     ])
     var result = useFilters(features, rfes, bigRocks)
-    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['Has Work'])
-    result.showEmptyRocks.value = true
     expect(result.filteredBigRocks.value).toHaveLength(2)
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['No Counts', 'Has Work'])
   })
 
-  it('filters by pillar (still hides empty by default)', function() {
+  it('filters by pillar including empty rocks', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref(sampleBigRocks)
     var result = useFilters(features, rfes, bigRocks)
 
     result.selectedPillar.value = 'Inference'
-    expect(result.filteredBigRocks.value).toHaveLength(2)
-    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['MaaS', 'Eval Hub'])
-  })
-
-  it('filters by pillar and can include empty rocks', function() {
-    var features = ref([])
-    var rfes = ref([])
-    var bigRocks = ref(sampleBigRocks)
-    var result = useFilters(features, rfes, bigRocks)
-
-    result.selectedPillar.value = 'Inference'
-    result.showEmptyRocks.value = true
-    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual([
-      'MaaS', 'Eval Hub', 'Empty Rock'
-    ])
+    expect(result.filteredBigRocks.value).toHaveLength(3)
+    expect(result.filteredBigRocks.value.map(function(r) { return r.name })).toEqual(['MaaS', 'Eval Hub', 'Empty Rock'])
   })
 
   it('filters by search query (name)', function() {
@@ -142,21 +116,18 @@ describe('filteredBigRocks', function() {
     var bigRocks = ref(null)
     var result = useFilters(features, rfes, bigRocks)
     expect(result.filteredBigRocks.value).toEqual([])
-    expect(result.emptyRockCount.value).toBe(0)
   })
 
-  it('clearFilters resets pillar but keeps empty-rock preference', function() {
+  it('clearFilters resets pillar', function() {
     var features = ref([])
     var rfes = ref([])
     var bigRocks = ref(sampleBigRocks)
     var result = useFilters(features, rfes, bigRocks)
 
     result.selectedPillar.value = 'Inference'
-    result.showEmptyRocks.value = true
     expect(result.filteredBigRocks.value).toHaveLength(3)
 
     result.clearFilters()
-    expect(result.showEmptyRocks.value).toBe(true)
     expect(result.filteredBigRocks.value).toHaveLength(4)
   })
 })

--- a/modules/releases/client/plan/components/FilterBar.vue
+++ b/modules/releases/client/plan/components/FilterBar.vue
@@ -11,8 +11,6 @@ const props = defineProps({
   selectedPriority: { type: String, default: '' },
   selectedTeams: { type: Array, default: () => [] },
   searchQuery: { type: String, default: '' },
-  showEmptyRocks: { type: Boolean, default: false },
-  emptyRockCount: { type: Number, default: 0 },
   hasActiveFilters: { type: Boolean, default: false }
 })
 
@@ -23,7 +21,6 @@ const emit = defineEmits([
   'update:selectedPriority',
   'update:selectedTeams',
   'update:searchQuery',
-  'update:showEmptyRocks',
   'clearFilters'
 ])
 
@@ -151,26 +148,6 @@ useClickOutside(teamsDropdownRef, function() {
         </label>
       </div>
     </div>
-
-    <label
-      v-if="activeTab === 'big-rocks'"
-      class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none"
-      title="Rocks with 0 Features and 0 RFEs for this release are hidden by default"
-    >
-      <input
-        type="checkbox"
-        :checked="showEmptyRocks"
-        @change="$emit('update:showEmptyRocks', $event.target.checked)"
-        class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
-      />
-      <span>Show empty rocks</span>
-      <span
-        v-if="!showEmptyRocks && emptyRockCount > 0"
-        class="text-xs text-gray-500 dark:text-gray-400"
-      >
-        ({{ emptyRockCount }} hidden)
-      </span>
-    </label>
 
     <button
       v-if="hasActiveFilters"

--- a/modules/releases/client/plan/composables/useFilters.js
+++ b/modules/releases/client/plan/composables/useFilters.js
@@ -1,13 +1,5 @@
 import { ref, computed } from 'vue'
 
-function rockChildCount(rock) {
-  return (rock.featureCount || 0) + (rock.rfeCount || 0)
-}
-
-function isEmptyRock(rock) {
-  return rockChildCount(rock) === 0
-}
-
 export function useFilters(features, rfes, bigRocks) {
   const selectedPillar = ref('')
   const selectedRock = ref('')
@@ -15,8 +7,6 @@ export function useFilters(features, rfes, bigRocks) {
   const selectedPriority = ref('')
   const selectedTeams = ref([])
   const searchQuery = ref('')
-  /** When false (default), rocks with 0 Features and 0 RFEs for this release are hidden. */
-  const showEmptyRocks = ref(false)
 
   function matchesFilters(item) {
     if (searchQuery.value) {
@@ -73,15 +63,9 @@ export function useFilters(features, rfes, bigRocks) {
     return rfes.value.filter(matchesFilters)
   })
 
-  const emptyRockCount = computed(() => {
-    if (!bigRocks.value) return 0
-    return bigRocks.value.filter(isEmptyRock).length
-  })
-
   const filteredBigRocks = computed(() => {
     if (!bigRocks.value) return []
     return bigRocks.value.filter(function(rock) {
-      if (!showEmptyRocks.value && isEmptyRock(rock)) return false
       if (selectedPillar.value && rock.pillar !== selectedPillar.value) return false
       if (searchQuery.value) {
         const q = searchQuery.value.toLowerCase()
@@ -119,8 +103,6 @@ export function useFilters(features, rfes, bigRocks) {
     selectedPriority,
     selectedTeams,
     searchQuery,
-    showEmptyRocks,
-    emptyRockCount,
     filteredFeatures,
     filteredRfes,
     filteredBigRocks,

--- a/modules/releases/client/plan/views/DashboardView.vue
+++ b/modules/releases/client/plan/views/DashboardView.vue
@@ -90,8 +90,6 @@ const {
   selectedPriority,
   selectedTeams,
   searchQuery,
-  showEmptyRocks,
-  emptyRockCount,
   filteredFeatures,
   filteredRfes,
   filteredBigRocks,
@@ -381,8 +379,6 @@ onMounted(async function() {
         v-model:selectedPriority="selectedPriority"
         v-model:selectedTeams="selectedTeams"
         v-model:searchQuery="searchQuery"
-        v-model:showEmptyRocks="showEmptyRocks"
-        :emptyRockCount="emptyRockCount"
         :hasActiveFilters="hasActiveFilters"
         @clearFilters="clearFilters"
       />

--- a/tests/integration/releases.spec.js
+++ b/tests/integration/releases.spec.js
@@ -533,21 +533,6 @@ test.describe('Releases Planning Health @releases', () => {
     expect(page.errors).toHaveLength(0);
   });
 
-  test('Big Rocks tab has Show empty rocks toggle (off by default)', async ({ page }) => {
-    await page.goto('/#/releases/plan');
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(DEFAULT_PAGE_WAIT_TIME);
-
-    const toggle = page.getByRole('checkbox', { name: /Show empty rocks/ });
-    await expect(toggle).toBeVisible();
-    await expect(toggle).not.toBeChecked();
-
-    await toggle.check();
-    await expect(toggle).toBeChecked();
-
-    expect(page.errors).toHaveLength(0);
-  });
-
   // Health tab is temporarily hidden from PlanView — skip until re-enabled
   test.skip('Health tab loads and shows planning mode banner when applicable', async ({ page }) => {
     await page.goto('/#/releases/plan?tab=health');


### PR DESCRIPTION
## Summary
- Removes the "Show empty rocks" checkbox toggle from the Big Rocks tab, so all big rocks (including those with 0 features/RFEs) are always displayed by default.
- Cleans up the `isEmptyRock`/`showEmptyRocks`/`emptyRockCount` filtering logic from `useFilters.js`, the checkbox UI from `FilterBar.vue`, and the pass-through bindings from `DashboardView.vue`.
- Updates unit tests (`use-filters-big-rocks.test.js`, `components.test.js`) and removes the integration test for the toggle (`releases.spec.js`).

## Test plan
- [ ] Verify Big Rocks tab shows all rocks (including empty ones) without any toggle
- [ ] Verify pillar filter still works correctly and includes empty rocks in filtered results
- [ ] Verify search, clear filters, and other filter bar controls remain functional
- [ ] Confirm no regressions on Features and RFEs tabs


Made with [Cursor](https://cursor.com)