### PR TITLE
feat(releases): CVE report enhancements — RHAI project expansion, sorting, and SLA compliance

### DIFF
--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -132,9 +132,9 @@
         </p>
       </section>
 
-      <!-- 1. RHOAI Open CVEs (bar chart) -->
+      <!-- 1. RHAI Open CVEs (bar chart) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">RHOAI Open CVEs</h3>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">RHAI Open CVEs</h3>
         <div style="height: 340px;">
           <Bar :data="openCvesChartData" :options="openCvesChartOptions" />
         </div>
@@ -292,10 +292,10 @@
         </p>
       </section>
 
-      <!-- 9. RHOAI False Positives (multi-series line) -->
+      <!-- 9. RHAI False Positives (multi-series line) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
         <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
-          RHOAI False Positives
+          RHAI False Positives
           <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
         </h3>
         <div style="height: 300px;">

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -10,7 +10,7 @@
         <ArrowLeft :size="18" />
       </button>
       <div class="flex-1">
-        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">RHOAI Sustaining (CVEs)</h2>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100">RHAI Sustaining (CVEs)</h2>
         <p v-if="data?.lastRefreshed" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
           Last refreshed: {{ formatDate(data.lastRefreshed) }}
         </p>
@@ -119,10 +119,10 @@
         </p>
       </section>
 
-      <!-- 4. Open RHOAI CVEs across all versions (pie) + 6. False Positive by VEX (doughnut) -->
+      <!-- 4. Open RHAI CVEs across all versions (pie) + 6. False Positive by VEX (doughnut) -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Open RHOAI CVEs across all versions</h3>
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">Open RHAI CVEs across all versions</h3>
           <div style="height: 300px;">
             <Pie :data="versionPieData" :options="versionPieOptions" />
           </div>
@@ -136,7 +136,7 @@
             False Positive by VEX Justification
             <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
           </h3>
-          <div style="height: 300px;">
+          <div style="height: 380px;">
             <Doughnut :data="vexDoughnutData" :options="vexPieOptions" />
           </div>
           <p class="text-xs text-gray-400 dark:text-gray-500 mt-2 text-right">
@@ -152,12 +152,16 @@
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-700">
               <th class="text-left py-2 pr-3 font-semibold text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800 z-10">Components</th>
-              <th v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ ver }}</th>
-              <th class="text-right py-2 pl-3 font-bold text-gray-900 dark:text-gray-100">Total</th>
+              <th v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-2 px-2 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap cursor-pointer select-none hover:text-gray-900 dark:hover:text-gray-100" @click="toggleVersionTableSort(ver)">
+                {{ ver }} <span class="text-[9px] ml-0.5" :class="versionSortIcon(ver).active ? 'text-gray-900 dark:text-gray-100' : 'text-gray-300 dark:text-gray-600'">{{ versionSortIcon(ver).char }}</span>
+              </th>
+              <th class="text-right py-2 pl-3 font-bold text-gray-900 dark:text-gray-100 cursor-pointer select-none hover:text-primary-600 dark:hover:text-primary-400" @click="toggleVersionTableSort('total')">
+                Total <span class="text-[9px] ml-0.5" :class="versionSortIcon('total').active ? 'text-gray-900 dark:text-gray-100' : 'text-gray-300 dark:text-gray-600'">{{ versionSortIcon('total').char }}</span>
+              </th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="row in agg.cvesAcrossVersions.value.rows" :key="row.component" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+            <tr v-for="row in sortedVersionTableRows" :key="row.component" class="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
               <td class="py-1.5 pr-3 text-gray-800 dark:text-gray-200 sticky left-0 bg-white dark:bg-gray-800 z-10">{{ row.component }}</td>
               <td v-for="ver in agg.cvesAcrossVersions.value.versions" :key="ver" class="text-right py-1.5 px-2 tabular-nums">
                 <button v-if="row.cells[ver]" class="font-semibold text-blue-600 dark:text-blue-400 underline decoration-dotted hover:decoration-solid cursor-pointer" @click="drillDownByMatrixCell(row.component, ver, row.cellJqls[ver])">{{ row.cells[ver] }}</button>
@@ -188,7 +192,7 @@
         </p>
       </section>
 
