### PR TITLE
feat: support ODH build type values in version filter

### DIFF
--- a/modules/ai-impact/__tests__/client/version-group.test.js
+++ b/modules/ai-impact/__tests__/client/version-group.test.js
@@ -42,6 +42,13 @@ describe('extractVersionGroup', () => {
     expect(extractVersionGroup('main')).toBeNull()
     expect(extractVersionGroup('EA1')).toBeNull()
   })
+
+  it('recognizes ODH build type values', () => {
+    expect(extractVersionGroup('CI')).toBe('CI')
+    expect(extractVersionGroup('ci')).toBe('CI')
+    expect(extractVersionGroup('Release')).toBe('Release')
+    expect(extractVersionGroup('release')).toBe('Release')
+  })
 })
 
 describe('collectVersionGroups', () => {
@@ -54,6 +61,15 @@ describe('collectVersionGroups', () => {
       'rhoai-3.6',
       'rhoai-2.21'
     ])).toEqual(['2.21', '3.5', '3.5.EA1', '3.6'])
+  })
+
+  it('places ODH build types after numeric versions', () => {
+    expect(collectVersionGroups([
+      'CI',
+      'rhoai-3.5',
+      'Release',
+      'rhoai-3.6'
+    ])).toEqual(['3.5', '3.6', 'CI', 'Release'])
   })
 })
 

--- a/modules/ai-impact/client/utils/version-group.js
+++ b/modules/ai-impact/client/utils/version-group.js
@@ -10,14 +10,23 @@
  *   "3.5" / "3.5.EA1" / "3.5.EA2"  → three options
  */
 
+// ODH build type values that are valid version group keys (not numeric releases).
+// Maps lowercase → canonical display form.
+const ODH_BUILD_TYPES = { ci: 'CI', release: 'Release' }
+
 /**
  * @param {string|null|undefined} name
- * @returns {string|null} Canonical group key, e.g. "3.5", "3.5.EA1"
+ * @returns {string|null} Canonical group key, e.g. "3.5", "3.5.EA1", "CI", "Release"
  */
 export function extractVersionGroup(name) {
   if (name == null) return null
   let s = String(name).toLowerCase().trim()
   if (!s) return null
+
+  // ODH build_type values map to their canonical form.
+  if (s in ODH_BUILD_TYPES) {
+    return ODH_BUILD_TYPES[s]
+  }
 
   s = s.replace(/\brhel\s+ai\b/g, 'rhelai')
   s = s.replace(/\.z(?=$|[.\s])/gi, '')
@@ -72,11 +81,14 @@ export function collectVersionGroups(versions) {
 }
 
 /**
- * Sort 3.4 < 3.4.EA1 < 3.4.EA2 < 3.5 < 3.5.EA1 …
+ * Sort 3.4 < 3.4.EA1 < 3.4.EA2 < 3.5 < 3.5.EA1 … < CI < Release
+ * Non-numeric labels (ODH build types) sort after all numeric versions.
  */
 function compareVersionGroups(a, b) {
   const pa = parseGroupKey(a)
   const pb = parseGroupKey(b)
+  if (pa.isLabel !== pb.isLabel) return pa.isLabel ? 1 : -1
+  if (pa.isLabel && pb.isLabel) return a.localeCompare(b)
   if (pa.major !== pb.major) return pa.major - pb.major
   if (pa.minor !== pb.minor) return pa.minor - pb.minor
   if (pa.patch !== pb.patch) return pa.patch - pb.patch
@@ -86,15 +98,15 @@ function compareVersionGroups(a, b) {
 
 function parseGroupKey(key) {
   const m = String(key).match(/^(\d+)\.(\d+)(?:\.(\d+))?(?:\.(EA\d+))?$/i)
-  if (!m) return { major: 0, minor: 0, patch: 0, phase: null, phaseRank: 0 }
+  if (!m) return { major: 0, minor: 0, patch: 0, phase: null, phaseRank: 0, isLabel: true }
   const phase = m[4] ? m[4].toUpperCase() : null
   return {
     major: Number(m[1]),
     minor: Number(m[2]),
     patch: m[3] ? Number(m[3]) : 0,
     phase,
-    // Base/GA first (0), then EA1, EA2, …
-    phaseRank: phase ? Number(phase.replace(/\D/g, '')) || 99 : 0
+    phaseRank: phase ? Number(phase.replace(/\D/g, '')) || 99 : 0,
+    isLabel: false
   }
 }
 


### PR DESCRIPTION
## Summary

- Accept `CI` and `Release` as valid version group keys in the component onboarding page version filter dropdown
- These values come from ODH component YAML `build_type` field (sent by the updated sync job in rhoai-component-onboarding)
- Non-numeric labels sort after all numeric RHOAI versions in the dropdown

## Context

The companion change in `rhoai-component-onboarding` now sends `target_rhoai_version` from the YAML for RHOAI issues and `build_type` (CI/Release) for ODH issues in the `targetVersion` field. This PR ensures the frontend filter recognizes and displays those ODH values.

## Test plan

- [ ] `extractVersionGroup('CI')` returns `'CI'`
- [ ] `extractVersionGroup('Release')` returns `'Release'`
- [ ] `collectVersionGroups(['CI', 'rhoai-3.5', 'Release', 'rhoai-3.6'])` returns `['3.5', '3.6', 'CI', 'Release']`
- [ ] Version filter dropdown shows CI/Release after numeric versions

Made with [Cursor](https://cursor.com)