### PR TITLE
feat(releases): add PM Hub feature drawer and clarify Docs Required

### DIFF
--- a/modules/releases/__tests__/client/plan/component-release-load-table.test.js
+++ b/modules/releases/__tests__/client/plan/component-release-load-table.test.js
@@ -601,7 +601,19 @@ function getSortValue(feature, column) {
   }
   if (column === 'assignee') return (feature.assignee || '').toLowerCase()
   if (column === 'pmOwner') return (feature.pmOwner || '').toLowerCase()
-  if (column === 'docs') return feature.docsRequired === 'Yes' ? 0 : 1
+  if (column === 'docs') {
+    var docs = feature.docsRequired
+    if (docs === 'Yes') {
+      var comps = feature.components || []
+      var hasDoc = false
+      for (var di = 0; di < comps.length; di++) {
+        if (comps[di] === 'Documentation' || comps[di] === 'Docs') { hasDoc = true; break }
+      }
+      return hasDoc ? 0 : 1
+    }
+    if (docs === 'No') return 2
+    return 3
+  }
   return ''
 }
 

--- a/modules/releases/__tests__/client/plan/docs-required-display.test.js
+++ b/modules/releases/__tests__/client/plan/docs-required-display.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  hasDocumentationComponent,
+  docsRequiredState,
+  docsRequiredLabel,
+  docsRequiredTitle,
+  docsRequiredChipClass
+} from '../../../client/plan/utils/docs-required-display.js'
+
+describe('docsRequiredDisplay', function() {
+  it('detects Documentation and Docs components', function() {
+    expect(hasDocumentationComponent({ components: ['Platform', 'Documentation'] })).toBe(true)
+    expect(hasDocumentationComponent({ components: ['Docs'] })).toBe(true)
+    expect(hasDocumentationComponent({ components: ['Platform', 'UXD'] })).toBe(false)
+  })
+
+  it('marks Yes + Documentation as yes', function() {
+    var f = { docsRequired: 'Yes', components: ['Platform', 'Documentation'] }
+    expect(docsRequiredState(f)).toBe('yes')
+    expect(docsRequiredLabel(f)).toBe('Yes')
+    expect(docsRequiredChipClass(f)).toContain('emerald')
+  })
+
+  it('warns when Yes without Documentation component', function() {
+    var f = { docsRequired: 'Yes', components: ['Platform', 'Serving'] }
+    expect(docsRequiredState(f)).toBe('yes-missing-component')
+    expect(docsRequiredLabel(f)).toBe('Yes')
+    expect(docsRequiredChipClass(f)).toContain('amber')
+    expect(docsRequiredTitle(f)).toContain('Documentation component is missing')
+  })
+
+  it('treats No as no without requiring Documentation', function() {
+    var f = { docsRequired: 'No', components: ['Platform'] }
+    expect(docsRequiredState(f)).toBe('no')
+    expect(docsRequiredLabel(f)).toBe('No')
+    expect(docsRequiredTitle(f)).toContain('Docs Required = No')
+  })
+
+  it('treats unset as unset', function() {
+    expect(docsRequiredState({ docsRequired: null, components: [] })).toBe('unset')
+    expect(docsRequiredLabel({ docsRequired: null })).toBe('—')
+    expect(docsRequiredTitle({ docsRequired: null })).toContain('not set')
+  })
+})