-      <!-- 5. CVEs by RHOAI Sustaining (assignee x status table) -->
+      <!-- 5. CVEs by RHAI Sustaining (assignee x status table) -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5 overflow-x-auto">
         <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by Assignee</h3>
         <table class="w-full text-xs">
@@ -455,6 +459,35 @@ function formatDate(iso) {
   })
 }
 
+// ─── CVEs across versions table sort ─────────────────────────────────────────
+
+const versionTableSort = ref({ column: 'component', direction: 'asc' })
+
+function toggleVersionTableSort(column) {
+  if (versionTableSort.value.column === column) {
+    versionTableSort.value.direction = versionTableSort.value.direction === 'asc' ? 'desc' : 'asc'
+  } else {
+    versionTableSort.value = { column, direction: 'desc' }
+  }
+}
+
+function versionSortIcon(column) {
+  if (versionTableSort.value.column !== column) return { char: '▲▼', active: false }
+  return { char: versionTableSort.value.direction === 'asc' ? '▲' : '▼', active: true }
+}
+
+const sortedVersionTableRows = computed(() => {
+  const raw = agg.cvesAcrossVersions.value.rows
+  if (!raw || !raw.length) return []
+  const col = versionTableSort.value.column
+  const dir = versionTableSort.value.direction === 'asc' ? 1 : -1
+  return [...raw].sort((a, b) => {
+    if (col === 'component') return dir * a.component.localeCompare(b.component)
+    if (col === 'total') return dir * (a.total - b.total)
+    return dir * ((a.cells[col] || 0) - (b.cells[col] || 0))
+  })
+})
+
 // ─── Due Date Buckets ────────────────────────────────────────────────────────
 
 const dueDateBuckets = computed(() => {
@@ -465,7 +498,7 @@ const dueDateBuckets = computed(() => {
     { key: 'lt30', label: 'Due Date in Less Than 30 Days', pct: dd.lessThan30.pct, count: dd.lessThan30.count, jql: dd.lessThan30.jql, classes: 'text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-800' },
     { key: '30-90', label: 'Due Date Between 30 and 90 Days', pct: dd.between30And90.pct, count: dd.between30And90.count, jql: dd.between30And90.jql, classes: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' },
     { key: 'gt90', label: 'Due Date More Than 90 Days', pct: dd.moreThan90.pct, count: dd.moreThan90.count, jql: dd.moreThan90.jql, classes: 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800' },
-    { key: 'none', label: 'None', pct: dd.none.pct, count: dd.none.count, jql: dd.none.jql, classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700' }
+    { key: 'none', label: 'None (No due date)', pct: dd.none.pct, count: dd.none.count, jql: dd.none.jql, classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700' }
   ]
 })
 
@@ -588,6 +621,12 @@ const PIE_LEGEND = {
   labels: { padding: 8, font: { size: 10 }, color: '#6b7280', usePointStyle: true, pointStyle: 'circle', boxWidth: 8 }
 }
 
+const PIE_LEGEND_BOTTOM = {
+  display: true,
+  position: 'bottom',
+  labels: { padding: 10, font: { size: 11 }, color: '#6b7280', usePointStyle: true, pointStyle: 'circle', boxWidth: 8 }
+}
+
 const versionPieOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
@@ -616,7 +655,7 @@ const vexPieOptions = computed(() => ({
   },
   onHover: (event, elements) => { event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default' },
   plugins: {
-    legend: PIE_LEGEND,
+    legend: PIE_LEGEND_BOTTOM,
     tooltip: { callbacks: { label: (ctx) => `${ctx.raw} issues — click to view in Jira` } }
   }
 }))

--- a/modules/releases/client/reports/CveSustainingReport.vue
+++ b/modules/releases/client/reports/CveSustainingReport.vue
@@ -90,6 +90,30 @@
         </div>
       </div>
 
+      <!-- SLA Compliance (quarter-over-quarter) -->
+      <section v-if="slaQuarters.length" class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
+        <div class="mb-4">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">CVE SLA Compliance</h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Resolved on or before due date. Only CVEs with both a due date and resolution date are evaluated.</p>
+        </div>
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <a v-for="(q, idx) in slaQuarters" :key="q.label"
+            :href="q.total_jql" target="_blank" rel="noopener noreferrer"
+            class="rounded-lg border p-4 text-center hover:shadow-md transition-shadow cursor-pointer block"
+            :class="slaCardClasses(q.pct)"
+            :title="`${q.label}: ${q.metSla} / ${q.total} CVEs met SLA — click to view in Jira`">
+            <p class="text-3xl font-extrabold">{{ q.pct }}%</p>
+            <div v-if="idx === slaQuarters.length - 1 && slaQuarters.length >= 2" class="mt-0.5">
+              <span class="text-[10px] font-semibold" :class="slaDeltaClass">
+                {{ slaDelta > 0 ? '+' : '' }}{{ slaDelta }}pp {{ slaDelta >= 0 ? '&#9650;' : '&#9660;' }}
+              </span>
+            </div>
+            <p class="text-[10px] font-semibold uppercase tracking-wide mt-1 opacity-80">{{ q.label }}</p>
+            <p class="text-xs mt-1 opacity-60">{{ q.metSla }} / {{ q.total }} met SLA</p>
+          </a>
+        </div>
+      </section>
+
       <!-- 2. CVEs by Due Date -->
       <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
         <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">CVEs by Due Date</h3>
@@ -132,10 +156,11 @@
         </section>
 
         <section class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5">
-          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
             False Positive by VEX Justification
             <span v-if="filters.hasActiveFilters.value" class="text-[10px] font-normal text-gray-400 dark:text-gray-500 ml-1">(all data)</span>
           </h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">All resolved false positives across all statuses</p>
           <div style="height: 380px;">
             <Doughnut :data="vexDoughnutData" :options="vexPieOptions" />
           </div>
@@ -501,6 +526,28 @@ const dueDateBuckets = computed(() => {
     { key: 'none', label: 'None (No due date)', pct: dd.none.pct, count: dd.none.count, jql: dd.none.jql, classes: 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700' }
   ]
 })
+
+// ─── SLA Compliance ──────────────────────────────────────────────────────────
+
+const slaQuarters = computed(() => data.value?.slaCompliance?.quarters || [])
+
+const slaDelta = computed(() => {
+  const q = slaQuarters.value
+  if (q.length < 2) return 0
+  return q[q.length - 1].pct - q[q.length - 2].pct
+})
+
+const slaDeltaClass = computed(() => {
+  if (slaDelta.value > 0) return 'text-emerald-600 dark:text-emerald-400'
+  if (slaDelta.value < 0) return 'text-red-600 dark:text-red-400'
+  return 'text-gray-500 dark:text-gray-400'
+})
+
+function slaCardClasses(pct) {
+  if (pct >= 80) return 'text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800'
+  if (pct >= 60) return 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800'
+  return 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
+}
 
 // ─── Chart Colors ────────────────────────────────────────────────────────────
 

--- a/modules/releases/client/reports/composables/useCveAggregation.js
+++ b/modules/releases/client/reports/composables/useCveAggregation.js
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 // ─── JQL constants (mirrored from server) ───────────────────────────────────
 
 const BASE_JQL = [
-  'project in (RHAIENG, RHOAIENG)',
+  'project in (RHAIENG, RHOAIENG, INFERENG, AIPCC)',
   '(labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is EMPTY)',
   'component not in (Documentation, PXE, Devops, testops)',
   'issuetype in (vulnerability)',
@@ -144,7 +144,11 @@ function buildVersionComponentMatrix(issues, searchBase, filterJql) {
   }
 
   const sortedComponents = [...components].sort()
-  const sortedVersions = [...versions].sort()
+  const sortedVersions = [...versions].sort().sort((a, b) => {
+    if (a === 'None') return 1
+    if (b === 'None') return -1
+    return 0
+  })
   const base = BASE_JQL + filterJql
 
   const rows = sortedComponents.map(comp => {

--- a/modules/releases/client/reports/registry.js
+++ b/modules/releases/client/reports/registry.js
@@ -39,8 +39,8 @@ export const reports = [
   },
   {
     id: 'cve-sustaining',
-    label: 'RHOAI Sustaining (CVEs)',
-    description: 'Open CVE tracking across RHOAI components and versions — due dates, assignee workload, VEX justifications, and trends.',
+    label: 'RHAI Sustaining (CVEs)',
+    description: 'Open CVE tracking across RHAI components and versions — due dates, assignee workload, VEX justifications, and trends.',
     icon: 'ShieldAlert',
     tags: ['Security', 'CVE', 'Sustaining'],
     component: defineAsyncComponent(() => import('./CveSustainingReport.vue'))

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -521,8 +521,9 @@ function buildSlaCompliance(allIssues, now) {
     const q = findQuarterBucket(quarters, resolved);
     if (!q) continue;
     q.total++;
-    const due = new Date(issue.fields.duedate);
-    if (resolved <= due) {
+    const resolvedDate = issue.fields.resolutiondate.slice(0, 10);
+    const dueDate = issue.fields.duedate;
+    if (resolvedDate <= dueDate) {
       q.metSla++;
     } else {
       q.missedSla++;

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -61,7 +61,12 @@ function quoteStatus(name) {
  *     summary: Get cached CVE sustaining metrics
  *     responses:
  *       200:
- *         description: Aggregated CVE sustaining metrics payload
+ *         description: >
+ *           Aggregated CVE sustaining metrics payload including open/all counts,
+ *           component breakdowns, due-date buckets, version matrix, assignee matrix,
+ *           VEX justification, created-vs-resolved trend, unresolved trend,
+ *           false-positives trend, SLA compliance (quarter-over-quarter),
+ *           and lightweight open-issue records for client-side filtering.
  *       404:
  *         description: No cached data — run a refresh first
  */
@@ -72,7 +77,9 @@ function quoteStatus(name) {
  *   post:
  *     tags: [Releases]
  *     summary: Refresh CVE sustaining metrics from Jira
- *     description: Fetches all matching CVEs from Jira, aggregates into visualization buckets, and caches results
+ *     description: >
+ *       Fetches all matching CVEs from Jira, aggregates into visualization
+ *       buckets (including SLA compliance per quarter), and caches results.
  *     responses:
  *       200:
  *         description: Refreshed CVE sustaining metrics payload
@@ -129,6 +136,7 @@ function aggregateMetrics(openIssues, allIssues) {
     createdVsResolved: buildCreatedVsResolved(allIssues, now),
     unresolved: buildUnresolvedTimeSeries(allIssues, now),
     falsePositivesTrend: buildFalsePositivesTrend(allIssues, now),
+    slaCompliance: buildSlaCompliance(allIssues, now),
     // Lightweight issue projections for client-side filtering
     openIssueRecords: openIssues.map(projectIssue),
     jiraSearchBase: JIRA_SEARCH
@@ -496,6 +504,51 @@ function buildFalsePositivesTrend(allIssues, now) {
   };
 }
 
+// 10. SLA Compliance (quarter-over-quarter)
+function buildSlaCompliance(allIssues, now) {
+  const RESOLVED_JQL = ALL_STATUSES_JQL + ' AND status in (Closed, Resolved) AND duedate is not EMPTY';
+
+  const eligible = allIssues.filter(i => {
+    const status = (i.fields?.status?.name || '').toLowerCase();
+    if (status !== 'closed' && status !== 'resolved') return false;
+    return i.fields?.duedate && i.fields?.resolutiondate;
+  });
+
+  const quarters = buildQuarterBuckets(now, 4);
+
+  for (const issue of eligible) {
+    const resolved = new Date(issue.fields.resolutiondate);
+    const q = findQuarterBucket(quarters, resolved);
+    if (!q) continue;
+    q.total++;
+    const due = new Date(issue.fields.duedate);
+    if (resolved <= due) {
+      q.metSla++;
+    } else {
+      q.missedSla++;
+    }
+  }
+
+  return {
+    quarters: quarters.map(q => {
+      const qStart = q.start.toISOString().slice(0, 10);
+      const qEndNext = new Date(q.end.getTime() + 1).toISOString().slice(0, 10);
+      return {
+        label: q.label,
+        quarterStart: qStart,
+        quarterEnd: q.end.toISOString().slice(0, 10),
+        total: q.total,
+        metSla: q.metSla,
+        missedSla: q.missedSla,
+        pct: q.total > 0 ? Math.round((q.metSla / q.total) * 100) : 0,
+        total_jql: jqlUrl(RESOLVED_JQL + ` AND resolved >= "${qStart}" AND resolved < "${qEndNext}"`),
+        metSla_jql: jqlUrl(RESOLVED_JQL + ` AND resolved >= "${qStart}" AND resolved < "${qEndNext}" AND resolved <= duedate`),
+        missedSla_jql: jqlUrl(RESOLVED_JQL + ` AND resolved >= "${qStart}" AND resolved < "${qEndNext}" AND resolved > duedate`)
+      };
+    })
+  };
+}
+
 // ─── Date Helpers ────────────────────────────────────────────────────────────
 
 function buildWeekBuckets(now, count) {
@@ -547,6 +600,37 @@ function findWeekBucket(weeks, date) {
 function findMonthBucket(months, date) {
   for (const m of months) {
     if (date >= m.start && date <= m.end) return m;
+  }
+  return null;
+}
+
+function buildQuarterBuckets(now, count) {
+  const quarters = [];
+  const currentQ = Math.floor(now.getMonth() / 3);
+  const currentY = now.getFullYear();
+
+  for (let i = 0; i < count; i++) {
+    let q = currentQ - i;
+    let y = currentY;
+    while (q < 0) { q += 4; y--; }
+    const startMonth = q * 3;
+    const start = new Date(y, startMonth, 1);
+    const end = new Date(y, startMonth + 3, 0, 23, 59, 59, 999);
+    quarters.push({
+      label: `Q${q + 1} ${y}`,
+      start,
+      end,
+      total: 0,
+      metSla: 0,
+      missedSla: 0
+    });
+  }
+  return quarters.reverse();
+}
+
+function findQuarterBucket(quarters, date) {
+  for (const q of quarters) {
+    if (date >= q.start && date <= q.end) return q;
   }
   return null;
 }

--- a/modules/releases/server/cve-sustaining/routes.js
+++ b/modules/releases/server/cve-sustaining/routes.js
@@ -1,7 +1,7 @@
 /**
  * CVE Sustaining sub-router.
  *
- * Serves cached CVE sustaining metrics for the RHOAI Sustaining (CVEs)
+ * Serves cached CVE sustaining metrics for the RHAI Sustaining (CVEs)
  * report. Data is fetched from Jira on demand via POST /refresh and
  * cached to local storage for fast subsequent reads.
  *
@@ -12,7 +12,7 @@ const STORAGE_PREFIX = 'releases/cve-sustaining';
 const STORAGE_FILE = `${STORAGE_PREFIX}/latest.json`;
 
 const BASE_JQL = [
-  'project in (RHAIENG, RHOAIENG)',
+  'project in (RHAIENG, RHOAIENG, INFERENG, AIPCC)',
   '(labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is EMPTY)',
   'component not in (Documentation, PXE, Devops, testops)',
   'issuetype in (vulnerability)',
@@ -20,7 +20,7 @@ const BASE_JQL = [
 ].join(' AND ');
 
 const ALL_STATUSES_JQL = [
-  'project in (RHAIENG, RHOAIENG)',
+  'project in (RHAIENG, RHOAIENG, INFERENG, AIPCC)',
   '(labels not in (RHOAI-releases, RHOAI-internal, devtestops-service) OR labels is EMPTY)',
   'component not in (Documentation, PXE, Devops, testops)',
   'issuetype in (vulnerability)'


### PR DESCRIPTION
## Summary

- **Expand CVE scope**: Include `INFERENG` and `AIPCC` Jira projects alongside `RHAIENG`/`RHOAIENG` in both server-side JQL and client-side drill-down links. Rename report from "RHOAI Sustaining" to "RHAI Sustaining".
- **Table sorting**: Add sortable column headers to the "CVEs across all versions" table (excluding Components column), with the "None" version pinned before Total.
- **SLA Compliance section**: New quarter-over-quarter view showing percentage of CVEs resolved on or before their due date, with color-coded cards (green/amber/red), trend delta arrow, and Jira drill-down links.
- **UI polish**: "None" due date bucket relabeled to "None (No due date)", doughnut chart legend moved to bottom for better readability, version pie chart title updated.

## Test plan

- [ ] Refresh CVE data from Jira and verify all 4 projects appear in results
- [ ] Verify "CVEs across all versions" table columns are sortable (click headers) except Components
- [ ] Verify "None" version column stays pinned before Total
- [ ] Verify SLA Compliance section shows 4 quarterly cards with correct color coding
- [ ] Verify SLA card Jira links open correct JQL queries
- [ ] Verify trend delta arrow appears on the most recent quarter card


Made with [Cursor](https://cursor.com)