### PR TITLE
fix(releases): derive Child epics count from Jira-synced feature.epics

### DIFF
--- a/modules/releases/__tests__/server/execution/jira-enrich.test.js
+++ b/modules/releases/__tests__/server/execution/jira-enrich.test.js
@@ -5,7 +5,8 @@ const {
   transformForEnrichment,
   extractIssueLinks,
   checkIsBlocked,
-  findLinkedRfeKey
+  findLinkedRfeKey,
+  fetchEpicsForFeatures
 } = require('../../../server/execution/jira-enrich')
 
 function makeJiraIssue(key, overrides = {}) {
@@ -295,5 +296,26 @@ describe('enrichFeatures', () => {
     expect(result.get('RHAISTRAT-1').epics).toEqual([{
       key: 'RHOAIENG-500', summary: 'Child epic', status: 'In Progress'
     }])
+  })
+})
+
+describe('fetchEpicsForFeatures', () => {
+  it('queries issuetype = Epic for parent / Epic Link children', async () => {
+    const mockFetchAll = vi.fn().mockResolvedValue([
+      {
+        key: 'RHOAIENG-1',
+        fields: {
+          summary: 'Child',
+          status: { name: 'New' },
+          parent: { key: 'RHAISTRAT-1' }
+        }
+      }
+    ])
+
+    const map = await fetchEpicsForFeatures(['RHAISTRAT-1'], null, mockFetchAll)
+
+    expect(mockFetchAll).toHaveBeenCalled()
+    expect(String(mockFetchAll.mock.calls[0][0])).toContain('issuetype = Epic')
+    expect(map.get('RHAISTRAT-1')).toHaveLength(1)
   })
 })

--- a/modules/releases/server/execution/__tests__/feature-store.test.js
+++ b/modules/releases/server/execution/__tests__/feature-store.test.js
@@ -1,10 +1,28 @@
 import { describe, it, expect } from 'vitest'
 
-const { mergeFeatureData, rebuildIndex, AI_REVIEW_FIELDS } = require('../feature-store')
+const { mergeFeatureData, rebuildIndex, deriveEpicCount, AI_REVIEW_FIELDS } = require('../feature-store')
 
 describe('AI_REVIEW_FIELDS', function() {
   it('includes aiReview', function() {
     expect(AI_REVIEW_FIELDS).toContain('aiReview')
+  })
+})
+
+describe('deriveEpicCount', function() {
+  it('prefers Jira feature.epics length when _sources.jira is set', function() {
+    expect(deriveEpicCount({
+      epics: [{ key: 'E-1' }, { key: 'E-2' }],
+      metrics: { totalEpics: 0 },
+      _sources: { jira: '2026-08-11T00:00:00.000Z' }
+    })).toBe(2)
+  })
+
+  it('falls back to metrics.totalEpics without Jira epic list', function() {
+    expect(deriveEpicCount({ metrics: { totalEpics: 5 } })).toBe(5)
+  })
+
+  it('returns 0 when neither epics nor metrics present', function() {
+    expect(deriveEpicCount({})).toBe(0)
   })
 })
 
@@ -128,5 +146,31 @@ describe('rebuildIndex — aiReview summary', function() {
 
     const index = stored['releases/execution/index.json']
     expect(index.features[0].aiReview).toBeNull()
+  })
+
+  it('indexes epicCount from Jira epics over stale metrics.totalEpics', async function() {
+    const stored = {}
+    const storage = {
+      listStorageFiles: async function() { return ['RHAISTRAT-2198.json'] },
+      readFromStorage: async function(path) {
+        if (path.endsWith('RHAISTRAT-2198.json')) {
+          return {
+            key: 'RHAISTRAT-2198',
+            summary: 'Validated Models',
+            epics: [{ key: 'RHOAIENG-1' }, { key: 'RHOAIENG-2' }],
+            metrics: { totalEpics: 0 },
+            _sources: { jira: '2026-08-11T00:00:00.000Z' }
+          }
+        }
+        return null
+      },
+      writeToStorage: async function(path, data) {
+        stored[path] = data
+      }
+    }
+
+    await rebuildIndex(storage)
+
+    expect(stored['releases/execution/index.json'].features[0].epicCount).toBe(2)
   })
 })

