### PR TITLE
fix(releases): persist Features List filters across navigation

### DIFF
--- a/modules/releases/__tests__/client/plan/features-list-filter-storage.test.js
+++ b/modules/releases/__tests__/client/plan/features-list-filter-storage.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  STORAGE_KEY,
+  DEFAULT_FILTERS,
+  saveFeaturesListFilters,
+  restoreFeaturesListFilters,
+  clearFeaturesListFiltersStorage
+} from '../../../client/plan/utils/features-list-filter-storage.js'
+
+describe('features-list-filter-storage', function() {
+  beforeEach(function() {
+    localStorage.clear()
+  })
+
+  afterEach(function() {
+    localStorage.clear()
+  })
+
+  it('returns null when nothing is stored', function() {
+    expect(restoreFeaturesListFilters()).toBeNull()
+  })
+
+  it('round-trips filters and selectedVersion', function() {
+    saveFeaturesListFilters({
+      outcome: ['Rock A'],
+      targetVersion: ['3.5'],
+      fixVersion: [],
+      component: ['Dashboard'],
+      priority: ['Major'],
+      team: [],
+      product: ['RHOAI'],
+      fpdorItems: ['Child epics'],
+      readiness: 'not-ready'
+    }, '3.5')
+
+    var restored = restoreFeaturesListFilters()
+    expect(restored).toBeTruthy()
+    expect(restored.selectedVersion).toBe('3.5')
+    expect(restored.filters.outcome).toEqual(['Rock A'])
+    expect(restored.filters.component).toEqual(['Dashboard'])
+    expect(restored.filters.fpdorItems).toEqual(['Child epics'])
+    expect(restored.filters.readiness).toBe('not-ready')
+    expect(restored.filters.fixVersion).toEqual([])
+  })
+
+  it('ignores non-array filter values', function() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      filters: { outcome: 'Rock A', component: ['Dashboard'] },
+      selectedVersion: '3.6'
+    }))
+    var restored = restoreFeaturesListFilters()
+    expect(restored.filters.outcome).toEqual([])
+    expect(restored.filters.component).toEqual(['Dashboard'])
+    expect(restored.selectedVersion).toBe('3.6')
+  })
+
+  it('clearFeaturesListFiltersStorage removes the key', function() {
+    saveFeaturesListFilters(DEFAULT_FILTERS, '3.5')
+    expect(localStorage.getItem(STORAGE_KEY)).toBeTruthy()
+    clearFeaturesListFiltersStorage()
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    expect(restoreFeaturesListFilters()).toBeNull()
+  })
+})

