### PR TITLE
feat: display parsed version in onboarding table column

### DIFF
--- a/modules/ai-impact/__tests__/client/version-group.test.js
+++ b/modules/ai-impact/__tests__/client/version-group.test.js
@@ -42,6 +42,13 @@ describe('extractVersionGroup', () => {
     expect(extractVersionGroup('main')).toBeNull()
     expect(extractVersionGroup('EA1')).toBeNull()
   })
+
+  it('recognizes ODH build type values', () => {
+    expect(extractVersionGroup('CI')).toBe('CI')
+    expect(extractVersionGroup('ci')).toBe('CI')
+    expect(extractVersionGroup('Release')).toBe('Release')
+    expect(extractVersionGroup('release')).toBe('Release')
+  })
 })
 
 describe('collectVersionGroups', () => {
@@ -54,6 +61,15 @@ describe('collectVersionGroups', () => {
       'rhoai-3.6',
       'rhoai-2.21'
     ])).toEqual(['2.21', '3.5', '3.5.EA1', '3.6'])
+  })
+
+  it('places ODH build types after numeric versions', () => {
+    expect(collectVersionGroups([
+      'CI',
+      'rhoai-3.5',
+      'Release',
+      'rhoai-3.6'
+    ])).toEqual(['3.5', '3.6', 'CI', 'Release'])
   })
 })
 

--- a/modules/ai-impact/client/components/ComponentOnboardingTable.vue
+++ b/modules/ai-impact/client/components/ComponentOnboardingTable.vue
@@ -2,7 +2,7 @@
 import { ref, computed, inject } from 'vue'
 import { useModuleLink } from '@shared/client/composables/useModuleLink'
 import MultiSelectDropdown from './MultiSelectDropdown.vue'
-import { collectVersionGroups, matchesVersionGroups, formatVersionGroupLabel } from '../utils/version-group.js'
+import { extractVersionGroup, collectVersionGroups, matchesVersionGroups, formatVersionGroupLabel } from '../utils/version-group.js'
 import {
   filterChipsRowClass,
   filterChipNeutralClass,
@@ -104,6 +104,12 @@ function clearAllFilters() {
   completionFilter.value = []
   productFilter.value = 'all'
   targetVersionFilter.value = []
+}
+
+function displayVersion(raw) {
+  if (!raw) return null
+  const group = extractVersionGroup(raw)
+  return group ? formatVersionGroupLabel(group) : raw
 }
 
 // ── Derived list ──────────────────────────────────────────────────────────────
@@ -440,7 +446,7 @@ function completionStatusDotClass(status) {
               </span>
             </td>
             <td class="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
-              {{ component.targetVersion || '—' }}
+              {{ displayVersion(component.targetVersion) || '—' }}
             </td>
             <td class="px-4 py-3">
               <div class="flex flex-wrap gap-1">
@@ -507,7 +513,7 @@ function completionStatusDotClass(status) {
                     </div>
                     <div v-if="component.targetVersion" class="flex gap-2">
                       <span class="text-gray-400 w-20 flex-shrink-0">Version</span>
-                      <span class="font-medium text-gray-700 dark:text-gray-300">{{ component.targetVersion }}</span>
+                      <span class="font-medium text-gray-700 dark:text-gray-300">{{ displayVersion(component.targetVersion) }}</span>
                     </div>
                     <div v-if="component.isOperator || detailCache[component.key]?.latest?.isOperator" class="flex gap-2">
                       <span class="text-gray-400 w-20 flex-shrink-0">Type</span>

--- a/modules/ai-impact/client/utils/version-group.js
+++ b/modules/ai-impact/client/utils/version-group.js
@@ -10,14 +10,23 @@
  *   "3.5" / "3.5.EA1" / "3.5.EA2"  → three options
  */
 
+// ODH build type values that are valid version group keys (not numeric releases).
+// Maps lowercase → canonical display form.
+const ODH_BUILD_TYPES = { ci: 'CI', release: 'Release' }
+
 /**
  * @param {string|null|undefined} name
- * @returns {string|null} Canonical group key, e.g. "3.5", "3.5.EA1"
+ * @returns {string|null} Canonical group key, e.g. "3.5", "3.5.EA1", "CI", "Release"
  */
 export function extractVersionGroup(name) {
   if (name == null) return null
   let s = String(name).toLowerCase().trim()
   if (!s) return null
+
+  // ODH build_type values map to their canonical form.
+  if (s in ODH_BUILD_TYPES) {
+    return ODH_BUILD_TYPES[s]
+  }
 
   s = s.replace(/\brhel\s+ai\b/g, 'rhelai')
   s = s.replace(/\.z(?=$|[.\s])/gi, '')
@@ -72,11 +81,14 @@ export function collectVersionGroups(versions) {
 }
 
 /**
- * Sort 3.4 < 3.4.EA1 < 3.4.EA2 < 3.5 < 3.5.EA1 …
+ * Sort 3.4 < 3.4.EA1 < 3.4.EA2 < 3.5 < 3.5.EA1 … < CI < Release
+ * Non-numeric labels (ODH build types) sort after all numeric versions.
  */
 function compareVersionGroups(a, b) {
   const pa = parseGroupKey(a)
   const pb = parseGroupKey(b)
+  if (pa.isLabel !== pb.isLabel) return pa.isLabel ? 1 : -1
+  if (pa.isLabel && pb.isLabel) return a.localeCompare(b)
   if (pa.major !== pb.major) return pa.major - pb.major
   if (pa.minor !== pb.minor) return pa.minor - pb.minor
   if (pa.patch !== pb.patch) return pa.patch - pb.patch
@@ -86,15 +98,15 @@ function compareVersionGroups(a, b) {
 
 function parseGroupKey(key) {
   const m = String(key).match(/^(\d+)\.(\d+)(?:\.(\d+))?(?:\.(EA\d+))?$/i)
-  if (!m) return { major: 0, minor: 0, patch: 0, phase: null, phaseRank: 0 }
+  if (!m) return { major: 0, minor: 0, patch: 0, phase: null, phaseRank: 0, isLabel: true }
   const phase = m[4] ? m[4].toUpperCase() : null
   return {
     major: Number(m[1]),
     minor: Number(m[2]),
     patch: m[3] ? Number(m[3]) : 0,
     phase,
-    // Base/GA first (0), then EA1, EA2, …
-    phaseRank: phase ? Number(phase.replace(/\D/g, '')) || 99 : 0
+    phaseRank: phase ? Number(phase.replace(/\D/g, '')) || 99 : 0,
+    isLabel: false
   }
 }
 


### PR DESCRIPTION
## Summary

- Normalize the raw `targetVersion` string through `extractVersionGroup` + `formatVersionGroupLabel` before displaying in the table column and detail panel
- This makes the table display match the version dropdown filter labels (e.g. `"3.6-ea-1"` renders as `"3.6 EA1"`, `"rhoai-3.5"` as `"3.5"`, `"CI"` stays `"CI"`)

Depends on: #1396

## Test plan

- [ ] Table column shows `3.6 EA1` instead of raw `3.6-ea-1`
- [ ] Detail panel shows the same parsed version
- [ ] `CI` and `Release` display unchanged
- [ ] Missing targetVersion still shows dash

Made with [Cursor](https://cursor.com)