--- a/modules/releases/server/execution/feature-store.js
+++ b/modules/releases/server/execution/feature-store.js
@@ -33,6 +33,21 @@ const PIPELINE_INDEX_FIELDS = [
 const AI_REVIEW_FIELDS = ['aiReview'];
 
 /**
+ * Prefer Jira-discovered child Epic list over pipeline metrics.totalEpics.
+ * fullJiraSync stores linked Epics on feature.epics; pipeline totalEpics can be stale.
+ *
+ * @param {object} feature
+ * @returns {number}
+ */
+function deriveEpicCount(feature) {
+  if (!feature) return 0
+  if (Array.isArray(feature.epics) && feature._sources && feature._sources.jira) {
+    return feature.epics.length
+  }
+  return feature.metrics ? (feature.metrics.totalEpics || 0) : 0
+}
+
+/**
  * Merge data from existing store, pipeline ingest, and Jira enrichment.
  * All three inputs are optional (may be null).
  *
@@ -197,9 +212,9 @@ async function rebuildIndex(storage) {
         : null,
       fixVersions: feature.fixVersions || [],
       labels: feature.labels || [],
-      // Derived from metrics
+      // Derived from metrics (epicCount prefers Jira feature.epics when synced)
       completionPct: feature.metrics ? (feature.metrics.completionPct || 0) : 0,
-      epicCount: feature.metrics ? (feature.metrics.totalEpics || 0) : 0,
+      epicCount: deriveEpicCount(feature),
       issueCount: feature.metrics ? (feature.metrics.totalIssues || 0) : 0,
       blockerCount: feature.metrics ? (feature.metrics.blockerCount || 0) : 0,
       health: feature.metrics ? (feature.metrics.health || null) : null,
@@ -242,6 +257,7 @@ module.exports = {
   mergeFeatureData,
   writeFeatures,
   rebuildIndex,
+  deriveEpicCount,
   DATA_PREFIX,
   JIRA_FIELDS,
   PIPELINE_FIELDS,

--- a/modules/releases/server/execution/jira-enrich.js
+++ b/modules/releases/server/execution/jira-enrich.js
@@ -361,7 +361,8 @@ async function fetchEpicsForFeatures(featureKeys, jiraRequestFn, fetchAllJqlResu
 
     const batchKeys = batches[bi];
     const keyList = batchKeys.map(k => '"' + k + '"').join(', ');
-    const jql = '("Epic Link" in (' + keyList + ') OR parent in (' + keyList + '))';
+    // Epic type only — matches Confluence Child epics DoR (linked child Epics)
+    const jql = 'issuetype = Epic AND (parent in (' + keyList + ') OR "Epic Link" in (' + keyList + '))';
     const fields = 'summary,status,parent,customfield_10014';
 
     try {

--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -281,7 +281,7 @@ describe('feature-query', function() {
       expect(feature.riceScore).toBe(150)
     })
 
-    it('counts linked child Epics via parent field', async function() {
+    it('does not run live child-epic enrichment on the request path', async function() {
       var features = [
         { key: 'RHAISTRAT-2198', fields: { summary: 'Validated Models' } }
       ]
@@ -298,22 +298,26 @@ describe('feature-query', function() {
       var client = mockJiraClient(features, children)
 
       var result = await fetchFeatures(client)
-      expect(result.get('RHAISTRAT-2198').epicCount).toBe(2)
+      expect(result.get('RHAISTRAT-2198').epicCount).toBe(0)
+      expect(client.fetchAllJqlResults).toHaveBeenCalledTimes(1)
       expect(client.fetchAllJqlResults.mock.calls.some(function(c) {
         return String(c[0]).indexOf('issuetype = Epic') !== -1
-      })).toBe(true)
+      })).toBe(false)
     })
   })
 
   describe('enrichChildEpicCounts', function() {
-    it('counts Epic Link customfield parents', async function() {
+    it('counts Epic Link customfield parents via fetchEpicsForFeatures', async function() {
       var map = new Map([
         ['RHAISTRAT-1', { key: 'RHAISTRAT-1', epicCount: 0 }]
       ])
       var client = {
-        fetchAllJqlResults: vi.fn().mockResolvedValue([
-          { key: 'RHOAIENG-1', fields: { customfield_10014: 'RHAISTRAT-1' } }
-        ])
+        fetchAllJqlResults: vi.fn().mockImplementation(function(jql) {
+          expect(String(jql)).toContain('issuetype = Epic')
+          return Promise.resolve([
+            { key: 'RHOAIENG-1', fields: { customfield_10014: 'RHAISTRAT-1' } }
+          ])
+        })
       }
       await enrichChildEpicCounts(client, map)
       expect(map.get('RHAISTRAT-1').epicCount).toBe(1)

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -1,5 +1,6 @@
 var { CUSTOM_FIELDS, serializeField, numericField } = require('../hygiene/jira-fetch')
 var { parseDescriptionSignals } = require('./health/description-scanner')
+var { fetchEpicsForFeatures } = require('../execution/jira-enrich')
 
 var QUERY_FIELDS = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions',
@@ -18,13 +19,6 @@ var QUERY_FIELDS = [
 ].join(',')
 
 var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status NOT IN (Closed, Done, Resolved, Cancelled)'
-
-var EPIC_BATCH_SIZE = 40
-var EPIC_THROTTLE_MS = 500
-
-function sleep(ms) {
-  return new Promise(function(resolve) { setTimeout(resolve, ms) })
-}
 
 function normalizeIssue(issue) {
   var fields = issue.fields || {}
@@ -82,7 +76,8 @@ function normalizeIssue(issue) {
 
 /**
  * Count Epic children linked via parent / Epic Link for each feature key.
- * Matches Confluence Child epics DoR (Child Issues section).
+ * Delegates to execution fetchEpicsForFeatures — offline / pipeline use only.
+ * Do not call from GET /feature-readiness (gateway timeout).
  *
  * @param {object} jiraClient
  * @param {Map<string, object>} featureMap
@@ -91,30 +86,13 @@ async function enrichChildEpicCounts(jiraClient, featureMap) {
   if (!jiraClient || !jiraClient.fetchAllJqlResults || !featureMap || featureMap.size === 0) return
 
   var keys = Array.from(featureMap.keys())
-  for (var start = 0; start < keys.length; start += EPIC_BATCH_SIZE) {
-    if (start > 0) await sleep(EPIC_THROTTLE_MS)
-    var batchKeys = keys.slice(start, start + EPIC_BATCH_SIZE)
-    var keyList = batchKeys.map(function(k) { return '"' + k + '"' }).join(', ')
-    // Epic type only — Confluence: "Linked child epics in engineering projects"
-    var jql = 'issuetype = Epic AND (parent in (' + keyList + ') OR "Epic Link" in (' + keyList + '))'
-    try {
-      var children = await jiraClient.fetchAllJqlResults(jql, 'parent,customfield_10014', { maxResults: 100 })
-      for (var i = 0; i < children.length; i++) {
-        var fields = children[i].fields || {}
-        var parentKey = (fields.parent && fields.parent.key) || fields.customfield_10014 || null
-        if (!parentKey || !featureMap.has(parentKey)) continue
-        var feat = featureMap.get(parentKey)
-        feat.epicCount = (feat.epicCount || 0) + 1
-      }
-    } catch (err) {
-      console.warn(
-        '[releases/planning] Child epic count batch ' +
-          (Math.floor(start / EPIC_BATCH_SIZE) + 1) +
-          ' failed: ' +
-          (err && err.message ? err.message : err)
-      )
-    }
-  }
+  var epicMap = await fetchEpicsForFeatures(keys, null, function(jql, fields, opts) {
+    return jiraClient.fetchAllJqlResults(jql, fields, opts)
+  })
+  epicMap.forEach(function(epics, parentKey) {
+    if (!featureMap.has(parentKey)) return
+    featureMap.get(parentKey).epicCount = Array.isArray(epics) ? epics.length : 0
+  })
 }
 
 async function fetchFeatures(jiraClient) {
@@ -126,7 +104,8 @@ async function fetchFeatures(jiraClient) {
     var normalized = normalizeIssue(issues[i])
     if (normalized.key) map.set(normalized.key, normalized)
   }
-  await enrichChildEpicCounts(jiraClient, map)
+  // Child epic counts come from execution store (fullJiraSync → feature.epics).
+  // Live enrichChildEpicCounts on this path caused Features List HTTP 504.
   return map
 }
 


### PR DESCRIPTION
## Summary
- **Fixes Features List HTTP 504:** removes live `enrichChildEpicCounts` from `GET /feature-readiness` (supersedes #1392).
- **Permanent Child epics accuracy:** execution index `epicCount` prefers Jira-synced `feature.epics.length` over stale pipeline `metrics.totalEpics`.
- **Epic-only discovery:** `fetchEpicsForFeatures` JQL requires `issuetype = Epic` (Confluence Child epics DoR).
- Planning `enrichChildEpicCounts` now delegates to that helper for offline/pipeline use only.

After deploy, run a full Jira sync / enrichment so stored `feature.epics` and the index rebuild; Features List then picks up correct Child epics without request-time Jira fan-out.

## Test plan
- [x] Unit: feature-query, feature-store, jira-enrich
- [ ] Features List loads (no HTTP 504)
- [ ] After Jira sync, features with linked child Epics (e.g. RHAISTRAT-2198) pass Child epics even if pipeline `totalEpics` was 0


Made with [Cursor](https://cursor.com)