### PR TITLE
fix(releases): count live Jira child Epics for FPDoR Child epics

### DIFF
--- a/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
+++ b/modules/releases/__tests__/client/plan/pm-hub-feature-drawer.test.js
@@ -86,7 +86,6 @@ describe('PM Hub feature slide tray', function() {
       },
       global: {
         stubs: {
-          HygieneViolations: true,
           Teleport: true
         }
       }

--- a/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
+++ b/modules/releases/client/plan/components/FeatureReadinessDrawer.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
-import HygieneViolations from '@shared/client/components/HygieneViolations.vue'
 import {
   worstFailedSeverity,
   severityBadgeClass,
@@ -233,10 +232,6 @@ const failedFpdorActions = computed(() => {
     .map(item => ({ name: item.name, action: FPDOR_TO_HYGIENE[item.name], detail: item.detail }))
 })
 
-const violationsList = computed(() => props.feature?.violations || [])
-const violationCount = computed(() => violationsList.value.length)
-
-const hygieneExpanded = ref(true)
 const breakdownExpanded = ref(false)
 
 const scoreBreakdown = computed(() => {
@@ -494,7 +489,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
               </div>
             </div>
 
-            <!-- Readiness-to-Hygiene Action Bridge -->
+            <!-- Actions for failed FPDoR items -->
             <div v-if="failedFpdorActions.length > 0" class="mt-4 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700">
               <p class="text-xs font-semibold text-amber-800 dark:text-amber-300 mb-2">Actions to resolve</p>
               <ul class="space-y-1.5">
@@ -503,41 +498,6 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKey))
                   <span>{{ act.action }}</span>
                 </li>
               </ul>
-            </div>
-          </section>
-
-          <!-- Hygiene Violations -->
-          <section class="px-4 py-4">
-            <button
-              type="button"
-              class="w-full flex items-center justify-between text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-3 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-              @click="hygieneExpanded = !hygieneExpanded"
-            >
-              <span class="flex items-center gap-2">
-                Hygiene
-                <span
-                  v-if="violationCount > 0"
-                  class="inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
-                >{{ violationCount }} {{ violationCount === 1 ? 'warning' : 'warnings' }}</span>
-                <span
-                  v-else-if="feature && feature.hygieneStatus === 'unknown'"
-                  class="inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
-                >Unknown</span>
-                <span
-                  v-else
-                  class="inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300"
-                >All clear</span>
-              </span>
-              <svg
-                class="w-3.5 h-3.5 transition-transform"
-                :class="hygieneExpanded ? 'rotate-180' : ''"
-                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-              </svg>
-            </button>
-            <div v-if="hygieneExpanded">
-              <HygieneViolations :violations="violationsList" :feature-key="feature?.key" :jira-base-url="jiraBaseUrl" />
             </div>
           </section>
 

--- a/modules/releases/client/plan/utils/fpdor-severity.js
+++ b/modules/releases/client/plan/utils/fpdor-severity.js
@@ -129,7 +129,7 @@ function pathChipClass(feature) {
 
 function pathChipTitle(feature) {
   if (isAiFirstFeature(feature)) {
-    return 'AI First — has strat-creator-* label (Confluence path)'
+    return 'AI First — has strat-creator-* label'
   }
   return 'Legacy — no strat-creator-* label'
 }

--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -1,7 +1,25 @@
 import { describe, it, expect, vi } from 'vitest'
 
-const { fetchFeatures, normalizeIssue, JQL, QUERY_FIELDS } = require('../feature-query')
+const {
+  fetchFeatures,
+  normalizeIssue,
+  enrichChildEpicCounts,
+  JQL,
+  QUERY_FIELDS
+} = require('../feature-query')
 const { CUSTOM_FIELDS } = require('../../hygiene/jira-fetch')
+
+/** Route feature list JQL vs child-epic enrichment JQL. */
+function mockJiraClient(featureIssues, childIssues) {
+  return {
+    fetchAllJqlResults: vi.fn().mockImplementation(function(jql) {
+      if (String(jql).indexOf('issuetype = Epic') !== -1) {
+        return Promise.resolve(childIssues || [])
+      }
+      return Promise.resolve(featureIssues || [])
+    })
+  }
+}
 
 describe('feature-query', function() {
 
@@ -194,12 +212,11 @@ describe('feature-query', function() {
     })
 
     it('calls fetchAllJqlResults with correct JQL and fields', async function() {
-      var mockFetch = vi.fn().mockResolvedValue([])
-      var client = { fetchAllJqlResults: mockFetch }
+      var client = mockJiraClient([])
 
       await fetchFeatures(client)
 
-      expect(mockFetch).toHaveBeenCalledWith(JQL, QUERY_FIELDS, { maxResults: 100 })
+      expect(client.fetchAllJqlResults).toHaveBeenCalledWith(JQL, QUERY_FIELDS, { maxResults: 100 })
     })
 
     it('returns Map keyed by issue key', async function() {
@@ -207,13 +224,14 @@ describe('feature-query', function() {
         { key: 'RHAISTRAT-100', fields: { summary: 'Feature A', status: { name: 'In Progress' } } },
         { key: 'RHAISTRAT-200', fields: { summary: 'Feature B', status: { name: 'New' } } }
       ]
-      var client = { fetchAllJqlResults: vi.fn().mockResolvedValue(issues) }
+      var client = mockJiraClient(issues)
 
       var result = await fetchFeatures(client)
 
       expect(result.size).toBe(2)
       expect(result.get('RHAISTRAT-100').summary).toBe('Feature A')
       expect(result.get('RHAISTRAT-200').summary).toBe('Feature B')
+      expect(result.get('RHAISTRAT-100').epicCount).toBe(0)
     })
 
     it('skips issues without a key', async function() {
@@ -222,7 +240,7 @@ describe('feature-query', function() {
         { key: null, fields: { summary: 'No key' } },
         { fields: { summary: 'Also no key' } }
       ]
-      var client = { fetchAllJqlResults: vi.fn().mockResolvedValue(issues) }
+      var client = mockJiraClient(issues)
 
       var result = await fetchFeatures(client)
 
@@ -245,7 +263,7 @@ describe('feature-query', function() {
       fields[CUSTOM_FIELDS.targetVersion] = { name: 'rhoai-3.6' }
       fields[CUSTOM_FIELDS.riceScore] = 150
 
-      var client = { fetchAllJqlResults: vi.fn().mockResolvedValue([{ key: 'RHAISTRAT-300', fields: fields }]) }
+      var client = mockJiraClient([{ key: 'RHAISTRAT-300', fields: fields }])
 
       var result = await fetchFeatures(client)
       var feature = result.get('RHAISTRAT-300')
@@ -261,6 +279,50 @@ describe('feature-query', function() {
       expect(feature.team).toBe('Platform')
       expect(feature.targetVersions).toEqual(['rhoai-3.6'])
       expect(feature.riceScore).toBe(150)
+    })
+
+    it('counts linked child Epics via parent field', async function() {
+      var features = [
+        { key: 'RHAISTRAT-2198', fields: { summary: 'Validated Models' } }
+      ]
+      var children = [
+        {
+          key: 'RHOAIENG-76148',
+          fields: { parent: { key: 'RHAISTRAT-2198' } }
+        },
+        {
+          key: 'RHOAIENG-76162',
+          fields: { parent: { key: 'RHAISTRAT-2198' } }
+        }
+      ]
+      var client = mockJiraClient(features, children)
+
+      var result = await fetchFeatures(client)
+      expect(result.get('RHAISTRAT-2198').epicCount).toBe(2)
+      expect(client.fetchAllJqlResults.mock.calls.some(function(c) {
+        return String(c[0]).indexOf('issuetype = Epic') !== -1
+      })).toBe(true)
+    })
+  })
+
+  describe('enrichChildEpicCounts', function() {
+    it('counts Epic Link customfield parents', async function() {
+      var map = new Map([
+        ['RHAISTRAT-1', { key: 'RHAISTRAT-1', epicCount: 0 }]
+      ])
+      var client = {
+        fetchAllJqlResults: vi.fn().mockResolvedValue([
+          { key: 'RHOAIENG-1', fields: { customfield_10014: 'RHAISTRAT-1' } }
+        ])
+      }
+      await enrichChildEpicCounts(client, map)
+      expect(map.get('RHAISTRAT-1').epicCount).toBe(1)
+    })
+
+    it('no-ops on empty map', async function() {
+      var client = { fetchAllJqlResults: vi.fn() }
+      await enrichChildEpicCounts(client, new Map())
+      expect(client.fetchAllJqlResults).not.toHaveBeenCalled()
     })
   })
 })
@@ -345,31 +407,29 @@ describe('expanded custom fields', function() {
     })
 
     it('fetchFeatures includes new fields in returned map entries', async function() {
-      var mockClient = {
-        fetchAllJqlResults: vi.fn().mockResolvedValue([
-          {
-            key: 'RHAISTRAT-NF7',
-            fields: {
-              summary: 'Full Feature',
-              status: { name: 'In Progress' },
-              issuetype: { name: 'Feature' },
-              assignee: { displayName: 'Dev' },
-              fixVersions: [{ name: 'rhoai-3.6' }],
-              components: [{ name: 'API' }],
-              labels: [],
-              priority: { name: 'Major' },
-              [CUSTOM_FIELDS.team]: { value: 'MyTeam' },
-              [CUSTOM_FIELDS.targetVersion]: { value: 'rhoai-3.6' },
-              [CUSTOM_FIELDS.riceScore]: 200,
-              [CUSTOM_FIELDS.statusSummary]: 'Looking good',
-              [CUSTOM_FIELDS.colorStatus]: { value: 'Green' },
-              [CUSTOM_FIELDS.releaseType]: { value: 'GA' },
-              [CUSTOM_FIELDS.docsRequired]: { value: 'Yes' },
-              [CUSTOM_FIELDS.targetEnd]: '2026-10-01'
-            }
+      var mockClient = mockJiraClient([
+        {
+          key: 'RHAISTRAT-NF7',
+          fields: {
+            summary: 'Full Feature',
+            status: { name: 'In Progress' },
+            issuetype: { name: 'Feature' },
+            assignee: { displayName: 'Dev' },
+            fixVersions: [{ name: 'rhoai-3.6' }],
+            components: [{ name: 'API' }],
+            labels: [],
+            priority: { name: 'Major' },
+            [CUSTOM_FIELDS.team]: { value: 'MyTeam' },
+            [CUSTOM_FIELDS.targetVersion]: { value: 'rhoai-3.6' },
+            [CUSTOM_FIELDS.riceScore]: 200,
+            [CUSTOM_FIELDS.statusSummary]: 'Looking good',
+            [CUSTOM_FIELDS.colorStatus]: { value: 'Green' },
+            [CUSTOM_FIELDS.releaseType]: { value: 'GA' },
+            [CUSTOM_FIELDS.docsRequired]: { value: 'Yes' },
+            [CUSTOM_FIELDS.targetEnd]: '2026-10-01'
           }
-        ])
-      }
+        }
+      ])
 
       var result = await fetchFeatures(mockClient)
       expect(result.size).toBe(1)

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -2418,6 +2418,43 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     expect(result.pendingReview[0].title).toBe('Jira Feature RHAISTRAT-900')
   })
 
+  it('prefers live jira epicCount for Child epics over stale exec count of 0', async function() {
+    var jiraFeatures = makeJiraMap([
+      makeJiraFeature('RHAISTRAT-2198', {
+        epicCount: 2,
+        components: ['Platform', 'Serving', 'UXD', 'Documentation'],
+        docsRequired: 'Yes',
+        labels: ['strat-creator-auto-created', 'strat-creator-human-sign-off', 'rp-qg1-pass'],
+        riceScore: 50,
+        releaseType: 'GA',
+        pmOwner: 'Jane'
+      })
+    ])
+    var readFromStorage = makeReadFromStorage({
+      ...convertToUnifiedFormat(makeFeaturesStore({
+        'RHAISTRAT-2198': {
+          key: 'RHAISTRAT-2198',
+          summary: 'Validated Models',
+          status: 'In Progress',
+          epicCount: 0
+        }
+      })),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/execution/index.json': makeExecIndex([
+        { key: 'RHAISTRAT-2198', epicCount: 0 }
+      ])
+    })
+
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) {
+      return f.key === 'RHAISTRAT-2198'
+    })
+    expect(feature).toBeTruthy()
+    expect(feature.epicCount).toBe(2)
+    var child = feature.fpdor.items.find(function(i) { return i.name === 'Child epics' })
+    expect(child.pass).toBe(true)
+  })
+
   it('falls back to execution index when jiraFeatures is null', async function() {
     var readFromStorage = makeReadFromStorage({
       ...convertToUnifiedFormat(makeFeaturesStore({})),

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -19,6 +19,13 @@ var QUERY_FIELDS = [
 
 var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status NOT IN (Closed, Done, Resolved, Cancelled)'
 
+var EPIC_BATCH_SIZE = 40
+var EPIC_THROTTLE_MS = 500
+
+function sleep(ms) {
+  return new Promise(function(resolve) { setTimeout(resolve, ms) })
+}
+
 function normalizeIssue(issue) {
   var fields = issue.fields || {}
   var assignee = fields.assignee
@@ -68,7 +75,45 @@ function normalizeIssue(issue) {
     targetEnd: serializeField(fields[CUSTOM_FIELDS.targetEnd]),
     pmOwner: pmOwner,
     effort: numericField(fields[CUSTOM_FIELDS.effort]),
-    descriptionSignals: parseDescriptionSignals(fields.description)
+    descriptionSignals: parseDescriptionSignals(fields.description),
+    epicCount: 0
+  }
+}
+
+/**
+ * Count Epic children linked via parent / Epic Link for each feature key.
+ * Matches Confluence Child epics DoR (Child Issues section).
+ *
+ * @param {object} jiraClient
+ * @param {Map<string, object>} featureMap
+ */
+async function enrichChildEpicCounts(jiraClient, featureMap) {
+  if (!jiraClient || !jiraClient.fetchAllJqlResults || !featureMap || featureMap.size === 0) return
+
+  var keys = Array.from(featureMap.keys())
+  for (var start = 0; start < keys.length; start += EPIC_BATCH_SIZE) {
+    if (start > 0) await sleep(EPIC_THROTTLE_MS)
+    var batchKeys = keys.slice(start, start + EPIC_BATCH_SIZE)
+    var keyList = batchKeys.map(function(k) { return '"' + k + '"' }).join(', ')
+    // Epic type only — Confluence: "Linked child epics in engineering projects"
+    var jql = 'issuetype = Epic AND (parent in (' + keyList + ') OR "Epic Link" in (' + keyList + '))'
+    try {
+      var children = await jiraClient.fetchAllJqlResults(jql, 'parent,customfield_10014', { maxResults: 100 })
+      for (var i = 0; i < children.length; i++) {
+        var fields = children[i].fields || {}
+        var parentKey = (fields.parent && fields.parent.key) || fields.customfield_10014 || null
+        if (!parentKey || !featureMap.has(parentKey)) continue
+        var feat = featureMap.get(parentKey)
+        feat.epicCount = (feat.epicCount || 0) + 1
+      }
+    } catch (err) {
+      console.warn(
+        '[releases/planning] Child epic count batch ' +
+          (Math.floor(start / EPIC_BATCH_SIZE) + 1) +
+          ' failed: ' +
+          (err && err.message ? err.message : err)
+      )
+    }
   }
 }
 
@@ -81,7 +126,14 @@ async function fetchFeatures(jiraClient) {
     var normalized = normalizeIssue(issues[i])
     if (normalized.key) map.set(normalized.key, normalized)
   }
+  await enrichChildEpicCounts(jiraClient, map)
   return map
 }
 
-module.exports = { fetchFeatures: fetchFeatures, normalizeIssue: normalizeIssue, JQL: JQL, QUERY_FIELDS: QUERY_FIELDS }
+module.exports = {
+  fetchFeatures: fetchFeatures,
+  normalizeIssue: normalizeIssue,
+  enrichChildEpicCounts: enrichChildEpicCounts,
+  JQL: JQL,
+  QUERY_FIELDS: QUERY_FIELDS
+}

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -427,7 +427,18 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
   var hygieneStatus = computeHygieneStatus(violations)
 
   var storyPoints = (health && health.storyPoints) || (candidate && candidate.storyPoints) || (jira && jira.storyPoints) || (exec && exec.storyPoints) || null
-  var epicCount = (health && health.epicCount) || (candidate && candidate.epicCount) || (exec && exec.epicCount) || 0
+  var epicCount
+  if (jira && jira.epicCount != null) {
+    epicCount = jira.epicCount
+  } else if (health && health.epicCount != null) {
+    epicCount = health.epicCount
+  } else if (candidate && candidate.epicCount != null) {
+    epicCount = candidate.epicCount
+  } else if (exec && exec.epicCount != null) {
+    epicCount = exec.epicCount
+  } else {
+    epicCount = 0
+  }
   var releaseType = (health && health.releaseType) || (candidate && candidate.phase) || (jira && jira.releaseType) || (exec && exec.releaseType) || null
   var assignee = deliveryOwner
   var pm = pmOwner || (health && health.pm) || (candidate && candidate.pm) || (exec && exec.pm) || null
@@ -576,6 +587,7 @@ async function buildFeatureReadiness(readFromStorage, jiraFeatures, listStorageF
       dataSource: merged.dataSource,
       labels: merged.labels || [],
       isAiFirst: isAiFirstFeature(merged),
+      epicCount: merged.epicCount || 0,
       confidence: confidence,
       readinessGates: readinessResult.gates,
       fpdor: readinessResult.fpdor,


### PR DESCRIPTION
## Summary
- Features List FPDoR **Child epics** was using cached exec/health `epicCount` only, so features like RHAISTRAT-2198 (with Jira child Epics) falsely failed.
- Live-count Epic children via `parent` / Epic Link when fetching RHAISTRAT features.
- Prefer that Jira `epicCount` in readiness merge over stale exec `0`.

## Test plan
- [ ] Features List: RHAISTRAT-2198 (or similar with Child Issues Epics) no longer fails **Child epics** after refresh
- [ ] Features without child Epics still fail Child epics (unless `epic-creator-auto-decomposed`)
- [ ] `npx vitest run modules/releases/server/planning/__tests__/feature-query.test.js modules/releases/server/planning/__tests__/feature-readiness.test.js -t 'Child epic|epicCount|enrichChild|prefers live jira|counts linked'`


Made with [Cursor](https://cursor.com)