### PR TITLE
fix(releases): stop live child-epic enrichment on feature-readiness

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -231,7 +231,7 @@ describe('feature-query', function() {
       expect(result.size).toBe(2)
       expect(result.get('RHAISTRAT-100').summary).toBe('Feature A')
       expect(result.get('RHAISTRAT-200').summary).toBe('Feature B')
-      expect(result.get('RHAISTRAT-100').epicCount).toBe(0)
+      expect(result.get('RHAISTRAT-100').epicCount).toBeNull()
     })
 
     it('skips issues without a key', async function() {
@@ -298,7 +298,7 @@ describe('feature-query', function() {
       var client = mockJiraClient(features, children)
 
       var result = await fetchFeatures(client)
-      expect(result.get('RHAISTRAT-2198').epicCount).toBe(0)
+      expect(result.get('RHAISTRAT-2198').epicCount).toBeNull()
       expect(client.fetchAllJqlResults).toHaveBeenCalledTimes(1)
       expect(client.fetchAllJqlResults.mock.calls.some(function(c) {
         return String(c[0]).indexOf('issuetype = Epic') !== -1

--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -281,7 +281,7 @@ describe('feature-query', function() {
       expect(feature.riceScore).toBe(150)
     })
 
-    it('counts linked child Epics via parent field', async function() {
+    it('does not run live child-epic enrichment on the request path', async function() {
       var features = [
         { key: 'RHAISTRAT-2198', fields: { summary: 'Validated Models' } }
       ]
@@ -298,10 +298,11 @@ describe('feature-query', function() {
       var client = mockJiraClient(features, children)
 
       var result = await fetchFeatures(client)
-      expect(result.get('RHAISTRAT-2198').epicCount).toBe(2)
+      expect(result.get('RHAISTRAT-2198').epicCount).toBe(0)
+      expect(client.fetchAllJqlResults).toHaveBeenCalledTimes(1)
       expect(client.fetchAllJqlResults.mock.calls.some(function(c) {
         return String(c[0]).indexOf('issuetype = Epic') !== -1
-      })).toBe(true)
+      })).toBe(false)
     })
   })
 

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -126,7 +126,10 @@ async function fetchFeatures(jiraClient) {
     var normalized = normalizeIssue(issues[i])
     if (normalized.key) map.set(normalized.key, normalized)
   }
-  await enrichChildEpicCounts(jiraClient, map)
+  // Do not run enrichChildEpicCounts here — batched live Jira searches over all
+  // open Features timeout the /feature-readiness gateway (HTTP 504). Keep the
+  // helper exported for offline/pipeline use; mergeFeatureData still prefers
+  // jira.epicCount when present.
   return map
 }
 

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -76,7 +76,7 @@ function normalizeIssue(issue) {
     pmOwner: pmOwner,
     effort: numericField(fields[CUSTOM_FIELDS.effort]),
     descriptionSignals: parseDescriptionSignals(fields.description),
-    epicCount: 0
+    epicCount: null
   }
 }
 


### PR DESCRIPTION
## Summary
- Removes `enrichChildEpicCounts` from the synchronous `fetchFeatures` path used by `GET /planning/feature-readiness`, which was causing Features List **HTTP 504** after #1391 (batched live Jira searches over all open RHAISTRAT Features).
- Keeps `enrichChildEpicCounts` exported for offline/pipeline use and still prefers `jira.epicCount` in merge when present.
- Child epics false fails from stale cache (e.g. RHAISTRAT-2198) remain until non-request-path enrichment exists.

## Test plan
- [x] Unit: `feature-query.test.js` (41 passed)
- [ ] Features List loads without HTTP 504 after deploy
- [ ] FPDoR still evaluates Child epics from cached exec/health counts


Made with [Cursor](https://cursor.com)