### PR TITLE
feat(releases): add Release Type column to feature readiness CSV export

### DIFF
--- a/modules/releases/client/plan/utils/feature-readiness-export.js
+++ b/modules/releases/client/plan/utils/feature-readiness-export.js
@@ -81,6 +81,7 @@ function exportFeatureReadinessCsv(features) {
       getter: function(f) { return (f.targetVersions || []).join('; ') }
     },
     { label: 'Fix Version', getter: function(f) { return f.fixVersion || '' } },
+    { label: 'Release Type', getter: function(f) { return f.releaseType || '' } },
     {
       label: 'Components',
       getter: function(f) {


### PR DESCRIPTION
## Summary

- Adds a **Release Type** column to the feature readiness CSV export (`exportFeatureReadinessCsv`)
- `f.releaseType` (`customfield_10851`) is already fetched from Jira and present on every feature object — this is a zero-risk, one-line addition
- Follows the same pattern as PR #1353 (Labels column)

## Why

The AI-First Release Planner applies DP/TP/GA confidence boosts based on Release Type. Without this column in the export, the planner has to parse Release Type from the feature title string (e.g. `^\[(TP|DP|GA)\]`), which is fragile — title formats vary by team (e.g. "Tech Preview - ..." doesn't match `[TP]`), causing the boost to silently not apply.

With this column, the planner (and any other CSV consumer) reads the structured Jira field directly instead of guessing from free text.

## Test plan

- [ ] Drop the updated CSV export into the AI-First Release Planner and verify the Release Type column appears with values like `DP`, `TP`, `GA` (or blank for standard features)
- [ ] Confirm existing CSV columns and ordering are unchanged (Release Type is inserted between Fix Version and Components)
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)