### PR TITLE
fix(releases): bound live Jira on feature-readiness to avoid 504

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 
 const {
   fetchFeatures,
+  fetchFeaturesWithTimeout,
   normalizeIssue,
   enrichChildEpicCounts,
   JQL,
@@ -51,6 +52,10 @@ describe('feature-query', function() {
       expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.team)
       expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.targetVersion)
       expect(QUERY_FIELDS).toContain(CUSTOM_FIELDS.riceScore)
+    })
+
+    it('omits description to keep the Features List request path light', function() {
+      expect(QUERY_FIELDS).not.toContain('description')
     })
   })
 
@@ -303,6 +308,35 @@ describe('feature-query', function() {
       expect(client.fetchAllJqlResults.mock.calls.some(function(c) {
         return String(c[0]).indexOf('issuetype = Epic') !== -1
       })).toBe(false)
+    })
+  })
+
+  describe('fetchFeaturesWithTimeout', function() {
+    it('returns null when jiraClient is missing', async function() {
+      expect(await fetchFeaturesWithTimeout(null)).toBeNull()
+    })
+
+    it('returns the feature map when fetch completes in time', async function() {
+      var client = mockJiraClient([
+        { key: 'RHAISTRAT-1', fields: { summary: 'Fast' } }
+      ])
+      var result = await fetchFeaturesWithTimeout(client, 5000)
+      expect(result).toBeInstanceOf(Map)
+      expect(result.get('RHAISTRAT-1').summary).toBe('Fast')
+    })
+
+    it('returns null when the live fetch exceeds the timeout', async function() {
+      var client = {
+        fetchAllJqlResults: vi.fn().mockImplementation(function() {
+          return new Promise(function(resolve) {
+            setTimeout(function() {
+              resolve([{ key: 'RHAISTRAT-SLOW', fields: { summary: 'Late' } }])
+            }, 200)
+          })
+        })
+      }
+      var result = await fetchFeaturesWithTimeout(client, 20)
+      expect(result).toBeNull()
     })
   })
 

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -5,7 +5,6 @@ var { fetchEpicsForFeatures } = require('../execution/jira-enrich')
 var QUERY_FIELDS = [
   'summary', 'status', 'issuetype', 'assignee', 'fixVersions',
   'components', 'labels', 'priority', 'created', 'updated',
-  'description',
   CUSTOM_FIELDS.team,
   CUSTOM_FIELDS.targetVersion,
   CUSTOM_FIELDS.riceScore,
@@ -19,6 +18,9 @@ var QUERY_FIELDS = [
 ].join(',')
 
 var JQL = 'project = RHAISTRAT AND issuetype IN (Feature, Initiative) AND status NOT IN (Closed, Done, Resolved, Cancelled)'
+
+/** Bound live Jira so /feature-readiness stays under the gateway timeout. */
+var FETCH_FEATURES_TIMEOUT_MS = 12000
 
 function normalizeIssue(issue) {
   var fields = issue.fields || {}
@@ -69,7 +71,8 @@ function normalizeIssue(issue) {
     targetEnd: serializeField(fields[CUSTOM_FIELDS.targetEnd]),
     pmOwner: pmOwner,
     effort: numericField(fields[CUSTOM_FIELDS.effort]),
-    descriptionSignals: parseDescriptionSignals(fields.description),
+    // null when description was not fetched — lets health/cache signals win in merge
+    descriptionSignals: fields.description ? parseDescriptionSignals(fields.description) : null,
     epicCount: 0
   }
 }
@@ -109,10 +112,44 @@ async function fetchFeatures(jiraClient) {
   return map
 }
 
+/**
+ * Like fetchFeatures, but abandons the wait after timeoutMs so the Features List
+ * can respond from execution/health cache instead of gateway-timing-out.
+ * The underlying Jira fetch may still complete in the background.
+ *
+ * @param {object} jiraClient
+ * @param {number} [timeoutMs]
+ * @returns {Promise<Map|null>} feature map, or null on timeout / empty / missing client
+ */
+async function fetchFeaturesWithTimeout(jiraClient, timeoutMs) {
+  if (!jiraClient || !jiraClient.fetchAllJqlResults) return null
+  var ms = timeoutMs != null ? timeoutMs : FETCH_FEATURES_TIMEOUT_MS
+  var timedOut = false
+  var timeout = new Promise(function(resolve) {
+    setTimeout(function() {
+      timedOut = true
+      resolve(null)
+    }, ms)
+  })
+  var result = await Promise.race([fetchFeatures(jiraClient), timeout])
+  if (timedOut || result == null) {
+    if (timedOut) {
+      console.warn(
+        '[releases/planning] Live Jira feature fetch exceeded ' + ms + 'ms; using cached readiness sources'
+      )
+    }
+    return null
+  }
+  if (result.size === 0) return null
+  return result
+}
+
 module.exports = {
   fetchFeatures: fetchFeatures,
+  fetchFeaturesWithTimeout: fetchFeaturesWithTimeout,
   normalizeIssue: normalizeIssue,
   enrichChildEpicCounts: enrichChildEpicCounts,
   JQL: JQL,
-  QUERY_FIELDS: QUERY_FIELDS
+  QUERY_FIELDS: QUERY_FIELDS,
+  FETCH_FEATURES_TIMEOUT_MS: FETCH_FEATURES_TIMEOUT_MS
 }

--- a/modules/releases/server/planning/routes.js
+++ b/modules/releases/server/planning/routes.js
@@ -27,7 +27,7 @@ const { logAudit, getAuditLog, computeFieldDiff } = require('./audit-log')
 const { blockDuringImpersonation } = require('../../../../shared/server/auth')
 const healthRoutes = require('./health/health-routes')
 var { buildFeatureReadiness } = require('./feature-readiness')
-var { fetchFeatures } = require('./feature-query')
+var { fetchFeaturesWithTimeout } = require('./feature-query')
 
 const { isValidVersionParam } = require('../version-utils')
 
@@ -474,8 +474,7 @@ module.exports = async function registerPlanningRoutes(router, context) {
       var jiraFeatures = null
       if (jiraClient) {
         try {
-          jiraFeatures = await fetchFeatures(jiraClient)
-          if (jiraFeatures.size === 0) jiraFeatures = null
+          jiraFeatures = await fetchFeaturesWithTimeout(jiraClient)
         } catch (jiraErr) {
           console.warn('[releases/planning] Jira feature query failed, falling back to execution index:', jiraErr.message)
         }


### PR DESCRIPTION
## Summary
- `/feature-readiness` now uses `fetchFeaturesWithTimeout` (12s). Slow Jira → fall back to execution/health cache instead of gateway **HTTP 504**.
- Drops `description` from the live Features List Jira field set (heavy ADF); `descriptionSignals` stay null so health/cache signals still apply.
- Keeps #1393 Child epics path (execution `feature.epics` / index `deriveEpicCount`).

## Test plan
- [x] Unit: `feature-query.test.js` (timeout + no description in QUERY_FIELDS)
- [ ] Features List loads in prod without HTTP 504
- [ ] When Jira is healthy and fast, live fields still enrich the list (`meta.jiraAvailable: true`)


Made with [Cursor](https://cursor.com)