### PR TITLE
feat(releases): clarify Features List AI First and RICE labels

### DIFF
--- a/modules/releases/__tests__/client/plan/fpdor-severity.test.js
+++ b/modules/releases/__tests__/client/plan/fpdor-severity.test.js
@@ -16,7 +16,7 @@ describe('fpdor-severity', function() {
     expect(fpdorItemSeverity('Delivery Owner')).toBe('critical')
     expect(fpdorItemSeverity('Child epics')).toBe('critical')
     expect(fpdorItemSeverity('Docs impact')).toBe('high')
-    expect(fpdorItemSeverity('RICE (4 dims)')).toBe('high')
+    expect(fpdorItemSeverity('RICE')).toBe('high')
     expect(fpdorItemSeverity('Acceptance criteria')).toBe('medium')
     expect(fpdorItemSeverity('UXD')).toBe('soft')
     expect(fpdorItemSeverity('Source RFE / AI SDLC')).toBe('soft')
@@ -25,7 +25,7 @@ describe('fpdor-severity', function() {
   it('covers all Confluence checklist names', function() {
     var expected = [
       'Target Version', 'Release Type', 'Components', 'PM', 'Delivery Owner',
-      'Priority', 'RICE (4 dims)', 'Docs impact',
+      'Priority', 'RICE', 'Docs impact',
       'Source RFE / AI SDLC', 'Requirements clarity', 'Acceptance criteria',
       'Risks & assumptions', 'Architectural alignment', 'UXD', 'Cross-team deps',
       'Feature human sign-off', 'Child epics'

--- a/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
@@ -150,7 +150,7 @@ const FPDOR_TO_HYGIENE = {
   'PM': 'Assign a product manager',
   'Delivery Owner': 'Assign a delivery owner (Assignee)',
   'Priority': 'Set Priority in Jira (or obtain rp-qg1-pass)',
-  'RICE (4 dims)': 'Set RICE score / Reach, Impact, Confidence, Effort (or obtain rp-qg1-pass)',
+  'RICE': 'Set RICE score / Reach, Impact, Confidence, Effort (or obtain rp-qg1-pass)',
   'Docs impact': 'Set Docs Required Yes/No; if Yes, add Documentation component (or obtain rp-qg1-pass)',
   'Source RFE / AI SDLC': 'Link an RFE (cloned-by / parent) or ensure strat-creator-auto-created',
   'Requirements clarity': 'Add problem/scope/out-of-scope sections, or obtain strat-creator-rubric-pass / human sign-off',

--- a/modules/releases/client/plan/components/FeatureReadinessRow.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessRow.vue
@@ -247,11 +247,12 @@ var scoreBreakdown = computed(function() {
       <RubricScoreBadge v-else :scores="feature.scores" :show-total="false" />
     </td>
 
-    <!-- Recommendation -->
+    <!-- AI First Recommends -->
     <td class="px-3 py-2.5 whitespace-nowrap">
       <span
         class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
         :class="recommendationClass(feature.recommendation)"
+        title="AI First pipeline recommendation"
       >{{ recommendationLabel(feature.recommendation) }}</span>
     </td>
 

--- a/modules/releases/client/plan/utils/feature-readiness-export.js
+++ b/modules/releases/client/plan/utils/feature-readiness-export.js
@@ -10,7 +10,7 @@ var FPDOR_MANDATORY_NAMES = [
   'PM',
   'Delivery Owner',
   'Priority',
-  'RICE (4 dims)',
+  'RICE',
   'Docs impact'
 ]
 

--- a/modules/releases/client/plan/utils/fpdor-severity.js
+++ b/modules/releases/client/plan/utils/fpdor-severity.js
@@ -21,7 +21,7 @@ var FPDOR_SEVERITY_BY_NAME = {
   // High
   'Release Type': 'high',
   Priority: 'high',
-  'RICE (4 dims)': 'high',
+  'RICE': 'high',
   'Docs impact': 'high',
   // Medium
   'Cross-team deps': 'medium',

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -121,7 +121,7 @@ const headers = [
   { id: 'h-comp',       label: 'Components',      scope: 'col' },
   { id: 'h-team',       label: 'Team',            scope: 'col' },
   { id: 'h-rubric',     label: 'Rubric',          scope: 'col' },
-  { id: 'h-rec',        label: 'Recommendation',  scope: 'col' },
+  { id: 'h-rec',        label: 'AI First Recommends',  scope: 'col', info: 'AI review verdict from the strat-creator (AI First) pipeline.' },
   { id: 'h-status',     label: 'Status',          scope: 'col' },
   { id: 'h-priority',   label: 'Priority',        scope: 'col' },
   { id: 'h-attention',  label: '',                scope: 'col' },

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -1515,7 +1515,7 @@ describe('buildFeatureReadiness', function() {
     it('humanVerified is not set on mandatory field items when sign-off label present', function() {
       var result = computeReadiness(readyFeature({ labels: ['strat-creator-auto-created', 'strat-creator-human-sign-off'] }))
       var items = result.fpdor.items
-      var riceItem = items.find(function(i) { return i.name === 'RICE (4 dims)' })
+      var riceItem = items.find(function(i) { return i.name === 'RICE' })
       var engItem = items.find(function(i) { return i.name === 'Cross-team deps' })
       var docsItem = items.find(function(i) { return i.name === 'Docs impact' })
       var tvItem = items.find(function(i) { return i.name === 'Target Version' })

--- a/modules/releases/server/planning/fpdor.js
+++ b/modules/releases/server/planning/fpdor.js
@@ -14,7 +14,7 @@ var MANDATORY_ITEMS = [
   'PM',
   'Delivery Owner',
   'Priority',
-  'RICE (4 dims)',
+  'RICE',
   'Docs impact'
 ]
 
@@ -269,10 +269,10 @@ function evalPriority(feature) {
 }
 
 function evalRice(feature) {
-  if (hasRiceScore(feature)) return passViaField('RICE (4 dims)', 'Passed via RICE score', 'mandatory')
-  if (hasRpQg1Pass(feature)) return passViaLabel('RICE (4 dims)', 'rp-qg1-pass', 'mandatory')
-  if (feature.riceScore == null) return evalItem('RICE (4 dims)', false, 'No RICE score in Jira', 'mandatory')
-  return evalItem('RICE (4 dims)', false, 'RICE score is 0', 'mandatory')
+  if (hasRiceScore(feature)) return passViaField('RICE', 'Passed via RICE score', 'mandatory')
+  if (hasRpQg1Pass(feature)) return passViaLabel('RICE', 'rp-qg1-pass', 'mandatory')
+  if (feature.riceScore == null) return evalItem('RICE', false, 'No RICE score in Jira', 'mandatory')
+  return evalItem('RICE', false, 'RICE score is 0', 'mandatory')
 }
 
 function evalDocsImpact(feature) {


### PR DESCRIPTION
## Summary
- Rename Features List **Recommendation** column to **AI First Recommends** (same approve/revise/reject values from strat-creator).
- Rename FPDoR checklist item **RICE (4 dims)** → **RICE** in server eval, severity map, drawer tip, export, and tests.

## Test plan
- [ ] Features List header shows **AI First Recommends**; cell values unchanged (Approve / Needs Revision / Reject / —)
- [ ] FPDoR popover/drawer checklist shows **RICE** (not “RICE (4 dims)”)
- [ ] Fail chips / severity still treat RICE as high severity
- [ ] `npx vitest run modules/releases/__tests__/client/plan/fpdor-severity.test.js modules/releases/server/planning/__tests__/feature-readiness.test.js -t 'FPDoR|fpdor|computeFPDoR'`


Made with [Cursor](https://cursor.com)