### PR TITLE
fix(releases): do not let live Jira epicCount 0 override cache

### DIFF
--- a/modules/releases/server/planning/__tests__/feature-query.test.js
+++ b/modules/releases/server/planning/__tests__/feature-query.test.js
@@ -236,7 +236,7 @@ describe('feature-query', function() {
       expect(result.size).toBe(2)
       expect(result.get('RHAISTRAT-100').summary).toBe('Feature A')
       expect(result.get('RHAISTRAT-200').summary).toBe('Feature B')
-      expect(result.get('RHAISTRAT-100').epicCount).toBe(0)
+      expect(result.get('RHAISTRAT-100').epicCount).toBeUndefined()
     })
 
     it('skips issues without a key', async function() {
@@ -303,7 +303,7 @@ describe('feature-query', function() {
       var client = mockJiraClient(features, children)
 
       var result = await fetchFeatures(client)
-      expect(result.get('RHAISTRAT-2198').epicCount).toBe(0)
+      expect(result.get('RHAISTRAT-2198').epicCount).toBeUndefined()
       expect(client.fetchAllJqlResults).toHaveBeenCalledTimes(1)
       expect(client.fetchAllJqlResults.mock.calls.some(function(c) {
         return String(c[0]).indexOf('issuetype = Epic') !== -1

--- a/modules/releases/server/planning/__tests__/feature-readiness.test.js
+++ b/modules/releases/server/planning/__tests__/feature-readiness.test.js
@@ -2418,7 +2418,7 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     expect(result.pendingReview[0].title).toBe('Jira Feature RHAISTRAT-900')
   })
 
-  it('prefers live jira epicCount for Child epics over stale exec count of 0', async function() {
+  it('prefers explicit jira epicCount for Child epics over stale exec count of 0', async function() {
     var jiraFeatures = makeJiraMap([
       makeJiraFeature('RHAISTRAT-2198', {
         epicCount: 2,
@@ -2451,6 +2451,60 @@ describe('buildFeatureReadiness — pass 3 (jiraFeatures)', function() {
     })
     expect(feature).toBeTruthy()
     expect(feature.epicCount).toBe(2)
+    var child = feature.fpdor.items.find(function(i) { return i.name === 'Child epics' })
+    expect(child.pass).toBe(true)
+  })
+
+  it('uses exec epicCount when live jira omits epicCount (request path does not discover children)', async function() {
+    var jiraFeature = makeJiraFeature('RHAISTRAT-1473', {
+      components: ['Platform', 'Serving', 'UXD', 'Documentation'],
+      docsRequired: 'Yes',
+      labels: ['strat-creator-auto-created', 'strat-creator-human-sign-off', 'rp-qg1-pass'],
+      riceScore: 50,
+      releaseType: 'GA',
+      pmOwner: 'Jane'
+    })
+    delete jiraFeature.epicCount
+    var jiraFeatures = makeJiraMap([jiraFeature])
+    var readFromStorage = makeReadFromStorage({
+      ...convertToUnifiedFormat(makeFeaturesStore({})),
+      'releases/planning/config.json': CONFIG_3_6,
+      'releases/planning/health-cache-3.6-all.json': {
+        features: [{
+          key: 'RHAISTRAT-1473',
+          deliveryOwner: 'Alice',
+          pmOwner: 'Jane',
+          targetRelease: 'rhoai-3.6',
+          storyPoints: 5,
+          epicCount: 0,
+          releaseType: 'GA',
+          components: ['Platform', 'Serving', 'UXD', 'Documentation'],
+          docsRequired: 'Yes'
+        }]
+      },
+      'releases/execution/index.json': makeExecIndex([
+        {
+          key: 'RHAISTRAT-1473',
+          summary: 'Tool Calling',
+          status: 'Release Pending',
+          epicCount: 5,
+          components: ['Platform', 'Serving', 'UXD', 'Documentation'],
+          docsRequired: 'Yes',
+          labels: ['strat-creator-auto-created', 'strat-creator-human-sign-off', 'rp-qg1-pass'],
+          riceScore: 50,
+          releaseType: 'GA',
+          assignee: 'Alice',
+          pm: 'Jane'
+        }
+      ])
+    })
+
+    var result = await buildFeatureReadiness(readFromStorage, jiraFeatures)
+    var feature = result.pendingReview.concat(result.ready).find(function(f) {
+      return f.key === 'RHAISTRAT-1473'
+    })
+    expect(feature).toBeTruthy()
+    expect(feature.epicCount).toBe(5)
     var child = feature.fpdor.items.find(function(i) { return i.name === 'Child epics' })
     expect(child.pass).toBe(true)
   })

--- a/modules/releases/server/planning/feature-query.js
+++ b/modules/releases/server/planning/feature-query.js
@@ -72,8 +72,9 @@ function normalizeIssue(issue) {
     pmOwner: pmOwner,
     effort: numericField(fields[CUSTOM_FIELDS.effort]),
     // null when description was not fetched — lets health/cache signals win in merge
-    descriptionSignals: fields.description ? parseDescriptionSignals(fields.description) : null,
-    epicCount: 0
+    descriptionSignals: fields.description ? parseDescriptionSignals(fields.description) : null
+    // Do not set epicCount here — live fetch does not discover child Epics.
+    // A placeholder 0 would override exec/health counts in mergeFeatureData.
   }
 }
 

--- a/modules/releases/server/planning/feature-readiness.js
+++ b/modules/releases/server/planning/feature-readiness.js
@@ -427,17 +427,28 @@ function mergeFeatureData(key, jiraFeatures, aiReviewMap, candidateIndex, health
   var hygieneStatus = computeHygieneStatus(violations)
 
   var storyPoints = (health && health.storyPoints) || (candidate && candidate.storyPoints) || (jira && jira.storyPoints) || (exec && exec.storyPoints) || null
-  var epicCount
-  if (jira && jira.epicCount != null) {
-    epicCount = jira.epicCount
-  } else if (health && health.epicCount != null) {
-    epicCount = health.epicCount
-  } else if (candidate && candidate.epicCount != null) {
-    epicCount = candidate.epicCount
-  } else if (exec && exec.epicCount != null) {
-    epicCount = exec.epicCount
-  } else {
-    epicCount = 0
+  // Prefer any positive epicCount (jira → health → candidate → exec). A placeholder 0
+  // from live Jira or a stale health cache must not override a real exec count.
+  var epicCount = 0
+  var epicSources = [
+    jira && jira.epicCount,
+    health && health.epicCount,
+    candidate && candidate.epicCount,
+    exec && exec.epicCount
+  ]
+  for (var ei = 0; ei < epicSources.length; ei++) {
+    if (epicSources[ei] != null && epicSources[ei] > 0) {
+      epicCount = epicSources[ei]
+      break
+    }
+  }
+  if (epicCount === 0) {
+    for (var ej = 0; ej < epicSources.length; ej++) {
+      if (epicSources[ej] != null) {
+        epicCount = epicSources[ej]
+        break
+      }
+    }
   }
   var releaseType = (health && health.releaseType) || (candidate && candidate.phase) || (jira && jira.releaseType) || (exec && exec.releaseType) || null
   var assignee = deliveryOwner


### PR DESCRIPTION
## Summary
- Live `fetchFeatures` no longer sets `epicCount: 0` (that placeholder was winning merge and failing Child epics for features like RHAISTRAT-1473 that have real child Epics in Jira / exec store).
- `mergeFeatureData` now prefers any **positive** `epicCount` across jira → health → candidate → exec, so a stale health `0` cannot override a synced exec count.

## Test plan
- [x] Unit: feature-query + feature-readiness (omit live epicCount; exec wins over health 0)
- [ ] After deploy, RHAISTRAT-1473 Child epics passes when exec index has epicCount > 0
- [ ] Features List still loads (no regression to 504)


Made with [Cursor](https://cursor.com)