### PR TITLE
fix(releases): use execution epicCount for PM Hub Child epics

### DIFF
--- a/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
+++ b/modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js
@@ -69,6 +69,73 @@ describe('buildFeatureObj', function () {
     expect(result).not.toHaveProperty('violations')
     expect(result.linkedRfeKey).toBe('RHAIRFE-1')
   })
+
+  it('passes Child epics when execution index has epicCount', function () {
+    var input = Object.assign({}, fullInput, { openChildCount: 0 })
+    var result = buildFeatureObj(input, ['rhoai-3.5'], null, { 'RHAIENG-123': 1 })
+    var childEpics = result.fpdor.items.find(function (item) {
+      return item.name === 'Child epics'
+    })
+    expect(childEpics).toBeTruthy()
+    expect(childEpics.pass).toBe(true)
+    expect(childEpics.detail).toMatch(/linked child epics/i)
+  })
+
+  it('ignores hygiene openChildCount for Child epics FPDoR', function () {
+    var input = Object.assign({}, fullInput, { openChildCount: 5 })
+    var result = buildFeatureObj(input, ['rhoai-3.5'], null, {})
+    var childEpics = result.fpdor.items.find(function (item) {
+      return item.name === 'Child epics'
+    })
+    expect(childEpics).toBeTruthy()
+    expect(childEpics.pass).toBe(false)
+  })
+
+  it('uses f.epicCount when no execution map entry', function () {
+    var input = Object.assign({}, fullInput, { epicCount: 2, openChildCount: 0 })
+    var result = buildFeatureObj(input, ['rhoai-3.5'])
+    var childEpics = result.fpdor.items.find(function (item) {
+      return item.name === 'Child epics'
+    })
+    expect(childEpics.pass).toBe(true)
+  })
+})
+
+describe('resolveEpicCount', function () {
+  const { resolveEpicCount, loadEpicCountByKey } = require('../../../server/pm-hub/routes')
+
+  it('prefers execution map over feature.epicCount', function () {
+    expect(resolveEpicCount({ key: 'A-1', epicCount: 9 }, { 'A-1': 1 })).toBe(1)
+  })
+
+  it('returns 0 when map has explicit zero', function () {
+    expect(resolveEpicCount({ key: 'A-1', epicCount: 9 }, { 'A-1': 0 })).toBe(0)
+  })
+
+  it('falls back to feature.epicCount when key missing from map', function () {
+    expect(resolveEpicCount({ key: 'A-1', epicCount: 3 }, {})).toBe(3)
+  })
+
+  it('does not use openChildCount', function () {
+    expect(resolveEpicCount({ key: 'A-1', openChildCount: 7 }, {})).toBe(0)
+  })
+
+  it('loadEpicCountByKey maps execution index epicCount by key', async function () {
+    var readFromStorage = async function (path) {
+      if (path === 'releases/execution/index.json') {
+        return {
+          features: [
+            { key: 'RHAISTRAT-2318', epicCount: 1 },
+            { key: 'RHAISTRAT-1', epicCount: 0 }
+          ]
+        }
+      }
+      return null
+    }
+    var map = await loadEpicCountByKey(readFromStorage)
+    expect(map['RHAISTRAT-2318']).toBe(1)
+    expect(map['RHAISTRAT-1']).toBe(0)
+  })
 })
 
 describe('computePmDoAligned / versionsStrictMatch', function () {

--- a/modules/releases/server/pm-hub/routes.js
+++ b/modules/releases/server/pm-hub/routes.js
@@ -12,6 +12,7 @@ const { JIRA_HOST } = require('../../../../shared/server/jira')
 const { filterCommittedFixVersions, parseReleaseName, compareReleasesTemporally } = require('./committed-definition')
 const { parseDescriptionSignals } = require('../planning/health/description-scanner')
 const { computeFPDoRReadiness, isAiFirstFeature } = require('../planning/fpdor')
+const { loadIndex } = require('../planning/cache-reader')
 
 const JIRA_SEARCH = JIRA_HOST + '/issues/?jql='
 const PM_HUB_PROJECTS = ['RHAIENG', 'RHOAIENG', 'INFERENG', 'AIPCC', 'RHAISTRAT', 'RHAIRFE']
@@ -416,7 +417,46 @@ function computeConfidence(isReady, fixVersion) {
   return 'ready'
 }
 
-function buildFeatureObj(f, targetVersions, rawIssue) {
+/**
+ * Child-epics FPDoR count for PM Hub.
+ * Prefer execution-index epicCount (same source as Features List / jira-sync).
+ * Do not use hygiene openChildCount — that is only filled for terminal features
+ * and counts any open child, not Epic children.
+ *
+ * @param {object} f - Transformed hygiene feature (or partial)
+ * @param {object} [epicCountByKey] - Map of issue key → epicCount from execution index
+ * @returns {number}
+ */
+function resolveEpicCount(f, epicCountByKey) {
+  var key = f && f.key
+  if (key && epicCountByKey && epicCountByKey[key] != null) {
+    return epicCountByKey[key] || 0
+  }
+  if (f && f.epicCount != null) return f.epicCount || 0
+  return 0
+}
+
+/**
+ * Build a key → epicCount map from the execution index (one storage read).
+ * @param {Function} readFromStorage
+ * @returns {Promise<object>}
+ */
+async function loadEpicCountByKey(readFromStorage) {
+  var byKey = {}
+  try {
+    var execIndex = await loadIndex(readFromStorage)
+    var features = (execIndex && execIndex.features) || []
+    for (var i = 0; i < features.length; i++) {
+      var ef = features[i]
+      if (ef && ef.key) byKey[ef.key] = ef.epicCount || 0
+    }
+  } catch (err) {
+    console.warn('[releases/pm-hub] Failed to load execution epic counts:', err.message)
+  }
+  return byKey
+}
+
+function buildFeatureObj(f, targetVersions, rawIssue, epicCountByKey) {
   var tv = targetVersions || []
   var labels = Array.isArray(f.labels) ? f.labels : []
   var fixVersions = f.fixVersions || []
@@ -444,7 +484,7 @@ function buildFeatureObj(f, targetVersions, rawIssue) {
     linkedRfeKey: f.linkedRfeKey || null,
     sourceRfe: f.linkedRfeKey || null,
     descriptionSignals: descriptionSignals,
-    epicCount: f.openChildCount || 0
+    epicCount: resolveEpicCount(f, epicCountByKey)
   }
 
   var fpdor = computeFPDoRReadiness(fpdorInput)
@@ -743,6 +783,8 @@ module.exports = async function registerPmHubRoutes(router, context) {
       }
 
       var versionGroups = {}
+      // Same Child epics source as Features List (jira-sync → execution index).
+      var epicCountByKey = await loadEpicCountByKey(context.storage.readFromStorage)
 
       function ensureGroup(vName, cName) {
         if (!versionGroups[vName]) {
@@ -795,7 +837,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
               if (componentNames.length > 0 && componentNames.indexOf(ucName) === -1) continue
               var uGroup = ensureGroup(committedFvOnly[ufi], ucName)
               if (!uGroup.committedFeatures.some(function(e) { return e.key === f.key })) {
-                uGroup.committedFeatures.push(buildFeatureObj(f, tvNames, rawIssue))
+                uGroup.committedFeatures.push(buildFeatureObj(f, tvNames, rawIssue, epicCountByKey))
                 uGroup.committedCount++
                 if (f.isBlocked) uGroup.blockedCount++
               }
@@ -829,7 +871,7 @@ module.exports = async function registerPmHubRoutes(router, context) {
         if (groupVersionKeys.length === 0) continue
 
         var isRequested = matchingTv.length > 0
-        var featureObj = buildFeatureObj(f, tvNames, rawIssue)
+        var featureObj = buildFeatureObj(f, tvNames, rawIssue, epicCountByKey)
 
         for (var gvi = 0; gvi < groupVersionKeys.length; gvi++) {
           var vKey = groupVersionKeys[gvi]
@@ -910,6 +952,8 @@ module.exports.PILLAR_CONFIG_FILE = PILLAR_CONFIG_FILE
 module.exports.backfillLeads = backfillLeads
 module.exports.computeVelocity = computeVelocity
 module.exports.buildFeatureObj = buildFeatureObj
+module.exports.resolveEpicCount = resolveEpicCount
+module.exports.loadEpicCountByKey = loadEpicCountByKey
 module.exports.extractTargetVersions = extractTargetVersions
 module.exports.filterCommittedFixVersions = filterCommittedFixVersions
 module.exports.computePmDoAligned = computePmDoAligned


### PR DESCRIPTION
## Summary
- PM Hub FPDoR Child epics was wired to hygiene `openChildCount`, which stays `0` for non-terminal features on the live Jira path — so items like RHAISTRAT-2318 always failed even with linked Epics in Jira.
- Source `epicCount` from `releases/execution/index.json` (same jira-sync path as Features List) when building PM Hub feature objects.
- Stop using `openChildCount` for Child epics evaluation.

## Test plan
- [ ] Unit tests: `npx vitest run modules/releases/__tests__/server/pm-hub/build-feature-obj.test.js`
- [ ] After deploy + successful jira-sync, open PM Hub for a feature with linked child Epics (e.g. RHAISTRAT-2318 → RHOAIUX-3180)
- [ ] Confirm slide tray Child epics shows pass when execution index has `epicCount ≥ 1`
- [ ] Confirm Features List and PM Hub Child epics agree for the same feature


Made with [Cursor](https://cursor.com)