### PR TITLE
fix(releases): make Risk Dashboard configurable only via gear icon settings

### DIFF
--- a/fixtures/releases/delivery/risk-dashboard-config.json
+++ b/fixtures/releases/delivery/risk-dashboard-config.json
@@ -1,0 +1,20 @@
+{
+  "portfolioReleases": [
+    {
+      "id": "pf-demo-35",
+      "name": "RHAI 3.5",
+      "releases": ["3.5", "3.5", "3.5"],
+      "codeFreezeDate": "2026-08-01",
+      "dueDate": "2026-08-15",
+      "enabled": true
+    },
+    {
+      "id": "pf-demo-36",
+      "name": "RHAI 3.6",
+      "releases": ["3.6", "3.6", "3.6"],
+      "codeFreezeDate": "2027-02-15",
+      "dueDate": "2027-03-01",
+      "enabled": true
+    }
+  ]
+}

--- a/modules/releases/__tests__/client/deliver/MainView.test.js
+++ b/modules/releases/__tests__/client/deliver/MainView.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { ref, computed, reactive } from 'vue'
+import { ref, computed } from 'vue'
 import MainView from '../../../client/deliver/views/MainView.vue'
 
 const mockApiRequest = vi.fn()
@@ -44,21 +44,8 @@ const mockReleases = [
   }
 ]
 
-function createMockFilter(releases = []) {
-  return {
-    filteredReleases: computed(() => releases),
-    selectedProducts: reactive(new Set()),
-    selectedVersions: reactive(new Set()),
-    allProducts: computed(() => []),
-    allVersions: computed(() => []),
-    visibleProducts: computed(() => []),
-    visibleVersions: computed(() => []),
-    toggleProduct: vi.fn(),
-    toggleVersion: vi.fn(),
-    clearProducts: vi.fn(),
-    clearVersions: vi.fn(),
-    resetFilters: vi.fn()
-  }
+function createMockAllAnalysisReleases(releases = []) {
+  return computed(() => releases)
 }
 
 function createMockAnalysisState(overrides = {}) {
@@ -93,12 +80,12 @@ function seedPortfolioConfig(releases) {
 
 function mountView(releases = [], analysisOverrides = {}) {
   if (releases.length) seedPortfolioConfig(releases)
-  const mockFilter = createMockFilter(releases)
+  const mockAllAnalysisReleases = createMockAllAnalysisReleases(releases)
   const mockAnalysis = createMockAnalysisState(analysisOverrides)
   return mount(MainView, {
     global: {
       provide: {
-        releaseFilter: mockFilter,
+        allAnalysisReleases: mockAllAnalysisReleases,
         analysisState: mockAnalysis
       }
     }

--- a/modules/releases/client/deliver/views/MainView.vue
+++ b/modules/releases/client/deliver/views/MainView.vue
@@ -108,7 +108,7 @@ import { useRiskDashboardConfig } from '../composables/useRiskDashboardConfig'
 import ReleaseVersionGroup from '../components/ReleaseVersionGroup.vue'
 import RiskDashboardSettingsPanel from '../components/RiskDashboardSettingsPanel.vue'
 
-const filter = inject('releaseFilter')
+const allAnalysisReleases = inject('allAnalysisReleases')
 const analysisState = inject('analysisState')
 const { loading, refreshing, error, analysis, refreshAnalysis } = analysisState
 
@@ -171,7 +171,7 @@ const portfolioMemberSet = computed(function () {
 })
 
 const allReleases = computed(() => {
-  const releases = filter.filteredReleases.value
+  const releases = allAnalysisReleases.value
 
   const now = new Date()
   const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))

--- a/modules/releases/client/views/DeliverView.vue
+++ b/modules/releases/client/views/DeliverView.vue
@@ -7,8 +7,8 @@
       <p class="text-xs">This may take a few minutes on first load.</p>
     </div>
 
-    <!-- Chip bar (visible once analysis has data) -->
-    <ReleaseChipBar v-if="allReleases.length" />
+    <!-- Chip bar (visible once analysis has data, hidden on Risk Dashboard which uses gear config only) -->
+    <ReleaseChipBar v-if="allReleases.length && activeTab !== 'risk-dashboard'" />
 
     <div class="border-b border-gray-200 dark:border-gray-700">
       <nav class="flex -mb-px px-4" aria-label="Deliver sub-tabs">
@@ -57,6 +57,7 @@ const allReleases = computed(() => {
 const filter = useReleaseFilter(allReleases)
 
 provide('releaseFilter', filter)
+provide('allAnalysisReleases', allReleases)
 provide('analysisState', { loading, refreshing, error, analysis, refreshAnalysis })
 provide('conformaState', conformaState)
 


### PR DESCRIPTION
## Summary
- Hides the Product/Version chip bar filter when the Risk Dashboard tab is active — the Risk Dashboard is now controlled exclusively through the gear icon (portfolio config settings).
- Injects unfiltered analysis releases (`allAnalysisReleases`) so the Risk Dashboard reads from the full release list, bypassing any chip bar state from other tabs (Release Blockers, Conforma Insights still use the chip bar as before).
- Adds a demo fixture for `risk-dashboard-config.json` with sample RHAI 3.5 and 3.6 portfolios.

## Test plan
- [ ] Verify chip bar is hidden on the Risk Dashboard tab
- [ ] Verify chip bar appears on Release Blockers and Conforma Insights tabs
- [ ] Verify Risk Dashboard shows only releases configured in gear icon settings
- [ ] Verify chip bar selections on other tabs do not affect Risk Dashboard
- [ ] Verify demo mode loads the risk dashboard config fixture correctly


Made with [Cursor](https://cursor.com)