### PR TITLE
feat(releases): attach FPDoR and PM/DO Aligned to PM Hub

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table-sort.test.js
@@ -63,12 +63,12 @@ function mountTable(props) {
 
 describe('ComponentReleaseLoadTable sorting (component)', function () {
   describe('header rendering', function () {
-    it('renders 13 sortable th elements when a component is expanded', async function () {
+    it('renders 14 sortable th elements when a component is expanded', async function () {
       var wrapper = mountTable()
       var groupHeader = wrapper.find('tr.cursor-pointer')
       await groupHeader.trigger('click')
       var ths = wrapper.findAll('th')
-      expect(ths.length).toBe(13)
+      expect(ths.length).toBe(14)
     })
 
     it('all headers have cursor-pointer class', async function () {

--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -113,6 +113,10 @@ function buildComponentGroups(groups) {
             releaseType: feat.releaseType,
             priority: feat.priority,
             isBlocked: feat.isBlocked,
+            pmDoAligned: !!feat.pmDoAligned,
+            fpdor: feat.fpdor || null,
+            confidence: feat.confidence || null,
+            isAiFirst: !!feat.isAiFirst,
             components: feat.components,
             fixVersions: feat.fixVersions || [],
             targetVersions: feat.targetVersions || [],
@@ -145,12 +149,12 @@ function buildComponentGroups(groups) {
     var reqCount = 0
     var comCount = 0
     var blkCount = 0
-    var riskCount = 0
+    var notAlignedCount = 0
     for (var fli = 0; fli < featureList.length; fli++) {
       if (featureList[fli].isRequested) reqCount++
       if (featureList[fli].isCommitted) comCount++
       if (featureList[fli].isBlocked) blkCount++
-      if (featureList[fli].riskLevel === 'high' || featureList[fli].riskLevel === 'medium') riskCount++
+      if (!featureList[fli].pmDoAligned) notAlignedCount++
     }
 
     result.push({
@@ -159,7 +163,7 @@ function buildComponentGroups(groups) {
       requestedCount: reqCount,
       committedCount: comCount,
       blockedCount: blkCount,
-      atRiskCount: riskCount
+      notAlignedCount: notAlignedCount
     })
   }
 
@@ -184,7 +188,8 @@ function makeFeature(overrides) {
     fixVersions: ['rhoai-3.5'],
     targetVersions: ['rhoai-3.5'],
     assignee: 'Alice',
-    pmOwner: 'Bob'
+    pmOwner: 'Bob',
+    pmDoAligned: true
   }, overrides)
 }
 

--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -569,7 +569,7 @@ describe('buildComponentGroups', function () {
 // Sort logic — inlined from ComponentReleaseLoadTable.vue
 // ---------------------------------------------------------------------------
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'type', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'assignee', 'pmOwner']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'pmDoAligned', 'readiness', 'assignee', 'pmOwner', 'docs']
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
 
@@ -593,8 +593,15 @@ function getSortValue(feature, column) {
     return feature.targetVersions && feature.targetVersions.length > 0 ? feature.targetVersions[0] : ''
   }
   if (column === 'blocked') return feature.isBlocked ? 1 : 0
+  if (column === 'pmDoAligned') return feature.pmDoAligned ? 0 : 1
+  if (column === 'readiness') {
+    if (!feature.fpdor) return 99
+    if (feature.fpdor.allApplicablePassed) return 0
+    return 1
+  }
   if (column === 'assignee') return (feature.assignee || '').toLowerCase()
   if (column === 'pmOwner') return (feature.pmOwner || '').toLowerCase()
+  if (column === 'docs') return feature.docsRequired === 'Yes' ? 0 : 1
   return ''
 }
 
@@ -917,7 +924,7 @@ describe('toggleSort', function () {
   })
 
   it('works for all valid sort columns', function () {
-    var columns = ['key', 'summary', 'priority', 'type', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'assignee', 'pmOwner']
+    var columns = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'pmDoAligned', 'readiness', 'assignee', 'pmOwner', 'docs']
     for (var i = 0; i < columns.length; i++) {
       var result = toggleSort({ column: null, direction: 'asc' }, columns[i])
       expect(result.column).toBe(columns[i])

--- a/modules/releases/__tests__/client/plan/pm-hub-docs-filter.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-docs-filter.test.js
@@ -50,6 +50,7 @@ function makeFeature(overrides) {
     fixVersions: ['rhoai-3.5'],
     targetVersions: ['rhoai-3.5'],
     riskLevel: 'low',
+    pmDoAligned: true,
     assignee: 'Alice',
     pmOwner: 'Bob',
     docsRequired: null
@@ -178,6 +179,7 @@ describe('buildFeatureObj includes docsRequired', function() {
       fixVersions: f.fixVersions || [],
       targetVersions: tv,
       riskLevel: 'low',
+    pmDoAligned: true,
       assignee: f.assignee || null,
       pmOwner: f.pmOwner || null,
       docsRequired: f.docsRequired || null

--- a/modules/releases/__tests__/client/plan/pm-hub-risk-column.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-risk-column.test.js
@@ -1,334 +1,81 @@
 /**
- * Tests for PM Hub risk column, at-risk counts, and fetchedAt timestamp.
- *
- * Covers:
- * - computeRiskLevel() server-side logic (inlined from routes.js)
- * - At-risk count in component group headers
- * - totalAtRisk summary card computation
- * - formattedFetchedAt computed property
- * - riskLevel sort ordering
+ * PM Hub PM/DO Aligned + readiness helpers (client-side aggregation).
  */
 import { describe, it, expect } from 'vitest'
 
-// ---------------------------------------------------------------------------
-// Inlined from modules/releases/server/pm-hub/routes.js
-// ---------------------------------------------------------------------------
-
-function computeRiskLevel(f, targetVersions) {
-  var hasFixVersion = f.fixVersions && f.fixVersions.length > 0
-  var hasTargetVersion = targetVersions && targetVersions.length > 0
-  if (!hasFixVersion && hasTargetVersion) return 'high'
-  if (hasFixVersion) {
-    var cs = (f.colorStatus || '').toLowerCase()
-    if (f.isBlocked || cs === 'red' || cs === 'yellow') return 'medium'
-  }
-  return 'low'
-}
-
-// ---------------------------------------------------------------------------
-// Inlined from ComponentReleaseLoadTable.vue
-// ---------------------------------------------------------------------------
-
-var RISK_ORDER = { 'high': 0, 'medium': 1, 'low': 2 }
-
-function getRiskSortValue(feature) {
-  var ro = RISK_ORDER[(feature.riskLevel || '').toLowerCase()]
-  return ro !== undefined ? ro : 99
-}
-
-function computeAtRiskCount(features) {
+function computeNotAlignedCount(features) {
   var count = 0
   for (var i = 0; i < features.length; i++) {
-    if (features[i].riskLevel === 'high' || features[i].riskLevel === 'medium') count++
+    if (!features[i].pmDoAligned) count++
   }
   return count
 }
 
-// ---------------------------------------------------------------------------
-// Inlined from ComponentReleaseLoadReport.vue
-// ---------------------------------------------------------------------------
-
-function computeTotalAtRisk(groups) {
+function computeTotalNotAligned(groups) {
+  var seen = {}
   var count = 0
-  for (var i = 0; i < groups.length; i++) {
-    var comps = groups[i].components || []
-    for (var ci = 0; ci < comps.length; ci++) count += comps[ci].atRiskCount || 0
+  for (var gi = 0; gi < groups.length; gi++) {
+    var comps = groups[gi].components || []
+    for (var ci = 0; ci < comps.length; ci++) {
+      var lists = [comps[ci].requestedFeatures || [], comps[ci].committedFeatures || []]
+      for (var li = 0; li < lists.length; li++) {
+        for (var fi = 0; fi < lists[li].length; fi++) {
+          var f = lists[li][fi]
+          if (!seen[f.key] && !f.pmDoAligned) {
+            seen[f.key] = true
+            count++
+          }
+        }
+      }
+    }
   }
   return count
 }
-
-function formatFetchedAt(isoString) {
-  if (!isoString) return null
-  try {
-    var d = new Date(isoString)
-    if (isNaN(d.getTime())) return null
-    return d.toLocaleString()
-  } catch { return null }
-}
-
-// ---------------------------------------------------------------------------
-// Test data factories
-// ---------------------------------------------------------------------------
 
 function makeFeature(overrides) {
   return Object.assign({
-    key: 'RHAIENG-1',
-    summary: 'Test feature',
-    status: 'In Progress',
-    colorStatus: 'Green',
-    releaseType: 'Feature',
-    priority: 'Major',
-    isBlocked: false,
-    components: ['Dashboard'],
-    fixVersions: ['rhoai-3.5'],
-    targetVersions: ['rhoai-3.5'],
-    riskLevel: 'low',
-    assignee: 'Alice',
-    pmOwner: 'Bob'
-  }, overrides)
+    key: 'X-1',
+    summary: 'Test',
+    pmDoAligned: false,
+    fpdor: { items: [], passedCount: 0, applicableCount: 17, allApplicablePassed: false },
+    confidence: 'not-ready'
+  }, overrides || {})
 }
 
-function makeComponentGroup(features) {
+function makeGroup(features) {
   return {
-    component: 'TestComp',
-    requestedFeatures: features,
-    committedFeatures: features,
-    requestedCount: features.length,
-    committedCount: features.length,
-    blockedCount: features.filter(function (f) { return f.isBlocked }).length,
-    atRiskCount: computeAtRiskCount(features)
+    component: 'Comp',
+    features: features,
+    notAlignedCount: computeNotAlignedCount(features)
   }
 }
 
-// ---------------------------------------------------------------------------
-// computeRiskLevel
-// ---------------------------------------------------------------------------
-
-describe('computeRiskLevel', function () {
-  it('returns high when no fix version but has target version', function () {
-    var f = { fixVersions: [], colorStatus: 'Green', isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('high')
-  })
-
-  it('returns high when fixVersions is null and target exists', function () {
-    var f = { fixVersions: null, colorStatus: 'Green', isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('high')
-  })
-
-  it('returns medium when committed but blocked', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Green', isBlocked: true }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
-  })
-
-  it('returns medium when committed but red status', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Red', isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
-  })
-
-  it('returns medium when committed but yellow status', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Yellow', isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
-  })
-
-  it('returns medium when committed, blocked, and red', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Red', isBlocked: true }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
-  })
-
-  it('returns low when committed and green', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'Green', isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('low')
-  })
-
-  it('returns low when no fix version and no target version', function () {
-    var f = { fixVersions: [], colorStatus: 'Green', isBlocked: false }
-    expect(computeRiskLevel(f, [])).toBe('low')
-  })
-
-  it('returns low when no fix version and target is null', function () {
-    var f = { fixVersions: [], colorStatus: 'Green', isBlocked: false }
-    expect(computeRiskLevel(f, null)).toBe('low')
-  })
-
-  it('is case-insensitive for colorStatus', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: 'RED', isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('medium')
-  })
-
-  it('handles missing colorStatus gracefully', function () {
-    var f = { fixVersions: ['rhoai-3.5'], colorStatus: null, isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('low')
-  })
-
-  it('handles undefined colorStatus', function () {
-    var f = { fixVersions: ['rhoai-3.5'], isBlocked: false }
-    expect(computeRiskLevel(f, ['rhoai-3.5'])).toBe('low')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Risk sort ordering
-// ---------------------------------------------------------------------------
-
-describe('riskLevel sort ordering', function () {
-  it('sorts high before medium before low', function () {
-    expect(getRiskSortValue({ riskLevel: 'high' })).toBe(0)
-    expect(getRiskSortValue({ riskLevel: 'medium' })).toBe(1)
-    expect(getRiskSortValue({ riskLevel: 'low' })).toBe(2)
-  })
-
-  it('returns 99 for missing riskLevel', function () {
-    expect(getRiskSortValue({})).toBe(99)
-    expect(getRiskSortValue({ riskLevel: null })).toBe(99)
-    expect(getRiskSortValue({ riskLevel: '' })).toBe(99)
-  })
-
-  it('is case-insensitive', function () {
-    expect(getRiskSortValue({ riskLevel: 'HIGH' })).toBe(0)
-    expect(getRiskSortValue({ riskLevel: 'Medium' })).toBe(1)
-    expect(getRiskSortValue({ riskLevel: 'LOW' })).toBe(2)
-  })
-
-  it('returns 99 for unknown values', function () {
-    expect(getRiskSortValue({ riskLevel: 'critical' })).toBe(99)
-    expect(getRiskSortValue({ riskLevel: 'none' })).toBe(99)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// At-risk count in component groups
-// ---------------------------------------------------------------------------
-
-describe('at-risk count in component groups', function () {
-  it('counts high and medium risk features', function () {
+describe('PM/DO Aligned aggregation', function () {
+  it('counts features that are not aligned', function () {
     var features = [
-      makeFeature({ key: 'X-1', riskLevel: 'high' }),
-      makeFeature({ key: 'X-2', riskLevel: 'medium' }),
-      makeFeature({ key: 'X-3', riskLevel: 'low' })
+      makeFeature({ key: 'X-1', pmDoAligned: true }),
+      makeFeature({ key: 'X-2', pmDoAligned: false }),
+      makeFeature({ key: 'X-3', pmDoAligned: false })
     ]
-    var group = makeComponentGroup(features)
-    expect(group.atRiskCount).toBe(2)
+    expect(computeNotAlignedCount(features)).toBe(2)
+    expect(makeGroup(features).notAlignedCount).toBe(2)
   })
 
-  it('returns 0 when all features are low risk', function () {
-    var features = [
-      makeFeature({ key: 'X-1', riskLevel: 'low' }),
-      makeFeature({ key: 'X-2', riskLevel: 'low' })
-    ]
-    var group = makeComponentGroup(features)
-    expect(group.atRiskCount).toBe(0)
+  it('dedupes by key across requested/committed lists', function () {
+    var f = makeFeature({ key: 'DUP-1', pmDoAligned: false })
+    var groups = [{
+      components: [{
+        requestedFeatures: [f],
+        committedFeatures: [f]
+      }]
+    }]
+    expect(computeTotalNotAligned(groups)).toBe(1)
   })
 
-  it('returns 0 for empty feature list', function () {
-    var group = makeComponentGroup([])
-    expect(group.atRiskCount).toBe(0)
-  })
-
-  it('counts all features when all are at risk', function () {
-    var features = [
-      makeFeature({ key: 'X-1', riskLevel: 'high' }),
-      makeFeature({ key: 'X-2', riskLevel: 'medium' }),
-      makeFeature({ key: 'X-3', riskLevel: 'high' })
-    ]
-    var group = makeComponentGroup(features)
-    expect(group.atRiskCount).toBe(3)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// totalAtRisk summary computation
-// ---------------------------------------------------------------------------
-
-describe('totalAtRisk summary card', function () {
-  it('sums atRiskCount across all components in all groups', function () {
-    var groups = [
-      {
-        version: 'rhoai-3.5',
-        components: [
-          { component: 'CompA', atRiskCount: 2 },
-          { component: 'CompB', atRiskCount: 1 }
-        ]
-      },
-      {
-        version: 'rhoai-3.6',
-        components: [
-          { component: 'CompC', atRiskCount: 3 }
-        ]
-      }
-    ]
-    expect(computeTotalAtRisk(groups)).toBe(6)
-  })
-
-  it('returns 0 when no components have at-risk features', function () {
-    var groups = [
-      {
-        version: 'rhoai-3.5',
-        components: [
-          { component: 'CompA', atRiskCount: 0 },
-          { component: 'CompB', atRiskCount: 0 }
-        ]
-      }
-    ]
-    expect(computeTotalAtRisk(groups)).toBe(0)
-  })
-
-  it('returns 0 for empty groups', function () {
-    expect(computeTotalAtRisk([])).toBe(0)
-  })
-
-  it('handles missing atRiskCount gracefully', function () {
-    var groups = [
-      {
-        version: 'rhoai-3.5',
-        components: [
-          { component: 'CompA' }
-        ]
-      }
-    ]
-    expect(computeTotalAtRisk(groups)).toBe(0)
-  })
-
-  it('handles groups with empty components array', function () {
-    var groups = [{ version: 'rhoai-3.5', components: [] }]
-    expect(computeTotalAtRisk(groups)).toBe(0)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// formattedFetchedAt
-// ---------------------------------------------------------------------------
-
-describe('formattedFetchedAt', function () {
-  it('formats a valid ISO string', function () {
-    var result = formatFetchedAt('2025-06-28T14:30:00.000Z')
-    expect(result).toBeTruthy()
-    expect(typeof result).toBe('string')
-    expect(result.length).toBeGreaterThan(0)
-  })
-
-  it('returns null for null input', function () {
-    expect(formatFetchedAt(null)).toBeNull()
-  })
-
-  it('returns null for undefined input', function () {
-    expect(formatFetchedAt(undefined)).toBeNull()
-  })
-
-  it('returns null for empty string', function () {
-    expect(formatFetchedAt('')).toBeNull()
-  })
-
-  it('returns null for invalid date string', function () {
-    expect(formatFetchedAt('not-a-date')).toBeNull()
-  })
-
-  it('returns null for nonsense string', function () {
-    expect(formatFetchedAt('abc123xyz')).toBeNull()
-  })
-
-  it('formats a date-only string', function () {
-    var result = formatFetchedAt('2025-06-28')
-    expect(result).toBeTruthy()
-    expect(typeof result).toBe('string')
+  it('returns 0 when all aligned', function () {
+    expect(computeNotAlignedCount([
+      makeFeature({ key: 'A', pmDoAligned: true }),
+      makeFeature({ key: 'B', pmDoAligned: true })
+    ])).toBe(0)
   })
 })

--- a/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
+++ b/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest'
 
-const { buildFeatureObj, extractTargetVersions } = require('../../../server/pm-hub/routes')
-
-// ---------------------------------------------------------------------------
-// buildFeatureObj
-// ---------------------------------------------------------------------------
+const {
+  buildFeatureObj,
+  extractTargetVersions,
+  computePmDoAligned,
+  versionsStrictMatch
+} = require('../../../server/pm-hub/routes')
 
 describe('buildFeatureObj', function () {
   var fullInput = {
@@ -20,102 +21,76 @@ describe('buildFeatureObj', function () {
     components: ['Inference', 'Serving'],
     fixVersions: ['rhoai-3.5', 'rhoai-3.6'],
     assignee: 'Alice',
-    pmOwner: 'Bob'
+    pmOwner: 'Bob',
+    labels: ['strat-creator-auto-created'],
+    riceScore: 12,
+    docsRequired: 'Yes',
+    linkedRfeKey: 'RHAIRFE-1'
   }
 
-  it('maps all fields from a fully-populated transformed issue', function () {
+  it('maps core fields and attaches FPDoR + alignment', function () {
     var result = buildFeatureObj(fullInput, ['rhoai-3.5'])
     expect(result.key).toBe('RHAIENG-123')
     expect(result.summary).toBe('Add model serving support')
-    expect(result.status).toBe('In Progress')
-    expect(result.statusCategory).toBe('In Progress')
-    expect(result.colorStatus).toBe('Green')
-    expect(result.statusSummary).toBe('<p>On track</p>')
-    expect(result.releaseType).toBe('Feature')
-    expect(result.priority).toBe('Major')
-    expect(result.isBlocked).toBe(false)
-    expect(result.components).toEqual(['Inference', 'Serving'])
-    expect(result.fixVersions).toEqual(['rhoai-3.5', 'rhoai-3.6'])
+    expect(result.title).toBe('Add model serving support')
     expect(result.targetVersions).toEqual(['rhoai-3.5'])
-    expect(result.assignee).toBe('Alice')
-    expect(result.pmOwner).toBe('Bob')
+    expect(result.fixVersions).toEqual(['rhoai-3.5', 'rhoai-3.6'])
+    expect(result.pmDoAligned).toBe(true)
+    expect(result.fpdor).toBeTruthy()
+    expect(Array.isArray(result.fpdor.items)).toBe(true)
+    expect(result.fpdor.totalCount).toBe(17)
+    expect(result.isAiFirst).toBe(true)
+    expect(result.confidence).toBeTruthy()
+    expect(result.labels).toEqual(['strat-creator-auto-created'])
   })
 
   it('defaults missing fields to null or empty', function () {
     var result = buildFeatureObj({ key: 'X-1' })
     expect(result.key).toBe('X-1')
     expect(result.summary).toBe('')
-    expect(result.status).toBeNull()
-    expect(result.statusCategory).toBeNull()
-    expect(result.colorStatus).toBeNull()
-    expect(result.statusSummary).toBeNull()
-    expect(result.releaseType).toBeNull()
-    expect(result.priority).toBeNull()
-    expect(result.isBlocked).toBe(false)
-    expect(result.components).toEqual([])
-    expect(result.fixVersions).toEqual([])
-    expect(result.targetVersions).toEqual([])
-    expect(result.assignee).toBeNull()
-    expect(result.pmOwner).toBeNull()
+    expect(result.pmDoAligned).toBe(false)
+    expect(result.isAiFirst).toBe(false)
+    expect(result.fpdor).toBeTruthy()
+    expect(result.confidence).toBe('not-ready')
   })
 
-  it('defaults targetVersions to empty array when not provided', function () {
-    var result = buildFeatureObj(fullInput)
-    expect(result.targetVersions).toEqual([])
+  it('marks pmDoAligned false when TV/FV mismatch', function () {
+    var result = buildFeatureObj(fullInput, ['rhoai-3.7'])
+    expect(result.pmDoAligned).toBe(false)
   })
 
-  it('passes through targetVersions array', function () {
-    var tvs = ['rhoai-3.5', 'rhelai-3.5']
-    var result = buildFeatureObj(fullInput, tvs)
-    expect(result.targetVersions).toEqual(['rhoai-3.5', 'rhelai-3.5'])
-  })
-
-  it('includes fixVersions from the transformed issue', function () {
-    var input = Object.assign({}, fullInput, { fixVersions: ['rhoai-3.6'] })
-    var result = buildFeatureObj(input, [])
-    expect(result.fixVersions).toEqual(['rhoai-3.6'])
-  })
-
-  it('defaults fixVersions to empty array when missing', function () {
-    var input = { key: 'X-2', fixVersions: undefined }
-    var result = buildFeatureObj(input, [])
-    expect(result.fixVersions).toEqual([])
-  })
-
-  it('preserves isBlocked true', function () {
-    var input = Object.assign({}, fullInput, { isBlocked: true })
-    var result = buildFeatureObj(input, [])
-    expect(result.isBlocked).toBe(true)
-  })
-
-  it('passes through priority from input', function () {
-    var input = Object.assign({}, fullInput, { priority: 'Critical' })
-    var result = buildFeatureObj(input, [])
-    expect(result.priority).toBe('Critical')
-  })
-
-  it('defaults priority to null when missing', function () {
-    var input = { key: 'X-3' }
-    var result = buildFeatureObj(input, [])
-    expect(result.priority).toBeNull()
-  })
-
-  it('does not include extra fields from the input', function () {
+  it('does not include unrelated hygiene fields', function () {
     var input = Object.assign({}, fullInput, {
       team: 'Some Team',
-      linkedRfeKey: 'RHAIRFE-99',
       violations: ['missing-summary']
     })
     var result = buildFeatureObj(input, [])
     expect(result).not.toHaveProperty('team')
-    expect(result).not.toHaveProperty('linkedRfeKey')
     expect(result).not.toHaveProperty('violations')
+    expect(result.linkedRfeKey).toBe('RHAIRFE-1')
   })
 })
 
-// ---------------------------------------------------------------------------
-// extractTargetVersions
-// ---------------------------------------------------------------------------
+describe('computePmDoAligned / versionsStrictMatch', function () {
+  it('returns true for exact string match', function () {
+    expect(versionsStrictMatch('rhoai-3.5', 'rhoai-3.5')).toBe(true)
+    expect(computePmDoAligned(['rhoai-3.5'], ['rhoai-3.5'])).toBe(true)
+  })
+
+  it('returns false when either side is missing', function () {
+    expect(computePmDoAligned([], ['rhoai-3.5'])).toBe(false)
+    expect(computePmDoAligned(['rhoai-3.5'], [])).toBe(false)
+  })
+
+  it('returns false for early delivery (FV before TV in same cycle)', function () {
+    // EA1 FV vs GA TV should not be strict match
+    expect(computePmDoAligned(['3.5 EA1 RHOAI RELEASE'], ['3.5 GA RHOAI RELEASE'])).toBe(false)
+  })
+
+  it('returns true when any FV matches any TV', function () {
+    expect(computePmDoAligned(['rhoai-3.4', 'rhoai-3.5'], ['rhoai-3.5', 'rhoai-3.6'])).toBe(true)
+  })
+})
 
 describe('extractTargetVersions', function () {
   var TV_FIELD = 'customfield_10855'
@@ -163,19 +138,5 @@ describe('extractTargetVersions', function () {
   it('skips entries with null name and value', function () {
     var raw = { fields: { [TV_FIELD]: [{ name: 'rhoai-3.5' }, null, { name: null }] } }
     expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
-  })
-
-  it('trims whitespace from version names', function () {
-    var raw = { fields: { [TV_FIELD]: [{ name: '  rhoai-3.5  ' }] } }
-    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5'])
-  })
-
-  it('handles mixed name and value entries', function () {
-    var raw = { fields: { [TV_FIELD]: [
-      { name: 'rhoai-3.5' },
-      { value: 'rhelai-3.5' },
-      { name: 'RHAII-3.5', value: 'ignored' }
-    ] } }
-    expect(extractTargetVersions(raw)).toEqual(['rhoai-3.5', 'rhelai-3.5', 'RHAII-3.5'])
   })
 })

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -1,6 +1,16 @@
 <script setup>
 import { reactive, computed } from 'vue'
 import { getComponentLeads } from '../../composables/componentLeads'
+import FPDoRPopover from './FPDoRPopover.vue'
+import { failedFpdorNames } from '../utils/feature-readiness-export.js'
+import {
+  fpdorItemSeverity,
+  severityChipClass,
+  severityLabel,
+  pathLabel,
+  pathChipClass,
+  pathChipTitle
+} from '../utils/fpdor-severity.js'
 
 const props = defineProps({
   groups: { type: Array, default: () => [] },
@@ -21,6 +31,7 @@ function getComponentVelocity(componentName) {
 }
 
 const JIRA_BASE = 'https://redhat.atlassian.net/browse'
+var MAX_VISIBLE_FAIL_CHIPS = 2
 
 const COMP_STYLE = {
   border: 'border-l-primary-500',
@@ -31,11 +42,10 @@ var expandedComponents = reactive({})
 
 // ═══ SORT STATE ═══
 
-var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'riskLevel', 'assignee', 'pmOwner', 'docs']
+var SORT_COLUMNS = ['key', 'summary', 'priority', 'releaseType', 'status', 'colorStatus', 'fixVersion', 'targetVersion', 'blocked', 'pmDoAligned', 'readiness', 'assignee', 'pmOwner', 'docs']
 
 var PRIORITY_ORDER = { 'Blocker': 0, 'Critical': 1, 'Major': 2, 'Normal': 3 }
 var COLOR_STATUS_ORDER = { 'red': 0, 'yellow': 1, 'green': 2 }
-var RISK_ORDER = { 'high': 0, 'medium': 1, 'low': 2 }
 
 var sortState = reactive({
   column: SORT_COLUMNS.indexOf(props.initialSort.column) !== -1 ? props.initialSort.column : null,
@@ -78,9 +88,11 @@ function getSortValue(feature, column) {
     return feature.targetVersions && feature.targetVersions.length > 0 ? feature.targetVersions[0] : ''
   }
   if (column === 'blocked') return feature.isBlocked ? 1 : 0
-  if (column === 'riskLevel') {
-    var ro = RISK_ORDER[(feature.riskLevel || '').toLowerCase()]
-    return ro !== undefined ? ro : 99
+  if (column === 'pmDoAligned') return feature.pmDoAligned ? 0 : 1
+  if (column === 'readiness') {
+    if (!feature.fpdor) return 99
+    if (feature.fpdor.allApplicablePassed) return 0
+    return 1
   }
   if (column === 'assignee') return (feature.assignee || '').toLowerCase()
   if (column === 'pmOwner') return (feature.pmOwner || '').toLowerCase()
@@ -106,6 +118,22 @@ function sortFeatures(features) {
 function sortIcon(column) {
   if (sortState.column !== column) return 'none'
   return sortState.direction
+}
+
+function visibleFailChips(feature) {
+  return failedFpdorNames(feature).slice(0, MAX_VISIBLE_FAIL_CHIPS)
+}
+
+function overflowFailCount(feature) {
+  return Math.max(0, failedFpdorNames(feature).length - MAX_VISIBLE_FAIL_CHIPS)
+}
+
+function chipClassForName(name) {
+  return severityChipClass(fpdorItemSeverity(name))
+}
+
+function chipTitleForName(name) {
+  return 'Failed FPDoR (' + severityLabel(fpdorItemSeverity(name)) + '): ' + name
 }
 
 function toggleComponent(component) {
@@ -204,7 +232,11 @@ var componentGroups = computed(function() {
             priority: feat.priority,
             isBlocked: feat.isBlocked,
             blockedBy: feat.blockedBy || [],
-            riskLevel: feat.riskLevel || 'low',
+            pmDoAligned: !!feat.pmDoAligned,
+            fpdor: feat.fpdor || null,
+            confidence: feat.confidence || null,
+            isAiFirst: !!feat.isAiFirst,
+            labels: feat.labels || [],
             components: feat.components,
             fixVersions: feat.fixVersions || [],
             targetVersions: feat.targetVersions || [],
@@ -242,12 +274,12 @@ var componentGroups = computed(function() {
     var reqCount = 0
     var comCount = 0
     var blkCount = 0
-    var riskCount = 0
+    var notAlignedCount = 0
     for (var fli = 0; fli < featureList.length; fli++) {
       if (featureList[fli].isRequested) reqCount++
       if (featureList[fli].isCommitted) comCount++
       if (featureList[fli].isBlocked) blkCount++
-      if (featureList[fli].riskLevel === 'high' || featureList[fli].riskLevel === 'medium') riskCount++
+      if (!featureList[fli].pmDoAligned) notAlignedCount++
     }
 
     result.push({
@@ -256,7 +288,7 @@ var componentGroups = computed(function() {
       requestedCount: reqCount,
       committedCount: comCount,
       blockedCount: blkCount,
-      atRiskCount: riskCount
+      notAlignedCount: notAlignedCount
     })
   }
 
@@ -299,7 +331,7 @@ defineExpose({ expandAll, collapseAll })
             :class="COMP_STYLE.border"
             @click="toggleComponent(comp.component)"
           >
-            <td colspan="13" class="px-4 py-3">
+            <td colspan="14" class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <svg
                   class="w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform duration-200 flex-shrink-0"
@@ -324,10 +356,10 @@ defineExpose({ expandAll, collapseAll })
                 >{{ comp.blockedCount }} blocked</span>
                 <span
                   class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold"
-                  :class="comp.atRiskCount > 0
+                  :class="comp.notAlignedCount > 0
                     ? 'bg-amber-100 dark:bg-amber-800/40 text-amber-700 dark:text-amber-300'
                     : 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'"
-                >{{ comp.atRiskCount }} at risk</span>
+                >{{ comp.notAlignedCount }} not aligned</span>
                 <span
                   v-if="getComponentVelocity(comp.component)"
                   class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300"
@@ -389,8 +421,11 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('blocked')">
               <span class="inline-flex items-center gap-1 justify-center">Blocked<SortArrow :direction="sortIcon('blocked')" /></span>
             </th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-20 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('riskLevel')">
-              <span class="inline-flex items-center gap-1 justify-center">At Risk<SortArrow :direction="sortIcon('riskLevel')" /></span>
+            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('pmDoAligned')" title="Yes when Target Version and Fix Version match">
+              <span class="inline-flex items-center gap-1 justify-center">PM/DO Aligned<SortArrow :direction="sortIcon('pmDoAligned')" /></span>
+            </th>
+            <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-[10rem] cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('readiness')">
+              <span class="inline-flex items-center gap-1">Readiness<SortArrow :direction="sortIcon('readiness')" /></span>
             </th>
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('assignee')">
               <span class="inline-flex items-center gap-1">Delivery Owner<SortArrow :direction="sortIcon('assignee')" /></span>
@@ -494,13 +529,39 @@ defineExpose({ expandAll, collapseAll })
               <td class="px-3 py-2.5 text-center">
                 <span
                   class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                  :class="{
-                    'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300': feature.riskLevel === 'high',
-                    'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300': feature.riskLevel === 'medium',
-                    'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300': feature.riskLevel === 'low'
-                  }"
-                  :title="feature.riskLevel === 'high' ? 'Not committed — has target version but no fix version' : feature.riskLevel === 'medium' ? 'Committed but blocked or status is red/yellow' : 'On track'"
-                >{{ feature.riskLevel === 'high' ? 'High' : feature.riskLevel === 'medium' ? 'Medium' : 'Low' }}</span>
+                  :class="feature.pmDoAligned
+                    ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+                    : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'"
+                  :title="feature.pmDoAligned
+                    ? 'Target Version and Fix Version match'
+                    : 'Target Version and Fix Version missing or do not match'"
+                >{{ feature.pmDoAligned ? 'Yes' : 'No' }}</span>
+              </td>
+              <td class="px-3 py-2.5">
+                <div v-if="feature.fpdor" class="flex flex-wrap items-center gap-1 max-w-[14rem]">
+                  <FPDoRPopover
+                    :fpdor="feature.fpdor"
+                    :confidence="feature.confidence"
+                  />
+                  <span
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    :class="pathChipClass(feature)"
+                    :title="pathChipTitle(feature)"
+                  >{{ pathLabel(feature) }}</span>
+                  <span
+                    v-for="name in visibleFailChips(feature)"
+                    :key="name"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    :class="chipClassForName(name)"
+                    :title="chipTitleForName(name)"
+                  >{{ name }}</span>
+                  <span
+                    v-if="overflowFailCount(feature) > 0"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium text-gray-500 dark:text-gray-400"
+                    :title="failedFpdorNames(feature).slice(MAX_VISIBLE_FAIL_CHIPS).join(', ')"
+                  >+{{ overflowFailCount(feature) }}</span>
+                </div>
+                <span v-else class="text-gray-300 dark:text-gray-600 text-xs">—</span>
               </td>
               <td class="px-3 py-2.5 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
                 {{ feature.assignee || '--' }}
@@ -523,7 +584,7 @@ defineExpose({ expandAll, collapseAll })
 
           <!-- Empty state -->
           <tr v-if="isComponentExpanded(comp.component) && comp.features.length === 0">
-            <td colspan="13" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+            <td colspan="14" class="px-8 py-6 text-sm text-gray-400 dark:text-gray-500 italic text-center">
               No features found for {{ comp.component }}
             </td>
           </tr>
@@ -531,7 +592,7 @@ defineExpose({ expandAll, collapseAll })
 
         <!-- No results -->
         <tr v-if="componentGroups.length === 0">
-          <td colspan="13" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
+          <td colspan="14" class="px-8 py-10 text-sm text-gray-400 dark:text-gray-500 italic text-center">
             No features match the current filters.
           </td>
         </tr>

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -334,9 +334,9 @@
           <span class="inline-flex items-center justify-center w-5 h-5 rounded bg-amber-100 dark:bg-amber-900/40">
             <svg class="w-3 h-3 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
           </span>
-          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">At Risk</span>
+          <span class="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Not Aligned</span>
         </div>
-        <div class="text-2xl font-bold ml-7" :class="totalAtRisk > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'">{{ totalAtRisk }}</div>
+        <div class="text-2xl font-bold ml-7" :class="totalNotAligned > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'" title="PM/DO Aligned = No (TV and FV missing or mismatch)">{{ totalNotAligned }}</div>
       </div>
       <div class="relative overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 px-4 py-3.5">
         <div class="absolute top-0 left-0 w-1 h-full bg-violet-500 rounded-l-xl" />
@@ -756,7 +756,7 @@ function filterGroups(includeTypeFilter) {
         requestedCount: newReq.length,
         committedCount: newCom.length,
         blockedCount: filtered.filter(function(ff) { return ff.isBlocked }).length,
-        atRiskCount: filtered.filter(function(ff) { return ff.riskLevel === 'high' || ff.riskLevel === 'medium' }).length
+        notAlignedCount: filtered.filter(function(ff) { return !ff.pmDoAligned }).length
       })
     }).filter(function(comp) {
       return (comp.requestedFeatures.length + comp.committedFeatures.length) > 0
@@ -956,7 +956,7 @@ var blockedPercent = computed(function() {
   return Math.round((totalBlocked.value / total) * 100)
 })
 
-var totalAtRisk = computed(function() {
+var totalNotAligned = computed(function() {
   var source = summaryFilteredGroups.value
   var seen = {}
   var count = 0
@@ -967,7 +967,7 @@ var totalAtRisk = computed(function() {
       for (var li = 0; li < lists.length; li++) {
         for (var fi = 0; fi < lists[li].length; fi++) {
           var f = lists[li][fi]
-          if (!seen[f.key] && (f.riskLevel === 'high' || f.riskLevel === 'medium')) {
+          if (!seen[f.key] && !f.pmDoAligned) {
             seen[f.key] = true
             count++
           }

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -9,7 +9,9 @@
 const { CUSTOM_FIELDS, transformIssue } = require('../hygiene/jira-fetch')
 const { blockDuringImpersonation } = require('../../../../shared/server/auth')
 const { JIRA_HOST } = require('../../../../shared/server/jira')
-const { filterCommittedFixVersions } = require('./committed-definition')
+const { filterCommittedFixVersions, parseReleaseName, compareReleasesTemporally } = require('./committed-definition')
+const { parseDescriptionSignals } = require('../planning/health/description-scanner')
+const { computeFPDoRReadiness, isAiFirstFeature } = require('../planning/fpdor')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 const PM_HUB_PROJECTS = ['RHAIENG', 'RHOAIENG', 'INFERENG', 'AIPCC', 'RHAISTRAT', 'RHAIRFE']
@@ -370,31 +372,89 @@ function formatAvg(value) {
 const DEFAULT_ISSUE_TYPES = ['Feature', 'Initiative']
 const FIELDS_TO_FETCH = [
   'summary', 'status', 'issuetype', 'assignee', 'priority', 'fixVersions', 'versions',
-  'components', 'labels', 'issuelinks',
+  'components', 'labels', 'issuelinks', 'description',
   CUSTOM_FIELDS.team,
   CUSTOM_FIELDS.releaseType,
   CUSTOM_FIELDS.statusSummary,
   CUSTOM_FIELDS.colorStatus,
   CUSTOM_FIELDS.productManager,
-  CUSTOM_FIELDS.docsRequired
+  CUSTOM_FIELDS.docsRequired,
+  CUSTOM_FIELDS.riceScore
 ].join(',')
 
-function computeRiskLevel(f, targetVersions) {
-  var hasFixVersion = f.fixVersions && f.fixVersions.length > 0
-  var hasTargetVersion = targetVersions && targetVersions.length > 0
-  if (!hasFixVersion && hasTargetVersion) return 'high'
-  if (hasFixVersion) {
-    var cs = (f.colorStatus || '').toLowerCase()
-    if (f.isBlocked || cs === 'red' || cs === 'yellow') return 'medium'
-  }
-  return 'low'
+/**
+ * PM/DO Aligned: Yes when some Fix Version strictly matches some Target Version.
+ * Match = identical string, or same normalized product + major.minor + event (cmp === 0).
+ * Missing TV or FV → not aligned. Early delivery (FV before TV) is NOT aligned.
+ */
+function versionsStrictMatch(a, b) {
+  if (!a || !b) return false
+  if (a === b) return true
+  var pa = parseReleaseName(a)
+  var pb = parseReleaseName(b)
+  if (!pa || !pb) return false
+  if (pa.product !== pb.product || pa.major !== pb.major || pa.minor !== pb.minor) return false
+  var cmp = compareReleasesTemporally(a, b)
+  return cmp === 0
 }
 
-function buildFeatureObj(f, targetVersions) {
+function computePmDoAligned(fixVersions, targetVersions) {
+  var fvs = Array.isArray(fixVersions) ? fixVersions : []
+  var tvs = Array.isArray(targetVersions) ? targetVersions : []
+  if (fvs.length === 0 || tvs.length === 0) return false
+  for (var i = 0; i < fvs.length; i++) {
+    for (var j = 0; j < tvs.length; j++) {
+      if (versionsStrictMatch(fvs[i], tvs[j])) return true
+    }
+  }
+  return false
+}
+
+function computeConfidence(isReady, fixVersion) {
+  if (!isReady) return 'not-ready'
+  if (fixVersion) return 'committed'
+  return 'ready'
+}
+
+function buildFeatureObj(f, targetVersions, rawIssue) {
   var tv = targetVersions || []
+  var labels = Array.isArray(f.labels) ? f.labels : []
+  var fixVersions = f.fixVersions || []
+  var descriptionSignals = { hasContent: false, signalCount: 0 }
+  if (rawIssue && rawIssue.fields) {
+    var fields = rawIssue.fields
+    var rendered = rawIssue.renderedFields || {}
+    var desc = rendered.description != null ? rendered.description : fields.description
+    descriptionSignals = parseDescriptionSignals(desc)
+  }
+
+  var fpdorInput = {
+    labels: labels,
+    targetVersions: tv,
+    fixVersion: fixVersions.length > 0 ? fixVersions[0] : null,
+    releaseType: f.releaseType || null,
+    components: f.components || [],
+    assignee: f.assignee || null,
+    deliveryOwner: f.assignee || null,
+    pmOwner: f.pmOwner || null,
+    pm: f.pmOwner || null,
+    priority: f.priority || null,
+    riceScore: f.riceScore != null ? f.riceScore : null,
+    docsRequired: f.docsRequired || null,
+    linkedRfeKey: f.linkedRfeKey || null,
+    sourceRfe: f.linkedRfeKey || null,
+    descriptionSignals: descriptionSignals,
+    epicCount: f.openChildCount || 0
+  }
+
+  var fpdor = computeFPDoRReadiness(fpdorInput)
+  var isAiFirst = isAiFirstFeature(fpdorInput)
+  var confidence = computeConfidence(!!fpdor.allApplicablePassed, fpdorInput.fixVersion)
+
   return {
     key: f.key,
     summary: f.summary || '',
+    title: f.summary || '',
     status: f.status || null,
     statusCategory: f.statusCategory || null,
     colorStatus: f.colorStatus || null,
@@ -404,12 +464,18 @@ function buildFeatureObj(f, targetVersions) {
     isBlocked: f.isBlocked || false,
     blockedBy: f.blockedBy || [],
     components: f.components || [],
-    fixVersions: f.fixVersions || [],
+    fixVersions: fixVersions,
     targetVersions: tv,
-    riskLevel: computeRiskLevel(f, tv),
+    pmDoAligned: computePmDoAligned(fixVersions, tv),
     assignee: f.assignee || null,
     pmOwner: f.pmOwner || null,
-    docsRequired: f.docsRequired || null
+    docsRequired: f.docsRequired || null,
+    labels: labels,
+    riceScore: f.riceScore != null ? f.riceScore : null,
+    linkedRfeKey: f.linkedRfeKey || null,
+    fpdor: fpdor,
+    isAiFirst: isAiFirst,
+    confidence: confidence
   }
 }
 
@@ -729,7 +795,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
               if (componentNames.length > 0 && componentNames.indexOf(ucName) === -1) continue
               var uGroup = ensureGroup(committedFvOnly[ufi], ucName)
               if (!uGroup.committedFeatures.some(function(e) { return e.key === f.key })) {
-                uGroup.committedFeatures.push(buildFeatureObj(f, tvNames))
+                uGroup.committedFeatures.push(buildFeatureObj(f, tvNames, rawIssue))
                 uGroup.committedCount++
                 if (f.isBlocked) uGroup.blockedCount++
               }
@@ -763,7 +829,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
         if (groupVersionKeys.length === 0) continue
 
         var isRequested = matchingTv.length > 0
-        var featureObj = buildFeatureObj(f, tvNames)
+        var featureObj = buildFeatureObj(f, tvNames, rawIssue)
 
         for (var gvi = 0; gvi < groupVersionKeys.length; gvi++) {
           var vKey = groupVersionKeys[gvi]
@@ -846,3 +912,5 @@ module.exports.computeVelocity = computeVelocity
 module.exports.buildFeatureObj = buildFeatureObj
 module.exports.extractTargetVersions = extractTargetVersions
 module.exports.filterCommittedFixVersions = filterCommittedFixVersions
+module.exports.computePmDoAligned = computePmDoAligned
+module.exports.versionsStrictMatch = versionsStrictMatch


### PR DESCRIPTION
## Summary
- Enrich PM Hub `buildFeatureObj` with Confluence FPDoR readiness (`fpdor`, confidence, AI First path) on the existing fetch/objects path.
- Replace At Risk with **PM/DO Aligned** (Yes when Target Version and Fix Version strictly match; No when missing or mismatch).
- PM Hub table: readiness column with FPDoR popover/fail chips; KPI **Not Aligned**.

## Test plan
- [ ] PM Hub Component Release Load: readiness column shows Ready / fail chips / path chip consistent with Features List FPDoR
- [ ] PM/DO Aligned is Yes only when TV and FV match (exact or normalized same version); EA vs GA mismatch → No
- [ ] KPI tile shows **Not Aligned** (not At Risk) and counts features with `pmDoAligned === false`
- [ ] `npx vitest run modules/releases/__tests__/server/pm-hub/ modules/releases/__tests__/client/plan/pm-hub-risk-column.test.js modules/releases/__tests__/client/plan/component-release-load-table.test.js modules/releases/__tests__/client/plan/pm-hub-docs-filter.test.js`


Made with [Cursor](https://cursor.com)