--- a/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import ComponentReleaseLoadTable from '../../../client/plan/components/ComponentReleaseLoadTable.vue'
+import FeatureReadinessDrawer from '../../../client/plan/components/FeatureReadinessDrawer.vue'
+
+function sampleGroups() {
+  var feature = {
+    key: 'RHAISTRAT-1748',
+    summary: 'Model-prompt pairing',
+    title: 'Model-prompt pairing',
+    status: 'In Progress',
+    priority: 'Major',
+    releaseType: 'TP',
+    isBlocked: false,
+    pmDoAligned: false,
+    confidence: 'ready',
+    isAiFirst: false,
+    labels: [],
+    components: ['GenAI Studio'],
+    fixVersions: [],
+    targetVersions: ['3.6 EA2 RHOAI RELEASE'],
+    assignee: 'Alice',
+    pmOwner: 'Bob',
+    fpdor: {
+      passedCount: 17,
+      applicableCount: 17,
+      allApplicablePassed: true,
+      items: [
+        { name: 'Target Version', pass: true, group: 'mandatory' },
+        { name: 'RICE', pass: true, group: 'mandatory' }
+      ]
+    }
+  }
+  return [{
+    version: '3.6 EA2 RHOAI RELEASE',
+    components: [{
+      component: 'GenAI Studio',
+      requestedFeatures: [feature],
+      committedFeatures: [],
+      requestedCount: 1,
+      committedCount: 0,
+      blockedCount: 0,
+      notAlignedCount: 1
+    }]
+  }]
+}
+
+describe('PM Hub feature slide tray', function() {
+  it('emits select when a feature row is clicked', async function() {
+    var wrapper = mount(ComponentReleaseLoadTable, {
+      props: { groups: sampleGroups() },
+      global: {
+        stubs: {
+          FPDoRPopover: true
+        }
+      }
+    })
+
+    // Expand component so feature rows render
+    var header = wrapper.find('tr.cursor-pointer')
+    expect(header.exists()).toBe(true)
+    await header.trigger('click')
+    await nextTick()
+
+    var featureRows = wrapper.findAll('tr[role="button"]')
+    expect(featureRows.length).toBeGreaterThan(0)
+    await featureRows[0].trigger('click')
+
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')[0][0].key).toBe('RHAISTRAT-1748')
+  })
+
+  it('opens FeatureReadinessDrawer with FPDoR for a PM Hub-shaped feature', async function() {
+    var feature = sampleGroups()[0].components[0].requestedFeatures[0]
+    var drawerFeature = Object.assign({}, feature, {
+      fixVersion: null,
+      deliveryOwner: feature.assignee,
+      dataSource: 'pm-hub'
+    })
+
+    var wrapper = mount(FeatureReadinessDrawer, {
+      props: {
+        feature: drawerFeature,
+        jiraBaseUrl: 'https://issues.redhat.com/browse'
+      },
+      global: {
+        stubs: {
+          HygieneViolations: true,
+          Teleport: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('RHAISTRAT-1748')
+    expect(wrapper.text()).toContain('Model-prompt pairing')
+    expect(wrapper.text()).toContain('FPDoR Readiness')
+    expect(wrapper.text()).toContain('Target Version')
+    expect(wrapper.text()).toContain('RICE')
+    // No empty AI review chrome for PM Hub rows without review meta
+    expect(wrapper.text()).not.toContain('Awaiting Sign-off')
+    expect(wrapper.text()).toContain('Jira')
+  })
+
+  it('does not emit select when the Jira key link is clicked', async function() {
+    var wrapper = mount(ComponentReleaseLoadTable, {
+      props: { groups: sampleGroups() },
+      global: { stubs: { FPDoRPopover: true } }
+    })
+
+    await wrapper.find('tr.cursor-pointer').trigger('click')
+    await nextTick()
+
+    var link = wrapper.find('a[href*="RHAISTRAT-1748"]')
+    expect(link.exists()).toBe(true)
+    await link.trigger('click')
+    expect(wrapper.emitted('select')).toBeFalsy()
+  })
+})

--- a/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
+++ b/modules/releases/client/plan/components/ComponentReleaseLoadTable.vue
@@ -11,6 +11,12 @@ import {
   pathChipClass,
   pathChipTitle
 } from '../utils/fpdor-severity.js'
+import {
+  docsRequiredState,
+  docsRequiredLabel,
+  docsRequiredTitle,
+  docsRequiredChipClass
+} from '../utils/docs-required-display.js'
 
 const props = defineProps({
   groups: { type: Array, default: () => [] },
@@ -19,7 +25,7 @@ const props = defineProps({
   initialSort: { type: Object, default: () => ({ column: null, direction: 'asc' }) }
 })
 
-var emit = defineEmits(['sort-changed'])
+var emit = defineEmits(['sort-changed', 'select'])
 
 function getComponentVelocity(componentName) {
   if (!props.velocity || !props.velocity.components) return null
@@ -96,7 +102,13 @@ function getSortValue(feature, column) {
   }
   if (column === 'assignee') return (feature.assignee || '').toLowerCase()
   if (column === 'pmOwner') return (feature.pmOwner || '').toLowerCase()
-  if (column === 'docs') return feature.docsRequired === 'Yes' ? 0 : 1
+  if (column === 'docs') {
+    var docsState = docsRequiredState(feature)
+    if (docsState === 'yes') return 0
+    if (docsState === 'yes-missing-component') return 1
+    if (docsState === 'no') return 2
+    return 3
+  }
   return ''
 }
 
@@ -225,6 +237,7 @@ var componentGroups = computed(function() {
           cg.features[feat.key] = {
             key: feat.key,
             summary: feat.summary,
+            title: feat.title || feat.summary || '',
             status: feat.status,
             colorStatus: feat.colorStatus,
             statusSummary: feat.statusSummary,
@@ -237,6 +250,8 @@ var componentGroups = computed(function() {
             confidence: feat.confidence || null,
             isAiFirst: !!feat.isAiFirst,
             labels: feat.labels || [],
+            riceScore: feat.riceScore != null ? feat.riceScore : null,
+            linkedRfeKey: feat.linkedRfeKey || null,
             components: feat.components,
             fixVersions: feat.fixVersions || [],
             targetVersions: feat.targetVersions || [],
@@ -433,8 +448,12 @@ defineExpose({ expandAll, collapseAll })
             <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-32 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('pmOwner')">
               <span class="inline-flex items-center gap-1">PM Owner<SortArrow :direction="sortIcon('pmOwner')" /></span>
             </th>
-            <th class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-16 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors" @click="toggleSort('docs')">
-              <span class="inline-flex items-center gap-1 justify-center">Docs<SortArrow :direction="sortIcon('docs')" /></span>
+            <th
+              class="px-3 py-2 text-center text-[11px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-28 cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+              @click="toggleSort('docs')"
+              title="Jira Docs Required field. Yes without a Documentation component fails Docs impact readiness."
+            >
+              <span class="inline-flex items-center gap-1 justify-center">Docs Required<SortArrow :direction="sortIcon('docs')" /></span>
             </th>
           </tr>
 
@@ -443,7 +462,12 @@ defineExpose({ expandAll, collapseAll })
             <tr
               v-for="feature in sortFeatures(comp.features)"
               :key="feature.key"
-              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+              role="button"
+              tabindex="0"
+              class="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
+              @click="emit('select', feature)"
+              @keydown.enter.prevent="emit('select', feature)"
+              @keydown.space.prevent="emit('select', feature)"
             >
               <td class="px-3 py-2.5 whitespace-nowrap">
                 <a
@@ -451,6 +475,7 @@ defineExpose({ expandAll, collapseAll })
                   target="_blank"
                   rel="noopener"
                   class="font-mono text-xs font-medium text-primary-600 dark:text-blue-400 hover:underline hover:text-primary-700 dark:hover:text-blue-300 transition-colors"
+                  @click.stop
                 >{{ feature.key }}</a>
               </td>
               <td class="px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100">
@@ -571,13 +596,15 @@ defineExpose({ expandAll, collapseAll })
               </td>
               <td class="px-3 py-2.5 text-center">
                 <span
-                  v-if="feature.docsRequired === 'Yes'"
-                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
-                >Yes</span>
-                <span
-                  v-else
-                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500"
-                >{{ feature.docsRequired || '—' }}</span>
+                  class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-semibold"
+                  :class="docsRequiredChipClass(feature)"
+                  :title="docsRequiredTitle(feature)"
+                >
+                  <template v-if="docsRequiredState(feature) === 'yes-missing-component'">
+                    Yes<span aria-hidden="true">⚠</span>
+                  </template>
+                  <template v-else>{{ docsRequiredLabel(feature) }}</template>
+                </span>
               </td>
             </tr>
           </template>

--- a/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
@@ -23,6 +23,36 @@ const isHealthPipeline = computed(() => props.feature?.dataSource === 'health-pi
 
 const RUBRIC_DIMS = ['feasibility', 'testability', 'scope', 'architecture']
 
+const hasAiReviewMeta = computed(function() {
+  var f = props.feature
+  if (!f) return false
+  return f.recommendation != null || f.humanReviewStatus != null
+})
+
+const hasRubricScores = computed(function() {
+  var s = props.feature && props.feature.scores
+  if (!s) return false
+  for (var i = 0; i < RUBRIC_DIMS.length; i++) {
+    if (s[RUBRIC_DIMS[i]] != null) return true
+  }
+  return false
+})
+
+const fixVersionDisplay = computed(function() {
+  var f = props.feature
+  if (!f) return null
+  if (f.fixVersion) return f.fixVersion
+  if (f.fixVersions && f.fixVersions.length) return f.fixVersions.join(', ')
+  return null
+})
+
+const dataSourceLabel = computed(function() {
+  var src = props.feature && props.feature.dataSource
+  if (src === 'health-pipeline') return 'Health Pipeline'
+  if (src === 'pm-hub' || src === 'jira') return 'Jira'
+  return 'Strategy Creator'
+})
+
 function reviewStatusClass(status) {
   switch (status) {
     case 'approved':        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
@@ -306,12 +336,16 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               </span>
             </template>
 
-            <!-- Strat-creator badges -->
-            <template v-else>
+            <!-- Strat-creator badges — only when AI review meta exists -->
+            <template v-else-if="hasAiReviewMeta">
               <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold" :class="reviewStatusClass(feature.humanReviewStatus)">
                 {{ reviewStatusLabel(feature.humanReviewStatus) }}
               </span>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold" :class="recommendationClass(feature.recommendation)">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold"
+                :class="recommendationClass(feature.recommendation)"
+                title="AI First Recommends"
+              >
                 {{ recommendationLabel(feature.recommendation) }}
               </span>
             </template>
@@ -329,7 +363,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
         <div class="flex-1 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-800">
 
           <!-- Priority Score -->
-          <section class="px-4 py-4">
+          <section v-if="feature.effectivePriorityScore != null" class="px-4 py-4">
             <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-3">Priority Score</p>
             <div class="flex items-center gap-3">
               <span
@@ -507,8 +541,8 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
             </div>
           </section>
 
-          <!-- Rubric (strat-creator features only; display/priority — does not gate FPDoR) -->
-          <section v-if="!isHealthPipeline" class="px-4 py-4">
+          <!-- Rubric (strat-creator features with scores; display/priority — does not gate FPDoR) -->
+          <section v-if="hasRubricScores" class="px-4 py-4">
             <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
               Rubric — {{ rubricTotal }} / 8
             </p>
@@ -611,7 +645,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               </dd>
 
               <dt class="text-gray-400 dark:text-gray-500">Fix Version</dt>
-              <dd class="font-mono text-gray-700 dark:text-gray-300">{{ feature.fixVersion || '—' }}</dd>
+              <dd class="font-mono text-gray-700 dark:text-gray-300">{{ fixVersionDisplay || '—' }}</dd>
 
               <dt class="text-gray-400 dark:text-gray-500 self-start">Components</dt>
               <dd>
@@ -653,7 +687,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               <dd class="text-gray-700 dark:text-gray-300">{{ feature.status || '—' }}</dd>
 
               <dt class="text-gray-400 dark:text-gray-500">Data Source</dt>
-              <dd class="text-gray-700 dark:text-gray-300">{{ isHealthPipeline ? 'Health Pipeline' : 'Strategy Creator' }}</dd>
+              <dd class="text-gray-700 dark:text-gray-300">{{ dataSourceLabel }}</dd>
 
             </dl>
           </section>

--- a/modules/releases/client/plan/utils/docs-required-display.js
+++ b/modules/releases/client/plan/utils/docs-required-display.js
@@ -1,0 +1,82 @@
+/**
+ * Docs Required column helpers for PM Hub.
+ * Column shows the Jira Docs Required field; warn when Yes but Documentation
+ * component is missing (same rule as FPDoR Docs impact).
+ */
+
+function normalizeComponentName(comp) {
+  if (!comp) return ''
+  if (typeof comp === 'string') return comp.trim()
+  if (comp.name) return String(comp.name).trim()
+  return String(comp).trim()
+}
+
+function hasDocumentationComponent(feature) {
+  var comps = (feature && feature.components) || []
+  if (!Array.isArray(comps)) return false
+  for (var i = 0; i < comps.length; i++) {
+    var name = normalizeComponentName(comps[i])
+    if (name === 'Documentation' || name === 'Docs') return true
+  }
+  return false
+}
+
+/**
+ * @returns {'yes' | 'yes-missing-component' | 'no' | 'unset'}
+ */
+function docsRequiredState(feature) {
+  var raw = feature && feature.docsRequired
+  if (raw == null || raw === '') return 'unset'
+  var normalized = String(raw).trim()
+  if (/^no$/i.test(normalized)) return 'no'
+  if (/^yes$/i.test(normalized)) {
+    return hasDocumentationComponent(feature) ? 'yes' : 'yes-missing-component'
+  }
+  return 'unset'
+}
+
+function docsRequiredLabel(feature) {
+  switch (docsRequiredState(feature)) {
+    case 'yes':
+    case 'yes-missing-component':
+      return 'Yes'
+    case 'no':
+      return 'No'
+    default:
+      return '—'
+  }
+}
+
+function docsRequiredTitle(feature) {
+  switch (docsRequiredState(feature)) {
+    case 'yes':
+      return 'Docs Required = Yes and Documentation component is set'
+    case 'yes-missing-component':
+      return 'Docs Required = Yes but Documentation component is missing — Docs impact fails until Documentation (or Docs) is added'
+    case 'no':
+      return 'Docs Required = No (Docs impact passes without Documentation component)'
+    default:
+      return 'Docs Required (Yes/No) not set — Docs impact fails until assessed'
+  }
+}
+
+function docsRequiredChipClass(feature) {
+  switch (docsRequiredState(feature)) {
+    case 'yes':
+      return 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+    case 'yes-missing-component':
+      return 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200'
+    case 'no':
+      return 'bg-gray-100 dark:bg-gray-700/60 text-gray-500 dark:text-gray-400'
+    default:
+      return 'bg-gray-100 dark:bg-gray-700/60 text-gray-400 dark:text-gray-500'
+  }
+}
+
+export {
+  hasDocumentationComponent,
+  docsRequiredState,
+  docsRequiredLabel,
+  docsRequiredTitle,
+  docsRequiredChipClass
+}

--- a/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
+++ b/modules/releases/client/plan/views/ComponentReleaseLoadReport.vue
@@ -243,7 +243,7 @@
             @click="toggleFilter('filterDocs', dv)"
             class="px-2.5 py-1 text-[11px] font-medium transition-colors"
             :class="filterDocs.includes(dv) ? 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'"
-          >{{ dv === 'Not set' ? 'Docs ?' : 'Docs ' + dv }}</button>
+          >{{ dv === 'Not set' ? 'Docs Required ?' : 'Docs Required ' + dv }}</button>
         </div>
 
         <!-- Delivery Owner -->
@@ -393,6 +393,7 @@
       :velocity="velocity"
       :initialSort="savedSort"
       @sort-changed="onSortChanged"
+      @select="selectedFeature = $event"
     />
 
     <!-- Pillar config panel -->
@@ -402,15 +403,45 @@
       @close="pillarPanelOpen = false"
       @saved="onPillarConfigSaved"
     />
+
+    <FeatureReadinessDrawer
+      :feature="drawerFeature"
+      :jiraBaseUrl="jiraBaseUrl"
+      @close="selectedFeature = null"
+      @navigate="navigateToFeature"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, inject } from 'vue'
 import { getApiBase } from '@shared/client/services/api'
 import { buildComponentLeadsMap } from '../../composables/componentLeads'
 import ComponentReleaseLoadTable from '../components/ComponentReleaseLoadTable.vue'
 import PillarConfigPanel from '../components/PillarConfigPanel.vue'
+import FeatureReadinessDrawer from '../components/FeatureReadinessDrawer.vue'
+
+const nav = inject('moduleNav', null)
+const jiraBaseUrl = 'https://issues.redhat.com/browse'
+
+function navigateToFeature(key) {
+  if (nav && typeof nav.navigateTo === 'function') {
+    nav.navigateTo('feature-detail', { key, from: 'plan-pm-hub' })
+  }
+}
+
+/** Normalize PM Hub row shape for FeatureReadinessDrawer. */
+function toDrawerFeature(feature) {
+  if (!feature) return null
+  var fixVersions = feature.fixVersions || []
+  return Object.assign({}, feature, {
+    title: feature.title || feature.summary || '',
+    fixVersion: feature.fixVersion || (fixVersions.length ? fixVersions[0] : null),
+    deliveryOwner: feature.deliveryOwner || feature.assignee || null,
+    sourceRfe: feature.sourceRfe || feature.linkedRfeKey || null,
+    dataSource: feature.dataSource || 'pm-hub'
+  })
+}
 
 const API_BASE = '/modules/releases/pm-hub'
 var STORAGE_KEY = 'pm-hub-filters'
@@ -449,6 +480,10 @@ var hasFetched = ref(false)
 var tableRef = ref(null)
 var fetchedAt = ref(null)
 var autoRefreshTimer = ref(null)
+var selectedFeature = ref(null)
+var drawerFeature = computed(function() {
+  return toDrawerFeature(selectedFeature.value)
+})
 
 var filterProduct = ref([])
 var filterType = ref([])


### PR DESCRIPTION
## Summary
- Open the Features List **slide tray** (`FeatureReadinessDrawer`) from PM Hub feature rows (Jira key links still open Jira only).
- Normalize PM Hub feature shape for the drawer; hide empty AI review / rubric / priority-score sections when that data is absent.
- Rename **Docs** → **Docs Required**; show amber **Yes⚠** when Docs Required is Yes but Documentation/Docs component is missing (same rule as FPDoR Docs impact).

## Test plan
- [ ] PM Hub: click a feature row → slide tray opens with FPDoR checklist and details
- [ ] Clicking the Jira key link does not open the tray
- [ ] Escape / backdrop closes the tray
- [ ] Docs Required column header + filter chips use the new label
- [ ] Yes + Documentation component → green Yes; Yes without it → amber Yes⚠ with tooltip; No / unset unchanged
- [ ] `npx vitest run modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js modules/releases/__tests__/client/plan/docs-required-display.test.js`


Made with [Cursor](https://cursor.com)