--- a/modules/releases/client/plan/utils/features-list-filter-storage.js
+++ b/modules/releases/client/plan/utils/features-list-filter-storage.js
@@ -1,0 +1,88 @@
+/**
+ * Persist Features List filters across navigation (e.g. feature-detail → back).
+ * Mirrors PM Hub's pm-hub-filters pattern.
+ */
+
+export var STORAGE_KEY = 'features-list-filters'
+
+export var DEFAULT_FILTERS = {
+  outcome: [],
+  targetVersion: [],
+  fixVersion: [],
+  component: [],
+  priority: [],
+  team: [],
+  product: [],
+  fpdorItems: [],
+  readiness: null
+}
+
+function asStringArray(value) {
+  if (!Array.isArray(value)) return []
+  return value.filter(function(item) {
+    return typeof item === 'string'
+  })
+}
+
+/**
+ * @param {object} filters
+ * @param {string} selectedVersion
+ */
+export function saveFeaturesListFilters(filters, selectedVersion) {
+  try {
+    var state = {
+      filters: {
+        outcome: asStringArray(filters && filters.outcome),
+        targetVersion: asStringArray(filters && filters.targetVersion),
+        fixVersion: asStringArray(filters && filters.fixVersion),
+        component: asStringArray(filters && filters.component),
+        priority: asStringArray(filters && filters.priority),
+        team: asStringArray(filters && filters.team),
+        product: asStringArray(filters && filters.product),
+        fpdorItems: asStringArray(filters && filters.fpdorItems),
+        readiness: filters && filters.readiness != null ? String(filters.readiness) : null
+      },
+      selectedVersion: typeof selectedVersion === 'string' ? selectedVersion : ''
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch (e) {
+    void e
+  }
+}
+
+/**
+ * @returns {{ filters: object, selectedVersion: string }|null}
+ */
+export function restoreFeaturesListFilters() {
+  try {
+    var raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    var state = JSON.parse(raw)
+    if (!state || typeof state !== 'object') return null
+    var saved = state.filters && typeof state.filters === 'object' ? state.filters : {}
+    return {
+      filters: {
+        outcome: asStringArray(saved.outcome),
+        targetVersion: asStringArray(saved.targetVersion),
+        fixVersion: asStringArray(saved.fixVersion),
+        component: asStringArray(saved.component),
+        priority: asStringArray(saved.priority),
+        team: asStringArray(saved.team),
+        product: asStringArray(saved.product),
+        fpdorItems: asStringArray(saved.fpdorItems),
+        readiness: saved.readiness != null && saved.readiness !== '' ? String(saved.readiness) : null
+      },
+      selectedVersion: typeof state.selectedVersion === 'string' ? state.selectedVersion : ''
+    }
+  } catch {
+    return null
+  }
+}
+
+export function clearFeaturesListFiltersStorage() {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (e) {
+    void e
+  }
+}

--- a/modules/releases/client/plan/views/FeatureReadinessView.vue
+++ b/modules/releases/client/plan/views/FeatureReadinessView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, inject } from 'vue'
+import { ref, computed, onMounted, inject, watch } from 'vue'
 import { useFeatureReadiness } from '../composables/useFeatureReadiness'
 import { useReleases } from '../composables/useReleasePlanning'
 import { useRefreshPolling } from '../composables/useRefreshPolling'
@@ -11,6 +11,11 @@ import {
   featureMatchesSharedFilters,
   exportFeatureReadinessCsv
 } from '../utils/feature-readiness-export.js'
+import {
+  DEFAULT_FILTERS,
+  saveFeaturesListFilters,
+  restoreFeaturesListFilters
+} from '../utils/features-list-filter-storage.js'
 
 const nav = inject('moduleNav')
 const jiraBaseUrl = 'https://issues.redhat.com/browse'
@@ -50,15 +55,10 @@ useRefreshPolling(refreshing, checkRefreshStatus, function() {
   loadFeatureReadiness()
 })
 
-onMounted(function() {
-  loadFeatureReadiness()
-  loadReleases()
-})
-
 const selectedFeature = ref(null)
 const selectedVersion = ref('')
 
-const filters = ref({
+const filters = ref(Object.assign({}, DEFAULT_FILTERS, {
   outcome: [],
   targetVersion: [],
   fixVersion: [],
@@ -66,8 +66,37 @@ const filters = ref({
   priority: [],
   team: [],
   product: [],
-  fpdorItems: [],
-  readiness: null
+  fpdorItems: []
+}))
+
+function restorePersistedFilters() {
+  var saved = restoreFeaturesListFilters()
+  if (!saved) return
+  filters.value = Object.assign({}, DEFAULT_FILTERS, saved.filters, {
+    outcome: saved.filters.outcome.slice(),
+    targetVersion: saved.filters.targetVersion.slice(),
+    fixVersion: saved.filters.fixVersion.slice(),
+    component: saved.filters.component.slice(),
+    priority: saved.filters.priority.slice(),
+    team: saved.filters.team.slice(),
+    product: saved.filters.product.slice(),
+    fpdorItems: saved.filters.fpdorItems.slice()
+  })
+  selectedVersion.value = saved.selectedVersion
+}
+
+watch(
+  [filters, selectedVersion],
+  function() {
+    saveFeaturesListFilters(filters.value, selectedVersion.value)
+  },
+  { deep: true }
+)
+
+onMounted(function() {
+  restorePersistedFilters()
+  loadFeatureReadiness()
+  loadReleases()
 })
 
 function matchesFilters(feature) {


### PR DESCRIPTION
## Summary
- Persist Features List filters + selected release in `localStorage` (`features-list-filters`).
- Restore on mount so Back from feature-detail returns to the previous filtered view (same approach as PM Hub).

## Test plan
- [x] Unit: `features-list-filter-storage.test.js`
- [ ] Set filters on Features List → open a feature key → Back → filters still applied
- [ ] Clear filters → navigate away and back → list remains unfiltered


Made with [Cursor](https://cursor.com)